### PR TITLE
Use 'mature' instead of 'shipping' to represent stable features

### DIFF
--- a/Source/WTF/Scripts/GeneratePreferences.rb
+++ b/Source/WTF/Scripts/GeneratePreferences.rb
@@ -239,7 +239,7 @@ class Preferences
   end
 
   # Corresponds to WebFeatureStatus enum cases. "developer" and up require human-readable names.
-  STATUSES = %w{ embedder unstable internal developer testable preview stable shipping }
+  STATUSES = %w{ embedder unstable internal developer testable preview stable mature }
 
   def initializeParsedPreferences(parsedPreferences)
     result = []

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -39,7 +39,7 @@
 #   debugging, A/B testing.
 #   ON by default. Some platforms may deviate from default behavior due to
 #   support or needed dependencies.
-# shipping::
+# mature::
 #   Already in general use, with no UI to toggle. Features in this status may be
 #   cleaned up and removed altogether.
 #   ON by default. Some platforms may deviate from default behavior due to
@@ -57,7 +57,7 @@
 # == Embedder Controls ==
 # embedder::
 #   Adjusts WebKit behavior for embedding application needs. Not part of a
-#   web platform feature or a "shipping" feature intended to be always-on.
+#   web platform feature or a "mature" feature intended to be always-on.
 #   ANY default value.
 #
 # == Defaults Overridable ==
@@ -695,7 +695,7 @@ BackspaceKeyNavigationEnabled:
 # FIXME: This is on by default in WebKit2. Perhaps we should consider turning it on for WebKitLegacy as well.
 BeaconAPIEnabled:
   type: bool
-  status: shipping
+  status: mature
   humanReadableName: "Beacon API"
   humanReadableDescription: "Beacon API"
   defaultValue:
@@ -2017,7 +2017,7 @@ EditableLinkBehavior:
 
 EmbedElementEnabled:
   type: bool
-  status: shipping
+  status: mature
   humanReadableName: "Embed Element"
   humanReadableDescription: "Embed Element"
   defaultValue:
@@ -2509,7 +2509,7 @@ GraphicsContextFiltersEnabled:
 
 HTTPEquivEnabled:
   type: bool
-  status: shipping
+  status: mature
   humanReadableName: "http-equiv"
   humanReadableDescription: "Enable http-equiv attribute"
   webcoreName: httpEquivEnabled
@@ -3197,7 +3197,7 @@ JavaScriptCanOpenWindowsAutomatically:
 
 JavaScriptEnabled:
   type: bool
-  status: shipping
+  status: mature
   humanReadableName: "JavaScript"
   humanReadableDescription: "Enable JavaScript"
   inspectorOverride: true
@@ -3518,7 +3518,7 @@ LocalFileContentSniffingEnabled:
 
 LocalStorageEnabled:
   type: bool
-  status: shipping
+  status: mature
   humanReadableName: "Local Storage"
   humanReadableDescription: "Enable Local Storage"
   webKitLegacyPreferenceKey: WebKitLocalStorageEnabledPreferenceKey
@@ -6663,7 +6663,7 @@ WebGLDraftExtensionsEnabled:
 
 WebGLEnabled:
   type: bool
-  status: shipping
+  status: mature
   humanReadableName: "WebGL"
   humanReadableDescription: "Enable WebGL"
   defaultValue:

--- a/Source/WebCore/Scripts/GenerateSettings.rb
+++ b/Source/WebCore/Scripts/GenerateSettings.rb
@@ -179,7 +179,7 @@ class Setting
     # settings that are on by default. Assuming embedder gets split into two
     # categories (off-by-default and on-by-default), only the latter should be
     # considered stable.
-    !@status or %w{ embedder internal stable shipping }.include? @status
+    !@status or %w{ embedder internal stable mature }.include? @status
   end
 end
 

--- a/Source/WebKit/UIProcess/API/APIFeatureStatus.h
+++ b/Source/WebKit/UIProcess/API/APIFeatureStatus.h
@@ -42,6 +42,6 @@ enum class FeatureStatus : uint8_t {
     // Enabled by default and ready for general use.
     Stable,
     // Enabled by default and in general use for more than a year.
-    Shipping
+    Mature
 };
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKFeature.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKFeature.mm
@@ -69,8 +69,8 @@
         return WebFeatureStatusPreview;
     case API::FeatureStatus::Stable:
         return WebFeatureStatusStable;
-    case API::FeatureStatus::Shipping:
-        return WebFeatureStatusShipping;
+    case API::FeatureStatus::Mature:
+        return WebFeatureStatusMature;
     default:
         ASSERT_NOT_REACHED();
     }

--- a/Source/WebKitLegacy/mac/WebView/WebFeature.h
+++ b/Source/WebKitLegacy/mac/WebView/WebFeature.h
@@ -47,7 +47,7 @@ typedef NS_ENUM(NSUInteger, WebFeatureStatus) {
     /// Enabled by default and ready for general use.
     WebFeatureStatusStable,
     /// Enabled by default and in general use for more than a year.
-    WebFeatureStatusShipping
+    WebFeatureStatusMature
 };
 
 @interface WebFeature : NSObject


### PR DESCRIPTION
#### c4c0ad0db413cf856ad127a189abec360db15694
<pre>
Use &apos;mature&apos; instead of &apos;shipping&apos; to represent stable features
<a href="https://bugs.webkit.org/show_bug.cgi?id=251545">https://bugs.webkit.org/show_bug.cgi?id=251545</a>
&lt;rdar://problem/104929045&gt;

Reviewed by Chris Dumez and Elliott Williams.

Replace &apos;shipping&apos; with &apos;mature&apos; in various feature-flag places.

* Source/WTF/Scripts/GeneratePreferences.rb:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Scripts/GenerateSettings.rb:
* Source/WebKit/UIProcess/API/APIFeatureStatus.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKFeature.mm:
(-[_WKFeature status]):
* Source/WebKitLegacy/mac/WebView/WebFeature.h:

Canonical link: <a href="https://commits.webkit.org/259755@main">https://commits.webkit.org/259755@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f2655a53bcfa744d1d16195d1dd343660f8ae98

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105738 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14825 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38604 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114955 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175091 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109640 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16232 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6022 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97991 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114753 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111490 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12361 "Found 1 new test failure: fast/dynamic/create-renderer-for-whitespace-only-text.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95325 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39817 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94216 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26967 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81539 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/95452 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8090 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28319 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/93636 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/5877 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8583 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4908 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30433 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14205 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47866 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/102350 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6746 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10137 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25520 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->