### PR TITLE
[ShadowRealm] Enable and fix imported idlharness tests

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5928,17 +5928,6 @@ imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/cs
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/cors-crossorigin-requests.html [ Pass Failure ]
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/cors-crossorigin-requests.html [ Pass Failure ]
 
-# Disable ShadowRealm (while running to ensure we do not crash)
-imported/w3c/web-platform-tests/compression/idlharness-shadowrealm.window.html [ Pass Failure ]
-imported/w3c/web-platform-tests/dom/idlharness-shadowrealm.window.html [ Pass Failure ]
-imported/w3c/web-platform-tests/encoding/idlharness-shadowrealm.window.html [ Pass Failure ]
-imported/w3c/web-platform-tests/hr-time/idlharness-shadowrealm.window.html [ Pass Failure ]
-imported/w3c/web-platform-tests/html/dom/idlharness-shadowrealm.window.html [ Pass Failure ]
-imported/w3c/web-platform-tests/performance-timeline/idlharness-shadowrealm.window.html [ Pass Failure ]
-imported/w3c/web-platform-tests/streams/idlharness-shadowrealm.window.html [ Pass Failure ]
-imported/w3c/web-platform-tests/url/idlharness-shadowrealm.window.html [ Pass Failure ]
-imported/w3c/web-platform-tests/user-timing/idlharness-shadowrealm.window.html [ Pass Failure ]
-
 # modulepreload is not supported
 imported/w3c/web-platform-tests/import-maps/acquiring/modulepreload.html [ Skip ]
 imported/w3c/web-platform-tests/import-maps/acquiring/modulepreload-link-header.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/compression/idlharness-shadowrealm.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/compression/idlharness-shadowrealm.window-expected.txt
@@ -1,5 +1,4 @@
 
-PASS setup
 PASS CompressionStream includes GenericTransformStream: member names are unique
 PASS DecompressionStream includes GenericTransformStream: member names are unique
 PASS CompressionStream interface: existence and properties of interface object

--- a/LayoutTests/imported/w3c/web-platform-tests/compression/idlharness-shadowrealm.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/compression/idlharness-shadowrealm.window.html
@@ -1,1 +1,1 @@
-<!-- This file is required for WebKit test infrastructure to run the templated test -->
+<!-- This file is required for WebKit test infrastructure to run the templated test --><!-- webkit-test-runner [ jscOptions=--useShadowRealm=true ] -->

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/idlharness-shadowrealm.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/idlharness-shadowrealm.window-expected.txt
@@ -1,5 +1,4 @@
 
-PASS setup
 PASS Partial interface Window: original interface defined
 PASS Partial interface Window: member names are unique
 PASS Partial interface Document: member names are unique

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/idlharness-shadowrealm.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/idlharness-shadowrealm.window.html
@@ -1,1 +1,1 @@
-<!-- This file is required for WebKit test infrastructure to run the templated test -->
+<!-- This file is required for WebKit test infrastructure to run the templated test --><!-- webkit-test-runner [ jscOptions=--useShadowRealm=true ] -->

--- a/LayoutTests/imported/w3c/web-platform-tests/encoding/idlharness-shadowrealm.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/encoding/idlharness-shadowrealm.window-expected.txt
@@ -1,5 +1,4 @@
 
-PASS setup
 PASS TextDecoder includes TextDecoderCommon: member names are unique
 PASS TextEncoder includes TextEncoderCommon: member names are unique
 PASS TextDecoderStream includes TextDecoderCommon: member names are unique

--- a/LayoutTests/imported/w3c/web-platform-tests/encoding/idlharness-shadowrealm.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/encoding/idlharness-shadowrealm.window.html
@@ -1,1 +1,1 @@
-<!-- This file is required for WebKit test infrastructure to run the templated test -->
+<!-- This file is required for WebKit test infrastructure to run the templated test --><!-- webkit-test-runner [ jscOptions=--useShadowRealm=true ] -->

--- a/LayoutTests/imported/w3c/web-platform-tests/hr-time/idlharness-shadowrealm.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/hr-time/idlharness-shadowrealm.window-expected.txt
@@ -1,5 +1,4 @@
 
