### PR TITLE
[fetch] Implement `Headers.prototype.getSetCookie`.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/headers/header-setcookie.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/headers/header-setcookie.any-expected.txt
@@ -1,0 +1,26 @@
+
+PASS Headers.prototype.get combines set-cookie headers in order
+PASS Headers iterator does not combine set-cookie headers
+PASS Headers iterator does not special case set-cookie2 headers
+PASS Headers iterator does not combine set-cookie & set-cookie2 headers
+PASS Headers iterator preserves set-cookie ordering
+PASS Headers iterator preserves per header ordering, but sorts keys alphabetically
+PASS Headers iterator preserves per header ordering, but sorts keys alphabetically (and ignores value ordering)
+PASS Headers iterator is correctly updated with set-cookie changes
+PASS Headers iterator is correctly updated with set-cookie changes #2
+PASS Headers.prototype.has works for set-cookie
+PASS Headers.prototype.append works for set-cookie
+PASS Headers.prototype.set works for set-cookie
+PASS Headers.prototype.delete works for set-cookie
+PASS Headers.prototype.getSetCookie with no headers present
+PASS Headers.prototype.getSetCookie with one header
+PASS Headers.prototype.getSetCookie with one header created from an object
+PASS Headers.prototype.getSetCookie with multiple headers
+PASS Headers.prototype.getSetCookie with an empty header
+PASS Headers.prototype.getSetCookie with two equal headers
+PASS Headers.prototype.getSetCookie ignores set-cookie2 headers
+PASS Headers.prototype.getSetCookie preserves header ordering
+PASS Adding Set-Cookie headers normalizes their value
+PASS Adding invalid Set-Cookie headers throws
+PASS Set-Cookie is a forbidden response header
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/headers/header-setcookie.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/headers/header-setcookie.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/headers/header-setcookie.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/headers/header-setcookie.any.js
@@ -1,0 +1,266 @@
+// META: title=Headers set-cookie special cases
+// META: global=window,worker
+
+const headerList = [
+  ["set-cookie", "foo=bar"],
+  ["Set-Cookie", "fizz=buzz; domain=example.com"],
+];
+
+const setCookie2HeaderList = [
+  ["set-cookie2", "foo2=bar2"],
+  ["Set-Cookie2", "fizz2=buzz2; domain=example2.com"],
+];
+
+function assert_nested_array_equals(actual, expected) {
+  assert_equals(actual.length, expected.length, "Array length is not equal");
+  for (let i = 0; i < expected.length; i++) {
+    assert_array_equals(actual[i], expected[i]);
+  }
+}
+
+test(function () {
+  const headers = new Headers(headerList);
+  assert_equals(
+    headers.get("set-cookie"),
+    "foo=bar, fizz=buzz; domain=example.com",
+  );
+}, "Headers.prototype.get combines set-cookie headers in order");
+
+test(function () {
+  const headers = new Headers(headerList);
+  const list = [...headers];
+  assert_nested_array_equals(list, [
+    ["set-cookie", "foo=bar"],
+    ["set-cookie", "fizz=buzz; domain=example.com"],
+  ]);
+}, "Headers iterator does not combine set-cookie headers");
+
+test(function () {
+  const headers = new Headers(setCookie2HeaderList);
+  const list = [...headers];
+  assert_nested_array_equals(list, [
+    ["set-cookie2", "foo2=bar2, fizz2=buzz2; domain=example2.com"],
+  ]);
+}, "Headers iterator does not special case set-cookie2 headers");
+
+test(function () {
+  const headers = new Headers([...headerList, ...setCookie2HeaderList]);
+  const list = [...headers];
+  assert_nested_array_equals(list, [
+    ["set-cookie", "foo=bar"],
+    ["set-cookie", "fizz=buzz; domain=example.com"],
+    ["set-cookie2", "foo2=bar2, fizz2=buzz2; domain=example2.com"],
+  ]);
+}, "Headers iterator does not combine set-cookie & set-cookie2 headers");
+
+test(function () {
+  // Values are in non alphabetic order, and the iterator should yield in the
+  // headers in the exact order of the input.
+  const headers = new Headers([
+    ["set-cookie", "z=z"],
+    ["set-cookie", "a=a"],
+    ["set-cookie", "n=n"],
+  ]);
+  const list = [...headers];
+  assert_nested_array_equals(list, [
+    ["set-cookie", "z=z"],
+    ["set-cookie", "a=a"],
+    ["set-cookie", "n=n"],
+  ]);
+}, "Headers iterator preserves set-cookie ordering");
+
+test(
+  function () {
+    const headers = new Headers([
+      ["xylophone-header", "1"],
+      ["best-header", "2"],
+      ["set-cookie", "3"],
+      ["a-cool-header", "4"],
+      ["set-cookie", "5"],
+      ["a-cool-header", "6"],
+      ["best-header", "7"],
+    ]);
+    const list = [...headers];
+    assert_nested_array_equals(list, [
+      ["a-cool-header", "4, 6"],
+      ["best-header", "2, 7"],
+      ["set-cookie", "3"],
+      ["set-cookie", "5"],
+      ["xylophone-header", "1"],
+    ]);
+  },
+  "Headers iterator preserves per header ordering, but sorts keys alphabetically",
+);
+
+test(
+  function () {
+    const headers = new Headers([
+      ["xylophone-header", "7"],
+      ["best-header", "6"],
+      ["set-cookie", "5"],
+      ["a-cool-header", "4"],
+      ["set-cookie", "3"],
+      ["a-cool-header", "2"],
+      ["best-header", "1"],
+    ]);
+    const list = [...headers];
+    assert_nested_array_equals(list, [
+      ["a-cool-header", "4, 2"],
+      ["best-header", "6, 1"],
+      ["set-cookie", "5"],
+      ["set-cookie", "3"],
+      ["xylophone-header", "7"],
+    ]);
+  },
+  "Headers iterator preserves per header ordering, but sorts keys alphabetically (and ignores value ordering)",
+);
+
+test(function () {
+  const headers = new Headers([["fizz", "buzz"], ["X-Header", "test"]]);
+  const iterator = headers[Symbol.iterator]();
+  assert_array_equals(iterator.next().value, ["fizz", "buzz"]);
+  headers.append("Set-Cookie", "a=b");
+  assert_array_equals(iterator.next().value, ["set-cookie", "a=b"]);
+  headers.append("Accept", "text/html");
+  assert_array_equals(iterator.next().value, ["set-cookie", "a=b"]);
+  assert_array_equals(iterator.next().value, ["x-header", "test"]);
+  headers.append("set-cookie", "c=d");
+  assert_array_equals(iterator.next().value, ["x-header", "test"]);
+  assert_true(iterator.next().done);
+}, "Headers iterator is correctly updated with set-cookie changes");
+
+test(function () {
+  const headers = new Headers([
+    ["set-cookie", "a"],
+    ["set-cookie", "b"],
+    ["set-cookie", "c"]
+  ]);
+  const iterator = headers[Symbol.iterator]();
+  assert_array_equals(iterator.next().value, ["set-cookie", "a"]);
+  headers.delete("set-cookie");
+  headers.append("set-cookie", "d");
+  headers.append("set-cookie", "e");
+  headers.append("set-cookie", "f");
+  assert_array_equals(iterator.next().value, ["set-cookie", "e"]);
+  assert_array_equals(iterator.next().value, ["set-cookie", "f"]);
+  assert_true(iterator.next().done);
+}, "Headers iterator is correctly updated with set-cookie changes #2");
+
+test(function () {
+  const headers = new Headers(headerList);
+  assert_true(headers.has("sEt-cOoKiE"));
+}, "Headers.prototype.has works for set-cookie");
+
+test(function () {
+  const headers = new Headers(setCookie2HeaderList);
+  headers.append("set-Cookie", "foo=bar");
+  headers.append("sEt-cOoKiE", "fizz=buzz");
+  const list = [...headers];
+  assert_nested_array_equals(list, [
+    ["set-cookie", "foo=bar"],
+    ["set-cookie", "fizz=buzz"],
+    ["set-cookie2", "foo2=bar2, fizz2=buzz2; domain=example2.com"],
+  ]);
+}, "Headers.prototype.append works for set-cookie");
+
+test(function () {
+  const headers = new Headers(headerList);
+  headers.set("set-cookie", "foo2=bar2");
+  const list = [...headers];
+  assert_nested_array_equals(list, [
+    ["set-cookie", "foo2=bar2"],
+  ]);
+}, "Headers.prototype.set works for set-cookie");
+
+test(function () {
+  const headers = new Headers(headerList);
+  headers.delete("set-Cookie");
+  const list = [...headers];
+  assert_nested_array_equals(list, []);
+}, "Headers.prototype.delete works for set-cookie");
+
+test(function () {
+  const headers = new Headers();
+  assert_array_equals(headers.getSetCookie(), []);
+}, "Headers.prototype.getSetCookie with no headers present");
+
+test(function () {
+  const headers = new Headers([headerList[0]]);
+  assert_array_equals(headers.getSetCookie(), ["foo=bar"]);
+}, "Headers.prototype.getSetCookie with one header");
+
+test(function () {
+  const headers = new Headers({ "Set-Cookie": "foo=bar" });
+  assert_array_equals(headers.getSetCookie(), ["foo=bar"]);
+}, "Headers.prototype.getSetCookie with one header created from an object");
+
+test(function () {
+  const headers = new Headers(headerList);
+  assert_array_equals(headers.getSetCookie(), [
+    "foo=bar",
+    "fizz=buzz; domain=example.com",
+  ]);
+}, "Headers.prototype.getSetCookie with multiple headers");
+
+test(function () {
+  const headers = new Headers([["set-cookie", ""]]);
+  assert_array_equals(headers.getSetCookie(), [""]);
+}, "Headers.prototype.getSetCookie with an empty header");
+
+test(function () {
+  const headers = new Headers([["set-cookie", "x"], ["set-cookie", "x"]]);
+  assert_array_equals(headers.getSetCookie(), ["x", "x"]);
+}, "Headers.prototype.getSetCookie with two equal headers");
+
+test(function () {
+  const headers = new Headers([
+    ["set-cookie2", "x"],
+    ["set-cookie", "y"],
+    ["set-cookie2", "z"],
+  ]);
+  assert_array_equals(headers.getSetCookie(), ["y"]);
+}, "Headers.prototype.getSetCookie ignores set-cookie2 headers");
+
+test(function () {
+  // Values are in non alphabetic order, and the iterator should yield in the
+  // headers in the exact order of the input.
+  const headers = new Headers([
+    ["set-cookie", "z=z"],
+    ["set-cookie", "a=a"],
+    ["set-cookie", "n=n"],
+  ]);
+  assert_array_equals(headers.getSetCookie(), ["z=z", "a=a", "n=n"]);
+}, "Headers.prototype.getSetCookie preserves header ordering");
+
+test(function () {
+  const headers = new Headers({"Set-Cookie": "  a=b\n"});
+  headers.append("set-cookie", "\n\rc=d  ");
+  assert_nested_array_equals([...headers], [
+    ["set-cookie", "a=b"],
+    ["set-cookie", "c=d"]
+  ]);
+  headers.set("set-cookie", "\te=f ");
+  assert_nested_array_equals([...headers], [["set-cookie", "e=f"]]);
+}, "Adding Set-Cookie headers normalizes their value");
+
+test(function () {
+  assert_throws_js(TypeError, () => {
+    new Headers({"set-cookie": "\0"});
+  });
+
+  const headers = new Headers();
+  assert_throws_js(TypeError, () => {
+    headers.append("Set-Cookie", "a\nb");
+  });
+  assert_throws_js(TypeError, () => {
+    headers.set("Set-Cookie", "a\rb");
+  });
+}, "Adding invalid Set-Cookie headers throws");
+
+test(function () {
+  const response = new Response();
+  response.headers.append("Set-Cookie", "foo=bar");
+  assert_array_equals(response.headers.getSetCookie(), []);
+  response.headers.append("sEt-cOokIe", "bar=baz");
+  assert_array_equals(response.headers.getSetCookie(), []);
+}, "Set-Cookie is a forbidden response header");

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/headers/header-setcookie.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/headers/header-setcookie.any.serviceworker-expected.txt
@@ -1,0 +1,26 @@
+
+PASS Headers.prototype.get combines set-cookie headers in order
+PASS Headers iterator does not combine set-cookie headers
+PASS Headers iterator does not special case set-cookie2 headers
+PASS Headers iterator does not combine set-cookie & set-cookie2 headers
+PASS Headers iterator preserves set-cookie ordering
+PASS Headers iterator preserves per header ordering, but sorts keys alphabetically
+PASS Headers iterator preserves per header ordering, but sorts keys alphabetically (and ignores value ordering)
+PASS Headers iterator is correctly updated with set-cookie changes
+PASS Headers iterator is correctly updated with set-cookie changes #2
+PASS Headers.prototype.has works for set-cookie
+PASS Headers.prototype.append works for set-cookie
+PASS Headers.prototype.set works for set-cookie
+PASS Headers.prototype.delete works for set-cookie
+PASS Headers.prototype.getSetCookie with no headers present
+PASS Headers.prototype.getSetCookie with one header
+PASS Headers.prototype.getSetCookie with one header created from an object
+PASS Headers.prototype.getSetCookie with multiple headers
+PASS Headers.prototype.getSetCookie with an empty header
+PASS Headers.prototype.getSetCookie with two equal headers
+PASS Headers.prototype.getSetCookie ignores set-cookie2 headers
+PASS Headers.prototype.getSetCookie preserves header ordering
+PASS Adding Set-Cookie headers normalizes their value
+PASS Adding invalid Set-Cookie headers throws
+PASS Set-Cookie is a forbidden response header
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/headers/header-setcookie.any.serviceworker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/headers/header-setcookie.any.serviceworker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/headers/header-setcookie.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/headers/header-setcookie.any.sharedworker-expected.txt
@@ -1,0 +1,26 @@
+
+PASS Headers.prototype.get combines set-cookie headers in order
+PASS Headers iterator does not combine set-cookie headers
+PASS Headers iterator does not special case set-cookie2 headers
+PASS Headers iterator does not combine set-cookie & set-cookie2 headers
+PASS Headers iterator preserves set-cookie ordering
+PASS Headers iterator preserves per header ordering, but sorts keys alphabetically
+PASS Headers iterator preserves per header ordering, but sorts keys alphabetically (and ignores value ordering)
+PASS Headers iterator is correctly updated with set-cookie changes
+PASS Headers iterator is correctly updated with set-cookie changes #2
+PASS Headers.prototype.has works for set-cookie
+PASS Headers.prototype.append works for set-cookie
+PASS Headers.prototype.set works for set-cookie
+PASS Headers.prototype.delete works for set-cookie
+PASS Headers.prototype.getSetCookie with no headers present
+PASS Headers.prototype.getSetCookie with one header
+PASS Headers.prototype.getSetCookie with one header created from an object
+PASS Headers.prototype.getSetCookie with multiple headers
+PASS Headers.prototype.getSetCookie with an empty header
+PASS Headers.prototype.getSetCookie with two equal headers
+PASS Headers.prototype.getSetCookie ignores set-cookie2 headers
+PASS Headers.prototype.getSetCookie preserves header ordering
+PASS Adding Set-Cookie headers normalizes their value
+PASS Adding invalid Set-Cookie headers throws
+PASS Set-Cookie is a forbidden response header
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/headers/header-setcookie.any.sharedworker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/headers/header-setcookie.any.sharedworker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/headers/header-setcookie.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/headers/header-setcookie.any.worker-expected.txt
@@ -1,0 +1,26 @@
+
+PASS Headers.prototype.get combines set-cookie headers in order
+PASS Headers iterator does not combine set-cookie headers
+PASS Headers iterator does not special case set-cookie2 headers
+PASS Headers iterator does not combine set-cookie & set-cookie2 headers
+PASS Headers iterator preserves set-cookie ordering
+PASS Headers iterator preserves per header ordering, but sorts keys alphabetically
+PASS Headers iterator preserves per header ordering, but sorts keys alphabetically (and ignores value ordering)
+PASS Headers iterator is correctly updated with set-cookie changes
+PASS Headers iterator is correctly updated with set-cookie changes #2
+PASS Headers.prototype.has works for set-cookie
+PASS Headers.prototype.append works for set-cookie
+PASS Headers.prototype.set works for set-cookie
+PASS Headers.prototype.delete works for set-cookie
+PASS Headers.prototype.getSetCookie with no headers present
+PASS Headers.prototype.getSetCookie with one header
+PASS Headers.prototype.getSetCookie with one header created from an object
+PASS Headers.prototype.getSetCookie with multiple headers
+PASS Headers.prototype.getSetCookie with an empty header
+PASS Headers.prototype.getSetCookie with two equal headers
+PASS Headers.prototype.getSetCookie ignores set-cookie2 headers
+PASS Headers.prototype.getSetCookie preserves header ordering
+PASS Adding Set-Cookie headers normalizes their value
+PASS Adding invalid Set-Cookie headers throws
+PASS Set-Cookie is a forbidden response header
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/headers/header-setcookie.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/headers/header-setcookie.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/headers/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/headers/w3c-import.log
@@ -14,6 +14,7 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/fetch/api/headers/header-setcookie.any.js
 /LayoutTests/imported/w3c/web-platform-tests/fetch/api/headers/header-values-normalize.any.js
 /LayoutTests/imported/w3c/web-platform-tests/fetch/api/headers/header-values.any.js
 /LayoutTests/imported/w3c/web-platform-tests/fetch/api/headers/headers-basic.any.js

