### PR TITLE
[WGSL] Implement additive & multiplicative expression parsing

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTForward.h
+++ b/Source/WebGPU/WGSL/AST/ASTForward.h
@@ -105,8 +105,10 @@ class Variable;
 class VariableQualifier;
 
 enum class AccessMode : uint8_t;
+enum class BinaryOperation : uint8_t;
 enum class ParameterRole : uint8_t;
 enum class StorageClass : uint8_t;
 enum class StructureRole : uint8_t;
+enum class UnaryOperation : uint8_t;
 
 } // namespace WGSL::AST

--- a/Source/WebGPU/WGSL/Lexer.cpp
+++ b/Source/WebGPU/WGSL/Lexer.cpp
@@ -41,6 +41,9 @@ Token Lexer<T>::lex()
         return makeToken(TokenType::EndOfFile);
 
     switch (m_current) {
+    case '%':
+        shift();
+        return makeToken(TokenType::Modulo);
     case '(':
         shift();
         return makeToken(TokenType::ParenLeft);
@@ -83,6 +86,9 @@ Token Lexer<T>::lex()
     case '*':
         shift();
         return makeToken(TokenType::Star);
+    case '/':
+        shift();
+        return makeToken(TokenType::Slash);
     case '.': {
         shift();
         unsigned offset = currentOffset();

--- a/Source/WebGPU/WGSL/ParserPrivate.h
+++ b/Source/WebGPU/WGSL/ParserPrivate.h
@@ -74,7 +74,9 @@ public:
     Expected<AST::Expression::Ref, Error> parseRelationalExpression(AST::Expression::Ref&& lhs);
     Expected<AST::Expression::Ref, Error> parseShiftExpression(AST::Expression::Ref&& lhs);
     Expected<AST::Expression::Ref, Error> parseAdditiveExpression(AST::Expression::Ref&& lhs);
+    Expected<AST::BinaryOperation, Error> parseAdditiveOperator();
     Expected<AST::Expression::Ref, Error> parseMultiplicativeExpression(AST::Expression::Ref&& lhs);
+    Expected<AST::BinaryOperation, Error> parseMultiplicativeOperator();
     Expected<AST::Expression::Ref, Error> parseUnaryExpression();
     Expected<AST::Expression::Ref, Error> parseSingularExpression();
     Expected<AST::Expression::Ref, Error> parsePostfixExpression(AST::Expression::Ref&& base, SourcePosition startPosition);

--- a/Source/WebGPU/WGSL/Token.cpp
+++ b/Source/WebGPU/WGSL/Token.cpp
@@ -113,6 +113,8 @@ String toString(TokenType type)
         return "-"_s;
     case TokenType::MinusMinus:
         return "--"_s;
+    case TokenType::Modulo:
+        return "%"_s;
     case TokenType::Plus:
         return "+"_s;
     case TokenType::PlusPlus:
@@ -125,6 +127,8 @@ String toString(TokenType type)
         return ")"_s;
     case TokenType::Semicolon:
         return ";"_s;
+    case TokenType::Slash:
+        return "/"_s;
     case TokenType::Star:
         return "*"_s;
     }

--- a/Source/WebGPU/WGSL/Token.h
+++ b/Source/WebGPU/WGSL/Token.h
@@ -83,12 +83,14 @@ enum class TokenType: uint32_t {
     LT,
     Minus,
     MinusMinus,
+    Modulo,
     Plus,
     PlusPlus,
     Period,
     ParenLeft,
     ParenRight,
     Semicolon,
+    Slash,
     Star,
     // FIXME: add all the other special tokens
 };

--- a/Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp
@@ -138,10 +138,13 @@ TEST(WGSLLexerTests, SpecialTokens)
     checkSingleToken("<"_s, TokenType::LT);
     checkSingleToken("-"_s, TokenType::Minus);
     checkSingleToken("--"_s, TokenType::MinusMinus);
+    checkSingleToken("%"_s, TokenType::Modulo);
     checkSingleToken("."_s, TokenType::Period);
     checkSingleToken("("_s, TokenType::ParenLeft);
     checkSingleToken(")"_s, TokenType::ParenRight);
     checkSingleToken(";"_s, TokenType::Semicolon);
+    checkSingleToken("/"_s, TokenType::Slash);
+    checkSingleToken("*"_s, TokenType::Star);
 }
 
 TEST(WGSLLexerTests, ComputeShader)