-PASS setup
 PASS Partial interface mixin WindowOrWorkerGlobalScope: original interface mixin defined
 PASS Partial interface mixin WindowOrWorkerGlobalScope: member names are unique
 PASS Partial interface Window: member names are unique

--- a/LayoutTests/imported/w3c/web-platform-tests/hr-time/idlharness-shadowrealm.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/hr-time/idlharness-shadowrealm.window.html
@@ -1,1 +1,1 @@
-<!-- This file is required for WebKit test infrastructure to run the templated test -->
+<!-- This file is required for WebKit test infrastructure to run the templated test --><!-- webkit-test-runner [ jscOptions=--useShadowRealm=true ] -->

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness-shadowrealm.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness-shadowrealm.window-expected.txt
@@ -1,5 +1,4 @@
 
-PASS setup
 PASS Partial interface Document: original interface defined
 PASS Partial interface Document: member names are unique
 PASS Partial interface mixin DocumentOrShadowRoot: original interface mixin defined

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness-shadowrealm.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness-shadowrealm.window.html
@@ -1,1 +1,1 @@
-<!-- This file is required for WebKit test infrastructure to run the templated test -->
+<!-- This file is required for WebKit test infrastructure to run the templated test --><!-- webkit-test-runner [ jscOptions=--useShadowRealm=true ] -->

--- a/LayoutTests/imported/w3c/web-platform-tests/performance-timeline/idlharness-shadowrealm.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/performance-timeline/idlharness-shadowrealm.window-expected.txt
@@ -1,5 +1,4 @@
 
-PASS setup
 PASS Partial interface Performance: original interface defined
 PASS Partial interface Performance: member names are unique
 PASS PerformanceEntry interface: existence and properties of interface object

--- a/LayoutTests/imported/w3c/web-platform-tests/performance-timeline/idlharness-shadowrealm.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/performance-timeline/idlharness-shadowrealm.window.html
@@ -1,1 +1,1 @@
-<!-- This file is required for WebKit test infrastructure to run the templated test -->
+<!-- This file is required for WebKit test infrastructure to run the templated test --><!-- webkit-test-runner [ jscOptions=--useShadowRealm=true ] -->

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/idlharness-shadowrealm.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/idlharness-shadowrealm.window-expected.txt
@@ -1,4 +1,136 @@
 
