### PR TITLE
Further adjust some heuristics in Document::urlForBindings()

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3554,18 +3554,14 @@ const URL& Document::urlForBindings() const
             return false;
 
         auto* topDocumentLoader = topDocument().loader();
-        if (!topDocumentLoader || !topDocumentLoader->networkConnectionIntegrityPolicy().contains(WebCore::NetworkConnectionIntegrity::Enabled))
+        if (!topDocumentLoader || !topDocumentLoader->networkConnectionIntegrityPolicy().contains(NetworkConnectionIntegrity::Enabled))
             return false;
 
         auto preNavigationURL = loader()->originalRequest().httpReferrer();
         if (preNavigationURL.isEmpty() || RegistrableDomain { URL { preNavigationURL } }.matches(securityOrigin().data()))
             return false;
 
-        auto sourceURL = frame()->script().sourceURL();
-        if (sourceURL && RegistrableDomain { *sourceURL }.matches(securityOrigin().data()))
-            return false;
-
-        return m_hasLoadedThirdPartyScript;
+        return mayBeExecutingThirdPartyScript();
     }();
 
     if (shouldAdjustURL)
@@ -6102,6 +6098,15 @@ void Document::popCurrentScript()
 {
     ASSERT(!m_currentScriptStack.isEmpty());
     m_currentScriptStack.removeLast();
+}
+
+bool Document::mayBeExecutingThirdPartyScript() const
+{
+    if (!m_hasLoadedThirdPartyScript)
+        return false;
+
+    auto sourceURL = currentSourceURL();
+    return sourceURL.isEmpty() || !RegistrableDomain { sourceURL }.matches(securityOrigin().data());
 }
 
 bool Document::shouldDeferAsynchronousScriptsUntilParsingFinishes() const

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1111,6 +1111,8 @@ public:
     void pushCurrentScript(Element*);
     void popCurrentScript();
 
+    bool mayBeExecutingThirdPartyScript() const;
+
     bool shouldDeferAsynchronousScriptsUntilParsingFinishes() const;
 
     bool supportsPaintTiming() const;

--- a/Source/WebCore/dom/ScriptExecutionContext.cpp
+++ b/Source/WebCore/dom/ScriptExecutionContext.cpp
@@ -71,12 +71,15 @@
 #include "WorkerOrWorkletThread.h"
 #include "WorkerThread.h"
 #include "WorkletGlobalScope.h"
+#include <JavaScriptCore/CallFrame.h>
 #include <JavaScriptCore/CatchScope.h>
 #include <JavaScriptCore/DeferredWorkTimer.h>
 #include <JavaScriptCore/Exception.h>
 #include <JavaScriptCore/JSPromise.h>
 #include <JavaScriptCore/ScriptCallStack.h>
+#include <JavaScriptCore/StackVisitor.h>
 #include <JavaScriptCore/StrongInlines.h>
+#include <JavaScriptCore/VM.h>
 #include <wtf/Lock.h>
 #include <wtf/MainThread.h>
 #include <wtf/Ref.h>
@@ -299,6 +302,35 @@ JSC::ScriptExecutionStatus ScriptExecutionContext::jscScriptExecutionStatus() co
     if (activeDOMObjectsAreStopped())
         return JSC::ScriptExecutionStatus::Stopped;
     return JSC::ScriptExecutionStatus::Running;
+}
+
+URL ScriptExecutionContext::currentSourceURL() const
+{
+    auto* globalObject = this->globalObject();
+    if (!globalObject)
+        return { };
+
+    auto& vm = globalObject->vm();
+    auto* topCallFrame = vm.topCallFrame;
+    if (!topCallFrame)
+        return { };
+
+    URL sourceURL;
+    StackVisitor::visit(topCallFrame, vm, [&sourceURL](auto& visitor) {
+        if (visitor->isNativeFrame())
+            return IterationStatus::Continue;
+
+        auto urlString = visitor->sourceURL();
+        if (urlString.isEmpty())
+            return IterationStatus::Continue;
+
+        sourceURL = URL { WTFMove(urlString) };
+        if (sourceURL.isValid())
+            return IterationStatus::Continue;
+
+        return IterationStatus::Done;
+    });
+    return sourceURL;
 }
 
 void ScriptExecutionContext::suspendActiveDOMObjects(ReasonForSuspension why)
@@ -585,7 +617,7 @@ bool ScriptExecutionContext::hasPendingActivity() const
     return false;
 }
 
-JSC::JSGlobalObject* ScriptExecutionContext::globalObject()
+JSC::JSGlobalObject* ScriptExecutionContext::globalObject() const
 {
     if (is<Document>(*this)) {
         auto frame = downcast<Document>(*this).frame();

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -42,6 +42,7 @@
 #include <wtf/Function.h>
 #include <wtf/HashSet.h>
 #include <wtf/ObjectIdentifier.h>
+#include <wtf/URL.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
@@ -156,6 +157,8 @@ public:
     bool activeDOMObjectsAreStopped() const { return m_activeDOMObjectsAreStopped; }
 
     JSC::ScriptExecutionStatus jscScriptExecutionStatus() const;
+
+    URL currentSourceURL() const;
 
     // Called from the constructor and destructors of ActiveDOMObject.
     void didCreateActiveDOMObject(ActiveDOMObject&);
@@ -273,7 +276,7 @@ public:
         return ensureRejectedPromiseTrackerSlow();
     }
 
-    WEBCORE_EXPORT JSC::JSGlobalObject* globalObject();
+    WEBCORE_EXPORT JSC::JSGlobalObject* globalObject() const;
 
     WEBCORE_EXPORT String domainForCachePartition() const;
     void setDomainForCachePartition(String&& domain) { m_domainForCachePartition = WTFMove(domain); }


### PR DESCRIPTION
#### 6c619520fb59603d2777e10a999cdf87d75343f1
<pre>
Further adjust some heuristics in Document::urlForBindings()
<a href="https://bugs.webkit.org/show_bug.cgi?id=251549">https://bugs.webkit.org/show_bug.cgi?id=251549</a>
Speculative fix for rdar://104792427

Reviewed by Chris Dumez.

Adjust some of the heuristics for determining whether to use the `adjustedURL` or not, inside
`Document::urlForBindings()`.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::urlForBindings const):
(WebCore::Document::mayBeExecutingThirdPartyScript const):

Add a new helper method on `Document` to return whether or not we *might* be executing third party
script, by checking the registrable domain of the `currentSourceURL()`. Deploy this in
`urlForBindings()` above in place of the current `ScriptController::sourceURL()` check, which is
currently only populated when a script is initially evaluated.

* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/ScriptExecutionContext.cpp:
(WebCore::ScriptExecutionContext::currentSourceURL const):

Add a helper method to grab the immediate source URL (first non-empty source URL) by walking call
frames, starting from the VM&apos;s top call frame.

(WebCore::ScriptExecutionContext::globalObject const):
(WebCore::ScriptExecutionContext::globalObject): Deleted.

Mark this method `const` so that we can use it from `currentSourceURL()`, and subsequently,
`Document::urlForBindings`.

* Source/WebCore/dom/ScriptExecutionContext.h:

Canonical link: <a href="https://commits.webkit.org/259760@main">https://commits.webkit.org/259760@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b130d9cefdecefd545bf1224f15959bd1da8f1c4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105793 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14862 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38642 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114992 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175122 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109696 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16281 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6061 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98025 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114781 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111545 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12387 "Found 1 new test failure: fast/dynamic/create-renderer-for-whitespace-only-text.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95356 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39841 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94251 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26997 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8133 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28349 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8616 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4936 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14242 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47896 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6751 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10172 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->