### PR TITLE
ASSERTION FAILED: !m_listeners.contains(connection) || m_listeners.get(connection) == identifier in StorageAreaBase

### DIFF
--- a/Source/WebCore/storage/StorageEventDispatcher.h
+++ b/Source/WebCore/storage/StorageEventDispatcher.h
@@ -40,7 +40,7 @@ class Storage;
 
 namespace StorageEventDispatcher {
 WEBCORE_EXPORT void dispatchSessionStorageEvents(const String& key, const String& oldValue, const String& newValue, Page&, const SecurityOrigin&, const String& url, const Function<bool(Storage&)>& isSourceStorage);
-WEBCORE_EXPORT void dispatchLocalStorageEvents(const String& key, const String& oldValue, const String& newValue, PageGroup&, const SecurityOrigin&, const String& url, const Function<bool(Storage&)>& isSourceStorage);
+WEBCORE_EXPORT void dispatchLocalStorageEvents(const String& key, const String& oldValue, const String& newValue, PageGroup*, const SecurityOrigin&, const String& url, const Function<bool(Storage&)>& isSourceStorage);
 }
 
 } // namespace WebCore

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -150,9 +150,9 @@ private:
     void getHandle(IPC::Connection&, WebCore::FileSystemHandleIdentifier, String&& name, CompletionHandler<void(Expected<std::pair<WebCore::FileSystemHandleIdentifier, bool>, FileSystemStorageError>)>&&);
     
     // Message handlers for WebStorage.
-    void connectToStorageArea(IPC::Connection&, WebCore::StorageType, StorageAreaMapIdentifier, StorageNamespaceIdentifier, const WebCore::ClientOrigin&, CompletionHandler<void(StorageAreaIdentifier, HashMap<String, String>, uint64_t)>&&);
-    void connectToStorageAreaSync(IPC::Connection&, WebCore::StorageType, StorageAreaMapIdentifier, StorageNamespaceIdentifier, const WebCore::ClientOrigin&, CompletionHandler<void(StorageAreaIdentifier, HashMap<String, String>, uint64_t)>&&);
-    void cancelConnectToStorageArea(IPC::Connection&, WebCore::StorageType, StorageNamespaceIdentifier, const WebCore::ClientOrigin&);
+    void connectToStorageArea(IPC::Connection&, WebCore::StorageType, StorageAreaMapIdentifier, std::optional<StorageNamespaceIdentifier>, const WebCore::ClientOrigin&, CompletionHandler<void(StorageAreaIdentifier, HashMap<String, String>, uint64_t)>&&);
+    void connectToStorageAreaSync(IPC::Connection&, WebCore::StorageType, StorageAreaMapIdentifier, std::optional<StorageNamespaceIdentifier>, const WebCore::ClientOrigin&, CompletionHandler<void(StorageAreaIdentifier, HashMap<String, String>, uint64_t)>&&);
+    void cancelConnectToStorageArea(IPC::Connection&, WebCore::StorageType, std::optional<StorageNamespaceIdentifier>, const WebCore::ClientOrigin&);
     void disconnectFromStorageArea(IPC::Connection&, StorageAreaIdentifier);
     void cloneSessionStorageNamespace(StorageNamespaceIdentifier, StorageNamespaceIdentifier);
     void setItem(IPC::Connection&, StorageAreaIdentifier, StorageAreaImplIdentifier, String&& key, String&& value, String&& urlString, CompletionHandler<void(bool, HashMap<String, String>&&)>&&);

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
@@ -42,9 +42,9 @@
     GetHandleNames(WebCore::FileSystemHandleIdentifier identifier) -> (Expected<Vector<String>, WebKit::FileSystemStorageError> result)
     GetHandle(WebCore::FileSystemHandleIdentifier identifier, String name) -> (Expected<std::pair<WebCore::FileSystemHandleIdentifier, bool>, WebKit::FileSystemStorageError> result)
 
