### PR TITLE
Web Inspector: Font Panel: Avoid needless refresh of FontStyles

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/FontVariationDetailsSectionRow.js
+++ b/Source/WebInspectorUI/UserInterface/Views/FontVariationDetailsSectionRow.js
@@ -59,6 +59,7 @@ WI.FontVariationDetailsSectionRow = class FontVariationDetailsSectionRow extends
         this._variationMaxValueElement.textContent = this._formatAxisValueAsString(maximumValue);
 
         this._inputRangeElement.addEventListener("input", (event) => {
+            this.value = event.target.value;
             this.dispatchEventToListeners(WI.FontVariationDetailsSectionRow.Event.VariationValueChanged, {tag: event.target.name, value: event.target.value});
         }, {signal: abortSignal});
 


### PR DESCRIPTION
#### 202e031fdd6bde16c53b3817fb7fe229cbcb1884
<pre>
Web Inspector: Font Panel: Avoid needless refresh of FontStyles
<a href="https://bugs.webkit.org/show_bug.cgi?id=250128">https://bugs.webkit.org/show_bug.cgi?id=250128</a>

Reviewed by Patrick Angle.

There are a number of expensive operations in the Fonts sidebar panel done in reaction
to style changes of the inspected node, like computing applicable font properties and their values,
and updating the Fonts panel DOM structure.

These operations must be done whenever styles change from outside the Fonts panel
so it can reflect the latest changes. But they don&apos;t have to be done live.
Throtting the update in reaction to changes from the outside is acceptable.

The slider inputs for editing variation axis values from the Fonts sidebar panel
are a source of high-frequency style changes.
This is necessary so that the inspected page reacts immediately to style changes.
But there&apos;s no need for the Fonts panel to react to style chagnes it originates.
In this scenario it is acceptable to inhibit updates of the Fonts panel and keep state local.

* Source/WebInspectorUI/UserInterface/Views/FontDetailsPanel.js:
(WI.FontDetailsPanel):
(WI.FontDetailsPanel.prototype.refresh):
(WI.FontDetailsPanel.prototype.update):
(WI.FontDetailsPanel.prototype._handleFontVariationValueChanged):
* Source/WebInspectorUI/UserInterface/Views/FontVariationDetailsSectionRow.js:
(WI.FontVariationDetailsSectionRow):

Canonical link: <a href="https://commits.webkit.org/259821@main">https://commits.webkit.org/259821@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7658a77d6c7da02f70c0933bfc80d682e9fc95ea

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106072 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15127 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38903 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115253 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/175347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16553 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6296 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98280 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111825 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95577 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/40142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94468 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27220 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8377 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28572 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8870 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/5119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14490 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48116 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6796 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10414 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->