### PR TITLE
Web Inspector: Implicitly nested property declarations inside non-style rules results in nested content being deleted during editing or displaying incorrect matched styles for elements

### DIFF
--- a/LayoutTests/inspector/css/getMatchedStylesForNode-expected.txt
+++ b/LayoutTests/inspector/css/getMatchedStylesForNode-expected.txt
@@ -186,7 +186,8 @@ Matched:
         "cssText": " z-index: 300; "
       },
       "sourceURL": "<filtered>",
-      "ruleId": "<filtered>"
+      "ruleId": "<filtered>",
+      "isImplicitlyNested": false
     },
     "matchingSelectors": [
       0
@@ -229,7 +230,8 @@ Matched:
         "cssText": " z-index: 200; "
       },
       "sourceURL": "<filtered>",
-      "ruleId": "<filtered>"
+      "ruleId": "<filtered>",
+      "isImplicitlyNested": false
     },
     "matchingSelectors": [
       0
@@ -272,7 +274,8 @@ Matched:
         "cssText": " z-index: 100; "
       },
       "sourceURL": "<filtered>",
-      "ruleId": "<filtered>"
+      "ruleId": "<filtered>",
+      "isImplicitlyNested": false
     },
     "matchingSelectors": [
       0
@@ -322,7 +325,8 @@ Pseudo:
             "cssText": " z-index: 1; "
           },
           "sourceURL": "<filtered>",
-          "ruleId": "<filtered>"
+          "ruleId": "<filtered>",
+          "isImplicitlyNested": false
         },
         "matchingSelectors": [
           0
@@ -370,7 +374,8 @@ Pseudo:
             "cssText": " z-index: 2; "
           },
           "sourceURL": "<filtered>",
-          "ruleId": "<filtered>"
+          "ruleId": "<filtered>",
+          "isImplicitlyNested": false
         },
         "matchingSelectors": [
           0
@@ -418,7 +423,8 @@ Pseudo:
             "cssText": " z-index: 4; "
           },
           "sourceURL": "<filtered>",
-          "ruleId": "<filtered>"
+          "ruleId": "<filtered>",
+          "isImplicitlyNested": false
         },
         "matchingSelectors": [
           0
@@ -466,7 +472,8 @@ Pseudo:
             "cssText": " z-index: 5; "
           },
           "sourceURL": "<filtered>",
-          "ruleId": "<filtered>"
+          "ruleId": "<filtered>",
+          "isImplicitlyNested": false
         },
         "matchingSelectors": [
           0
@@ -514,7 +521,8 @@ Pseudo:
             "cssText": " z-index: 6; "
           },
           "sourceURL": "<filtered>",
-          "ruleId": "<filtered>"
+          "ruleId": "<filtered>",
+          "isImplicitlyNested": false
         },
         "matchingSelectors": [
           0
@@ -562,7 +570,8 @@ Pseudo:
             "cssText": " z-index: 7; "
           },
           "sourceURL": "<filtered>",
-          "ruleId": "<filtered>"
+          "ruleId": "<filtered>",
+          "isImplicitlyNested": false
         },
         "matchingSelectors": [
           0
@@ -610,7 +619,8 @@ Pseudo:
             "cssText": " z-index: 8; "
           },
           "sourceURL": "<filtered>",
-          "ruleId": "<filtered>"
+          "ruleId": "<filtered>",
+          "isImplicitlyNested": false
         },
         "matchingSelectors": [
           0
@@ -658,7 +668,8 @@ Pseudo:
             "cssText": " z-index: 9; "
           },
           "sourceURL": "<filtered>",
-          "ruleId": "<filtered>"
+          "ruleId": "<filtered>",
+          "isImplicitlyNested": false
         },
         "matchingSelectors": [
           0
@@ -706,7 +717,8 @@ Pseudo:
             "cssText": " z-index: 10; "
           },
           "sourceURL": "<filtered>",
-          "ruleId": "<filtered>"
+          "ruleId": "<filtered>",
+          "isImplicitlyNested": false
         },
         "matchingSelectors": [
           0
@@ -754,7 +766,8 @@ Pseudo:
             "cssText": " z-index: 11; "
           },
           "sourceURL": "<filtered>",
-          "ruleId": "<filtered>"
+          "ruleId": "<filtered>",
+          "isImplicitlyNested": false
         },
         "matchingSelectors": [
           0
@@ -802,7 +815,8 @@ Pseudo:
             "cssText": " z-index: 12; "
           },
           "sourceURL": "<filtered>",
-          "ruleId": "<filtered>"
+          "ruleId": "<filtered>",
+          "isImplicitlyNested": false
         },
         "matchingSelectors": [
           0
@@ -850,7 +864,8 @@ Pseudo:
             "cssText": " z-index: 13; "
           },
           "sourceURL": "<filtered>",
-          "ruleId": "<filtered>"
+          "ruleId": "<filtered>",
+          "isImplicitlyNested": false
         },
         "matchingSelectors": [
           0
@@ -908,7 +923,8 @@ Inherited:
               "text": "(min-width: 0px)",
               "sourceURL": "<filtered>"
             }
-          ]
+          ],
+          "isImplicitlyNested": false
         },
         "matchingSelectors": [
           0
@@ -951,7 +967,8 @@ Inherited:
             "cssText": " color: red; "
           },
           "sourceURL": "<filtered>",
-          "ruleId": "<filtered>"
+          "ruleId": "<filtered>",
+          "isImplicitlyNested": false
         },
         "matchingSelectors": [
           0
@@ -1003,7 +1020,8 @@ Inherited:
               "range": "<filtered>",
               "sourceURL": "<filtered>"
             }
-          ]
+          ],
+          "isImplicitlyNested": false
         },
         "matchingSelectors": [
           0
@@ -1062,7 +1080,8 @@ Inherited:
               "range": "<filtered>",
               "sourceURL": "<filtered>"
             }
-          ]
+          ],
+          "isImplicitlyNested": false
         },
         "matchingSelectors": [
           0
@@ -1112,7 +1131,8 @@ Inherited:
               "text": "(min-width: 3px)",
               "sourceURL": "<filtered>"
             }
-          ]
+          ],
+          "isImplicitlyNested": false
         },
         "matchingSelectors": [
           0
@@ -1162,7 +1182,8 @@ Inherited:
               "text": "(min-width: 4px)",
               "sourceURL": "<filtered>"
             }
