### PR TITLE
[@property] Set registered initial values to RenderStyle

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-animation-expected.txt
@@ -8,7 +8,7 @@ PASS Ongoing animation picks up redeclared inherits flag
 PASS Ongoing animation picks up redeclared meaning of 'unset'
 PASS Transitioning from initial value
 PASS Transitioning from specified value
-FAIL Transition triggered by initial value change assert_equals: expected "150px" but got "200px"
+PASS Transition triggered by initial value change
 PASS No transition when changing types
 PASS No transition when removing @property rule
 PASS Unregistered properties referencing animated properties update correctly.

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/typedom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/typedom-expected.txt
@@ -311,7 +311,7 @@ PASS Specified <length>+ is reified CSSUnparsedValue by iterator [attributeStyle
 PASS Specified <length>+ is reified CSSUnparsedValue by iterator [styleMap]
 PASS Specified <length># is reified CSSUnparsedValue by iterator [attributeStyleMap]
 PASS Specified <length># is reified CSSUnparsedValue by iterator [styleMap]
-FAIL Registered property with initial value show up on iteration of computedStyleMap assert_true: expected true got false
+PASS Registered property with initial value show up on iteration of computedStyleMap
 PASS Computed * is reified as CSSUnparsedValue by iterator
 PASS Computed <angle> is reified as CSSUnitValue by iterator
 PASS Computed <custom-ident> is reified as CSSKeywordValue by iterator

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-registered-custom-properties-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-registered-custom-properties-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Registered custom properties are included in CSSComputedStyleDeclaration assert_not_equals: got disallowed value -1
-FAIL Only relevant custom properties are included assert_not_equals: got disallowed value -1
+PASS Registered custom properties are included in CSSComputedStyleDeclaration
+PASS Only relevant custom properties are included
 

--- a/Source/WebCore/css/CSSVariableReferenceValue.cpp
+++ b/Source/WebCore/css/CSSVariableReferenceValue.cpp
@@ -123,7 +123,7 @@ bool CSSVariableReferenceValue::resolveVariableReference(CSSParserTokenRange ran
         if (functionId == CSSValueEnv)
             return builderState.document().constantProperties().values().get(variableName);
 
-        return builderState.style().customPropertyValue(variableName, builderState.document().customPropertyRegistry());
+        return builderState.style().customPropertyValue(variableName);
     }();
 
     if (!property || property->isInvalid()) {

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -2724,7 +2724,7 @@ RefPtr<CSSValue> ComputedStyleExtractor::customPropertyValue(const AtomString& p
     if (!style)
         return nullptr;
 
-    auto* value = style->customPropertyValue(propertyName, styledElement->document().customPropertyRegistry());
+    auto* value = style->customPropertyValue(propertyName);
 
     return const_cast<CSSCustomPropertyValue*>(value);
 }

--- a/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp
+++ b/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp
@@ -101,7 +101,7 @@ Vector<StylePropertyMapReadOnly::StylePropertyMapEntry> ComputedStylePropertyMap
 
     for (auto* map : { &nonInheritedCustomProperties, &inheritedCustomProperties }) {
         for (const auto& it : *map)
-            values.uncheckedAppend(makeKeyValuePair(it.key, StylePropertyMapReadOnly::reifyValueToVector(it.value.copyRef(), std::nullopt, m_element->document())));
+            values.uncheckedAppend(makeKeyValuePair(it.key, StylePropertyMapReadOnly::reifyValueToVector(const_cast<CSSCustomPropertyValue*>(it.value.get()), std::nullopt, m_element->document())));
     }
 
     std::sort(values.begin(), values.end(), [](const auto& a, const auto& b) {

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -108,6 +108,11 @@ std::unique_ptr<RenderStyle> RenderStyle::createPtr()
     return clonePtr(defaultStyle());
 }
 
+std::unique_ptr<RenderStyle> RenderStyle::createPtrWithRegisteredInitialValues(const Style::CustomPropertyRegistry& registry)
+{
+    return clonePtr(registry.initialValuePrototypeStyle());
+}
+
 RenderStyle RenderStyle::clone(const RenderStyle& style)
 {
     return RenderStyle(style, Clone);
@@ -347,6 +352,14 @@ void RenderStyle::inheritFrom(const RenderStyle& inheritParent)
 
     if (m_svgStyle != inheritParent.m_svgStyle)
         m_svgStyle.access().inheritFrom(inheritParent.m_svgStyle.get());
+}
+
+void RenderStyle::inheritIgnoringCustomPropertiesFrom(const RenderStyle& inheritParent)
+{
+    auto oldCustomProperties = m_rareInheritedData->customProperties;
+    inheritFrom(inheritParent);
+    if (oldCustomProperties != m_rareInheritedData->customProperties)
+        m_rareInheritedData.access().customProperties = oldCustomProperties;
 }
 
 void RenderStyle::fastPathInheritFrom(const RenderStyle& inheritParent)
@@ -1172,8 +1185,8 @@ inline static bool changedCustomPaintWatchedProperty(const RenderStyle& a, const
                 RefPtr<const CSSValue> valueA;
                 RefPtr<const CSSValue> valueB;
                 if (isCustomPropertyName(name)) {
-                    valueA = a.customPropertyValueWithoutResolvingInitial(name);
-                    valueB = b.customPropertyValueWithoutResolvingInitial(name);
+                    valueA = a.customPropertyValue(name);
+                    valueB = b.customPropertyValue(name);
                 } else {
                     CSSPropertyID propertyID = cssPropertyID(name);
                     if (!propertyID)
@@ -2638,41 +2651,39 @@ void RenderStyle::setColumnStylesFromPaginationMode(const Pagination::Mode& pagi
     }
 }
 
-void RenderStyle::deduplicateInheritedCustomProperties(const RenderStyle& other)
+void RenderStyle::deduplicateCustomProperties(const RenderStyle& other)
 {
-    auto& properties = const_cast<DataRef<StyleCustomPropertyData>&>(m_rareInheritedData->customProperties);
-    auto& otherProperties = other.m_rareInheritedData->customProperties;
-    if (properties.ptr() != otherProperties.ptr() && *properties == *otherProperties)
+    auto deduplicate = [&](auto& data, auto& otherData) {
+        auto& properties = const_cast<DataRef<StyleCustomPropertyData>&>(data->customProperties);
+        auto& otherProperties = otherData->customProperties;
+        if (properties.ptr() == otherProperties.ptr() || *properties != *otherProperties)
+            return;
         properties = otherProperties;
+        if (data == otherData)
+            data = otherData;
+    };
+
+    deduplicate(m_rareInheritedData, other.m_rareInheritedData);
+    deduplicate(m_rareNonInheritedData, other.m_rareNonInheritedData);
 }
 
-void RenderStyle::setInheritedCustomPropertyValue(const AtomString& name, Ref<CSSCustomPropertyValue>&& value)
+void RenderStyle::setCustomPropertyValue(Ref<const CSSCustomPropertyValue>&& value, bool isInherited)
 {
-    auto* existingValue = m_rareInheritedData->customProperties->values.get(name);
-    if (existingValue && existingValue->equals(value.get()))
-        return;
-    m_rareInheritedData.access().customProperties.access().setCustomPropertyValue(name, WTFMove(value));
+    auto set = [&](auto& data) {
+        auto& name = value->name();
+        auto* existingValue = data->customProperties->values.get(name);
+        if (existingValue && existingValue->equals(value.get()))
+            return;
+        data.access().customProperties.access().setCustomPropertyValue(name, WTFMove(value));
+    };
+
+    if (isInherited)
+        set(m_rareInheritedData);
+    else
+        set(m_rareNonInheritedData);
 }
 
-void RenderStyle::setNonInheritedCustomPropertyValue(const AtomString& name, Ref<CSSCustomPropertyValue>&& value)
-{
-    auto* existingValue = m_rareNonInheritedData->customProperties->values.get(name);
-    if (existingValue && existingValue->equals(value.get()))
-        return;
-    m_rareNonInheritedData.access().customProperties.access().setCustomPropertyValue(name, WTFMove(value));
-}
-
-const CSSCustomPropertyValue* RenderStyle::customPropertyValue(const AtomString& name, const Style::CustomPropertyRegistry& registry) const
-{
-    if (auto* value = customPropertyValueWithoutResolvingInitial(name))
-        return value;
-
-    // Alternatively we could just initialize the registered initial values to each RenderStyle.
-    auto* registered = registry.get(name);
-    return registered ? registered->initialValue.get() : nullptr;
-}
-
-const CSSCustomPropertyValue* RenderStyle::customPropertyValueWithoutResolvingInitial(const AtomString& name) const
+const CSSCustomPropertyValue* RenderStyle::customPropertyValue(const AtomString& name) const
 {
     for (auto* map : { &nonInheritedCustomProperties(), &inheritedCustomProperties() }) {
         if (auto* value = map->get(name))

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -156,6 +156,7 @@ public:
 
     static RenderStyle create();
     static std::unique_ptr<RenderStyle> createPtr();
+    static std::unique_ptr<RenderStyle> createPtrWithRegisteredInitialValues(const Style::CustomPropertyRegistry&);
 
     static RenderStyle clone(const RenderStyle&);
     static RenderStyle cloneIncludingPseudoElements(const RenderStyle&);
@@ -172,6 +173,7 @@ public:
     bool operator!=(const RenderStyle& other) const { return !(*this == other); }
 
     void inheritFrom(const RenderStyle&);
+    void inheritIgnoringCustomPropertiesFrom(const RenderStyle&);
     void fastPathInheritFrom(const RenderStyle&);
     void copyNonInheritedFrom(const RenderStyle&);
     void copyContentFrom(const RenderStyle&);
@@ -198,12 +200,10 @@ public:
 
     const CustomPropertyValueMap& inheritedCustomProperties() const { return m_rareInheritedData->customProperties->values; }
     const CustomPropertyValueMap& nonInheritedCustomProperties() const { return m_rareNonInheritedData->customProperties->values; }
-    const CSSCustomPropertyValue* customPropertyValue(const AtomString&, const Style::CustomPropertyRegistry&) const;
-    const CSSCustomPropertyValue* customPropertyValueWithoutResolvingInitial(const AtomString&) const;
+    const CSSCustomPropertyValue* customPropertyValue(const AtomString&) const;
 
-    void deduplicateInheritedCustomProperties(const RenderStyle&);
-    void setInheritedCustomPropertyValue(const AtomString& name, Ref<CSSCustomPropertyValue>&&);
-    void setNonInheritedCustomPropertyValue(const AtomString& name, Ref<CSSCustomPropertyValue>&&);
+    void deduplicateCustomProperties(const RenderStyle&);
+    void setCustomPropertyValue(Ref<const CSSCustomPropertyValue>&&, bool isInherited);
     bool customPropertiesEqual(const RenderStyle&) const;
 
     void setUsesViewportUnits() { m_nonInheritedFlags.usesViewportUnits = true; }

--- a/Source/WebCore/rendering/style/StyleCustomPropertyData.h
+++ b/Source/WebCore/rendering/style/StyleCustomPropertyData.h
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-using CustomPropertyValueMap = HashMap<AtomString, RefPtr<CSSCustomPropertyValue>>;
+using CustomPropertyValueMap = HashMap<AtomString, RefPtr<const CSSCustomPropertyValue>>;
 
 class StyleCustomPropertyData : public RefCounted<StyleCustomPropertyData> {
 public:
@@ -52,7 +52,7 @@ public:
 
     bool operator!=(const StyleCustomPropertyData& other) const { return !(*this == other); }
     
-    void setCustomPropertyValue(const AtomString& name, Ref<CSSCustomPropertyValue>&& value)
+    void setCustomPropertyValue(const AtomString& name, Ref<const CSSCustomPropertyValue>&& value)
     {
         values.set(name, WTFMove(value));
     }

--- a/Source/WebCore/style/CustomPropertyRegistry.cpp
+++ b/Source/WebCore/style/CustomPropertyRegistry.cpp
@@ -30,6 +30,7 @@
 #include "Document.h"
 #include "Element.h"
 #include "KeyframeEffect.h"
+#include "RenderStyle.h"
 #include "StyleBuilder.h"
 #include "StyleResolver.h"
 #include "StyleScope.h"
@@ -40,6 +41,7 @@ namespace Style {
 
 CustomPropertyRegistry::CustomPropertyRegistry(Scope& scope)
     : m_scope(scope)
+    , m_initialValuePrototypeStyle(RenderStyle::createPtr())
 {
 }
 
@@ -71,8 +73,8 @@ bool CustomPropertyRegistry::registerFromAPI(CSSRegisteredCustomProperty&& prope
     }).isNewEntry;
 
     if (success) {
+        invalidate(property.name);
         m_scope.didChangeStyleSheetEnvironment();
-        notifyAnimationsOfCustomPropertyRegistration(property.name);
     }
 
     return success;
@@ -132,15 +134,50 @@ void CustomPropertyRegistry::registerFromStylesheet(const StyleRuleProperty::Des
     // https://drafts.css-houdini.org/css-properties-values-api/#determining-registration
     m_propertiesFromStylesheet.set(property.name, makeUnique<const CSSRegisteredCustomProperty>(WTFMove(property)));
 
-    // Changing property registration may affect computed property values in the cache.
-    m_scope.invalidateMatchedDeclarationsCache();
-
-    notifyAnimationsOfCustomPropertyRegistration(property.name);
+    invalidate(property.name);
 }
 
 void CustomPropertyRegistry::clearRegisteredFromStylesheets()
 {
+    if (m_propertiesFromStylesheet.isEmpty())
+        return;
+
     m_propertiesFromStylesheet.clear();
+    invalidate(nullAtom());
+}
+
+const RenderStyle& CustomPropertyRegistry::initialValuePrototypeStyle() const
+{
+    if (m_hasInvalidPrototypeStyle) {
+        m_hasInvalidPrototypeStyle = false;
+
+        auto oldStyle = std::exchange(m_initialValuePrototypeStyle, RenderStyle::createPtr());
+
+        auto initializeToStyle = [&](auto& map) {
+            for (auto& property : map.values()) {
+                if (property->initialValue && !property->initialValue->isInvalid())
+                    m_initialValuePrototypeStyle->setCustomPropertyValue(*property->initialValue, property->inherits);
+            }
+        };
+
+        initializeToStyle(m_propertiesFromStylesheet);
+        initializeToStyle(m_propertiesFromAPI);
+
+        m_initialValuePrototypeStyle->deduplicateCustomProperties(*oldStyle);
+    }
+
+    return *m_initialValuePrototypeStyle;
+}
+
+void CustomPropertyRegistry::invalidate(const AtomString& customProperty)
+{
+    m_hasInvalidPrototypeStyle = true;
+    // Changing property registration may affect computed property values in the cache.
+    m_scope.invalidateMatchedDeclarationsCache();
+
+    // FIXME: Invalidate all?
+    if (!customProperty.isNull())
+        notifyAnimationsOfCustomPropertyRegistration(customProperty);
 }
 
 void CustomPropertyRegistry::notifyAnimationsOfCustomPropertyRegistration(const AtomString& customProperty)

--- a/Source/WebCore/style/CustomPropertyRegistry.h
+++ b/Source/WebCore/style/CustomPropertyRegistry.h
@@ -29,6 +29,9 @@
 #include <wtf/HashMap.h>
 
 namespace WebCore {
+
+class RenderStyle;
+
 namespace Style {
 
 class Scope;
@@ -45,13 +48,19 @@ public:
     void registerFromStylesheet(const StyleRuleProperty::Descriptor&);
     void clearRegisteredFromStylesheets();
 
+    const RenderStyle& initialValuePrototypeStyle() const;
+
 private:
+    void invalidate(const AtomString&);
     void notifyAnimationsOfCustomPropertyRegistration(const AtomString&);
 
     Scope& m_scope;
 
     HashMap<AtomString, std::unique_ptr<const CSSRegisteredCustomProperty>> m_propertiesFromAPI;
     HashMap<AtomString, std::unique_ptr<const CSSRegisteredCustomProperty>> m_propertiesFromStylesheet;
+
+    mutable std::unique_ptr<RenderStyle> m_initialValuePrototypeStyle;
+    mutable bool m_hasInvalidPrototypeStyle { false };
 };
 
 }

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -164,7 +164,7 @@ public:
 
     static void applyInitialCustomProperty(BuilderState&, const CSSRegisteredCustomProperty*, const AtomString& name);
     static void applyInheritCustomProperty(BuilderState&, const CSSRegisteredCustomProperty*, const AtomString& name);
-    static void applyValueCustomProperty(BuilderState&, const CSSRegisteredCustomProperty*, CSSCustomPropertyValue&);
+    static void applyValueCustomProperty(BuilderState&, const CSSRegisteredCustomProperty*, const CSSCustomPropertyValue&);
 
     static void applyValueColor(BuilderState&, CSSValue&);
 
@@ -2154,7 +2154,7 @@ inline void BuilderCustom::applyValueColor(BuilderState& builderState, CSSValue&
 inline void BuilderCustom::applyInitialCustomProperty(BuilderState& builderState, const CSSRegisteredCustomProperty* registered, const AtomString& name)
 {
     if (registered && registered->initialValue) {
-        applyValueCustomProperty(builderState, registered, const_cast<CSSCustomPropertyValue&>(*registered->initialValue));
+        applyValueCustomProperty(builderState, registered, *registered->initialValue);
         return;
     }
 
@@ -2166,20 +2166,17 @@ inline void BuilderCustom::applyInheritCustomProperty(BuilderState& builderState
 {
     auto* parentValue = builderState.parentStyle().inheritedCustomProperties().get(name);
     if (parentValue && !(registered && !registered->inherits))
-        applyValueCustomProperty(builderState, registered, *parentValue);
+        applyValueCustomProperty(builderState, registered, const_cast<CSSCustomPropertyValue&>(*parentValue));
     else
         applyInitialCustomProperty(builderState, registered, name);
 }
 
-inline void BuilderCustom::applyValueCustomProperty(BuilderState& builderState, const CSSRegisteredCustomProperty* registered, CSSCustomPropertyValue& value)
+inline void BuilderCustom::applyValueCustomProperty(BuilderState& builderState, const CSSRegisteredCustomProperty* registered, const CSSCustomPropertyValue& value)
 {
     ASSERT(value.isResolved());
-    const auto& name = value.name();
 
-    if (!registered || registered->inherits)
-        builderState.style().setInheritedCustomPropertyValue(name, value);
-    else
-        builderState.style().setNonInheritedCustomPropertyValue(name, value);
+    bool isInherited = !registered || registered->inherits;
+    builderState.style().setCustomPropertyValue(value, isInherited);
 }
 
 inline void BuilderCustom::applyInitialContainIntrinsicWidth(BuilderState& builderState)

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -243,8 +243,12 @@ ResolvedStyle Resolver::styleForElement(const Element& element, const Resolution
     auto state = State(element, context.parentStyle, context.documentElementStyle);
 
     if (state.parentStyle()) {
-        state.setStyle(RenderStyle::createPtr());
-        state.style()->inheritFrom(*state.parentStyle());
+        state.setStyle(RenderStyle::createPtrWithRegisteredInitialValues(document().customPropertyRegistry()));
+        if (&element == document().documentElement()) {
+            // Initial values for custom properties are inserted to the document element style. Don't overwrite them.
+            state.style()->inheritIgnoringCustomPropertiesFrom(*state.parentStyle());
+        } else
+            state.style()->inheritFrom(*state.parentStyle());
     } else {
         state.setStyle(defaultStyleForElement(&element));
         state.setParentStyle(RenderStyle::clonePtr(*state.style()));
@@ -481,7 +485,7 @@ std::optional<ResolvedStyle> Resolver::styleForPseudoElement(const Element& elem
     auto state = State(element, context.parentStyle, context.documentElementStyle);
 
     if (state.parentStyle()) {
-        state.setStyle(RenderStyle::createPtr());
+        state.setStyle(RenderStyle::createPtrWithRegisteredInitialValues(document().customPropertyRegistry()));
         state.style()->inheritFrom(*state.parentStyle());
     } else {
         state.setStyle(defaultStyleForElement(&element));
@@ -541,7 +545,7 @@ std::unique_ptr<RenderStyle> Resolver::styleForPage(int pageIndex)
 
 std::unique_ptr<RenderStyle> Resolver::defaultStyleForElement(const Element* element)
 {
-    auto style = RenderStyle::createPtr();
+    auto style = RenderStyle::createPtrWithRegisteredInitialValues(document().customPropertyRegistry());
 
     FontCascadeDescription fontDescription;
     fontDescription.setRenderingMode(settings().fontRenderingMode());

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -634,7 +634,7 @@ ElementUpdate TreeResolver::createAnimatedElementUpdate(ResolvedStyle&& resolved
     // Deduplication speeds up equality comparisons as the properties inherit to descendants.
     // FIXME: There should be a more general mechanism for this.
     if (oldStyle)
-        newStyle->deduplicateInheritedCustomProperties(*oldStyle);
+        newStyle->deduplicateCustomProperties(*oldStyle);
 
     auto change = oldStyle ? determineChange(*oldStyle, *newStyle) : Change::Renderer;
 


### PR DESCRIPTION
#### ffe6d89e6fa50326715ba03ddd7134bc0d891dbc
<pre>
[@property] Set registered initial values to RenderStyle
<a href="https://bugs.webkit.org/show_bug.cgi?id=251575">https://bugs.webkit.org/show_bug.cgi?id=251575</a>
rdar://104953759

Reviewed by Antoine Quint.

Remove the need to provide the registry to RenderStyle::customPropertyValue().

This is done by maintaining a prototype style in CustomPropertyRegistry that is cloned
to make the initial styles in the style resolver.

* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-animation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/typedom-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-registered-custom-properties-expected.txt:

This also fixes some bugs.

* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::blendCustomProperty):
(WebCore::CSSPropertyAnimation::propertyRequiresBlendingForAccumulativeIteration):
(WebCore::CSSPropertyAnimation::propertiesEqual):
(WebCore::CSSPropertyAnimation::canPropertyBeInterpolated):
* Source/WebCore/css/CSSVariableReferenceValue.cpp:
(WebCore::CSSVariableReferenceValue::resolveVariableReference const):
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::ComputedStyleExtractor::customPropertyValue):
* Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp:
(WebCore::ComputedStylePropertyMapReadOnly::entries const):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::createPtrWithRegisteredInitialValues):
(WebCore::RenderStyle::inheritIgnoringCustomPropertiesFrom):
(WebCore::changedCustomPaintWatchedProperty):
(WebCore::RenderStyle::deduplicateCustomProperties):

Also dedupe non-inherited properties.

(WebCore::RenderStyle::setCustomPropertyValue):

Make this a single function.

(WebCore::RenderStyle::customPropertyValue const):
(WebCore::RenderStyle::deduplicateInheritedCustomProperties): Deleted.
(WebCore::RenderStyle::setInheritedCustomPropertyValue): Deleted.
(WebCore::RenderStyle::setNonInheritedCustomPropertyValue): Deleted.
(WebCore::RenderStyle::customPropertyValueWithoutResolvingInitial const): Deleted.
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/StyleCustomPropertyData.h:
(WebCore::StyleCustomPropertyData::setCustomPropertyValue):
* Source/WebCore/style/CustomPropertyRegistry.cpp:
(WebCore::Style::CustomPropertyRegistry::CustomPropertyRegistry):
(WebCore::Style::CustomPropertyRegistry::registerFromAPI):
(WebCore::Style::CustomPropertyRegistry::registerFromStylesheet):
(WebCore::Style::CustomPropertyRegistry::clearRegisteredFromStylesheets):
(WebCore::Style::CustomPropertyRegistry::initialValuePrototypeStyle const):

Maintain the initial value prototype style.

(WebCore::Style::CustomPropertyRegistry::invalidate):
* Source/WebCore/style/CustomPropertyRegistry.h:
* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyInitialCustomProperty):
(WebCore::Style::BuilderCustom::applyInheritCustomProperty):
(WebCore::Style::BuilderCustom::applyValueCustomProperty):
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::styleForElement):

Clone the initial style from the prototype.

(WebCore::Style::Resolver::styleForPseudoElement):
(WebCore::Style::Resolver::defaultStyleForElement):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::createAnimatedElementUpdate):

Canonical link: <a href="https://commits.webkit.org/259807@main">https://commits.webkit.org/259807@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e0a407019fff6ce2293ad2ca25c89f0ea4bc341

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106012 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15068 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38845 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115194 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/175302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109915 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16492 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/6249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98220 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111765 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95525 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/40099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/94420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/27168 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8322 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28520 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8812 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/6249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14436 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48063 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6785 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10356 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->