### PR TITLE
Reduce bridging and run-time creation of strings

### DIFF
--- a/Source/JavaScriptCore/API/JSWrapperMap.mm
+++ b/Source/JavaScriptCore/API/JSWrapperMap.mm
@@ -69,7 +69,7 @@ static NSString *selectorToPropertyName(const char* start)
     // Use 'index' to check for colons, if there are none, this is easy!
     const char* firstColon = strchr(start, ':');
     if (!firstColon)
-        return [NSString stringWithUTF8String:start];
+        return @(start);
 
     // 'header' is the length of string up to the first colon.
     size_t header = firstColon - start;
@@ -101,7 +101,7 @@ static NSString *selectorToPropertyName(const char* start)
         // If we get here, we've consumed a ':' - wash, rinse, repeat.
     }
 done:
-    return [NSString stringWithUTF8String:buffer.data()];
+    return @(buffer.data());
 }
 
 static bool constructorHasInstance(JSContextRef ctx, JSObjectRef constructorRef, JSValueRef possibleInstance, JSValueRef*)

--- a/Source/JavaScriptCore/testmem/testmem.mm
+++ b/Source/JavaScriptCore/testmem/testmem.mm
@@ -74,7 +74,7 @@ int main(int argc, char* argv[])
         iterations = iters;
     }
 
-    NSString *path = [NSString stringWithUTF8String:argv[1]];
+    NSString *path = @(argv[1]);
     NSString *script = [[NSString alloc] initWithContentsOfFile:path encoding:NSUTF8StringEncoding error:nil];
     if (!script) {
         printf("Can't open file: %s\n", argv[1]);

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -3259,7 +3259,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     char description[2048];
     formatForDebugger(visiblePositionRange, description, sizeof(description));
 
-    return [NSString stringWithUTF8String:description];
+    return @(description);
 }
 
 - (void)showNodeForTextMarker:(AXTextMarkerRef)textMarker

--- a/Source/WebCore/bridge/objc/objc_class.mm
+++ b/Source/WebCore/bridge/objc/objc_class.mm
@@ -167,7 +167,7 @@ Field* ObjcClass::fieldNamed(PropertyName propertyName, Instance* instance) cons
     ClassStructPtr thisClass = _isa;
 
     CString jsName = name.ascii();
-    RetainPtr<CFStringRef> fieldName = adoptCF(CFStringCreateWithCString(NULL, jsName.data(), kCFStringEncodingASCII));
+    auto fieldName = adoptNS([NSString stringWithCString: jsName.data() encoding:NSASCIIStringEncoding]);
     id targetObject = (static_cast<ObjcInstance*>(instance))->getObject();
 #if PLATFORM(IOS_FAMILY)
     IGNORE_WARNINGS_BEGIN("undeclared-selector")
@@ -195,7 +195,7 @@ Field* ObjcClass::fieldNamed(PropertyName propertyName, Instance* instance) cons
             if ([thisClass respondsToSelector:@selector(webScriptNameForKey:)])
                 mappedName = [thisClass webScriptNameForKey:UTF8KeyName];
 
