### PR TITLE
REGRESSION({259017,259250}@main): [JSC] fix ENABLE(WEBASSEMBLY)

### DIFF
--- a/Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.h
+++ b/Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.h
@@ -121,7 +121,6 @@ namespace JSC { namespace FTL {
     macro(JSRopeString_fiber2, JSRopeString::offsetOfFiber2()) \
     macro(JSScope_next, JSScope::offsetOfNext()) \
     macro(JSSymbolTableObject_symbolTable, JSSymbolTableObject::offsetOfSymbolTable()) \
-    macro(JSWebAssemblyInstance_moduleRecord, JSWebAssemblyInstance::offsetOfModuleRecord()) \
     macro(NativeExecutable_asString, NativeExecutable::offsetOfAsString()) \
     macro(RegExpObject_regExpAndFlags, RegExpObject::offsetOfRegExpAndFlags()) \
     macro(RegExpObject_lastIndex, RegExpObject::offsetOfLastIndex()) \
@@ -167,8 +166,15 @@ namespace JSC { namespace FTL {
     macro(WeakMapImpl_buffer,  WeakMapImpl<WeakMapBucket<WeakMapBucketDataKey>>::offsetOfBuffer()) \
     macro(WeakMapBucket_value, WeakMapBucket<WeakMapBucketDataKeyValue>::offsetOfValue()) \
     macro(WeakMapBucket_key, WeakMapBucket<WeakMapBucketDataKeyValue>::offsetOfKey()) \
-    macro(WebAssemblyModuleRecord_exportsObject, WebAssemblyModuleRecord::offsetOfExportsObject()) \
     macro(Symbol_symbolImpl, Symbol::offsetOfSymbolImpl()) \
+
+#if ENABLE(WEBASSEMBLY)
+#define FOR_EACH_ABSTRACT_FIELD_WASM(macro) \
+    macro(JSWebAssemblyInstance_moduleRecord, JSWebAssemblyInstance::offsetOfModuleRecord()) \
+    macro(WebAssemblyModuleRecord_exportsObject, WebAssemblyModuleRecord::offsetOfExportsObject())
+#else
+#define FOR_EACH_ABSTRACT_FIELD_WASM(macro)
+#endif
 
 #define FOR_EACH_INDEXED_ABSTRACT_HEAP(macro) \
     macro(ArrayStorage_vector, ArrayStorage::vectorOffset(), sizeof(WriteBarrier<Unknown>)) \
@@ -210,6 +216,7 @@ public:
 
 #define ABSTRACT_FIELD_DECLARATION(name, offset) AbstractHeap name;
     FOR_EACH_ABSTRACT_FIELD(ABSTRACT_FIELD_DECLARATION)
+    FOR_EACH_ABSTRACT_FIELD_WASM(ABSTRACT_FIELD_DECLARATION)
 #undef ABSTRACT_FIELD_DECLARATION
     
     AbstractHeap& JSCell_freeListNext;

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -5192,9 +5192,11 @@ IGNORE_CLANG_WARNINGS_END
 
     void compileGetWebAssemblyInstanceExports()
     {
+#if ENABLE(WEBASSEMBLY)
         LValue base = lowCell(m_node->child1());
         LValue moduleRecord = m_out.loadPtr(base, m_heaps.JSWebAssemblyInstance_moduleRecord);
         setJSValue(m_out.loadPtr(moduleRecord, m_heaps.WebAssemblyModuleRecord_exportsObject));
+#endif
     }
 
     LValue typedArrayLength(LValue base, bool acceptResizable, std::optional<TypedArrayType> typedArrayType)
@@ -11629,6 +11631,7 @@ IGNORE_CLANG_WARNINGS_END
 
     void compileCallWasm()
     {
+#if ENABLE(WEBASSEMBLY)
         Node* node = m_node;
         WebAssemblyFunction* wasmFunction = node->castOperand<WebAssemblyFunction*>();
         JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
@@ -11853,6 +11856,7 @@ IGNORE_CLANG_WARNINGS_END
                 break;
             }
         }
+#endif
     }
 
     void compileVarargsLength()


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=251357

Reviewed by NOBODY (OOPS!).

FTL: macros can't hold any #defines, so add a new set:

    FOR_EACH_ABSTRACT_FIELD_WASM

Signed-off-by: Thomas Devoogdt <thomas.devoogdt@barco.com><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d5a211f367413c0d0cf740b898865e1d06968016

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105848 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14916 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38696 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115046 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175174 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16335 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6115 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98081 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114818 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111597 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12434 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95404 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39976 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94294 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27046 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81634 "3 api tests failed or timed out") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/95544 "Found 145 new JSC stress test failures: microbenchmarks/memcpy-wasm-large.js.ftl-eager, microbenchmarks/memcpy-wasm-large.js.ftl-eager-no-cjit, microbenchmarks/memcpy-wasm-large.js.ftl-eager-no-cjit-b3o1, microbenchmarks/memcpy-wasm-medium.js.bytecode-cache, microbenchmarks/memcpy-wasm-medium.js.default, microbenchmarks/memcpy-wasm-medium.js.ftl-eager, microbenchmarks/memcpy-wasm-medium.js.ftl-eager-no-cjit, microbenchmarks/memcpy-wasm-medium.js.ftl-eager-no-cjit-b3o1, microbenchmarks/memcpy-wasm-medium.js.ftl-no-cjit-b3o0, microbenchmarks/memcpy-wasm-medium.js.ftl-no-cjit-no-inline-validate ... (failure)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8187 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28398 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/94826 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/5984 "Found 156 new JSC stress test failures: microbenchmarks/memcpy-wasm-large.js.ftl-eager, microbenchmarks/memcpy-wasm-large.js.ftl-eager-no-cjit, microbenchmarks/memcpy-wasm-large.js.ftl-eager-no-cjit-b3o1, microbenchmarks/memcpy-wasm-medium.js.bytecode-cache, microbenchmarks/memcpy-wasm-medium.js.default, microbenchmarks/memcpy-wasm-medium.js.ftl-eager, microbenchmarks/memcpy-wasm-medium.js.ftl-eager-no-cjit, microbenchmarks/memcpy-wasm-medium.js.ftl-eager-no-cjit-b3o1, microbenchmarks/memcpy-wasm-medium.js.ftl-no-cjit-b3o0, microbenchmarks/memcpy-wasm-medium.js.ftl-no-cjit-no-inline-validate ... (failure)") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8669 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4994 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30449 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14296 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47946 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/103573 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10226 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25681 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->