### PR TITLE
[Xcode] Add an experimental setting to build with sccache

### DIFF
--- a/PerformanceTests/DecoderTest/Configurations/DebugRelease.xcconfig
+++ b/PerformanceTests/DecoderTest/Configurations/DebugRelease.xcconfig
@@ -38,3 +38,5 @@ WK_DEFAULT_LTO_MODE = $(WK_USER_LTO_MODE_none);
 WK_CCACHE_DIR = $(SRCROOT)/../../Tools/ccache;
 #include "../../../Tools/ccache/ccache.xcconfig"
 
+WK_SCCACHE_DIR = $(SRCROOT)/../../Tools/sccache;
+#include "../../../Tools/sccache/sccache.xcconfig"

--- a/Source/JavaScriptCore/Configurations/DebugRelease.xcconfig
+++ b/Source/JavaScriptCore/Configurations/DebugRelease.xcconfig
@@ -49,3 +49,6 @@ WK_DEFAULT_LTO_MODE = $(WK_USER_LTO_MODE_none);
 
 WK_CCACHE_DIR = $(SRCROOT)/../../Tools/ccache;
 #include "../../../Tools/ccache/ccache.xcconfig"
+
+WK_SCCACHE_DIR = $(SRCROOT)/../../Tools/sccache;
+#include "../../../Tools/sccache/sccache.xcconfig"

--- a/Source/ThirdParty/ANGLE/Configurations/DebugRelease.xcconfig
+++ b/Source/ThirdParty/ANGLE/Configurations/DebugRelease.xcconfig
@@ -23,3 +23,6 @@ MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 
 WK_CCACHE_DIR = $(SRCROOT)/../../../Tools/ccache;
 #include "../../../../Tools/ccache/ccache.xcconfig"
+
+WK_SCCACHE_DIR = $(SRCROOT)/../../../Tools/sccache;
+#include "../../../../Tools/sccache/sccache.xcconfig"

--- a/Source/ThirdParty/libwebrtc/Configurations/DebugRelease.xcconfig
+++ b/Source/ThirdParty/libwebrtc/Configurations/DebugRelease.xcconfig
@@ -47,6 +47,9 @@ WK_DEFAULT_LTO_MODE = $(WK_USER_LTO_MODE_none);
 WK_CCACHE_DIR = $(SRCROOT)/../../../Tools/ccache;
 #include "../../../../Tools/ccache/ccache.xcconfig"
 
+WK_SCCACHE_DIR = $(SRCROOT)/../../../Tools/sccache;
+#include "../../../../Tools/sccache/sccache.xcconfig"
+
 OTHER_LDFLAGS[config=Debug][sdk=iphone*] = $(inherited) -framework UIKit -framework CoreGraphics
 OTHER_LDFLAGS[config=Debug][sdk=appletv*] = $(inherited) -framework UIKit -framework CoreGraphics
 OTHER_LDFLAGS[config=Debug][sdk=watch*] = $(inherited) -framework UIKit -framework CoreGraphics

--- a/Source/WTF/Configurations/DebugRelease.xcconfig
+++ b/Source/WTF/Configurations/DebugRelease.xcconfig
@@ -42,3 +42,6 @@ WK_DEFAULT_LTO_MODE = $(WK_USER_LTO_MODE_none);
 
 WK_CCACHE_DIR = $(SRCROOT)/../../Tools/ccache;
 #include "../../../Tools/ccache/ccache.xcconfig"
+
+WK_SCCACHE_DIR = $(SRCROOT)/../../Tools/sccache;
+#include "../../../Tools/sccache/sccache.xcconfig"

--- a/Source/WebCore/Configurations/DebugRelease.xcconfig
+++ b/Source/WebCore/Configurations/DebugRelease.xcconfig
@@ -45,6 +45,9 @@ WK_DEFAULT_LTO_MODE = $(WK_USER_LTO_MODE_none);
 WK_CCACHE_DIR = $(SRCROOT)/../../Tools/ccache;
 #include "../../../Tools/ccache/ccache.xcconfig"
 
