### PR TITLE
Preallocate quota for FileSystemSyncAccessHandle

### DIFF
--- a/LayoutTests/storage/filesystemaccess/resources/sync-access-handle-storage-limit.js
+++ b/LayoutTests/storage/filesystemaccess/resources/sync-access-handle-storage-limit.js
@@ -5,9 +5,7 @@ if (this.importScripts) {
 
 description("This test checks FileSystemSyncAccessHandle returns error when limit is reached");
 
-const quota = 400 * 1024; // Default quota for an origin in TestRunner.
-var accessHandle, fileHandle;
-
+var accessHandle, fileHandle, quota;
 async function test() 
 {
     try {
@@ -27,4 +25,8 @@ async function test()
     }
 }
 
-test();
+addEventListener('message', (event) => {
+    quota = event.data;
+    debug("quota is set to " + quota);
+    test();
+});

--- a/LayoutTests/storage/filesystemaccess/sync-access-handle-storage-limit-worker-expected.txt
+++ b/LayoutTests/storage/filesystemaccess/sync-access-handle-storage-limit-worker-expected.txt
@@ -4,6 +4,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 Starting worker: resources/sync-access-handle-storage-limit.js
+[Worker] quota is set to 1048576
 PASS [Worker] accessHandle.write(new Uint8Array(quota - 1).buffer) did not throw exception.
 PASS [Worker] accessHandle.write(new Uint8Array(2).buffer) threw exception QuotaExceededError: The quota has been exceeded..
 PASS successfullyParsed is true

--- a/LayoutTests/storage/filesystemaccess/sync-access-handle-storage-limit-worker.html
+++ b/LayoutTests/storage/filesystemaccess/sync-access-handle-storage-limit-worker.html
@@ -4,8 +4,15 @@
 </head>
 <body>
 <script>
-if (window.testRunner)
+// FileSystemSyncAccessHandle requires to hold at least 1 MB space.
+const quota = 1024 * 1024;
+if (window.testRunner) {
+    testRunner.setQuota(quota);
     testRunner.setAllowStorageQuotaIncrease(false);
-worker = startWorker('resources/sync-access-handle-storage-limit.js');</script>
+}
+const worker = startWorker('resources/sync-access-handle-storage-limit.js');
+// worker.postMessage({ name:"quota", quota:quota });
+worker.postMessage(quota);
+</script>
 </body>
 </html>

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -74,6 +74,7 @@ interface TestRunner {
     boolean hasDOMCache(DOMString origin);
     unsigned long domCacheSize(DOMString origin);
     undefined setAllowStorageQuotaIncrease(boolean value);
+    undefined setQuota(unsigned long long quota);
 
     // Special options.
     undefined keepWebHistory();

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -2024,6 +2024,11 @@ void TestRunner::setAllowStorageQuotaIncrease(bool willIncrease)
     postSynchronousPageMessage("SetAllowStorageQuotaIncrease", willIncrease);
 }
 
+void TestRunner::setQuota(uint64_t quota)
+{
+    postSynchronousMessage("SetQuota", quota);
+}
+
 void TestRunner::getApplicationManifestThen(JSValueRef callback)
 {
     cacheTestRunnerCallback(GetApplicationManifestCallbackID, callback);

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -160,6 +160,7 @@ public:
     bool hasDOMCache(JSStringRef origin);
     uint64_t domCacheSize(JSStringRef origin);
     void setAllowStorageQuotaIncrease(bool);
+    void setQuota(uint64_t);
 
     // Failed load condition testing
     void forceImmediateCompletion();

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1196,6 +1196,8 @@ bool TestController::resetStateToConsistentValues(const TestOptions& options, Re
     m_shouldLogCanAuthenticateAgainstProtectionSpace = false;
 
     setHidden(false);
+    setAllowStorageQuotaIncrease(true);
+    setQuota(40 * KB);
 
     if (!platformResetStateToConsistentValues(options))
         return false;
@@ -3386,6 +3388,11 @@ uint64_t TestController::domCacheSize(WKStringRef origin)
 
 #if !PLATFORM(COCOA)
 void TestController::setAllowStorageQuotaIncrease(bool)
+{
+    // FIXME: To implement.
+}
+
+void TestController::setQuota(uint64_t)
 {
     // FIXME: To implement.
 }

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -317,6 +317,7 @@ public:
     uint64_t domCacheSize(WKStringRef origin);
 
     void setAllowStorageQuotaIncrease(bool);
+    void setQuota(uint64_t);
 
     bool didReceiveServerRedirectForProvisionalNavigation() const { return m_didReceiveServerRedirectForProvisionalNavigation; }
     void clearDidReceiveServerRedirectForProvisionalNavigation() { m_didReceiveServerRedirectForProvisionalNavigation = false; }

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -1331,6 +1331,11 @@ WKRetainPtr<WKTypeRef> TestInvocation::didReceiveSynchronousMessageFromInjectedB
         TestController::singleton().setAllowStorageQuotaIncrease(booleanValue(messageBody));
         return nullptr;
     }
+    
+    if (WKStringIsEqualToUTF8CString(messageName, "SetQuota")) {
+        TestController::singleton().setQuota(uint64Value(messageBody));
+        return nullptr;
+    }
 
     if (WKStringIsEqualToUTF8CString(messageName, "InjectUserScript")) {
         TestController::singleton().injectUserScript(stringValue(messageBody));

--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -326,8 +326,6 @@ void TestController::cocoaResetStateToConsistentValues(const TestOptions& option
         [platformView.configuration.preferences setTextInteractionEnabled:options.textInteractionEnabled()];
     }
 
-    [globalWebsiteDataStoreDelegateClient() setAllowRaisingQuota:YES];
-
     WebCoreTestSupport::setAdditionalSupportedImageTypesForTesting(String::fromLatin1(options.additionalSupportedImageTypes().c_str()));
 }
 
@@ -516,6 +514,11 @@ bool TestController::keyExistsInKeychain(const String& attrLabel, const String& 
 void TestController::setAllowStorageQuotaIncrease(bool value)
 {
     [globalWebsiteDataStoreDelegateClient() setAllowRaisingQuota: value];
+}
+
+void TestController::setQuota(uint64_t quota)
+{
+    [globalWebsiteDataStoreDelegateClient() setQuota:quota];
 }
 
 void TestController::setAllowsAnySSLCertificate(bool allows)

--- a/Tools/WebKitTestRunner/cocoa/TestWebsiteDataStoreDelegate.h
+++ b/Tools/WebKitTestRunner/cocoa/TestWebsiteDataStoreDelegate.h
@@ -29,8 +29,10 @@
 @private
     BOOL _shouldAllowRaisingQuota;
     BOOL _shouldAllowAnySSLCertificate;
+    NSUInteger _quota;
 }
 - (instancetype)init;
 - (void)setAllowRaisingQuota:(BOOL)shouldAllowRaisingQuota;
+- (void)setQuota:(NSUInteger)quota;
 - (void)setAllowAnySSLCertificate:(BOOL)shouldAllowAnySSLCertificate;
 @end

--- a/Tools/WebKitTestRunner/cocoa/TestWebsiteDataStoreDelegate.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestWebsiteDataStoreDelegate.mm
@@ -36,17 +36,28 @@
 - (instancetype)init
 {
     _shouldAllowRaisingQuota = false;
+    _quota = 40 * KB;
     return self;
 }
 
-- (void)requestStorageSpace:(NSURL *)mainFrameURL frameOrigin:(NSURL *)frameURL quota:(NSUInteger)quota currentSize:(NSUInteger)currentSize spaceRequired:(NSUInteger)spaceRequired decisionHandler:(void (^)(unsigned long long))decisionHandler
+- (void)requestStorageSpace:(NSURL *)mainFrameURL frameOrigin:(NSURL *)frameURL quota:(NSUInteger)currentQuota currentSize:(NSUInteger)currentSize spaceRequired:(NSUInteger)spaceRequired decisionHandler:(void (^)(unsigned long long))decisionHandler
 {
-    decisionHandler(_shouldAllowRaisingQuota ? quota + currentSize + spaceRequired : quota);
+    auto totalSpaceRequired = currentSize + spaceRequired;
+    if (_shouldAllowRaisingQuota || totalSpaceRequired <= _quota)
+        return decisionHandler(totalSpaceRequired);
+
+    // Deny request by not changing quota.
+    decisionHandler(currentQuota);
 }
 
 - (void)setAllowRaisingQuota:(BOOL)shouldAllowRaisingQuota
 {
     _shouldAllowRaisingQuota = shouldAllowRaisingQuota;
+}
+
+- (void)setQuota:(NSUInteger)quota
+{
+    _quota = quota;
 }
 
 - (void)didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition disposition, NSURLCredential * _Nullable credential))completionHandler


