### PR TITLE
[web-animations] animation of color list custom properties with iterationComposite is incorrect

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-color-comma-list-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-color-comma-list-expected.txt
@@ -3,6 +3,6 @@ PASS Animating a custom property of type <color>#
 PASS Animating a custom property of type <color># with a single keyframe
 PASS Animating a custom property of type <color># with additivity
 PASS Animating a custom property of type <color># with a single keyframe and additivity
-FAIL Animating a custom property of type <color># with iterationComposite assert_equals: expected "rgb(125, 125, 125), rgb(250, 250, 250)" but got "rgb(25, 25, 25), rgb(50, 50, 50)"
+PASS Animating a custom property of type <color># with iterationComposite
 PASS Animating a custom property of type <color># with different lengths is discrete
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-color-space-list-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-color-space-list-expected.txt
@@ -3,6 +3,6 @@ PASS Animating a custom property of type <color>+
 PASS Animating a custom property of type <color>+ with a single keyframe
 PASS Animating a custom property of type <color>+ with additivity
 PASS Animating a custom property of type <color>+ with a single keyframe and additivity
-FAIL Animating a custom property of type <color>+ with iterationComposite assert_equals: expected "rgb(125, 125, 125) rgb(250, 250, 250)" but got "rgb(25, 25, 25) rgb(50, 50, 50)"
+PASS Animating a custom property of type <color>+ with iterationComposite
 PASS Animating a custom property of type <color>+ with different lengths is discrete
 


### PR DESCRIPTION
#### d96394a8f3434b88c03b9b8f09633136c2baf36e
<pre>
[web-animations] animation of color list custom properties with iterationComposite is incorrect
<a href="https://bugs.webkit.org/show_bug.cgi?id=251574">https://bugs.webkit.org/show_bug.cgi?id=251574</a>

Reviewed by Antti Koivisto.

Certain types require interpolation for each iteration when `iterationComposite` is used. While we
had logic in place for this in CSSPropertyAnimation::propertyRequiresBlendingForAccumulativeIteration()
for `SyntaxValue` custom properties, we did not for `SyntaxValueList`. We factor the code that determined
whether interpolation was required for the `SyntaxValue` case in a new static method which we now also
call for each value in a `SyntaxValueList`.

* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-color-comma-list-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-color-space-list-expected.txt:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::syntaxValuesRequireBlendingForAccumulativeIteration):
(WebCore::CSSPropertyAnimation::propertyRequiresBlendingForAccumulativeIteration):

Canonical link: <a href="https://commits.webkit.org/259761@main">https://commits.webkit.org/259761@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8972b75a3d918a3c032c0ce6083a5237a7582dad

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105835 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14903 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38683 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115033 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175167 "Failed to checkout and rebase branch from PR 9507") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109737 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16322 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6102 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98068 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111584 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12425 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95393 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39964 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94282 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27035 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8174 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28387 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8656 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4971 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14283 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47935 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10213 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3619 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->