### PR TITLE
[JSC] Add support for new Set.prototype methods

### DIFF
--- a/JSTests/stress/set-prototype-intersection.js
+++ b/JSTests/stress/set-prototype-intersection.js
@@ -1,0 +1,78 @@
+//@ runDefault("--useSetMethods=1")
+
+function assert(a, e, m) {
+    if (a !== e)
+        throw new Error(m);
+}
+
+function assertArrayContent(a, e) {
+    assert(a.length, e.length, "Size of arrays doesn't match");
+    for (var i = 0; i < a.length; i++)
+        assert(a[i], e[i], "a[" + i + "] = " + a[i] + " but e[" + i + "] = " + e[i]);
+}
+
+let obj1 = { };
+let array1 = [ ];
+
+let set1 = new Set([1]);
+let set2 = new Set([2, 1]);
+let set3 = new Set([3, 1]);
+let set4 = new Set([1, 2, 3]);
+let set5 = new Set([obj1, array1, set1, 3, 1]);
+let map1 = new Map([["a", 1], ["b", 2], [obj1, array1]]);
+
+assertArrayContent(Array.from(set1.intersection(set2)), [1]);
+assertArrayContent(Array.from(set1.intersection(set3)), [1]);
+assertArrayContent(Array.from(set2.intersection(set3)), [1]);
+assertArrayContent(Array.from(set2.intersection(set4)), [2, 1]);
+assertArrayContent(Array.from(set3.intersection(set4)), [3, 1]);
+assertArrayContent(Array.from(set5.intersection(set3)), [3, 1]);
+assertArrayContent(Array.from(set5.intersection(map1)), [obj1]);
+
+try {
+    // Not an object
+    set1.intersection(1);
+} catch (e) {
+    if (e != "TypeError: Set.prototype.intersection expects the first parameter to be an object")
+        throw e;
+}
+
+try {
+    set1.intersection({ });
+} catch (e) {
+    if (e != "TypeError: Set.prototype.intersection expects other.size to be a non-NaN number")
+        throw e;
+}
+
+try {
+    set1.intersection({ size:NaN });
+} catch (e) {
+    if (e != "TypeError: Set.prototype.intersection expects other.size to be a non-NaN number")
+        throw e;
+}
+
+try {
+    set1.intersection({ size:1 });
+} catch (e) {
+    if (e != "TypeError: Set.prototype.intersection expects other.has to be callable")
+        throw e;
+}
+
+try {
+    set1.intersection({ size:1, has(v) { return v == 1; } });
+} catch (e) {
+    if (e != "TypeError: Set.prototype.intersection expects other.keys to be callable")
+        throw e;
+}
+
+let error = new Error();
+try {
+    set1.intersection({ size:1, has(v) { return v == 1; }, keys() { throw error } });
+} catch (e) {
+    if (e != error)
+        throw e;
+}
+
+
+assertArrayContent(Array.from(set1.intersection({ size:1, has(v) { return set1.has(v); }, keys() { return set1.keys() } })), [1]);
+assertArrayContent(Array.from(set4.intersection({ size:1, has(v) { return set1.has(v); }, keys() { return set1.keys() } })), [1]);

