### PR TITLE
[css-animations] css/css-animations/responsive/column-width-001.html makes incorrect assumption about clamping

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/responsive/column-width-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/responsive/column-width-001-expected.txt
@@ -1,5 +1,5 @@
 
 PASS column-width responds to font-size changes
-FAIL column-width clamps to 0px assert_equals: expected "0px" but got "20px"
+PASS column-width clamps to 0px
 PASS column-width responds to inherited changes
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/responsive/column-width-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/responsive/column-width-001.html
@@ -61,7 +61,7 @@ test(() => {
   const second = document.getElementById('second');
   assert_equals(getComputedStyle(second).columnWidth, '30px');
   second.style.fontSize = '90px';
-  assert_equals(getComputedStyle(second).columnWidth, '0px');
+  assert_equals(getComputedStyle(second).columnWidth, '20px');
 }, 'column-width clamps to 0px');
 
 test(() => {


### PR DESCRIPTION
#### 834e0faa5db4454b09a39e9f5f1c66f4d94ce883
<pre>
[css-animations] css/css-animations/responsive/column-width-001.html makes incorrect assumption about clamping
<a href="https://bugs.webkit.org/show_bug.cgi?id=251578">https://bugs.webkit.org/show_bug.cgi?id=251578</a>

Reviewed by Antti Koivisto.

This test made the wrong assumption about how values are clamped, per the discussion
at <a href="https://github.com/web-platform-tests/wpt/issues/37053.">https://github.com/web-platform-tests/wpt/issues/37053.</a> We already fixed similar
tests under web-animations/responsive in <a href="https://github.com/web-platform-tests/wpt/commit/9565baf729.">https://github.com/web-platform-tests/wpt/commit/9565baf729.</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/responsive/column-width-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/responsive/column-width-001.html:

Canonical link: <a href="https://commits.webkit.org/259751@main">https://commits.webkit.org/259751@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1880ba0549e7a5a661c496ae0280869728349caf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105837 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14905 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38685 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115035 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/175159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16324 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6104 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98070 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111586 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95391 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39966 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94283 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27033 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8176 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28385 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8658 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14285 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47933 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10215 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3611 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->