### PR TITLE
Fix variable liveness for try catch in DFG

### DIFF
--- a/JSTests/stress/try-catch-backwards-propagation.js
+++ b/JSTests/stress/try-catch-backwards-propagation.js
@@ -1,0 +1,171 @@
+function throwFunction() {
+    throw 2;
+}
+
+let a = [0.1];
+
+// --------- try catch with throw function ---------
+function foo1(i) {
+    let x = a[1];
+    try {
+        throwFunction();
+    } catch { }
+    if (x !== undefined) {
+        throw new Error(`x is ${x} at iteration ${i}`);
+    }
+}
+
+function foo2(i) {
+    let x = a[1];
+    try {
+        throwFunction();
+    } catch {
+        if (x !== undefined) {
+            throw new Error(`x is ${x} at iteration ${i}`);
+        }
+    }
+}
+
+function foo3(i) {
+    let x = a[1];
+    try {
+        if (i % 2)
+            throwFunction();
+    } catch { }
+    if (x !== undefined) {
+        throw new Error(`x is ${x} at iteration ${i}`);
+    }
+}
+
+// --------- try catch with throw ---------
+function foo4(i) {
+    let x = a[1];
+    try {
+        throw new Error();
+    } catch { }
+    if (x !== undefined) {
+        throw new Error(`x is ${x} at iteration ${i}`);
+    }
+}
+
+function foo5(i) {
+    let x = a[1];
+    try {
+        throw new Error();
+    } catch {
+        if (x !== undefined) {
+            throw new Error(`x is ${x} at iteration ${i}`);
+        }
+    }
+}
+
+function foo6(i) {
+    let x = a[1];
+    try {
+        if (i % 2)
+            throw new Error();
+    } catch { }
+    if (x !== undefined) {
+        throw new Error(`x is ${x} at iteration ${i}`);
+    }
+}
+
+// --------- try catch finally with throw function ---------
+function foo7(i) {
+    let x = a[1];
+    try {
+        throw new Error();
+    } catch {
+    } finally { }
+    if (x !== undefined) {
+        throw new Error(`x is ${x} at iteration ${i}`);
+    }
+}
+
+function foo8(i) {
+    let x = a[1];
+    try {
+        throw new Error();
+    } catch {
+    } finally {
+        if (x !== undefined) {
+            throw new Error(`x is ${x} at iteration ${i}`);
+        }
+    }
+}
+
+function foo9(i) {
+    let x = a[1];
+    try {
+        if (i % 2)
+            throw new Error();
+    } catch {
+    } finally { }
+    if (x !== undefined) {
+        throw new Error(`x is ${x} at iteration ${i}`);
+    }
+}
+
+// --------- try catch finally with throw function ---------
+function foo10(i) {
+    let x = a[1];
+    try {
+        throwFunction();
+    } catch {
+    } finally { }
+    if (x !== undefined) {
+        throw new Error(`x is ${x} at iteration ${i}`);
+    }
+}
+
+function foo11(i) {
+    let x = a[1];
+    try {
+        throwFunction();
+    } catch {
+    } finally {
+        if (x !== undefined) {
+            throw new Error(`x is ${x} at iteration ${i}`);
+        }
+    }
+}
+
+function foo12(i) {
+    let x = a[1];
+    try {
+        if (i % 2)
+            throwFunction();
+    } catch {
+    } finally { }
+    if (x !== undefined) {
+        throw new Error(`x is ${x} at iteration ${i}`);
+    }
+}
+
+function opt() {
+    var b = false;
+    var c = -b;
+    try {
+        throw "";
+    } catch (e) {
+    }
+    return c;
+}
+
+for (let i = 0; i < 100000; i++) {
+    foo1(i);
+    foo2(i);
+    foo3(i);
+    foo4(i);
+    foo5(i);
+    foo6(i);
+    foo7(i);
+    foo8(i);
+    foo9(i);
+    foo10(i);
+    foo11(i);
+    foo12(i);
+
+    if (1 / opt() === Infinity)
+        throw Error(`Should be -Infinity`);
+}

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -49,6 +49,7 @@
 #include "DFGClobberize.h"
 #include "DFGClobbersExitState.h"
 #include "DFGGraph.h"
+#include "DFGLiveCatchVariablePreservationPhase.h"
 #include "DOMJITGetterSetter.h"
 #include "DeleteByStatus.h"
 #include "FunctionCodeBlock.h"
@@ -9184,6 +9185,10 @@ void ByteCodeParser::parse()
     parseCodeBlock();
     linkBlocks(inlineStackEntry.m_unlinkedBlocks, inlineStackEntry.m_blockLinkingTargets);
 
+    // We insert catch variable preservation here to show all bytecode
+    // uses to the subsequent backward propagation phase.
+    performLiveCatchVariablePreservationPhase(m_graph);
+
     // We run backwards propagation now because the soundness of that phase
     // relies on seeing the graph as if it were an IR over bytecode, since
     // the spec-correctness of that phase relies on seeing all bytecode uses.
@@ -9296,7 +9301,7 @@ void ByteCodeParser::parse()
                 RELEASE_ASSERT(node->op() != ForceOSRExit);
         }
     }
