### PR TITLE
Importing an exported v128 global should be possible

### DIFF
--- a/JSTests/wasm/stress/simd-import-global-2.js
+++ b/JSTests/wasm/stress/simd-import-global-2.js
@@ -1,0 +1,64 @@
+//@ requireOptions("--useWebAssemblySIMD=1")
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+async function test() {
+    assert.throws(() => new WebAssembly.Global({ value: "v128" }), TypeError, "WebAssembly.Global expects its 'value' field to be the string 'i32', 'i64', 'f32', 'f64', 'anyfunc', 'funcref', or 'externref'")
+    const exportV128 = await instantiate(`
+    (module
+        (global (;0;) v128 v128.const i32x4 0x00000000 0x00000000 0x00000000 0x00000000)
+        (export "global" (global 0))
+    )`, { }, { simd: true })
+
+    if (typeof WebAssembly.Global.prototype.type !== 'undefined')
+        assert.eq(exportV128.exports.global.type().value, "v128")
+    assert.throws(() => exportV128.exports.global.value, WebAssembly.RuntimeError, "Cannot get value of v128 global (evaluating 'exportV128.exports.global.value')")
+
+    await instantiate(`
+    (module
+        (import "x" "v128" (global v128))
+    )`, { x: { v128: exportV128.exports.global } }, { simd: true })
+
+    const exportMutV128 = await instantiate(`
+    (module
+        (global (;0;) (mut v128) v128.const i32x4 0x00000000 0x00000000 0x00000000 0x00000000)
+        (export "global" (global 0))
+    )`, { }, { simd: true })
+    await instantiate(`
+    (module
+        (import "x" "v128" (global (mut v128)))
+    )`, { x: { v128: exportMutV128.exports.global } }, { simd: true })
+
+    await assert.throwsAsync(instantiate(`
+    (module
+        (import "x" "v128" (global (mut v128)))
+    )`, { x: { v128: exportV128.exports.global } }, { simd: true }), WebAssembly.LinkError, "imported global x:v128 must be a same mutability (evaluating 'new WebAssembly.Instance(module, imports)')")
+
+    await assert.throwsAsync(instantiate(`
+    (module
+        (import "x" "v128" (global i64))
+    )`, { x: { v128: exportV128.exports.global } }, { simd: true }), WebAssembly.LinkError, "imported global x:v128 must be a same type (evaluating 'new WebAssembly.Instance(module, imports)')")
+
+    const exportI64 = await instantiate(`
+    (module
+        (global i64 i64.const 0)
+        (export "global" (global 0))
+    )`, { }, { simd: true })
+    await assert.throwsAsync(instantiate(`
+    (module
+        (import "x" "v128" (global v128))
+    )`, { x: { v128: exportI64.exports.global } }, { simd: true }), WebAssembly.LinkError, "imported global x:v128 must be a same type (evaluating 'new WebAssembly.Instance(module, imports)')")
+
+    const exportI64Mut = await instantiate(`
+    (module
+        (global i64 i64.const 0)
+        (export "global" (global 0))
+    )`, { }, { simd: true })
+    await assert.throwsAsync(instantiate(`
+    (module
+        (import "x" "v128" (global (mut v128)))
+    )`, { x: { v128: exportI64Mut.exports.global } }, { simd: true }), WebAssembly.LinkError, "imported global x:v128 must be a same type (evaluating 'new WebAssembly.Instance(module, imports)')")
+}
+
+assert.asyncTest(test())

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -4684,7 +4684,9 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
             setNonCellTypeForNode(node, SpecBytecodeDouble);
             break;
         }
+        case Wasm::TypeKind::V128:
         default: {
+            RELEASE_ASSERT_NOT_REACHED();
             break;
         }
         }

--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -1191,6 +1191,7 @@ private:
                             success = false;
                         break;
                     }
+                    case Wasm::TypeKind::V128:
                     default: {
                         success = false;
                         break;
@@ -1212,6 +1213,7 @@ private:
                     case Wasm::TypeKind::F64: {
                         break;
                     }
+                    case Wasm::TypeKind::V128:
                     default: {
                         success = false;
                         break;
@@ -1274,6 +1276,7 @@ private:
                         m_graph.varArgChild(m_node, 2 + index) = Edge(result, DoubleRepUse);
                         break;
                     }
+                    case Wasm::TypeKind::V128:
                     default:
                         RELEASE_ASSERT_NOT_REACHED();
                     }
@@ -1299,6 +1302,7 @@ private:
                     case Wasm::TypeKind::F64: {
                         break;
                     }
+                    case Wasm::TypeKind::V128:
                     default: {
                         break;
                     }

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -11702,6 +11702,7 @@ IGNORE_CLANG_WARNINGS_END
                 else
                     arguments.append(ConstrainedValue(lowDouble(m_graph.varArgChild(node, 2 + i)), ValueRep::reg(wasmCallInfo.params[i].location.fpr())));
                 break;
+            case Wasm::TypeKind::V128:
             default:
                 RELEASE_ASSERT_NOT_REACHED();
             }
@@ -11761,6 +11762,7 @@ IGNORE_CLANG_WARNINGS_END
                 patchpoint->resultConstraints = { ValueRep::reg(wasmCallInfo.results[0].location.fpr()) };
                 break;
             }