-    ConnectToStorageArea(WebCore::StorageType type, WebKit::StorageAreaMapIdentifier sourceIdentifier, WebKit::StorageNamespaceIdentifier namespaceIdentifier, struct WebCore::ClientOrigin origin) -> (WebKit::StorageAreaIdentifier identifier, HashMap<String, String> items, uint64_t messageIdentifier)
-    ConnectToStorageAreaSync(WebCore::StorageType type, WebKit::StorageAreaMapIdentifier sourceIdentifier, WebKit::StorageNamespaceIdentifier namespaceIdentifier, struct WebCore::ClientOrigin origin) -> (WebKit::StorageAreaIdentifier identifier, HashMap<String, String> items, uint64_t messageIdentifier) Synchronous
-    CancelConnectToStorageArea(WebCore::StorageType type, WebKit::StorageNamespaceIdentifier namespaceIdentifier, struct WebCore::ClientOrigin origin)
+    ConnectToStorageArea(WebCore::StorageType type, WebKit::StorageAreaMapIdentifier sourceIdentifier, std::optional<WebKit::StorageNamespaceIdentifier> namespaceIdentifier, struct WebCore::ClientOrigin origin) -> (WebKit::StorageAreaIdentifier identifier, HashMap<String, String> items, uint64_t messageIdentifier)
+    ConnectToStorageAreaSync(WebCore::StorageType type, WebKit::StorageAreaMapIdentifier sourceIdentifier, std::optional<WebKit::StorageNamespaceIdentifier> namespaceIdentifier, struct WebCore::ClientOrigin origin) -> (WebKit::StorageAreaIdentifier identifier, HashMap<String, String> items, uint64_t messageIdentifier) Synchronous
+    CancelConnectToStorageArea(WebCore::StorageType type, std::optional<WebKit::StorageNamespaceIdentifier> namespaceIdentifier, struct WebCore::ClientOrigin origin)
     DisconnectFromStorageArea(WebKit::StorageAreaIdentifier identifier)
     CloneSessionStorageNamespace(WebKit::StorageNamespaceIdentifier fromStorageNamespaceID, WebKit::StorageNamespaceIdentifier toStorageNamespaceID)
     SetItem(WebKit::StorageAreaIdentifier identifier, WebKit::StorageAreaImplIdentifier implIdentifier, String key, String value, String urlString) -> (bool hasError, HashMap<String, String> allItems)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -653,7 +653,7 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
     pageConfiguration.applicationCacheStorage = &WebProcess::singleton().applicationCacheStorage();
     pageConfiguration.databaseProvider = WebDatabaseProvider::getOrCreate(m_pageGroup->pageGroupID());
     pageConfiguration.pluginInfoProvider = &WebPluginInfoProvider::singleton();
-    pageConfiguration.storageNamespaceProvider = WebStorageNamespaceProvider::getOrCreate(*m_pageGroup);
+    pageConfiguration.storageNamespaceProvider = WebStorageNamespaceProvider::getOrCreate();
     pageConfiguration.visitedLinkStore = VisitedLinkTableController::getOrCreate(parameters.visitedLinkTableID);
 
 #if ENABLE(APPLE_PAY)
@@ -717,7 +717,7 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
     
     m_page = makeUnique<Page>(WTFMove(pageConfiguration));
 
-    WebStorageNamespaceProvider::incrementUseCount(*m_pageGroup, sessionStorageNamespaceIdentifier());
+    WebStorageNamespaceProvider::incrementUseCount(sessionStorageNamespaceIdentifier());
 
     updatePreferences(parameters.store);
 
@@ -1126,7 +1126,7 @@ WebPage::~WebPage()
         m_footerBanner->detachFromPage();
 #endif
 
-    WebStorageNamespaceProvider::decrementUseCount(*m_pageGroup, sessionStorageNamespaceIdentifier());
+    WebStorageNamespaceProvider::decrementUseCount(sessionStorageNamespaceIdentifier());
 
 #ifndef NDEBUG
     webPageCounter.decrement();

--- a/Source/WebKit/WebProcess/WebStorage/StorageAreaMap.cpp
+++ b/Source/WebKit/WebProcess/WebStorage/StorageAreaMap.cpp
@@ -33,14 +33,12 @@
 #include "StorageAreaMapMessages.h"
 #include "StorageNamespaceImpl.h"
 #include "WebPage.h"
