### PR TITLE
[WK2] Add and use TriviallyCopyableArgumentCoder

### DIFF
--- a/Source/WebCore/platform/audio/cocoa/CAAudioStreamDescription.h
+++ b/Source/WebCore/platform/audio/cocoa/CAAudioStreamDescription.h
@@ -80,13 +80,13 @@ private:
 template<class Encoder>
 void CAAudioStreamDescription::encode(Encoder& encoder) const
 {
-    encoder.encodeObject(m_streamDescription);
+    encoder << m_streamDescription;
 }
 
 template<class Decoder>
 std::optional<CAAudioStreamDescription> CAAudioStreamDescription::decode(Decoder& decoder)
 {
-    auto asbd = decoder.template decodeObject<AudioStreamBasicDescription>();
+    auto asbd = decoder.template decode<AudioStreamBasicDescription>();
     if (!asbd)
         return std::nullopt;
     return CAAudioStreamDescription { *asbd };

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCapabilities.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCapabilities.h
@@ -114,19 +114,19 @@ private:
 template<class Encoder>
 void CapabilityValueOrRange::encode(Encoder& encoder) const
 {
-    encoder.encodeObject(m_minOrValue);
-    encoder.encodeObject(m_max);
+    encoder << m_minOrValue;
+    encoder << m_max;
     encoder << m_type;
 }
 
 template<class Decoder>
 bool CapabilityValueOrRange::decode(Decoder& decoder, CapabilityValueOrRange& valueOrRange)
 {
-    auto minOrValue = decoder.template decodeObject<ValueUnion>();
+    auto minOrValue = decoder.template decode<ValueUnion>();
     if (!minOrValue)
         return false;
 
-    auto max = decoder.template decodeObject<ValueUnion>();
+    auto max = decoder.template decode<ValueUnion>();
     if (!max)
         return false;
 

--- a/Source/WebKit/Platform/IPC/ArgumentCoders.h
+++ b/Source/WebKit/Platform/IPC/ArgumentCoders.h
@@ -55,22 +55,6 @@
 
 namespace IPC {
 
-// An argument coder works on POD types
-template<typename T> struct SimpleArgumentCoder {
-    static_assert(std::is_trivially_copyable_v<T>);
-
-    template<typename Encoder>
-    static void encode(Encoder& encoder, const T& t)
-    {
-        encoder.encodeObject(t);
-    }
-
-    static std::optional<T> decode(Decoder& decoder)
-    {
-        return decoder.decodeObject<T>();
-    }
-};
-
 template<typename T, size_t Extent> struct ArgumentCoder<Span<T, Extent>> {
     template<typename Encoder>
     static void encode(Encoder& encoder, const Span<T, Extent>& span)

--- a/Source/WebKit/Shared/TextCheckerState.h
+++ b/Source/WebKit/Shared/TextCheckerState.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "ArgumentCoders.h"
+#include <wtf/ArgumentCoder.h>
 
 namespace WebKit {
 
@@ -45,5 +45,5 @@ struct TextCheckerState {
 } // namespace WebKit
 
 namespace IPC {
-template<> struct ArgumentCoder<WebKit::TextCheckerState> : SimpleArgumentCoder<WebKit::TextCheckerState> { };
+template<> struct ArgumentCoder<WebKit::TextCheckerState> : TriviallyCopyableArgumentCoder<WebKit::TextCheckerState> { };
 };

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -88,7 +88,6 @@
 #include <WebCore/ProgressBarPart.h>
 #include <WebCore/PromisedAttachmentInfo.h>
 #include <WebCore/ProtectionSpace.h>
-#include <WebCore/RectEdges.h>
 #include <WebCore/Region.h>
 #include <WebCore/RegistrableDomain.h>
 #include <WebCore/Report.h>
@@ -129,7 +128,6 @@
 #include <WebCore/TranslateTransformOperation.h>
 #include <WebCore/UserStyleSheet.h>
 #include <WebCore/VelocityData.h>
-#include <WebCore/ViewportArguments.h>
 #include <WebCore/WindowFeatures.h>
 #include <wtf/URL.h>
 #include <wtf/text/CString.h>
@@ -137,6 +135,7 @@
 
 #if PLATFORM(COCOA)
 #include "ArgumentCodersCF.h"
+#include <WebCore/CAAudioStreamDescription.h>
 #endif
 
 #if PLATFORM(IOS_FAMILY)
@@ -261,29 +260,6 @@ std::optional<DOMCacheEngine::Record> ArgumentCoder<DOMCacheEngine::Record>::dec
 
     return {{ WTFMove(identifier), WTFMove(updateResponseCounter), WTFMove(requestHeadersGuard), WTFMove(request), WTFMove(options.value()), WTFMove(referrer), WTFMove(responseHeadersGuard), WTFMove(response), WTFMove(responseBody), responseBodySize }};
 }
-
-void ArgumentCoder<RectEdges<bool>>::encode(Encoder& encoder, const RectEdges<bool>& boxEdges)
-{
-    SimpleArgumentCoder<RectEdges<bool>>::encode(encoder, boxEdges);
-}
-    
-std::optional<RectEdges<bool>> ArgumentCoder<RectEdges<bool>>::decode(Decoder& decoder)
-{
-    return SimpleArgumentCoder<RectEdges<bool>>::decode(decoder);
-}
-
-#if ENABLE(META_VIEWPORT)
-void ArgumentCoder<ViewportArguments>::encode(Encoder& encoder, const ViewportArguments& viewportArguments)
-{
-    SimpleArgumentCoder<ViewportArguments>::encode(encoder, viewportArguments);
-}
-
-std::optional<ViewportArguments> ArgumentCoder<ViewportArguments>::decode(Decoder& decoder)
-{
-    return SimpleArgumentCoder<ViewportArguments>::decode(decoder);
-}
-
-#endif // ENABLE(META_VIEWPORT)
 
 void ArgumentCoder<Length>::encode(Encoder& encoder, const Length& length)
 {
@@ -1773,5 +1749,19 @@ std::optional<RefPtr<WebCore::ReportBody>> ArgumentCoder<RefPtr<WebCore::ReportB
     ASSERT_NOT_REACHED();
     return std::nullopt;
 }
+
+#if PLATFORM(COCOA)
+
+void ArgumentCoder<AudioStreamBasicDescription>::encode(Encoder& encoder, const AudioStreamBasicDescription& asbd)
+{
+    TriviallyCopyableArgumentCoder<AudioStreamBasicDescription>::encode(encoder, asbd);
+}
+
+std::optional<AudioStreamBasicDescription> ArgumentCoder<AudioStreamBasicDescription>::decode(Decoder& decoder)
+{
+    return TriviallyCopyableArgumentCoder<AudioStreamBasicDescription>::decode(decoder);
+}
+
+#endif
 
 } // namespace IPC

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -44,12 +44,15 @@
 #include <WebCore/NetworkLoadMetrics.h>
 #include <WebCore/NotificationDirection.h>
 #include <WebCore/RealtimeMediaSource.h>
+#include <WebCore/RealtimeMediaSourceCapabilities.h>
+#include <WebCore/RectEdges.h>
 #include <WebCore/RenderingMode.h>
 #include <WebCore/ScrollSnapOffsetsInfo.h>
 #include <WebCore/ScrollTypes.h>
 #include <WebCore/SerializedPlatformDataCueValue.h>
 #include <WebCore/ServiceWorkerTypes.h>
 #include <WebCore/StoredCredentialsPolicy.h>
+#include <WebCore/ViewportArguments.h>
 #include <WebCore/WorkerType.h>
 #include <wtf/ArgumentCoder.h>
 #include <wtf/EnumTraits.h>
@@ -92,6 +95,8 @@
 #endif
 
 #if PLATFORM(COCOA)
+typedef struct AudioStreamBasicDescription AudioStreamBasicDescription;
+
 #include "ArgumentCodersCF.h"
 #endif
 
@@ -220,16 +225,10 @@ template<> struct ArgumentCoder<WebCore::DOMCacheEngine::Record> {
     static std::optional<WebCore::DOMCacheEngine::Record> decode(Decoder&);
 };
 
-template<> struct ArgumentCoder<WebCore::RectEdges<bool>> {
-    static void encode(Encoder&, const WebCore::RectEdges<bool>&);
-    static std::optional<WebCore::RectEdges<bool>> decode(Decoder&);
-};
+template<> struct ArgumentCoder<WebCore::RectEdges<bool>> : TriviallyCopyableArgumentCoder<WebCore::RectEdges<bool>> { };
 
 #if ENABLE(META_VIEWPORT)
-template<> struct ArgumentCoder<WebCore::ViewportArguments> {
-    static void encode(Encoder&, const WebCore::ViewportArguments&);
-    static std::optional<WebCore::ViewportArguments> decode(Decoder&);
-};
+template<> struct ArgumentCoder<WebCore::ViewportArguments> : TriviallyCopyableArgumentCoder<WebCore::ViewportArguments> { };
 #endif
 
 template<> struct ArgumentCoder<WebCore::Length> {
@@ -285,6 +284,11 @@ template<> struct ArgumentCoder<WebCore::ResourceError> {
 template<> struct ArgumentCoder<WebCore::KeypressCommand> {
     static void encode(Encoder&, const WebCore::KeypressCommand&);
     static std::optional<WebCore::KeypressCommand> decode(Decoder&);
+};
+
+template<> struct ArgumentCoder<AudioStreamBasicDescription> {
+    static void encode(Encoder&, const AudioStreamBasicDescription&);
+    static std::optional<AudioStreamBasicDescription> decode(Decoder&);
 };
 
 #endif // PLATFORM(COCOA)
@@ -538,6 +542,12 @@ template<> struct ArgumentCoder<RefPtr<WebCore::ReportBody>> {
     static void encode(Encoder&, const RefPtr<WebCore::ReportBody>&);
     static std::optional<RefPtr<WebCore::ReportBody>> decode(Decoder&);
 };
+
+#if ENABLE(MEDIA_STREAM)
+
+template<> struct ArgumentCoder<WebCore::CapabilityValueOrRange::ValueUnion> : TriviallyCopyableArgumentCoder<WebCore::CapabilityValueOrRange::ValueUnion> { };
+
+#endif
 
 } // namespace IPC
 

--- a/Source/WebKit/Shared/win/WebCoreArgumentCodersWin.cpp
+++ b/Source/WebKit/Shared/win/WebCoreArgumentCodersWin.cpp
@@ -36,16 +36,7 @@ namespace IPC {
 
 using namespace WebCore;
 
-template<> struct ArgumentCoder<LOGFONT> {
-    static void encode(Encoder& encoder, const LOGFONT& logFont)
-    {
-        encoder.encodeObject(logFont);
-    }
-    static std::optional<LOGFONT> decode(Decoder& decoder)
-    {
-        return decoder.decodeObject<LOGFONT>();
-    }
-};
+template<> struct ArgumentCoder<LOGFONT> : TriviallyCopyableArgumentCoder<LOGFONT> { };
 
 void ArgumentCoder<Font>::encodePlatformData(Encoder& encoder, const Font& font)
 {


### PR DESCRIPTION
#### c71a406e692818f81b1d341f9dcfe4acdea039d2
<pre>
[WK2] Add and use TriviallyCopyableArgumentCoder
<a href="https://bugs.webkit.org/show_bug.cgi?id=251511">https://bugs.webkit.org/show_bug.cgi?id=251511</a>

Reviewed by NOBODY (OOPS!).

Add TriviallyCopyableArgumentCoder, a simple struct template providing encode
and decode functions for any trivially copyable class that invoke encodeObject()
and decodeObject() functions on the encoder and decoder classes, respectively.

Different ArgumentCoder specializations (assuming they are specialized for some
trivially copyable type) can inherit from this struct to gain the necessary
encoding and decoding functionality.

ArgumentCoder specialization for any arithmetic type is changed to inherit from
TriviallyCopyableArgumentCoder. ArgumentCoder specializations inheriting from
this struct are added for different types currently using encodeObject() and
decodeObject() methods directly. AudioStreamBasicDescription specialization
avoids inheritance so that the Cocoa-specific CAAudioStreamDescription header
is limited to being included only in the WebCoreArgumentCoders implementation
file.

SimpleArgumentCoder usage and inheritance is removed in favor of using
TriviallyCopyableArgumentCoder.

* Source/WTF/wtf/ArgumentCoder.h:
(IPC::TriviallyCopyableArgumentCoder::encode):
(IPC::TriviallyCopyableArgumentCoder::decode):
(IPC::ArgumentCoder&lt;bool&gt;::encode):
(IPC::ArgumentCoder&lt;bool&gt;::decode):
* Source/WebCore/platform/audio/cocoa/CAAudioStreamDescription.h:
(WebCore::CAAudioStreamDescription::encode const):
(WebCore::CAAudioStreamDescription::decode):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceCapabilities.h:
(WebCore::CapabilityValueOrRange::encode const):
(WebCore::CapabilityValueOrRange::decode):
* Source/WebKit/Platform/IPC/ArgumentCoders.h:
(IPC::SimpleArgumentCoder::encode): Deleted.
(IPC::SimpleArgumentCoder::decode): Deleted.
* Source/WebKit/Shared/TextCheckerState.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;AudioStreamBasicDescription&gt;::encode):
(IPC::ArgumentCoder&lt;AudioStreamBasicDescription&gt;::decode):
(IPC::ArgumentCoder&lt;RectEdges&lt;bool&gt;&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;RectEdges&lt;bool&gt;&gt;::decode): Deleted.
(IPC::ArgumentCoder&lt;ViewportArguments&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;ViewportArguments&gt;::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.h:
* Source/WebKit/Shared/win/WebCoreArgumentCodersWin.cpp:
(IPC::ArgumentCoder&lt;LOGFONT&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;LOGFONT&gt;::decode): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c71a406e692818f81b1d341f9dcfe4acdea039d2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106010 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15065 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38842 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115193 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175301 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109914 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16489 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6248 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98219 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114929 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111763 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12554 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95524 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40094 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94419 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27167 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81763 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/95668 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8321 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28519 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/95002 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/6134 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8811 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5080 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30490 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14435 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48062 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/103744 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10355 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25719 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->