### PR TITLE
Rename SubimageCacheWithTimer to CGSubimageCacheWithTimer

### DIFF
--- a/Source/WebCore/PlatformAppleWin.cmake
+++ b/Source/WebCore/PlatformAppleWin.cmake
@@ -100,6 +100,7 @@ list(APPEND WebCore_SOURCES
     platform/graphics/ca/win/WKCACFViewLayerTreeHost.cpp
     platform/graphics/ca/win/WebTiledBackingLayerWin.cpp
 
+    platform/graphics/cg/CGSubimageCacheWithTimer.cpp
     platform/graphics/cg/ColorCG.cpp
     platform/graphics/cg/ColorSpaceCG.cpp
     platform/graphics/cg/FloatPointCG.cpp
@@ -123,7 +124,6 @@ list(APPEND WebCore_SOURCES
     platform/graphics/cg/PDFDocumentImage.cpp
     platform/graphics/cg/PathCG.cpp
     platform/graphics/cg/PatternCG.cpp
-    platform/graphics/cg/SubimageCacheWithTimer.cpp
     platform/graphics/cg/TransformationMatrixCG.cpp
     platform/graphics/cg/UTIRegistry.cpp
 

--- a/Source/WebCore/PlatformMac.cmake
+++ b/Source/WebCore/PlatformMac.cmake
@@ -281,6 +281,7 @@ list(APPEND WebCore_SOURCES
     platform/graphics/ca/cocoa/WebSystemBackdropLayer.mm
     platform/graphics/ca/cocoa/WebTiledBackingLayer.mm
 
+    platform/graphics/cg/CGSubimageCacheWithTimer.cpp
     platform/graphics/cg/ColorCG.cpp
     platform/graphics/cg/ColorSpaceCG.cpp
     platform/graphics/cg/FloatPointCG.cpp
@@ -304,7 +305,6 @@ list(APPEND WebCore_SOURCES
     platform/graphics/cg/PDFDocumentImage.cpp
     platform/graphics/cg/PathCG.cpp
     platform/graphics/cg/PatternCG.cpp
-    platform/graphics/cg/SubimageCacheWithTimer.cpp
     platform/graphics/cg/TransformationMatrixCG.cpp
     platform/graphics/cg/UTIRegistry.cpp
 

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -371,6 +371,7 @@ platform/graphics/ca/cocoa/PlatformCALayerContentsDelayedReleaser.mm
 platform/graphics/ca/cocoa/WebSystemBackdropLayer.mm
 platform/graphics/ca/cocoa/WebTiledBackingLayer.mm
 platform/graphics/ca/cocoa/WebVideoContainerLayer.mm
+platform/graphics/cg/CGSubimageCacheWithTimer.cpp
 platform/graphics/cg/ColorCG.cpp
 platform/graphics/cg/ColorSpaceCG.cpp
 platform/graphics/cg/FloatPointCG.cpp
@@ -396,7 +397,6 @@ platform/graphics/cg/NativeImageCG.cpp
 platform/graphics/cg/PDFDocumentImage.cpp
 platform/graphics/cg/PathCG.cpp
 platform/graphics/cg/PatternCG.cpp
-platform/graphics/cg/SubimageCacheWithTimer.cpp
 platform/graphics/cg/TransformationMatrixCG.cpp
 platform/graphics/cg/UTIRegistry.cpp
 platform/graphics/cocoa/AudioTrackPrivateWebM.cpp

--- a/Source/WebCore/page/cocoa/MemoryReleaseCocoa.mm
+++ b/Source/WebCore/page/cocoa/MemoryReleaseCocoa.mm
@@ -26,13 +26,13 @@
 #import "config.h"
 #import "MemoryRelease.h"
 
+#import "CGSubimageCacheWithTimer.h"
 #import "FontCache.h"
 #import "GCController.h"
 #import "HTMLNameCache.h"
 #import "IOSurfacePool.h"
 #import "LayerPool.h"
 #import "LocaleCocoa.h"
-#import "SubimageCacheWithTimer.h"
 #import <notify.h>
 #import <pal/spi/ios/GraphicsServicesSPI.h>
 
@@ -65,7 +65,7 @@ void platformReleaseMemory(Critical)
     IOSurfacePool::sharedPool().discardAllSurfaces();
 
 #if CACHE_SUBIMAGES
-    SubimageCacheWithTimer::clear();
+    CGSubimageCacheWithTimer::clear();
 #endif
 }
 
@@ -74,7 +74,7 @@ void platformReleaseGraphicsMemory(Critical)
     IOSurfacePool::sharedPool().discardAllSurfaces();
 
 #if CACHE_SUBIMAGES
-    SubimageCacheWithTimer::clear();
+    CGSubimageCacheWithTimer::clear();
 #endif
 }
 

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -30,6 +30,7 @@
 #if USE(CG)
 
 #include "AffineTransform.h"
+#include "CGSubimageCacheWithTimer.h"
 #include "DisplayListRecorder.h"
 #include "FloatConversion.h"
 #include "Gradient.h"
@@ -40,7 +41,6 @@
 #include "Path.h"
 #include "Pattern.h"
 #include "ShadowBlur.h"
-#include "SubimageCacheWithTimer.h"
 #include "Timer.h"
 #include <pal/spi/cg/CoreGraphicsSPI.h>
 #include <wtf/MathExtras.h>
@@ -270,7 +270,7 @@ void GraphicsContextCG::drawNativeImage(NativeImage& nativeImage, const FloatSiz
         }
 
 #if CACHE_SUBIMAGES
-        return SubimageCacheWithTimer::getSubimage(image, physicalSubimageRect);
+        return CGSubimageCacheWithTimer::getSubimage(image, physicalSubimageRect);
 #else
         return adoptCF(CGImageCreateWithImageInRect(image, physicalSubimageRect));
 #endif

--- a/Source/WebCore/platform/graphics/cg/NativeImageCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/NativeImageCG.cpp
@@ -28,8 +28,8 @@
 
 #if USE(CG)
 
+#include "CGSubimageCacheWithTimer.h"
 #include "GraphicsContextCG.h"
-#include "SubimageCacheWithTimer.h"
 
 namespace WebCore {
 
@@ -72,7 +72,7 @@ DestinationColorSpace NativeImage::colorSpace() const
 void NativeImage::clearSubimages()
 {
 #if CACHE_SUBIMAGES
-    SubimageCacheWithTimer::clearImage(m_platformImage.get());
+    CGSubimageCacheWithTimer::clearImage(m_platformImage.get());
 #endif
 }
 


### PR DESCRIPTION
#### dcd501fb2a549c0ef50a22553f4463289268c2c0
<pre>
Rename SubimageCacheWithTimer to CGSubimageCacheWithTimer
<a href="https://bugs.webkit.org/show_bug.cgi?id=251641">https://bugs.webkit.org/show_bug.cgi?id=251641</a>
rdar://104980275

Reviewed by Simon Fraser.

Since SubimageCacheWithTimer caches sub images of a CGImage only, rename it
CGSubimageCacheWithTimer. Then we can use CachedSubimage for caching a sub image
of an Image.

* Source/WebCore/PlatformAppleWin.cmake:
* Source/WebCore/PlatformMac.cmake:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/page/cocoa/MemoryReleaseCocoa.mm:
(WebCore::platformReleaseMemory):
(WebCore::platformReleaseGraphicsMemory):
* Source/WebCore/platform/graphics/cg/CGSubimageCacheWithTimer.cpp: Renamed from Source/WebCore/platform/graphics/cg/SubimageCacheWithTimer.cpp.
(WebCore::CGSubimageCacheWithTimer::getSubimage):
(WebCore::CGSubimageCacheWithTimer::clearImage):
(WebCore::CGSubimageCacheWithTimer::clear):
(WebCore::CGSubimageRequest::CGSubimageRequest):
(WebCore::CGSubimageCacheAdder::hash):
(WebCore::CGSubimageCacheAdder::equal):
(WebCore::CGSubimageCacheAdder::translate):
(WebCore::CGSubimageCacheWithTimer::CGSubimageCacheWithTimer):
(WebCore::CGSubimageCacheWithTimer::pruneCacheTimerFired):
(WebCore::CGSubimageCacheWithTimer::prune):
(WebCore::CGSubimageCacheWithTimer::subimage):
(WebCore::CGSubimageCacheWithTimer::clearImageAndSubimages):
(WebCore::CGSubimageCacheWithTimer::clearAll):
(WebCore::CGSubimageCacheWithTimer::subimageCache):
(WebCore::CGSubimageCacheWithTimer::subimageCacheExists):
* Source/WebCore/platform/graphics/cg/CGSubimageCacheWithTimer.h: Renamed from Source/WebCore/platform/graphics/cg/SubimageCacheWithTimer.h.
(WebCore::CGSubimageCacheWithTimer::CacheEntryTraits::isEmptyValue):
(WebCore::CGSubimageCacheWithTimer::CacheEntryTraits::constructDeletedValue):
(WebCore::CGSubimageCacheWithTimer::CacheEntryTraits::isDeletedValue):
(WebCore::CGSubimageCacheWithTimer::CacheHash::hash):
(WebCore::CGSubimageCacheWithTimer::CacheHash::equal):
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::drawNativeImage):
* Source/WebCore/platform/graphics/cg/NativeImageCG.cpp:
(WebCore::NativeImage::clearSubimages):

Canonical link: <a href="https://commits.webkit.org/259817@main">https://commits.webkit.org/259817@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/efdfc7920d9bf01bb391838f837a124da0dcb6c4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105989 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15047 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38824 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115172 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175283 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109893 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16471 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6232 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98201 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114913 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111742 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12540 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95512 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40080 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94405 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27155 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8303 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28507 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8791 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5070 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14417 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48050 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6794 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10337 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->