--- a/JSTests/stress/set-prototype-isDisjointfrom.js
+++ b/JSTests/stress/set-prototype-isDisjointfrom.js
@@ -1,0 +1,92 @@
+//@ runDefault("--useSetMethods=1")
+
+function assert(a, e, m) {
+    if (a !== e)
+        throw new Error(m);
+}
+
+function assertArrayContent(a, e) {
+    assert(a.length, e.length, "Size of arrays doesn't match");
+    for (var i = 0; i < a.length; i++)
+        assert(a[i], e[i], "a[" + i + "] = " + a[i] + " but e[" + i + "] = " + e[i]);
+}
+
+let obj1 = { };
+let array1 = [ ];
+
+let set1 = new Set([1]);
+let set2 = new Set([2, 1]);
+let set3 = new Set([3, 1]);
+let set4 = new Set([1, 2, 3]);
+let set5 = new Set([obj1, array1, set1, 3, 1]);
+let set6 = new Set([obj1, array1, set1]);
+let map1 = new Map([["a", 1], ["b", 2], [obj1, array1]]);
+let map2 = new Map([[3, 1], [1, 2]]);
+
+assert(set1.isDisjointFrom(set2), false);
+assert(set2.isDisjointFrom(set1), false);
+assert(set1.isDisjointFrom(set3), false);
+assert(set3.isDisjointFrom(set1), false);
+assert(set3.isDisjointFrom(set2), false);
+assert(set2.isDisjointFrom(set3), false);
+assert(set4.isDisjointFrom(set3), false);
+assert(set2.isDisjointFrom(set4), false);
+assert(set2.isDisjointFrom(set5), false);
+assert(set3.isDisjointFrom(set5), false);
+assert(set5.isDisjointFrom(set3), false);
+
+assert(set1.isDisjointFrom(set6), true);
+assert(set6.isDisjointFrom(set1), true);
+assert(set4.isDisjointFrom(set6), true);
+assert(set6.isDisjointFrom(set4), true);
+
+assert(set3.isDisjointFrom(map1), true);
+assert(set3.isDisjointFrom(map2), false);
+
+try {
+    // Not an object
+    set1.isDisjointFrom(1);
+} catch (e) {
+    if (e != "TypeError: Set.prototype.isDisjointFrom expects the first parameter to be an object")
+        throw e;
+}
+
+try {
+    set1.isDisjointFrom({ });
+} catch (e) {
+    if (e != "TypeError: Set.prototype.isDisjointFrom expects other.size to be a non-NaN number")
+        throw e;
+}
+
+try {
+    set1.isDisjointFrom({ size:NaN });
+} catch (e) {
+    if (e != "TypeError: Set.prototype.isDisjointFrom expects other.size to be a non-NaN number")
+        throw e;
+}
+
+try {
+    set1.isDisjointFrom({ size:1 });
+} catch (e) {
+    if (e != "TypeError: Set.prototype.isDisjointFrom expects other.has to be callable")
+        throw e;
+}
+
+try {
+    set1.isDisjointFrom({ size:1, has(v) { return v == 1; } });
+} catch (e) {
+    if (e != "TypeError: Set.prototype.isDisjointFrom expects other.keys to be callable")
+        throw e;
+}
+
+let error = new Error();
+try {
+    set1.isDisjointFrom({ size:1, has(v) { return v == 1; }, keys() { throw error } });
+} catch (e) {
+    if (e != error)
+        throw e;
+}
+
+assert(set1.isDisjointFrom({ size:1, has(v) { return set1.has(v); }, keys() { return set1.keys() } }), false);
+assert(set4.isDisjointFrom({ size:1, has(v) { return set1.has(v); }, keys() { return set1.keys() } }), false);
+assert(set6.isDisjointFrom({ size:1, has(v) { return set1.has(v); }, keys() { return set1.keys() } }), true);

--- a/JSTests/stress/set-prototype-isSubsetOf.js
+++ b/JSTests/stress/set-prototype-isSubsetOf.js
@@ -1,0 +1,84 @@
+//@ runDefault("--useSetMethods=1")
+
+function assert(a, e, m) {
+    if (a !== e)
+        throw new Error(m);
+}
+
+function assertArrayContent(a, e) {
+    assert(a.length, e.length, "Size of arrays doesn't match");
+    for (var i = 0; i < a.length; i++)
+        assert(a[i], e[i], "a[" + i + "] = " + a[i] + " but e[" + i + "] = " + e[i]);
+}
+
+let obj1 = { };
+let array1 = [ ];
+
+let set1 = new Set([1]);
+let set2 = new Set([2, 1]);
+let set3 = new Set([3, 1]);
+let set4 = new Set([1, 2, 3]);
+let set5 = new Set([obj1, array1, set1, 3, 1]);
+let map1 = new Map([["a", 1], ["b", 2], [obj1, array1]]);
+let map2 = new Map([[3, 1], [1, 2]]);
+
+assert(set1.isSubsetOf(set2), true);
+assert(set2.isSubsetOf(set1), false);
+assert(set1.isSubsetOf(set3), true);
+assert(set3.isSubsetOf(set1), false);
+assert(set3.isSubsetOf(set2), false);
+assert(set2.isSubsetOf(set3), false);
+assert(set4.isSubsetOf(set3), false);
+assert(set2.isSubsetOf(set4), true);
+assert(set2.isSubsetOf(set5), false);
+assert(set3.isSubsetOf(set5), true);
+
+assert(set3.isSubsetOf(map1), false);
+assert(set3.isSubsetOf(map2), true);
+
+try {
+    // Not an object
+    set1.isSubsetOf(1);
+} catch (e) {
+    if (e != "TypeError: Set.prototype.isSubsetOf expects the first parameter to be an object")
+        throw e;
+}
+
+try {
+    set1.isSubsetOf({ });
+} catch (e) {
+    if (e != "TypeError: Set.prototype.isSubsetOf expects other.size to be a non-NaN number")
+        throw e;
+}
+
+try {
+    set1.isSubsetOf({ size:NaN });
+} catch (e) {
+    if (e != "TypeError: Set.prototype.isSubsetOf expects other.size to be a non-NaN number")
+        throw e;
+}
+
+try {
+    set1.isSubsetOf({ size:1 });
+} catch (e) {
+    if (e != "TypeError: Set.prototype.isSubsetOf expects other.has to be callable")
+        throw e;
+}
+
+try {
+    set1.isSubsetOf({ size:1, has(v) { return v == 1; } });
+} catch (e) {
+    if (e != "TypeError: Set.prototype.isSubsetOf expects other.keys to be callable")
+        throw e;
+}
+
+let error = new Error();
+try {
+    set1.isSubsetOf({ size:1, has(v) { return v == 1; }, keys() { throw error } });
+} catch (e) {
+    if (e != error)
+        throw e;
+}
+
+assert(set1.isSubsetOf({ size:1, has(v) { return set1.has(v); }, keys() { return set1.keys() } }), true);
+assert(set4.isSubsetOf({ size:1, has(v) { return set1.has(v); }, keys() { return set1.keys() } }), false);

