### PR TITLE
Reduce build times by refactoring FrameView.h

### DIFF
--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -53,6 +53,7 @@
 #include "ContentData.h"
 #include "CursorList.h"
 #include "CustomPropertyRegistry.h"
+#include "FontCascade.h"
 #include "FontSelectionValueInlines.h"
 #include "GridPositionsResolver.h"
 #include "NodeRenderStyle.h"

--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -38,6 +38,7 @@
 #include "ImageBuffer.h"
 #include "InspectorInstrumentation.h"
 #include "StyleCanvasImage.h"
+#include "RenderElement.h"
 #include "WebCoreOpaqueRoot.h"
 #include "WorkerClient.h"
 #include "WorkerGlobalScope.h"

--- a/Source/WebCore/html/HTMLAttachmentElement.cpp
+++ b/Source/WebCore/html/HTMLAttachmentElement.cpp
@@ -45,6 +45,7 @@
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/UUID.h>
 #include <wtf/URLParser.h>
+#include <wtf/unicode/CharacterNames.h>
 
 #if ENABLE(SERVICE_CONTROLS)
 #include "ImageControlsMac.h"

--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -35,6 +35,7 @@
 #include "Chrome.h"
 #include "ChromeClient.h"
 #include "ColorBlending.h"
+#include "ContainerNode.h"
 #include "DOMWindow.h"
 #include "DebugPageOverlays.h"
 #include "DocumentInlines.h"
@@ -199,6 +200,7 @@ FrameView::FrameView(Frame& frame)
     , m_delayedScrollToFocusedElementTimer(*this, &FrameView::scrollToFocusedElementTimerFired)
     , m_speculativeTilingEnableTimer(*this, &FrameView::speculativeTilingEnableTimerFired)
     , m_delayedTextFragmentIndicatorTimer(*this, &FrameView::textFragmentIndicatorTimerFired)
+    , m_mediaType(screenAtom())
 {
     init();
 
@@ -1603,6 +1605,21 @@ void FrameView::removeSlowRepaintObject(RenderElement& renderer)
 
     m_slowRepaintObjects = nullptr;
     updateCanBlitOnScrollRecursively();
+}
+
+bool FrameView::hasSlowRepaintObject(const RenderElement& renderer) const
+{
+    return m_slowRepaintObjects && m_slowRepaintObjects->contains(renderer);
+}
+
+bool FrameView::hasSlowRepaintObjects() const
+{
+    return m_slowRepaintObjects && !m_slowRepaintObjects->isEmptyIgnoringNullReferences();
+}
+
+bool FrameView::hasViewportConstrainedObjects() const
+{
+    return m_viewportConstrainedObjects && !m_viewportConstrainedObjects->isEmptyIgnoringNullReferences();
 }
 
 void FrameView::addViewportConstrainedObject(RenderLayerModelObject& object)
@@ -3196,13 +3213,13 @@ void FrameView::addedOrRemovedScrollbar()
     InspectorInstrumentation::didAddOrRemoveScrollbars(*this);
 }
 
-TiledBacking::Scrollability FrameView::computeScrollability() const
+OptionSet<TiledBacking::Scrollability> FrameView::computeScrollability() const
 {
     auto* page = m_frame->page();
 
     // Use smaller square tiles if the Window is not active to facilitate app napping.
     if (!page || !page->isWindowActive())
-        return TiledBacking::HorizontallyScrollable | TiledBacking::VerticallyScrollable;
+        return { TiledBacking::Scrollability::HorizontallyScrollable, TiledBacking::Scrollability::VerticallyScrollable };
 
     bool horizontallyScrollable;
     bool verticallyScrollable;
@@ -3224,12 +3241,12 @@ TiledBacking::Scrollability FrameView::computeScrollability() const
         verticallyScrollable = clippedByAncestorView || verticalScrollbar();
     }
 
-    TiledBacking::Scrollability scrollability = TiledBacking::NotScrollable;
+    OptionSet<TiledBacking::Scrollability> scrollability = TiledBacking::Scrollability::NotScrollable;
     if (horizontallyScrollable)
-        scrollability = TiledBacking::HorizontallyScrollable;
+        scrollability.add(TiledBacking::Scrollability::HorizontallyScrollable);
 
     if (verticallyScrollable)
-        scrollability |= TiledBacking::VerticallyScrollable;
+        scrollability.add(TiledBacking::Scrollability::VerticallyScrollable);
 
     return scrollability;
 }