-Harness Error (FAIL), message = ReferenceError: Can't find variable: ShadowRealm
-
+PASS ReadableStreamDefaultReader includes ReadableStreamGenericReader: member names are unique
+PASS ReadableStreamBYOBReader includes ReadableStreamGenericReader: member names are unique
+PASS ReadableStream interface: existence and properties of interface object
+PASS ReadableStream interface object length
+PASS ReadableStream interface object name
+PASS ReadableStream interface: existence and properties of interface prototype object
+PASS ReadableStream interface: existence and properties of interface prototype object's "constructor" property
+PASS ReadableStream interface: existence and properties of interface prototype object's @@unscopables property
+FAIL ReadableStream interface: attribute locked assert_true: property should be enumerable expected true got false
+FAIL ReadableStream interface: operation cancel(optional any) assert_true: property should be enumerable expected true got false
+FAIL ReadableStream interface: operation getReader(optional ReadableStreamGetReaderOptions) assert_true: property should be enumerable expected true got false
+FAIL ReadableStream interface: operation pipeThrough(ReadableWritablePair, optional StreamPipeOptions) assert_true: property should be enumerable expected true got false
+FAIL ReadableStream interface: operation pipeTo(WritableStream, optional StreamPipeOptions) assert_true: property should be enumerable expected true got false
+FAIL ReadableStream interface: operation tee() assert_true: property should be enumerable expected true got false
+FAIL ReadableStream interface: async iterable<any> undefined is not an object (evaluating 'desc.value')
+PASS ReadableStreamDefaultReader interface: existence and properties of interface object
+PASS ReadableStreamDefaultReader interface object length
+PASS ReadableStreamDefaultReader interface object name
+PASS ReadableStreamDefaultReader interface: existence and properties of interface prototype object
+PASS ReadableStreamDefaultReader interface: existence and properties of interface prototype object's "constructor" property
+PASS ReadableStreamDefaultReader interface: existence and properties of interface prototype object's @@unscopables property
+PASS ReadableStreamDefaultReader interface: operation read()
+PASS ReadableStreamDefaultReader interface: operation releaseLock()
+PASS ReadableStreamDefaultReader interface: attribute closed
+PASS ReadableStreamDefaultReader interface: operation cancel(optional any)
+FAIL ReadableStreamBYOBReader interface: existence and properties of interface object assert_own_property: self does not have own property "ReadableStreamBYOBReader" expected property "ReadableStreamBYOBReader" missing
+FAIL ReadableStreamBYOBReader interface object length assert_own_property: self does not have own property "ReadableStreamBYOBReader" expected property "ReadableStreamBYOBReader" missing
+FAIL ReadableStreamBYOBReader interface object name assert_own_property: self does not have own property "ReadableStreamBYOBReader" expected property "ReadableStreamBYOBReader" missing
+FAIL ReadableStreamBYOBReader interface: existence and properties of interface prototype object assert_own_property: self does not have own property "ReadableStreamBYOBReader" expected property "ReadableStreamBYOBReader" missing
+FAIL ReadableStreamBYOBReader interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "ReadableStreamBYOBReader" expected property "ReadableStreamBYOBReader" missing
+FAIL ReadableStreamBYOBReader interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "ReadableStreamBYOBReader" expected property "ReadableStreamBYOBReader" missing
+FAIL ReadableStreamBYOBReader interface: operation read(ArrayBufferView) assert_own_property: self does not have own property "ReadableStreamBYOBReader" expected property "ReadableStreamBYOBReader" missing
+FAIL ReadableStreamBYOBReader interface: operation releaseLock() assert_own_property: self does not have own property "ReadableStreamBYOBReader" expected property "ReadableStreamBYOBReader" missing
+FAIL ReadableStreamBYOBReader interface: attribute closed assert_own_property: self does not have own property "ReadableStreamBYOBReader" expected property "ReadableStreamBYOBReader" missing
+FAIL ReadableStreamBYOBReader interface: operation cancel(optional any) assert_own_property: self does not have own property "ReadableStreamBYOBReader" expected property "ReadableStreamBYOBReader" missing
+PASS ReadableStreamDefaultController interface: existence and properties of interface object
+PASS ReadableStreamDefaultController interface object length
+PASS ReadableStreamDefaultController interface object name
+PASS ReadableStreamDefaultController interface: existence and properties of interface prototype object
+PASS ReadableStreamDefaultController interface: existence and properties of interface prototype object's "constructor" property
+PASS ReadableStreamDefaultController interface: existence and properties of interface prototype object's @@unscopables property
+PASS ReadableStreamDefaultController interface: attribute desiredSize
+PASS ReadableStreamDefaultController interface: operation close()
+PASS ReadableStreamDefaultController interface: operation enqueue(optional any)
+PASS ReadableStreamDefaultController interface: operation error(optional any)
+FAIL ReadableByteStreamController interface: existence and properties of interface object assert_own_property: self does not have own property "ReadableByteStreamController" expected property "ReadableByteStreamController" missing
+FAIL ReadableByteStreamController interface object length assert_own_property: self does not have own property "ReadableByteStreamController" expected property "ReadableByteStreamController" missing
+FAIL ReadableByteStreamController interface object name assert_own_property: self does not have own property "ReadableByteStreamController" expected property "ReadableByteStreamController" missing
+FAIL ReadableByteStreamController interface: existence and properties of interface prototype object assert_own_property: self does not have own property "ReadableByteStreamController" expected property "ReadableByteStreamController" missing
+FAIL ReadableByteStreamController interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "ReadableByteStreamController" expected property "ReadableByteStreamController" missing
+FAIL ReadableByteStreamController interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "ReadableByteStreamController" expected property "ReadableByteStreamController" missing
+FAIL ReadableByteStreamController interface: attribute byobRequest assert_own_property: self does not have own property "ReadableByteStreamController" expected property "ReadableByteStreamController" missing
+FAIL ReadableByteStreamController interface: attribute desiredSize assert_own_property: self does not have own property "ReadableByteStreamController" expected property "ReadableByteStreamController" missing
+FAIL ReadableByteStreamController interface: operation close() assert_own_property: self does not have own property "ReadableByteStreamController" expected property "ReadableByteStreamController" missing
+FAIL ReadableByteStreamController interface: operation enqueue(ArrayBufferView) assert_own_property: self does not have own property "ReadableByteStreamController" expected property "ReadableByteStreamController" missing
+FAIL ReadableByteStreamController interface: operation error(optional any) assert_own_property: self does not have own property "ReadableByteStreamController" expected property "ReadableByteStreamController" missing
+FAIL ReadableStreamBYOBRequest interface: existence and properties of interface object assert_own_property: self does not have own property "ReadableStreamBYOBRequest" expected property "ReadableStreamBYOBRequest" missing
+FAIL ReadableStreamBYOBRequest interface object length assert_own_property: self does not have own property "ReadableStreamBYOBRequest" expected property "ReadableStreamBYOBRequest" missing
+FAIL ReadableStreamBYOBRequest interface object name assert_own_property: self does not have own property "ReadableStreamBYOBRequest" expected property "ReadableStreamBYOBRequest" missing
+FAIL ReadableStreamBYOBRequest interface: existence and properties of interface prototype object assert_own_property: self does not have own property "ReadableStreamBYOBRequest" expected property "ReadableStreamBYOBRequest" missing
+FAIL ReadableStreamBYOBRequest interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "ReadableStreamBYOBRequest" expected property "ReadableStreamBYOBRequest" missing
+FAIL ReadableStreamBYOBRequest interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "ReadableStreamBYOBRequest" expected property "ReadableStreamBYOBRequest" missing
+FAIL ReadableStreamBYOBRequest interface: attribute view assert_own_property: self does not have own property "ReadableStreamBYOBRequest" expected property "ReadableStreamBYOBRequest" missing
+FAIL ReadableStreamBYOBRequest interface: operation respond(unsigned long long) assert_own_property: self does not have own property "ReadableStreamBYOBRequest" expected property "ReadableStreamBYOBRequest" missing
+FAIL ReadableStreamBYOBRequest interface: operation respondWithNewView(ArrayBufferView) assert_own_property: self does not have own property "ReadableStreamBYOBRequest" expected property "ReadableStreamBYOBRequest" missing
+PASS WritableStream interface: existence and properties of interface object
+PASS WritableStream interface object length
+PASS WritableStream interface object name
+PASS WritableStream interface: existence and properties of interface prototype object
+PASS WritableStream interface: existence and properties of interface prototype object's "constructor" property
+PASS WritableStream interface: existence and properties of interface prototype object's @@unscopables property
+PASS WritableStream interface: attribute locked
+PASS WritableStream interface: operation abort(optional any)
+PASS WritableStream interface: operation close()
+PASS WritableStream interface: operation getWriter()
+PASS WritableStreamDefaultWriter interface: existence and properties of interface object
+PASS WritableStreamDefaultWriter interface object length
+PASS WritableStreamDefaultWriter interface object name
+PASS WritableStreamDefaultWriter interface: existence and properties of interface prototype object
+PASS WritableStreamDefaultWriter interface: existence and properties of interface prototype object's "constructor" property
+PASS WritableStreamDefaultWriter interface: existence and properties of interface prototype object's @@unscopables property
+PASS WritableStreamDefaultWriter interface: attribute closed
+PASS WritableStreamDefaultWriter interface: attribute desiredSize
+PASS WritableStreamDefaultWriter interface: attribute ready
+PASS WritableStreamDefaultWriter interface: operation abort(optional any)
+PASS WritableStreamDefaultWriter interface: operation close()
+PASS WritableStreamDefaultWriter interface: operation releaseLock()
+PASS WritableStreamDefaultWriter interface: operation write(optional any)
+PASS WritableStreamDefaultController interface: existence and properties of interface object
+PASS WritableStreamDefaultController interface object length
+PASS WritableStreamDefaultController interface object name
+PASS WritableStreamDefaultController interface: existence and properties of interface prototype object
+PASS WritableStreamDefaultController interface: existence and properties of interface prototype object's "constructor" property
+PASS WritableStreamDefaultController interface: existence and properties of interface prototype object's @@unscopables property
+PASS WritableStreamDefaultController interface: attribute signal
+FAIL WritableStreamDefaultController interface: operation error(optional any) assert_equals: property has wrong .length expected 0 but got 1
+PASS TransformStream interface: existence and properties of interface object
+PASS TransformStream interface object length
+PASS TransformStream interface object name
+PASS TransformStream interface: existence and properties of interface prototype object
+PASS TransformStream interface: existence and properties of interface prototype object's "constructor" property
+PASS TransformStream interface: existence and properties of interface prototype object's @@unscopables property
+PASS TransformStream interface: attribute readable
+FAIL TransformStream interface: attribute writable assert_equals: getter must have the name 'get writable' expected "get writable" but got "writable"
+PASS TransformStreamDefaultController interface: existence and properties of interface object
+PASS TransformStreamDefaultController interface object length
+PASS TransformStreamDefaultController interface object name
+PASS TransformStreamDefaultController interface: existence and properties of interface prototype object
+PASS TransformStreamDefaultController interface: existence and properties of interface prototype object's "constructor" property
+PASS TransformStreamDefaultController interface: existence and properties of interface prototype object's @@unscopables property
+PASS TransformStreamDefaultController interface: attribute desiredSize
+PASS TransformStreamDefaultController interface: operation enqueue(optional any)
+PASS TransformStreamDefaultController interface: operation error(optional any)
+PASS TransformStreamDefaultController interface: operation terminate()
+PASS ByteLengthQueuingStrategy interface: existence and properties of interface object
+PASS ByteLengthQueuingStrategy interface object length
+PASS ByteLengthQueuingStrategy interface object name
+PASS ByteLengthQueuingStrategy interface: existence and properties of interface prototype object
+PASS ByteLengthQueuingStrategy interface: existence and properties of interface prototype object's "constructor" property
+PASS ByteLengthQueuingStrategy interface: existence and properties of interface prototype object's @@unscopables property
+PASS ByteLengthQueuingStrategy interface: attribute highWaterMark
+FAIL ByteLengthQueuingStrategy interface: attribute size assert_throws_js: getting property on prototype object must throw TypeError function "function () {
+    [native code]
+}" did not throw
+PASS CountQueuingStrategy interface: existence and properties of interface object
+PASS CountQueuingStrategy interface object length
+PASS CountQueuingStrategy interface object name
+PASS CountQueuingStrategy interface: existence and properties of interface prototype object
+PASS CountQueuingStrategy interface: existence and properties of interface prototype object's "constructor" property
+PASS CountQueuingStrategy interface: existence and properties of interface prototype object's @@unscopables property
+PASS CountQueuingStrategy interface: attribute highWaterMark
+FAIL CountQueuingStrategy interface: attribute size assert_throws_js: getting property on prototype object must throw TypeError function "function () {
+    [native code]
+}" did not throw
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/idlharness-shadowrealm.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/idlharness-shadowrealm.window.html
@@ -1,1 +1,1 @@
-<!-- This file is required for WebKit test infrastructure to run the templated test -->
+<!-- This file is required for WebKit test infrastructure to run the templated test --><!-- webkit-test-runner [ jscOptions=--useShadowRealm=true ] -->