--- a/JSTests/stress/set-prototype-isSupersetOf.js
+++ b/JSTests/stress/set-prototype-isSupersetOf.js
@@ -1,0 +1,85 @@
+//@ runDefault("--useSetMethods=1")
+
+function assert(a, e, m) {
+    if (a !== e)
+        throw new Error(m);
+}
+
+function assertArrayContent(a, e) {
+    assert(a.length, e.length, "Size of arrays doesn't match");
+    for (var i = 0; i < a.length; i++)
+        assert(a[i], e[i], "a[" + i + "] = " + a[i] + " but e[" + i + "] = " + e[i]);
+}
+
+let obj1 = { };
+let array1 = [ ];
+
+let set1 = new Set([1]);
+let set2 = new Set([2, 1]);
+let set3 = new Set([3, 1]);
+let set4 = new Set([1, 2, 3]);
+let set5 = new Set([obj1, array1, set1, 3, 1]);
+let map1 = new Map([["a", 1], ["b", 2], [obj1, array1]]);
+let map2 = new Map([[3, 1], [1, 2]]);
+
+assert(set1.isSupersetOf(set2), false);
+assert(set2.isSupersetOf(set1), true);
+assert(set1.isSupersetOf(set3), false);
+assert(set3.isSupersetOf(set1), true);
+assert(set3.isSupersetOf(set2), false);
+assert(set2.isSupersetOf(set3), false);
+assert(set4.isSupersetOf(set3), true);
+assert(set2.isSupersetOf(set4), false);
+assert(set2.isSupersetOf(set5), false);
+assert(set3.isSupersetOf(set5), false);
+assert(set5.isSupersetOf(set3), true);
+
+assert(set3.isSupersetOf(map1), false);
+assert(set3.isSupersetOf(map2), true);
+
+try {
+    // Not an object
+    set1.isSupersetOf(1);
+} catch (e) {
+    if (e != "TypeError: Set.prototype.isSupersetOf expects the first parameter to be an object")
+        throw e;
+}
+
+try {
+    set1.isSupersetOf({ });
+} catch (e) {
+    if (e != "TypeError: Set.prototype.isSupersetOf expects other.size to be a non-NaN number")
+        throw e;
+}
+
+try {
+    set1.isSupersetOf({ size:NaN });
+} catch (e) {
+    if (e != "TypeError: Set.prototype.isSupersetOf expects other.size to be a non-NaN number")
+        throw e;
+}
+
+try {
+    set1.isSupersetOf({ size:1 });
+} catch (e) {
+    if (e != "TypeError: Set.prototype.isSupersetOf expects other.has to be callable")
+        throw e;
+}
+
+try {
+    set1.isSupersetOf({ size:1, has(v) { return v == 1; } });
+} catch (e) {
+    if (e != "TypeError: Set.prototype.isSupersetOf expects other.keys to be callable")
+        throw e;
+}
+
+let error = new Error();
+try {
+    set1.isSupersetOf({ size:1, has(v) { return v == 1; }, keys() { throw error } });
+} catch (e) {
+    if (e != error)
+        throw e;
+}
+
+assert(set1.isSupersetOf({ size:1, has(v) { return set1.has(v); }, keys() { return set1.keys() } }), true);
+assert(set4.isSupersetOf({ size:1, has(v) { return set1.has(v); }, keys() { return set1.keys() } }), true);