--- a/Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp
@@ -27,6 +27,7 @@
 #include "ASTAttribute.h"
 #include "ASTTypeName.h"
 #include "Parser.h"
+#include "ParserPrivate.h"
 
 #include "AST.h"
 #include "Lexer.h"
@@ -74,6 +75,14 @@ inline Expected<WGSL::AST::ShaderModule, WGSL::Error> parse(const String& wgsl)
     WGSL::Configuration configuration;
     configuration.maxBuffersPlusVertexBuffersForVertexStage = 8;
     return WGSL::parseLChar(wgsl, configuration);
+}
+
+Expected<WGSL::AST::Expression::Ref, WGSL::Error> parseExpression(const String& wgsl)
+{
+    WGSL::Lexer<LChar> lexer(wgsl);
+    WGSL::Parser parser(lexer);
+
+    return parser.parseExpression();
 }
 
 static void testStruct(ASCIILiteral program, const Vector<String>& fieldNames, const Vector<String>& typeNames)
@@ -493,6 +502,105 @@ TEST(WGSLParserTests, BinaryExpression)
         EXPECT_EQ(rhs.identifier(), "y"_s);
     }
 }
+
+TEST(WGSLParserTests, BinaryExpression2)
+{
+    EXPECT_EXPRESSION(expression, parseExpression(R"(x - y + 1)"_s));
+    EXPECT_TRUE(is<WGSL::AST::BinaryExpression>(expression));
+    auto& binaryExpression = downcast<WGSL::AST::BinaryExpression>(expression.get());
+
+    {
+        // op: +
+        EXPECT_EQ(binaryExpression.operation(), WGSL::AST::BinaryOperation::Add);
+        // lhs: x - y
+        EXPECT_TRUE(is<WGSL::AST::BinaryExpression>(binaryExpression.leftExpression()));
+        // rhs: 1
+        EXPECT_TRUE(is<WGSL::AST::AbstractIntegerLiteral>(binaryExpression.rightExpression()));
+        checkIntLiteral(binaryExpression.rightExpression(), 1);
+    }
+
+    {
+        EXPECT_TRUE(is<WGSL::AST::BinaryExpression>(binaryExpression.leftExpression()));
+        auto& binaryExpression2 = downcast<WGSL::AST::BinaryExpression>(binaryExpression.leftExpression());
+        // op: -
+        EXPECT_EQ(binaryExpression2.operation(), WGSL::AST::BinaryOperation::Subtract);
+        // lhs: x
+        EXPECT_TRUE(is<WGSL::AST::IdentifierExpression>(binaryExpression2.leftExpression()));
+        auto& lhs = downcast<WGSL::AST::IdentifierExpression>(binaryExpression2.leftExpression());
+        EXPECT_EQ(lhs.identifier(), "x"_s);
+        // rhs: y
+        EXPECT_TRUE(is<WGSL::AST::IdentifierExpression>(binaryExpression2.rightExpression()));
+        auto& rhs = downcast<WGSL::AST::IdentifierExpression>(binaryExpression2.rightExpression());
+        EXPECT_EQ(rhs.identifier(), "y"_s);
+    }
+}
+
+TEST(WGSLParserTests, BinaryExpression3)
+{
+    EXPECT_EXPRESSION(expression, parseExpression(R"(x + y * z)"_s));
+    EXPECT_TRUE(is<WGSL::AST::BinaryExpression>(expression));
+    auto& binaryExpression = downcast<WGSL::AST::BinaryExpression>(expression.get());
+
+    {
+        // op: +
+        EXPECT_EQ(binaryExpression.operation(), WGSL::AST::BinaryOperation::Add);
+        // lhs: x
+        EXPECT_TRUE(is<WGSL::AST::IdentifierExpression>(binaryExpression.leftExpression()));
+        auto& lhs = downcast<WGSL::AST::IdentifierExpression>(binaryExpression.leftExpression());
+        EXPECT_EQ(lhs.identifier(), "x"_s);
+        // rhs: y * z
+        EXPECT_TRUE(is<WGSL::AST::BinaryExpression>(binaryExpression.rightExpression()));
+    }
+
+    {
+        EXPECT_TRUE(is<WGSL::AST::BinaryExpression>(binaryExpression.rightExpression()));
+        auto& binaryExpression2 = downcast<WGSL::AST::BinaryExpression>(binaryExpression.rightExpression());
+        // op: *
+        EXPECT_EQ(binaryExpression2.operation(), WGSL::AST::BinaryOperation::Multiply);
+        // lhs: y
+        EXPECT_TRUE(is<WGSL::AST::IdentifierExpression>(binaryExpression2.leftExpression()));
+        auto& lhs = downcast<WGSL::AST::IdentifierExpression>(binaryExpression2.leftExpression());
+        EXPECT_EQ(lhs.identifier(), "y"_s);
+        // rhs: z
+        EXPECT_TRUE(is<WGSL::AST::IdentifierExpression>(binaryExpression2.rightExpression()));
+        auto& rhs = downcast<WGSL::AST::IdentifierExpression>(binaryExpression2.rightExpression());
+        EXPECT_EQ(rhs.identifier(), "z"_s);
+    }
+}
+
+TEST(WGSLParserTests, BinaryExpression4)
+{
+    EXPECT_EXPRESSION(expression, parseExpression(R"(x / y + z)"_s));
+    EXPECT_TRUE(is<WGSL::AST::BinaryExpression>(expression));
+    auto& binaryExpression = downcast<WGSL::AST::BinaryExpression>(expression.get());
+
+    {
+        // op: +
+        EXPECT_EQ(binaryExpression.operation(), WGSL::AST::BinaryOperation::Add);
+        // lhs: x * y
+        EXPECT_TRUE(is<WGSL::AST::BinaryExpression>(binaryExpression.leftExpression()));
+        // rhs: z
+        EXPECT_TRUE(is<WGSL::AST::IdentifierExpression>(binaryExpression.rightExpression()));
+        auto& rhs = downcast<WGSL::AST::IdentifierExpression>(binaryExpression.rightExpression());
+        EXPECT_EQ(rhs.identifier(), "z"_s);
+    }
+
+    {
+        EXPECT_TRUE(is<WGSL::AST::BinaryExpression>(binaryExpression.leftExpression()));
+        auto& binaryExpression2 = downcast<WGSL::AST::BinaryExpression>(binaryExpression.leftExpression());
+        // op: /
+        EXPECT_EQ(binaryExpression2.operation(), WGSL::AST::BinaryOperation::Divide);
+        // lhs: x
+        EXPECT_TRUE(is<WGSL::AST::IdentifierExpression>(binaryExpression2.leftExpression()));
+        auto& lhs = downcast<WGSL::AST::IdentifierExpression>(binaryExpression2.leftExpression());
+        EXPECT_EQ(lhs.identifier(), "x"_s);
+        // rhs: y
+        EXPECT_TRUE(is<WGSL::AST::IdentifierExpression>(binaryExpression2.rightExpression()));
+        auto& rhs = downcast<WGSL::AST::IdentifierExpression>(binaryExpression2.rightExpression());
+        EXPECT_EQ(rhs.identifier(), "y"_s);
+    }
+}
+
 #pragma mark -
 #pragma mark WebGPU Example Shaders
 