--- a/Source/WebCore/Modules/fetch/FetchHeaders.idl
+++ b/Source/WebCore/Modules/fetch/FetchHeaders.idl
@@ -37,6 +37,7 @@ typedef (sequence<sequence<ByteString>> or record<ByteString, ByteString>) Heade
     undefined append(ByteString name, ByteString value);
     [ImplementedAs=remove] undefined delete(ByteString name);
     ByteString? get(ByteString name);
+    sequence<ByteString> getSetCookie();
     boolean has(ByteString name);
     undefined set(ByteString name, ByteString value);
 


### PR DESCRIPTION
#### 77fd8deab6cb8bda8d3e265dc91ab65685fdc84d
<pre>
[fetch] Implement `Headers.prototype.getSetCookie`.
<a href="https://bugs.webkit.org/show_bug.cgi?id=251194">https://bugs.webkit.org/show_bug.cgi?id=251194</a>

Reviewed by Youenn Fablet.

This change implements the `getSetCookie` method of the fetch spec&apos;s
`Headers` interface. This change allows storing `Set-Cookie` headers as
a list of values, and retrieving the separate values, rather than their
combined representation, which is ambiguous. This change also makes it
so iterating through `Headers` objects will yield `Set-Cookie` headers
separately rather than combined, which is part of the same change in the
fetch spec.