--- a/JSTests/stress/set-prototype-symmetricDifference.js
+++ b/JSTests/stress/set-prototype-symmetricDifference.js
@@ -1,0 +1,78 @@
+//@ runDefault("--useSetMethods=1")
+
+function assert(a, e, m) {
+    if (a !== e)
+        throw new Error(m);
+}
+
+function assertArrayContent(a, e) {
+    assert(a.length, e.length, "Size of arrays doesn't match");
+    for (var i = 0; i < a.length; i++)
+        assert(a[i], e[i], "a[" + i + "] = " + a[i] + " but e[" + i + "] = " + e[i]);
+}
+
+let obj1 = { };
+let array1 = [ ];
+
+let set1 = new Set([1]);
+let set2 = new Set([2, 1]);
+let set3 = new Set([3, 1]);
+let set4 = new Set([1, 2, 3]);
+let set5 = new Set([obj1, array1, set1, 3, 1]);
+let map1 = new Map([["a", 1], ["b", 2], [obj1, array1]]);
+
+assertArrayContent(Array.from(set1.symmetricDifference(set2)), [2]);
+assertArrayContent(Array.from(set1.symmetricDifference(set3)), [3]);
+assertArrayContent(Array.from(set2.symmetricDifference(set3)), [2, 3]);
+assertArrayContent(Array.from(set2.symmetricDifference(set4)), [3]);
+assertArrayContent(Array.from(set3.symmetricDifference(set4)), [2]);
+assertArrayContent(Array.from(set5.symmetricDifference(set3)), [obj1, array1, set1]);
+assertArrayContent(Array.from(set5.symmetricDifference(map1)), [array1, set1, 3, 1, "a", "b"]);
+
+try {
+    // Not an object
+    set1.symmetricDifference(1);
+} catch (e) {
+    if (e != "TypeError: Set.prototype.symmetricDifference expects the first parameter to be an object")
+        throw e;
+}
+
+try {
+    set1.symmetricDifference({ });
+} catch (e) {
+    if (e != "TypeError: Set.prototype.symmetricDifference expects other.size to be a non-NaN number")
+        throw e;
+}
+
+try {
+    set1.symmetricDifference({ size:NaN });
+} catch (e) {
+    if (e != "TypeError: Set.prototype.symmetricDifference expects other.size to be a non-NaN number")
+        throw e;
+}
+
+try {
+    set1.symmetricDifference({ size:1 });
+} catch (e) {
+    if (e != "TypeError: Set.prototype.symmetricDifference expects other.has to be callable")
+        throw e;
+}
+
+try {
+    set1.symmetricDifference({ size:1, has(v) { return v == 1; } });
+} catch (e) {
+    if (e != "TypeError: Set.prototype.symmetricDifference expects other.keys to be callable")
+        throw e;
+}
+
+let error = new Error();
+try {
+    set1.symmetricDifference({ size:1, has(v) { return v == 1; }, keys() { throw error } });
+} catch (e) {
+    if (e != error)
+        throw e;
+}
+
+
+assertArrayContent(Array.from(set1.symmetricDifference({ size:1, has(v) { return set1.has(v); }, keys() { return set1.keys() } })), []);
+assertArrayContent(Array.from(set4.symmetricDifference({ size:1, has(v) { return set1.has(v); }, keys() { return set1.keys() } })), [2, 3]);

--- a/JSTests/stress/set-prototype-union.js
+++ b/JSTests/stress/set-prototype-union.js
@@ -1,0 +1,75 @@
+//@ runDefault("--useSetMethods=1")
+
+function assert(a, e, m) {
+    if (a !== e)
+        throw new Error(m);
+}
+
+function assertArrayContent(a, e) {
+    assert(a.length, e.length, "Size of arrays doesn't match");
+    for (var i = 0; i < a.length; i++)
+        assert(a[i], e[i], "a[" + i + "] = " + a[i] + " but e[" + i + "] = " + e[i]);
+}
+
+let obj1 = { };
+let array1 = [ ];
+
+let set1 = new Set([1]);
+let set2 = new Set([2, 1]);
+let set3 = new Set([3, 1]);
+let set4 = new Set([obj1, array1, set1]);
+let map1 = new Map([["a", 1], ["b", 2]]);
+
+assertArrayContent(Array.from(set1.union(set2)), [1, 2]);
+assertArrayContent(Array.from(set1.union(set3)), [1, 3]);
+assertArrayContent(Array.from(set2.union(set3)), [2, 1, 3]);
+assertArrayContent(Array.from(set4.union(set3)), [obj1, array1, set1, 3, 1]);
+assertArrayContent(Array.from(set4.union(map1)), [obj1, array1, set1, "a", "b"]);
+
+try {
+    // Not an object
+    set1.union(1);
+} catch (e) {
+    if (e != "TypeError: Set.prototype.union expects the first parameter to be an object")
+        throw e;
+}
+
+try {
+    set1.union({ });
+} catch (e) {
+    if (e != "TypeError: Set.prototype.union expects other.size to be a non-NaN number")
+        throw e;
+}
+
+try {
+    set1.union({ size:NaN });
+} catch (e) {
+    if (e != "TypeError: Set.prototype.union expects other.size to be a non-NaN number")
+        throw e;
+}
+
+try {
+    set1.union({ size:1 });
+} catch (e) {
+    if (e != "TypeError: Set.prototype.union expects other.has to be callable")
+        throw e;
+}
+
+try {
+    set1.union({ size:1, has(v) { return v == 1; } });
+} catch (e) {
+    if (e != "TypeError: Set.prototype.union expects other.keys to be callable")
+        throw e;
+}
+
+let error = new Error();
+try {
+    set1.union({ size:1, has(v) { return v == 1; }, keys() { throw error } });
+} catch (e) {
+    if (e != error)
+        throw e;
+}
+
+
+assertArrayContent(Array.from(set1.union({ size:1, has(v) { return set1.has(v); }, keys() { return set1.keys() } })), [1]);
+assertArrayContent(Array.from(set4.union({ size:1, has(v) { return set1.has(v); }, keys() { return set1.keys() } })), [obj1, array1, set1, 1]);