+WK_SCCACHE_DIR = $(SRCROOT)/../../Tools/sccache;
+#include "../../../Tools/sccache/sccache.xcconfig"
+
 WK_WEBCORE_ADDITIONS_PATH = ../../../Internal/WebKit/WebKitAdditions/Additions/WebCore
 WK_WEBCORE_DERIVEDSOURCES_INPUT_XCFILELIST_ADDITIONS = $(WK_WEBCORE_DERIVEDSOURCES_INPUT_XCFILELIST_ADDITIONS_$(USE_INTERNAL_SDK))
 WK_WEBCORE_DERIVEDSOURCES_INPUT_XCFILELIST_ADDITIONS_ =

--- a/Source/WebCore/PAL/Configurations/DebugRelease.xcconfig
+++ b/Source/WebCore/PAL/Configurations/DebugRelease.xcconfig
@@ -44,3 +44,6 @@ WK_DEFAULT_LTO_MODE = $(WK_USER_LTO_MODE_none);
 
 WK_CCACHE_DIR = $(SRCROOT)/../../../Tools/ccache;
 #include "../../../../Tools/ccache/ccache.xcconfig"
+
+WK_SCCACHE_DIR = $(SRCROOT)/../../../Tools/sccache;
+#include "../../../../Tools/sccache/sccache.xcconfig"

--- a/Source/WebCore/PAL/ThirdParty/libavif/Configurations/DebugRelease.xcconfig
+++ b/Source/WebCore/PAL/ThirdParty/libavif/Configurations/DebugRelease.xcconfig
@@ -44,3 +44,6 @@ WK_DEFAULT_LTO_MODE = $(WK_USER_LTO_MODE_none);
 
 WK_CCACHE_DIR = $(SRCROOT)/../../../../../Tools/ccache;
 #include "../../../../../Tools/ccache/ccache.xcconfig"
+
+WK_SCCACHE_DIR = $(SRCROOT)/../../../../../Tools/sccache;
+#include "../../../../../Tools/sccache/sccache.xcconfig"

--- a/Source/WebCore/PAL/ThirdParty/libavif/ThirdParty/dav1d/Configurations/DebugRelease.xcconfig
+++ b/Source/WebCore/PAL/ThirdParty/libavif/ThirdParty/dav1d/Configurations/DebugRelease.xcconfig
@@ -44,3 +44,6 @@ WK_DEFAULT_LTO_MODE = $(WK_USER_LTO_MODE_none);
 
 WK_CCACHE_DIR = $(SRCROOT)/../../../../../../../Tools/ccache;
 #include "../../../../../../../Tools/ccache/ccache.xcconfig"
+
+WK_SCCACHE_DIR = $(SRCROOT)/../../../../../../../Tools/sccache;
+#include "../../../../../../../Tools/sccache/sccache.xcconfig"

--- a/Source/WebGPU/Configurations/DebugRelease.xcconfig
+++ b/Source/WebGPU/Configurations/DebugRelease.xcconfig
@@ -44,3 +44,6 @@ WK_DEFAULT_LTO_MODE = $(WK_USER_LTO_MODE_none);
 
 WK_CCACHE_DIR = $(SRCROOT)/../../Tools/ccache;
 #include "../../../Tools/ccache/ccache.xcconfig"
+
+WK_SCCACHE_DIR = $(SRCROOT)/../../Tools/sccache;
+#include "../../../Tools/sccache/sccache.xcconfig"

--- a/Source/WebKit/Configurations/DebugRelease.xcconfig
+++ b/Source/WebKit/Configurations/DebugRelease.xcconfig
@@ -56,6 +56,9 @@ WK_DEFAULT_LTO_MODE = $(WK_USER_LTO_MODE_none);
 WK_CCACHE_DIR = $(SRCROOT)/../../Tools/ccache;
 #include "../../../Tools/ccache/ccache.xcconfig"
 
+WK_SCCACHE_DIR = $(SRCROOT)/../../Tools/sccache;
+#include "../../../Tools/sccache/sccache.xcconfig"
+
 WK_WEBKIT_ADDITIONS_PATH = ../../../Internal/WebKit/WebKitAdditions/Additions/WebKit
 WK_WEBKIT_DERIVEDSOURCES_INPUT_XCFILELIST_ADDITIONS = $(WK_WEBKIT_DERIVEDSOURCES_INPUT_XCFILELIST_ADDITIONS_$(USE_INTERNAL_SDK))
 WK_WEBKIT_DERIVEDSOURCES_INPUT_XCFILELIST_ADDITIONS_ =