Given that `Set-Cookie` is a forbidden header name in both requests and
responses, this will not be useful for any uses of `Headers` related to
fetch. It does allows some non-fetch use cases, however, and enables
further compatibility with server-side runtimes that do allow this
header.

Rather than refactoring `HTTPHeaderMap` to not combine (all) headers,
this implementation makes use of the fact that `Set-Cookie` is forbidden
for both requests and responses, to store the `Set-Cookie` values in a
vector of strings directly in `FetchHeaders` instead. This needed such
header name to be special-cased in almost every operation of this class.
And in order to have `Set-Cookie` headers properly appear in their right
order in the pair iterator, `m_keys` has been changed to be a pair where
the second element is an index into the `Set-Cookie` values vector,
which is ignored for other header names.

Fetch spec PR: <a href="https://github.com/whatwg/fetch/pull/1346">https://github.com/whatwg/fetch/pull/1346</a>

This commit also imports the corresponding WPT tests from
<a href="https://github.com/web-platform-tests/wpt/pull/31442">https://github.com/web-platform-tests/wpt/pull/31442</a>, and adds some
additional tests.

* Source/WebCore/Modules/fetch/FetchHeaders.cpp:
(WebCore::appendToHeaderMap):
(WebCore::fillHeaderMap):
(WebCore::FetchHeaders::create):
(WebCore::FetchHeaders::fill):
(WebCore::FetchHeaders::append):
(WebCore::FetchHeaders::remove):
(WebCore::FetchHeaders::get const):
(WebCore::FetchHeaders::getSetCookie const):
(WebCore::FetchHeaders::has const):
(WebCore::FetchHeaders::set):
(WebCore::FetchHeaders::Iterator::next):
* Source/WebCore/Modules/fetch/FetchHeaders.h:
(WebCore::FetchHeaders::create):
(WebCore::FetchHeaders::fastGet const):
(WebCore::FetchHeaders::fastHas const):
(WebCore::FetchHeaders::fastSet):
(WebCore::FetchHeaders::FetchHeaders):
* Source/WebCore/Modules/fetch/FetchHeaders.idl:
* Source/WebCore/platform/network/ResourceResponseBase.cpp:
(WebCore::ResourceResponseBase::httpHeaderField const):

Canonical link: <a href="https://commits.webkit.org/260533@main">https://commits.webkit.org/260533@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6b517708ea0783b6584fc2482d00defd414b8be

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108634 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17735 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41488 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117744 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/117945 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112517 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19186 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9012 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100866 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114401 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14384 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97618 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42354 "Found 3 new test failures: webgl/2.0.y/conformance/glsl/bugs/character-set.html, webgl/2.0.y/conformance/glsl/misc/fragcolor-fragdata-invariant.html, webgl/2.0.y/conformance2/renderbuffers/multisampled-depth-renderbuffer-initialization.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96360 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29256 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/84083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10543 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30606 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11301 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/7519 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16692 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50202 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7278 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12889 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->