### PR TITLE
Reduce build times by refactoring JSDOMGlobalObject.h

### DIFF
--- a/Source/WebCore/bindings/js/JSDOMAttribute.h
+++ b/Source/WebCore/bindings/js/JSDOMAttribute.h
@@ -25,6 +25,7 @@
 
 #include "JSDOMCastThisValue.h"
 #include "JSDOMExceptionHandling.h"
+#include <JavaScriptCore/Error.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
@@ -35,6 +35,7 @@
 #include "FrameDestructionObserverInlines.h"
 #include "JSAbortAlgorithm.h"
 #include "JSAbortSignal.h"
+#include "JSDOMGlobalObjectInlines.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSDOMWindow.h"
 #include "JSEventListener.h"
@@ -59,6 +60,7 @@
 #include "ShadowRealmGlobalScope.h"
 #include "SharedWorkerGlobalScope.h"
 #include "StructuredClone.h"
+#include "WebCoreJSBuiltinInternals.h"
 #include "WebCoreJSClientData.h"
 #include "WorkerGlobalScope.h"
 #include "WorkletGlobalScope.h"
@@ -101,7 +103,7 @@ JSDOMGlobalObject::JSDOMGlobalObject(VM& vm, Structure* structure, Ref<DOMWrappe
     , m_constructors(makeUnique<DOMConstructors>())
     , m_world(WTFMove(world))
     , m_worldIsNormal(m_world->isNormal())
-    , m_builtinInternalFunctions(vm)
+    , m_builtinInternalFunctions(makeUniqueRefWithoutFastMallocCheck<JSBuiltinInternalFunctions>(vm))
     , m_crossOriginFunctionMap(vm)
     , m_crossOriginGetterSetterMap(vm)
 {
@@ -253,7 +255,7 @@ JSC_DEFINE_HOST_FUNCTION(signalAbort, (JSGlobalObject*, CallFrame* callFrame))
 
 SUPPRESS_ASAN void JSDOMGlobalObject::addBuiltinGlobals(VM& vm)
 {
-    m_builtinInternalFunctions.initialize(*this);
+    m_builtinInternalFunctions->initialize(*this);
 
     auto& builtinNames = WebCore::builtinNames(vm);
     JSDOMGlobalObject::GlobalPropertyInfo staticGlobals[] = {
@@ -369,7 +371,7 @@ void JSDOMGlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     for (auto& constructor : thisObject->constructors().array())
         visitor.append(constructor);
 
-    thisObject->m_builtinInternalFunctions.visit(visitor);
+    thisObject->m_builtinInternalFunctions->visit(visitor);
 }
 
 DEFINE_VISIT_CHILDREN(JSDOMGlobalObject);

--- a/Source/WebCore/bindings/js/JSDOMGuardedObject.cpp
+++ b/Source/WebCore/bindings/js/JSDOMGuardedObject.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "JSDOMGuardedObject.h"
 
+#include "JSDOMGlobalObjectInlines.h"
 
 namespace WebCore {
 using namespace JSC;

--- a/Source/WebCore/bindings/js/JSDOMMapLike.cpp
+++ b/Source/WebCore/bindings/js/JSDOMMapLike.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "JSDOMMapLike.h"
 
+#include "WebCoreJSBuiltinInternals.h"
 #include "WebCoreJSClientData.h"
 #include <JavaScriptCore/CatchScope.h>
 #include <JavaScriptCore/HashMapImplInlines.h>

--- a/Source/WebCore/bindings/js/JSDOMSetLike.cpp
+++ b/Source/WebCore/bindings/js/JSDOMSetLike.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "JSDOMSetLike.h"
 
+#include "WebCoreJSBuiltinInternals.h"
 #include "WebCoreJSClientData.h"
 #include <JavaScriptCore/CatchScope.h>
 #include <JavaScriptCore/JSSet.h>

--- a/Source/WebCore/bindings/js/JSDOMWindowCustom.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWindowCustom.cpp
@@ -33,6 +33,7 @@
 #include "JSDOMConvertNullable.h"
 #include "JSDOMConvertNumbers.h"
 #include "JSDOMConvertStrings.h"
+#include "JSDOMGlobalObjectInlines.h"
 #include "JSDOMMicrotask.h"
 #include "JSDatabase.h"
 #include "JSDatabaseCallback.h"

--- a/Source/WebCore/bindings/js/JSDocumentCustom.cpp
+++ b/Source/WebCore/bindings/js/JSDocumentCustom.cpp
@@ -24,6 +24,7 @@
 #include "FrameDestructionObserverInlines.h"
 #include "JSCSSStyleSheet.h"
 #include "JSDOMConvert.h"
+#include "JSDOMGlobalObjectInlines.h"
 #include "JSDOMWindowCustom.h"
 #include "JSHTMLDocument.h"
 #include "JSXMLDocument.h"

--- a/Source/WebCore/bindings/js/JSEventTargetCustom.cpp
+++ b/Source/WebCore/bindings/js/JSEventTargetCustom.cpp
@@ -30,6 +30,7 @@
 #include "EventTarget.h"
 #include "EventTargetHeaders.h"
 #include "EventTargetInterfaces.h"
+#include "JSDOMGlobalObjectInlines.h"
 #include "JSDOMWindow.h"
 #include "JSEventListener.h"
 #include "JSWindowProxy.h"

--- a/Source/WebCore/bindings/js/JSNavigatorCustom.cpp
+++ b/Source/WebCore/bindings/js/JSNavigatorCustom.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "JSNavigator.h"
 
+#include "WebCoreJSBuiltinInternals.h"
 #include "WebCoreJSClientData.h"
 #include "WebCoreOpaqueRoot.h"
 #include <JavaScriptCore/CatchScope.h>

--- a/Source/WebCore/bindings/js/JSValueInWrappedObject.h
+++ b/Source/WebCore/bindings/js/JSValueInWrappedObject.h
@@ -26,9 +26,9 @@
 
 #include "DOMWrapperWorld.h"
 #include "JSDOMWrapper.h"
-#include <JavaScriptCore/JSCJSValue.h>
+#include <JavaScriptCore/JSCJSValueInlines.h>
 #include <JavaScriptCore/SlotVisitor.h>
-#include <JavaScriptCore/Weak.h>
+#include <JavaScriptCore/WeakInlines.h>
 #include <variant>
 
 namespace WebCore {

--- a/Source/WebCore/bindings/js/ReadableStream.cpp
+++ b/Source/WebCore/bindings/js/ReadableStream.cpp
@@ -31,6 +31,7 @@
 #include "JSDOMConvertSequences.h"
 #include "JSReadableStreamSink.h"
 #include "JSReadableStreamSource.h"
+#include "WebCoreJSBuiltinInternals.h"
 #include "WebCoreJSClientData.h"
 
 

--- a/Source/WebCore/inspector/CommandLineAPIModule.cpp
+++ b/Source/WebCore/inspector/CommandLineAPIModule.cpp
@@ -27,6 +27,7 @@
 #include "CommandLineAPIModule.h"
 
 #include "JSDOMGlobalObject.h"
+#include "WebCoreJSBuiltinInternals.h"
 #include "WebInjectedScriptManager.h"
 #include <JavaScriptCore/HeapInlines.h>
 #include <JavaScriptCore/InjectedScript.h>


### PR DESCRIPTION
#### bd35435fc6d728ae3c5c185df96264d86160c5bd
<pre>
Reduce build times by refactoring JSDOMGlobalObject.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=251570">https://bugs.webkit.org/show_bug.cgi?id=251570</a>
rdar://104949069

Reviewed by Ryosuke Niwa.

Move inline methods into JSDOMGlobalObjectInlines.h, and add that include to all source files
where those inlines are used.

Allow JSBuiltinInternalFunctions to be forward declared by putting the m_builtinInternalFunctions
in a UniqueRef rather than a bare object.

Fix some drive-by build errors revealed by removing inline headers from JSDOMGlobalObject.h.

Canonical link: <a href="https://commits.webkit.org/259903@main">https://commits.webkit.org/259903@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18dbc8c8ec5f67c312c29e77dfcdc20d5b0c4cdb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105906 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14974 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38752 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115100 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175221 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109808 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16392 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6167 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98134 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114855 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111656 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12477 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95453 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40035 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94342 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27097 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81700 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8238 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28451 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8720 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5031 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14350 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47991 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6843 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10274 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->