### PR TITLE
[web-animations] keyframes should be recomputed if a custom property registration changes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-animation-expected.txt
@@ -1,11 +1,11 @@
 
 PASS @keyframes works with @property
 PASS @keyframes picks up the latest @property in the document
-FAIL Ongoing animation picks up redeclared custom property assert_equals: expected "rgb(150, 150, 150)" but got "0px"
+PASS Ongoing animation picks up redeclared custom property
 PASS Ongoing animation matches new keyframes against the current registration
-FAIL Ongoing animation picks up redeclared intial value assert_equals: expected "250px" but got "200px"
+PASS Ongoing animation picks up redeclared intial value
 PASS Ongoing animation picks up redeclared inherits flag
-FAIL Ongoing animation picks up redeclared meaning of 'unset' assert_equals: expected "250px" but got "200px"
+PASS Ongoing animation picks up redeclared meaning of 'unset'
 PASS Transitioning from initial value
 PASS Transitioning from specified value
 FAIL Transition triggered by initial value change assert_equals: expected "150px" but got "200px"

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -796,6 +796,17 @@ void KeyframeEffect::keyframesRuleDidChange()
     invalidate();
 }
 
+void KeyframeEffect::customPropertyRegistrationDidChange(const AtomString& customProperty)
+{
+    // If the registration of a custom property is changed, we should recompute keyframes
+    // at the next opportunity as the initial value, inherited value, etc. could have changed.
+    if (!m_blendingKeyframes.properties().contains(customProperty))
+        return;
+
+    clearBlendingKeyframes();
+    invalidate();
+}
+
 ExceptionOr<void> KeyframeEffect::processKeyframes(JSGlobalObject& lexicalGlobalObject, Document& document, Strong<JSObject>&& keyframesInput)
 {
     Ref protectedDocument { document };

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -168,6 +168,7 @@ public:
     bool hasImplicitKeyframes() const;
 
     void keyframesRuleDidChange();
+    void customPropertyRegistrationDidChange(const AtomString&);
 
     bool canBeAccelerated() const;
     bool preventsAcceleration() const;

--- a/Source/WebCore/style/CustomPropertyRegistry.h
+++ b/Source/WebCore/style/CustomPropertyRegistry.h
@@ -46,6 +46,8 @@ public:
     void clearRegisteredFromStylesheets();
 
 private:
+    void notifyAnimationsOfCustomPropertyRegistration(const AtomString&);
+
     Scope& m_scope;
 
     HashMap<AtomString, std::unique_ptr<const CSSRegisteredCustomProperty>> m_propertiesFromAPI;


### PR DESCRIPTION
#### 70fad032590132bb48443215af1766a1bf3a5828
<pre>
[web-animations] keyframes should be recomputed if a custom property registration changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=251509">https://bugs.webkit.org/show_bug.cgi?id=251509</a>

Reviewed by Antti Koivisto.

If the registration of a custom property is changed, we must recompute keyframes of any effects
with keyframes targeting that custom property. To that end, we add a new method on KeyframeEffect
that the CustomPropertyRegistry can call into to notify the change of a custom property&apos;s
registration.

* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-animation-expected.txt:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::customPropertyRegistrationDidChange):
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/style/CustomPropertyRegistry.cpp:
(WebCore::Style::CustomPropertyRegistry::registerFromAPI):
(WebCore::Style::CustomPropertyRegistry::registerFromStylesheet):
(WebCore::Style::CustomPropertyRegistry::notifyAnimationsOfCustomPropertyRegistration):
* Source/WebCore/style/CustomPropertyRegistry.h:

Canonical link: <a href="https://commits.webkit.org/259737@main">https://commits.webkit.org/259737@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9d0f77872d4f1af3286bd56579f304e9c83c9c8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105660 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14751 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38535 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114888 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175029 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109562 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16157 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5950 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97927 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114698 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111414 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12293 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95267 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39767 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94157 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26906 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81484 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8019 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28259 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8515 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4848 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14136 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47807 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10068 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3605 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->