### PR TITLE
Composed screen becomes blank/empty for overflow-y scroll area with and rounded border radious

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
@@ -277,7 +277,7 @@ void TextureMapperLayer::paintSelfAndChildren(TextureMapperPaintOptions& options
         clipTransform.multiply(options.transform);
         clipTransform.multiply(m_layerTransforms.combined);
         if (m_state.contentsRectClipsDescendants)
-            options.textureMapper.beginClip(clipTransform, m_state.contentsClippingRect);
+            options.textureMapper.beginClip(clipTransform, FloatRoundedRect(layerRect()));
         else {
             clipTransform.translate(m_state.boundsOrigin.x(), m_state.boundsOrigin.y());
             options.textureMapper.beginClip(clipTransform, FloatRoundedRect(layerRect()));


### PR DESCRIPTION
#### 73d5a45ccda6254165ce4ad3413e70911cd80bca
<pre>
Composed screen becomes blank/empty for overflow-y scroll area with and rounded border radious
<a href="https://bugs.webkit.org/show_bug.cgi?id=251571">https://bugs.webkit.org/show_bug.cgi?id=251571</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp:
(WebCore::TextureMapperLayer::paintSelfAndChildren):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73d5a45ccda6254165ce4ad3413e70911cd80bca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105818 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14886 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38666 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115016 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175145 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109720 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16305 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6085 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98049 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114798 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111569 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12402 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95376 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39960 "Found 4 new test failures: compositing/clipping/border-radius-with-composited-descendant-nested.html, compositing/clipping/border-radius-with-composited-descendant.html, compositing/iframes/border-radius-composited-frame.html, compositing/iframes/border-uneven-radius-composited-frame.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94266 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27017 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81592 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8157 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28369 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8639 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4957 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14266 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47917 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10196 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->