-          ]
+          ],
+          "isImplicitlyNested": false
         },
         "matchingSelectors": [
           0

--- a/LayoutTests/inspector/css/getMatchedStylesForNodeNestingStyleGrouping-expected.txt
+++ b/LayoutTests/inspector/css/getMatchedStylesForNodeNestingStyleGrouping-expected.txt
@@ -3,22 +3,61 @@ Tests for the CSS.getMatchedStyleForNode command and container rule groups.
 
 == Running test suite: CSS.getMatchedStyleForNode.NestingStyleGrouping
 -- Running test case: CSS.getMatchedStyleForNode.NestingStyleGrouping.NormalProperty
-PASS: Should have 1 authored rules.
+PASS: Should have 3 authored rules.
 - Testing rule #0
+PASS: Selector text should be "&".
+PASS: Rule should not be an implicitly nested rule.
+PASS: "color" property value should be "yellow".
+PASS: Rule should have 2 grouping(s).
+PASS: Grouping 0 should have a type of "media-rule".
+PASS: Grouping 0 should have a text of "(min-width: 0px)".
+PASS: Grouping 1 should have a type of "style-rule".
+PASS: Grouping 1 should have a text of "#outerA".
+- Testing rule #1
+PASS: Selector text should be "&".
+PASS: Rule should be an implicitly nested rule.
+PASS: "color" property value should be "purple".
+PASS: Rule should have 2 grouping(s).
+PASS: Grouping 0 should have a type of "media-rule".
+PASS: Grouping 0 should have a text of "(min-width: 0px)".
+PASS: Grouping 1 should have a type of "style-rule".
+PASS: Grouping 1 should have a text of "#outerA".
+- Testing rule #2
 PASS: Selector text should be "#outerA".
+PASS: Rule should not be an implicitly nested rule.
 PASS: "color" property value should be "red".
 PASS: Rule should have no groupings.
 
 -- Running test case: CSS.getMatchedStyleForNode.NestingStyleGrouping.NestedRulePropertyWithImplicitAmpersand
-PASS: Should have 2 authored rules.
+PASS: Should have 4 authored rules.
 - Testing rule #0
 PASS: Selector text should be ".innerA".
+PASS: Rule should not be an implicitly nested rule.
 PASS: "color" property value should be "green".
 PASS: Rule should have 1 grouping(s).
 PASS: Grouping 0 should have a type of "style-rule".
 PASS: Grouping 0 should have a text of "#outerA".
 - Testing rule #1
+PASS: Selector text should be "&".
+PASS: Rule should not be an implicitly nested rule.
+PASS: "color" property value should be "yellow".
+PASS: Rule should have 2 grouping(s).
+PASS: Grouping 0 should have a type of "media-rule".
+PASS: Grouping 0 should have a text of "(min-width: 0px)".
+PASS: Grouping 1 should have a type of "style-rule".
+PASS: Grouping 1 should have a text of "#outerA".
+- Testing rule #2
+PASS: Selector text should be "&".
+PASS: Rule should be an implicitly nested rule.
+PASS: "color" property value should be "purple".
+PASS: Rule should have 2 grouping(s).
+PASS: Grouping 0 should have a type of "media-rule".
+PASS: Grouping 0 should have a text of "(min-width: 0px)".
+PASS: Grouping 1 should have a type of "style-rule".
+PASS: Grouping 1 should have a text of "#outerA".
+- Testing rule #3
 PASS: Selector text should be "#outerA".
+PASS: Rule should not be an implicitly nested rule.
 PASS: "color" property value should be "red".
 PASS: Rule should have no groupings.
 
@@ -26,6 +65,7 @@ PASS: Rule should have no groupings.
 PASS: Should have 1 authored rules.
 - Testing rule #0
 PASS: Selector text should be ".outer:not(&)".
+PASS: Rule should not be an implicitly nested rule.
 PASS: "color" property value should be "blue".
 PASS: Rule should have 1 grouping(s).
 PASS: Grouping 0 should have a type of "style-rule".

--- a/LayoutTests/inspector/css/getMatchedStylesForNodeNestingStyleGrouping.html
+++ b/LayoutTests/inspector/css/getMatchedStylesForNodeNestingStyleGrouping.html
@@ -7,12 +7,13 @@ function test()
 {
     let suite = InspectorTest.createAsyncSuite("CSS.getMatchedStyleForNode.NestingStyleGrouping");
 
-    function expectRuleAtIndex(rules, index, {selectorText, colorPropertyValue, groupings})
+    function expectRuleAtIndex(rules, index, {selectorText, isImplicitlyNested, colorPropertyValue, groupings})
     {
         InspectorTest.log(`- Testing rule #${index}`);
 
         let rule = rules[index];
         InspectorTest.expectEqual(rule.selectorText, selectorText, `Selector text should be "${selectorText}".`);
+        InspectorTest.expectEqual(rule.isImplicitlyNested, isImplicitlyNested || false, `Rule should${isImplicitlyNested ? " " : " not "}be an implicitly nested rule.`);
         InspectorTest.expectEqual(rule.style.propertyForName("color").value, colorPropertyValue, `"color" property value should be "${colorPropertyValue}".`);
 
         if (!groupings) {
@@ -60,9 +61,26 @@ function test()
         name: "CSS.getMatchedStyleForNode.NestingStyleGrouping.NormalProperty",
         description: "Non-nested properties should be visible even when nested style rules are present.",
         selector: "#outerA",
-        expectedAuthoredRuleCount: 1,
+        expectedAuthoredRuleCount: 3,
         authoredRulesHandler(rules) {
             expectRuleAtIndex(rules, 0, {
+                selectorText: "&",
+                colorPropertyValue: "yellow",
+                groupings: [
+                    {type: WI.CSSGrouping.Type.MediaRule, text: "(min-width: 0px)"},
+                    {type: WI.CSSGrouping.Type.StyleRule, text: "#outerA"},
+                ],
+            });
+            expectRuleAtIndex(rules, 1, {
+                selectorText: "&",
+                isImplicitlyNested: true,
+                colorPropertyValue: "purple",
+                groupings: [
+                    {type: WI.CSSGrouping.Type.MediaRule, text: "(min-width: 0px)"},
+                    {type: WI.CSSGrouping.Type.StyleRule, text: "#outerA"},
+                ],
+            });
+            expectRuleAtIndex(rules, 2, {
                 selectorText: "#outerA",
                 colorPropertyValue: "red",
             });
@@ -73,7 +91,7 @@ function test()
         name: "CSS.getMatchedStyleForNode.NestingStyleGrouping.NestedRulePropertyWithImplicitAmpersand",
         description: "Nested rules with an implicit ampersand should have a grouping representing the outer style rule.",
         selector: "#outerA .innerA",
-        expectedAuthoredRuleCount: 2,
+        expectedAuthoredRuleCount: 4,
         authoredRulesHandler(rules) {
             expectRuleAtIndex(rules, 0, {
                 selectorText: ".innerA",
@@ -83,6 +101,23 @@ function test()
                 ],
             });
             expectRuleAtIndex(rules, 1, {
+                selectorText: "&",
+                colorPropertyValue: "yellow",
+                groupings: [
+                    {type: WI.CSSGrouping.Type.MediaRule, text: "(min-width: 0px)"},
+                    {type: WI.CSSGrouping.Type.StyleRule, text: "#outerA"},
+                ],
+            });
+            expectRuleAtIndex(rules, 2, {
+                selectorText: "&",
+                isImplicitlyNested: true,
+                colorPropertyValue: "purple",
+                groupings: [
+                    {type: WI.CSSGrouping.Type.MediaRule, text: "(min-width: 0px)"},
+                    {type: WI.CSSGrouping.Type.StyleRule, text: "#outerA"},
+                ],
+            });
+            expectRuleAtIndex(rules, 3, {
                 selectorText: "#outerA",
                 colorPropertyValue: "red",
             });
@@ -111,6 +146,16 @@ function test()
 <style>
     #outerA {
         color: red;
+
+        @media(min-width: 0px) {
+            background-color: blue;
+            
+            & {
+                color: yellow;
+            }
+
+            color: purple;
+        }
 
         .innerA {
             color: green;

--- a/LayoutTests/inspector/css/modify-css-property-expected.txt
+++ b/LayoutTests/inspector/css/modify-css-property-expected.txt
@@ -45,3 +45,19 @@ PASS: Uncommented property should be enabled.
 PASS: Style declaration text should be empty.
 PASS: Style declaration text should have new property name.
 
+-- Running test case: ModifyCSSProperty.EnsureNestedRulesEditingDoesNotTrampleInnerRules
+PASS: Outer style declaration text should contain the expected `color` property.
+PASS: Outer style declaration text should contain the new `color` value.
+PASS: Inner implicit style declaration text should contain the expected `color` property.
+PASS: Inner implicit style declaration text should contain the new `color` value.
+PASS: Inner explicit style declaration text should contain the expected `color` property.
+PASS: Inner explicit style declaration text should contain the new `color` value.
+
+-- Running test case: ModifyCSSProperty.EnsureNestedRulesEditingDoesNotTrampleInnerRulesOriginalExcludesNewlines
+PASS: Outer style declaration text should contain the expected `color` property.
+PASS: Outer style declaration text should contain the new `color` value.
+PASS: Inner implicit style declaration text should contain the expected `color` property.
+PASS: Inner implicit style declaration text should contain the new `color` value.
+PASS: Inner explicit style declaration text should contain the expected `color` property.
+PASS: Inner explicit style declaration text should contain the new `color` value.
+

--- a/LayoutTests/inspector/css/modify-css-property.html
+++ b/LayoutTests/inspector/css/modify-css-property.html
@@ -345,11 +345,122 @@ function test() {
         }
     });
 
+    function addTestCase({name, description, selector, authoredRulesHandler})
+    {
+        suite.addTestCase({
+            name,
+            description,
+            async test() {
+                let documentNode = await WI.domManager.requestDocument();
+                let nodeId = await documentNode.querySelector(selector);
+                let domNode = WI.domManager.nodeForId(nodeId);
+                InspectorTest.assert(domNode, `Should find DOM Node for selector '#item'.`);
+
+                let domNodeStyles = WI.cssManager.stylesForNode(domNode);
+                InspectorTest.assert(domNodeStyles, `Should find CSS Styles for DOM Node.`);
+                await domNodeStyles.refresh();
+
+                let flatInheritedRules = domNodeStyles.inheritedRules.flatMap((inheritedRuleInfo) => inheritedRuleInfo.matchedRules);
+
+                let authoredRules = [...domNodeStyles.matchedRules, ...flatInheritedRules].filter((rule) => rule.type === WI.CSSStyleSheet.Type.Author);
+                await authoredRulesHandler(authoredRules, domNodeStyles);
+            },
+        });
+    }
+
+    function findRuleStyleInRules(rules, {selector, nestingRootSelector}) {
+        for (let rule of rules) {
+            if (rule.selectorText !== selector)
+                continue;
+
+            if (!nestingRootSelector)
+                return rule.style;
+
+            for (let grouping of rule.groupings) {
+                if (grouping.type !== WI.CSSGrouping.Type.StyleRule)
+                    continue;
+
+                if (grouping.text !== nestingRootSelector)
+                    continue;
+
+                return rule.style;
+            }
+        }
+        InspectorTest.fail(`No rule found with selector "${selector}" nested under selector "${nestingRootSelector}".`);
+    }
+
+    function getColorProperty(styleDeclaration) {
+        for (let property of styleDeclaration.properties) {
+            if (property.name === "color")
+                return property;
+        }
+        InspectorTest.fail("No color property found in style declaration.");
+    }
+
+    addTestCase({
+        name: "ModifyCSSProperty.EnsureNestedRulesEditingDoesNotTrampleInnerRules",
+        description: "",
+        selector: ".rule-f",
+        async authoredRulesHandler(authoredRules, domNodeStyles) {
+            let outerRuleStyle = findRuleStyleInRules(authoredRules, { selector: ".rule-f" });
+            InspectorTest.expectEqual(outerRuleStyle.text, "\n    color: red;\n\n    @media(min-width: 0px) {\n        &.explicit-nested-rule { \n            color: blue;\n        }\n\n        color: green;\n    }\n", "Outer style declaration text should contain the expected `color` property.");
+            let outerRuleStyleChangedPromise = domNodeStyles.awaitEvent(WI.DOMNodeStyles.Event.Refreshed);
+            getColorProperty(outerRuleStyle).rawValue = "magenta";
+            await outerRuleStyleChangedPromise;
+            InspectorTest.expectEqual(outerRuleStyle.text, "\n    color: magenta;\n\n    @media(min-width: 0px) {\n        &.explicit-nested-rule { \n            color: blue;\n        }\n\n        color: green;\n    }\n\n", "Outer style declaration text should contain the new `color` value.");
+
+            let innerImplicitRuleStyle = findRuleStyleInRules(authoredRules, { selector: "&", nestingRootSelector: ".rule-f" });
+            InspectorTest.expectEqual(innerImplicitRuleStyle.text, "\n        &.explicit-nested-rule { \n            color: blue;\n        }\n\n        color: green;\n    ", "Inner implicit style declaration text should contain the expected `color` property.");
+            let innerImplicitRuleStyleChangedPromise = domNodeStyles.awaitEvent(WI.DOMNodeStyles.Event.Refreshed);
+            getColorProperty(innerImplicitRuleStyle).rawValue = "yellow";
+            await innerImplicitRuleStyleChangedPromise;
+            InspectorTest.expectEqual(innerImplicitRuleStyle.text, "\n            color: yellow;\n        \n            &.explicit-nested-rule { \n            color: blue;\n        }\n\n        ", "Inner implicit style declaration text should contain the new `color` value.");
+
+            let innerExplicitRuleStyle = findRuleStyleInRules(authoredRules,  { selector: "&.explicit-nested-rule", nestingRootSelector: ".rule-f" });
+            InspectorTest.expectEqual(innerExplicitRuleStyle.text, " \n            color: blue;\n        ", "Inner explicit style declaration text should contain the expected `color` property.");
+            let innerExplicitRuleStyleChangedPromise = domNodeStyles.awaitEvent(WI.DOMNodeStyles.Event.Refreshed);
+            getColorProperty(innerExplicitRuleStyle).rawValue = "cyan";
+            await innerExplicitRuleStyleChangedPromise;
+            InspectorTest.expectEqual(innerExplicitRuleStyle.text, "\n            color: cyan;\n        \n        ", "Inner explicit style declaration text should contain the new `color` value.");
+        },
+    })
+
+    addTestCase({
+        name: "ModifyCSSProperty.EnsureNestedRulesEditingDoesNotTrampleInnerRulesOriginalExcludesNewlines",
+        description: "",
+        selector: ".rule-g",
+        async authoredRulesHandler(authoredRules, domNodeStyles) {
+            let outerRuleStyle = findRuleStyleInRules(authoredRules, { selector: ".rule-g" });
+            InspectorTest.expectEqual(outerRuleStyle.text, " color: red; @media(min-width: 0px) { &.explicit-nested-rule { color: blue; } color: green; } ", "Outer style declaration text should contain the expected `color` property.");
+            let outerRuleStyleChangedPromise = domNodeStyles.awaitEvent(WI.DOMNodeStyles.Event.Refreshed);
+            getColorProperty(outerRuleStyle).rawValue = "magenta";
+            await outerRuleStyleChangedPromise;
+            InspectorTest.expectEqual(outerRuleStyle.text, "\n    color: magenta;\n\n    @media(min-width: 0px) { &.explicit-nested-rule { color: blue; } color: green; }\n\n", "Outer style declaration text should contain the new `color` value.");
+
+            let innerImplicitRuleStyle = findRuleStyleInRules(authoredRules, { selector: "&", nestingRootSelector: ".rule-g" });
+            InspectorTest.expectEqual(innerImplicitRuleStyle.text, " &.explicit-nested-rule { color: blue; } color: green; ", "Inner implicit style declaration text should contain the expected `color` property.");
+            let innerImplicitRuleStyleChangedPromise = domNodeStyles.awaitEvent(WI.DOMNodeStyles.Event.Refreshed);
+            getColorProperty(innerImplicitRuleStyle).rawValue = "yellow";
+            await innerImplicitRuleStyleChangedPromise;
+            InspectorTest.expectEqual(innerImplicitRuleStyle.text, "\n            color: yellow;\n        \n            &.explicit-nested-rule { color: blue; }\n\n        ", "Inner implicit style declaration text should contain the new `color` value.");
+
+            let innerExplicitRuleStyle = findRuleStyleInRules(authoredRules,  { selector: "&.explicit-nested-rule", nestingRootSelector: ".rule-g" });
+            InspectorTest.expectEqual(innerExplicitRuleStyle.text, " color: blue; ", "Inner explicit style declaration text should contain the expected `color` property.");
+            let innerExplicitRuleStyleChangedPromise = domNodeStyles.awaitEvent(WI.DOMNodeStyles.Event.Refreshed);
+            getColorProperty(innerExplicitRuleStyle).rawValue = "cyan";
+            await innerExplicitRuleStyleChangedPromise;
+            InspectorTest.expectEqual(innerExplicitRuleStyle.text, "\n            color: cyan;\n        \n        ", "Inner explicit style declaration text should contain the new `color` value.");
+        },
+    })
+
     WI.domManager.requestDocument((documentNode) => {
         documentNode.querySelector("#x", (contentNodeId) => {
             if (contentNodeId) {
                 let domNode = WI.domManager.nodeForId(contentNodeId);
                 nodeStyles = WI.cssManager.stylesForNode(domNode);
+
+                let flatInheritedRules = nodeStyles.inheritedRules.flatMap((inheritedRuleInfo) => inheritedRuleInfo.matchedRules);
+                authoredRules = [...nodeStyles.matchedRules, ...flatInheritedRules].filter((rule) => rule.type === WI.CSSStyleSheet.Type.Author);
 
                 if (nodeStyles.needsRefresh) {
                     nodeStyles.singleFireEventListener(WI.DOMNodeStyles.Event.Refreshed, (event) => {
@@ -368,6 +479,6 @@ function test() {
 </head>
 <body onload="runTest()">
     <p>Testing that CSSStyleDeclaration update immediately after modifying its properties when it is not locked.</p>
-    <div id="x" class="test-node rule-a rule-b rule-c rule-d rule-e" style="width: 100px"></div>
+    <div id="x" class="test-node rule-a rule-b rule-c rule-d rule-e rule-f rule-g explicit-nested-rule" style="width: 100px"></div>
 </body>
 </html>

--- a/LayoutTests/inspector/css/resources/modify-css-property.css
+++ b/LayoutTests/inspector/css/resources/modify-css-property.css
@@ -16,3 +16,15 @@
 .rule-e {
     color: darkseagreen;
 }
+.rule-f {
+    color: red;
+
+    @media(min-width: 0px) {
+        &.explicit-nested-rule { 
+            color: blue;
+        }
+
+        color: green;
+    }
+}
+.rule-g { color: red; @media(min-width: 0px) { &.explicit-nested-rule { color: blue; } color: green; } }

--- a/Source/JavaScriptCore/inspector/protocol/CSS.json
+++ b/Source/JavaScriptCore/inspector/protocol/CSS.json
@@ -161,7 +161,8 @@
                 { "name": "sourceLine", "type": "integer", "description": "Line ordinal of the rule selector start character in the resource."},
                 { "name": "origin", "$ref": "StyleSheetOrigin", "description": "Parent stylesheet's origin."},
                 { "name": "style", "$ref": "CSSStyle", "description": "Associated style declaration." },
-                { "name": "groupings", "type": "array", "items": { "$ref": "Grouping" }, "optional": true, "description": "Grouping list array (for rules involving @media/@supports). The array enumerates CSS groupings starting with the innermost one, going outwards." }
+                { "name": "groupings", "type": "array", "items": { "$ref": "Grouping" }, "optional": true, "description": "Grouping list array (for rules involving @media/@supports). The array enumerates CSS groupings starting with the innermost one, going outwards." },
+                { "name": "isImplicitlyNested", "type": "boolean", "optional": true, "description": "<code>true</code> if this style is for a rule implicitly wrapping properties declared inside of CSSGrouping." }
             ]
         },
         {

--- a/Source/WebCore/css/CSSPropertySourceData.h
+++ b/Source/WebCore/css/CSSPropertySourceData.h
@@ -92,9 +92,8 @@ struct CSSRuleSourceData : public RefCounted<CSSRuleSourceData> {
 
     CSSRuleSourceData(StyleRuleType type)
         : type(type)
+        , styleSourceData(CSSStyleSourceData::create())
     {
-        if (type == StyleRuleType::Style || type == StyleRuleType::FontFace || type == StyleRuleType::Page)
-            styleSourceData = CSSStyleSourceData::create();
     }
 
     StyleRuleType type;
@@ -105,14 +104,15 @@ struct CSSRuleSourceData : public RefCounted<CSSRuleSourceData> {
     // Range of the rule body (e.g. style text for style rules) in the enclosing source.
     SourceRange ruleBodyRange;
 
-    // Only for CSSStyleRules.
+    // Only for CSSStyleRules. Not applicable if `isImplicitlyNested`.
     SelectorRangeList selectorRanges;
 
-    // Only for CSSStyleRules, CSSFontFaceRules, and CSSPageRules.
     RefPtr<CSSStyleSourceData> styleSourceData;
 
-    // Only for CSSMediaRules.
     RuleSourceDataList childRules;
+
+    bool isImplicitlyNested { false };
+    bool containsImplicitlyNestedProperties { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -581,10 +581,15 @@ Vector<RefPtr<StyleRuleBase>> CSSParserImpl::consumeRegularRuleList(CSSParserTok
     Vector<RefPtr<StyleRuleBase>> rules;
     if (isNestedContext()) {
         runInNewNestingContext([&]() {
-            consumeStyleBlock(block, StyleRuleType::Style);
+            consumeStyleBlock(block, StyleRuleType::Style, ParsingStyleDeclarationsInRuleList::Yes);
             if (!topContext().m_parsedProperties.isEmpty()) {
-                // This at-rule contains orphan declarations, we attach them to an implicit parent nesting rule
+                // This at-rule contains orphan declarations, we attach them to an implicit parent nesting rule. Web
+                // Inspector expects this rule to occur first in the children rules, and to contain all orphaned
+                // property declarations.
                 rules.append(createNestingParentRule());
+
+                if (m_observerWrapper)
+                    m_observerWrapper->observer().markRuleBodyContainsImplicitlyNestedProperties();
             }
             for (auto& rule : topContext().m_parsedRules)
                 rules.append(rule.ptr());
@@ -1097,7 +1102,7 @@ RefPtr<StyleRuleBase> CSSParserImpl::consumeStyleRule(CSSParserTokenRange prelud
     return styleRule;
 }
 
-void CSSParserImpl::consumeDeclarationListOrStyleBlockHelper(CSSParserTokenRange range, StyleRuleType ruleType, OnlyDeclarations onlyDeclarations)
+void CSSParserImpl::consumeDeclarationListOrStyleBlockHelper(CSSParserTokenRange range, StyleRuleType ruleType, OnlyDeclarations onlyDeclarations, ParsingStyleDeclarationsInRuleList isParsingStyleDeclarationsInRuleList)
 {
     auto nestedRulesAllowed = [&]() {
         return m_styleRuleNestingDepth && context().cssNestingEnabled && onlyDeclarations == OnlyDeclarations::No;        
@@ -1108,7 +1113,8 @@ void CSSParserImpl::consumeDeclarationListOrStyleBlockHelper(CSSParserTokenRange
 
     bool useObserver = m_observerWrapper && (ruleType == StyleRuleType::Style || ruleType == StyleRuleType::Keyframe || ruleType == StyleRuleType::CounterStyle);
     if (useObserver) {
-        m_observerWrapper->observer().startRuleBody(m_observerWrapper->previousTokenStartOffset(range));
+        if (isParsingStyleDeclarationsInRuleList == ParsingStyleDeclarationsInRuleList::No)
+            m_observerWrapper->observer().startRuleBody(m_observerWrapper->previousTokenStartOffset(range));
         m_observerWrapper->skipCommentsBefore(range, true);
     }
 
@@ -1172,7 +1178,8 @@ void CSSParserImpl::consumeDeclarationListOrStyleBlockHelper(CSSParserTokenRange
     // Yield remaining comments
     if (useObserver) {
         m_observerWrapper->yieldCommentsBefore(range);
-        m_observerWrapper->observer().endRuleBody(m_observerWrapper->endOffset(range));
+        if (isParsingStyleDeclarationsInRuleList == ParsingStyleDeclarationsInRuleList::No)
+            m_observerWrapper->observer().endRuleBody(m_observerWrapper->endOffset(range));
     }
 }
 
@@ -1191,9 +1198,9 @@ void CSSParserImpl::consumeDeclarationList(CSSParserTokenRange range, StyleRuleT
     consumeDeclarationListOrStyleBlockHelper(range, ruleType, OnlyDeclarations::Yes);
 }
 
-void CSSParserImpl::consumeStyleBlock(CSSParserTokenRange range, StyleRuleType ruleType)
+void CSSParserImpl::consumeStyleBlock(CSSParserTokenRange range, StyleRuleType ruleType, ParsingStyleDeclarationsInRuleList isParsingStyleDeclarationsInRuleList)
 {
-    consumeDeclarationListOrStyleBlockHelper(range, ruleType, OnlyDeclarations::No);
+    consumeDeclarationListOrStyleBlockHelper(range, ruleType, OnlyDeclarations::No, isParsingStyleDeclarationsInRuleList);
 }
 
 static void removeTrailingWhitespace(const CSSParserTokenRange& range, const CSSParserToken*& position)

--- a/Source/WebCore/css/parser/CSSParserImpl.h
+++ b/Source/WebCore/css/parser/CSSParserImpl.h
@@ -162,10 +162,13 @@ private:
         Yes,
         No
     };
+
+    enum class ParsingStyleDeclarationsInRuleList : bool { No, Yes };
+
     // FIXME: We should return value for all those functions instead of using class member attributes.
-    void consumeDeclarationListOrStyleBlockHelper(CSSParserTokenRange, StyleRuleType, OnlyDeclarations);
+    void consumeDeclarationListOrStyleBlockHelper(CSSParserTokenRange, StyleRuleType, OnlyDeclarations, ParsingStyleDeclarationsInRuleList = ParsingStyleDeclarationsInRuleList::No);
     void consumeDeclarationList(CSSParserTokenRange, StyleRuleType);
-    void consumeStyleBlock(CSSParserTokenRange, StyleRuleType);
+    void consumeStyleBlock(CSSParserTokenRange, StyleRuleType, ParsingStyleDeclarationsInRuleList = ParsingStyleDeclarationsInRuleList::No);
     void consumeDeclaration(CSSParserTokenRange, StyleRuleType);
     void consumeDeclarationValue(CSSParserTokenRange, CSSPropertyID, bool important, StyleRuleType);
     void consumeCustomPropertyValue(CSSParserTokenRange, const AtomString& propertyName, bool important);

--- a/Source/WebCore/css/parser/CSSParserObserver.h
+++ b/Source/WebCore/css/parser/CSSParserObserver.h
@@ -38,6 +38,7 @@ public:
     virtual void observeSelector(unsigned startOffset, unsigned endOffset) = 0;
     virtual void startRuleBody(unsigned offset) = 0;
     virtual void endRuleBody(unsigned offset) = 0;
+    virtual void markRuleBodyContainsImplicitlyNestedProperties() = 0;
     virtual void observeProperty(unsigned startOffset, unsigned endOffset, bool isImportant, bool isParsed) = 0;
     virtual void observeComment(unsigned startOffset, unsigned endOffset) = 0;
 };

--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2010, Google Inc. All rights reserved.
- * Copyright (C) 2021-2022, Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023, Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -126,6 +126,23 @@ static CSSParserContext parserContextForDocument(Document* document)
     return document ? CSSParserContext(*document) : strictCSSParserContext();
 }
 
+static ASCIILiteral atRuleIdentifierForType(StyleRuleType styleRuleType)
+{
+    switch (styleRuleType) {
+    case StyleRuleType::Media:
+        return "@media"_s;
+    case StyleRuleType::Supports:
+        return "@supports"_s;
+    case StyleRuleType::LayerBlock:
+        return "@layer"_s;
+    case StyleRuleType::Container:
+        return "@container"_s;
+    default:
+        ASSERT_NOT_REACHED();
+        return ""_s;
+    }
+}
+
 static bool isValidRuleHeaderText(const String& headerText, StyleRuleType styleRuleType, Document* document, CSSParserEnum::IsNestedContext isNestedContext)
 {
     auto isValidAtRuleHeaderText = [&] (const String& atRuleIdentifier) {
@@ -164,13 +181,10 @@ static bool isValidRuleHeaderText(const String& headerText, StyleRuleType styleR
         return !!parser.parseSelector(headerText, nullptr, isNestedContext);
     }
     case StyleRuleType::Media:
-        return isValidAtRuleHeaderText("@media"_s);
     case StyleRuleType::Supports:
-        return isValidAtRuleHeaderText("@supports"_s);
     case StyleRuleType::LayerBlock:
-        return isValidAtRuleHeaderText("@layer"_s);
     case StyleRuleType::Container:
-        return isValidAtRuleHeaderText("@container"_s);
+        return isValidAtRuleHeaderText(atRuleIdentifierForType(styleRuleType));
     default:
         return false;
     }
@@ -276,6 +290,7 @@ private:
     void observeSelector(unsigned startOffset, unsigned endOffset) override;
     void startRuleBody(unsigned) override;
     void endRuleBody(unsigned) override;
+    void markRuleBodyContainsImplicitlyNestedProperties() override;
     void observeProperty(unsigned startOffset, unsigned endOffset, bool isImportant, bool isParsed) override;
     void observeComment(unsigned startOffset, unsigned endOffset) override;
     
@@ -351,10 +366,32 @@ void StyleSheetHandler::endRuleBody(unsigned offset)
     m_currentRuleDataStack.last()->ruleBodyRange.end = offset;
     auto rule = popRuleData();
     fixUnparsedPropertyRanges(rule.ptr());
+
+    if (rule->containsImplicitlyNestedProperties && rule->styleSourceData->propertyData.size()) {
+        // Property declarations made outside of a Style rule will become part of a special inferred `& {}` rule after
+        // the parser has already sent observers their notification of the property. In order to match the CSSOM
+        // representation this must be handled here as well, otherwise the flat rule lists will differ in length.
+        auto inferredStyleRule = CSSRuleSourceData::create(StyleRuleType::Style);
+        inferredStyleRule->isImplicitlyNested = true;
+        inferredStyleRule->ruleHeaderRange = rule->ruleHeaderRange;
+        inferredStyleRule->ruleBodyRange = rule->ruleBodyRange;
+
+        std::swap(rule->styleSourceData, inferredStyleRule->styleSourceData);
+
+        // Inferred style rules are always logically placed at the start of their parent rule.
+        rule->childRules.insert(0, WTFMove(inferredStyleRule));
+    }
+
     if (m_currentRuleDataStack.isEmpty())
         m_ruleSourceDataResult->append(WTFMove(rule));
     else
         m_currentRuleDataStack.last()->childRules.append(WTFMove(rule));
+}
+
+void StyleSheetHandler::markRuleBodyContainsImplicitlyNestedProperties()
+{
+    ASSERT(!m_currentRuleDataStack.isEmpty());
+    m_currentRuleDataStack.last()->containsImplicitlyNestedProperties = true;
 }
 
 Ref<CSSRuleSourceData> StyleSheetHandler::popRuleData()
@@ -919,11 +956,6 @@ RefPtr<CSSRuleSourceData> InspectorStyle::extractSourceData() const
     return m_parentStyleSheet->ruleSourceDataFor(m_style.ptr());
 }
 
-ExceptionOr<void> InspectorStyle::setText(const String& text)
-{
-    return m_parentStyleSheet->setStyleText(m_style.ptr(), text);
-}
-
 String InspectorStyle::shorthandValue(const String& shorthandProperty) const
 {
     String value = m_style->getPropertyValue(shorthandProperty);
@@ -1404,6 +1436,9 @@ RefPtr<Protocol::CSS::CSSRule> InspectorStyleSheet::buildObjectForRule(CSSStyleR
     if (groupingsPayload->length())
         result->setGroupings(WTFMove(groupingsPayload));
 
+    if (auto sourceData = ruleSourceDataFor(rule))
+        result->setIsImplicitlyNested(sourceData->isImplicitlyNested);
+
     return result;
 }
 
@@ -1437,23 +1472,90 @@ Ref<Protocol::CSS::CSSStyle> InspectorStyleSheet::buildObjectForStyle(CSSStyleDe
     return result;
 }
 
-ExceptionOr<void> InspectorStyleSheet::setStyleText(const InspectorCSSId& id, const String& text, String* oldText)
+static inline bool isNotSpaceOrTab(UChar character)
 {
-    auto inspectorStyle = inspectorStyleForId(id);
-    if (!inspectorStyle)
+    return character != ' ' && character != '\t';
+}
+
+ExceptionOr<void> InspectorStyleSheet::setRuleStyleText(const InspectorCSSId& id, const String& newText, String* oldText, IsUndo isUndo)
+{
+    auto* cssRule = ruleForId(id);
+    if (!cssRule)
         return Exception { NotFoundError };
 
+    RefPtr<CSSRuleSourceData> sourceData = ruleSourceDataFor(cssRule);
+    if (!sourceData)
+        return Exception { NotFoundError };
+
+    RefPtr<CSSRuleSourceData> logicalContainingRuleSourceData = sourceData->isImplicitlyNested ? ruleSourceDataFor(cssRule->parentRule()) : sourceData;
+    if (!logicalContainingRuleSourceData)
+        return Exception { NotFoundError };
+
+    unsigned bodyStart = logicalContainingRuleSourceData->ruleBodyRange.start;
+    unsigned bodyEnd = logicalContainingRuleSourceData->ruleBodyRange.end;
+    ASSERT(bodyStart <= bodyEnd);
+
+    String styleSheetText = m_parsedStyleSheet->text();
+    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(bodyEnd <= styleSheetText.length());
+
     if (oldText) {
-        auto result = inspectorStyle->text();
-        if (result.hasException())
-            return result.releaseException();
-        *oldText = result.releaseReturnValue();
+        // In order to perform a faithful undo, text has to be restored to its non-canonicalized form.
+        *oldText = styleSheetText.substring(bodyStart, bodyEnd - bodyStart);
     }
 
-    auto result = inspectorStyle->setText(text);
-    if (!result.hasException())
-        fireStyleSheetChanged();
-    return result;
+    auto setPatchedStyleSheetText = [&](String& patchedStyleSheetText) {
+        setText(patchedStyleSheetText);
+        reparseStyleSheet(patchedStyleSheetText);
+    };
+
+    if (isUndo == IsUndo::Yes) {
+        // Undo operations will be performed with complete style text, including nested rules.
+        auto patchedStyleSheetText = makeStringByReplacing(styleSheetText, bodyStart, bodyEnd - bodyStart , newText);
+        setPatchedStyleSheetText(patchedStyleSheetText);
+        return { };
+    }
+
+    auto indentation = emptyString();
+    auto startOfSecondLine = newText.find('\n');
+    if (startOfSecondLine != notFound) {
+        ++startOfSecondLine;
+        auto endOfSecondLineWhitespace = newText.find(isNotSpaceOrTab, startOfSecondLine);
+        if (endOfSecondLineWhitespace != notFound)
+            indentation = newText.substring(startOfSecondLine, endOfSecondLineWhitespace - startOfSecondLine);
+    }
+
+    // Because style declarations can contain a mix of property declarations and nested rules, we canonicalize the order
+    // so that all property declarations occurs before child rules.
+    StringBuilder replacementBodyText;
+    replacementBodyText.append(newText);
+
+    for (auto& childRuleSourceData : logicalContainingRuleSourceData->childRules) {
+        if (childRuleSourceData->isImplicitlyNested)
+            continue;
+
+        unsigned childStart = childRuleSourceData->ruleHeaderRange.start;
+        unsigned childEnd = childRuleSourceData->ruleBodyRange.end;
+        ASSERT(childStart <= childEnd);
+        RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(childEnd <= styleSheetText.length());
+
+        replacementBodyText.append('\n', indentation);
+
+        // Non-style rules don't include the `@rule` prelude in their header range.
+        if (childRuleSourceData->type != StyleRuleType::Style)
+            replacementBodyText.append(atRuleIdentifierForType(childRuleSourceData->type));
+
+        replacementBodyText.appendSubstring(styleSheetText, childStart, childEnd - childStart);
+        replacementBodyText.append("}\n");
+    }
+
+    auto closingIndentationLineStart = newText.reverseFind('\n');
+    if (closingIndentationLineStart != notFound)
+        replacementBodyText.appendSubstring(newText, closingIndentationLineStart);
+
+    auto patchedStyleSheetText = makeStringByReplacing(styleSheetText, bodyStart, bodyEnd - bodyStart , replacementBodyText);
+    setPatchedStyleSheetText(patchedStyleSheetText);
+
+    return { };
 }
 
 ExceptionOr<String> InspectorStyleSheet::text() const
@@ -1604,30 +1706,6 @@ void InspectorStyleSheet::ensureFlatRules() const
         collectFlatRules(asCSSRuleList(pageStyleSheet()), &m_flatRules);
 }
 
-ExceptionOr<void> InspectorStyleSheet::setStyleText(CSSStyleDeclaration* style, const String& text)
-{
-    if (!m_pageStyleSheet)
-        return Exception { NotFoundError };
-    if (!ensureParsedDataReady())
-        return Exception { NotFoundError };
-
-    String patchedStyleSheetText;
-    bool success = styleSheetTextWithChangedStyle(style, text, &patchedStyleSheetText);
-    if (!success)
-        return Exception { NotFoundError };
-
-    InspectorCSSId id = ruleOrStyleId(style);
-    if (id.isEmpty())
-        return Exception { NotFoundError };
-
-    auto setCssTextResult = style->setCssText(text);
-    if (setCssTextResult.hasException())
-        return setCssTextResult.releaseException();
-
-    m_parsedStyleSheet->setText(patchedStyleSheetText);
-    return { };
-}
-
 bool InspectorStyleSheet::styleSheetTextWithChangedStyle(CSSStyleDeclaration* style, const String& newStyleText, String* result)
 {
     if (!style)
@@ -1771,9 +1849,10 @@ ExceptionOr<String> InspectorStyleSheetForInlineStyle::text() const
     return String { m_styleText };
 }
 
-ExceptionOr<void> InspectorStyleSheetForInlineStyle::setStyleText(CSSStyleDeclaration* style, const String& text)
+ExceptionOr<void> InspectorStyleSheetForInlineStyle::setRuleStyleText(const InspectorCSSId&, const String& text, String* oldText, IsUndo)
 {
-    ASSERT_UNUSED(style, style == &inlineStyle());
+    if (oldText)
+        *oldText = m_styleText;
 
     {
         InspectorCSSAgent::InlineStyleOverrideScope overrideScope(m_element->document());

--- a/Source/WebCore/inspector/InspectorStyleSheet.h
+++ b/Source/WebCore/inspector/InspectorStyleSheet.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2010, Google Inc. All rights reserved.
- * Copyright (C) 2022, Apple Inc. All rights reserved.
+ * Copyright (C) 2023, Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -131,7 +131,6 @@ public:
     Ref<JSON::ArrayOf<Inspector::Protocol::CSS::CSSComputedStyleProperty>> buildArrayForComputedStyle() const;
 
     ExceptionOr<String> text() const;
-    ExceptionOr<void> setText(const String&);
 
 private:
     InspectorStyle(const InspectorCSSId& styleId, Ref<CSSStyleDeclaration>&&, InspectorStyleSheet* parentStyleSheet);
@@ -179,7 +178,9 @@ public:
     RefPtr<Inspector::Protocol::CSS::CSSRule> buildObjectForRule(CSSStyleRule*);
     Ref<Inspector::Protocol::CSS::CSSStyle> buildObjectForStyle(CSSStyleDeclaration*);
     RefPtr<Inspector::Protocol::CSS::Grouping> buildObjectForGrouping(CSSRule*);
-    ExceptionOr<void> setStyleText(const InspectorCSSId&, const String& text, String* oldText);
+
+    enum class IsUndo : bool { No, Yes };
+    virtual ExceptionOr<void> setRuleStyleText(const InspectorCSSId&, const String& newText, String* oldText, IsUndo = IsUndo::No);
 
     virtual ExceptionOr<String> text() const;
     virtual CSSStyleDeclaration* styleForId(const InspectorCSSId&) const;
@@ -200,7 +201,6 @@ protected:
     virtual RefPtr<InspectorStyle> inspectorStyleForId(const InspectorCSSId&);
 
     // Also accessed by friend class InspectorStyle.
-    virtual ExceptionOr<void> setStyleText(CSSStyleDeclaration*, const String&);
     virtual Vector<size_t> lineEndings() const;
 
 private:
@@ -241,6 +241,7 @@ public:
     void didModifyElementAttribute();
     ExceptionOr<String> text() const final;
     CSSStyleDeclaration* styleForId(const InspectorCSSId& id) const final { ASSERT_UNUSED(id, !id.ordinal()); return &inlineStyle(); }
+    ExceptionOr<void> setRuleStyleText(const InspectorCSSId&, const String& newText, String* oldText, InspectorStyleSheet::IsUndo = InspectorStyleSheet::IsUndo::No) final;
 
 private:
     InspectorStyleSheetForInlineStyle(InspectorPageAgent*, const String& id, Ref<StyledElement>&&, Inspector::Protocol::CSS::StyleSheetOrigin, Listener*);
@@ -253,7 +254,6 @@ private:
     RefPtr<InspectorStyle> inspectorStyleForId(const InspectorCSSId&) final;
 
     // Also accessed by friend class InspectorStyle.
-    ExceptionOr<void> setStyleText(CSSStyleDeclaration*, const String&) final;
     Vector<size_t> lineEndings() const final;
 
     CSSStyleDeclaration& inlineStyle() const;

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
@@ -165,12 +165,12 @@ public:
 
     ExceptionOr<void> undo() override
     {
-        return m_styleSheet->setStyleText(m_cssId, m_oldText, nullptr);
+        return m_styleSheet->setRuleStyleText(m_cssId, m_oldText, nullptr, InspectorStyleSheet::IsUndo::Yes);
     }
 
     ExceptionOr<void> redo() override
     {
-        return m_styleSheet->setStyleText(m_cssId, m_text, &m_oldText);
+        return m_styleSheet->setRuleStyleText(m_cssId, m_text, &m_oldText);
     }
 
     String mergeId() override

--- a/Source/WebInspectorUI/UserInterface/Models/CSSRule.js
+++ b/Source/WebInspectorUI/UserInterface/Models/CSSRule.js
@@ -25,7 +25,7 @@
 
 WI.CSSRule = class CSSRule extends WI.Object
 {
-    constructor(nodeStyles, ownerStyleSheet, id, type, sourceCodeLocation, selectorText, selectors, matchedSelectorIndices, style, groupings)
+    constructor(nodeStyles, ownerStyleSheet, id, type, sourceCodeLocation, selectorText, selectors, matchedSelectorIndices, style, groupings, isImplicitlyNested)
     {
         super();
 
@@ -36,6 +36,7 @@ WI.CSSRule = class CSSRule extends WI.Object
         this._id = id || null;
         this._type = type || null;
         this._initialState = null;
+        this._isImplicitlyNested = isImplicitlyNested || false;
 
         this.update(sourceCodeLocation, selectorText, selectors, matchedSelectorIndices, style, groupings, true);
     }
@@ -51,6 +52,7 @@ WI.CSSRule = class CSSRule extends WI.Object
     get matchedSelectorIndices() { return this._matchedSelectorIndices; }
     get style() { return this._style; }
     get groupings() { return this._groupings; }
+    get isImplicitlyNested() { return this._isImplicitlyNested; }
 
     get editable()
     {

--- a/Source/WebInspectorUI/UserInterface/Models/CSSStyleDeclaration.js
+++ b/Source/WebInspectorUI/UserInterface/Models/CSSStyleDeclaration.js
@@ -108,7 +108,7 @@ WI.CSSStyleDeclaration = class CSSStyleDeclaration extends WI.Object
 
     get selectorEditable()
     {
-        return this._ownerRule && this._ownerRule.editable && InspectorBackend.hasCommand("CSS.setRuleSelector");
+        return this._ownerRule && this._ownerRule.editable && !this._ownerRule.isImplicitlyNested && InspectorBackend.hasCommand("CSS.setRuleSelector");
     }
 
     get locked() { return this._locked; }

--- a/Source/WebInspectorUI/UserInterface/Models/DOMNodeStyles.js
+++ b/Source/WebInspectorUI/UserInterface/Models/DOMNodeStyles.js
@@ -768,7 +768,7 @@ WI.DOMNodeStyles = class DOMNodeStyles extends WI.Object
         if (styleSheet)
             this._trackedStyleSheets.add(styleSheet);
 
-        rule = new WI.CSSRule(this, styleSheet, id, type, sourceCodeLocation, selectorText, selectors, matchedSelectorIndices, style, groupings);
+        rule = new WI.CSSRule(this, styleSheet, id, type, sourceCodeLocation, selectorText, selectors, matchedSelectorIndices, style, groupings, payload.isImplicitlyNested);
 
         if (mapKey)
             this._rulesMap.set(mapKey, rule);


### PR DESCRIPTION
#### b1dd655b710e45f59c91ef803255a8dbc4fc94e1
<pre>
Web Inspector: Implicitly nested property declarations inside non-style rules results in nested content being deleted during editing or displaying incorrect matched styles for elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=251565">https://bugs.webkit.org/show_bug.cgi?id=251565</a>
rdar://104821946

Reviewed by Devin Rousso.

InspectorStyleSheet was built with the assumption that Style rules contained property declarations, and nothing else.
CSS nesting has proven this assumption wrong in significant ways by allowing properties and other rules to be declared,
interleaved inside a rule. This includes inside @ rules, which previously could not contain property delcarations
directly.

This means during editing, we only want to replace the property declarations, not the full body of a rule, since the
rule may contain other rules. Luckily, canonically all property declarations occur before all nested rules, so we can
safely move nested rules below to make our lives a bit easier with no harm to the meaning of the style sheet.

This fix adds instrumentation to the CSS parser so we can be informed of the new &quot;implicit&quot; nested rule that contains
properties inside of non-style rules. It also overhauls how rule body text is edited, much like we had to last year for
rule header text.

* LayoutTests/inspector/css/getMatchedStylesForNode-expected.txt:
- Account for new property of CSSRule.

* LayoutTests/inspector/css/getMatchedStylesForNodeNestingStyleGrouping-expected.txt:
* LayoutTests/inspector/css/getMatchedStylesForNodeNestingStyleGrouping.html:
* LayoutTests/inspector/css/modify-css-property-expected.txt:
* LayoutTests/inspector/css/modify-css-property.html:
* LayoutTests/inspector/css/resources/modify-css-property.css:
- Add test cases for implicitly nested rules and their siblings, children, and parents.

* Source/JavaScriptCore/inspector/protocol/CSS.json:
- Mark implicitly nested rules so that the frontend can prevent the editing of their selector.

* Source/WebCore/css/CSSPropertySourceData.h:
(WebCore::CSSRuleSourceData::CSSRuleSourceData):
- The container rule types can now contain properties, so we always need to have the buffer for that information ready,
since we won&apos;t be informed by the parser that an implicit nested context was created until after we have observed the
properties themselves.

* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumeRegularRuleList):
(WebCore::CSSParserImpl::consumeDeclarationListOrStyleBlockHelper):
(WebCore::CSSParserImpl::consumeStyleBlock):
* Source/WebCore/css/parser/CSSParserImpl.h:
- Don&apos;t send duplicate bodyStart/bodyEnd messages to the observer.
- Notify the observer when the engine has created an implict nested rule inside a body.

* Source/WebCore/css/parser/CSSParserObserver.h:

* Source/WebCore/inspector/InspectorStyleSheet.cpp:
(WebCore::atRuleIdentifierForType):
(WebCore::isValidRuleHeaderText):
- Pull the mapping of types to their keyword text for reuse in setting new style text.

(WebCore::StyleSheetHandler::endRuleBody):
- In order to maintain parity with CSSOM&apos;s representation of styles, we need to create an implictly nested rule to
match against the CSSOM&apos;s implicitly nested rule. This also allows us to inform the frontend that said CSSOM rule was
implicitly nested, since the OM itself doesn&apos;t carry this information.

(WebCore::StyleSheetHandler::markRuleBodyContainsImplicitlyNestedProperties):
- Observe to mark the style rule data as containing implicitly nested properties, which will then trigger us to take those properties and mvoe them to a special implicit style rule data object.

(WebCore::InspectorStyleSheet::buildObjectForRule):

(WebCore::isNotSpaceOrTab):
(WebCore::InspectorStyleSheet::setRuleStyleText):
- Overhaul the setting of style text.
- Undo/oldText is handled specially because we want to restore the sheet back to the non-canonical form after an edit.
- The frontend does not provide nested rules as part of its new text, so we must readd them ourselves, which we can do
from the original style sheet.
- Indentation is matched to the new property delcartion text provided by the frontend.

(WebCore::InspectorStyleSheetForInlineStyle::setRuleStyleText):
- Match the method signature for non-inline styles, and simplify the indirection previously present for setting a style
rule&apos;s/inline style&apos;s text.

(WebCore::InspectorStyle::setText): Deleted.
(WebCore::InspectorStyleSheet::setStyleText): Deleted.
(WebCore::InspectorStyleSheetForInlineStyle::setStyleText): Deleted.
* Source/WebCore/inspector/InspectorStyleSheet.h:

* Source/WebCore/inspector/agents/InspectorCSSAgent.cpp:
- Adopt new method to set the body text of a rule.

* Source/WebInspectorUI/UserInterface/Models/CSSRule.js:
(WI.CSSRule):
(WI.CSSRule.prototype.get isImplicitlyNested):
* Source/WebInspectorUI/UserInterface/Models/CSSStyleDeclaration.js:
(WI.CSSStyleDeclaration.prototype.get selectorEditable):
* Source/WebInspectorUI/UserInterface/Models/DOMNodeStyles.js:
(WI.DOMNodeStyles.prototype._parseRulePayload):
- Mark the selector of implicitly nested rules as non-editable.

Canonical link: <a href="https://commits.webkit.org/261329@main">https://commits.webkit.org/261329@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ee4354830c5410955a9ea536a5fa478718bc7e2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111169 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20308 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43729 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2593 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120005 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115122 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21682 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11409 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2216 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116925 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16107 "Found 1 new test failure: fast/scrolling/keyboard-scrolling-distance-pageDown.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99286 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103729 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98064 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30948 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44622 "") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/99737 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12823 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32283 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86510 "Found 2 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state-changed, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/10925 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13359 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9275 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/100889 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18781 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31458 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7850 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15310 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/108924 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26860 "Passed tests") | 
<!--EWS-Status-Bubble-End-->