### PR TITLE
SVGLengthValue::fromCSSPrimitiveValue() doesn't have enough context to resolve font-relative units

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/painting/parsing/stroke-dasharray-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/painting/parsing/stroke-dasharray-computed-expected.txt
@@ -1,8 +1,8 @@
 
 PASS Property stroke-dasharray value 'none'
 PASS Property stroke-dasharray value '10'
-FAIL Property stroke-dasharray value 'calc(10px + 0.5em)' assert_equals: expected "30px" but got "10px"
-FAIL Property stroke-dasharray value 'calc(10px - 0.5em)' assert_equals: expected "0px" but got "10px"
+PASS Property stroke-dasharray value 'calc(10px + 0.5em)'
+PASS Property stroke-dasharray value 'calc(10px - 0.5em)'
 PASS Property stroke-dasharray value '40%'
 FAIL Property stroke-dasharray value 'calc(50% + 60px)' assert_equals: expected "calc(50% + 60px)" but got "0"
 PASS Property stroke-dasharray value '10px 20% 30px'

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/strokeDasharray-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/strokeDasharray-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL strokeDasharray responsive to style changes assert_not_equals: got disallowed value "0px, 0px"
+PASS strokeDasharray responsive to style changes
 

--- a/LayoutTests/svg/css/scientific-numbers-expected.txt
+++ b/LayoutTests/svg/css/scientific-numbers-expected.txt
@@ -86,7 +86,7 @@ PASS getComputedStyle(text).baselineShift is "800px"
 
 Test if value and 'ex' still works
 PASS getComputedStyle(text).baselineShift is "baseline"
-PASS getComputedStyle(text).baselineShift is "400px"
+PASS parseFloat(getComputedStyle(text).baselineShift) is within 0.01 of 640
 
 Trailing and leading whitespaces
 PASS getComputedStyle(text).baselineShift is "baseline"

--- a/LayoutTests/svg/css/scientific-numbers.html
+++ b/LayoutTests/svg/css/scientific-numbers.html
@@ -3,6 +3,12 @@
 <head>
 <script src="../../svg/dynamic-updates/resources/SVGTestCase.js"></script>
 <script src="../../resources/js-test-pre.js"></script>
+<style>
+* {
+    font-family: 'Ahem';
+    font-size: 16px;
+}
+</style>
 </head>
 <body>
 <p id="description"></p>
@@ -19,14 +25,17 @@ text.setAttribute("x", "100px");
 text.setAttribute("y", "100px");
 rootSVGElement.appendChild(text);
 
-function test(valueString, expectedValue) {
+function test(valueString, expectedValue, tolerance) {
 	// Reset baseline-shift to baseline.
 	text.setAttribute("baseline-shift", "baseline");
 	shouldBeEqualToString("getComputedStyle(text).baselineShift", "baseline");
 
 	// Run test
 	text.setAttribute("baseline-shift", valueString);
-	shouldBeEqualToString("getComputedStyle(text).baselineShift", expectedValue);
+    if (tolerance)
+        shouldBeCloseTo("parseFloat(getComputedStyle(text).baselineShift)", parseFloat(expectedValue), tolerance);
+    else
+        shouldBeEqualToString("getComputedStyle(text).baselineShift", expectedValue);
 }
 
 debug("");
@@ -83,7 +92,7 @@ test("50em", "800px");
 
 debug("");
 debug("Test if value and 'ex' still works");
-test("50ex", "400px");
+test("50ex", "640px", 0.01);
 
 debug("");
 debug("Trailing and leading whitespaces");

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -1569,9 +1569,9 @@ inline bool BuilderConverter::convertSmoothScrolling(BuilderState&, const CSSVal
     return downcast<CSSPrimitiveValue>(value).valueID() == CSSValueSmooth;
 }
 
-inline SVGLengthValue BuilderConverter::convertSVGLengthValue(BuilderState&, const CSSValue& value, ShouldConvertNumberToPxLength shouldConvertNumberToPxLength)
+inline SVGLengthValue BuilderConverter::convertSVGLengthValue(BuilderState& builderState, const CSSValue& value, ShouldConvertNumberToPxLength shouldConvertNumberToPxLength)
 {
-    return SVGLengthValue::fromCSSPrimitiveValue(downcast<CSSPrimitiveValue>(value), shouldConvertNumberToPxLength);
+    return SVGLengthValue::fromCSSPrimitiveValue(downcast<CSSPrimitiveValue>(value), builderState.cssToLengthConversionData(), shouldConvertNumberToPxLength);
 }
 
 inline Vector<SVGLengthValue> BuilderConverter::convertSVGLengthVector(BuilderState& builderState, const CSSValue& value, ShouldConvertNumberToPxLength shouldConvertNumberToPxLength)

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -1228,7 +1228,7 @@ inline void BuilderCustom::applyValueBaselineShift(BuilderState& builderState, C
         }
     } else {
         svgStyle.setBaselineShift(BaselineShift::Length);
-        svgStyle.setBaselineShiftValue(SVGLengthValue::fromCSSPrimitiveValue(primitiveValue));
+        svgStyle.setBaselineShiftValue(SVGLengthValue::fromCSSPrimitiveValue(primitiveValue, builderState.cssToLengthConversionData()));
     }
 }
 