--- a/Source/WebKitLegacy/mac/Configurations/DebugRelease.xcconfig
+++ b/Source/WebKitLegacy/mac/Configurations/DebugRelease.xcconfig
@@ -46,3 +46,6 @@ WK_DEFAULT_LTO_MODE = $(WK_USER_LTO_MODE_none);
 
 WK_CCACHE_DIR = $(SRCROOT)/../../Tools/ccache;
 #include "../../../../Tools/ccache/ccache.xcconfig"
+
+WK_SCCACHE_DIR = $(SRCROOT)/../../Tools/sccache;
+#include "../../../../Tools/sccache/sccache.xcconfig"

--- a/Source/bmalloc/Configurations/DebugRelease.xcconfig
+++ b/Source/bmalloc/Configurations/DebugRelease.xcconfig
@@ -42,3 +42,6 @@ WK_DEFAULT_LTO_MODE = $(WK_USER_LTO_MODE_none);
 
 WK_CCACHE_DIR = $(SRCROOT)/../../Tools/ccache;
 #include "../../../Tools/ccache/ccache.xcconfig"
+
+WK_SCCACHE_DIR = $(SRCROOT)/../../Tools/sccache;
+#include "../../../Tools/sccache/sccache.xcconfig"

--- a/Tools/DumpRenderTree/mac/Configurations/DebugRelease.xcconfig
+++ b/Tools/DumpRenderTree/mac/Configurations/DebugRelease.xcconfig
@@ -42,3 +42,6 @@ VALIDATE_DEPENDENCIES_NATIVE_TARGET_YES = $(WK_VALIDATE_DEPENDENCIES);
 
 WK_CCACHE_DIR = $(SRCROOT)/../ccache;
 #include "../../../ccache/ccache.xcconfig"
+
+WK_SCCACHE_DIR = $(SRCROOT)/../sccache;
+#include "../../../sccache/sccache.xcconfig"

--- a/Tools/MiniBrowser/Configurations/DebugRelease.xcconfig
+++ b/Tools/MiniBrowser/Configurations/DebugRelease.xcconfig
@@ -39,3 +39,6 @@ VALIDATE_DEPENDENCIES_NATIVE_TARGET_YES = $(WK_VALIDATE_DEPENDENCIES);
 
 WK_CCACHE_DIR = $(SRCROOT)/../ccache;
 #include? "../../ccache/ccache.xcconfig"
+
+WK_SCCACHE_DIR = $(SRCROOT)/../sccache;
+#include? "../../sccache/sccache.xcconfig"

--- a/Tools/MobileMiniBrowser/Configurations/DebugRelease.xcconfig
+++ b/Tools/MobileMiniBrowser/Configurations/DebugRelease.xcconfig
@@ -35,3 +35,6 @@ VALIDATE_DEPENDENCIES_NATIVE_TARGET_YES = $(WK_VALIDATE_DEPENDENCIES);
 
 WK_CCACHE_DIR = $(SRCROOT)/../ccache;
 #include "../../ccache/ccache.xcconfig"
+
+WK_SCCACHE_DIR = $(SRCROOT)/../sccache;
+#include "../../sccache/sccache.xcconfig"

--- a/Tools/TestWebKitAPI/Configurations/DebugRelease.xcconfig
+++ b/Tools/TestWebKitAPI/Configurations/DebugRelease.xcconfig
@@ -41,3 +41,6 @@ WK_RELOCATABLE_FRAMEWORKS = YES;
 
 WK_CCACHE_DIR = $(SRCROOT)/../ccache;
 #include "../../ccache/ccache.xcconfig"
+
+WK_SCCACHE_DIR = $(SRCROOT)/../sccache;
+#include "../../sccache/sccache.xcconfig"

