### PR TITLE
Fix bug in MediaFormatReader::copyTrackArray() found by new libcpp assertions

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/MediaToolboxSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/MediaToolboxSPI.h
@@ -42,6 +42,7 @@
 enum {
     kMTPluginFormatReaderError_AllocationFailure = -16501,
     kMTPluginFormatReaderError_ParsingFailure = -16503,
+    kMTPluginFormatReaderError_InternalFailure = -16504,
     kMTPluginSampleCursorError_NoSamples = -16507,
     kMTPluginSampleCursorError_LocationNotAvailable = -16508,
     kMTPluginByteSourceError_EndOfStream = -16511,

--- a/Source/WebKit/Shared/mac/MediaFormatReader/MediaFormatReader.cpp
+++ b/Source/WebKit/Shared/mac/MediaFormatReader/MediaFormatReader.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2020-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -278,6 +278,9 @@ OSStatus MediaFormatReader::copyTrackArray(CFArrayRef* trackArrayCopy)
         assertIsHeld(m_parseTracksLock);
         return m_parseTracksStatus.has_value() || action.aborted();
     });
+
+    if (action.aborted())
+        return kMTPluginFormatReaderError_InternalFailure;
 
     if (*m_parseTracksStatus != noErr)
         return *m_parseTracksStatus;


### PR DESCRIPTION
#### d7a2a7053e05b629fe7271bf8566c19200aa0903
<pre>
Fix bug in MediaFormatReader::copyTrackArray() found by new libcpp assertions
<a href="https://bugs.webkit.org/show_bug.cgi?id=251617">https://bugs.webkit.org/show_bug.cgi?id=251617</a>
rdar://104967552

Reviewed by Andy Estes and Jer Noble.

Dont dereference `m_parseTracksStatus` if the action was aborted, since
m_parseTracksStatus will be std::nullopt in this case.

* Source/WebKit/Shared/mac/MediaFormatReader/MediaFormatReader.cpp:
(WebKit::MediaFormatReader::copyTrackArray):

Canonical link: <a href="https://commits.webkit.org/259794@main">https://commits.webkit.org/259794@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/962c2ec6fa2d7094fdb48c5d51125b13c6588336

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105933 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14999 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38777 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115122 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/175240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109834 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16418 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/6185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98156 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111683 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95468 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/40040 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94365 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27112 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8259 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28465 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8744 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/6185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14372 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48007 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6777 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10294 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->