### PR TITLE
[Cocoa] startTime of dynamically added EXT-X-DATERANGE metadata cues is always 0

### DIFF
--- a/LayoutTests/http/tests/media/hls/track-in-band-ext-x-date-range-start-time-expected.txt
+++ b/LayoutTests/http/tests/media/hls/track-in-band-ext-x-date-range-start-time-expected.txt
@@ -1,0 +1,28 @@
+
+Test that #EXT-X-DATERANGE metadata cues have valid start time.
+
+RUN(video.src = "http://127.0.0.1:8000/media/resources/hls/dynamic-ext-date-range.py")
+EVENT(addtrack)
+RUN(track = video.textTracks[0])
+RUN(track.mode = "hidden")
+EVENT(playing)
+EVENT(cuechange)
+
+EXPECTED (track.cues[0].startTime == '0') OK
+EXPECTED (track.cues[1].startTime != '0') OK
+EXPECTED (track.cues[2].startTime != '0') OK
+EXPECTED (track.cues[3].startTime != '0') OK
+EXPECTED (track.cues[4].startTime != '0') OK
+EXPECTED (track.cues[5].startTime != '0') OK
+EXPECTED (track.cues[6].startTime != '0') OK
+EXPECTED (track.cues[7].startTime != '0') OK
+EXPECTED (track.cues[8].startTime != '0') OK
+EXPECTED (track.cues[9].startTime != '0') OK
+EXPECTED (track.cues[10].startTime != '0') OK
+EXPECTED (track.cues[11].startTime != '0') OK
+EXPECTED (track.cues[12].startTime != '0') OK
+EXPECTED (track.cues[13].startTime != '0') OK
+EXPECTED (track.cues[14].startTime != '0') OK
+
+END OF TEST
+

--- a/LayoutTests/http/tests/media/hls/track-in-band-ext-x-date-range-start-time.html
+++ b/LayoutTests/http/tests/media/hls/track-in-band-ext-x-date-range-start-time.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+
+        <script src=../../../media-resources/video-test.js></script>
+        <script src=../../../media-resources/media-file.js></script>
+
+        <script>
+            let cuechangeCount = 0;
+
+            async function start()
+            {
+                failTestIn(10000);
+
+                findMediaElement();
+
+                waitForAndFail(video, 'error')
+                run('video.src = "http://127.0.0.1:8000/media/resources/hls/dynamic-ext-date-range.py"');
+
+                await waitFor(video.textTracks, 'addtrack')
+                run('track = video.textTracks[0]');
+                run('track.mode = "hidden"');
+
+                await waitFor(video, 'playing');
+
+                await waitFor(track, 'cuechange');
+                while (track.cues.length < 14)
+                    await sleepFor(.1);
+
+                consoleWrite('');
+                testExpected(`track.cues[0].startTime`, 0, '==');
+                for (let i = 1; i < track.cues.length; i++)
+                    testExpected(`track.cues[${i}].startTime`, 0, '!=');
+
+                video.pause();
+                consoleWrite('');
+                endTest();
+            }
+        </script>
+    </head>
+    <body onload='start()'>
+        <video controls muted autoplay></video>
+        <p>Test that #EXT-X-DATERANGE metadata cues have valid start time.</p>
+    </body>
+</html>