-            if ((mappedName && [mappedName isEqual:(__bridge NSString *)fieldName.get()]) || [keyName isEqual:(__bridge NSString *)fieldName.get()]) {
+            if ((mappedName && [mappedName isEqual:fieldName.get()]) || [keyName isEqual:fieldName.get()]) {
                 auto newField = makeUnique<ObjcField>((__bridge CFStringRef)keyName);
                 field = newField.get();
                 m_fieldCache.add(name.impl(), WTFMove(newField));
@@ -226,7 +226,7 @@ Field* ObjcClass::fieldNamed(PropertyName propertyName, Instance* instance) cons
                 if ([thisClass respondsToSelector:@selector(webScriptNameForKey:)])
                     mappedName = [thisClass webScriptNameForKey:objcIvarName];
 
-                if ((mappedName && [mappedName isEqual:(__bridge NSString *)fieldName.get()]) || !strcmp(objcIvarName, jsName.data())) {
+                if ((mappedName && [mappedName isEqual:fieldName.get()]) || !strcmp(objcIvarName, jsName.data())) {
                     auto newField = makeUnique<ObjcField>(objcIVar);
                     field = newField.get();
                     m_fieldCache.add(name.impl(), WTFMove(newField));

--- a/Source/WebCore/platform/audio/mac/AudioBusMac.mm
+++ b/Source/WebCore/platform/audio/mac/AudioBusMac.mm
@@ -42,7 +42,7 @@ RefPtr<AudioBus> AudioBus::loadPlatformResource(const char* name, float sampleRa
 {
     @autoreleasepool {
         NSBundle *bundle = [NSBundle bundleForClass:[WebCoreAudioBundleClass class]];
-        NSURL *audioFileURL = [bundle URLForResource:[NSString stringWithUTF8String:name] withExtension:@"wav" subdirectory:@"audio"];
+        NSURL *audioFileURL = [bundle URLForResource:@(name) withExtension:@"wav" subdirectory:@"audio"];
         if (NSData *audioData = [NSData dataWithContentsOfURL:audioFileURL options:NSDataReadingMappedIfSafe error:nil])
             return createBusFromInMemoryAudioFile([audioData bytes], [audioData length], false, sampleRate);
     }

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.mm
@@ -94,8 +94,8 @@ void GameControllerGamepadProvider::controllerDidConnect(GCController *controlle
         if (!serviceInfo.service)
             continue;
 
-        auto cfVendorID = adoptCF((CFNumberRef)IOHIDServiceClientCopyProperty(serviceInfo.service, (__bridge CFStringRef)@(kIOHIDVendorIDKey)));
-        auto cfProductID = adoptCF((CFNumberRef)IOHIDServiceClientCopyProperty(serviceInfo.service, (__bridge CFStringRef)@(kIOHIDProductIDKey)));
+        auto cfVendorID = adoptCF((CFNumberRef)IOHIDServiceClientCopyProperty(serviceInfo.service, CFSTR(kIOHIDVendorIDKey)));
+        auto cfProductID = adoptCF((CFNumberRef)IOHIDServiceClientCopyProperty(serviceInfo.service, CFSTR(kIOHIDProductIDKey)));
 
         int vendorID, productID;
         CFNumberGetValue(cfVendorID.get(), kCFNumberIntType, &vendorID);

--- a/Source/WebCore/platform/graphics/mac/ImageMac.mm
+++ b/Source/WebCore/platform/graphics/mac/ImageMac.mm
@@ -59,7 +59,7 @@ void BitmapImage::invalidatePlatformData()
 Ref<Image> Image::loadPlatformResource(const char *name)
 {
     NSBundle *bundle = [NSBundle bundleForClass:[WebCoreBundleFinder class]];
-    NSString *imagePath = [bundle pathForResource:[NSString stringWithUTF8String:name] ofType:@"png"];
+    NSString *imagePath = [bundle pathForResource:@(name) ofType:@"png"];
     NSData *namedImageData = [NSData dataWithContentsOfFile:imagePath];
     if (namedImageData) {
         auto image = BitmapImage::create();

--- a/Source/WebCore/platform/ios/WebAVPlayerController.mm
+++ b/Source/WebCore/platform/ios/WebAVPlayerController.mm
@@ -130,7 +130,7 @@ static double WebAVPlayerControllerLiveStreamSeekableTimeRangeMinimumDuration = 
 
     for (unsigned i = 0; i < count; i++) {
         objc_property_t property = properties[i];
-        NSString *propertyName = [NSString stringWithUTF8String:property_getName(property)];
+        NSString *propertyName = @(property_getName(property));
         if ([propertyNameFromKeyPath isEqualToString:propertyName]) {
             target = _playerController.get();
             break;

--- a/Source/WebCore/platform/mac/PlatformPasteboardMac.mm
+++ b/Source/WebCore/platform/mac/PlatformPasteboardMac.mm
@@ -375,8 +375,7 @@ int64_t PlatformPasteboard::setURL(const PasteboardURL& pasteboardURL)
         return 0;
 
     NSArray *urlWithTitle = @[ @[ urlString ], @[ pasteboardURL.title ] ];
-    NSString *pasteboardType = [NSString stringWithUTF8String:WebURLsWithTitlesPboardType];
-    BOOL didWriteData = [m_pasteboard setPropertyList:urlWithTitle forType:pasteboardType];
+    BOOL didWriteData = [m_pasteboard setPropertyList:urlWithTitle forType:@(WebURLsWithTitlesPboardType)];
     if (!didWriteData)
         return 0;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/NSAttributedString.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/NSAttributedString.mm
@@ -456,7 +456,7 @@ static NSMutableArray<NSURL *> *readOnlyAccessPaths()
 {
     [self _loadFromHTMLWithOptions:options contentLoader:^WKNavigation *(WKWebView *webView) {
         auto* textEncodingName = dynamic_objc_cast<NSString>(options[NSTextEncodingNameDocumentOption]);
-        auto characterEncoding = static_cast<NSStringEncoding>(dynamic_objc_cast<NSNumber>(options[NSCharacterEncodingDocumentOption]).unsignedIntegerValue);
+        unsigned long characterEncoding = (dynamic_objc_cast<NSNumber>(options[NSCharacterEncodingDocumentOption]).unsignedLongValue);
         auto* baseURL = dynamic_objc_cast<NSURL>(options[NSBaseURLDocumentOption]);
 
         if (characterEncoding && !textEncodingName) {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -398,9 +398,9 @@ static void hardwareKeyboardAvailabilityChangedCallback(CFNotificationCenterRef,
 
     _page->contentSizeCategoryDidChange([self _contentSizeCategory]);
 
-    auto notificationName = adoptNS([[NSString alloc] initWithCString:kGSEventHardwareKeyboardAvailabilityChangedNotification encoding:NSUTF8StringEncoding]);
+    auto notificationName = adoptCF(CFStringCreateWithCString(kCFAllocatorDefault, kGSEventHardwareKeyboardAvailabilityChangedNotification, kCFStringEncodingUTF8));
     auto notificationBehavior = static_cast<CFNotificationSuspensionBehavior>(CFNotificationSuspensionBehaviorCoalesce | _CFNotificationObserverIsObjC);
-    CFNotificationCenterAddObserver(CFNotificationCenterGetDarwinNotifyCenter(), (__bridge const void *)(self), hardwareKeyboardAvailabilityChangedCallback, (__bridge CFStringRef)notificationName.get(), nullptr, notificationBehavior);
+    CFNotificationCenterAddObserver(CFNotificationCenterGetDarwinNotifyCenter(), (__bridge const void *)(self), hardwareKeyboardAvailabilityChangedCallback, notificationName.get(), nullptr, notificationBehavior);
 #endif // PLATFORM(IOS_FAMILY)
 
 #if ENABLE(META_VIEWPORT)
@@ -664,8 +664,8 @@ static void hardwareKeyboardAvailabilityChangedCallback(CFNotificationCenterRef,
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     [_scrollView setInternalDelegate:nil];
 
-    auto notificationName = adoptNS([[NSString alloc] initWithCString:kGSEventHardwareKeyboardAvailabilityChangedNotification encoding:NSUTF8StringEncoding]);
-    CFNotificationCenterRemoveObserver(CFNotificationCenterGetDarwinNotifyCenter(), (__bridge const void *)(self), (__bridge CFStringRef)notificationName.get(), nullptr);
+    auto notificationName = adoptCF(CFStringCreateWithCString(kCFAllocatorDefault, kGSEventHardwareKeyboardAvailabilityChangedNotification, kCFStringEncodingUTF8));
+    CFNotificationCenterRemoveObserver(CFNotificationCenterGetDarwinNotifyCenter(), (__bridge const void *)(self), notificationName.get(), nullptr);
 #endif
 
 #if HAVE(UIKIT_RESIZABLE_WINDOWS)

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKSystemPreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKSystemPreferences.mm
@@ -40,8 +40,7 @@ constexpr auto CaptivePortalConfigurationIgnoreFileName = @"com.apple.WebKit.cpm
     if (preferenceValue.get() == kCFBooleanTrue)
         return true;
 
-    key = adoptCF(CFStringCreateWithCString(kCFAllocatorDefault, LDMEnabledKey, kCFStringEncodingUTF8));
-    preferenceValue = adoptCF(CFPreferencesCopyValue(key.get(), kCFPreferencesAnyApplication, kCFPreferencesCurrentUser, kCFPreferencesAnyHost));
+    preferenceValue = adoptCF(CFPreferencesCopyValue(LDMEnabledKey, kCFPreferencesAnyApplication, kCFPreferencesCurrentUser, kCFPreferencesAnyHost));
     return preferenceValue.get() == kCFBooleanTrue;
 }
 
@@ -50,7 +49,7 @@ constexpr auto CaptivePortalConfigurationIgnoreFileName = @"com.apple.WebKit.cpm
     auto key = adoptCF(CFStringCreateWithCString(kCFAllocatorDefault, WKLockdownModeEnabledKey.characters(), kCFStringEncodingUTF8));
     CFPreferencesSetValue(key.get(), enabled ? kCFBooleanTrue : kCFBooleanFalse, kCFPreferencesAnyApplication, kCFPreferencesCurrentUser, kCFPreferencesAnyHost);
     CFPreferencesSynchronize(kCFPreferencesAnyApplication, kCFPreferencesCurrentUser, kCFPreferencesAnyHost);
-    CFNotificationCenterPostNotification(CFNotificationCenterGetDarwinNotifyCenter(), (__bridge CFStringRef)WKLockdownModeContainerConfigurationChangedNotification, nullptr, nullptr, true);
+    CFNotificationCenterPostNotification(CFNotificationCenterGetDarwinNotifyCenter(), WKLockdownModeContainerConfigurationChangedNotification, nullptr, nullptr, true);
 }
 
 + (BOOL)isCaptivePortalModeIgnored:(NSString *)containerPath
@@ -84,7 +83,7 @@ constexpr auto CaptivePortalConfigurationIgnoreFileName = @"com.apple.WebKit.cpm
     else
         [[NSFileManager defaultManager] removeItemAtPath:cpmconfigIgnoreFilePath error:NULL];
 
-    CFNotificationCenterPostNotification(CFNotificationCenterGetDarwinNotifyCenter(), (__bridge CFStringRef)WKLockdownModeContainerConfigurationChangedNotification, nullptr, nullptr, true);
+    CFNotificationCenterPostNotification(CFNotificationCenterGetDarwinNotifyCenter(), WKLockdownModeContainerConfigurationChangedNotification, nullptr, nullptr, true);
 #endif
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKSystemPreferencesInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKSystemPreferencesInternal.h
@@ -25,7 +25,7 @@
 
 #import "_WKSystemPreferences.h"
 
-constexpr auto LDMEnabledKey = "LDMGlobalEnabled";
+const auto LDMEnabledKey = CFSTR("LDMGlobalEnabled");
 constexpr auto WKLockdownModeEnabledKey = "WKLockdownModeEnabled"_s;
 // This string must remain consistent with the lockdown mode notification name in privacy settings.
-constexpr auto WKLockdownModeContainerConfigurationChangedNotification = @"WKCaptivePortalModeContainerConfigurationChanged";
+const auto WKLockdownModeContainerConfigurationChangedNotification = CFSTR("WKCaptivePortalModeContainerConfigurationChanged");

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -172,12 +172,8 @@ static NSString * const WebKitSuppressMemoryPressureHandlerDefaultsKey = @"WebKi
 
 static NSString * const WebKitMediaStreamingActivity = @"WebKitMediaStreamingActivity";
 
-#if ENABLE(TRACKING_PREVENTION) && !RELEASE_LOG_DISABLED
-static NSString * const WebKitLogCookieInformationDefaultsKey = @"WebKitLogCookieInformation";
-#endif
-
 #if HAVE(POWERLOG_TASK_MODE_QUERY) && ENABLE(GPU_PROCESS)
-static NSString * const kPLTaskingStartNotificationGlobal = @"kPLTaskingStartNotificationGlobal";
+static CFStringRef const kPLTaskingStartNotificationGlobal = CFSTR("kPLTaskingStartNotificationGlobal");
 #endif
 
 #if PLATFORM(IOS_FAMILY) && !PLATFORM(MACCATALYST)
@@ -468,7 +464,7 @@ void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process
 #endif
 
 #if ENABLE(TRACKING_PREVENTION) && !RELEASE_LOG_DISABLED
-    parameters.shouldLogUserInteraction = [defaults boolForKey:WebKitLogCookieInformationDefaultsKey];
+    parameters.shouldLogUserInteraction = [defaults boolForKey:@"WebKitLogCookieInformation"];
 #endif
 
     auto screenProperties = WebCore::collectScreenProperties();
@@ -824,7 +820,7 @@ void WebProcessPool::registerNotificationObservers()
     });
 
 #if PLATFORM(COCOA)
-    addCFNotificationObserver(lockdownModeConfigurationUpdateCallback, (__bridge CFStringRef)WKLockdownModeContainerConfigurationChangedNotification);
+    addCFNotificationObserver(lockdownModeConfigurationUpdateCallback, WKLockdownModeContainerConfigurationChangedNotification);
 #endif
 
 #if HAVE(PER_APP_ACCESSIBILITY_PREFERENCES)
@@ -842,7 +838,7 @@ void WebProcessPool::registerNotificationObservers()
     addCFNotificationObserver(mediaAccessibilityPreferencesChangedCallback, kMAXCaptionAppearanceSettingsChangedNotification);
 #endif
 #if HAVE(POWERLOG_TASK_MODE_QUERY) && ENABLE(GPU_PROCESS)
-    addCFNotificationObserver(powerLogTaskModeStartedCallback, (__bridge CFStringRef)kPLTaskingStartNotificationGlobal);
+    addCFNotificationObserver(powerLogTaskModeStartedCallback, kPLTaskingStartNotificationGlobal);
 #endif // HAVE(POWERLOG_TASK_MODE_QUERY) && ENABLE(GPU_PROCESS)
 }
 
@@ -881,7 +877,7 @@ void WebProcessPool::unregisterNotificationObservers()
     m_powerSourceNotifier = nullptr;
     
 #if PLATFORM(COCOA)
-    removeCFNotificationObserver((__bridge CFStringRef)WKLockdownModeContainerConfigurationChangedNotification);
+    removeCFNotificationObserver(WKLockdownModeContainerConfigurationChangedNotification);
 #endif
 
 #if HAVE(PER_APP_ACCESSIBILITY_PREFERENCES)
@@ -895,7 +891,7 @@ void WebProcessPool::unregisterNotificationObservers()
     removeCFNotificationObserver(kMAXCaptionAppearanceSettingsChangedNotification);
 #endif
 #if HAVE(POWERLOG_TASK_MODE_QUERY) && ENABLE(GPU_PROCESS)
-    removeCFNotificationObserver((__bridge CFStringRef)kPLTaskingStartNotificationGlobal);
+    removeCFNotificationObserver(kPLTaskingStartNotificationGlobal);
 #endif
     m_weakObserver = nil;
 }

--- a/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
@@ -918,13 +918,13 @@ String WebInspectorUIProxy::inspectorTestPageURL()
 
 DebuggableInfoData WebInspectorUIProxy::infoForLocalDebuggable()
 {
-    NSDictionary *plist = adoptCF(_CFCopySystemVersionDictionary()).bridgingAutorelease();
+    CFDictionaryRef plist = adoptCF(_CFCopySystemVersionDictionary()).autorelease();
 
     DebuggableInfoData result;
     result.debuggableType = Inspector::DebuggableType::WebPage;
     result.targetPlatformName = "macOS"_s;
-    result.targetBuildVersion = plist[static_cast<NSString *>(_kCFSystemVersionBuildVersionKey)];
-    result.targetProductVersion = plist[static_cast<NSString *>(_kCFSystemVersionProductUserVisibleVersionKey)];
+    result.targetBuildVersion = CFDictionaryGetValue(plist, _kCFSystemVersionBuildVersionKey);
+    result.targetProductVersion = CFDictionaryGetValue(plist, _kCFSystemVersionProductUserVisibleVersionKey);
     result.targetIsSimulator = false;
 
     return result;

--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
@@ -155,8 +155,7 @@ void WebsiteDataStore::platformSetNetworkParameters(WebsiteDataStoreParameters& 
             resourceLoadStatisticsManualPrevalentResource = WebCore::RegistrableDomain { url };
     }
 #if !RELEASE_LOG_DISABLED
-    static NSString * const WebKitLogCookieInformationDefaultsKey = @"WebKitLogCookieInformation";
-    shouldLogCookieInformation = [defaults boolForKey:WebKitLogCookieInformationDefaultsKey];
+    shouldLogCookieInformation = [defaults boolForKey:@"WebKitLogCookieInformation"];
 #endif
 #endif // ENABLE(TRACKING_PREVENTION)
 

--- a/Source/WebKit/UIProcess/mac/WKPrintingView.mm
+++ b/Source/WebKit/UIProcess/mac/WKPrintingView.mm
@@ -449,9 +449,9 @@ static void prepareDataForPrintingOnSecondaryThread(WKPrintingView *view)
     return 0; // Invalid page number.
 }
 
-static NSString *linkDestinationName(PDFDocument *document, PDFDestination *destination)
+static CFStringRef createLinkDestinationName(PDFDocument *document, PDFDestination *destination)
 {
-    return [NSString stringWithFormat:@"%lu-%f-%f", (unsigned long)[document indexForPage:destination.page], destination.point.x, destination.point.y];
+    return CFStringCreateWithFormat(kCFAllocatorDefault, NULL, CFSTR("%lu-%f-%f"), (unsigned long)[document indexForPage:destination.page], destination.point.x, destination.point.y]);
 }
 
 - (void)_drawPDFDocument:(PDFDocument *)pdfDocument page:(unsigned)page atPoint:(NSPoint)point
@@ -483,7 +483,9 @@ static NSString *linkDestinationName(PDFDocument *document, PDFDestination *dest
 
     for (const auto& destination : _linkDestinationsPerPage[page]) {
         CGPoint destinationPoint = CGPointApplyAffineTransform(NSPointToCGPoint([destination point]), transform);
-        CGPDFContextAddDestinationAtPoint(context, (__bridge CFStringRef)linkDestinationName(pdfDocument, destination.get()), destinationPoint);
+        CFStringRef destinationName = createLinkDestinationName(pdfDocument, destination.get());
+        CGPDFContextAddDestinationAtPoint(context, destinationName, destinationPoint);
+        CFRelease(destinationName);
     }
 
     for (PDFAnnotation *annotation in [pdfPage annotations]) {
@@ -500,7 +502,9 @@ static NSString *linkDestinationName(PDFDocument *document, PDFDestination *dest
             PDFDestination *destination = [linkAnnotation destination];
             if (!destination)
                 continue;
-            CGPDFContextSetDestinationForRect(context, (__bridge CFStringRef)linkDestinationName(pdfDocument, destination), transformedRect);
+            CFStringRef destinationName = createLinkDestinationName(pdfDocument, destination)
+            CGPDFContextSetDestinationForRect(context, destinationName, transformedRect);
+            CFRelease(destinationName);
             continue;
         }
 

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -614,16 +614,14 @@ RetainPtr<NSDictionary> WebProcess::additionalStateForDiagnosticReport() const
     {
         auto memoryUsageStats = adoptNS([[NSMutableDictionary alloc] init]);
         for (auto& it : PerformanceLogging::memoryUsageStatistics(ShouldIncludeExpensiveComputations::Yes)) {
-            auto keyString = adoptNS([[NSString alloc] initWithUTF8String:it.key]);
-            [memoryUsageStats setObject:@(it.value) forKey:keyString.get()];
+            [memoryUsageStats setObject:@(it.value) forKey:@(it.key)];
         }
         [stateDictionary setObject:memoryUsageStats.get() forKey:@"Memory Usage Stats"];
     }
     {
         auto jsObjectCounts = adoptNS([[NSMutableDictionary alloc] init]);
         for (auto& it : PerformanceLogging::javaScriptObjectCounts()) {
-            auto keyString = adoptNS([[NSString alloc] initWithUTF8String:it.key]);
-            [jsObjectCounts setObject:@(it.value) forKey:keyString.get()];
+            [jsObjectCounts setObject:@(it.value) forKey:@(it.key)];
         }
         [stateDictionary setObject:jsObjectCounts.get() forKey:@"JavaScript Object Counts"];
     }

--- a/Source/WebKitLegacy/mac/Misc/WebCoreStatistics.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebCoreStatistics.mm
@@ -84,7 +84,7 @@ static RetainPtr<NSCountedSet> createNSCountedSet(const HashCountedSet<const cha
 {
     auto result = adoptNS([[NSCountedSet alloc] initWithCapacity:set.size()]);
     for (auto& entry : set) {
-        auto key = [NSString stringWithUTF8String:entry.key];
+        auto key = @(entry.key);
         for (unsigned i = 0; i < entry.value; ++i)
             [result addObject:key];
     }

--- a/Source/WebKitLegacy/mac/Misc/WebLocalizableStrings.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebLocalizableStrings.mm
@@ -49,7 +49,7 @@ NSString *WebLocalizedString(WebLocalizableStringsBundle *stringsBundle, const c
     } else {
         bundle = stringsBundle->bundle;
         if (bundle == nil) {
-            bundle = [NSBundle bundleWithIdentifier:[NSString stringWithUTF8String:stringsBundle->identifier]];
+            bundle = [NSBundle bundleWithIdentifier:@(stringsBundle->identifier)];
             ASSERT(bundle);
             stringsBundle->bundle = bundle;
         }

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -2577,9 +2577,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [[NSNotificationCenter defaultCenter] 
             addObserver:self selector:@selector(markedTextUpdate:) 
                    name:WebMarkedTextUpdatedNotification object:nil];
-    auto notificationName = adoptNS([[NSString alloc] initWithCString:kGSEventHardwareKeyboardAvailabilityChangedNotification encoding:NSUTF8StringEncoding]);
+    auto notificationName = adoptCF(CFStringCreateWithCString(kCFAllocatorDefault, kGSEventHardwareKeyboardAvailabilityChangedNotification, kCFStringEncodingUTF8));
     auto notificationBehavior = static_cast<CFNotificationSuspensionBehavior>(CFNotificationSuspensionBehaviorCoalesce | _CFNotificationObserverIsObjC);
-    CFNotificationCenterAddObserver(CFNotificationCenterGetDarwinNotifyCenter(), (__bridge const void *)(self), hardwareKeyboardAvailabilityChangedCallback, (__bridge CFStringRef)notificationName.get(), nullptr, notificationBehavior);
+    CFNotificationCenterAddObserver(CFNotificationCenterGetDarwinNotifyCenter(), (__bridge const void *)(self), hardwareKeyboardAvailabilityChangedCallback, notificationName.get(), nullptr, notificationBehavior);
 #endif
 
 #if PLATFORM(MAC)
@@ -2596,8 +2596,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 #if PLATFORM(IOS_FAMILY)
     [[NSNotificationCenter defaultCenter] removeObserver:self name:WebMarkedTextUpdatedNotification object:nil];
-    auto notificationName = adoptNS([[NSString alloc] initWithCString:kGSEventHardwareKeyboardAvailabilityChangedNotification encoding:NSUTF8StringEncoding]);
-    CFNotificationCenterRemoveObserver(CFNotificationCenterGetDarwinNotifyCenter(), (__bridge const void *)(self), (__bridge CFStringRef)notificationName.get(), nullptr);
+    auto notificationName = adoptCF(CFStringCreateWithCString(kCFAllocatorDefault, kGSEventHardwareKeyboardAvailabilityChangedNotification, kCFStringEncodingUTF8));
+    CFNotificationCenterRemoveObserver(CFNotificationCenterGetDarwinNotifyCenter(), (__bridge const void *)(self), notificationName.get(), nullptr);
 #endif
 
     // We can't assert that close has already been called because

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -8408,7 +8408,7 @@ FORWARD(toggleUnderline)
 
     auto nsurlCacheDirectory = adoptCF(_CFURLCacheCopyCacheDirectory([[NSURLCache sharedURLCache] _CFURLCache]));
     if (!nsurlCacheDirectory)
-        nsurlCacheDirectory = (__bridge CFStringRef)NSHomeDirectory();
+        nsurlCacheDirectory = CFCopyHomeDirectoryURL();
 
     static uint64_t memSize = ramSize() / 1024 / 1024;
 

--- a/Tools/DumpRenderTree/mac/DumpRenderTree.mm
+++ b/Tools/DumpRenderTree/mac/DumpRenderTree.mm
@@ -133,7 +133,7 @@ extern "C" {
 
 static RetainPtr<NSString> toNS(const std::string& string)
 {
-    return adoptNS([[NSString alloc] initWithUTF8String:string.c_str()]);
+    return adoptNS(@(string.c_str()]));
 }
 
 #if !PLATFORM(IOS_FAMILY)
@@ -1046,7 +1046,7 @@ static void initializeGlobalsFromCommandLineOptions(int argc, const char *argv[]
 static void addTestPluginsToPluginSearchPath(const char* executablePath)
 {
 #if !PLATFORM(IOS_FAMILY)
-    NSString *pwd = [[NSString stringWithUTF8String:executablePath] stringByDeletingLastPathComponent];
+    NSString *pwd = [@(executablePath) stringByDeletingLastPathComponent];
     [WebPluginDatabase setAdditionalWebPlugInPaths:@[pwd]];
     [[WebPluginDatabase sharedDatabase] refresh];
 #endif
@@ -1148,7 +1148,7 @@ static void prepareConsistentTestingEnvironment()
 #endif
 
     if (webCoreLogging.length())
-        [[NSUserDefaults standardUserDefaults] setValue:[NSString stringWithUTF8String:webCoreLogging.c_str()] forKey:@"WebCoreLogging"];
+        [[NSUserDefaults standardUserDefaults] setValue:@(webCoreLogging.c_str()) forKey:@"WebCoreLogging"];
 }
 
 const char crashedMessage[] = "#CRASHED\n";
@@ -1200,11 +1200,11 @@ void dumpRenderTree(int argc, const char *argv[])
     [NSURLRequest setAllowsAnyHTTPSCertificate:YES forHost:@"localhost"];
     [NSURLRequest setAllowsAnyHTTPSCertificate:YES forHost:@"127.0.0.1"];
     for (auto& localhostAlias : localhostAliases)
-        [NSURLRequest setAllowsAnyHTTPSCertificate:YES forHost:[NSString stringWithUTF8String:localhostAlias.c_str()]];
+        [NSURLRequest setAllowsAnyHTTPSCertificate:YES forHost:@(localhostAlias.c_str())];
 
     if (allowAnyHTTPSCertificateForAllowedHosts) {
         for (auto& host : allowedHosts)
-            [NSURLRequest setAllowsAnyHTTPSCertificate:YES forHost:[NSString stringWithUTF8String:host.c_str()]];
+            [NSURLRequest setAllowsAnyHTTPSCertificate:YES forHost:@(host.c_str()];
     }
 
     if (threaded)
@@ -1896,7 +1896,7 @@ static void runTest(const std::string& inputLine)
     auto pathOrURL = command.pathOrURL;
     dumpPixelsForCurrentTest = command.shouldDumpPixels || dumpPixelsForAllTests;
 
-    NSString *pathOrURLString = [NSString stringWithUTF8String:pathOrURL.c_str()];
+    NSString *pathOrURLString = @(pathOrURL.c_str());
     if (!pathOrURLString) {
         fprintf(stderr, "Failed to parse \"%s\" as UTF-8\n", pathOrURL.c_str());
         return;

--- a/Tools/DumpRenderTree/mac/ResourceLoadDelegate.mm
+++ b/Tools/DumpRenderTree/mac/ResourceLoadDelegate.mm
@@ -168,7 +168,7 @@ BOOL canAuthenticateServerTrustAgainstProtectionSpace(NSString *host)
     NSURL *url = [request URL];
     NSString *host = [url host];
     if (host && (NSOrderedSame == [[url scheme] caseInsensitiveCompare:@"http"] || NSOrderedSame == [[url scheme] caseInsensitiveCompare:@"https"])) {
-        NSString *testURL = [NSString stringWithUTF8String:gTestRunner->testURL().c_str()];
+        NSString *testURL = @(gTestRunner->testURL().c_str());
         NSString *lowercaseTestURL = [testURL lowercaseString];
         NSString *testHost = 0;
         if ([lowercaseTestURL hasPrefix:@"http:"] || [lowercaseTestURL hasPrefix:@"https:"])
@@ -188,11 +188,10 @@ BOOL canAuthenticateServerTrustAgainstProtectionSpace(NSString *host)
     auto newRequest = adoptNS([request mutableCopy]);
     const set<string>& clearHeaders = gTestRunner->willSendRequestClearHeaders();
     for (set<string>::const_iterator header = clearHeaders.begin(); header != clearHeaders.end(); ++header) {
-        auto nsHeader = adoptNS([[NSString alloc] initWithUTF8String:header->c_str()]);
-        [newRequest setValue:nil forHTTPHeaderField:nsHeader.get()];
+        [newRequest setValue:nil forHTTPHeaderField:@(header->c_str())];
     }
     if (auto* destination = gTestRunner->redirectionDestinationForURL([[url absoluteString] UTF8String]))
-        [newRequest setURL:[NSURL URLWithString:[NSString stringWithUTF8String:destination]]];
+        [newRequest setURL:[NSURL URLWithString:@(destination)]];
 
     return newRequest.autorelease();
 }

--- a/Tools/DumpRenderTree/mac/UIDelegate.mm
+++ b/Tools/DumpRenderTree/mac/UIDelegate.mm
@@ -383,13 +383,13 @@ static NSString *addLeadingSpaceStripTrailingSpaces(NSString *string)
         return;
     }
 
-    NSURL *baseURL = [NSURL URLWithString:[NSString stringWithUTF8String:gTestRunner->testURL().c_str()]];
+    NSURL *baseURL = [NSURL URLWithString:@(gTestRunner->testURL().c_str())];
     auto filePaths = createNSArray(openPanelFiles, [&] (const std::string& filePath) {
-        return [NSURL fileURLWithPath:[NSString stringWithUTF8String:filePath.c_str()] relativeToURL:baseURL].path;
+        return [NSURL fileURLWithPath:@(filePath.c_str()) relativeToURL:baseURL].path;
     });
 
 #if PLATFORM(IOS_FAMILY)
-    NSURL *firstURL = [NSURL fileURLWithPath:[NSString stringWithUTF8String:openPanelFiles[0].c_str()] relativeToURL:baseURL];
+    NSURL *firstURL = [NSURL fileURLWithPath:@(openPanelFiles[0].c_str()) relativeToURL:baseURL];
     NSString *displayString = firstURL.lastPathComponent;
     auto& iconData = gTestRunner->openPanelFilesMediaIcon();
     CGImageRef imageRef = nullptr;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Badging.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Badging.mm
@@ -200,7 +200,7 @@ TEST(Badging, APIWindow)
     webView.get().UIDelegate = badgeDelegate.get();
     [webView synchronouslyLoadRequest:server.request("/"_s)];
 
-    NSString *nsCheckForBadgeFunctions = [NSString stringWithUTF8String:checkForBadgeFunctions];
+    NSString *nsCheckForBadgeFunctions = @(checkForBadgeFunctions);
     static bool done = false;
     [webView callAsyncJavaScript:nsCheckForBadgeFunctions arguments:nil inFrame:nil inContentWorld:WKContentWorld.pageWorld completionHandler:^(id result, NSError *error) {
         EXPECT_TRUE([result isEqualToString:@"0 0 0 0 "]);
@@ -245,7 +245,7 @@ TEST(Badging, APIWindow)
     }];
     TestWebKitAPI::Util::run(&done);
 
-    NSString *nsExerciseBadgeFunctions = [NSString stringWithUTF8String:exerciseBadgeFunctions];
+    NSString *nsExerciseBadgeFunctions = @(exerciseBadgeFunctions);
     done = false;
     [webView callAsyncJavaScript:nsExerciseBadgeFunctions arguments:nil inFrame:nil inContentWorld:WKContentWorld.pageWorld completionHandler:^(id result, NSError *error) {
         EXPECT_TRUE([result isEqualToString:@"DONE"]);
@@ -567,7 +567,7 @@ TEST(Badging, ServiceWorkerOverride)
     TestWebKitAPI::Util::run(&workerRunning);
 
     // Confirm that the WKWebView's window object does NOT have the badging functions exposed
-    NSString *nsCheckForBadgeFunctions = [NSString stringWithUTF8String:checkForBadgeFunctions];
+    NSString *nsCheckForBadgeFunctions = @(checkForBadgeFunctions);
     static bool done = false;
     [webView callAsyncJavaScript:nsCheckForBadgeFunctions arguments:nil inFrame:nil inContentWorld:WKContentWorld.pageWorld completionHandler:^(id result, NSError *error) {
         EXPECT_TRUE([result isEqualToString:@"0 0 0 0 "]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FTP.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FTP.mm
@@ -108,7 +108,7 @@ TEST(WKWebView, FTPSubresource)
     setInjectedBundleClient(webView.get());
     
     consoleMessages = [NSMutableArray arrayWithCapacity:2];
-    [webView synchronouslyLoadHTMLString:[NSString stringWithUTF8String:subresourceBytes]];
+    [webView synchronouslyLoadHTMLString:@(subresourceBytes)];
 
     EXPECT_EQ([consoleMessages count], 2u);
     EXPECT_TRUE([consoleMessages.get()[0] isEqualToString:@"FTP URLs are disabled"]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ShouldOpenExternalURLsInNewWindowActions.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ShouldOpenExternalURLsInNewWindowActions.mm
@@ -280,9 +280,9 @@ TEST(WebKit, IFrameWithSameOriginAsMainFramePropagates)
         
         NSString *responseText = nil;
         if ([[task request].URL.absoluteString containsString:@"iframe.html"])
-            responseText = [NSString stringWithUTF8String:iframeBytes];
+            responseText = @(iframeBytes);
         else if ([[task request].URL.absoluteString containsString:@"mainframe.html"])
-            responseText = [NSString stringWithUTF8String:mainFrameBytes];
+            responseText = @(mainFrameBytes);
 
         auto response = adoptNS([[NSURLResponse alloc] initWithURL:requestURL MIMEType:@"text/html" expectedContentLength:[responseText length] textEncodingName:nil]);
         [task didReceiveResponse:response.get()];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKURLSchemeHandler-1.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKURLSchemeHandler-1.mm
@@ -718,7 +718,7 @@ TEST(URLSchemeHandler, XHRPost)
             EXPECT_FALSE(reached);
             reached = true;
             // The length of this is variable
-            auto *formDataString = [NSString stringWithUTF8String:static_cast<const char*>(task.request.HTTPBody.bytes)];
+            auto *formDataString = @(static_cast<const char*>(task.request.HTTPBody.bytes));
             EXPECT_TRUE([formDataString containsString:@"Content-Disposition: form-data; name=\"foo\""]);
             EXPECT_TRUE([formDataString containsString:@"baz"]);
             EXPECT_TRUE([formDataString containsString:@"WebKitFormBoundary"]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
@@ -275,7 +275,7 @@ TEST(WebPushD, BasicCommunication)
         if (!debugMessage)
             return;
 
-        NSString *nsMessage = [NSString stringWithUTF8String:debugMessage];
+        NSString *nsMessage = @(debugMessage);
 
         // Ignore possible connections/messages from webpushtool
         if ([nsMessage hasPrefix:@"[webpushtool "])

--- a/Tools/TestWebKitAPI/cocoa/DaemonTestUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/DaemonTestUtilities.mm
@@ -56,7 +56,7 @@ static RetainPtr<NSURL> currentExecutableLocation()
     buffer.resize(size + 1);
     _NSGetExecutablePath(buffer.data(), &size);
     buffer[size] = '\0';
-    auto pathString = adoptNS([[NSString alloc] initWithUTF8String:buffer.data()]);
+    auto pathString = adoptNS(@(buffer.data());
     return adoptNS([[NSURL alloc] initFileURLWithPath:pathString.get() isDirectory:NO]);
 }
 

--- a/Tools/TestWebKitAPI/cocoa/PlatformUtilitiesCocoa.mm
+++ b/Tools/TestWebKitAPI/cocoa/PlatformUtilitiesCocoa.mm
@@ -42,7 +42,7 @@ NSString *toNS(WKStringRef string)
     size_t stringLength = WKStringGetUTF8CString(string, buffer.get(), bufferSize);
     buffer[stringLength] = '\0';
 
-    return [NSString stringWithUTF8String:buffer.get()];
+    return @(buffer.get());
 }
 
 NSString *toNS(WKRetainPtr<WKStringRef> string)

--- a/Tools/TestWebKitAPI/mac/JavaScriptTestMac.mm
+++ b/Tools/TestWebKitAPI/mac/JavaScriptTestMac.mm
@@ -35,7 +35,7 @@ namespace TestWebKitAPI {
 
 ::testing::AssertionResult runJSTest(const char*, const char*, const char*, WebView *webView, const char* script, const char* expectedResult)
 {
-    NSString *actualResult = [webView stringByEvaluatingJavaScriptFromString:[NSString stringWithUTF8String:script]];
+    NSString *actualResult = [webView stringByEvaluatingJavaScriptFromString:@(script)];
     return compareJSResult(script, [actualResult UTF8String], expectedResult);
 }
 

--- a/Tools/TestWebKitAPI/mac/PlatformUtilitiesMac.mm
+++ b/Tools/TestWebKitAPI/mac/PlatformUtilitiesMac.mm
@@ -44,7 +44,7 @@ WKStringRef createInjectedBundlePath()
 
 WKURLRef createURLForResource(const char* resource, const char* extension)
 {
-    NSURL *nsURL = [[NSBundle mainBundle] URLForResource:[NSString stringWithUTF8String:resource] withExtension:[NSString stringWithUTF8String:extension] subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *nsURL = [[NSBundle mainBundle] URLForResource:@(resource) withExtension:@(extension) subdirectory:@"TestWebKitAPI.resources"];
     return WKURLCreateWithCFURL((__bridge CFURLRef)nsURL);
 }
 

--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -118,10 +118,10 @@ void TestController::cocoaPlatformInitialize(const Options& options)
         WTFCrash();
     
     if (options.webCoreLogChannels.length())
-        [[NSUserDefaults standardUserDefaults] setValue:[NSString stringWithUTF8String:options.webCoreLogChannels.c_str()] forKey:@"WebCoreLogging"];
+        [[NSUserDefaults standardUserDefaults] setValue:@(options.webCoreLogChannels.c_str()) forKey:@"WebCoreLogging"];
 
     if (options.webKitLogChannels.length())
-        [[NSUserDefaults standardUserDefaults] setValue:[NSString stringWithUTF8String:options.webKitLogChannels.c_str()] forKey:@"WebKit2Logging"];
+        [[NSUserDefaults standardUserDefaults] setValue:@(options.webKitLogChannels.c_str()) forKey:@"WebKit2Logging"];
 }
 
 WKContextRef TestController::platformContext()
@@ -155,7 +155,7 @@ void TestController::platformInitializeDataStore(WKPageConfigurationRef, const T
         if (!useEphemeralSession)
             configureWebsiteDataStoreTemporaryDirectories((WKWebsiteDataStoreConfigurationRef)websiteDataStoreConfig.get());
         if (standaloneWebApplicationURL.length())
-            [websiteDataStoreConfig setStandaloneApplicationURL:[NSURL URLWithString:[NSString stringWithUTF8String:standaloneWebApplicationURL.c_str()]]];
+            [websiteDataStoreConfig setStandaloneApplicationURL:[NSURL URLWithString:@(standaloneWebApplicationURL.c_str())]];
 #if PLATFORM(IOS_FAMILY)
         if (options.enableInAppBrowserPrivacy())
             [websiteDataStoreConfig setEnableInAppBrowserPrivacyForTesting:YES];
@@ -200,7 +200,7 @@ void TestController::platformCreateWebView(WKPageConfigurationRef, const TestOpt
 
     auto applicationManifest = options.applicationManifest();
     if (applicationManifest.length()) {
-        auto manifestPath = [NSString stringWithUTF8String:applicationManifest.c_str()];
+        auto manifestPath = @(applicationManifest.c_str());
         NSString *text = [NSString stringWithContentsOfFile:manifestPath usedEncoding:nullptr error:nullptr];
         [copiedConfiguration _setApplicationManifest:[_WKApplicationManifest applicationManifestFromJSON:text manifestURL:nil documentURL:nil]];
     }


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=250937

Reviewed by NOBODY (OOPS!).

In many places, we are needlessly bridging for the sake of calling Objective-C methods and Core Foundation functions where the functions/methods work just fine.

This PR addresses the places where bridging needlessly takes place.<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86bdd6409a1b97d0c4f6b8c2640d783c9ceed539

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106058 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/15114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/38890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/115240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/175332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109961 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16538 "Hash 86bdd640 for PR 9517 does not build (failure)") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/6284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/98267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111811 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/76/builds/16538 "Hash 86bdd640 for PR 9517 does not build (failure)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/38890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/98267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/76/builds/16538 "Hash 86bdd640 for PR 9517 does not build (failure)") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/38890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/98267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/95699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/8365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/38890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/95050 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/6182 "Built successfully and passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/8857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/6284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30492 "Passed tests") | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14477 "Hash 86bdd640 for PR 9517 does not build (failure)") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/38890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/103793 "Built successfully") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/10401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25721 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->