--- a/Source/JavaScriptCore/builtins/BuiltinNames.h
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.h
@@ -155,6 +155,7 @@ namespace JSC {
     macro(setBucketHead) \
     macro(setBucketNext) \
     macro(setBucketKey) \
+    macro(setClone) \
     macro(setPrototypeDirect) \
     macro(setPrototypeDirectOrThrow) \
     macro(regExpBuiltinExec) \

--- a/Source/JavaScriptCore/builtins/SetPrototype.js
+++ b/Source/JavaScriptCore/builtins/SetPrototype.js
@@ -44,3 +44,256 @@ function forEach(callback /*, thisArg */)
         callback.@call(thisArg, key, key, this);
     } while (true);
 }
+
+function union(other)
+{
+    "use strict";
+
+    if (!@isSet(this))
+        @throwTypeError("Set operation called on non-Set object");
+
+    // Get Set Record
+    if (!@isObject(other))
+        @throwTypeError("Set.prototype.union expects the first parameter to be an object");
+    var size = @toNumber(other.size);
+    // size is NaN
+    if (size !== size)
+        @throwTypeError("Set.prototype.union expects other.size to be a non-NaN number");
+
+    var has = other.has;
+    if (!@isCallable(has))
+        @throwTypeError("Set.prototype.union expects other.has to be callable");
+
+    var keys = other.keys;
+    if (!@isCallable(keys))
+        @throwTypeError("Set.prototype.union expects other.keys to be callable");
+
+    var iterator = keys.@call(other, keys);
+    var wrapper = {
+        @@iterator: function () { return iterator; }
+    };
+
+    var result = @setClone(this);
+    for (var key of wrapper)
+        result.@add(key);
+
+    return result;
+}
+
+function intersection(other)
+{
+    "use strict";
+
+    if (!@isSet(this))
+        @throwTypeError("Set operation called on non-Set object");
+
+    // Get Set Record
+    if (!@isObject(other))
+        @throwTypeError("Set.prototype.intersection expects the first parameter to be an object");
+    var size = @toNumber(other.size);
+    // size is NaN
+    if (size !== size)
+        @throwTypeError("Set.prototype.intersection expects other.size to be a non-NaN number");
+
+    var has = other.has;
+    if (!@isCallable(has))
+        @throwTypeError("Set.prototype.intersection expects other.has to be callable");
+
+    var keys = other.keys;
+    if (!@isCallable(keys))
+        @throwTypeError("Set.prototype.intersection expects other.keys to be callable");
+
+    var result = new @Set();
+    if (this.@size <= size) {
+        var bucket = @setBucketHead(this);
+
+        do {
+            bucket = @setBucketNext(bucket);
+            if (bucket === @sentinelSetBucket)
+                break;
+            var key = @setBucketKey(bucket);
+            if (has.@call(other, key))
+                result.@add(key);
+        } while (true);
+    } else {
+        // FIXME: This path needs to have the iteration order of the receiver but we don't have a good way to compare in constant time the relative ordering of two keys.
+        // https://bugs.webkit.org/show_bug.cgi?id=251869
+        var iterator = keys.@call(other, keys);
+        var wrapper = {
+            @@iterator: function () { return iterator; }
+        };
+
+        for (var key of wrapper) {
+            if (this.@has(key))
+                result.@add(key);
+        }
+    }
+
+    return result;
+}
+
+function symmetricDifference(other)
+{
+    "use strict";
+
+    if (!@isSet(this))
+        @throwTypeError("Set operation called on non-Set object");
+
+    // Get Set Record
+    if (!@isObject(other))
+        @throwTypeError("Set.prototype.symmetricDifference expects the first parameter to be an object");
+    var size = @toNumber(other.size);
+    // size is NaN
+    if (size !== size)
+        @throwTypeError("Set.prototype.symmetricDifference expects other.size to be a non-NaN number");
+
+    var has = other.has;
+    if (!@isCallable(has))
+        @throwTypeError("Set.prototype.symmetricDifference expects other.has to be callable");
+
+    var keys = other.keys;
+    if (!@isCallable(keys))
+        @throwTypeError("Set.prototype.symmetricDifference expects other.keys to be callable");
+
+    var iterator = keys.@call(other, keys);
+    var wrapper = {
+        @@iterator: function () { return iterator; }
+    };
+
+    var result = @setClone(this);
+    for (var key of wrapper) {
+        if (result.@has(key))
+            result.@delete(key);
+        else
+            result.@add(key);
+    }
+
+    return result;
+}
+
+function isSubsetOf(other)
+{
+    "use strict";
+
+    if (!@isSet(this))
+        @throwTypeError("Set operation called on non-Set object");
+
+    // Get Set Record
+    if (!@isObject(other))
+        @throwTypeError("Set.prototype.isSubsetOf expects the first parameter to be an object");
+    var size = @toNumber(other.size);
+    // size is NaN
+    if (size !== size)
+        @throwTypeError("Set.prototype.isSubsetOf expects other.size to be a non-NaN number");
+
+    var has = other.has;
+    if (!@isCallable(has))
+        @throwTypeError("Set.prototype.isSubsetOf expects other.has to be callable");
+
+    var keys = other.keys;
+    if (!@isCallable(keys))
+        @throwTypeError("Set.prototype.isSubsetOf expects other.keys to be callable");
+
+    if (this.@size > size)
+        return false;
+
+    var bucket = @setBucketHead(this);
+
+    do {
+        bucket = @setBucketNext(bucket);
+        if (bucket === @sentinelSetBucket)
+            break;
+        var key = @setBucketKey(bucket);
+        if (!has.@call(other, key))
+            return false;
+    } while (true);
+
+    return true;
+}
+
+function isSupersetOf(other)
+{
+    "use strict";
+
+    if (!@isSet(this))
+        @throwTypeError("Set operation called on non-Set object");
+
+    // Get Set Record
+    if (!@isObject(other))
+        @throwTypeError("Set.prototype.isSupersetOf expects the first parameter to be an object");
+    var size = @toNumber(other.size);
+    // size is NaN
+    if (size !== size)
+        @throwTypeError("Set.prototype.isSupersetOf expects other.size to be a non-NaN number");
+
+    var has = other.has;
+    if (!@isCallable(has))
+        @throwTypeError("Set.prototype.isSupersetOf expects other.has to be callable");
+
+    var keys = other.keys;
+    if (!@isCallable(keys))
+        @throwTypeError("Set.prototype.isSupersetOf expects other.keys to be callable");
+
+    if (this.@size < size)
+        return false;
+
+    var iterator = keys.@call(other, keys);
+    var wrapper = {
+        @@iterator: function () { return iterator; }
+    };
+
+    for (var key of wrapper) {
+        if (!this.@has(key))
+            return false;
+    }
+    return true;
+}
+
+function isDisjointFrom(other)
+{
+    "use strict";
+
+    if (!@isSet(this))
+        @throwTypeError("Set operation called on non-Set object");
+
+    // Get Set Record
+    if (!@isObject(other))
+        @throwTypeError("Set.prototype.isDisjointFrom expects the first parameter to be an object");
+    var size = @toNumber(other.size);
+    // size is NaN
+    if (size !== size)
+        @throwTypeError("Set.prototype.isDisjointFrom expects other.size to be a non-NaN number");
+
+    var has = other.has;
+    if (!@isCallable(has))
+        @throwTypeError("Set.prototype.isDisjointFrom expects other.has to be callable");
+
+    var keys = other.keys;
+    if (!@isCallable(keys))
+        @throwTypeError("Set.prototype.isDisjointFrom expects other.keys to be callable");
+
+    if (this.@size <= size) {
+        var bucket = @setBucketHead(this);
+
+        do {
+            bucket = @setBucketNext(bucket);
+            if (bucket === @sentinelSetBucket)
+                break;
+            var key = @setBucketKey(bucket);
+            if (has.@call(other, key))
+                return false;
+        } while (true);
+    } else {
+        var iterator = keys.@call(other, keys);
+        var wrapper = {
+            @@iterator: function () { return iterator; }
+        };
+
+        for (var key of wrapper) {
+            if (this.@has(key))
+                return false;
+        }
+    }
+
+    return true;
+}

