### PR TITLE
Renderer is leftover when we are doing a flip from display:contents to display:none and then calling focus()

### DIFF
--- a/LayoutTests/fast/css/content/leftover-renderer-after-displayType-change-on-focus-expected.txt
+++ b/LayoutTests/fast/css/content/leftover-renderer-after-displayType-change-on-focus-expected.txt
@@ -1,0 +1,3 @@
+Pass if no crash
+
+

--- a/LayoutTests/fast/css/content/leftover-renderer-after-displayType-change-on-focus.html
+++ b/LayoutTests/fast/css/content/leftover-renderer-after-displayType-change-on-focus.html
@@ -1,0 +1,15 @@
+<style>
+.dc, .dc * { display: contents }
+</style>
+<body><p>Pass if no crash</p>
+<span></span>
+<div id="x6" hidden class="dc"><div id="x22"><div> </div></div></div>
+<script>
+  if (window.testRunner)
+    testRunner.dumpAsText();
+  document.body.offsetLeft;
+  x6.classList.remove('dc');
+  x6.focus();
+  document.body.offsetLeft;
+  x22.innerHTML = "";
+</script>

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -336,11 +336,14 @@ static inline bool mayHaveDisplayContents(Element *element)
 {
     return element && (element->hasDisplayContents() || element->displayContentsChanged());
 }
-
+static inline bool childNodesMayHaveRenderers(Element *element)
+{
+    return element && element->ancestorCreatedRendererForChildNodes();
+}
 static inline void destroyRenderTreeIfNeeded(Node& child)
 {
     auto childAsElement = dynamicDowncast<Element>(child);
-    if (!child.renderer() && !mayHaveDisplayContents(childAsElement))
+    if (!child.renderer() && !mayHaveDisplayContents(childAsElement) && !childNodesMayHaveRenderers(childAsElement))
         return;
     if (childAsElement)
         RenderTreeUpdater::tearDownRenderers(*childAsElement);

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -107,6 +107,7 @@ struct SameSizeAsNode : public EventTarget {
     bool deletionHasBegun;
     bool inRemovedLastRefFunction;
     bool adoptionIsRequired;
+    bool ancestorCreatedRendererForChildNodes;
 #endif
     uint32_t refCountAndParentBit;
     uint32_t nodeFlags;
@@ -2632,7 +2633,24 @@ void Node::updateAncestorConnectedSubframeCountForRemoval() const
     for (Node* node = parentOrShadowHostNode(); node; node = node->parentOrShadowHostNode())
         node->decrementConnectedSubframeCount(count);
 }
+void Node::setAncestorCreatedRendererForChildNodes(bool created) const
+{
+#if ASSERT_ENABLED
+    m_ancestorCreatedRendererForChildNodes = created;
+#else
+    UNUSED_PARAM(created);
+#endif
+}
 
+bool Node::ancestorCreatedRendererForChildNodes() const
+{
+#if ASSERT_ENABLED
+    return m_ancestorCreatedRendererForChildNodes;
+#else
+    return false;
+#endif
+    
+}
 void Node::updateAncestorConnectedSubframeCountForInsertion() const
 {
     unsigned count = connectedSubframeCount();

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -517,6 +517,7 @@ public:
     bool m_deletionHasBegun { false };
     mutable bool m_inRemovedLastRefFunction { false };
     bool m_adoptionIsRequired { true };
+    mutable bool m_ancestorCreatedRendererForChildNodes { false };
 #endif
 
     HashMap<Ref<MutationObserver>, MutationRecordDeliveryOptions> registeredMutationObservers(MutationObserverOptionType, const QualifiedName* attributeName);
@@ -548,6 +549,8 @@ public:
     static int32_t flagIsLink() { return static_cast<int32_t>(NodeFlag::IsLink); }
     static int32_t flagIsParsingChildrenFinished() { return static_cast<int32_t>(NodeFlag::IsParsingChildrenFinished); }
 #endif // ENABLE(JIT)
+    void setAncestorCreatedRendererForChildNodes(bool) const;
+    bool ancestorCreatedRendererForChildNodes() const;
 
 protected:
     enum class NodeFlag : uint32_t {

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -517,6 +517,7 @@ void RenderTreeUpdater::updateTextRenderer(Text& text, const Style::TextUpdate* 
         return;
     createTextRenderer(text, textUpdate);
     renderingParent().didCreateOrDestroyChildRenderer = true;
+    text.parentNode()->setAncestorCreatedRendererForChildNodes(true);
 }
 
 void RenderTreeUpdater::storePreviousRenderer(Node& node)


### PR DESCRIPTION
#### 81ae31009d01126c6bfa382c7e9b3b01f5771a2e
<pre>
Renderer is leftover when we are doing a flip from display:contents to display:none and then calling focus()
<a href="https://bugs.webkit.org/show_bug.cgi?id=250354">https://bugs.webkit.org/show_bug.cgi?id=250354</a>
rdar://102808896

Reviewed by NOBODY (OOPS!).

The basic bug here is that we are doing a flip from display:contents to display:none and then calling focus(). That computes focusability using Element::resolveComputedStyle and that causes us to forget we used to have display:contents . Then we force render tree update which fails to remove the text renderer in the formerly display:contents tree because it thinks it is a display:none tree without renderers. The fix updates a flag in the parentNode of the left over renderer to mark that a renderer is created for a child by its anscestor.

* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::childNodesMayHaveRenderers):
(WebCore::destroyRenderTreeIfNeeded):
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::setAncestorCreatedRendererForChildNodes const):
(WebCore::Node::ancestorCreatedRendererForChildNodes const):
* Source/WebCore/dom/Node.h:
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::RenderTreeUpdater::updateTextRenderer):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81ae31009d01126c6bfa382c7e9b3b01f5771a2e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107273 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/16329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/40056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/116429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/115882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/111172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/17758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/7570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/99427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/113038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12463 "Found 1 new test failure: fast/css/content/quote-crash-when-floating.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95438 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40012 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94328 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27082 "Found 1 new test failure: fast/css/content/leftover-renderer-after-displayType-change-on-focus.html (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81675 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state (failure)") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/9368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28436 "Found 1 new test failure: fast/css/content/quote-crash-when-floating.html (failure)") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/10008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5022 "Found 60 new test failures: animations/additive-transform-animations.html, animations/duplicate-keys.html, animations/stop-animation-on-suspend.html, compositing/background-color/background-color-alpha-with-opacity.html, compositing/backing/non-composited-visibility-change.html, compositing/backing/solid-color-with-paints-into-ancestor.html, compositing/clipping/nested-overflow-with-border-radius.html, compositing/contents-scale/hidpi-tests/rasterization-scale.html, compositing/filters/backdrop-filter-rect-border-radius.html, compositing/iframes/border-radius-composited-frame.html ... (failure)") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/15523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47976 "Passed tests") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/11559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->