### PR TITLE
[GTK] Update documentation

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp
@@ -215,12 +215,6 @@ void webkitFaviconDatabaseGetFaviconInternal(WebKitFaviconDatabase* database, co
  * This is an asynchronous method. When the operation is finished, callback will
  * be invoked. You can then call webkit_favicon_database_get_favicon_finish()
  * to get the result of the operation.
- *
- * You must call webkit_web_context_set_favicon_database_directory() for
- * the #WebKitWebContext associated with this #WebKitFaviconDatabase
- * before attempting to use this function; otherwise,
- * webkit_favicon_database_get_favicon_finish() will return
- * %WEBKIT_FAVICON_DATABASE_ERROR_NOT_INITIALIZED.
  */
 void webkit_favicon_database_get_favicon(WebKitFaviconDatabase* database, const gchar* pageURI, GCancellable* cancellable, GAsyncReadyCallback callback, gpointer userData)
 {

--- a/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.h.in
@@ -63,7 +63,7 @@ struct _WebKitFaviconDatabaseClass {
 
 /**
  * WebKitFaviconDatabaseError:
- * @WEBKIT_FAVICON_DATABASE_ERROR_NOT_INITIALIZED: The #WebKitFaviconDatabase has not been initialized yet
+ * @WEBKIT_FAVICON_DATABASE_ERROR_NOT_INITIALIZED: The #WebKitFaviconDatabase is closed
  * @WEBKIT_FAVICON_DATABASE_ERROR_FAVICON_NOT_FOUND: There is not an icon available for the requested URL
  * @WEBKIT_FAVICON_DATABASE_ERROR_FAVICON_UNKNOWN: There might be an icon for the requested URL, but its data is unknown at the moment
  *

--- a/Source/WebKit/gtk/migrating-to-webkitgtk-6.0.md
+++ b/Source/WebKit/gtk/migrating-to-webkitgtk-6.0.md
@@ -28,7 +28,12 @@ JavaScriptCore API (e.g. [type@JSC.Context] and [type@JSC.Object]) that is
 available since 2.22. It also includes the entire GObject DOM API (e.g.
 `WebKitDOMDocument`), which has been removed without replacement. Use JavaScript
 to interact with and manipulate the DOM instead, perhaps via
-[method@WebKit.WebView.run_javascript] or [method@JSC.ValueObject.invoke_method].
+[method@WebKit.WebView.evaluate_javascript] or
+[method@WebKit.WebView.call_async_javascript_function] in the UI process, or
+[method@JSC.ValueObject.invoke_method] in the web process.
+
+Run your application with the environment variable `G_ENABLE_DIAGNOSTIC=1` to
+notice use of deprecated signals and properties.
 
 ## Upgrade to GTK 4
 
@@ -75,10 +80,10 @@ accordingly.
 
 ## Changes to WebKitWebView Construction
 
-`webkit_web_view_new_with_context()`, `webkit_web_view_new_with_settings()`, and
-`webkit_web_view_new_with_user_content_manager()` have all been removed. You
-may directly use `g_object_new()` instead. [ctor@WebKit.WebView.new] and
-[ctor@WebKit.WebView.new_with_related_view] both remain.
+`webkit_web_view_new_with_context()`, `webkit_web_view_new_with_settings()`,
+`webkit_web_view_new_with_user_content_manager()`, and
+`webkit_web_view_new_with_related_view()` have all been removed. You
+may directly use `g_object_new()` instead. [ctor@WebKit.WebView.new] remains.
 
 ## Network Session API
 
@@ -88,12 +93,30 @@ APIs have been moved from [type@WebKit.WebContext] and [type@WebKit.WebsiteDataM
 [type@WebKit.NetworkSession]. There's a default global persistent session that you can get with
 [func@WebKit.NetworkSession.get_default]. You can also create new sessions with
 [ctor@WebKit.NetworkSession.new] for persistent sessions and [ctor@WebKit.NetworkSession.new_ephemeral]
-for ephemeral sessions. It's no longer possible to create a [type@WebKit.WebsiteDataManager], it's now
+for ephemeral sessions. It's no longer possible to create a [type@WebKit.WebsiteDataManager]; it's now
 created by the [type@WebKit.NetworkSession] automatically at construction time. The [type@WebKit.NetworkSession]
 to be used must be passed to the [type@WebKit.WebView] as a construct parameter. You can pass the
 same [type@WebKit.NetworkSession] object to several web views to use the same session. The only exception
 is automation mode, which uses its own ephemeral session that is configured by the automation
-session capabilities.
+session capabilities. If you notice that your application uses [type@WebKit.WebContext] or
+[type@WebKit.WebsiteDataManager] APIs that no longer exist, look for replacement APIs
+in [type@WebKit.NetworkSession].
+
+`webkit_web_context_clear_cache()` does not have a direct replacement, but you
+can use [method@WebKit.WebsiteDataManager.clear] to achieve the same effect.
+
+The `WebKitWebContext::download-started` signal has been removed. Use
+[signal@WebKit.NetworkSession::download-started] instead.
+
+## Favicon Database
+
+[type@WebKit.FaviconDatabase] is now owned by [type@WebKit.WebsiteDataManager]
+instead of [type@WebKit.WebContext]. Use
+[method@WebKit.WebsiteDataManager.set_favicons_enabled] to enable the favicon
+database.
+
+There is no replacement for `webkit_web_context_set_favicon_database_directory()`.
+Favicons will be stored in the base cache directory of the website data manager.
 
 ## Hardware Acceleration Policy
 

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitFaviconDatabase.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitFaviconDatabase.cpp
@@ -43,7 +43,7 @@ public:
 #endif
     {
 #if ENABLE(2022_GLIB_API)
-        // In 2022 API when favicons are disdabled, the database is nullptr.
+        // In 2022 API when favicons are disabled, the database is nullptr.
         g_assert_null(m_database.get());
 #else
         g_assert_true(WEBKIT_IS_FAVICON_DATABASE(m_database.get()));


### PR DESCRIPTION
#### a9f86aa9b53889b394c9b31435af884d802fda46
<pre>
[GTK] Update documentation
<a href="https://bugs.webkit.org/show_bug.cgi?id=251519">https://bugs.webkit.org/show_bug.cgi?id=251519</a>

Reviewed by Carlos Garcia Campos.

* Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.h.in:
* Source/WebKit/gtk/migrating-to-webkitgtk-6.0.md:
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitFaviconDatabase.cpp:

Canonical link: <a href="https://commits.webkit.org/259967@main">https://commits.webkit.org/259967@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4902ca42999ba562fd03b7b221d678631fcd3261

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106573 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/15589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/39382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115758 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/115399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110482 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17084 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6817 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98768 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112341 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/39382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/40539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/94859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/39382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/8816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/39382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/9358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/5983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/14977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/39382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6891 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/10897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->