--- a/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
+++ b/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
@@ -43,6 +43,7 @@ class JSGlobalObject;
     v(setBucketHead, nullptr) \
     v(setBucketNext, nullptr) \
     v(setBucketKey, nullptr) \
+    v(setClone, nullptr) \
     v(setPrototypeDirect, nullptr) \
     v(setPrototypeDirectOrThrow, nullptr) \
     v(copyDataProperties, nullptr) \

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -1500,6 +1500,9 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::setBucketKey)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "setBucketKey"_s, setPrivateFuncSetBucketKey, ImplementationVisibility::Private, JSSetBucketKeyIntrinsic));
         });
+    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::setClone)].initLater([] (const Initializer<JSCell>& init) {
+            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "setClone"_s, setPrivateFuncClone, ImplementationVisibility::Private));
+        });
 
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::importModule)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "importModule"_s, globalFuncImportModule, ImplementationVisibility::Private));

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -549,6 +549,9 @@ bool canUseWebAssemblyFastMemory();
     v(Bool, useArrayFromAsync, true, Normal, "Expose the Array.fromAsync.") \
     v(Bool, useArrayGroupMethod, true, Normal, "Expose the group() and groupToMap() methods on Array.") \
     v(Bool, useAtomicsWaitAsync, true, Normal, "Expose the waitAsync() methods on Atomics.") \
