### PR TITLE
[@property] Ensure style is up to date in ComputedStylePropertyMapReadOnly::entries

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/typedom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/typedom-expected.txt
@@ -312,16 +312,16 @@ PASS Specified <length>+ is reified CSSUnparsedValue by iterator [styleMap]
 PASS Specified <length># is reified CSSUnparsedValue by iterator [attributeStyleMap]
 PASS Specified <length># is reified CSSUnparsedValue by iterator [styleMap]
 FAIL Registered property with initial value show up on iteration of computedStyleMap assert_true: expected true got false
-FAIL Computed * is reified as CSSUnparsedValue by iterator undefined is not an object (evaluating 'result.length')
-FAIL Computed <angle> is reified as CSSUnitValue by iterator undefined is not an object (evaluating 'result.length')
-FAIL Computed <custom-ident> is reified as CSSKeywordValue by iterator undefined is not an object (evaluating 'result.length')
-FAIL Computed <image> is reified as CSSImageValue by iterator undefined is not an object (evaluating 'result.length')
-FAIL Computed <integer> is reified as CSSUnitValue by iterator undefined is not an object (evaluating 'result.length')
-FAIL Computed <length> is reified as CSSUnitValue by iterator undefined is not an object (evaluating 'result.length')
-FAIL Computed <number> is reified as CSSUnitValue by iterator undefined is not an object (evaluating 'result.length')
-FAIL Computed <percentage> is reified as CSSUnitValue by iterator undefined is not an object (evaluating 'result.length')
-FAIL Computed <resolution> is reified as CSSUnitValue by iterator undefined is not an object (evaluating 'result.length')
-FAIL Computed <time> is reified as CSSUnitValue by iterator undefined is not an object (evaluating 'result.length')
-FAIL Computed none | thing | THING is reified as CSSKeywordValue by iterator undefined is not an object (evaluating 'result.length')
-FAIL Computed <angle> | <length> is reified as CSSUnitValue by iterator undefined is not an object (evaluating 'result.length')
+PASS Computed * is reified as CSSUnparsedValue by iterator
+PASS Computed <angle> is reified as CSSUnitValue by iterator
+PASS Computed <custom-ident> is reified as CSSKeywordValue by iterator
+FAIL Computed <image> is reified as CSSImageValue by iterator assert_true: expected true got false
+PASS Computed <integer> is reified as CSSUnitValue by iterator
+PASS Computed <length> is reified as CSSUnitValue by iterator
+PASS Computed <number> is reified as CSSUnitValue by iterator
+PASS Computed <percentage> is reified as CSSUnitValue by iterator
+PASS Computed <resolution> is reified as CSSUnitValue by iterator
+PASS Computed <time> is reified as CSSUnitValue by iterator
+PASS Computed none | thing | THING is reified as CSSKeywordValue by iterator
+PASS Computed <angle> | <length> is reified as CSSUnitValue by iterator
 

--- a/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp
+++ b/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp
@@ -66,6 +66,9 @@ RefPtr<CSSValue> ComputedStylePropertyMapReadOnly::customPropertyValue(const Ato
 unsigned ComputedStylePropertyMapReadOnly::size() const
 {
     // https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymapreadonly-size
+
+    ComputedStyleExtractor::updateStyleIfNeededForProperty(m_element.get(), CSSPropertyCustom);
+
     auto* style = m_element->computedStyle();
     if (!style)
         return 0;
@@ -77,6 +80,10 @@ Vector<StylePropertyMapReadOnly::StylePropertyMapEntry> ComputedStylePropertyMap
 {
     // https://drafts.css-houdini.org/css-typed-om-1/#the-stylepropertymap
     Vector<StylePropertyMapReadOnly::StylePropertyMapEntry> values;
+
+    // Ensure custom property counts are correct.
+    ComputedStyleExtractor::updateStyleIfNeededForProperty(m_element.get(), CSSPropertyCustom);
+
     auto* style = m_element->computedStyle();
     if (!style)
         return values;
@@ -85,8 +92,10 @@ Vector<StylePropertyMapReadOnly::StylePropertyMapEntry> ComputedStylePropertyMap
     const auto& nonInheritedCustomProperties = style->nonInheritedCustomProperties();
     const auto& exposedComputedCSSPropertyIDs = m_element->document().exposedComputedCSSPropertyIDs();
     values.reserveInitialCapacity(exposedComputedCSSPropertyIDs.size() + inheritedCustomProperties.size() + nonInheritedCustomProperties.size());
+
+    ComputedStyleExtractor extractor { m_element.ptr() };
     for (auto propertyID : exposedComputedCSSPropertyIDs) {
-        auto value = ComputedStyleExtractor(m_element.ptr()).propertyValue(propertyID, ComputedStyleExtractor::UpdateLayout::No, ComputedStyleExtractor::PropertyValueType::Computed);
+        auto value = extractor.propertyValue(propertyID, ComputedStyleExtractor::UpdateLayout::No, ComputedStyleExtractor::PropertyValueType::Computed);
         values.uncheckedAppend(makeKeyValuePair(nameString(propertyID), StylePropertyMapReadOnly::reifyValueToVector(WTFMove(value), propertyID, m_element->document())));
     }
 


### PR DESCRIPTION
#### 414ff00191187e3403f8a98e39a30a73f9f0ccd4
<pre>
[@property] Ensure style is up to date in ComputedStylePropertyMapReadOnly::entries
<a href="https://bugs.webkit.org/show_bug.cgi?id=251517">https://bugs.webkit.org/show_bug.cgi?id=251517</a>
rdar://104916732

Reviewed by Alan Baradlay.

* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/typedom-expected.txt:
* Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp:
(WebCore::ComputedStylePropertyMapReadOnly::size const):
(WebCore::ComputedStylePropertyMapReadOnly::entries const):

Ensure style is up to date for custom properties so that we get the correct count.

Canonical link: <a href="https://commits.webkit.org/259703@main">https://commits.webkit.org/259703@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/565f3522def5cc239e09ef6a925a196aa9264cad

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105673 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14764 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38548 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114901 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/175041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109575 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16170 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5963 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97940 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111427 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95285 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/94165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26925 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8032 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28278 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8528 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14149 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47825 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6702 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10081 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->