### PR TITLE
[ iOS Release ] imported/w3c/web-platform-tests/webcodecs/videoFrame-texImage.any.worker.html  is a constant text only failure.

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3890,8 +3890,6 @@ webkit.org/b/251192 [ Release arm64 ] imported/w3c/web-platform-tests/webcodecs/
 
 webkit.org/b/251216 imported/w3c/web-platform-tests/fetch/metadata/generated/css-font-face.sub.tentative.html [ Pass Failure ]
 
-webkit.org/b/251234 imported/w3c/web-platform-tests/webcodecs/videoFrame-texImage.any.worker.html [ Failure ]
-
 webkit.org/b/251302 accessibility/ios-simulator/table-cell-ranges.html [ Failure ]
 
 webkit.org/b/251306 http/tests/in-app-browser-privacy/sub-frame-redirect-to-non-app-bound-domain-blocked.html [ Pass Crash ]

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/webcodecs/videoFrame-texImage.any.worker-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/webcodecs/videoFrame-texImage.any.worker-expected.txt
@@ -1,8 +1,0 @@
-
-FAIL texImage2D with 48x36 srgb VideoFrame. assert_equals: expected 150 but got 151
-PASS texSubImage2D with 48x36 srgb VideoFrame.
-FAIL texImage2D with 480x360 srgb VideoFrame. assert_equals: expected 150 but got 151
-PASS texSubImage2D with 480x360 srgb VideoFrame.
-PASS texImage2D with a closed VideoFrame.
-PASS texSubImage2D with a closed VideoFrame.
-


### PR DESCRIPTION
#### b1e18f0d12ca3be2cbb505ff5013bfad51045ba5
<pre>
[ iOS Release ] imported/w3c/web-platform-tests/webcodecs/videoFrame-texImage.any.worker.html  is a constant text only failure.
<a href="https://bugs.webkit.org/show_bug.cgi?id=251234">https://bugs.webkit.org/show_bug.cgi?id=251234</a>
rdar://problem/104720207

Reviewed by Eric Carlson.

The fast code path does not work on iOS simulator when the image needs to be converted to YUV before becoming a texture.
We fallback to the SW code path in that case.

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/webcodecs/videoFrame-texImage.any.worker-expected.txt: Removed.
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::texImageSourceHelper):

Canonical link: <a href="https://commits.webkit.org/259745@main">https://commits.webkit.org/259745@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49b8e7e70d1e9032616f83c51659c0133624b3e1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105650 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14741 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38525 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114878 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175023 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109552 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16147 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5940 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97917 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114692 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111404 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12280 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95260 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39756 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94144 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26899 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81472 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8009 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28252 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8506 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4838 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14126 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47800 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6736 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10058 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->