+    /* FIXME: Set.prototype.intersection's iterate the other object path needs to have the iteration order of the receiver but we don't have a good way to compare in constant time the relative ordering of two keys. */ \
+    /* https://bugs.webkit.org/show_bug.cgi?id=251869 */ \
+    v(Bool, useSetMethods, false, Normal, "Expose the various Set.prototype methods for handling combinations of sets") \
     v(Bool, useImportAssertion, false, Normal, "Enable import assertion.") \
     v(Bool, useIntlDurationFormat, true, Normal, "Expose the Intl DurationFormat.") \
     v(Bool, useResizableArrayBuffer, true, Normal, "Expose ResizableArrayBuffer feature.") \

--- a/Source/JavaScriptCore/runtime/SetConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/SetConstructor.cpp
@@ -136,4 +136,14 @@ JSC_DEFINE_HOST_FUNCTION(setPrivateFuncSetBucketKey, (JSGlobalObject*, CallFrame
     return JSValue::encode(bucket->key());
 }
 
+JSC_DEFINE_HOST_FUNCTION(setPrivateFuncClone, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    ASSERT(jsDynamicCast<JSSet*>(callFrame->argument(0)));
+    JSSet* set = jsCast<JSSet*>(callFrame->uncheckedArgument(0));
+    RELEASE_AND_RETURN(scope, JSValue::encode(set->clone(globalObject, vm, globalObject->setStructure())));
+}
+
 }

--- a/Source/JavaScriptCore/runtime/SetConstructor.h
+++ b/Source/JavaScriptCore/runtime/SetConstructor.h
@@ -59,5 +59,6 @@ STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(SetConstructor, InternalFunction);
 JSC_DECLARE_HOST_FUNCTION(setPrivateFuncSetBucketHead);
 JSC_DECLARE_HOST_FUNCTION(setPrivateFuncSetBucketNext);
 JSC_DECLARE_HOST_FUNCTION(setPrivateFuncSetBucketKey);
+JSC_DECLARE_HOST_FUNCTION(setPrivateFuncClone);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/SetPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/SetPrototype.cpp
@@ -90,6 +90,15 @@ void SetPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
     putDirectWithoutTransition(vm, vm.propertyNames->iteratorSymbol, values, static_cast<unsigned>(PropertyAttribute::DontEnum));
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 
+    if (Options::useSetMethods()) {
+        JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().unionPublicName(), setPrototypeUnionCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+        JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().intersectionPublicName(), setPrototypeIntersectionCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+        JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().symmetricDifferencePublicName(), setPrototypeSymmetricDifferenceCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+        JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().isSubsetOfPublicName(), setPrototypeIsSubsetOfCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+        JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().isSupersetOfPublicName(), setPrototypeIsSupersetOfCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+        JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().isDisjointFromPublicName(), setPrototypeIsDisjointFromCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    }
+
     globalObject->installSetPrototypeWatchpoint(this);
 }
 


### PR DESCRIPTION
#### ff30d6f8aba3d3638bd80f5ccea91d9e03535598
<pre>
[JSC] Add support for new Set.prototype methods
<a href="https://bugs.webkit.org/show_bug.cgi?id=251510">https://bugs.webkit.org/show_bug.cgi?id=251510</a>