--- a/LayoutTests/http/tests/media/resources/hls/dynamic-ext-date-range.py
+++ b/LayoutTests/http/tests/media/resources/hls/dynamic-ext-date-range.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+# See the HLS ITEF spec: <http://tools.ietf.org/id/draft-pantos-http-live-streaming-12.txt>
+
+import os
+import sys
+from datetime import datetime
+from datetime import timedelta
+from urllib.parse import parse_qs
+
+sys.stdout.write(
+    'status: 200\r\n'
+    'Connection: close\r\n'
+    'Last-Modified: {modified} GMT\r\n'
+    'Pragma: no-cache\r\n'
+    'Etag: "{size}-{mtime}"\r\n'
+    'Content-Type: application/x-mpegurl\r\n\r\n'.format(modified=datetime.utcnow().strftime('%a, %d %b %Y %H:%M:%S'), size=os.path.getsize(__file__), mtime=os.stat(__file__).st_mtime)
+)
+
+chunk_duration = 6.0272
+chunk_count = 5
+chunk_time = datetime.utcnow()
+
+sys.stdout.write(
+    '#EXTM3U\n'
+    '#EXT-X-PLAYLIST-TYPE:EVENT\n'
+    '#EXT-X-VERSION:3\n'
+    '#EXT-X-MEDIA-SEQUENCE:0\n'
+    '#EXT-X-TARGETDURATION:8\n'
+    '#EXT-X-PROGRAM-DATE-TIME:{}\n'
+    .format(chunk_time.strftime('%Y-%m-%dT%H:%M:%S.%fZ'))
+)
+
+for chunk in range(0, chunk_count):
+    sys.stdout.write(
+        '#EXTINF:{},\n'
+        '#EXT-X-DATERANGE:ID="cue.1.{}",START-DATE="{}",DURATION=5.000000,X-TEST-DATA="data.1.{}"\n'
+        '#EXT-X-DATERANGE:ID="cue.2.{}",START-DATE="{}",DURATION=5.000000,X-TEST-DATA="data.2.{}"\n'
+        '#EXT-X-DATERANGE:ID="cue.3.{}",START-DATE="{}",DURATION=5.000000,X-TEST-DATA="data.3.{}"\n'
+        'test.ts\n'
+        .format(chunk_duration,
+                chunk, chunk_time.strftime('%Y-%m-%dT%H:%M:%S.%fZ'), chunk,
+                chunk, (chunk_time + timedelta(seconds=2)).strftime('%Y-%m-%dT%H:%M:%S.%fZ'), chunk,
+                chunk, (chunk_time + timedelta(seconds=3)).strftime('%Y-%m-%dT%H:%M:%S.%fZ'), chunk)
+    )
+    chunk_time += timedelta(seconds=5)
+
+sys.stdout.write('#EXT-X-ENDLIST\n')

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -7826,7 +7826,11 @@ const std::optional<Vector<FourCC>>& HTMLMediaElement::allowedMediaCaptionFormat
 
 void HTMLMediaElement::mediaPlayerBufferedTimeRangesChanged()
 {
-    if (!m_textTracks || m_bufferedTimeRangesChangedTaskCancellationGroup.hasPendingTask())
+    if (!m_textTracks || m_readyState < HAVE_ENOUGH_DATA || m_bufferedTimeRangesChangedTaskCancellationGroup.hasPendingTask())
+        return;
+
+    auto duration = durationMediaTime();
+    if (!duration.isValid() || duration.toDouble() < 60.)
         return;
 
     auto logSiteIdentifier = LOGIDENTIFIER;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -3588,7 +3588,7 @@ void MediaPlayerPrivateAVFoundationObjC::metadataGroupDidArrive(const RetainPtr<
         // is zero assume the metadata items start at the beginning of the stream.
         double groupStartTime = 0;
         if (auto currentDate = m_avPlayerItem.get().currentDate.timeIntervalSince1970)
-            groupStartTime = groupStartDate - currentDate - currentTime.toDouble();
+            groupStartTime = groupStartDate - (currentDate - currentTime.toDouble());
 
         auto groupCopy = adoptNS([[NSMutableArray alloc] init]);
         for (AVMetadataItem *item in group.items) {


### PR DESCRIPTION
#### b63b9425c88b7c4bc0af59caf9b3241d002842a9
<pre>
[Cocoa] startTime of dynamically added EXT-X-DATERANGE metadata cues is always 0
<a href="https://bugs.webkit.org/show_bug.cgi?id=251541">https://bugs.webkit.org/show_bug.cgi?id=251541</a>
rdar://104142471

Reviewed by Jer Noble.

The start time of a metadata group was calculated incorrectly.

* LayoutTests/http/tests/media/hls/track-in-band-ext-x-date-range-start-time-expected.txt: Added.
* LayoutTests/http/tests/media/hls/track-in-band-ext-x-date-range-start-time.html: Added.
* LayoutTests/http/tests/media/resources/hls/dynamic-ext-date-range.py: Added.

* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::metadataGroupDidArrive): Correct `startTime`
calculation.

Canonical link: <a href="https://commits.webkit.org/259924@main">https://commits.webkit.org/259924@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bce4212d1c405eec43cb7c490b83fcca47b83b05

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106115 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15168 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38943 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115299 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175376 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110020 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16658 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6396 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98324 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114996 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111871 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12674 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95600 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40173 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94547 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27243 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81852 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8419 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28595 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8913 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5191 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14532 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48139 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6858 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10458 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->