### PR TITLE
[GTK][WPE] Add new JavaScript execution APIs

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/APISerializedScriptValueGLib.cpp
+++ b/Source/WebKit/UIProcess/API/glib/APISerializedScriptValueGLib.cpp
@@ -104,7 +104,7 @@ GRefPtr<JSCValue> SerializedScriptValue::deserialize(WebCore::SerializedScriptVa
 
 static GRefPtr<JSCValue> valueFromGVariant(JSCContext* context, GVariant* variant)
 {
-    if (g_variant_is_container(variant)) {
+    if (g_variant_is_of_type(variant, G_VARIANT_TYPE("a{sv}"))) {
         auto result = adoptGRef(jsc_value_new_object(context, nullptr, nullptr));
         GVariantIter iter;
         g_variant_iter_init(&iter, variant);
@@ -138,7 +138,6 @@ static GRefPtr<JSCValue> valueFromGVariant(JSCContext* context, GVariant* varian
     if (g_variant_is_of_type(variant, G_VARIANT_TYPE_STRING))
         return adoptGRef(jsc_value_new_string(context, g_variant_get_string(variant, nullptr)));
 
-    g_warning("Unhandled %s GVariant for conversion to JSCValue", g_variant_get_type_string(variant));
     return nullptr;
 }
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitError.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitError.h.in
@@ -136,11 +136,15 @@ typedef enum {
 /**
  * WebKitJavascriptError:
  * @WEBKIT_JAVASCRIPT_ERROR_SCRIPT_FAILED: An exception was raised in JavaScript execution
+ * @WEBKIT_JAVASCRIPT_ERROR_INVALID_PARAMETER: An unsupported parameter has been used to call and async function from API. Since 2.40
+ * @WEBKIT_JAVASCRIPT_ERROR_INVALID_RESULT: The result of JavaScript execution could not be returned. Since 2.40
  *
  * Enum values used to denote errors happening when executing JavaScript
  */
 typedef enum {
-    WEBKIT_JAVASCRIPT_ERROR_SCRIPT_FAILED = 699
+    WEBKIT_JAVASCRIPT_ERROR_SCRIPT_FAILED = 699,
+    WEBKIT_JAVASCRIPT_ERROR_INVALID_PARAMETER = 600,
+    WEBKIT_JAVASCRIPT_ERROR_INVALID_RESULT = 601,
 } WebKitJavascriptError;
 
 /**

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
@@ -638,29 +638,61 @@ webkit_web_view_get_javascript_global_context        (WebKitWebView             
 #endif
 
 WEBKIT_API void
+webkit_web_view_evaluate_javascript                  (WebKitWebView             *web_view,
+                                                      const char                *script,
+                                                      gssize                     length,
+                                                      const char                *world_name,
+                                                      const char                *source_uri,
+                                                      GCancellable              *cancellable,
+                                                      GAsyncReadyCallback        callback,
+                                                      gpointer                   user_data);
+
+WEBKIT_API WebKitJavascriptResult *
+webkit_web_view_evaluate_javascript_finish           (WebKitWebView             *web_view,
+                                                      GAsyncResult              *result,
+                                                      GError                   **error);
+
+WEBKIT_API void
+webkit_web_view_call_async_javascript_function       (WebKitWebView             *web_view,
+                                                      const char                *body,
+                                                      gssize                     length,
+                                                      GVariant                  *arguments,
+                                                      const char                *world_name,
+                                                      const char                *source_uri,
+                                                      GCancellable              *cancellable,
+                                                      GAsyncReadyCallback        callback,
+                                                      gpointer                   user_data);
+
+WEBKIT_API WebKitJavascriptResult *
+webkit_web_view_call_async_javascript_function_finish(WebKitWebView             *web_view,
+                                                      GAsyncResult              *result,
+                                                      GError                   **error);
+
+#if !ENABLE(2022_GLIB_API)
+WEBKIT_DEPRECATED_FOR(webkit_web_view_evaluate_javascript) void
 webkit_web_view_run_javascript                       (WebKitWebView             *web_view,
                                                       const gchar               *script,
                                                       GCancellable              *cancellable,
                                                       GAsyncReadyCallback        callback,
                                                       gpointer                   user_data);
-WEBKIT_API WebKitJavascriptResult *
+WEBKIT_DEPRECATED_FOR(webkit_web_view_evaluate_javascript_finish) WebKitJavascriptResult *
 webkit_web_view_run_javascript_finish                (WebKitWebView             *web_view,
                                                       GAsyncResult              *result,
                                                       GError                   **error);
 
-WEBKIT_API void
+WEBKIT_DEPRECATED_FOR(webkit_web_view_evaluate_javascript) void
 webkit_web_view_run_javascript_in_world              (WebKitWebView             *web_view,
                                                       const gchar               *script,
                                                       const gchar               *world_name,
                                                       GCancellable              *cancellable,
                                                       GAsyncReadyCallback        callback,
                                                       gpointer                   user_data);
-WEBKIT_API WebKitJavascriptResult *
+WEBKIT_DEPRECATED_FOR(webkit_web_view_evaluate_javascript_finish) WebKitJavascriptResult *
 webkit_web_view_run_javascript_in_world_finish       (WebKitWebView             *web_view,
                                                       GAsyncResult              *result,
                                                       GError                   **error);
 
-WEBKIT_API void
+WEBKIT_DEPRECATED_FOR(webkit_web_view_call_async_javascript_function) void
 webkit_web_view_run_async_javascript_function_in_world (WebKitWebView           *web_view,
                                                         const gchar             *body,
                                                         GVariant                *arguments,
@@ -669,17 +701,18 @@ webkit_web_view_run_async_javascript_function_in_world (WebKitWebView           
                                                         GAsyncReadyCallback      callback,
                                                         gpointer                 user_data);
 
-WEBKIT_API void
+WEBKIT_DEPRECATED_FOR(webkit_web_view_evaluate_javascript) void
 webkit_web_view_run_javascript_from_gresource        (WebKitWebView             *web_view,
                                                       const gchar               *resource,
                                                       GCancellable              *cancellable,
                                                       GAsyncReadyCallback        callback,
                                                       gpointer                   user_data);
 
-WEBKIT_API WebKitJavascriptResult *
+WEBKIT_DEPRECATED_FOR(webkit_web_view_evaluate_javascript_finish) WebKitJavascriptResult *
 webkit_web_view_run_javascript_from_gresource_finish (WebKitWebView             *web_view,
                                                       GAsyncResult              *result,
                                                       GError                   **error);
+#endif
 
 WEBKIT_API WebKitWebResource *
 webkit_web_view_get_main_resource                    (WebKitWebView             *web_view);

--- a/Source/WebKit/UIProcess/API/gtk/WebKitRemoteInspectorProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitRemoteInspectorProtocolHandler.cpp
@@ -158,7 +158,7 @@ void RemoteInspectorProtocolHandler::updateTargetList(WebKitWebView* webView)
     GString* script = g_string_new("document.getElementById('targetlist').innerHTML='");
     clientForWebView->appendTargertList(script, RemoteInspectorClient::InspectorType::UI, RemoteInspectorClient::ShouldEscapeSingleQuote::Yes);
     g_string_append(script, "';");
-    webkit_web_view_run_javascript(webView, script->str, nullptr, nullptr, nullptr);
+    webkit_web_view_evaluate_javascript(webView, script->str, script->len, nullptr, nullptr, nullptr, nullptr, nullptr);
     g_string_free(script, TRUE);
 }
 

--- a/Source/WebKit/UIProcess/API/wpe/qt/WPEQtView.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/qt/WPEQtView.cpp
@@ -406,7 +406,7 @@ static void jsAsyncReadyCallback(GObject* object, GAsyncResult* result, gpointer
 {
     GError* error { nullptr };
     std::unique_ptr<JavascriptCallbackData> data(reinterpret_cast<JavascriptCallbackData*>(userData));
-    WebKitJavascriptResult* jsResult = webkit_web_view_run_javascript_finish(WEBKIT_WEB_VIEW(object), result, &error);
+    WebKitJavascriptResult* jsResult = webkit_web_view_evaluate_javascript_finish(WEBKIT_WEB_VIEW(object), result, &error);
     if (!jsResult) {
         qWarning("Error running javascript: %s", error->message);
         g_error_free(error);
@@ -456,7 +456,8 @@ static void jsAsyncReadyCallback(GObject* object, GAsyncResult* result, gpointer
 void WPEQtView::runJavaScript(const QString& script, const QJSValue& callback)
 {
     std::unique_ptr<JavascriptCallbackData> data = std::make_unique<JavascriptCallbackData>(callback, QPointer<WPEQtView>(this));
-    webkit_web_view_run_javascript(m_webView, script.toUtf8().constData(), nullptr, jsAsyncReadyCallback, data.release());
+    auto utf8Script = script.toUtf8();
+    webkit_web_view_evaluate_javascript(m_webView, utf8Script.constData(), utf8Script.size(), nullptr, nullptr, nullptr, jsAsyncReadyCallback, data.release());
 }
 
 void WPEQtView::mousePressEvent(QMouseEvent* event)

--- a/Tools/MiniBrowser/gtk/BrowserTab.c
+++ b/Tools/MiniBrowser/gtk/BrowserTab.c
@@ -784,7 +784,7 @@ void browser_tab_load_uri(BrowserTab *tab, const char *uri)
         return;
     }
 
-    webkit_web_view_run_javascript(tab->webView, strstr(uri, "javascript:"), NULL, NULL, NULL);
+    webkit_web_view_evaluate_javascript(tab->webView, strstr(uri, "javascript:"), -1, NULL, NULL, NULL, NULL, NULL);
 }
 
 GtkWidget *browser_tab_get_title_widget(BrowserTab *tab)

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestBackForwardList.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestBackForwardList.cpp
@@ -349,7 +349,7 @@ static void testWebKitWebViewSessionStateWithFormData(BackForwardListTest* test,
     test->loadURI(htmlURL.get());
     test->waitUntilLoadFinished();
 
-    webkit_web_view_run_javascript(test->m_webView, "submitForm();", nullptr, nullptr, nullptr);
+    webkit_web_view_evaluate_javascript(test->m_webView, "submitForm();", -1, nullptr, nullptr, nullptr, nullptr, nullptr);
     test->waitUntilLoadFinished();
 
     WebKitWebViewSessionState* state = webkit_web_view_get_session_state(test->m_webView);

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestResources.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestResources.cpp
@@ -727,7 +727,7 @@ static void testWebViewSyncRequestOnMaxConns(SyncRequestOnMaxConnsTest* test, gc
 
     for (unsigned i = 0; i < 2; ++i) {
         GUniquePtr<char> xhr(g_strdup_printf("xhr = new XMLHttpRequest; xhr.open('GET', '/sync-request-on-max-conns-xhr%u', false); xhr.send();", i));
-        webkit_web_view_run_javascript(test->m_webView, xhr.get(), nullptr, nullptr, nullptr);
+        webkit_web_view_evaluate_javascript(test->m_webView, xhr.get(), -1, nullptr, nullptr, nullptr, nullptr, nullptr);
     }
 
     // By default sync XHRs have a 10 seconds timeout, we don't want to wait all that so use our own timeout.

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestSSL.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestSSL.cpp
@@ -496,8 +496,7 @@ public:
 
         server->addWebSocketHandler(serverWebSocketCallback, this);
         GUniquePtr<char> createWebSocketJS(g_strdup_printf(webSocketTestJSFormat, server->getWebSocketURIForPath("/foo").data()));
-        webkit_web_view_run_javascript(m_webView, createWebSocketJS.get(), nullptr, nullptr, nullptr);
-        g_main_loop_run(m_mainLoop);
+        runJavaScriptAndWait(createWebSocketJS.get());
         server->removeWebSocketHandler();
 
         return m_events;

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebExtensions.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebExtensions.cpp
@@ -357,8 +357,7 @@ public:
 
     void runJavaScriptAndWaitUntilFormSubmitted(const char* js)
     {
-        webkit_web_view_run_javascript(m_webView, js, nullptr, nullptr, nullptr);
-        g_main_loop_run(m_mainLoop);
+        runJavaScriptAndWait(js);
     }
 
     GRefPtr<GDBusProxy> m_proxy;

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebContext.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebContext.cpp
@@ -757,8 +757,7 @@ public:
     {
         m_webSocketRequestReceived = WebSocketServerType::Unknown;
         GUniquePtr<char> createWebSocket(g_strdup_printf("var ws = new WebSocket('%s');", kServer->getWebSocketURIForPath("/foo").data()));
-        webkit_web_view_run_javascript(m_webView, createWebSocket.get(), nullptr, nullptr, nullptr);
-        g_main_loop_run(m_mainLoop);
+        runJavaScriptAndWait(createWebSocket.get());
         return m_webSocketRequestReceived;
     }
 #endif

--- a/Tools/TestWebKitAPI/glib/WebKitGLib/WebViewTest.h
+++ b/Tools/TestWebKitAPI/glib/WebKitGLib/WebViewTest.h
@@ -74,10 +74,12 @@ public:
 #endif
 
     WebKitJavascriptResult* runJavaScriptAndWaitUntilFinished(const char* javascript, GError**, WebKitWebView* = nullptr);
+    WebKitJavascriptResult* runJavaScriptAndWaitUntilFinished(const char* javascript, gsize, GError**);
     WebKitJavascriptResult* runJavaScriptFromGResourceAndWaitUntilFinished(const char* resource, GError**);
-    WebKitJavascriptResult* runJavaScriptInWorldAndWaitUntilFinished(const char* javascript, const char* world, GError**);
+    WebKitJavascriptResult* runJavaScriptInWorldAndWaitUntilFinished(const char* javascript, const char* world, const char* sourceURI, GError**);
     WebKitJavascriptResult* runAsyncJavaScriptFunctionInWorldAndWaitUntilFinished(const char* body, GVariant* arguments, const char* world, GError**);
     WebKitJavascriptResult* runJavaScriptWithoutForcedUserGesturesAndWaitUntilFinished(const char* javascript, GError**);
+    void runJavaScriptAndWait(const char* javascript);
 
     // Javascript result helpers.
     static char* javascriptResultToCString(WebKitJavascriptResult*);


### PR DESCRIPTION
#### c07c7ce77b199a76905c2adeff5f4cfc2cc06a33
<pre>
[GTK][WPE] Add new JavaScript execution APIs
<a href="https://bugs.webkit.org/show_bug.cgi?id=241420">https://bugs.webkit.org/show_bug.cgi?id=241420</a>

Reviewed by Adrian Perez de Castro and Michael Catanzaro.

Add webkit_web_view_evaluate_javascript() and
webkit_web_view_call_async_javascript_function() and deprecate all other
JavaScript execution funtions. The new functions add a length parameter
to allow running code containing null characters and the source URI that
is shown in exception messages.

* Source/WebKit/UIProcess/API/glib/WebKitError.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(webkitWebViewRunJavaScriptWithParams):
(webkitWebViewRunJavascriptWithoutForcedUserGestures):
(webkit_web_view_evaluate_javascript):
(webkit_web_view_evaluate_javascript_finish):
(parseAsyncFunctionArguments):
(webkit_web_view_call_async_javascript_function):
(webkit_web_view_call_async_javascript_function_finish):
(webkit_web_view_run_javascript):
(webkit_web_view_run_javascript_in_world):
(webkit_web_view_run_async_javascript_function_in_world):
(resourcesStreamReadCallback):
* Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in:
* Source/WebKit/UIProcess/API/gtk/WebKitRemoteInspectorProtocolHandler.cpp:
(WebKit::RemoteInspectorProtocolHandler::updateTargetList):
* Tools/MiniBrowser/gtk/BrowserTab.c:
(browser_tab_load_uri):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestBackForwardList.cpp:
(testWebKitWebViewSessionStateWithFormData):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestResources.cpp:
(testWebViewSyncRequestOnMaxConns):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestSSL.cpp:
(WebSocketTest::connectToServerAndWaitForEvents):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebExtensions.cpp:
(FormSubmissionTest::runJavaScriptAndWaitUntilFormSubmitted):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitUserContentManager.cpp:
(isStyleSheetInjectedForURLAtPath):
(isScriptInjectedForURLAtPath):
(UserScriptMessageTest::postMessageAndWaitUntilReceived):
(UserScriptMessageTest::runAsyncJavaScriptFinished):
(UserScriptMessageTest::postMessageAndWaitForPromiseResolved):
(testUserContentManagerScriptMessageInWorldReceived):
(testUserContentManagerScriptMessageWithReplyReceived):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebContext.cpp:
(ProxyTest::createWebSocketAndWaitUntilConnected):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebView.cpp:
(testWebViewRunJavaScript):
* Tools/TestWebKitAPI/glib/WebKitGLib/WebViewTest.cpp:
(runJavaScriptReadyCallback):
(runAsyncJavaScriptFunctionInWorldReadyCallback):
(WebViewTest::runJavaScriptAndWaitUntilFinished):
(WebViewTest::runJavaScriptFromGResourceAndWaitUntilFinished):
(WebViewTest::runJavaScriptInWorldAndWaitUntilFinished):
(WebViewTest::runAsyncJavaScriptFunctionInWorldAndWaitUntilFinished):
(WebViewTest::runJavaScriptWithoutForcedUserGesturesAndWaitUntilFinished):
(WebViewTest::runJavaScriptAndWait):
(runJavaScriptFromGResourceReadyCallback): Deleted.
(runJavaScriptInWorldReadyCallback): Deleted.
* Tools/TestWebKitAPI/glib/WebKitGLib/WebViewTest.h:

Canonical link: <a href="https://commits.webkit.org/259852@main">https://commits.webkit.org/259852@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a15aabfbd96fcc6f95ac10583fd6ac6b713840d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106017 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15073 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38850 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115199 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175353 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109920 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16497 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6253 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98226 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114934 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111770 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12559 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95529 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40101 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94424 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27172 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81777 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8327 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28524 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8817 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5081 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14441 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48067 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10361 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3668 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->