Reviewed by Yusuke Suzuki.

This patch adds support for the <a href="https://github.com/tc39/proposal-set-methods">https://github.com/tc39/proposal-set-methods</a> proposal, which is currently at stage 3.
In order to unobservably make a copy of a set this patch adds a new setClone intrisic, otherwise everything else is just
normal builtins code. There is one outstanding issue that intersection is supposed to return a Set with the same iteration
order as the this value. Given our implementation of iteration order being a linked list that&apos;s not efficient. Pending spec discussion
this implementation just skips that step. See: <a href="https://bugs.webkit.org/show_bug.cgi?id=251869">https://bugs.webkit.org/show_bug.cgi?id=251869</a>

* JSTests/stress/set-prototype-intersection.js: Added.
(assert):
(assertArrayContent):
(catch):
(try.set1.intersection.has):
(try.set1.intersection.keys):
(assertArrayContent.Array.from.set1.intersection.has):
(assertArrayContent.Array.from.set1.intersection.keys):
(assertArrayContent.Array.from.set4.intersection.has):
(assertArrayContent.Array.from.set4.intersection.keys):
* JSTests/stress/set-prototype-isDisjointfrom.js: Added.
(assert):
(assertArrayContent):
(catch):
(try.set1.isDisjointFrom.has):
(try.set1.isDisjointFrom.keys):
(assert.set1.isDisjointFrom.has):
(assert.set1.isDisjointFrom.keys):
(assert.set4.isDisjointFrom.has):
(assert.set4.isDisjointFrom.keys):
(assert.set6.isDisjointFrom.has):
(assert.set6.isDisjointFrom.keys):
* JSTests/stress/set-prototype-isSubsetOf.js: Added.
(assert):
(assertArrayContent):
(catch):
(try.set1.isSubsetOf.has):
(try.set1.isSubsetOf.keys):
(assert.set1.isSubsetOf.has):
(assert.set1.isSubsetOf.keys):
(assert.set4.isSubsetOf.has):
(assert.set4.isSubsetOf.keys):
* JSTests/stress/set-prototype-isSupersetOf.js: Added.
(assert):
(assertArrayContent):
(catch):
(try.set1.isSupersetOf.has):
(try.set1.isSupersetOf.keys):
(assert.set1.isSupersetOf.has):
(assert.set1.isSupersetOf.keys):
(assert.set4.isSupersetOf.has):
(assert.set4.isSupersetOf.keys):
* JSTests/stress/set-prototype-symmetricDifference.js: Added.
(assert):
(assertArrayContent):
(catch):
(try.set1.symmetricDifference.has):
(try.set1.symmetricDifference.keys):
(assertArrayContent.Array.from.set1.symmetricDifference.has):
(assertArrayContent.Array.from.set1.symmetricDifference.keys):
(assertArrayContent.Array.from.set4.symmetricDifference.has):
(assertArrayContent.Array.from.set4.symmetricDifference.keys):
* JSTests/stress/set-prototype-union.js: Added.
(assert):
(assertArrayContent):
(catch):
(try.set1.union.has):
(try.set1.union.keys):
(assertArrayContent.Array.from.set1.union.has):
(assertArrayContent.Array.from.set1.union.keys):
(assertArrayContent.Array.from.set4.union.has):
(assertArrayContent.Array.from.set4.union.keys):
* Source/JavaScriptCore/builtins/BuiltinNames.h:
* Source/JavaScriptCore/builtins/SetPrototype.js:
(union.wrapper.iterator):
(union):
(intersection.else.wrapper.iterator):
(intersection):
(symmetricDifference.wrapper.iterator):
(symmetricDifference):
(isSubsetOf):
(isSupersetOf.wrapper.iterator):
(isSupersetOf):
(isDisjointFrom.else.wrapper.iterator):
(isDisjointFrom):
* Source/JavaScriptCore/bytecode/LinkTimeConstant.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/runtime/SetConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/SetConstructor.h:
* Source/JavaScriptCore/runtime/SetPrototype.cpp:
(JSC::SetPrototype::finishCreation):

Canonical link: <a href="https://commits.webkit.org/260033@main">https://commits.webkit.org/260033@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03770e32c2f5fbbce1f9980be6fa005265b0d1d3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106779 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15793 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39565 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115968 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115545 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17297 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/7049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98974 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112548 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96098 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/40712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95000 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/27750 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/96317 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8986 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/29105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/95787 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/6920 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9551 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/7049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/30698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15155 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48648 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/104538 "Built successfully") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/6929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11074 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25890 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3740 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->