### PR TITLE
[WGSL] Factor out context logic from MangleNames pass

### DIFF
--- a/Source/WebGPU/WGSL/ContextProvider.h
+++ b/Source/WebGPU/WGSL/ContextProvider.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/HashMap.h>
+
+namespace WGSL {
+
+namespace AST {
+class Identifier;
+}
+
+template<typename ContextValue>
+class ContextProvider {
+    class Context;
+    friend class ContextScope;
+
+protected:
+    using ContextMap = HashMap<String, ContextValue>;
+
+    class ContextScope {
+    public:
+        ContextScope(ContextProvider*);
+        ~ContextScope();
+
+    private:
+        ContextProvider& m_provider;
+        Context* m_previousContext;
+    };
+
+    ContextProvider();
+
+    const ContextValue& introduceVariable(const AST::Identifier&, ContextValue&&);
+    const ContextValue* readVariable(const AST::Identifier&) const;
+
+private:
+    class Context {
+    public:
+        Context(const Context *const parent);
+
+        const ContextValue* lookup(const AST::Identifier&) const;
+        const ContextValue& add(const AST::Identifier&, ContextValue&&);
+
+    private:
+        const Context* m_parent { nullptr };
+        ContextMap m_map;
+    };
+
+    Context* m_context;
+    Vector<Context> m_contexts;
+    ContextScope m_globalScope;
+};
+
+} // namespace WGSL

--- a/Source/WebGPU/WGSL/ContextProviderInlines.h
+++ b/Source/WebGPU/WGSL/ContextProviderInlines.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ASTIdentifier.h"
+#include "ContextProvider.h"
+
+namespace WGSL {
+
+template<typename Value>
+ContextProvider<Value>::Context::Context(const Context *const parent)
+    : m_parent(parent)
+{
+}
+
+template<typename Value>
+const Value* ContextProvider<Value>::Context::lookup(const AST::Identifier& name) const
+{
+    auto it = m_map.find(name.id());
+    if (it != m_map.end())
+        return &it->value;
+    if (m_parent)
+        return m_parent->lookup(name);
+    return nullptr;
+}
+
+template<typename Value>
+const Value& ContextProvider<Value>::Context::add(const AST::Identifier& name, Value&& value)
+{
+    auto result = m_map.add(name.id(), WTFMove(value));
+    ASSERT(result.isNewEntry);
+    return result.iterator->value;
+}
+
+template<typename Value>
+ContextProvider<Value>::ContextScope::ContextScope(ContextProvider<Value>* provider)
+    : m_provider(*provider)
+    , m_previousContext(provider->m_context)
+{
+    m_provider.m_contexts.append(Context { m_previousContext });
+    m_provider.m_context = &m_provider.m_contexts.last();
+}
+
+template<typename Value>
+ContextProvider<Value>::ContextScope::~ContextScope()
+{
+    m_provider.m_context = m_previousContext;
+    m_provider.m_contexts.removeLast();
+}
+
+template<typename Value>
+ContextProvider<Value>::ContextProvider()
+    : m_context(nullptr)
+    , m_contexts()
+    , m_globalScope(this)
+{
+}
+
+template<typename Value>
+auto ContextProvider<Value>::introduceVariable(const AST::Identifier& name, Value&& value) -> const Value& 
+{
+    return m_context->add(name, WTFMove(value));
+}
+
+template<typename Value>
+auto ContextProvider<Value>::readVariable(const AST::Identifier& name) const -> const Value*
+{
+    return m_context->lookup(name);
+}
+
+} // namespace WGSL

--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -126,6 +126,8 @@
 		9789C31A297EA105009E9006 /* CallGraph.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9789C318297EA105009E9006 /* CallGraph.cpp */; };
 		978A9125298A4E8400B37E5E /* MangleNames.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 978A9123298A4E8400B37E5E /* MangleNames.cpp */; };
 		978A9126298A4E8400B37E5E /* MangleNames.h in Headers */ = {isa = PBXBuildFile; fileRef = 978A9124298A4E8400B37E5E /* MangleNames.h */; };
+		978A912A298AB60200B37E5E /* ContextProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 978A9129298AB60200B37E5E /* ContextProvider.h */; };
+		978A912C298AB8EE00B37E5E /* ContextProviderInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 978A912B298AB8EE00B37E5E /* ContextProviderInlines.h */; };
 		979240B6297018290050EA2C /* MetalCodeGenerator.h in Headers */ = {isa = PBXBuildFile; fileRef = 979240B2297018290050EA2C /* MetalCodeGenerator.h */; };
 		979240B7297018290050EA2C /* MetalFunctionWriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 979240B3297018290050EA2C /* MetalFunctionWriter.h */; };
 		979240B8297018290050EA2C /* MetalCodeGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 979240B4297018290050EA2C /* MetalCodeGenerator.cpp */; };
