### PR TITLE
Add static assertions in generated serialization code to verify correct member ordering

### DIFF
--- a/Source/WebCore/Modules/indexeddb/shared/IDBDatabaseInfo.cpp
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBDatabaseInfo.cpp
@@ -36,8 +36,8 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(IDBDatabaseInfo);
 IDBDatabaseInfo::IDBDatabaseInfo(const String& name, uint64_t version, uint64_t maxIndexID, uint64_t maxObjectStoreID, HashMap<uint64_t, IDBObjectStoreInfo>&& objectStoreMap)
     : m_name(name)
     , m_version(version)
-    , m_maxObjectStoreID(maxObjectStoreID)
     , m_maxIndexID(maxIndexID)
+    , m_maxObjectStoreID(maxObjectStoreID)
     , m_objectStoreMap(WTFMove(objectStoreMap))
 {
 }
@@ -45,8 +45,8 @@ IDBDatabaseInfo::IDBDatabaseInfo(const String& name, uint64_t version, uint64_t 
 IDBDatabaseInfo::IDBDatabaseInfo(const IDBDatabaseInfo& other, IsolatedCopyTag)
     : m_name(other.m_name.isolatedCopy())
     , m_version(other.m_version)
-    , m_maxObjectStoreID(other.m_maxObjectStoreID)
     , m_maxIndexID(other.m_maxIndexID)
+    , m_maxObjectStoreID(other.m_maxObjectStoreID)
 {
     for (const auto& entry : other.m_objectStoreMap)
         m_objectStoreMap.set(entry.key, entry.value.isolatedCopy());

--- a/Source/WebCore/Modules/indexeddb/shared/IDBDatabaseInfo.h
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBDatabaseInfo.h
@@ -78,8 +78,8 @@ private:
 
     String m_name;
     uint64_t m_version { 0 };
-    uint64_t m_maxObjectStoreID { 0 };
     uint64_t m_maxIndexID { 0 };
+    uint64_t m_maxObjectStoreID { 0 };
 
     HashMap<uint64_t, IDBObjectStoreInfo> m_objectStoreMap;
 

--- a/Source/WebCore/platform/graphics/Pattern.h
+++ b/Source/WebCore/platform/graphics/Pattern.h
@@ -50,14 +50,14 @@ class Pattern final : public RefCounted<Pattern> {
 public:
     struct Parameters {
         Parameters(bool repeatX = true, bool repeatY = true, AffineTransform patternSpaceTransform = { })
-            : patternSpaceTransform(patternSpaceTransform)
-            , repeatX(repeatX)
+            : repeatX(repeatX)
             , repeatY(repeatY)
+            , patternSpaceTransform(patternSpaceTransform)
         {
         }
-        AffineTransform patternSpaceTransform;
         bool repeatX;
         bool repeatY;
+        AffineTransform patternSpaceTransform;
     };
 
     WEBCORE_EXPORT static Ref<Pattern> create(SourceImage&& tileImage, const Parameters& = { });

--- a/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
@@ -16,22 +16,22 @@ headers: "StructHeader.h" "FirstMemberType.h" "SecondMemberType.h"
 [Nested] class Namespace::OtherClass {
     [ReturnEarlyIfTrue] bool isNull
     int a
-    bool b
+    [BitField] bool b
     [SecureCodingAllowed=[NSArray.class, PAL::getDDScannerResultClass()]] RetainPtr<NSArray> dataDetectorResults;
 }
 
-[Return=Ref] class Namespace::ReturnRefClass {
+[RefCounted] class Namespace::ReturnRefClass {
     double functionCall().member1
     double functionCall().member2
     std::unique_ptr<int> uniqueMember
 }
 
-[LegacyPopulateFrom=EmptyConstructor] struct Namespace::EmptyConstructorStruct {
+[LegacyPopulateFromEmptyConstructor, CustomMemberLayout] struct Namespace::EmptyConstructorStruct {
     int m_int;
     double m_double;
 }
 
-[LegacyPopulateFrom=EmptyConstructor] class Namespace::EmptyConstructorNullable {
+[LegacyPopulateFromEmptyConstructor] class Namespace::EmptyConstructorNullable {
     [ReturnEarlyIfTrue] bool m_isNull;
 #if CONDITION_AROUND_M_TYPE_AND_M_VALUE
     MemberType m_type;

--- a/Source/WebKit/Shared/API/APIError.serialization.in
+++ b/Source/WebKit/Shared/API/APIError.serialization.in
@@ -22,6 +22,6 @@
 
 headers: "APIError.h"
 
-[Return=Ref, CustomHeader=True] class API::Error {
+[RefCounted, CustomHeader=True] class API::Error {
     WebCore::ResourceError platformError()
 };

--- a/Source/WebKit/Shared/API/APIFrameHandle.serialization.in
+++ b/Source/WebKit/Shared/API/APIFrameHandle.serialization.in
@@ -22,7 +22,7 @@
 
 headers: "APIFrameHandle.h"
 
-[Return=Ref, CustomHeader=True] class API::FrameHandle {
+[RefCounted, CustomHeader=True] class API::FrameHandle {
     WebCore::FrameIdentifier frameID()
     bool isAutoconverting()
 };

--- a/Source/WebKit/Shared/API/APIGeometry.serialization.in
+++ b/Source/WebKit/Shared/API/APIGeometry.serialization.in
@@ -22,17 +22,17 @@
 
 headers: "APIGeometry.h"
 
-[Return=Ref, CustomHeader=True] class API::Size {
+[RefCounted, CustomHeader=True] class API::Size {
     double size().width
     double size().height
 };
 
-[Return=Ref, CustomHeader=True] class API::Point {
+[RefCounted, CustomHeader=True] class API::Point {
     double point().x
     double point().y
 };
 
-[Return=Ref, CustomHeader=True] class API::Rect {
+[RefCounted, CustomHeader=True] class API::Rect {
     double rect().origin.x
     double rect().origin.y
     double rect().size.width

--- a/Source/WebKit/Shared/API/APIPageHandle.serialization.in
+++ b/Source/WebKit/Shared/API/APIPageHandle.serialization.in
@@ -22,7 +22,7 @@
 
 headers: "APIPageHandle.h"
 
-[Return=Ref, CustomHeader=True] class API::PageHandle {
+[RefCounted, CustomHeader=True] class API::PageHandle {
     WebKit::WebPageProxyIdentifier pageProxyID()
     WebCore::PageIdentifier webPageID()
     bool isAutoconverting()

--- a/Source/WebKit/Shared/API/APIURL.serialization.in
+++ b/Source/WebKit/Shared/API/APIURL.serialization.in
@@ -22,6 +22,6 @@
 
 headers: "APIURL.h"
 
-[Return=Ref, CustomHeader=True] class API::URL {
+[RefCounted, CustomHeader=True] class API::URL {
     WTF::String string()
 };

--- a/Source/WebKit/Shared/API/APIURLRequest.serialization.in
+++ b/Source/WebKit/Shared/API/APIURLRequest.serialization.in
@@ -22,6 +22,6 @@
 
 headers: "APIURLRequest.h"
 
-[Return=Ref, CustomHeader=True] class API::URLRequest {
+[RefCounted, CustomHeader=True] class API::URLRequest {
     WebCore::ResourceRequest resourceRequest()
 };

--- a/Source/WebKit/Shared/API/APIURLResponse.serialization.in
+++ b/Source/WebKit/Shared/API/APIURLResponse.serialization.in
@@ -22,6 +22,6 @@
 
 headers: "APIURLResponse.h"
 
-[Return=Ref, CustomHeader=True] class API::URLResponse {
+[RefCounted, CustomHeader=True] class API::URLResponse {
     WebCore::ResourceResponse resourceResponse()
 };

--- a/Source/WebKit/Shared/SessionState.serialization.in
+++ b/Source/WebKit/Shared/SessionState.serialization.in
@@ -37,7 +37,7 @@ header: "SessionState.h"
     std::optional<WallTime> expectedFileModificationTime;
 };
 
-[CustomHeader, LegacyPopulateFrom=EmptyConstructor] class WebKit::FrameState {
+[CustomHeader, LegacyPopulateFromEmptyConstructor] class WebKit::FrameState {
     String urlString;
     String originalURLString;
     String referrer;

--- a/Source/WebKit/Shared/ShareableBitmap.serialization.in
+++ b/Source/WebKit/Shared/ShareableBitmap.serialization.in
@@ -33,6 +33,6 @@ header: "ShareableBitmap.h"
     [Validator='!WebKit::ShareableBitmap::numBytesForSize(*m_size, *m_configuration).hasOverflowed() && m_handle->size() >= WebKit::ShareableBitmap::numBytesForSize(*m_size, *m_configuration)'] WebKit::ShareableBitmapConfiguration m_configuration;
 }
 
-[Return=Ref, CreateUsing=createReadOnly] class WebKit::ShareableBitmap {
+[RefCounted, CreateUsing=createReadOnly] class WebKit::ShareableBitmap {
     std::optional<WebKit::ShareableBitmapHandle> createReadOnlyHandle()
 }

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -149,7 +149,7 @@ class WebCore::IDBDatabaseInfo {
     HashMap<uint64_t, WebCore::IDBObjectStoreInfo> m_objectStoreMap
 }
 
-struct WebCore::IDBKeyRangeData {
+[CustomMemberLayout] struct WebCore::IDBKeyRangeData {
     [ReturnEarlyIfTrue] bool isNull;
 
     WebCore::IDBKeyData lowerKey;
@@ -222,7 +222,7 @@ class WebCore::IDBRequestData {
 }
 
 # FIXME: When decoding from IPC, databaseName can be null, and the non-empty constructor asserts that this is not the case.
-[LegacyPopulateFrom=EmptyConstructor] class WebCore::IDBDatabaseIdentifier {
+[LegacyPopulateFromEmptyConstructor] class WebCore::IDBDatabaseIdentifier {
     String m_databaseName
     WebCore::ClientOrigin m_origin
     bool m_isTransient
@@ -233,7 +233,7 @@ struct WebCore::IDBDatabaseNameAndVersion {
     uint64_t version;
 }
 
-[LegacyPopulateFrom=EmptyConstructor] class WebCore::IDBResultData {
+[LegacyPopulateFromEmptyConstructor] class WebCore::IDBResultData {
     WebCore::IDBResultType m_type;
     WebCore::IDBResourceIdentifier m_requestIdentifier;
     WebCore::IDBError m_error;
@@ -246,7 +246,7 @@ struct WebCore::IDBDatabaseNameAndVersion {
     uint64_t m_resultInteger;
 }
 
-[LegacyPopulateFrom=EmptyConstructor] class WebCore::IDBKeyData {
+[LegacyPopulateFromEmptyConstructor, CustomMemberLayout] class WebCore::IDBKeyData {
     [ReturnEarlyIfTrue] bool m_isNull;
     WebCore::IndexedDB::KeyType m_type;
     std::variant<Vector<WebCore::IDBKeyData>, String, double, WebCore::ThreadSafeDataBuffer> m_value;
@@ -314,10 +314,10 @@ struct CGAffineTransform {
     WebCore::FloatSize size()
 }
 
-[Return=Ref, CustomHeader=True] class WebCore::LinearTimingFunction {
+[RefCounted, CustomHeader=True] class WebCore::LinearTimingFunction {
 };
 
-[Return=Ref, CustomHeader=True] class WebCore::CubicBezierTimingFunction {
+[RefCounted, CustomHeader=True] class WebCore::CubicBezierTimingFunction {
     WebCore::CubicBezierTimingFunction::TimingFunctionPreset timingFunctionPreset()
     double x1()
     double y1()
@@ -325,19 +325,19 @@ struct CGAffineTransform {
     double y2()
 };
 
-[Return=Ref, CustomHeader=True] class WebCore::StepsTimingFunction {
+[RefCounted, CustomHeader=True] class WebCore::StepsTimingFunction {
     int numberOfSteps()
     std::optional<WebCore::StepsTimingFunction::StepPosition> stepPosition()
 };
 
-[Return=Ref, CustomHeader=True] class WebCore::SpringTimingFunction {
+[RefCounted, CustomHeader=True] class WebCore::SpringTimingFunction {
     double mass()
     double stiffness()
     double damping()
     double initialVelocity()
 };
 
-[LegacyPopulateFrom=EmptyConstructor] struct WebCore::ResourceLoadStatistics {
+[LegacyPopulateFromEmptyConstructor] struct WebCore::ResourceLoadStatistics {
     WebCore::RegistrableDomain registrableDomain;
     WallTime lastSeen;
     bool hadUserInteraction;
@@ -625,13 +625,13 @@ struct WebCore::ApplePayShippingMethod {
 #endif
 }
 
-[Return=Ref] class WebCore::ApplePayError {
+[RefCounted] class WebCore::ApplePayError {
     WebCore::ApplePayErrorCode code()
     std::optional<WebCore::ApplePayErrorContactField> contactField()
     String message()
 }
 
-[Return=Ref, AdditionalEncoder=StreamConnectionEncoder] class WebCore::ApplePayButtonSystemImage {
+[RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::ApplePayButtonSystemImage {
     WebCore::ApplePayButtonType m_applePayButtonType
     WebCore::ApplePayButtonStyle m_applePayButtonStyle
     String m_locale
@@ -639,7 +639,7 @@ struct WebCore::ApplePayShippingMethod {
 }
 
 enum class WebCore::ApplePayLogoStyle : bool
-[Return=Ref, AdditionalEncoder=StreamConnectionEncoder] class WebCore::ApplePayLogoSystemImage {
+[RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::ApplePayLogoSystemImage {
     WebCore::ApplePayLogoStyle applePayLogoStyle()
 }
 
@@ -878,7 +878,7 @@ struct WebCore::PushSubscriptionData {
 };
 #endif
 
-[Return=Ref] class WebCore::DeprecationReportBody {
+[RefCounted] class WebCore::DeprecationReportBody {
     String id()
     WallTime anticipatedRemoval()
     String message()
@@ -887,13 +887,13 @@ struct WebCore::PushSubscriptionData {
     std::optional<unsigned> columnNumber()
 };
 
-[Return=Ref] class WebCore::Report {
+[RefCounted] class WebCore::Report {
     String type()
     String url()
     RefPtr<WebCore::ReportBody> body()
 };
 
-[Return=Ref] class WebCore::TestReportBody {
+[RefCounted] class WebCore::TestReportBody {
     String message()
 }
 
@@ -945,7 +945,7 @@ struct WebCore::WebLockManagerSnapshot {
 };
 
 #if ENABLE(WEB_AUTHN)
-[LegacyPopulateFrom=EmptyConstructor] struct WebCore::AuthenticationExtensionsClientInputs {
+[LegacyPopulateFromEmptyConstructor] struct WebCore::AuthenticationExtensionsClientInputs {
     String appid;
     bool googleLegacyAppidSupport;
 }
@@ -1099,7 +1099,7 @@ enum class WebCore::RenderingPurpose : uint8_t {
 };
 
 #if ENABLE(CONTENT_FILTERING_IN_NETWORKING_PROCESS)
-[LegacyPopulateFrom=EmptyConstructor] class WebCore::MockContentFilterSettings {
+[LegacyPopulateFromEmptyConstructor] class WebCore::MockContentFilterSettings {
     bool m_enabled;
     WebCore::MockContentFilterSettings::DecisionPoint m_decisionPoint;
     WebCore::MockContentFilterSettings::Decision m_decision;
@@ -1271,9 +1271,9 @@ header: <WebCore/ResourceRequest.h>
     WebCore::ResourceRequestBase::SameSiteDisposition m_sameSiteDisposition;
     WebCore::ResourceLoadPriority m_priority;
     WebCore::ResourceRequestRequester m_requester;
-    bool m_allowCookies;
-    bool m_isTopSite;
-    bool m_isAppInitiated;
+    [BitField] bool m_allowCookies;
+    [BitField] bool m_isTopSite;
+    [BitField] bool m_isAppInitiated;
 };
 
 #if USE(SOUP)
@@ -1442,7 +1442,7 @@ struct WebCore::MediaStreamRequest {
     bool isUserGesturePriviledged;
     WebCore::PageIdentifier pageIdentifier;
 }
-[LegacyPopulateFrom=EmptyConstructor, CustomHeader] class WebCore::MediaTrackConstraintSetMap {
+[LegacyPopulateFromEmptyConstructor, CustomHeader] class WebCore::MediaTrackConstraintSetMap {
     std::optional<WebCore::IntConstraint> m_width;
     std::optional<WebCore::IntConstraint> m_height;
     std::optional<WebCore::IntConstraint> m_sampleRate;
@@ -1651,7 +1651,7 @@ enum class WebCore::PixelFormat : uint8_t {
     WebCore::DestinationColorSpace colorSpace;
 };
 
-[Return=Ref] class WebCore::TextIndicator {
+[RefCounted] class WebCore::TextIndicator {
     WebCore::TextIndicatorData data();
 };
 
@@ -1692,7 +1692,7 @@ class WebCore::DatabaseDetails {
     std::optional<WallTime> modificationTime();
 };
 
-[Return=Ref] class WebCore::DecomposedGlyphs {
+[RefCounted] class WebCore::DecomposedGlyphs {
     WebCore::PositionedGlyphs positionedGlyphs();
     WebCore::RenderingResourceIdentifier renderingResourceIdentifier();
 }
@@ -1896,21 +1896,21 @@ header: <WebCore/KeyboardScroll.h>
     WebCore::ScrollDirection direction;
 };
 
-[Return=Ref] class WebCore::NotificationResources {
+[RefCounted] class WebCore::NotificationResources {
     RefPtr<WebCore::Image> icon();
 };
 
-[Return=Ref] class WebCore::IdentityTransformOperation {
+[RefCounted] class WebCore::IdentityTransformOperation {
 }
 
-[Return=Ref] class WebCore::TranslateTransformOperation {
+[RefCounted] class WebCore::TranslateTransformOperation {
     WebCore::Length x();
     WebCore::Length y();
     WebCore::Length z();
     WebCore::TransformOperation::Type type();
 }
 
-[Return=Ref] class WebCore::RotateTransformOperation {
+[RefCounted] class WebCore::RotateTransformOperation {
     double x();
     double y();
     double z();
@@ -1918,28 +1918,28 @@ header: <WebCore/KeyboardScroll.h>
     WebCore::TransformOperation::Type type();
 }
 
-[Return=Ref] class WebCore::ScaleTransformOperation {
+[RefCounted] class WebCore::ScaleTransformOperation {
     double x();
     double y();
     double z();
     WebCore::TransformOperation::Type type();
 }
 
-[Return=Ref] class WebCore::SkewTransformOperation {
+[RefCounted] class WebCore::SkewTransformOperation {
     double angleX();
     double angleY();
     WebCore::TransformOperation::Type type();
 }
 
-[Return=Ref] class WebCore::PerspectiveTransformOperation {
+[RefCounted] class WebCore::PerspectiveTransformOperation {
     std::optional<WebCore::Length> perspective();
 }
 
-[Return=Ref] class WebCore::MatrixTransformOperation {
+[RefCounted] class WebCore::MatrixTransformOperation {
     WebCore::TransformationMatrix matrix();
 }
 
-[Return=Ref] class WebCore::Matrix3DTransformOperation {
+[RefCounted] class WebCore::Matrix3DTransformOperation {
     WebCore::TransformationMatrix matrix();
 }
 
@@ -1965,7 +1965,7 @@ class WebCore::TransformOperations {
     float angleRadians;
 };
 
-[Return=Ref, AdditionalEncoder=StreamConnectionEncoder] class WebCore::Gradient {
+[RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::Gradient {
     std::variant<WebCore::Gradient::LinearData, WebCore::Gradient::RadialData, WebCore::Gradient::ConicData> data();
     WebCore::ColorInterpolationMethod colorInterpolationMethod();
     WebCore::GradientSpreadMethod spreadMethod();
@@ -1983,7 +1983,7 @@ class WebCore::TransformOperations {
     WebCore::AffineTransform patternSpaceTransform;
 }
 
-[Return=Ref, AdditionalEncoder=StreamConnectionEncoder] class WebCore::Pattern {
+[RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::Pattern {
     WebCore::SourceImage tileImage();
     WebCore::Pattern::Parameters parameters();
 }
@@ -2089,31 +2089,31 @@ header: <WebCore/BasicShapes.h>
     WebCore::BasicShapeRadius::Type type();
 }
 
-[Return=Ref, CustomHeader] class WebCore::BasicShapeCircle {
+[RefCounted, CustomHeader] class WebCore::BasicShapeCircle {
     WebCore::BasicShapeCenterCoordinate centerX();
     WebCore::BasicShapeCenterCoordinate centerY();
     WebCore::BasicShapeRadius radius();
 }
 
-[Return=Ref, CustomHeader] class WebCore::BasicShapeEllipse {
+[RefCounted, CustomHeader] class WebCore::BasicShapeEllipse {
     WebCore::BasicShapeCenterCoordinate centerX();
     WebCore::BasicShapeCenterCoordinate centerY();
     WebCore::BasicShapeRadius radiusX();
     WebCore::BasicShapeRadius radiusY();
 }
 
-[Return=Ref, CustomHeader] class WebCore::BasicShapePolygon {
+[RefCounted, CustomHeader] class WebCore::BasicShapePolygon {
     WebCore::WindRule windRule();
     Vector<WebCore::Length> values();
 }
 
-[Return=Ref, CustomHeader] class WebCore::BasicShapePath {
+[RefCounted, CustomHeader] class WebCore::BasicShapePath {
     std::unique_ptr<WebCore::SVGPathByteStream> byteStream();
     float zoom();
     WebCore::WindRule windRule();
 }
 
-[Return=Ref, CustomHeader] class WebCore::BasicShapeInset {
+[RefCounted, CustomHeader] class WebCore::BasicShapeInset {
     WebCore::Length right();
     WebCore::Length top();
     WebCore::Length bottom();
@@ -2145,16 +2145,16 @@ header: <WebCore/RenderStyleConstants.h>
 };
 
 header: <WebCore/PathOperation.h>
-[Return=Ref, CustomHeader] class WebCore::ReferencePathOperation {
+[RefCounted, CustomHeader] class WebCore::ReferencePathOperation {
     std::optional<WebCore::Path> path();
 }
 
-[Return=Ref, CustomHeader] class WebCore::ShapePathOperation {
+[RefCounted, CustomHeader] class WebCore::ShapePathOperation {
     Ref<WebCore::BasicShape> shape();
     WebCore::CSSBoxType referenceBox();
 }
 
-[Return=Ref, CustomHeader] class WebCore::BoxPathOperation {
+[RefCounted, CustomHeader] class WebCore::BoxPathOperation {
     WebCore::Path path();
     WebCore::CSSBoxType referenceBox();
 }
@@ -2167,7 +2167,7 @@ header: <WebCore/PathOperation.h>
     Sides
 };
 
-[Return=Ref, CustomHeader] class WebCore::RayPathOperation {
+[RefCounted, CustomHeader] class WebCore::RayPathOperation {
     float angle();
     WebCore::RayPathOperation::Size size();
     bool isContaining();
@@ -2491,7 +2491,7 @@ enum class WebCore::StyleAppearance : uint8_t {
 };
 
 #if ENABLE(APPLE_PAY)
-[Return=Ref, AdditionalEncoder=StreamConnectionEncoder] class WebCore::ApplePayButtonPart {
+[RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::ApplePayButtonPart {
     WebCore::ApplePayButtonType buttonType();
     WebCore::ApplePayButtonStyle buttonStyle();
     String locale();
@@ -2504,19 +2504,19 @@ enum class WebCore::StyleAppearance : uint8_t {
     EvenLessGood
 };
 
-[Return=Ref, AdditionalEncoder=StreamConnectionEncoder] class WebCore::MeterPart {
+[RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::MeterPart {
     WebCore::MeterPart::GaugeRegion gaugeRegion();
     double value();
     double minimum();
     double maximum();
 };
 
-[Return=Ref, AdditionalEncoder=StreamConnectionEncoder] class WebCore::ProgressBarPart {
+[RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::ProgressBarPart {
     double position();
     Seconds animationStartTime();
 };
 
-[Return=Ref, AdditionalEncoder=StreamConnectionEncoder] class WebCore::SliderTrackPart {
+[RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::SliderTrackPart {
     WebCore::StyleAppearance type();
     WebCore::IntSize thumbSize();
     WebCore::IntRect trackBounds();
@@ -2715,7 +2715,7 @@ struct WebCore::SameSiteInfo {
     bool isSafeHTTPMethod;
 };
 
-[Return=Ref] class WebCore::SecurityOrigin {
+[RefCounted] class WebCore::SecurityOrigin {
     WebCore::SecurityOriginData m_data;
     String m_domain;
     String m_filePath;
@@ -2740,7 +2740,7 @@ struct WebCore::CookieRequestHeaderFieldProxy {
     WebCore::IncludeSecureCookies includeSecureCookies;
 };
 
-[Return=Ref] class WebCore::FormData {
+[RefCounted, CustomMemberLayout] class WebCore::FormData {
     bool m_alwaysStream;
     Vector<char> m_boundary;
     Vector<WebCore::FormDataElement> m_elements;
@@ -3093,7 +3093,7 @@ class WebCore::SpeechRecognitionUpdate {
 };
 
 #if USE(SYSTEM_PREVIEW)
-[Return=Ref, AdditionalEncoder=StreamConnectionEncoder] class WebCore::ARKitBadgeSystemImage {
+[RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::ARKitBadgeSystemImage {
     WebCore::RenderingResourceIdentifier imageIdentifier();
     WebCore::FloatSize m_imageSize;
 };
@@ -3252,7 +3252,7 @@ header: <WebCore/ImageDecoder.h>
     Seconds duration;
 }
 
-[Return=Ref, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DistantLightSource {
+[RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DistantLightSource {
     float m_azimuth;
     float m_elevation;
 };

--- a/Source/WebKit/Shared/mac/SecItemResponseData.h
+++ b/Source/WebKit/Shared/mac/SecItemResponseData.h
@@ -32,8 +32,8 @@ namespace WebKit {
 class SecItemResponseData {
 public:
     SecItemResponseData(OSStatus code, RetainPtr<CFTypeRef>&& result)
-        : m_resultObject(WTFMove(result))
-        , m_resultCode(code) { }
+        : m_resultCode(code)
+        , m_resultObject(WTFMove(result)) { }
 
     RetainPtr<CFTypeRef>& resultObject() { return m_resultObject; }
     OSStatus resultCode() const { return m_resultCode; }
@@ -41,8 +41,8 @@ public:
 private:
     friend struct IPC::ArgumentCoder<WebKit::SecItemResponseData, void>;
 
-    RetainPtr<CFTypeRef> m_resultObject;
     OSStatus m_resultCode;
+    RetainPtr<CFTypeRef> m_resultObject;
 };
     
 } // namespace WebKit


### PR DESCRIPTION
#### b369d6af63fe770df55f19584fbd8dea19c43b40
<pre>
Add static assertions in generated serialization code to verify correct member ordering
<a href="https://bugs.webkit.org/show_bug.cgi?id=251536">https://bugs.webkit.org/show_bug.cgi?id=251536</a>
rdar://104925697

Reviewed by Ben Nham.

Also document all attributes and remove unneeded ones.

* Source/WebCore/Modules/indexeddb/shared/IDBDatabaseInfo.cpp:
(WebCore::IDBDatabaseInfo::IDBDatabaseInfo):
* Source/WebCore/Modules/indexeddb/shared/IDBDatabaseInfo.h:
* Source/WebCore/platform/graphics/Pattern.h:
* Source/WebKit/Scripts/generate-serializers.py:
(SerializedType.__init__):
(SerializedType.can_assert_member_order_is_correct):
(check_type_members):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
(IPC::ArgumentCoder&lt;Namespace::OtherClass&gt;::encode):
(IPC::ArgumentCoder&lt;Namespace::EmptyConstructorNullable&gt;::encode):
(IPC::ArgumentCoder&lt;NullableSoftLinkedMember&gt;::encode):
* Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in:
* Source/WebKit/Shared/API/APIError.serialization.in:
* Source/WebKit/Shared/API/APIFrameHandle.serialization.in:
* Source/WebKit/Shared/API/APIGeometry.serialization.in:
* Source/WebKit/Shared/API/APIPageHandle.serialization.in:
* Source/WebKit/Shared/API/APIURL.serialization.in:
* Source/WebKit/Shared/API/APIURLRequest.serialization.in:
* Source/WebKit/Shared/API/APIURLResponse.serialization.in:
* Source/WebKit/Shared/SessionState.serialization.in:
* Source/WebKit/Shared/ShareableBitmap.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Shared/mac/SecItemResponseData.h:
(WebKit::SecItemResponseData::SecItemResponseData):

Canonical link: <a href="https://commits.webkit.org/259784@main">https://commits.webkit.org/259784@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be856658fc31583f53e0b23a2bcb4e880fe8599a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105807 "15 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14875 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38655 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115005 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175132 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109709 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16294 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6074 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98036 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114791 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111558 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12393 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95367 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39851 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/109253 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94257 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27008 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81581 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8146 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28360 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8628 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4946 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14255 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47908 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10185 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3630 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->