-    
+
     m_graph.determineReachability();
     m_graph.killUnreachableBlocks();
 

--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -725,7 +725,7 @@ void Graph::determineReachability()
     }
 }
 
-void Graph::resetReachability()
+void Graph::clearReachability()
 {
     for (BlockIndex blockIndex = m_blocks.size(); blockIndex--;) {
         BasicBlock* block = m_blocks[blockIndex].get();
@@ -734,7 +734,11 @@ void Graph::resetReachability()
         block->isReachable = false;
         block->predecessors.clear();
     }
-    
+}
+
+void Graph::resetReachability()
+{
+    clearReachability();
     determineReachability();
 }
 

--- a/Source/JavaScriptCore/dfg/DFGGraph.h
+++ b/Source/JavaScriptCore/dfg/DFGGraph.h
@@ -547,6 +547,7 @@ public:
     void killUnreachableBlocks();
     
     void determineReachability();
+    void clearReachability();
     void resetReachability();
     
     void computeRefCounts();

--- a/Source/JavaScriptCore/dfg/DFGLiveCatchVariablePreservationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGLiveCatchVariablePreservationPhase.cpp
@@ -36,10 +36,10 @@
 
 namespace JSC { namespace DFG {
 
-class LiveCatchVariablePreservationPhase : public Phase {
+class LiveCatchVariablePreservationPhase {
 public:
     LiveCatchVariablePreservationPhase(Graph& graph)
-        : Phase(graph, "live catch variable preservation phase")
+        : m_graph(graph)
     {
     }
 
@@ -50,14 +50,17 @@ public:
         if (!m_graph.m_hasExceptionHandlers)
             return false;
 
+        m_graph.determineReachability();
+
         InsertionSet insertionSet(m_graph);
-        if (m_graph.m_hasExceptionHandlers) {
-            for (BasicBlock* block : m_graph.blocksInNaturalOrder()) {
+        for (BasicBlock* block : m_graph.blocksInNaturalOrder()) {
+            if (block->isReachable) {
                 handleBlockForTryCatch(block, insertionSet);
                 insertionSet.execute(block);
             }
         }
 
+        m_graph.clearReachability();
         return true;
     }
 
@@ -221,11 +224,13 @@ public:
         m_graph.m_variableAccessData.append(operand);
         return &m_graph.m_variableAccessData.last();
     }
+
+    Graph& m_graph;
 };
 
 bool performLiveCatchVariablePreservationPhase(Graph& graph)
 {
-    return runPhase<LiveCatchVariablePreservationPhase>(graph);
+    return LiveCatchVariablePreservationPhase(graph).run();
 }
 
 } } // namespace JSC::DFG

--- a/Source/JavaScriptCore/dfg/DFGPlan.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPlan.cpp
@@ -236,8 +236,6 @@ Plan::CompilationPath Plan::compileInThreadImpl()
         dfg.dump();
     }
 
-    RUN_PHASE(performLiveCatchVariablePreservationPhase);
-
     RUN_PHASE(performCPSRethreading);
     RUN_PHASE(performUnification);
     RUN_PHASE(performPredictionInjection);


### PR DESCRIPTION
#### 5e1033a7cd0361a94d7af3ca78c81873f33aa6a8
<pre>
Fix variable liveness for try catch in DFG
<a href="https://bugs.webkit.org/show_bug.cgi?id=239758">https://bugs.webkit.org/show_bug.cgi?id=239758</a>
rdar://92654142

Reviewed by Yusuke Suzuki.

There is no successor and predecessor relationship between try and catch
block in DFG, in other words node flags cannot be passed from catch block
to its `predecessors`. If a variable defined outside the try catch block
but only be used in the catch block, then our compiler would mis-analyze
the liveness of the varible w.r.t the catch block. Therefore,
`LiveCatchVariablePreservationPhase` should be to performed before backwards propagation.

* JSTests/stress/try-catch-backwards-propagation.js: Added.
(throwFunction):
(foo1):
(foo2):
(foo3):
(foo4):
(foo5):
(foo6):
(foo7):
(foo8):
(foo9):
(foo10):
(foo11):
(foo12):
(opt):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::parse):
* Source/JavaScriptCore/dfg/DFGLiveCatchVariablePreservationPhase.cpp:
(JSC::DFG::LiveCatchVariablePreservationPhase::LiveCatchVariablePreservationPhase):
(JSC::DFG::LiveCatchVariablePreservationPhase::handleBlockForTryCatch):
(JSC::DFG::performLiveCatchVariablePreservationPhase):
* Source/JavaScriptCore/dfg/DFGPlan.cpp:
(JSC::DFG::Plan::compileInThreadImpl):

Canonical link: <a href="https://commits.webkit.org/259839@main">https://commits.webkit.org/259839@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2c8ac41013934f0fe5632c8d72338b470569b74

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106120 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15173 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38949 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115304 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/175381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16605 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6345 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98328 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/115000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111876 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/95606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/40178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94502 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/27249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/95737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8424 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/28601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/95116 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/6245 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8918 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/5149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30512 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14537 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48145 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/103862 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6805 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10463 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25739 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->