### PR DESCRIPTION
#### 459a045d57da232e5149f017fb41038df2a58545
<pre>
Preallocate quota for FileSystemSyncAccessHandle
<a href="https://bugs.webkit.org/show_bug.cgi?id=251642">https://bugs.webkit.org/show_bug.cgi?id=251642</a>
rdar://104980443

Reviewed by Youenn Fablet.

QuotaManager is in network process, and FileSystemSyncAcessHandle performs file operation in web process, so web process
needs to message network process when it needs to use more space. However, FileSystemSyncAccessHandle::write is sync and
supposed to be performant, which means we should unblock them if possible. This patch makes QuotaManager allocate more
capacity to FileSystemSyncAccessHandle than it requests, so that FileSystemSyncAccessHandle would not need to send a
message on each write).

The current allocation policy for requested capacity x is:
1. If x &lt;= 1MB, new capacity is 1MB.
2. If 1MB &lt; x &lt; 256MB, new capacity is 2^(log2(x) + 1).
3. If x &gt;= 256MB, new capacity is (x / 128MB + 1) * 128MB.

With this change, FileSystemSyncAcessHandle tests will start to fail if we disallow quota to increase (e.g. disallow it
to check if quota error can be thrown), because TestRunner sets origin quota to be 40KB by default, and each
FileSystemSyncAcessHandle requests at least 1MB. To fix this, this patch adds a new setQuota() function on TestRunner to
allow configuring quota for each test.