--- a/Tools/WebGPUPlayground/Configurations/DebugRelease.xcconfig
+++ b/Tools/WebGPUPlayground/Configurations/DebugRelease.xcconfig
@@ -44,3 +44,6 @@ WK_DEFAULT_LTO_MODE = $(WK_USER_LTO_MODE_none);
 
 WK_CCACHE_DIR = $(SRCROOT)/../../Tools/ccache;
 #include "../../../Tools/ccache/ccache.xcconfig"
+
+WK_SCCACHE_DIR = $(SRCROOT)/../../Tools/sccache;
+#include "../../../Tools/sccache/sccache.xcconfig"

--- a/Tools/WebKitTestRunner/Configurations/DebugRelease.xcconfig
+++ b/Tools/WebKitTestRunner/Configurations/DebugRelease.xcconfig
@@ -37,3 +37,6 @@ VALIDATE_DEPENDENCIES_NATIVE_TARGET_YES = $(WK_VALIDATE_DEPENDENCIES);
 
 WK_CCACHE_DIR = $(SRCROOT)/../ccache;
 #include "../../ccache/ccache.xcconfig"
+
+WK_SCCACHE_DIR = $(SRCROOT)/../sccache;
+#include "../../sccache/sccache.xcconfig"

--- a/Tools/lldb/lldbWebKitTester/Configurations/DebugRelease.xcconfig
+++ b/Tools/lldb/lldbWebKitTester/Configurations/DebugRelease.xcconfig
@@ -39,3 +39,6 @@ VALIDATE_DEPENDENCIES_NATIVE_TARGET_YES = $(WK_VALIDATE_DEPENDENCIES);
 
 WK_CCACHE_DIR = $(SRCROOT)/../../../Tools/ccache;
 #include "../../../ccache/ccache.xcconfig"
+
+WK_SCCACHE_DIR = $(SRCROOT)/../../../Tools/sccache;
+#include "../../../sccache/sccache.xcconfig"

--- a/Tools/sccache/README.md
+++ b/Tools/sccache/README.md
@@ -1,0 +1,20 @@
+# Prerequisites
+
+- Xcode
+- ```sccache(1)``` installed in /usr/local/bin
+
+# Building with sccache
+
+- ```make ARGS="WK_USE_SCCACHE=YES"```
+- ```build-webkit WK_USE_SCCACHE=YES```
+- Build in the Xcode UI by adding ```WK_USE_SCCACHE = YES;``` to Tools/sccache/sccache.xcconfig (FIXME: this dirties the working directory).
+
+# Configuring sccache
+
+The maximum cache size is 10GB by default, but a WebKit Debug build can require 20GB or more:
+
+export SCCACHE_CACHE_SIZE="50G
+
+# Viewing cache statistics
+
+- ```sccache -s```

