### PR TITLE
[ATSPI] Make the rest of Atspi enums enum classes

### DIFF
--- a/Source/WebCore/accessibility/atspi/AccessibilityAtspiEnums.h
+++ b/Source/WebCore/accessibility/atspi/AccessibilityAtspiEnums.h
@@ -153,7 +153,6 @@ enum class Role {
     ContentInsertion,
     Mark,
     Suggestion,
-    LastDefinedRole,
 };
 
 enum class State : uint64_t {
@@ -235,7 +234,7 @@ enum class CoordinateType {
     ParentCoordinates,
 };
 
-enum ComponentLayer {
+enum class ComponentLayer {
     InvalidLayer,
     BackgroundLayer,
     CanvasLayer,
@@ -256,7 +255,7 @@ enum class ScrollType {
     Anywhere
 };
 
-enum TextBoundaryType {
+enum class TextBoundaryType {
     CharBoundary,
     WordStartBoundary,
     WordEndBoundary,
@@ -266,7 +265,7 @@ enum TextBoundaryType {
     LineEndBoundary
 };
 
-enum TextGranularityType {
+enum class TextGranularityType {
     CharGranularity,
     WordGranularity,
     SentenceGranularity,
@@ -274,7 +273,7 @@ enum TextGranularityType {
     ParagraphGranularity
 };
 
-enum CollectionMatchType {
+enum class CollectionMatchType {
     MatchInvalid,
     MatchAll,
     MatchAny,
@@ -282,7 +281,7 @@ enum CollectionMatchType {
     MatchEmpty
 };
 
-enum CollectionSortOrder {
+enum class CollectionSortOrder {
     SortOrderInvalid,
     SortOrderCanonical,
     SortOrderFlow,

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.h
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.h
@@ -182,8 +182,8 @@ private:
     bool focus() const;
     float opacity() const;
 
-    static TextGranularity atspiBoundaryToTextGranularity(uint32_t);
-    static TextGranularity atspiGranularityToTextGranularity(uint32_t);
+    static TextGranularity atspiBoundaryToTextGranularity(Atspi::TextBoundaryType);
+    static TextGranularity atspiGranularityToTextGranularity(Atspi::TextGranularityType);
     CString text(int, int) const;
     CString textAtOffset(int, TextGranularity, int&, int&) const;
     int characterAtOffset(int) const;
@@ -239,25 +239,25 @@ private:
 
         struct {
             OptionSet<Atspi::State> value;
-            uint16_t type { 0 };
+            Atspi::CollectionMatchType type;
         } states;
 
         struct {
             HashMap<String, Vector<String>> value;
-            uint16_t type { 0 };
+            Atspi::CollectionMatchType type;
         } attributes;
 
         struct {
             Vector<Atspi::Role> value;
-            uint16_t type { 0 };
+            Atspi::CollectionMatchType type;
         } roles;
 
         struct {
             Vector<String> value;
-            uint16_t type { 0 };
+            Atspi::CollectionMatchType type;
         } interfaces;
     };
-    Vector<RefPtr<AccessibilityObjectAtspi>> matches(CollectionMatchRule&, uint32_t sortOrder, uint32_t maxResultCount, bool traverse);
+    Vector<RefPtr<AccessibilityObjectAtspi>> matches(CollectionMatchRule&, Atspi::CollectionSortOrder, uint32_t maxResultCount, bool traverse);
     void addMatchesInCanonicalOrder(Vector<RefPtr<AccessibilityObjectAtspi>>&, CollectionMatchRule&, uint32_t maxResultCount, bool traverse);
 
     static OptionSet<Interface> interfacesForObject(AXCoreObject&);

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectCollectionAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectCollectionAtspi.cpp
@@ -38,13 +38,13 @@ GDBusInterfaceVTable AccessibilityObjectAtspi::s_collectionFunctions = {
             int count;
             gboolean traverse;
             g_variant_get(parameters, "(@(aiia{ss}iaiiasib)uib)", &rule.outPtr(), &sortyBy, &count, &traverse);
-            if (sortyBy > Atspi::CollectionSortOrder::SortOrderReverseTab) {
+            if (sortyBy > static_cast<uint32_t>(Atspi::CollectionSortOrder::SortOrderReverseTab)) {
                 g_dbus_method_invocation_return_error(invocation, G_DBUS_ERROR, G_DBUS_ERROR_INVALID_ARGS, "Not a valid sort order: %u", sortyBy);
                 return;
             }
             CollectionMatchRule matchRule(rule.get());
             GVariantBuilder builder = G_VARIANT_BUILDER_INIT(G_VARIANT_TYPE("a(so)"));
-            for (const auto& wrapper : atspiObject->matches(matchRule, sortyBy, std::max<int>(0, count), traverse))
+            for (const auto& wrapper : atspiObject->matches(matchRule, static_cast<Atspi::CollectionSortOrder>(sortyBy), std::max<int>(0, count), traverse))
                 g_variant_builder_add(&builder, "@(so)", wrapper->reference());
             g_dbus_method_invocation_return_value(invocation, g_variant_new("(a(so))", &builder));
         } else if (!g_strcmp0(methodName, "GetMatchesTo") || !g_strcmp0(methodName, "GetMatchesFrom") || !g_strcmp0(methodName, "GetActiveDescendant"))
@@ -80,7 +80,7 @@ AccessibilityObjectAtspi::CollectionMatchRule::CollectionMatchRule(GVariant* rul
         }
         i++;
     }
-    states.type = statesMatchType;
+    states.type = static_cast<Atspi::CollectionMatchType>(statesMatchType);
 
     const char* attributeName;
     const char* attributeValue;
@@ -107,7 +107,7 @@ AccessibilityObjectAtspi::CollectionMatchRule::CollectionMatchRule(GVariant* rul
             addResult.iterator->value.append(makeStringByReplacingAll(unescapedValue, "\\\\"_s, "\\"_s));
         }
     }
-    attributes.type = attributesMatchType;
+    attributes.type = static_cast<Atspi::CollectionMatchType>(attributesMatchType);
 
     Atspi::Role role;
     i = 0;
@@ -118,12 +118,12 @@ AccessibilityObjectAtspi::CollectionMatchRule::CollectionMatchRule(GVariant* rul
         }
         i++;
     }
-    roles.type = rolesMatchType;
+    roles.type = static_cast<Atspi::CollectionMatchType>(rolesMatchType);
 
     const char* interface;
     while (g_variant_iter_next(interfacesIter.get(), "&s", &interface))
         interfaces.value.append(String::fromUTF8(interface));
-    interfaces.type = interfacesMatchType;
+    interfaces.type = static_cast<Atspi::CollectionMatchType>(interfacesMatchType);
 }
 
 bool AccessibilityObjectAtspi::CollectionMatchRule::matchInterfaces(AccessibilityObjectAtspi& axObject)
@@ -346,7 +346,7 @@ void AccessibilityObjectAtspi::addMatchesInCanonicalOrder(Vector<RefPtr<Accessib
     }
 }
 
-Vector<RefPtr<AccessibilityObjectAtspi>> AccessibilityObjectAtspi::matches(CollectionMatchRule& rule, uint32_t sortOrder, uint32_t maxResultCount, bool traverse)
+Vector<RefPtr<AccessibilityObjectAtspi>> AccessibilityObjectAtspi::matches(CollectionMatchRule& rule, Atspi::CollectionSortOrder sortOrder, uint32_t maxResultCount, bool traverse)
 {
     if (!m_coreObject)
         return { };
@@ -367,7 +367,7 @@ Vector<RefPtr<AccessibilityObjectAtspi>> AccessibilityObjectAtspi::matches(Colle
     case Atspi::CollectionSortOrder::SortOrderTab:
     case Atspi::CollectionSortOrder::SortOrderReverseFlow:
     case Atspi::CollectionSortOrder::SortOrderReverseTab:
-        g_warning("Atspi collection sort method %u not implemented yet", sortOrder);
+        g_warning("Atspi collection sort method %u not implemented yet", static_cast<uint32_t>(sortOrder));
         break;
 
     }

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectComponentAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectComponentAtspi.cpp
@@ -62,7 +62,7 @@ GDBusInterfaceVTable AccessibilityObjectAtspi::s_componentFunctions = {
             auto rect = atspiObject->elementRect(Atspi::CoordinateType::ParentCoordinates);
             g_dbus_method_invocation_return_value(invocation, g_variant_new("(ii)", rect.width(), rect.height()));
         } else if (!g_strcmp0(methodName, "GetLayer"))
-            g_dbus_method_invocation_return_value(invocation, g_variant_new("(u)", Atspi::ComponentLayer::WidgetLayer));
+            g_dbus_method_invocation_return_value(invocation, g_variant_new("(u)", static_cast<uint32_t>(Atspi::ComponentLayer::WidgetLayer)));
         else if (!g_strcmp0(methodName, "GetMDIZOrder"))
             g_dbus_method_invocation_return_value(invocation, g_variant_new("(n)", 0));
         else if (!g_strcmp0(methodName, "GrabFocus"))

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
@@ -39,7 +39,7 @@
 
 namespace WebCore {
 
-AccessibilityObjectAtspi::TextGranularity AccessibilityObjectAtspi::atspiBoundaryToTextGranularity(uint32_t boundaryType)
+AccessibilityObjectAtspi::TextGranularity AccessibilityObjectAtspi::atspiBoundaryToTextGranularity(Atspi::TextBoundaryType boundaryType)
 {
     switch (boundaryType) {
     case Atspi::TextBoundaryType::CharBoundary:
@@ -60,7 +60,7 @@ AccessibilityObjectAtspi::TextGranularity AccessibilityObjectAtspi::atspiBoundar
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-AccessibilityObjectAtspi::TextGranularity AccessibilityObjectAtspi::atspiGranularityToTextGranularity(uint32_t boundaryType)
+AccessibilityObjectAtspi::TextGranularity AccessibilityObjectAtspi::atspiGranularityToTextGranularity(Atspi::TextGranularityType boundaryType)
 {
     switch (boundaryType) {
     case Atspi::TextGranularityType::CharGranularity:
@@ -88,7 +88,7 @@ GDBusInterfaceVTable AccessibilityObjectAtspi::s_textFunctions = {
             uint32_t granularityType;
             g_variant_get(parameters, "(iu)", &offset, &granularityType);
             int start = 0, end = 0;
-            auto text = atspiObject->textAtOffset(offset, atspiGranularityToTextGranularity(granularityType), start, end);
+            auto text = atspiObject->textAtOffset(offset, atspiGranularityToTextGranularity(static_cast<Atspi::TextGranularityType>(granularityType)), start, end);
             g_dbus_method_invocation_return_value(invocation, g_variant_new("(sii)", text.isNull() ? "" : text.data(), start, end));
         } else if (!g_strcmp0(methodName, "GetText")) {
             int start, end;
@@ -106,7 +106,7 @@ GDBusInterfaceVTable AccessibilityObjectAtspi::s_textFunctions = {
             uint32_t boundaryType;
             g_variant_get(parameters, "(iu)", &offset, &boundaryType);
             int start = 0, end = 0;
-            auto text = atspiObject->textAtOffset(offset, atspiBoundaryToTextGranularity(boundaryType), start, end);
+            auto text = atspiObject->textAtOffset(offset, atspiBoundaryToTextGranularity(static_cast<Atspi::TextBoundaryType>(boundaryType)), start, end);
             g_dbus_method_invocation_return_value(invocation, g_variant_new("(sii)", text.isNull() ? "" : text.data(), start, end));
         } else if (!g_strcmp0(methodName, "GetTextAfterOffset"))
             g_dbus_method_invocation_return_error_literal(invocation, G_DBUS_ERROR, G_DBUS_ERROR_NOT_SUPPORTED, "");

--- a/Source/WebCore/accessibility/atspi/AccessibilityRootAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityRootAtspi.cpp
@@ -277,7 +277,7 @@ GDBusInterfaceVTable AccessibilityRootAtspi::s_componentFunctions = {
             auto rect = rootObject.frameRect(Atspi::CoordinateType::ParentCoordinates);
             g_dbus_method_invocation_return_value(invocation, g_variant_new("((ii))", rect.width(), rect.height()));
         } else if (!g_strcmp0(methodName, "GetLayer"))
-            g_dbus_method_invocation_return_value(invocation, g_variant_new("(u)", Atspi::ComponentLayer::WidgetLayer));
+            g_dbus_method_invocation_return_value(invocation, g_variant_new("(u)", static_cast<uint32_t>(Atspi::ComponentLayer::WidgetLayer)));
         else if (!g_strcmp0(methodName, "GetMDIZOrder"))
             g_dbus_method_invocation_return_value(invocation, g_variant_new("(n)", 0));
         else if (!g_strcmp0(methodName, "GrabFocus"))


### PR DESCRIPTION
#### c532174126f0cbbb32713695794a02931a6c5371
<pre>
[ATSPI] Make the rest of Atspi enums enum classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=251598">https://bugs.webkit.org/show_bug.cgi?id=251598</a>

Reviewed by Michael Catanzaro.

It should improve code readability.

* Source/WebCore/accessibility/atspi/AccessibilityAtspiEnums.h:
(): Deleted.
* Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.h:
* Source/WebCore/accessibility/atspi/AccessibilityObjectCollectionAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::CollectionMatchRule::CollectionMatchRule):
(WebCore::AccessibilityObjectAtspi::matches):
* Source/WebCore/accessibility/atspi/AccessibilityObjectComponentAtspi.cpp:
* Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::atspiBoundaryToTextGranularity):
(WebCore::AccessibilityObjectAtspi::atspiGranularityToTextGranularity):
* Source/WebCore/accessibility/atspi/AccessibilityRootAtspi.cpp:

Canonical link: <a href="https://commits.webkit.org/259768@main">https://commits.webkit.org/259768@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55d6bf2cefd2c7990abbafa0fc13e6c5e5f22c17

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105874 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14942 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38721 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115072 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/175194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109776 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16373 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6141 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98106 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111623 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95427 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/40004 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94329 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27071 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8212 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28425 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8694 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/5016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14321 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47965 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6761 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10249 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->