### PR TITLE
[web-animations] keyframes should be recomputed when "bolder" or "lighter" is used on a "font-weight" property

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/fontWeight-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/fontWeight-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Relative font weight bolder responsive to style changes assert_not_equals: got disallowed value "400"
-FAIL Relative font weight lighter responsive to style changes assert_not_equals: got disallowed value "700"
+PASS Relative font weight bolder responsive to style changes
+PASS Relative font weight lighter responsive to style changes
 

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -896,6 +896,7 @@ void KeyframeEffect::updateBlendingKeyframes(RenderStyle& elementStyle, const St
     m_inheritedProperties.clear();
     m_currentColorProperties.clear();
     m_containsCSSVariableReferences = false;
+    m_hasRelativeFontWeight = false;
 
     for (auto& keyframe : m_parsedKeyframes) {
         KeyframeValue keyframeValue(keyframe.computedOffset, nullptr);
@@ -927,6 +928,8 @@ void KeyframeEffect::updateBlendingKeyframes(RenderStyle& elementStyle, const St
                         m_inheritedProperties.add(property.id());
                     else if (valueId == CSSValueCurrentcolor)
                         m_currentColorProperties.add(property.id());
+                    else if (property.id() == CSSPropertyFontWeight && (valueId == CSSValueBolder || valueId == CSSValueLighter))
+                        m_hasRelativeFontWeight = true;
                 }
             }
         }
