### PR TITLE
[GStreamer][EME][Thunder] Add PlayReady support

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
@@ -125,8 +125,14 @@ const Vector<String>& CDMFactoryThunder::supportedKeySystems() const
             supportedKeySystems.append(String::fromLatin1(GStreamerEMEUtilities::s_WidevineKeySystem));
         if (opencdm_is_type_supported(GStreamerEMEUtilities::s_ClearKeyKeySystem, emptyString.c_str()) == ERROR_NONE)
             supportedKeySystems.append(String::fromLatin1(GStreamerEMEUtilities::s_ClearKeyKeySystem));
+        if (opencdm_is_type_supported(GStreamerEMEUtilities::s_PlayReadyKeySystems[0], emptyString.c_str()) == ERROR_NONE) {
+            supportedKeySystems.append(String::fromLatin1(GStreamerEMEUtilities::s_PlayReadyKeySystems[0]));
+            supportedKeySystems.append(String::fromLatin1(GStreamerEMEUtilities::s_PlayReadyKeySystems[1]));
+        }
         GST_DEBUG("%zu supported key systems", supportedKeySystems.size());
-    };
+        ASSERT_WITH_MESSAGE(!supportedKeySystems.isEmpty() || !isThunderRanked(), "Thunder is up-ranked as preferred "
+            "decryptor but Thunder is not supporting any encryption system. Is Thunder running? Are the plugins built?");
+    }
     return supportedKeySystems;
 }
 
@@ -440,6 +446,20 @@ void CDMInstanceSessionThunder::keyUpdatedCallback(KeyIDType&& keyID)
     auto keyStatus = status(keyID);
     GST_DEBUG("updated with with key status %s", toString(keyStatus));
     m_doesKeyStoreNeedMerging |= m_keyStore.add(KeyHandle::create(keyStatus, WTFMove(keyID), BoxPtr<OpenCDMSession>(m_session)));
+    auto instance = cdmInstanceThunder();
+    if (instance && GStreamerEMEUtilities::isPlayReadyKeySystem(instance->keySystem())) {
+        // PlayReady corner case hack: It happens that the key ID
+        // required by the stream and reported by the CDM have
+        // different endianness of the 4-2-2 GUID components.
+        RELEASE_ASSERT(keyID.size() >= 8);
+        KeyIDType swappedKeyID(keyID);
+        std::swap(swappedKeyID[0], swappedKeyID[3]);
+        std::swap(swappedKeyID[1], swappedKeyID[2]);
+        std::swap(swappedKeyID[4], swappedKeyID[5]);
+        std::swap(swappedKeyID[6], swappedKeyID[7]);
+        GST_MEMDUMP("updated swapped key", swappedKeyID.data(), swappedKeyID.size());
+        m_doesKeyStoreNeedMerging |= m_keyStore.add(KeyHandle::create(keyStatus, WTFMove(swappedKeyID), BoxPtr<OpenCDMSession>(m_session)));
+    }
 }
 
 void CDMInstanceSessionThunder::keysUpdateDoneCallback()


### PR DESCRIPTION
#### 38fc0ce11b211e73e15546de9b6db7721a83bf9d
<pre>
[GStreamer][EME][Thunder] Add PlayReady support
<a href="https://bugs.webkit.org/show_bug.cgi?id=251587">https://bugs.webkit.org/show_bug.cgi?id=251587</a>

Reviewed by Philippe Normand.

Enable PlayReady if the Thunder plugins are present.

Also add a small check just in case there is no Thunder running in debug mode.

Added key ID corner case hack. Sometimes PlayReady key IDs come with some bytes swapped so we add both original and
swapped key IDs to the hashmap.

* Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp:
(WebCore::CDMFactoryThunder::supportedKeySystems const):
(WebCore::CDMInstanceSessionThunder::keyUpdatedCallback):

Canonical link: <a href="https://commits.webkit.org/259890@main">https://commits.webkit.org/259890@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc47bd6df8674b48e2abeeb97d6bd8d8e7b48099

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105857 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14925 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38705 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115055 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175181 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109759 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16344 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6219 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98090 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114825 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111606 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12442 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95412 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39983 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94303 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27055 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81651 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8196 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28408 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8678 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5060 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14305 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47954 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6835 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10234 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->