-#include "WebPageGroupProxy.h"
 #include "WebProcess.h"
 #include <WebCore/DOMWindow.h>
 #include <WebCore/Document.h>
 #include <WebCore/EventNames.h>
 #include <WebCore/Frame.h>
 #include <WebCore/Page.h>
-#include <WebCore/PageGroup.h>
 #include <WebCore/SecurityOriginData.h>
 #include <WebCore/Storage.h>
 #include <WebCore/StorageEventDispatcher.h>
@@ -258,9 +256,7 @@ void StorageAreaMap::dispatchLocalStorageEvent(const std::optional<StorageAreaIm
 {
     ASSERT(isLocalStorage(type()));
 
-    // Namespace IDs for local storage namespaces are currently equivalent to web page group IDs.
-    auto& pageGroup = *WebProcess::singleton().webPageGroup(m_namespace.pageGroupID())->corePageGroup();
-    StorageEventDispatcher::dispatchLocalStorageEvents(key, oldValue, newValue, pageGroup, m_securityOrigin, urlString, [storageAreaImplID](auto& storage) {
+    StorageEventDispatcher::dispatchLocalStorageEvents(key, oldValue, newValue, nullptr, m_securityOrigin, urlString, [storageAreaImplID](auto& storage) {
         return static_cast<StorageAreaImpl&>(storage.area()).identifier() == storageAreaImplID;
     });
 }

--- a/Source/WebKit/WebProcess/WebStorage/StorageNamespaceImpl.h
+++ b/Source/WebKit/WebProcess/WebStorage/StorageNamespaceImpl.h
@@ -46,16 +46,14 @@ public:
     using Identifier = StorageNamespaceIdentifier;
 
     static Ref<StorageNamespaceImpl> createSessionStorageNamespace(Identifier, WebCore::PageIdentifier, const WebCore::SecurityOrigin&, unsigned quotaInBytes);
-    static Ref<StorageNamespaceImpl> createLocalStorageNamespace(Identifier, unsigned quotaInBytes);
-    static Ref<StorageNamespaceImpl> createTransientLocalStorageNamespace(Identifier, WebCore::SecurityOrigin& topLevelOrigin, uint64_t quotaInBytes);
+    static Ref<StorageNamespaceImpl> createLocalStorageNamespace(unsigned quotaInBytes);
+    static Ref<StorageNamespaceImpl> createTransientLocalStorageNamespace(WebCore::SecurityOrigin& topLevelOrigin, uint64_t quotaInBytes);
 
     virtual ~StorageNamespaceImpl() = default;
 
     WebCore::StorageType storageType() const { return m_storageType; }
-    Identifier storageNamespaceID() const { return m_storageNamespaceID; }
-    // Namespace IDs for local storage namespaces are currently equivalent to web page group IDs.
+    std::optional<Identifier> storageNamespaceID() const { return m_storageNamespaceID; }
     WebCore::PageIdentifier sessionStoragePageID() const;
-    PageGroupIdentifier pageGroupID() const;
     const WebCore::SecurityOrigin* topLevelOrigin() const final { return m_topLevelOrigin.get(); }
     unsigned quotaInBytes() const { return m_quotaInBytes; }
     PAL::SessionID sessionID() const override;
@@ -65,7 +63,7 @@ public:
     void setSessionIDForTesting(PAL::SessionID) override;
 
 private:
-    StorageNamespaceImpl(WebCore::StorageType, Identifier, const std::optional<WebCore::PageIdentifier>&, const WebCore::SecurityOrigin* topLevelOrigin, unsigned quotaInBytes);
+    StorageNamespaceImpl(WebCore::StorageType, const std::optional<WebCore::PageIdentifier>&, const WebCore::SecurityOrigin* topLevelOrigin, unsigned quotaInBytes, std::optional<Identifier> = std::nullopt);
 
     Ref<WebCore::StorageArea> storageArea(const WebCore::SecurityOrigin&) final;
     uint64_t storageAreaMapCountForTesting() const final { return m_storageAreaMaps.size(); }
@@ -74,13 +72,12 @@ private:
     Ref<WebCore::StorageNamespace> copy(WebCore::Page&) override;
 
     const WebCore::StorageType m_storageType;
-    const Identifier m_storageNamespaceID;
     std::optional<WebCore::PageIdentifier> m_sessionPageID;
 
     // Used for transient local storage and session storage namespaces, nullptr otherwise.
     const RefPtr<const WebCore::SecurityOrigin> m_topLevelOrigin;
-
     const unsigned m_quotaInBytes;
+    std::optional<Identifier> m_storageNamespaceID;
 
     HashMap<WebCore::SecurityOriginData, std::unique_ptr<StorageAreaMap>> m_storageAreaMaps;
 };

--- a/Source/WebKit/WebProcess/WebStorage/WebStorageNamespaceProvider.h
+++ b/Source/WebKit/WebProcess/WebStorage/WebStorageNamespaceProvider.h
@@ -31,27 +31,22 @@
 
 namespace WebKit {
 
-class WebPageGroupProxy;
-
-class WebStorageNamespaceProvider final : public WebCore::StorageNamespaceProvider {
+class WebStorageNamespaceProvider final : public WebCore::StorageNamespaceProvider, public CanMakeWeakPtr<WebStorageNamespaceProvider> {
 public:
-    static Ref<WebStorageNamespaceProvider> getOrCreate(WebPageGroupProxy&);
+    static Ref<WebStorageNamespaceProvider> getOrCreate();
     virtual ~WebStorageNamespaceProvider();
 
-    static void incrementUseCount(const WebPageGroupProxy&, const StorageNamespaceImpl::Identifier);
-    static void decrementUseCount(const WebPageGroupProxy&, const StorageNamespaceImpl::Identifier);
+    static void incrementUseCount(const StorageNamespaceImpl::Identifier);
+    static void decrementUseCount(const StorageNamespaceImpl::Identifier);
 
 private:
-    explicit WebStorageNamespaceProvider(StorageNamespaceIdentifier localStorageIdentifier);
+    explicit WebStorageNamespaceProvider();
 
     Ref<WebCore::StorageNamespace> createLocalStorageNamespace(unsigned quota, PAL::SessionID) override;
     Ref<WebCore::StorageNamespace> createTransientLocalStorageNamespace(WebCore::SecurityOrigin&, unsigned quota, PAL::SessionID) override;
 
     RefPtr<WebCore::StorageNamespace> sessionStorageNamespace(const WebCore::SecurityOrigin&, WebCore::Page&, ShouldCreateNamespace) final;
     void copySessionStorageNamespace(WebCore::Page&, WebCore::Page&) final;
-
-    const StorageNamespaceIdentifier m_localStorageNamespaceIdentifier;
-
     struct SessionStorageNamespaces {
         unsigned useCount { 0 };
         HashMap<WebCore::SecurityOriginData, RefPtr<WebCore::StorageNamespace>> map;

--- a/Source/WebKitLegacy/Storage/StorageAreaImpl.cpp
+++ b/Source/WebKitLegacy/Storage/StorageAreaImpl.cpp
@@ -282,7 +282,7 @@ void StorageAreaImpl::dispatchStorageEvent(const String& key, const String& oldV
         return storage.frame() == &sourceFrame;
     };
     if (isLocalStorage(m_storageType))
-        StorageEventDispatcher::dispatchLocalStorageEvents(key, oldValue, newValue, page->group(), m_securityOrigin, sourceFrame.document()->url().string(), WTFMove(isSourceStorage));
+        StorageEventDispatcher::dispatchLocalStorageEvents(key, oldValue, newValue, &page->group(), m_securityOrigin, sourceFrame.document()->url().string(), WTFMove(isSourceStorage));
     else
         StorageEventDispatcher::dispatchSessionStorageEvents(key, oldValue, newValue, *page, m_securityOrigin, sourceFrame.document()->url().string(), WTFMove(isSourceStorage));
 }


### PR DESCRIPTION
#### dcf41af3936b535cd2875e868290874ab7ac3a65
<pre>
ASSERTION FAILED: !m_listeners.contains(connection) || m_listeners.get(connection) == identifier in StorageAreaBase
<a href="https://bugs.webkit.org/show_bug.cgi?id=251612">https://bugs.webkit.org/show_bug.cgi?id=251612</a>
rdar://104609918

Reviewed by Alex Christensen.

The assertion ensures that web process will not have two StorageAreaMaps that connect to the same StorageArea. We avoid
having two StorageAreaMaps mapping to the same area because StorageAreaMap may need to send sync message for connection
(StorageAreaMap::connectSync()), and we don&apos;t want sync message if unnecessary.

In current implementation, each web process is associated with a session. In web process, each page points to a
WebStorageNameSpaceProvider picked based on page group (WebStorageNamespaceProvider::getOrCreate(WebPageGroupProxy&amp;)).
Each WebStorageNamespaceProvider has one local StorageNamespace (WebCore::StorageNamespaceProvider), and each
StorageNamespace has multiple StorageAreaMaps (keyed by origin). Therefore, in web process, StorageAreaMap is identified
by { SessionID, PageGroupID, ClientOrigin }. However, in network process, StorageArea is identified by
{ SessionID, ClientOrigin }.

We used to have PageGroupID in key because we wanted to separate storage between groups in WebKitLegacy. As we moved
to WebKit, we still have it in key on the client side (web process), but not in the server side (network process), so
two StorageAreaMaps in different page groups can point to the same database, making it pointless to keep PageGroupID.
Therefore, this patch just drops PageGroup from WebStorage in WebKit.

* Source/WebCore/storage/StorageEventDispatcher.cpp:
(WebCore::StorageEventDispatcher::dispatchLocalStorageEvents):
* Source/WebCore/storage/StorageEventDispatcher.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::connectToStorageArea):
(WebKit::NetworkStorageManager::connectToStorageAreaSync):
(WebKit::NetworkStorageManager::cancelConnectToStorageArea):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_appHighlightsVisible):
(WebKit::WebPage::~WebPage):
* Source/WebKit/WebProcess/WebStorage/StorageAreaMap.cpp:
(WebKit::StorageAreaMap::dispatchLocalStorageEvent):
* Source/WebKit/WebProcess/WebStorage/StorageNamespaceImpl.cpp:
(WebKit::StorageNamespaceImpl::createSessionStorageNamespace):
(WebKit::StorageNamespaceImpl::createLocalStorageNamespace):
(WebKit::StorageNamespaceImpl::createTransientLocalStorageNamespace):
(WebKit::StorageNamespaceImpl::StorageNamespaceImpl):
(WebKit::StorageNamespaceImpl::copy):
(WebKit::StorageNamespaceImpl::pageGroupID const): Deleted.
* Source/WebKit/WebProcess/WebStorage/StorageNamespaceImpl.h:
* Source/WebKit/WebProcess/WebStorage/WebStorageNamespaceProvider.cpp:
(WebKit::existingStorageNameSpaceProvider):
(WebKit::WebStorageNamespaceProvider::getOrCreate):
(WebKit::WebStorageNamespaceProvider::incrementUseCount):
(WebKit::WebStorageNamespaceProvider::decrementUseCount):
(WebKit::WebStorageNamespaceProvider::WebStorageNamespaceProvider):
(WebKit::WebStorageNamespaceProvider::createLocalStorageNamespace):
(WebKit::WebStorageNamespaceProvider::createTransientLocalStorageNamespace):
(): Deleted.
(WebKit::WebStorageNamespaceProvider::~WebStorageNamespaceProvider): Deleted.
* Source/WebKit/WebProcess/WebStorage/WebStorageNamespaceProvider.h:
* Source/WebKitLegacy/Storage/StorageAreaImpl.cpp:
(WebKit::StorageAreaImpl::dispatchStorageEvent):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/LocalStoragePersistence.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/259876@main">https://commits.webkit.org/259876@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/759f9c3f8d0919c5dcb77f1998d8deab4125064c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106273 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15327 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39112 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115466 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175571 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110183 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16769 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6543 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98489 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115151 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112037 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12757 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95740 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40309 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94631 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27383 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81999 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8567 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28735 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9077 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5302 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14690 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48281 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6825 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10613 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->