--- a/Tools/sccache/sccache-clang
+++ b/Tools/sccache/sccache-clang
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+
+position=1
+while [[ $position -le $# ]]; do
+    case "${!position}" in
+    -isysroot)
+        position=$(($position + 1))
+        sdk="${!position}"
+        break
+        ;;
+    esac
+    position=$(($position + 1))
+done
+$(dirname "$0")/sccache-wrapper $(xcrun -f -sdk "$sdk" "${_XCRUN_TOOL:-clang}") "$@"

--- a/Tools/sccache/sccache-clang++
+++ b/Tools/sccache/sccache-clang++
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+
+_XCRUN_TOOL="clang++" $(dirname "$0")/sccache-clang "$@"

--- a/Tools/sccache/sccache-wrapper
+++ b/Tools/sccache/sccache-wrapper
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# Copyright (C) 2017 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+
+try_one()
+{
+    [[ -x "$1" && ! -d "$1" ]] && { SCCACHE="$1"; return 0; }
+    return 1
+}
+
+try()
+{
+    [[ -n "${SCCACHE}" ]] && return 0
+    try_one "$1" || \
+    try_one "$1/sccache" || \
+    try_one "$1/bin/sccache"
+}
+
+try $(which ccache &> /dev/null)
+try /usr/local
+try /opt/brew
+try /opt/homebrew
+try "${HOMEBREW_TEMP}/../brew"
+try "${HOMEBREW_TEMP}/../../brew"
+
+if [[ -n "${SCCACHE}" ]]; then
+    SCCACHE_SLOPPINESS="pch_defines,time_macros" "${SCCACHE}" "$@"
+else
+    "$@"
+fi

--- a/Tools/sccache/sccache.xcconfig
+++ b/Tools/sccache/sccache.xcconfig
@@ -1,0 +1,32 @@
+// Copyright (C) 2017 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+CC = $(CC_$(WK_USE_SCCACHE));
+CC_YES = $(WK_SCCACHE_DIR)/sccache-clang;
+CC_NO = $(CC);
+CC_ = $(CC_NO);
+
+LDPLUSPLUS = $(LDPLUSPLUS_$(WK_USE_SCCACHE));
+LDPLUSPLUS_YES = $(WK_SCCACHE_DIR)/sccache-clang++;
+LDPLUSPLUS_NO = $(LDPLUSPLUS);
+LDPLUSPLUS_ = $(LDPLUSPLUS_NO);


### PR DESCRIPTION
#### 2b44f0f34a165ef8cb3f999c6a41bc5a5ec3811f
<pre>
[Xcode] Add an experimental setting to build with sccache
<a href="https://bugs.webkit.org/show_bug.cgi?id=251605">https://bugs.webkit.org/show_bug.cgi?id=251605</a>

Reviewed by NOBODY (OOPS!).

On systems with sccache(8) installed, this patch adds experimental support
for it to Xcode builds. It can be enabled with the WK_USE_SCCACHE build setting.

When sccache is enabled, CC is overridden to invoke Tools/sccache/sccache-clang. This
is very similar to how ccache support with Xcode works.

* PerformanceTests/DecoderTest/Configurations/DebugRelease.xcconfig:
* Source/JavaScriptCore/Configurations/DebugRelease.xcconfig:
* Source/ThirdParty/ANGLE/Configurations/DebugRelease.xcconfig:
* Source/ThirdParty/libwebrtc/Configurations/DebugRelease.xcconfig:
* Source/WTF/Configurations/DebugRelease.xcconfig:
* Source/WebCore/Configurations/DebugRelease.xcconfig:
* Source/WebCore/PAL/Configurations/DebugRelease.xcconfig:
* Source/WebCore/PAL/ThirdParty/libavif/Configurations/DebugRelease.xcconfig:
* Source/WebCore/PAL/ThirdParty/libavif/ThirdParty/dav1d/Configurations/DebugRelease.xcconfig:
* Source/WebGPU/Configurations/DebugRelease.xcconfig:
* Source/WebKit/Configurations/DebugRelease.xcconfig:
* Source/WebKitLegacy/mac/Configurations/DebugRelease.xcconfig:
* Source/bmalloc/Configurations/DebugRelease.xcconfig:
* Tools/DumpRenderTree/mac/Configurations/DebugRelease.xcconfig:
* Tools/MiniBrowser/Configurations/DebugRelease.xcconfig:
* Tools/MobileMiniBrowser/Configurations/DebugRelease.xcconfig:
* Tools/TestWebKitAPI/Configurations/DebugRelease.xcconfig:
* Tools/WebGPUPlayground/Configurations/DebugRelease.xcconfig:
* Tools/WebKitTestRunner/Configurations/DebugRelease.xcconfig:
* Tools/lldb/lldbWebKitTester/Configurations/DebugRelease.xcconfig:
* Tools/sccache/README.md: Added.
* Tools/sccache/sccache-clang: Added.
* Tools/sccache/sccache-clang++: Added.
* Tools/sccache/sccache-wrapper: Added.
* Tools/sccache/sccache.xcconfig: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b44f0f34a165ef8cb3f999c6a41bc5a5ec3811f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105901 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14969 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38747 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115095 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175217 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109803 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16387 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6163 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98129 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114852 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111651 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12475 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95446 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40022 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94340 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27090 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81682 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/95585 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8234 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28444 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/94884 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/6037 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8715 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5028 "Found 1 new test failure: fast/events/blur-remove-parent-crash.html (failure)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30460 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14345 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47984 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/103632 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10270 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25692 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->