### PR TITLE
[GLib] Fix typo of cache_directory parameter to webkit_network_session_new

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.cpp
@@ -254,10 +254,10 @@ WebKitNetworkSession* webkit_network_session_get_default()
 /**
  * webkit_network_session_new:
  * @data_directory: (nullable): a base directory for data, or %NULL
- * @cache_directrory: (nullable): a base direfctory for caches, or %NULL
+ * @cache_directory: (nullable): a base directory for caches, or %NULL
  *
  * Creates a new #WebKitNetworkSession with a persistent #WebKitWebsiteDataManager.
- * The parameters @data_directory and @cache_directrory will be used as construct
+ * The parameters @data_directory and @cache_directory will be used as construct
  * properties of the #WebKitWebsiteDataManager of the network session. Note that if
  * %NULL is passed, the default directory will be passed to #WebKitWebsiteDataManager
  * so that webkit_website_data_manager_get_base_data_directory() and

--- a/Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.h.in
@@ -68,7 +68,7 @@ webkit_network_session_get_default                               (void);
 
 WEBKIT_API WebKitNetworkSession *
 webkit_network_session_new                                       (const char                   *data_directory,
-                                                                  const char                   *cache_directrory);
+                                                                  const char                   *cache_directory);
 WEBKIT_API WebKitNetworkSession *
 webkit_network_session_new_ephemeral                             (void);
 


### PR DESCRIPTION
#### 35dee875229dca0d0a03c6a8359e32ca5ec27a64
<pre>
[GLib] Fix typo of cache_directory parameter to webkit_network_session_new
<a href="https://bugs.webkit.org/show_bug.cgi?id=251534">https://bugs.webkit.org/show_bug.cgi?id=251534</a>

Reviewed by Adrian Perez de Castro.

This is an introspection API break, so it&apos;s good to catch it early.

* Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.h.in:

Canonical link: <a href="https://commits.webkit.org/259732@main">https://commits.webkit.org/259732@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb8ead29dc7e1a9b18c55e0273406259048174fb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105765 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14846 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38626 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114974 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16256 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6045 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98008 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111517 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/95342 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/94229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26983 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8113 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/28335 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8600 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14226 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47882 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6728 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10156 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->