### PR TITLE
[WPE] Minor fixes and spelling in cross-toolchain helper

### DIFF
--- a/Tools/Scripts/cross-toolchain-helper
+++ b/Tools/Scripts/cross-toolchain-helper
@@ -534,7 +534,7 @@ def maybe_quote_run_cmd(argv_list, cmd_key):
     new_argv_list = argv_list[0:i]
 
     # Everything after cmd_key gets converted into one argument separated
-    # by spaces. If some of this arguments has an space then quote it.
+    # by spaces. If any of the arguments has a space then quote it.
     command_str = argv_list[i]
     for command_arg in argv_list[i+1:]:
         if ' ' in command_arg:
@@ -546,7 +546,7 @@ def maybe_quote_run_cmd(argv_list, cmd_key):
     return new_argv_list
 
 
-def main():
+def main(args):
 
     conf_sub_dir = os.path.join('Tools', 'yocto')
     targets_conf_sub_path = os.path.join(conf_sub_dir, 'targets.conf')
@@ -564,7 +564,7 @@ def main():
 
     parser = argparse.ArgumentParser('usage: %prog [options]', allow_abbrev=False,
                                     epilog='NOTE: The script "build-webkit" will call this script when the flag "--cross-target" is passed to it. That allows to cross-build WebKit for the target directly with the script build-webkit. '
-                                    'Any environment variables this script recognizes like  WEBKIT_CROSS_WIPE_ON_CHANGE or WEBKIT_CROSS_EXPORT_ENV can be also used with the build-webkit script. '
+                                    'Any environment variables this script recognizes like WEBKIT_CROSS_WIPE_ON_CHANGE or WEBKIT_CROSS_EXPORT_ENV can be also used with the build-webkit script.'
                                     'If you want to know more details check the documentation at: "{doc_path}"'.format(doc_path=os.path.join(conf_sub_dir,'README.md')))
     action = parser.add_argument_group('action')
     run_cmd_key = '--cross-toolchain-run-cmd'
@@ -576,7 +576,7 @@ def main():
                              'If you pass this flag (or you set the environment variable "WEBKIT_CROSS_WIPE_ON_CHANGE" to "0") then it will not wipe it.')
     parser.add_argument('--no-export-default-environment', action='store_true', dest='no_export_environment',
                         help='This tool may export some environment variables defined in "{targets_sub_path}" for the target. '
-                             'This environment variables are usually used to change the default build parameters of the script "build-webkit". '
+                             'These environment variables are usually used to change the default build parameters of the script "build-webkit". '
                              'If you pass this flag (or you set the environment variable "WEBKIT_CROSS_EXPORT_ENV" to "0") then it will not export those.'.format(targets_sub_path=targets_conf_sub_path))
     action.add_argument('--print-available-targets', dest='print_targets', action='store_true',
                         help='Print the available targets (one per line)')
@@ -592,11 +592,11 @@ def main():
                         help='Build the cross toolchain (only if still not built) and then execute \"command\" inside cross environment. '
                              '\033[91mIMPORTANT\033[0m: This argument is the last one, any strings after it, even if separated by spaces or quotes will be considered part of the command to be executed. '
                              'This means that any options this script understands (like --help) will not be recognized by the script if passed after this switch, but instead will be considered part of the command to execute.')
-    options = parser.parse_args(args=maybe_quote_run_cmd(sys.argv[1:], run_cmd_key))
+    options = parser.parse_args(args=maybe_quote_run_cmd(args, run_cmd_key))
     configure_logging(options.log_level)
 
-    # Note: When modifiying this script, take into account that the script 'build-webkit'
-    # uses this script as a wrapper when the option '-cross-target' is passed to 'build-webkit'.
+    # Note: When modifying this script, take into account that the script 'build-webkit'
+    # uses this script as a wrapper when the option '--cross-target' is passed to 'build-webkit'.
     # More specifically, 'build-webkit' calls this script for the following use-cases:
     # 1. --print-available-targets (so it knows which targets are available)
     # 2. --cross-toolchain-run-cmd (to execute cmake and ninja/make inside the cross env)
@@ -651,4 +651,4 @@ def main():
     return retcode
 
 if __name__ == '__main__':
-    sys.exit(main())
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
#### 9c589630735a0f5d75d3b930ab4a6bbdfb632145
<pre>
[WPE] Minor fixes and spelling in cross-toolchain helper
<a href="https://bugs.webkit.org/show_bug.cgi?id=251520">https://bugs.webkit.org/show_bug.cgi?id=251520</a>

Reviewed by Carlos Alberto Lopez Perez.

* Tools/Scripts/cross-toolchain-helper: Fix a few spelling issues and allow the script to be used
from third-party Python scripts.

Canonical link: <a href="https://commits.webkit.org/259758@main">https://commits.webkit.org/259758@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eeceed994d7befdc6cfe1ff16273297a7a76250d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105838 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14906 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38686 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115036 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/175160 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109740 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16325 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6105 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98071 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111587 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95392 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39969 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94284 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27034 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8177 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28386 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8659 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4973 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14286 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47934 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6748 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10216 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->