### PR TITLE
[JSC][armv7] Fix wasm ref.as_non_null

### DIFF
--- a/Source/JavaScriptCore/llint/WebAssembly32_64.asm
+++ b/Source/JavaScriptCore/llint/WebAssembly32_64.asm
@@ -159,7 +159,7 @@ end)
 wasmOp(ref_as_non_null, WasmRefAsNonNull, macro(ctx)
     mload2i(ctx, m_ref, t1, t0)
     bieq t1, NullTag, .nullRef
-    returni(ctx, t0)
+    return2i(ctx, t1, t0)
 
 .nullRef:
     throwException(NullRefAsNonNull)

--- a/Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp
@@ -676,12 +676,19 @@ private:
         inst.args.append(tmp.tmp());
     }
 
-    void emitMove(const TypedTmp& src, const TypedTmp& dst)
+    // emitMoveWithoutTypeCheck is like emitMove, but does not assert anything
+    // about the wasm types of `src` and `dst` (in no-assert builds, they are the same)
+    void emitMoveWithoutTypeCheck(const TypedTmp& src, const TypedTmp& dst)
     {
         if (src == dst)
             return;
-        ASSERT(isSubtype(src.type(), dst.type()));
         append(moveOpForValueType(src.type()), src, dst);
+    }
+
+    void emitMove(const TypedTmp& src, const TypedTmp& dst)
+    {
+        ASSERT(isSubtype(src.type(), dst.type()));
+        emitMoveWithoutTypeCheck(src, dst);
     }
 
     void emitMove(const ValueLocation& location, const TypedTmp& dest)

--- a/Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h
+++ b/Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h
@@ -1251,7 +1251,7 @@ auto AirIRGeneratorBase<Derived, ExpressionType>::addRefAsNonNull(ExpressionType
 {
     emitThrowOnNullReference(reference, ExceptionType::NullRefAsNonNull);
     result = self().tmpForType(Type { TypeKind::Ref, reference.type().index });
-    append(Move, reference, result);
+    self().emitMoveWithoutTypeCheck(reference, result);
     return { };
 }
 


### PR DESCRIPTION
#### 6055ee6392589ea77765c0a3d4d8b8898a6534ff
<pre>
[JSC][armv7] Fix wasm ref.as_non_null
<a href="https://bugs.webkit.org/show_bug.cgi?id=251606">https://bugs.webkit.org/show_bug.cgi?id=251606</a>

Reviewed by Yusuke Suzuki.

Right now, the implementation of this instruction triggers assertion failures in
both LLInt and the BBQ/Air backends on 32-bit ARM.

For LLInt, the incorrect `return` instruction is used, use `return2i` since refs
are two-word values.

For the Air backend, we need to use `emitMove` (again, because refs are two-word
values); here, we also need a version that doesn&apos;t assert in the JIT that the
dest is a supertype of the source TypedTmp--since the whole point of
ref.as_non_null is that it works as a checked coercion... So, I&apos;ve added that as
`emitMoveWithoutTypeCheck`

* Source/JavaScriptCore/llint/WebAssembly32_64.asm:
* Source/JavaScriptCore/wasm/WasmAirIRGenerator32_64.cpp:
(JSC::Wasm::AirIRGenerator32::emitMoveWithoutTypeCheck):
(JSC::Wasm::AirIRGenerator32::emitMove):
* Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp:
(JSC::Wasm::AirIRGenerator64::emitMoveWithoutTypeCheck):
(JSC::Wasm::AirIRGenerator64::emitMove):
* Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h:
(JSC::Wasm::ExpressionType&gt;::addRefAsNonNull):

Canonical link: <a href="https://commits.webkit.org/259958@main">https://commits.webkit.org/259958@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2026ff584a578cc3d02085c3ed8fd89c45c7c887

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105897 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14964 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38744 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115092 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175214 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16383 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6160 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98126 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114849 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111647 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12476 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95445 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40017 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94341 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27089 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81676 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/95582 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8231 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28443 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/94879 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/6034 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8712 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5026 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30459 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14342 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47983 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/103627 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6886 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10267 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25691 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->