+            case Wasm::TypeKind::V128:
             default:
                 RELEASE_ASSERT_NOT_REACHED();
                 break;
@@ -11848,6 +11850,7 @@ IGNORE_CLANG_WARNINGS_END
                 setJSValue(boxDouble(purifyNaN(patchpoint)));
                 break;
             }
+            case Wasm::TypeKind::V128:
             default:
                 RELEASE_ASSERT_NOT_REACHED();
                 break;

--- a/Source/JavaScriptCore/wasm/WasmGlobal.h
+++ b/Source/JavaScriptCore/wasm/WasmGlobal.h
@@ -68,6 +68,7 @@ public:
     Wasm::Mutability mutability() const { return m_mutability; }
     JSValue get(JSGlobalObject*) const;
     uint64_t getPrimitive() const { return m_value.m_primitive; }
+    v128_t getVector() const { return m_value.m_vector; }
     void set(JSGlobalObject*, JSValue);
     DECLARE_VISIT_AGGREGATE;
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h
@@ -126,6 +126,7 @@ public:
             pointer->set(vm, this, JSValue::decode(value));
             break;
         }
+        case Wasm::TypeKind::V128:
         default:
             RELEASE_ASSERT_NOT_REACHED();
             break;

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyGlobal.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyGlobal.cpp
@@ -105,6 +105,9 @@ JSObject* JSWebAssemblyGlobal::type(JSGlobalObject* globalObject)
     case Wasm::TypeKind::F64:
         valueString = jsNontrivialString(vm, "f64"_s);
         break;
+    case Wasm::TypeKind::V128:
+        valueString = jsNontrivialString(vm, "v128"_s);
+        break;
     default: {
         if (Wasm::isFuncref(valueType))
             valueString = jsNontrivialString(vm, "funcref"_s);

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyHelpers.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyHelpers.h
@@ -181,6 +181,7 @@ ALWAYS_INLINE JSValue toJSValue(JSGlobalObject* globalObject, const Wasm::Type t
     case Wasm::TypeKind::Externref:
     case Wasm::TypeKind::Funcref:
         return bitwise_cast<JSValue>(bits);
+    case Wasm::TypeKind::V128:
     default:
         break;
     }
@@ -201,6 +202,8 @@ ALWAYS_INLINE uint64_t fromJSValue(JSGlobalObject* globalObject, const Wasm::Typ
         RELEASE_AND_RETURN(scope, bitwise_cast<uint32_t>(value.toFloat(globalObject)));
     case Wasm::TypeKind::F64:
         RELEASE_AND_RETURN(scope, bitwise_cast<uint64_t>(value.toNumber(globalObject)));
+    case Wasm::TypeKind::V128:
+        RELEASE_ASSERT_NOT_REACHED();
     default: {
         if (Wasm::isExternref(type)) {
             if (!type.isNullable() && value.isNull())

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
@@ -347,6 +347,7 @@ CodePtr<JSEntryPtrTag> WebAssemblyFunction::jsCallEntrypointSlow()
             }
             break;
         }
+        case Wasm::TypeKind::V128:
         default:
             RELEASE_ASSERT_NOT_REACHED();
         }

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyGlobalConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyGlobalConstructor.cpp
@@ -137,6 +137,9 @@ JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblyGlobal, (JSGlobalObject* globalOb
         }
         break;
     }
+    case Wasm::TypeKind::V128:
+        RELEASE_ASSERT_NOT_REACHED();
+        break;
     default: {
         if (Wasm::isFuncref(type)) {
             if (argument.isUndefined())

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -252,6 +252,9 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
                     case Wasm::TypeKind::F64:
                         m_instance->instance().setGlobal(import.kindIndex, globalValue->global()->getPrimitive());
                         break;
+                    case Wasm::TypeKind::V128:
+                        m_instance->instance().setGlobal(import.kindIndex, globalValue->global()->getVector());
+                        break;
                     default:
                         if (Wasm::isExternref(declaredGlobalType)) {
                             value = globalValue->global()->get(globalObject);


### PR DESCRIPTION
#### 18a076e402b4852d319c7755b34095d1df6d7917
<pre>
Importing an exported v128 global should be possible
<a href="https://bugs.webkit.org/show_bug.cgi?id=251551">https://bugs.webkit.org/show_bug.cgi?id=251551</a>
rdar://104745582

Reviewed by Mark Lam.

We missed a case here, let&apos;s just fix it.

* JSTests/wasm/stress/simd-import-global-2.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.async test):
* Source/JavaScriptCore/wasm/WasmGlobal.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
(JSC::WebAssemblyModuleRecord::initializeImports):

Canonical link: <a href="https://commits.webkit.org/259791@main">https://commits.webkit.org/259791@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88a4e9b068e8774899cdd0bbe42c02f3eab6a64a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105760 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14842 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38622 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114970 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175102 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16251 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6041 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98004 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114764 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111512 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12360 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95338 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39824 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94224 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26980 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81546 "Found 1 new API test failure: /WebKitGTK/TestWebExtensions:/webkit/WebKitWebExtension/page-id (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/95465 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8109 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28332 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/93659 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/5898 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8596 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4921 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30435 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14222 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47879 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/102373 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10152 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25522 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3635 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->