### PR TITLE
Drop tag arguments early on backends than don't use them

### DIFF
--- a/Source/JavaScriptCore/offlineasm/arm.rb
+++ b/Source/JavaScriptCore/offlineasm/arm.rb
@@ -335,6 +335,7 @@ class Sequence
 
     def getModifiedListARMCommon
         result = @list
+        result = riscDropTags(result)
         result = riscLowerSimpleBranchOps(result)
         result = riscLowerHardBranchOps(result)
         result = riscLowerShiftOps(result)

--- a/Source/JavaScriptCore/offlineasm/arm64.rb
+++ b/Source/JavaScriptCore/offlineasm/arm64.rb
@@ -446,6 +446,10 @@ end
 
 class Sequence
     def getModifiedListARM64(result = @list)
+        result = riscDropTags(result)
+        getModifiedListARM64Common(result)
+    end
+    def getModifiedListARM64Common(result = @list)
         result = riscLowerNot(result)
         result = riscLowerSimpleBranchOps(result)
 

--- a/Source/JavaScriptCore/offlineasm/arm64e.rb
+++ b/Source/JavaScriptCore/offlineasm/arm64e.rb
@@ -29,7 +29,7 @@ end
 class Sequence
     def getModifiedListARM64E
         result = riscLowerMisplacedAddresses(@list)
-        getModifiedListARM64(result)
+        getModifiedListARM64Common(result)
     end
 end
 

--- a/Source/JavaScriptCore/offlineasm/mips.rb
+++ b/Source/JavaScriptCore/offlineasm/mips.rb
@@ -700,6 +700,7 @@ class Sequence
             end
         }
 
+        result = riscDropTags(result)
         result = mipsAddPICCode(result)
         result = mipsLowerFarBranchOps(result)
         result = mipsLowerSimpleBranchOps(result)

--- a/Source/JavaScriptCore/offlineasm/risc.rb
+++ b/Source/JavaScriptCore/offlineasm/risc.rb
@@ -737,3 +737,22 @@ def riscLowerTest(list)
     }
     return newList
 end
+
+def riscDropTags(list)
+    list.collect {
+        |node|
+        ret = node
+        if node.is_a?(Instruction)
+            case node.opcode
+            when "jmp", "call"
+                if node.operands.size > 1
+                    # Delete the extra pointer tagging arguments, otherwise
+                    # riscLowerMalformedImmediatesRecurse will pointlessly load
+                    # them in a register.
+                    ret = Instruction.new(node.codeOrigin, node.opcode, [node.operands[0]])
+                end
+            end
+        end
+        ret
+    }
+end

--- a/Source/JavaScriptCore/offlineasm/riscv64.rb
+++ b/Source/JavaScriptCore/offlineasm/riscv64.rb
@@ -1539,6 +1539,7 @@ class Sequence
     def getModifiedListRISCV64
         result = @list
 
+        result = riscDropTags(result)
         result = riscLowerMalformedAddresses(result) {
             | node, address |
             if address.is_a? Address


### PR DESCRIPTION
#### 0faaa00680c05d74beb242290abcd539243e0222
<pre>
Drop tag arguments early on backends than don&apos;t use them
<a href="https://bugs.webkit.org/show_bug.cgi?id=251603">https://bugs.webkit.org/show_bug.cgi?id=251603</a>

Reviewed by Yusuke Suzuki.

The extra arguments to call/jmp for pointer tagging are only used on
arm64e. However, on all risc platforms, riscLowerMalformedImmediates
will emit extra code to load the values in a register.

Instead, drop the extra tag arguments early so that none of the other
passes can get confused.

* Source/JavaScriptCore/offlineasm/arm.rb:
* Source/JavaScriptCore/offlineasm/arm64.rb:
* Source/JavaScriptCore/offlineasm/arm64e.rb:
* Source/JavaScriptCore/offlineasm/mips.rb:
* Source/JavaScriptCore/offlineasm/risc.rb:
* Source/JavaScriptCore/offlineasm/riscv64.rb:

Canonical link: <a href="https://commits.webkit.org/260359@main">https://commits.webkit.org/260359@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0dab755559f09cabfeda8b080e128ddd9ffdfcc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106326 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15380 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39166 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115520 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115209 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16858 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6596 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98544 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112090 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12801 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95785 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40361 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94676 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27428 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82050 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/95932 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8621 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28780 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/95332 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/6470 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9130 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5351 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30601 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14762 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48326 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/104072 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7168 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10695 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25790 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->