--- a/LayoutTests/imported/w3c/web-platform-tests/url/idlharness-shadowrealm.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/idlharness-shadowrealm.window-expected.txt
@@ -1,5 +1,4 @@
 
-PASS setup
 PASS URL interface: existence and properties of interface object
 PASS URL interface object length
 PASS URL interface object name

--- a/LayoutTests/imported/w3c/web-platform-tests/url/idlharness-shadowrealm.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/idlharness-shadowrealm.window.html
@@ -1,1 +1,1 @@
-<!-- This file is required for WebKit test infrastructure to run the templated test -->
+<!-- This file is required for WebKit test infrastructure to run the templated test --><!-- webkit-test-runner [ jscOptions=--useShadowRealm=true ] -->

--- a/LayoutTests/imported/w3c/web-platform-tests/user-timing/idlharness-shadowrealm.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/user-timing/idlharness-shadowrealm.window-expected.txt
@@ -1,5 +1,4 @@
 
-PASS setup
 PASS Partial interface Performance: original interface defined
 PASS Partial interface Performance: member names are unique
 PASS PerformanceMark interface: existence and properties of interface object

--- a/LayoutTests/imported/w3c/web-platform-tests/user-timing/idlharness-shadowrealm.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/user-timing/idlharness-shadowrealm.window.html
@@ -1,1 +1,1 @@
-<!-- This file is required for WebKit test infrastructure to run the templated test -->
+<!-- This file is required for WebKit test infrastructure to run the templated test --><!-- webkit-test-runner [ jscOptions=--useShadowRealm=true ] -->