@@ -5879,6 +5896,11 @@ void FrameView::setScrollPinningBehavior(ScrollPinningBehavior pinning)
 ScrollBehaviorForFixedElements FrameView::scrollBehaviorForFixedElements() const
 {
     return m_frame->settings().backgroundShouldExtendBeyondPage() ? StickToViewportBounds : StickToDocumentBounds;
+}
+
+AbstractFrame& FrameView::frame() const
+{
+    return m_frame;
 }
 
 RenderView* FrameView::renderView() const

--- a/Source/WebCore/page/FrameView.h
+++ b/Source/WebCore/page/FrameView.h
@@ -27,21 +27,13 @@
 #include "AbstractFrameView.h"
 #include "AdjustViewSizeOrNot.h"
 #include "Color.h"
-#include "ContainerNode.h"
 #include "FrameViewLayoutContext.h"
-#include "GraphicsContext.h"
 #include "LayoutMilestone.h"
 #include "LayoutRect.h"
-#include "NullGraphicsContext.h"
 #include "Pagination.h"
 #include "PaintPhase.h"
-#include "RenderElement.h"
-#include "RenderLayerModelObject.h"
 #include "RenderPtr.h"
-#include "ScrollView.h"
 #include "SimpleRange.h"
-#include "StyleColor.h"
-#include "TiledBacking.h"
 #include <memory>
 #include <wtf/Forward.h>
 #include <wtf/Function.h>
