### PR TITLE
[web-animations] keyframes should be recomputed when the "currentcolor" value is used on a custom property

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-animation-expected.txt
@@ -13,4 +13,6 @@ PASS No transition when changing types
 PASS No transition when removing @property rule
 PASS Unregistered properties referencing animated properties update correctly.
 PASS Registered properties referencing animated properties update correctly.
+PASS CSS animation setting "currentColor" for a custom property on a keyframe is responsive to changing "color" on the parent.
+PASS JS-originated animation setting "currentColor" for a custom property on a keyframe is responsive to changing "color" on the parent.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-animation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-animation.html
@@ -338,4 +338,59 @@ test_with_at_property({
   });
 }, 'Registered properties referencing animated properties update correctly.');
 
+test_with_at_property({
+  syntax: '"<color>"',
+  inherits: false,
+  initialValue: 'black'
+}, (name) => {
+  with_style_node(`
+    @keyframes test {
+      from { ${name}: currentcolor; }
+      to { ${name}: rgb(200, 200, 200); }
+    }
+    #outer {
+      color: rgb(100, 100, 100);
+    }
+    #div {
+      animation: test 100s -50s linear paused;
+    }
+  `, (style) => {
+    assert_equals(getComputedStyle(div).getPropertyValue(name), 'rgb(150, 150, 150)');
+
+    outer.style.color = 'rgb(50, 50, 50)';
+    assert_equals(getComputedStyle(div).getPropertyValue(name), 'rgb(125, 125, 125)');
+
+    outer.style.color = 'rgb(150, 150, 150)';
+    assert_equals(getComputedStyle(div).getPropertyValue(name), 'rgb(175, 175, 175)');
+
+    outer.style.removeProperty("color");
+  });
+}, 'CSS animation setting "currentColor" for a custom property on a keyframe is responsive to changing "color" on the parent.');
+
+test_with_at_property({
+  syntax: '"<color>"',
+  inherits: false,
+  initialValue: 'black'
+}, (name) => {
+  with_style_node(`
+    #outer {
+      color: rgb(100, 100, 100);
+    }
+  `, () => {
+    const animation = div.animate({ [name]: ["currentcolor", "rgb(200, 200, 200)"]}, 1000);
+    animation.currentTime = 500;
+    animation.pause();
+
+    assert_equals(getComputedStyle(div).getPropertyValue(name), 'rgb(150, 150, 150)');
+
+    outer.style.color = 'rgb(50, 50, 50)';
+    assert_equals(getComputedStyle(div).getPropertyValue(name), 'rgb(125, 125, 125)');
+
+    outer.style.color = 'rgb(150, 150, 150)';
+    assert_equals(getComputedStyle(div).getPropertyValue(name), 'rgb(175, 175, 175)');
+
+    outer.style.removeProperty("color");
+  });
+}, 'JS-originated animation setting "currentColor" for a custom property on a keyframe is responsive to changing "color" on the parent.');
+
 </script>

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -28,6 +28,7 @@
 
 #include "Animation.h"
 #include "CSSAnimation.h"
+#include "CSSCustomPropertyValue.h"
 #include "CSSKeyframeRule.h"
 #include "CSSPrimitiveValue.h"
 #include "CSSPropertyAnimation.h"
@@ -930,6 +931,9 @@ void KeyframeEffect::updateBlendingKeyframes(RenderStyle& elementStyle, const St
                         m_currentColorProperties.add(property.id());
                     else if (property.id() == CSSPropertyFontWeight && (valueId == CSSValueBolder || valueId == CSSValueLighter))
                         m_hasRelativeFontWeight = true;
+                } else if (auto* customPropertyValue = dynamicDowncast<CSSCustomPropertyValue>(cssValue)) {
+                    if (customPropertyValue->isCurrentColor())
+                        m_currentColorProperties.add(customPropertyValue->name());
                 }
             }
         }

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -247,7 +247,7 @@ private:
     KeyframeList m_blendingKeyframes { emptyAtom() };
     HashSet<AnimatableProperty> m_animatedProperties;
     HashSet<CSSPropertyID> m_inheritedProperties;
-    HashSet<CSSPropertyID> m_currentColorProperties;
+    HashSet<AnimatableProperty> m_currentColorProperties;
     Vector<ParsedKeyframe> m_parsedKeyframes;
     Vector<AcceleratedAction> m_pendingAcceleratedActions;
     RefPtr<Element> m_target;

--- a/Source/WebCore/css/CSSCustomPropertyValue.cpp
+++ b/Source/WebCore/css/CSSCustomPropertyValue.cpp
@@ -152,4 +152,12 @@ Ref<const CSSVariableData> CSSCustomPropertyValue::asVariableData() const
     });
 }
 
+bool CSSCustomPropertyValue::isCurrentColor() const
+{
+    // FIXME: it's surprising that setting a custom property to "currentcolor"
+    // results in m_value being a CSSVariableReferenceValue rather than a
+    // CSSValueID set to CSSValueCurrentcolor or a StyleValue.
+    return std::holds_alternative<Ref<CSSVariableReferenceValue>>(m_value) && std::get<Ref<CSSVariableReferenceValue>>(m_value)->customCSSText() == "currentcolor"_s;
+}
+
 }

