### PR TITLE
The Interaction regions layer tree should not include perspectives

### DIFF
--- a/LayoutTests/interaction-region/perspective-expected.txt
+++ b/LayoutTests/interaction-region/perspective-expected.txt
@@ -1,0 +1,184 @@
+
+(CALayer tree root
+  (layer bounds [x: 0 y: 0 width: 800 height: 600])
+  (layer position [x: 400 y: 400])
+  (sublayers
+    (
+      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+      (layer position [x: 400 y: 400])
+      (sublayers
+        (
+          (layer bounds [x: 0 y: 0 width: 800 height: 640])
+          (layer anchorPoint [x: 0 y: 0])
+          (sublayers
+            (
+              (layer bounds [x: 0 y: 0 width: 800 height: 640])
+              (layer anchorPoint [x: 0 y: 0])
+              (sublayers
+                (
+                  (layer bounds [x: 0 y: 0 width: 800 height: 640])
+                  (layer position [x: 400 y: 400])
+                  (sublayers
+                    (
+                      (layer bounds [x: 0 y: 0 width: 800 height: 640])
+                      (layer position [x: 400 y: 400])
+                      (sublayers
+                        (
+                          (layer bounds [x: 0 y: 0 width: 800 height: 640])
+                          (layer anchorPoint [x: 0 y: 0])
+                          (sublayers
+                            (
+                              (layer bounds [x: 0 y: 0 width: 800 height: 640])
+                              (layer anchorPoint [x: 0 y: 0])
+                              (sublayers
+                                (
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                  (sublayers
+                                    (
+                                      (layer bounds [x: 0 y: 0 width: 800 height: 512])
+                                      (layer anchorPoint [x: 0 y: 0]))
+                                    (
+                                      (layer bounds [x: 0 y: 0 width: 800 height: 128])
+                                      (layer position [x: 0 y: 0])
+                                      (layer anchorPoint [x: 0 y: 0]))))
+                                (
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                  (layer anchorPoint [x: 0 y: 0])
+                                  (sublayers
+                                    (
+                                      (layer bounds [x: 0 y: 0 width: 800 height: 200.5])
+                                      (layer position [x: 400 y: 400])
+                                      (layer anchorPoint [x: 0.5 y: 0.5])
+                                      (sublayer transform [1.00, 0.00, 0.00, 0.00, 0.00, 1.00, 0.00, 0.00, 0.00, 0.00, 1.00, -0.00, 0.00, 0.00, 0.00, 1.00])
+                                      (sublayers
+                                        (
+                                          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                          (sublayers
+                                            (
+                                              (layer bounds [x: 0 y: 0 width: 200 height: 200.5])
+                                              (layer position [x: 100 y: 100])
+                                              (layer anchorPoint [x: 0.5 y: 0.5])
+                                              (transform [1.00, 0.00, 0.00, 0.00, 0.00, 1.00, 0.00, 0.00, 0.00, 0.00, 1.00, 0.00, 10.00, -10.00, 0.00, 1.00]))))
+                                        (
+                                          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                          (sublayers
+                                            (
+                                              (layer bounds [x: 0 y: 0 width: 200 height: 200.5])
+                                              (layer position [x: 100 y: 100])
+                                              (layer anchorPoint [x: 0.5 y: 0.5])
+                                              (transform [1.00, 0.00, 0.00, 0.00, 0.00, 0.00, 1.00, 0.00, 0.00, -1.00, 0.00, 0.00, 0.00, 0.00, 0.00, 1.00]))))
+                                        (
+                                          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                          (sublayers
+                                            (
+                                              (layer bounds [x: 0 y: 0 width: 200 height: 200.5])
+                                              (layer position [x: 100 y: 100])
+                                              (layer anchorPoint [x: 0.5 y: 0.5])
+                                              (transform [1.00, 0.00, 0.00, 0.00, 0.00, 1.00, 0.00, 0.00, 0.00, 0.00, 1.00, 0.00, 10.00, -20.00, -120.00, 1.00]))))))))))))
+                        (
+                          (layer bounds [x: 0 y: 0 width: 800 height: 640])
+                          (layer position [x: 400 y: 400])
+                          (sublayers
+                            (
+                              (layer bounds [x: 0 y: 0 width: 800 height: 640])
+                              (layer anchorPoint [x: 0 y: 0])
+                              (sublayers
+                                (
+                                  (layer bounds [x: 0 y: 0 width: 800 height: 640])
+                                  (layer anchorPoint [x: 0 y: 0])
+                                  (sublayers
+                                    (
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (sublayers
+                                        (
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 512])
+                                          (layer anchorPoint [x: 0 y: 0]))
+                                        (
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 128])
+                                          (layer position [x: 0 y: 0])
+                                          (layer anchorPoint [x: 0 y: 0]))))
+                                    (
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer anchorPoint [x: 0 y: 0])
+                                      (sublayers
+                                        (
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 200.5])
+                                          (layer position [x: 400 y: 400])
+                                          (layer anchorPoint [x: 0.5 y: 0.5])
+                                          (sublayers
+                                            (
+                                              (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                              (sublayers
+                                                (
+                                                  (layer bounds [x: 0 y: 0 width: 200 height: 200.5])
+                                                  (layer position [x: 100 y: 100])
+                                                  (layer anchorPoint [x: 0.5 y: 0.5])
+                                                  (transform [1.00, 0.00, 0.00, 0.00, 0.00, 1.00, 0.00, 0.00, 0.00, 0.00, 1.00, 0.00, 10.00, -10.00, 0.00, 1.00])
+                                                  (sublayers
+                                                    (
+                                                      (type interaction)
+                                                      (layer bounds [x: 0 y: 0 width: 90 height: 26])
+                                                      (layer position [x: 42 y: 42]))))))
+                                            (
+                                              (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                              (sublayers
+                                                (
+                                                  (layer bounds [x: 0 y: 0 width: 200 height: 200.5])
+                                                  (layer position [x: 100 y: 100])
+                                                  (layer anchorPoint [x: 0.5 y: 0.5])
+                                                  (transform [1.00, 0.00, 0.00, 0.00, 0.00, 0.00, 1.00, 0.00, 0.00, -1.00, 0.00, 0.00, 0.00, 0.00, 0.00, 1.00])
+                                                  (sublayers
+                                                    (
+                                                      (type interaction)
+                                                      (layer bounds [x: 0 y: 0 width: 90 height: 26])
+                                                      (layer position [x: 42 y: 42]))))))
+                                            (
+                                              (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                              (sublayers
+                                                (
+                                                  (layer bounds [x: 0 y: 0 width: 200 height: 200.5])
+                                                  (layer position [x: 100 y: 100])
+                                                  (layer anchorPoint [x: 0.5 y: 0.5])
+                                                  (transform [1.00, 0.00, 0.00, 0.00, 0.00, 1.00, 0.00, 0.00, 0.00, 0.00, 1.00, 0.00, 10.00, -20.00, 0.00, 1.00])
+                                                  (sublayers
+                                                    (
+                                                      (type interaction)
+                                                      (layer bounds [x: 0 y: 0 width: 90 height: 26])
+                                                      (layer position [x: 42 y: 42]))))))))))))))))))))))
+            (
+              (layer bounds [x: 0 y: 0 width: 0 height: 0]))
+            (
+              (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
+        (
+          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+          (layer anchorPoint [x: 0 y: 0]))
+        (
+          (layer bounds [x: 0 y: 0 width: 794 height: 3])
+          (layer position [x: 400 y: 400])
+          (sublayers
+            (
+              (layer bounds [x: 0 y: 0 width: 794 height: 3])
+              (layer position [x: 397 y: 397])
+              (layer zPosition 1000)
+              (sublayers
+                (
+                  (layer bounds [x: 0 y: 0 width: 794 height: 3])
+                  (layer position [x: 397 y: 397]))))
+            (
+              (layer bounds [x: 0 y: 0 width: 794 height: 3])
+              (layer position [x: 397 y: 397]))))
+        (
+          (layer bounds [x: 0 y: 0 width: 3 height: 594])
+          (layer position [x: 795.5 y: 795.5])
+          (sublayers
+            (
+              (layer bounds [x: 0 y: 0 width: 3 height: 594])
+              (layer position [x: 1.5 y: 1.5])
+              (layer zPosition 1000)
+              (sublayers
+                (
+                  (layer bounds [x: 0 y: 0 width: 3 height: 594])
+                  (layer position [x: 1.5 y: 1.5]))))
+            (
+              (layer bounds [x: 0 y: 0 width: 3 height: 594])
+              (layer position [x: 1.5 y: 1.5]))))))))

