### PR TITLE
[web-animations] ASSERT(node.isConnected()) reached in Style::Scope::forNode() in css/css-animations/CSSAnimation-getKeyframes-crash.html

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/CSSAnimation-getKeyframes-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/CSSAnimation-getKeyframes-crash.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="help" href="https://crbug.com/1326225">
+  <title>Crash test calling getKeyframes on an orphaned element</title>
+</head>
+<style type="text/css">
+  @keyframes anim {
+    from { left: 0; }
+  }
+</style>
+<body>
+  <div id="container">
+    <div id="target">
+    </div>
+  </div>
+</body>
+<script type="text/javascript">
+  target.style.animation = "anim 0.01s";
+  var animation = target.getAnimations()[0];
+  container.innerHTML = 1;
+  animation.effect.getKeyframes()[0].hasOwnProperty();
+</script>
+</html>

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -666,6 +666,9 @@ auto KeyframeEffect::getKeyframes(Document& document) -> Vector<ComputedKeyframe
         if (!is<CSSAnimation>(animation()))
             return { };
 
+        if (!m_target || !m_target->isConnected())
+            return { };
+
         auto& backingAnimation = downcast<CSSAnimation>(*animation()).backingAnimation();
         auto* styleScope = Style::Scope::forOrdinal(*m_target, backingAnimation.nameStyleScopeOrdinal());
         if (!styleScope)


### PR DESCRIPTION
#### 0f60938da30b2360f6b007b8d5a7adc3a720616f
<pre>
[web-animations] ASSERT(node.isConnected()) reached in Style::Scope::forNode() in css/css-animations/CSSAnimation-getKeyframes-crash.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=251516">https://bugs.webkit.org/show_bug.cgi?id=251516</a>

Reviewed by Antti Koivisto.

We should check that the effect&apos;s target is non-null and connected before calling Style::Scope::forOrdinal()
with that target as the first parameter. This caused a crash in a newly-imported WPT test.

* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/CSSAnimation-getKeyframes-crash.html: Added.
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::getKeyframes):

Canonical link: <a href="https://commits.webkit.org/259735@main">https://commits.webkit.org/259735@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d3b4a937a7c8ab86674ce1ba2df6cac67fa211b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105672 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14763 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38547 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114900 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175040 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109574 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16169 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5962 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97939 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111426 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12298 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95282 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39777 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94162 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26922 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81494 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8031 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28275 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8527 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4858 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14148 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47822 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10080 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3603 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->