### PR TITLE
Refactor cssText() to share more code between grouping at-rules

### DIFF
--- a/Source/WebCore/css/CSSContainerRule.cpp
+++ b/Source/WebCore/css/CSSContainerRule.cpp
@@ -52,15 +52,9 @@ const StyleRuleContainer& CSSContainerRule::styleRuleContainer() const
 String CSSContainerRule::cssText() const
 {
     StringBuilder builder;
-
     builder.append("@container ");
-
     CQ::serialize(builder, styleRuleContainer().containerQuery());
-
-    builder.append(" {\n");
     appendCSSTextForItems(builder);
-    builder.append('}');
-
     return builder.toString();
 }
 

--- a/Source/WebCore/css/CSSGroupingRule.h
+++ b/Source/WebCore/css/CSSGroupingRule.h
@@ -48,6 +48,9 @@ protected:
     void reattach(StyleRuleBase&) override;
     void appendCSSTextForItems(StringBuilder&) const;
 
+    // https://drafts.csswg.org/cssom/#serialize-a-css-rule
+    void cssTextForDeclsAndRules(StringBuilder& decls, StringBuilder& rules) const;
+
 private:
     Ref<StyleRuleGroup> m_groupRule;
     mutable Vector<RefPtr<CSSRule>> m_childRuleCSSOMWrappers;

--- a/Source/WebCore/css/CSSLayerBlockRule.cpp
+++ b/Source/WebCore/css/CSSLayerBlockRule.cpp
@@ -50,16 +50,13 @@ Ref<CSSLayerBlockRule> CSSLayerBlockRule::create(StyleRuleLayer& rule, CSSStyleS
 
 String CSSLayerBlockRule::cssText() const
 {
-    StringBuilder result;
+    StringBuilder builder;
 
-    result.append("@layer ");
+    builder.append("@layer");
     if (auto name = this->name(); !name.isEmpty())
-        result.append(name, " ");
-    result.append("{\n");
-    appendCSSTextForItems(result);
-    result.append('}');
-
-    return result.toString();
+        builder.append(" ", name);
+    appendCSSTextForItems(builder);
+    return builder.toString();
 }
 
 String CSSLayerBlockRule::name() const

--- a/Source/WebCore/css/CSSMediaRule.cpp
+++ b/Source/WebCore/css/CSSMediaRule.cpp
@@ -54,11 +54,10 @@ void CSSMediaRule::setMediaQueries(MQ::MediaQueryList&& queries)
 
 String CSSMediaRule::cssText() const
 {
-    StringBuilder result;
-    result.append("@media ", conditionText(), " {\n");
-    appendCSSTextForItems(result);
-    result.append('}');
-    return result.toString();
+    StringBuilder builder;
+    builder.append("@media ", conditionText());
+    appendCSSTextForItems(builder);
+    return builder.toString();
 }
 
 String CSSMediaRule::conditionText() const

--- a/Source/WebCore/css/CSSSupportsRule.cpp
+++ b/Source/WebCore/css/CSSSupportsRule.cpp
@@ -50,11 +50,10 @@ Ref<CSSSupportsRule> CSSSupportsRule::create(StyleRuleSupports& rule, CSSStyleSh
 
 String CSSSupportsRule::cssText() const
 {
-    StringBuilder result;
-    result.append("@supports ", conditionText(), " {\n");
-    appendCSSTextForItems(result);
-    result.append('}');
-    return result.toString();
+    StringBuilder builder;
+    builder.append("@supports ", conditionText());
+    appendCSSTextForItems(builder);
+    return builder.toString();
 }
 
 String CSSSupportsRule::conditionText() const

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -1132,8 +1132,7 @@ void CSSParserImpl::consumeDeclarationListOrStyleBlockHelper(CSSParserTokenRange
                 auto rule = consumeAtRule(range, RegularRules);
                 if (!rule)
                     break;
-                // FIXME: add @scope
-                if (!rule->isMediaRule() && !rule->isSupportsRule() && !rule->isLayerRule() && !rule->isContainerRule())
+                if (!rule->isGroupRule())
                     break;
                 topContext().m_parsedRules.append(*rule);
             } else {


### PR DESCRIPTION
#### f2c69208138b9fc7b202db0dba43a43696e4a22e
<pre>
Refactor cssText() to share more code between grouping at-rules
<a href="https://bugs.webkit.org/show_bug.cgi?id=251633">https://bugs.webkit.org/show_bug.cgi?id=251633</a>
rdar://104977959

Reviewed by Antti Koivisto.

This is a pure refactoring without any behavioral change.

* Source/WebCore/css/CSSContainerRule.cpp:
(WebCore::CSSContainerRule::cssText const):
* Source/WebCore/css/CSSGroupingRule.cpp:
(WebCore::CSSGroupingRule::appendCSSTextForItems const):
(WebCore::CSSGroupingRule::cssTextForDeclsAndRules const):
* Source/WebCore/css/CSSGroupingRule.h:
* Source/WebCore/css/CSSLayerBlockRule.cpp:
(WebCore::CSSLayerBlockRule::cssText const):
* Source/WebCore/css/CSSMediaRule.cpp:
(WebCore::CSSMediaRule::cssText const):
* Source/WebCore/css/CSSSupportsRule.cpp:
(WebCore::CSSSupportsRule::cssText const):
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumeDeclarationListOrStyleBlockHelper):

Canonical link: <a href="https://commits.webkit.org/259815@main">https://commits.webkit.org/259815@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bcf3886ea0094250d4de26d37edc4a9ed7756e0f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106030 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15086 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38862 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115212 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/175315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109933 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16510 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6263 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98239 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111783 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95542 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/40110 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94435 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27185 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8339 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28537 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8830 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/5092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14452 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48080 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6792 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10374 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->