--- a/Tools/DumpRenderTree/TestOptions.cpp
+++ b/Tools/DumpRenderTree/TestOptions.cpp
@@ -171,6 +171,8 @@ const TestFeatures& TestOptions::defaults()
 #if ENABLE(GPU_PROCESS) && ENABLE(WEBGL)
             { "UseGPUProcessForWebGLEnabled", false },
 #endif
+            // FIXME: This feature does nothing unless the jscOption "useShadowRealm" is also supplied.
+            { "WebAPIsInShadowRealmEnabled", true },
         };
 #if PLATFORM(WIN)
         features.uint32WebPreferenceFeatures = {

--- a/Tools/WebKitTestRunner/TestOptions.cpp
+++ b/Tools/WebKitTestRunner/TestOptions.cpp
@@ -142,6 +142,8 @@ const TestFeatures& TestOptions::defaults()
 #if ENABLE(GPU_PROCESS) && ENABLE(WEBGL) && !PLATFORM(WIN)
             { "UseGPUProcessForWebGLEnabled", fullGPUProcessEnabledValue },
 #endif
+            // FIXME: This feature does nothing unless the jscOption "useShadowRealm" is also supplied.
+            { "WebAPIsInShadowRealmEnabled", true },
         };
         features.stringWebPreferenceFeatures = {
             { "CursiveFontFamily", "Apple Chancery" },


### PR DESCRIPTION
#### 6538093a85eed3c8b212813daadfe3585ca7f37d
<pre>
[ShadowRealm] Enable and fix imported idlharness tests
https://bugs.webkit.org/show_bug.cgi?id=251795

Reviewed by NOBODY (OOPS!).

This removes the PASS/FAIL expectation for imported ShadowRealm tests,
adds the JSC feature flag for the skipped tests, and fixes up the test expectations.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/compression/idlharness-shadowrealm.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/compression/idlharness-shadowrealm.window.html:
* LayoutTests/imported/w3c/web-platform-tests/dom/idlharness-shadowrealm.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/idlharness-shadowrealm.window.html:
* LayoutTests/imported/w3c/web-platform-tests/encoding/idlharness-shadowrealm.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/encoding/idlharness-shadowrealm.window.html:
* LayoutTests/imported/w3c/web-platform-tests/hr-time/idlharness-shadowrealm.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/hr-time/idlharness-shadowrealm.window.html:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness-shadowrealm.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness-shadowrealm.window.html:
* LayoutTests/imported/w3c/web-platform-tests/performance-timeline/idlharness-shadowrealm.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/performance-timeline/idlharness-shadowrealm.window.html:
* LayoutTests/imported/w3c/web-platform-tests/streams/idlharness-shadowrealm.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/streams/idlharness-shadowrealm.window.html:
* LayoutTests/imported/w3c/web-platform-tests/url/idlharness-shadowrealm.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/url/idlharness-shadowrealm.window.html:
* LayoutTests/imported/w3c/web-platform-tests/user-timing/idlharness-shadowrealm.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/user-timing/idlharness-shadowrealm.window.html:
* Tools/DumpRenderTree/TestOptions.cpp:
(WTR::TestOptions::defaults):
* Tools/WebKitTestRunner/TestOptions.cpp:
(WTR::TestOptions::defaults):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6538093a85eed3c8b212813daadfe3585ca7f37d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106348 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15402 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39188 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115541 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175645 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110258 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16879 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6619 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98565 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115228 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112112 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12820 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95803 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40377 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94695 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27446 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82069 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8638 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28797 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9150 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5367 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14780 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48344 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10712 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->