@@ -1072,7 +1075,7 @@ void KeyframeEffect::computeCSSAnimationBlendingKeyframes(const RenderStyle& una
 
     KeyframeList keyframeList(AtomString { backingAnimation.name().string });
     if (auto* styleScope = Style::Scope::forOrdinal(*m_target, backingAnimation.nameStyleScopeOrdinal()))
-        styleScope->resolver().keyframeStylesForAnimation(*m_target, unanimatedStyle, resolutionContext, keyframeList, m_containsCSSVariableReferences, m_inheritedProperties, m_currentColorProperties);
+        styleScope->resolver().keyframeStylesForAnimation(*m_target, unanimatedStyle, resolutionContext, keyframeList, m_containsCSSVariableReferences, m_hasRelativeFontWeight, m_inheritedProperties, m_currentColorProperties);
 
     // Ensure resource loads for all the frames.
     for (auto& keyframe : keyframeList) {

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -183,6 +183,7 @@ public:
     bool hasExplicitlyInheritedKeyframeProperty() const { return m_hasExplicitlyInheritedKeyframeProperty; }
     bool hasPropertySetToCurrentColor() const;
     bool hasColorSetToCurrentColor() const;
+    bool hasRelativeFontWeight() const { return m_hasRelativeFontWeight; }
 
 private:
     KeyframeEffect(Element*, PseudoId);
@@ -268,6 +269,7 @@ private:
     bool m_hasKeyframeComposingAcceleratedProperty { false };
     bool m_containsCSSVariableReferences { false };
     bool m_hasExplicitlyInheritedKeyframeProperty { false };
+    bool m_hasRelativeFontWeight { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/animation/KeyframeEffectStack.cpp
+++ b/Source/WebCore/animation/KeyframeEffectStack.cpp
@@ -197,8 +197,13 @@ OptionSet<AnimationImpact> KeyframeEffectStack::applyKeyframeEffects(RenderStyle
                 && previousLastStyleChangeEventStyle->color() != targetStyle.color();
         };
 
+        auto fontWeightChanged = [&]() {
+            return effect->hasRelativeFontWeight() && previousLastStyleChangeEventStyle
+                && previousLastStyleChangeEventStyle->fontWeight() != targetStyle.fontWeight();
+        };
+
         auto logicalPropertyDidChange = propertyAffectingLogicalPropertiesChanged && effect->animatesDirectionAwareProperty();
-        if (logicalPropertyDidChange || fontSizeChanged || inheritedPropertyChanged() || cssVariableChanged() || currentColorPropertyChanged())
+        if (logicalPropertyDidChange || fontSizeChanged || inheritedPropertyChanged() || cssVariableChanged() || currentColorPropertyChanged() || fontWeightChanged())
             effect->propertyAffectingKeyframeResolutionDidChange(unanimatedStyle, resolutionContext);
 
         animation->resolve(targetStyle, resolutionContext);

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -430,7 +430,7 @@ Vector<Ref<StyleRuleKeyframe>> Resolver::keyframeRulesForName(const AtomString& 
     return deduplicatedKeyframes;
 }
 
-void Resolver::keyframeStylesForAnimation(const Element& element, const RenderStyle& elementStyle, const ResolutionContext& context, KeyframeList& list, bool& containsCSSVariableReferences, HashSet<CSSPropertyID>& inheritedProperties, HashSet<CSSPropertyID>& currentColorProperties)
+void Resolver::keyframeStylesForAnimation(const Element& element, const RenderStyle& elementStyle, const ResolutionContext& context, KeyframeList& list, bool& containsCSSVariableReferences, bool& hasRelativeFontWeight, HashSet<CSSPropertyID>& inheritedProperties, HashSet<CSSPropertyID>& currentColorProperties)
 {
     inheritedProperties.clear();
     currentColorProperties.clear();
@@ -442,6 +442,7 @@ void Resolver::keyframeStylesForAnimation(const Element& element, const RenderSt
         return;
 
     containsCSSVariableReferences = false;
+    hasRelativeFontWeight = false;
     // Construct and populate the style for each keyframe.
     for (auto& keyframeRule : keyframeRules) {
         // Add this keyframe style to all the indicated key times
@@ -465,6 +466,8 @@ void Resolver::keyframeStylesForAnimation(const Element& element, const RenderSt
                             inheritedProperties.add(property.id());
                         else if (valueId == CSSValueCurrentcolor)
                             currentColorProperties.add(property.id());
+                        else if (property.id() == CSSPropertyFontWeight && (valueId == CSSValueBolder || valueId == CSSValueLighter))
+                            hasRelativeFontWeight = true;
                     }
                 }
             }

--- a/Source/WebCore/style/StyleResolver.h
+++ b/Source/WebCore/style/StyleResolver.h
@@ -95,7 +95,7 @@ public:
 
     ResolvedStyle styleForElement(const Element&, const ResolutionContext&, RuleMatchingBehavior = RuleMatchingBehavior::MatchAllRules);
 
-    void keyframeStylesForAnimation(const Element&, const RenderStyle& elementStyle, const ResolutionContext&, KeyframeList&, bool& containsCSSVariableReferences, HashSet<CSSPropertyID>& inheritedProperties, HashSet<CSSPropertyID>& currentColorProperties);
+    void keyframeStylesForAnimation(const Element&, const RenderStyle& elementStyle, const ResolutionContext&, KeyframeList&, bool& containsCSSVariableReferences, bool& hasRelativeFontWeight, HashSet<CSSPropertyID>& inheritedProperties, HashSet<CSSPropertyID>& currentColorProperties);
 
     WEBCORE_EXPORT std::optional<ResolvedStyle> styleForPseudoElement(const Element&, const PseudoElementRequest&, const ResolutionContext&);
 


### PR DESCRIPTION
#### 91d257012a7475b808814fea435ad36d1bf8043f
<pre>
[web-animations] keyframes should be recomputed when &quot;bolder&quot; or &quot;lighter&quot; is used on a &quot;font-weight&quot; property
<a href="https://bugs.webkit.org/show_bug.cgi?id=251493">https://bugs.webkit.org/show_bug.cgi?id=251493</a>

Reviewed by Antti Koivisto.

Keyframes can set the &quot;font-weight&quot; property to &quot;bolder&quot; or &quot;lighter&quot;. When such values are used, we
recompute keyframes if the inherited &quot;font-weight&quot; value changes while an animation is active.

* LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/fontWeight-expected.txt:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::updateBlendingKeyframes):
(WebCore::KeyframeEffect::computeCSSAnimationBlendingKeyframes):
* Source/WebCore/animation/KeyframeEffect.h:
(WebCore::KeyframeEffect::hasRelativeFontWeight const):
* Source/WebCore/animation/KeyframeEffectStack.cpp:
(WebCore::KeyframeEffectStack::applyKeyframeEffects):
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::keyframeStylesForAnimation):
* Source/WebCore/style/StyleResolver.h:

Canonical link: <a href="https://commits.webkit.org/259740@main">https://commits.webkit.org/259740@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e776c1aa2b580ef2ab596925b771ecc77954f4ac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105814 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14882 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38662 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115012 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/175141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109716 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16301 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6081 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/98044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111565 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/95373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/98044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/94264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/27014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/98044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8153 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/28366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8635 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14262 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/47914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10192 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3609 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->