--- a/Tools/TestWebKitAPI/Tests/WGSL/TestWGSLAPI.h
+++ b/Tools/TestWebKitAPI/Tests/WGSL/TestWGSLAPI.h
@@ -33,6 +33,14 @@
         } \
     } while (false)
 
+#define EXPECT_EXPRESSION(name, expr) \
+    auto name##Expected = expr; \
+    if (!name##Expected) { \
+        ::TestWGSLAPI::logCompilationError(name##Expected.error()); \
+        return; \
+    } \
+    auto& name = *name##Expected;
+
 namespace WGSL {
 class CompilationMessage;
 }


### PR DESCRIPTION
#### 8c49f9898715b5df8bf06c82b633bf55b009d9ee
<pre>
[WGSL] Implement additive &amp; multiplicative expression parsing
<a href="https://bugs.webkit.org/show_bug.cgi?id=251573">https://bugs.webkit.org/show_bug.cgi?id=251573</a>
rdar://problem/104951203

Reviewed by Tadeu Zagallo.

Implement parsing of expressions involving +, -, *, / and % with correct
precedence by handling -, / and % operators.

Canonical link: <a href="https://commits.webkit.org/259780@main">https://commits.webkit.org/259780@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c861a558d6e134006388780bc5f598f76aac9813

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105823 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14891 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38671 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115021 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175148 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109725 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16310 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6090 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98055 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111573 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12407 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95380 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39915 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94272 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27021 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8162 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28373 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8644 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4960 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14271 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47921 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6768 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10201 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->