### PR TITLE
JSStringCreateWithCFString can now use CFIndex

### DIFF
--- a/Source/JavaScriptCore/API/JSStringRefCF.cpp
+++ b/Source/JavaScriptCore/API/JSStringRefCF.cpp
@@ -37,16 +37,14 @@ JSStringRef JSStringCreateWithCFString(CFStringRef string)
 {
     JSC::initialize();
 
-    // We cannot use CFIndex here since CFStringGetLength can return values larger than
-    // it can hold.  (<rdar://problem/6806478>)
-    size_t length = CFStringGetLength(string);
+    CFIndex length = CFStringGetLength(string);
     if (!length)
         return &OpaqueJSString::create(reinterpret_cast<const LChar*>(""), 0).leakRef();
 
     Vector<LChar, 1024> lcharBuffer(length);
     CFIndex usedBufferLength;
     CFIndex convertedSize = CFStringGetBytes(string, CFRangeMake(0, length), kCFStringEncodingISOLatin1, 0, false, lcharBuffer.data(), length, &usedBufferLength);
-    if (static_cast<size_t>(convertedSize) == length && static_cast<size_t>(usedBufferLength) == length)
+    if (convertedSize == length && usedBufferLength == length)
         return &OpaqueJSString::create(lcharBuffer.data(), length).leakRef();
 
     Vector<UniChar> buffer(length);


### PR DESCRIPTION
#### 115f2370e6f35139cb1672d1b4cc89fd0d3d0121
<pre>
JSStringCreateWithCFString can now use CFIndex
<a href="https://bugs.webkit.org/show_bug.cgi?id=251619">https://bugs.webkit.org/show_bug.cgi?id=251619</a>

&lt;rdar://problem/6806478&gt;
Reviewed by Yusuke Suzuki.

The original size_t workaround came about 14 years ago, right when Apple was still compiling for PowerPC. Basically, so many devices ran on 32 bits.

A long type can hold onto the required length now, so we no longer need to worry about it.

*Source/JavaScriptCore/API/JSStringRefCF.cpp: JSStringRef JSStringCreateWithCFString(CFStringRef string):

Canonical link: <a href="https://commits.webkit.org/260083@main">https://commits.webkit.org/260083@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/558c9d7193fc707db66c8cef35c1954c6bb3efe2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106444 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15470 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39262 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115631 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115297 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16959 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6695 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98644 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112210 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12880 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95850 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40434 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94755 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27494 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82140 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/96029 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8702 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28846 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/95456 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/6589 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9234 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5421 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30626 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14856 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48392 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/104193 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6962 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10783 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25817 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->