--- a/LayoutTests/interaction-region/perspective.html
+++ b/LayoutTests/interaction-region/perspective.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<style>
+    body {
+        margin: 0;
+        perspective: 400px;
+    }
+    section {
+        width: 200px;
+        height: 200px;
+    }
+
+</style>
+<script src="../resources/ui-helper.js"></script>
+<body>
+<section id="test">
+    <section style="transform: translate3d(10px, -10px, 0)">
+        <h2>2D Transform</h2>
+        <a href="#">This is a link</a>
+    </section>
+
+    <section style="transform: rotateX(90deg); will-change: transform">
+        <h2>Rotate layer</h2>
+        <a href="#">This is a link</a>
+    </section>
+
+    <section style="transform: translate3d(10px, -20px, -120px);">
+        <h2>3D Transform</h2>
+        <a href="#">This is a link</a>
+    </section>
+</div>
+
+</section>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+window.onload = async function () {
+    if (!window.internals)
+        return;
+
+    await UIHelper.ensureStablePresentationUpdate();
+    results.textContent = await UIHelper.getCALayerTree();
+    document.getElementById('test').remove();
+
+    testRunner.notifyDone();
+};
+</script>
+</body>
+</html>
+

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -92,6 +92,10 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
         return makeString("[x: ", point.x, " y: ", point.x, "]");
     };
 