--- a/Source/WebCore/svg/SVGLengthValue.h
+++ b/Source/WebCore/svg/SVGLengthValue.h
@@ -69,7 +69,7 @@ public:
     static SVGLengthValue construct(SVGLengthMode, StringView, SVGParsingError&, SVGLengthNegativeValuesMode = SVGLengthNegativeValuesMode::Allow);
     static SVGLengthValue blend(const SVGLengthValue& from, const SVGLengthValue& to, float progress);
 
-    static SVGLengthValue fromCSSPrimitiveValue(const CSSPrimitiveValue&, ShouldConvertNumberToPxLength = ShouldConvertNumberToPxLength::No);
+    static SVGLengthValue fromCSSPrimitiveValue(const CSSPrimitiveValue&, const CSSToLengthConversionData&, ShouldConvertNumberToPxLength = ShouldConvertNumberToPxLength::No);
     Ref<CSSPrimitiveValue> toCSSPrimitiveValue(const Element* = nullptr) const;
 
     SVGLengthType lengthType() const { return m_lengthType; }


### PR DESCRIPTION
#### af0cc1eb786affd266fb29a6ebfe02718e7086d7
<pre>
SVGLengthValue::fromCSSPrimitiveValue() doesn&apos;t have enough context to resolve font-relative units
<a href="https://bugs.webkit.org/show_bug.cgi?id=204826">https://bugs.webkit.org/show_bug.cgi?id=204826</a>

Reviewed by Antti Koivisto.

Pass a CSSToLengthConversionData argument to SVGLengthValue::fromCSSPrimitiveValue() such that we
may call computeLength() on the provided primitive value to resolve font-relative units.

This also changes the behavior of baseline-shift which now accounts for ex units, so
adjusting the relevant test to include a font to have reliable measurements across platforms
and a new expected value.

* LayoutTests/imported/w3c/web-platform-tests/svg/painting/parsing/stroke-dasharray-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/strokeDasharray-expected.txt:
* LayoutTests/svg/css/scientific-numbers-expected.txt:
* LayoutTests/svg/css/scientific-numbers.html:
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertSVGLengthValue):
* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyValueBaselineShift):
* Source/WebCore/svg/SVGLengthValue.cpp:
(WebCore::SVGLengthValue::fromCSSPrimitiveValue):
* Source/WebCore/svg/SVGLengthValue.h:

Canonical link: <a href="https://commits.webkit.org/259836@main">https://commits.webkit.org/259836@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8bcbd16c49c9409fb8edf5f54c3574fa75d0a8f2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106113 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15166 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38941 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115297 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/175374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110018 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16598 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6338 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98322 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111869 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/95604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/40171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94497 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/27247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8417 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/28599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8911 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/5146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14530 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/48143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10456 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3660 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->