### PR TITLE
[WK2] Clean up IPC::Decoder class

### DIFF
--- a/Source/WebKit/Platform/IPC/Decoder.cpp
+++ b/Source/WebKit/Platform/IPC/Decoder.cpp
@@ -153,17 +153,6 @@ std::unique_ptr<Decoder> Decoder::unwrapForTesting(Decoder& decoder)
     return wrappedDecoder;
 }
 
-const uint8_t* Decoder::decodeFixedLengthReference(size_t size, size_t alignment)
-{
-    if (!alignBufferPosition(alignment, size))
-        return nullptr;
-
-    const uint8_t* data = m_bufferPos;
-    m_bufferPos += size;
-
-    return data;
-}
-
 std::optional<Attachment> Decoder::takeLastAttachment()
 {
     if (m_attachments.isEmpty()) {


### PR DESCRIPTION
#### d03e9c87ee9f7695fefd1038996e4d49e467b06f
<pre>
[WK2] Clean up IPC::Decoder class
<a href="https://bugs.webkit.org/show_bug.cgi?id=251518">https://bugs.webkit.org/show_bug.cgi?id=251518</a>

Reviewed by Kimmo Kinnunen.

Remove unused IPC::Decoder methods along with unused helper functions. These
were made redundant during recent work around adoption of Span-based decoding.

* Source/WebKit/Platform/IPC/Decoder.cpp:
(IPC::Decoder::decodeFixedLengthReference): Deleted.
* Source/WebKit/Platform/IPC/Decoder.h:
(IPC::Decoder::bufferIsLargeEnoughToContain const): Deleted.
(IPC::roundUpToAlignment): Deleted.
(IPC::Decoder::alignBufferPosition): Deleted.
(IPC::Decoder::decodeFixedLengthData): Deleted.

Canonical link: <a href="https://commits.webkit.org/259749@main">https://commits.webkit.org/259749@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/983bb50c5b603ee29464ecd51c7c07de1593a707

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105674 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14765 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38549 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114902 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16171 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5964 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97941 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114710 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111428 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12302 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95280 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39779 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94166 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26919 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81498 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8033 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28272 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8529 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4860 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14150 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47820 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6742 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10082 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->