+    auto transformToArray = [] (auto t) {
+        return std::array<double, 16> { t.m11, t.m12, t.m13, t.m14, t.m21, t.m22, t.m23, t.m24, t.m31, t.m32, t.m33, t.m34, t.m41, t.m42, t.m43, t.m44 };
+    };
+
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
     if ([layer valueForKey:@"WKInteractionRegion"])
         ts.dumpProperty("type", "interaction");
@@ -112,6 +116,11 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 
     if (layer.anchorPointZ)
         ts.dumpProperty("layer anchorPointZ", makeString(layer.anchorPointZ));
+
+    if (!CATransform3DIsIdentity(layer.transform))
+        ts.dumpProperty("transform", transformToArray(layer.transform));
+    if (!CATransform3DIsIdentity(layer.sublayerTransform))
+        ts.dumpProperty("sublayer transform", transformToArray(layer.sublayerTransform));
 
     if (traverse && layer.sublayers.count > 0) {
         TextStream::GroupScope scope(ts);


### PR DESCRIPTION
#### 686048b6ddb5b019ba0a47bd8c38d6bf82b77bed
<pre>
The Interaction regions layer tree should not include perspectives
<a href="https://bugs.webkit.org/show_bug.cgi?id=251543">https://bugs.webkit.org/show_bug.cgi?id=251543</a>
&lt;rdar://104378717&gt;

Reviewed by NOBODY (OOPS!).

When updating the interaction regions layer tree we ignore sublayer
transforms (only used for perspective), and only apply the 2D part of
transforms.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::applyGeometryPropertiesToLayer):
Add a FlattenPerspectiveTransforms parameters.
(WebKit::RemoteLayerTreePropertyApplier::applyPropertiesToLayer):
(WebKit::RemoteLayerTreePropertyApplier::applyProperties):
Skip sublayer transforms for Interaction Regions layers.
Extract the CGAffineTransform part of the transform for Interaction
Regions layers.

* LayoutTests/interaction-region/perspective-expected.txt: Added.
* LayoutTests/interaction-region/perspective.html: Added.
Add a new test with content using perspectives.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(dumpCALayer):
Add transform and sublayer transform to the dump format.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/686048b6ddb5b019ba0a47bd8c38d6bf82b77bed

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105739 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14826 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38605 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114956 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175092 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16233 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6023 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97992 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114754 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111491 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12346 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95323 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39819 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94210 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26965 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81541 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8091 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28317 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8584 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4910 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14206 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47864 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10138 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->