--- a/Source/WebCore/css/CSSCustomPropertyValue.h
+++ b/Source/WebCore/css/CSSCustomPropertyValue.h
@@ -107,6 +107,7 @@ public:
     bool isResolved() const { return !std::holds_alternative<Ref<CSSVariableReferenceValue>>(m_value); }
     bool isUnset() const { return std::holds_alternative<CSSValueID>(m_value) && std::get<CSSValueID>(m_value) == CSSValueUnset; }
     bool isInvalid() const { return std::holds_alternative<CSSValueID>(m_value) && std::get<CSSValueID>(m_value) == CSSValueInvalid; }
+    bool isCurrentColor() const;
     bool containsCSSWideKeyword() const;
 
     const VariantValue& value() const { return m_value; }

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -30,6 +30,7 @@
 #include "config.h"
 #include "StyleResolver.h"
 
+#include "CSSCustomPropertyValue.h"
 #include "CSSFontSelector.h"
 #include "CSSKeyframeRule.h"
 #include "CSSKeyframesRule.h"
@@ -434,7 +435,7 @@ Vector<Ref<StyleRuleKeyframe>> Resolver::keyframeRulesForName(const AtomString& 
     return deduplicatedKeyframes;
 }
 
-void Resolver::keyframeStylesForAnimation(const Element& element, const RenderStyle& elementStyle, const ResolutionContext& context, KeyframeList& list, bool& containsCSSVariableReferences, bool& hasRelativeFontWeight, HashSet<CSSPropertyID>& inheritedProperties, HashSet<CSSPropertyID>& currentColorProperties)
+void Resolver::keyframeStylesForAnimation(const Element& element, const RenderStyle& elementStyle, const ResolutionContext& context, KeyframeList& list, bool& containsCSSVariableReferences, bool& hasRelativeFontWeight, HashSet<CSSPropertyID>& inheritedProperties, HashSet<AnimatableProperty>& currentColorProperties)
 {
     inheritedProperties.clear();
     currentColorProperties.clear();
@@ -472,6 +473,9 @@ void Resolver::keyframeStylesForAnimation(const Element& element, const RenderSt
                             currentColorProperties.add(property.id());
                         else if (property.id() == CSSPropertyFontWeight && (valueId == CSSValueBolder || valueId == CSSValueLighter))
                             hasRelativeFontWeight = true;
+                    } else if (auto* customPropertyValue = dynamicDowncast<CSSCustomPropertyValue>(cssValue)) {
+                        if (customPropertyValue->isCurrentColor())
+                            currentColorProperties.add(customPropertyValue->name());
                     }
                 }
             }

--- a/Source/WebCore/style/StyleResolver.h
+++ b/Source/WebCore/style/StyleResolver.h
@@ -95,7 +95,7 @@ public:
 
     ResolvedStyle styleForElement(const Element&, const ResolutionContext&, RuleMatchingBehavior = RuleMatchingBehavior::MatchAllRules);
 
-    void keyframeStylesForAnimation(const Element&, const RenderStyle& elementStyle, const ResolutionContext&, KeyframeList&, bool& containsCSSVariableReferences, bool& hasRelativeFontWeight, HashSet<CSSPropertyID>& inheritedProperties, HashSet<CSSPropertyID>& currentColorProperties);
+    void keyframeStylesForAnimation(const Element&, const RenderStyle& elementStyle, const ResolutionContext&, KeyframeList&, bool& containsCSSVariableReferences, bool& hasRelativeFontWeight, HashSet<CSSPropertyID>& inheritedProperties, HashSet<AnimatableProperty>& currentColorProperties);
 
     WEBCORE_EXPORT std::optional<ResolvedStyle> styleForPseudoElement(const Element&, const PseudoElementRequest&, const ResolutionContext&);
 


### PR DESCRIPTION
#### b1a5811b30178cebdc1e9ee15161b67f162b1721
<pre>
[web-animations] keyframes should be recomputed when the &quot;currentcolor&quot; value is used on a custom property
<a href="https://bugs.webkit.org/show_bug.cgi?id=251591">https://bugs.webkit.org/show_bug.cgi?id=251591</a>

Reviewed by Antti Koivisto.

We keep a set of CSS properties set to &quot;currentcolor&quot; in a KeyframeEffect but until now only considered
&quot;standard&quot; CSS properties. We now also consider custom properties by changing the set&apos;s type from
HashSet&lt;CSSPropertyID&gt; to HashSet&lt;AnimatableProperty&gt;.

* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-animation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-animation.html:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::updateBlendingKeyframes):
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/css/CSSCustomPropertyValue.cpp:
(WebCore::CSSCustomPropertyValue::isCurrentColor const):
* Source/WebCore/css/CSSCustomPropertyValue.h:
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::keyframeStylesForAnimation):
* Source/WebCore/style/StyleResolver.h:

Canonical link: <a href="https://commits.webkit.org/259808@main">https://commits.webkit.org/259808@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dabcc3f50213e4b1c5e8b9819d868aa7f11a5810

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105864 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14932 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38712 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115062 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175202 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109766 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16351 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6131 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98097 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114829 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111613 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12448 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95425 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39997 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94315 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27070 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81655 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8203 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28423 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8684 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5008 "Found 60 new test failures: animations/additive-transform-animations.html, animations/duplicate-keys.html, compositing/background-color/background-color-alpha-with-opacity.html, compositing/backing/non-composited-visibility-change.html, compositing/backing/solid-color-with-paints-into-ancestor.html, compositing/clipping/border-radius-with-composited-descendant-dynamic.html, compositing/clipping/nested-overflow-with-border-radius.html, compositing/contents-scale/hidpi-tests/rasterization-scale.html, compositing/debug-borders-dynamic.html, compositing/iframes/border-radius-composited-frame.html ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14312 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47963 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10240 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3644 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->