@@ -330,6 +332,8 @@
 		9789C319297EA105009E9006 /* CallGraph.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CallGraph.h; sourceTree = "<group>"; };
 		978A9123298A4E8400B37E5E /* MangleNames.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MangleNames.cpp; sourceTree = "<group>"; };
 		978A9124298A4E8400B37E5E /* MangleNames.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MangleNames.h; sourceTree = "<group>"; };
+		978A9129298AB60200B37E5E /* ContextProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ContextProvider.h; sourceTree = "<group>"; };
+		978A912B298AB8EE00B37E5E /* ContextProviderInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ContextProviderInlines.h; sourceTree = "<group>"; };
 		979240B2297018290050EA2C /* MetalCodeGenerator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MetalCodeGenerator.h; sourceTree = "<group>"; };
 		979240B3297018290050EA2C /* MetalFunctionWriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MetalFunctionWriter.h; sourceTree = "<group>"; };
 		979240B4297018290050EA2C /* MetalCodeGenerator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MetalCodeGenerator.cpp; sourceTree = "<group>"; };
@@ -465,6 +469,8 @@
 				33EA186727BC1B1400A1DD52 /* CompilationMessage.cpp */,
 				33EA186527BC1AD500A1DD52 /* CompilationMessage.h */,
 				1CEBD8042716BFAB00A5254D /* config.h */,
+				978A9129298AB60200B37E5E /* ContextProvider.h */,
+				978A912B298AB8EE00B37E5E /* ContextProviderInlines.h */,
 				979240C729769AC00050EA2C /* EntryPointRewriter.cpp */,
 				979240C629769AC00050EA2C /* EntryPointRewriter.h */,
 				97F547B6298055D90011D79A /* GlobalVariableRewriter.cpp */,
@@ -688,6 +694,8 @@
 				3A12AEC828FCEEC400C1B975 /* ASTWhileStatement.h in Headers */,
 				3A12AEB228FCE94C00C1B975 /* ASTWorkgroupSizeAttribute.h in Headers */,
 				33EA186627BC1AD500A1DD52 /* CompilationMessage.h in Headers */,
+				978A912A298AB60200B37E5E /* ContextProvider.h in Headers */,
+				978A912C298AB8EE00B37E5E /* ContextProviderInlines.h in Headers */,
 				979240C829769AC00050EA2C /* EntryPointRewriter.h in Headers */,
 				97F547B9298055D90011D79A /* GlobalVariableRewriter.h in Headers */,
 				338BB2D427B6B66C00E066AB /* Lexer.h in Headers */,


### PR DESCRIPTION
#### 0d49272caea1d1837813cb67302e346ffe067936
<pre>
[WGSL] Factor out context logic from MangleNames pass
<a href="https://bugs.webkit.org/show_bug.cgi?id=251523">https://bugs.webkit.org/show_bug.cgi?id=251523</a>
&lt;rdar://problem/104921139&gt;

Reviewed by Myles C. Maxfield.

Move the context logic out of the MangleNames pass so it can be
reused in the type checking pass.

* Source/WebGPU/WGSL/ContextProvider.h: Added.
* Source/WebGPU/WGSL/ContextProviderInlines.h: Added.
(WGSL::ContextProvider&lt;Value&gt;::Context::Context):
(WGSL::ContextProvider&lt;Value&gt;::Context::lookup const):
(WGSL::ContextProvider&lt;Value&gt;::Context::add):
(WGSL::ContextProvider&lt;Value&gt;::ContextScope::ContextScope):
(WGSL::ContextProvider&lt;Value&gt;::ContextScope::~ContextScope):
(WGSL::ContextProvider&lt;Value&gt;::ContextProvider):
(WGSL::ContextProvider&lt;Value&gt;::introduceVariable const):
(WGSL::ContextProvider&lt;Value&gt;::readVariable const const):
* Source/WebGPU/WGSL/MangleNames.cpp:
(WGSL::NameManglerVisitor::run):
(WGSL::NameManglerVisitor::introduceVariable):
(WGSL::NameManglerVisitor::readVariable const):
(WGSL::NameManglerVisitor::Context::Context): Deleted.
(WGSL::NameManglerVisitor::Context::lookup const): Deleted.
(WGSL::NameManglerVisitor::Context::add): Deleted.
(WGSL::NameManglerVisitor::ContextScope::ContextScope): Deleted.
(WGSL::NameManglerVisitor::ContextScope::~ContextScope): Deleted.
* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/259748@main">https://commits.webkit.org/259748@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/668d6f6b4ce22cb2e2270f24d31f458a58eda6cf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105693 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14784 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38566 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114918 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16190 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5981 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97957 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114724 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111446 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12315 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95297 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39796 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94179 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26937 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81513 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8049 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28290 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8545 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4875 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14166 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47837 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6741 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10098 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->