* LayoutTests/storage/filesystemaccess/resources/sync-access-handle-storage-limit.js:
* LayoutTests/storage/filesystemaccess/sync-access-handle-storage-limit-worker-expected.txt:
* LayoutTests/storage/filesystemaccess/sync-access-handle-storage-limit-worker.html:
* Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp:
(WebKit::FileSystemStorageHandle::requestNewCapacityForSyncAccessHandle):
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::setQuota):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::resetStateToConsistentValues):
(WTR::TestController::setQuota):
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveSynchronousMessageFromInjectedBundle):
* Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm:
(WTR::TestController::cocoaResetStateToConsistentValues):
(WTR::TestController::setQuota):
* Tools/WebKitTestRunner/cocoa/TestWebsiteDataStoreDelegate.h:
* Tools/WebKitTestRunner/cocoa/TestWebsiteDataStoreDelegate.mm:
(-[TestWebsiteDataStoreDelegate init]):
(-[TestWebsiteDataStoreDelegate requestStorageSpace:frameOrigin:quota:currentSize:spaceRequired:decisionHandler:]):
(-[TestWebsiteDataStoreDelegate setQuota:]):

Canonical link: <a href="https://commits.webkit.org/259946@main">https://commits.webkit.org/259946@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/589174e9f68563e5c783b7f38c154f9b4e16ad64

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106393 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15433 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39220 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115584 "Built successfully") | [💥 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175686 "An unexpected error occured. Recent messages:Pull request contains relevant changes; Failed to print configuration") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110302 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16916 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6654 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98662 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115254 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112159 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12846 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95829 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/40462 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94721 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27472 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8662 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28824 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9189 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5396 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14814 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48370 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6872 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10741 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->