@@ -59,10 +51,13 @@ class TextStream;
 namespace WebCore {
 
 class AXObjectCache;
+class AbstractFrame;
+class ContainerNode;
 class Element;
 class EventRegionContext;
 class FloatSize;
 class Frame;
+class GraphicsContext;
 class HTMLFrameOwnerElement;
 class Page;
 class RenderBox;
@@ -77,6 +72,15 @@ class RenderView;
 class RenderWidget;
 class ScrollingCoordinator;
 class ScrollAnchoringController;
+class TiledBacking;
+
+struct ScrollRectToVisibleOptions;
+struct SimpleRange;
+struct VelocityData;
+
+enum class NullGraphicsContextPaintInvalidationReasons : uint8_t;
+enum class StyleColorOptions : uint8_t;
+enum class TiledBackingScrollability : uint8_t;
 
 namespace Display {
 class View;
@@ -103,7 +107,7 @@ public:
     FrameViewType viewType() const final { return FrameViewType::Local; }
 
     // FIXME: This should return Frame. If it were a RemoteFrame, we would have a RemoteFrameView.
-    AbstractFrame& frame() const { return m_frame; }
+    WEBCORE_EXPORT AbstractFrame& frame() const;
 
     WEBCORE_EXPORT RenderView* renderView() const;
 
@@ -343,16 +347,16 @@ public:
 
     void addSlowRepaintObject(RenderElement&);
     void removeSlowRepaintObject(RenderElement&);
-    bool hasSlowRepaintObject(const RenderElement& renderer) const { return m_slowRepaintObjects && m_slowRepaintObjects->contains(renderer); }
-    bool hasSlowRepaintObjects() const { return m_slowRepaintObjects && !m_slowRepaintObjects->isEmptyIgnoringNullReferences(); }
+    bool hasSlowRepaintObject(const RenderElement& renderer) const;
+    bool hasSlowRepaintObjects() const;
     WeakHashSet<RenderElement>* slowRepaintObjects() const { return m_slowRepaintObjects.get(); }
 
     // Includes fixed- and sticky-position objects.
     void addViewportConstrainedObject(RenderLayerModelObject&);
     void removeViewportConstrainedObject(RenderLayerModelObject&);
     const WeakHashSet<RenderLayerModelObject>* viewportConstrainedObjects() const { return m_viewportConstrainedObjects.get(); }
-    bool hasViewportConstrainedObjects() const { return m_viewportConstrainedObjects && !m_viewportConstrainedObjects->isEmptyIgnoringNullReferences(); }
-    
+    WEBCORE_EXPORT bool hasViewportConstrainedObjects() const;
+
     float frameScaleFactor() const;
 
     // Functions for querying the current scrolled position, negating the effects of overhang
@@ -649,7 +653,7 @@ public:
     WEBCORE_EXPORT void availableContentSizeChanged(AvailableSizeChangeReason) final;
 
     void updateTiledBackingAdaptiveSizing();
-    TiledBacking::Scrollability computeScrollability() const;
+    OptionSet<TiledBackingScrollability> computeScrollability() const;
 
     void addPaintPendingMilestones(OptionSet<LayoutMilestone>);
     void firePaintRelatedMilestonesIfNeeded();
@@ -735,7 +739,7 @@ private:
     bool scrollContentsFastPath(const IntSize& scrollDelta, const IntRect& rectToScroll, const IntRect& clipRect) final;
     void scrollContentsSlowPath(const IntRect& updateRect) final;
 
-    void traverseForPaintInvalidation(NullGraphicsContext::PaintInvalidationReasons);
+    void traverseForPaintInvalidation(NullGraphicsContextPaintInvalidationReasons);
     void repaintSlowRepaintObjects();
 
     bool isVerticalDocument() const final;
@@ -946,7 +950,7 @@ private:
     Color m_baseBackgroundColor { Color::white };
     IntSize m_lastViewportSize;
 
-    AtomString m_mediaType { screenAtom() };
+    AtomString m_mediaType;
     AtomString m_mediaTypeWhenNotPrinting;
 
     Vector<FloatRect> m_trackedRepaintRects;

--- a/Source/WebCore/platform/graphics/NullGraphicsContext.h
+++ b/Source/WebCore/platform/graphics/NullGraphicsContext.h
@@ -29,14 +29,16 @@
 
 namespace WebCore {
 
+enum class NullGraphicsContextPaintInvalidationReasons : uint8_t {
+    None,
+    InvalidatingControlTints,
+    InvalidatingImagesWithAsyncDecodes,
+    DetectingContentfulPaint
+};
+
 class NullGraphicsContext : public GraphicsContext {
 public:
-    enum class PaintInvalidationReasons : uint8_t {
-        None,
-        InvalidatingControlTints,
-        InvalidatingImagesWithAsyncDecodes,
-        DetectingContentfulPaint
-    };
+    using PaintInvalidationReasons = NullGraphicsContextPaintInvalidationReasons;
 
     NullGraphicsContext() = default;
 

--- a/Source/WebCore/platform/graphics/TiledBacking.h
+++ b/Source/WebCore/platform/graphics/TiledBacking.h
@@ -50,6 +50,12 @@ enum ScrollingModeIndication {
     AsyncScrollingIndication
 };
 
+enum class TiledBackingScrollability : uint8_t {
+    NotScrollable           = 0,
+    HorizontallyScrollable  = 1 << 0,
+    VerticallyScrollable    = 1 << 1
+};
+
 class TiledBacking {
 public:
     virtual ~TiledBacking() = default;
@@ -71,13 +77,8 @@ public:
 
     virtual void setTileSizeUpdateDelayDisabledForTesting(bool) = 0;
     
-    enum {
-        NotScrollable           = 0,
-        HorizontallyScrollable  = 1 << 0,
-        VerticallyScrollable    = 1 << 1
-    };
-    typedef unsigned Scrollability;
-    virtual void setScrollability(Scrollability) = 0;
+    using Scrollability = TiledBackingScrollability;
+    virtual void setScrollability(OptionSet<Scrollability>) = 0;
 
     virtual void prepopulateRect(const FloatRect&) = 0;
 

--- a/Source/WebCore/platform/graphics/ca/TileController.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileController.cpp
@@ -242,7 +242,7 @@ void TileController::setVelocity(const VelocityData& velocity)
         setNeedsRevalidateTiles();
 }
 
-void TileController::setScrollability(Scrollability scrollability)
+void TileController::setScrollability(OptionSet<Scrollability> scrollability)
 {
     if (scrollability == m_scrollability)
         return;
@@ -568,10 +568,10 @@ IntSize TileController::computeTileSize()
 
     IntSize tileSize(kDefaultTileSize, kDefaultTileSize);
 
-    if (m_scrollability == NotScrollable) {
+    if (m_scrollability == Scrollability::NotScrollable) {
         IntSize scaledSize = expandedIntSize(boundsWithoutMargin().size() * tileGrid().scale());
         tileSize = scaledSize.constrainedBetween(IntSize(kDefaultTileSize, kDefaultTileSize), maxTileSize);
-    } else if (m_scrollability == VerticallyScrollable)
+    } else if (m_scrollability == Scrollability::VerticallyScrollable)
         tileSize.setWidth(std::min(std::max<int>(ceilf(boundsWithoutMargin().width() * tileGrid().scale()), kDefaultTileSize), maxTileSize.width()));
 
     LOG_WITH_STREAM(Scrolling, stream << "TileController::tileSize newSize=" << tileSize);

--- a/Source/WebCore/platform/graphics/ca/TileController.h
+++ b/Source/WebCore/platform/graphics/ca/TileController.h
@@ -158,7 +158,7 @@ private:
     void setTiledScrollingIndicatorPosition(const FloatPoint&) final;
     void setTopContentInset(float) final;
     void setVelocity(const VelocityData&) final;
-    void setScrollability(Scrollability) final;
+    void setScrollability(OptionSet<Scrollability>) final;
     void prepopulateRect(const FloatRect&) final;
     void setIsInWindow(bool) final;
     bool isInWindow() const final { return m_isInWindow; }
@@ -223,7 +223,7 @@ private:
 
     int m_marginSize { kDefaultTileSize };
 
-    Scrollability m_scrollability { HorizontallyScrollable | VerticallyScrollable };
+    OptionSet<Scrollability> m_scrollability { Scrollability::HorizontallyScrollable, Scrollability::VerticallyScrollable };
 
     // m_marginTop and m_marginBottom are the height in pixels of the top and bottom margin tiles. The width
     // of those tiles will be equivalent to the width of the other tiles in the grid. m_marginRight and

--- a/Source/WebCore/rendering/AttachmentLayout.h
+++ b/Source/WebCore/rendering/AttachmentLayout.h
@@ -33,6 +33,9 @@
 
 OBJC_CLASS NSDictionary;
 
+typedef const struct __CTFont* CTFontRef;
+typedef const struct __CTLine * CTLineRef;
+
 namespace WebCore {
 
 class Image;

--- a/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
@@ -35,6 +35,7 @@
 #include "LegacyRenderSVGRoot.h"
 #include "LegacyRenderSVGShapeInlines.h"
 #include "NodeRenderStyle.h"
+#include "NullGraphicsContext.h"
 #include "RenderImage.h"
 #include "RenderIterator.h"
 #include "RenderSVGContainer.h"

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
@@ -50,7 +50,7 @@
 #include <WebCore/Page.h>
 #include <WebCore/Position.h>
 #include <WebCore/Range.h>
-#include <WebCore/RenderObject.h>
+#include <WebCore/RenderElement.h>
 #include <WebCore/SimpleRange.h>
 #include <WebCore/Text.h>
 #include <WebCore/VisiblePosition.h>

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp
@@ -33,6 +33,7 @@
 #include <WebCore/BitmapImage.h>
 #include <WebCore/Document.h>
 #include <WebCore/Frame.h>
+#include <WebCore/FrameDestructionObserverInlines.h>
 #include <WebCore/FrameLoader.h>
 #include <WebCore/FrameView.h>
 #include <WebCore/GraphicsContext.h>

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.cpp
@@ -35,6 +35,7 @@
 #include <WebCore/Document.h>
 #include <WebCore/Frame.h>
 #include <WebCore/FrameView.h>
+#include <WebCore/GraphicsContext.h>
 #include <WebCore/GraphicsLayerTextureMapper.h>
 #include <WebCore/Page.h>
 #include <WebCore/Settings.h>

--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -51,6 +51,7 @@
 #include <WebCore/PlatformMouseEvent.h>
 #include <WebCore/PluginDocument.h>
 #include <WebCore/Range.h>
+#include <WebCore/RenderObject.h>
 #include <WebCore/SimpleRange.h>
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp
@@ -99,7 +99,7 @@ public:
     void setTopContentInset(float) final { }
     void setVelocity(const VelocityData&) final { }
     void setTileSizeUpdateDelayDisabledForTesting(bool) final { };
-    void setScrollability(Scrollability) final { }
+    void setScrollability(OptionSet<Scrollability>) final { }
     void prepopulateRect(const FloatRect&) final { }
     void setIsInWindow(bool) final { }
     bool isInWindow() const final { return m_isInWindow; }


### PR DESCRIPTION
#### 4c8702ace4ab5ce127a144a8339bfee8f5b48a24
<pre>
Reduce build times by refactoring FrameView.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=251626">https://bugs.webkit.org/show_bug.cgi?id=251626</a>
rdar://104975520

Reviewed by Brent Fulgham.

Forward declare more things in FrameView.h and remove #include statements.

In order to forward-declare some enumerations used in FrameView.h, those enums
needed to be moved out of their classes&apos; scopes, and in one case, need to be
converted to an OptionSet.

Canonical link: <a href="https://commits.webkit.org/259960@main">https://commits.webkit.org/259960@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7a3415829d68abcbccb46075373ecc16e5c26c2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106458 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15482 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39274 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115645 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175745 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110366 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16971 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6707 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98656 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115309 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112224 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12891 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95865 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40450 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94766 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27509 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82163 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8714 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28861 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9247 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5432 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14868 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48407 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6887 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10795 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->