### PR TITLE
Allow WKWebpagePreferences to pass a list of content rule list identifiers to be disabled

### DIFF
--- a/Source/WebCore/contentextensions/ContentExtensionsBackend.h
+++ b/Source/WebCore/contentextensions/ContentExtensionsBackend.h
@@ -67,10 +67,13 @@ public:
         bool sawIgnorePreviousRules { false };
         Vector<DeserializedAction> actions;
     };
-    WEBCORE_EXPORT Vector<ActionsFromContentRuleList> actionsForResourceLoad(const ResourceLoadInfo&) const;
+
+    enum class ShouldSkipRuleList : bool { No, Yes };
+    using RuleListFilter = Function<ShouldSkipRuleList(const String&)>;
+    WEBCORE_EXPORT Vector<ActionsFromContentRuleList> actionsForResourceLoad(const ResourceLoadInfo&, const RuleListFilter& = { [](const String&) { return ShouldSkipRuleList::No; } }) const;
     WEBCORE_EXPORT StyleSheetContents* globalDisplayNoneStyleSheet(const String& identifier) const;
 
-    ContentRuleListResults processContentRuleListsForLoad(Page&, const URL&, OptionSet<ResourceType>, DocumentLoader& initiatingDocumentLoader, const URL& redirectFrom);
+    ContentRuleListResults processContentRuleListsForLoad(Page&, const URL&, OptionSet<ResourceType>, DocumentLoader& initiatingDocumentLoader, const URL& redirectFrom, const RuleListFilter&);
     WEBCORE_EXPORT ContentRuleListResults processContentRuleListsForPingLoad(const URL&, const URL& mainDocumentURL, const URL& frameURL);
 
     static const String& displayNoneCSSRule();

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -158,6 +158,9 @@ enum class ColorSchemePreference : uint8_t {
     Dark
 };
 
+enum class DisabledContentExtensionsMode : bool { None, All };
+using DisabledContentExtensions = std::variant<DisabledContentExtensionsMode, HashSet<String>>;
+
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(DocumentLoader);
 class DocumentLoader
     : public RefCounted<DocumentLoader>
@@ -313,8 +316,8 @@ public:
     void stopLoadingSubresources();
     WEBCORE_EXPORT void stopLoadingAfterXFrameOptionsOrContentSecurityPolicyDenied(ResourceLoaderIdentifier, const ResourceResponse&);
 
-    bool userContentExtensionsEnabled() const { return m_userContentExtensionsEnabled; }
-    void setUserContentExtensionsEnabled(bool enabled) { m_userContentExtensionsEnabled = enabled; }
+    const DisabledContentExtensions& disabledContentExtensions() const { return m_disabledContentExtensions; }
+    void setDisabledContentExtensions(DisabledContentExtensions&& disabledExtensions) { m_disabledContentExtensions = WTFMove(disabledExtensions); }
 
     bool allowsActiveContentRuleListActionsForURL(const String& contentRuleListIdentifier, const URL&) const;
     WEBCORE_EXPORT void setActiveContentRuleListActionPatterns(const HashMap<String, Vector<String>>&);
@@ -675,6 +678,7 @@ private:
     String m_customUserAgentAsSiteSpecificQuirks;
     String m_customNavigatorPlatform;
     MemoryCompactRobinHoodHashMap<String, Vector<UserContentURLPattern>> m_activeContentRuleListActionPatterns;
+    DisabledContentExtensions m_disabledContentExtensions { DisabledContentExtensionsMode::None };
 
     ScriptExecutionContextIdentifier m_resultingClientId;
 
@@ -701,7 +705,6 @@ private:
 
     bool m_allowContentChangeObserverQuirk { false };
     bool m_idempotentModeAutosizingOnlyHonorsPercentages { false };
-    bool m_userContentExtensionsEnabled { true };
 
     bool m_isRequestFromClientOrUserInput { false };
     bool m_lastNavigationWasAppInitiated { true };

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1814,7 +1814,7 @@ void FrameLoader::reload(OptionSet<ReloadOption> options)
     loader->setIsRequestFromClientOrUserInput(m_documentLoader->isRequestFromClientOrUserInput());
     applyShouldOpenExternalURLsPolicyToNewDocumentLoader(m_frame, loader, InitiatedByMainFrame::Unknown, m_documentLoader->shouldOpenExternalURLsPolicyToPropagate());
 
-    loader->setUserContentExtensionsEnabled(!options.contains(ReloadOption::DisableContentBlockers));
+    loader->setDisabledContentExtensions({ options.contains(ReloadOption::DisableContentBlockers) ? DisabledContentExtensionsMode::All : DisabledContentExtensionsMode::None });
     
     ResourceRequest& request = loader->request();
 

--- a/Source/WebKit/Shared/WebsitePoliciesData.h
+++ b/Source/WebKit/Shared/WebsitePoliciesData.h
@@ -53,7 +53,7 @@ namespace WebKit {
 struct WebsitePoliciesData {
     static void applyToDocumentLoader(WebsitePoliciesData&&, WebCore::DocumentLoader&);
 
-    bool contentBlockersEnabled { true };
+    WebCore::DisabledContentExtensions disabledContentExtensions;
     HashMap<WTF::String, Vector<WTF::String>> activeContentRuleListActionPatterns;
     OptionSet<WebsiteAutoplayQuirk> allowedAutoplayQuirks;
     WebsiteAutoplayPolicy autoplayPolicy { WebsiteAutoplayPolicy::Default };

--- a/Source/WebKit/UIProcess/API/APIWebsitePolicies.h
+++ b/Source/WebKit/UIProcess/API/APIWebsitePolicies.h
@@ -61,9 +61,12 @@ public:
 
     WebKit::WebsitePoliciesData data();
 
-    bool contentBlockersEnabled() const { return m_contentBlockersEnabled; }
-    void setContentBlockersEnabled(bool enabled) { m_contentBlockersEnabled = enabled; }
-    
+    bool contentBlockersEnabled() const;
+    void setContentBlockersEnabled(bool);
+
+    void setDisabledContentRuleListIdentifiers(HashSet<WTF::String>&&);
+    HashSet<WTF::String> disabledContentRuleListIdentifiers() const;
+
     void setActiveContentRuleListActionPatterns(HashMap<WTF::String, Vector<WTF::String>>&& patterns) { m_activeContentRuleListActionPatterns = WTFMove(patterns); }
     const HashMap<WTF::String, Vector<WTF::String>>& activeContentRuleListActionPatterns() const { return m_activeContentRuleListActionPatterns; }
     
@@ -150,7 +153,7 @@ public:
 
 private:
     // FIXME: replace most or all of these members with a WebsitePoliciesData.
-    bool m_contentBlockersEnabled { true };
+    WebCore::DisabledContentExtensions m_disabledContentExtensions { WebCore::DisabledContentExtensionsMode::None };
     HashMap<WTF::String, Vector<WTF::String>> m_activeContentRuleListActionPatterns;
     OptionSet<WebKit::WebsiteAutoplayQuirk> m_allowedAutoplayQuirks;
     WebKit::WebsiteAutoplayPolicy m_autoplayPolicy { WebKit::WebsiteAutoplayPolicy::Default };

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
@@ -202,6 +202,26 @@ private:
     return _websitePolicies->contentBlockersEnabled();
 }
 
+- (void)_setDisabledContentRuleListIdentifiers:(NSSet<NSString *> *)identifiers
+{
+    _websitePolicies->setDisabledContentRuleListIdentifiers([&] {
+        HashSet<String> result;
+        result.reserveInitialCapacity(identifiers.count);
+        for (NSString *identifier in identifiers)
+            result.add(identifier);
+        return result;
+    }());
+}
+
+- (NSSet<NSString *> *)_disabledContentRuleListIdentifiers
+{
+    auto identifiers = _websitePolicies->disabledContentRuleListIdentifiers();
+    auto result = adoptNS([[NSMutableSet alloc] initWithCapacity:identifiers.size()]);
+    for (auto& identifier : identifiers)
+        [result addObject:identifier];
+    return result.get();
+}
+
 - (void)_setActiveContentRuleListActionPatterns:(NSDictionary<NSString *, NSSet<NSString *> *> *)patterns
 {
     __block HashMap<String, Vector<String>> map;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h
@@ -93,6 +93,7 @@ typedef NS_OPTIONS(NSUInteger, _WKWebsiteNetworkConnectionIntegrityPolicy) {
 @interface WKWebpagePreferences (WKPrivate)
 
 @property (nonatomic, setter=_setContentBlockersEnabled:) BOOL _contentBlockersEnabled;
+@property (nonatomic, copy, setter=_setDisabledContentRuleListIdentifiers:) NSSet<NSString *> *_disabledContentRuleListIdentifiers WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 @property (nonatomic, copy, setter=_setActiveContentRuleListActionPatterns:) NSDictionary<NSString *, NSSet<NSString *> *> *_activeContentRuleListActionPatterns WK_API_AVAILABLE(macos(13.0), ios(16.0));
 @property (nonatomic, setter=_setAllowedAutoplayQuirks:) _WKWebsiteAutoplayQuirk _allowedAutoplayQuirks;
 @property (nonatomic, setter=_setAutoplayPolicy:) _WKWebsiteAutoplayPolicy _autoplayPolicy;

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1229,6 +1229,7 @@
 		F4F405BC1D4C0D1C007A9707 /* full-size-autoplaying-video-with-audio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4F405BA1D4C0CF8007A9707 /* full-size-autoplaying-video-with-audio.html */; };
 		F4F405BD1D4C0D1C007A9707 /* skinny-autoplaying-video-with-audio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4F405BB1D4C0CF8007A9707 /* skinny-autoplaying-video-with-audio.html */; };
 		F4F5BB5221667BAA002D06B9 /* TestFontOptions.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4F5BB5121667BAA002D06B9 /* TestFontOptions.mm */; };
+		F4F9AD1C298C73DD00F92EDF /* load-image.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4F9AD13298C715D00F92EDF /* load-image.html */; };
 		F4FA2A4F24D1F05700618A46 /* AttributedSubstringForProposedRange.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4FA2A4E24D1F05700618A46 /* AttributedSubstringForProposedRange.mm */; };
 		F4FA91811E61849B007B8C1D /* WKWebViewMacEditingTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4FA917F1E61849B007B8C1D /* WKWebViewMacEditingTests.mm */; };
 		F4FA91831E61857B007B8C1D /* double-click-does-not-select-trailing-space.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4FA91821E618566007B8C1D /* double-click-does-not-select-trailing-space.html */; };
@@ -1697,6 +1698,7 @@
 				A11E7DA024A169F900026745 /* link-with-hover-menu.html in Copy Resources */,
 				3128A81323763FAC00D90D40 /* link-with-image.html in Copy Resources */,
 				378E64791632707400B6C676 /* link-with-title.html in Copy Resources */,
+				F4F9AD1C298C73DD00F92EDF /* load-image.html in Copy Resources */,
 				573255A622139BC700396AE8 /* load-web-archive-1.html in Copy Resources */,
 				573255A722139BC700396AE8 /* load-web-archive-2.html in Copy Resources */,
 				57901FB11CAF142D00ED64F9 /* LoadInvalidURLRequest.html in Copy Resources */,
@@ -3511,6 +3513,7 @@
 		F4F405BB1D4C0CF8007A9707 /* skinny-autoplaying-video-with-audio.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "skinny-autoplaying-video-with-audio.html"; sourceTree = "<group>"; };
 		F4F5BB5021667BAA002D06B9 /* TestFontOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestFontOptions.h; sourceTree = "<group>"; };
 		F4F5BB5121667BAA002D06B9 /* TestFontOptions.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TestFontOptions.mm; sourceTree = "<group>"; };
+		F4F9AD13298C715D00F92EDF /* load-image.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "load-image.html"; sourceTree = "<group>"; };
 		F4FA282924CD012700618A46 /* FormValidation.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FormValidation.mm; sourceTree = "<group>"; };
 		F4FA2A4E24D1F05700618A46 /* AttributedSubstringForProposedRange.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AttributedSubstringForProposedRange.mm; sourceTree = "<group>"; };
 		F4FA917F1E61849B007B8C1D /* WKWebViewMacEditingTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebViewMacEditingTests.mm; sourceTree = "<group>"; };
@@ -4692,6 +4695,7 @@
 				F41AB99D1EF4692C0083FA08 /* link-and-target-div.html */,
 				F46128D1211E2D2500D9FADB /* link-in-iframe-and-input.html */,
 				3128A81223763F0B00D90D40 /* link-with-image.html */,
+				F4F9AD13298C715D00F92EDF /* load-image.html */,
 				CA7787FE228CEFC700E50463 /* local-storage-process-crashes.html */,
 				9368A25D229EFB3A00A829CA /* local-storage-process-suspends-1.html */,
 				9368A25C229EFB3A00A829CA /* local-storage-process-suspends-2.html */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/load-image.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/load-image.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+function canLoadImage(url) {
+    return new Promise(resolve => {
+        let element = document.createElement("img");
+        let complete = event => {
+            element.remove();
+            resolve(event.type !== "error");
+        };
+        element.addEventListener("load", complete);
+        element.addEventListener("error", complete);
+        element.setAttribute("src", url);
+        document.body.appendChild(element);
+    });
+};
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### d8024c41f86ab3fcdc746444cfd671d2699e4893
<pre>
Allow WKWebpagePreferences to pass a list of content rule list identifiers to be disabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=251645">https://bugs.webkit.org/show_bug.cgi?id=251645</a>
rdar://104453682

Reviewed by Alex Christensen.

Add a new property to provide a fine-grained way to disable `WKContentRuleList`s by identifier, in
the case when content blockers are not disabled using the extant SPI `-_contentBlockersEnabled`. See
below for more details.

Test: WebpagePreferences.DisableContentRuleListsByIdentifier

* Source/WebCore/contentextensions/ContentExtensionsBackend.cpp:
(WebCore::ContentExtensions::ContentExtensionsBackend::actionsForResourceLoad const):

Add an argument to take a filter function that can be used to skip processing content rule lists
given the rule list identifier; use this to skip content rule lists that are explicitly disabled via
the new SPI.

(WebCore::ContentExtensions::ContentExtensionsBackend::processContentRuleListsForLoad):
* Source/WebCore/contentextensions/ContentExtensionsBackend.h:
(WebCore::ContentExtensions::ContentExtensionsBackend::actionsForResourceLoad):
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::setDisabledContentExtensions):
(WebCore::DocumentLoader::disabledContentExtensions const):

Add a getter and setter for the new variant that determines whether (and which) content rule lists
we should disable.

* Source/WebCore/loader/DocumentLoader.h:
(WebCore::DocumentLoader::userContentExtensionsEnabled const): Deleted.
(WebCore::DocumentLoader::setUserContentExtensionsEnabled): Deleted.

Merge the existing bit for `m_userContentExtensionsEnabled` and the new set of disabled content
rule list identifiers into a single `std::variant`, which contains one of the two following
alternatives:

1. An enum flag indicating that content rule lists should be enabled or disabled globally.
2. A `HashSet` of content rule list identifiers to disable.

We also add a typedef, `DisabledContentExtensions`, to more cleanly encapsulate this data structure.

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::reload):
* Source/WebCore/page/UserContentProvider.cpp:
(WebCore::ruleListFilter):
(WebCore::UserContentProvider::processContentRuleListsForLoad):
* Source/WebKit/Shared/WebsitePoliciesData.cpp:
(WebKit::WebsitePoliciesData::encode const):
(WebKit::WebsitePoliciesData::decode):
(WebKit::WebsitePoliciesData::applyToDocumentLoader):

Change the state here to also match that of `DocumentLoader`, by replacing the current boolean
`m_contentBlockersEnabled` flag with `DisabledContentExtensions` state instead, which determines
whether or not we want to globally enable, globally disable or selectively disable content
extensions for this navigation.

* Source/WebKit/Shared/WebsitePoliciesData.h:
* Source/WebKit/UIProcess/API/APIWebsitePolicies.cpp:
(API::WebsitePolicies::copy const):
(API::WebsitePolicies::contentBlockersEnabled const):
(API::WebsitePolicies::setContentBlockersEnabled):

Set `DisabledContentExtensions` to either `DisabledContentExtensionsMode::None` or
`DisabledContentExtensionsMode::All`.

(API::WebsitePolicies::setDisabledContentRuleListIdentifiers):

Set `DisabledContentExtensions` to the given set of rule list identifiers.

(API::WebsitePolicies::disabledContentRuleListIdentifiers const):
(API::WebsitePolicies::data):
* Source/WebKit/UIProcess/API/APIWebsitePolicies.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm:
(-[WKWebpagePreferences _setDisabledContentRuleListIdentifiers:]):
(-[WKWebpagePreferences _disabledContentRuleListIdentifiers]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/load-image.html: Added.

Add an API test to exercise this new SPI.

Canonical link: <a href="https://commits.webkit.org/259930@main">https://commits.webkit.org/259930@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25669c00f3a67cb99f0e4f6496fdfa06b877d150

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106442 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/15468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39260 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115629 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/175731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110349 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16957 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6693 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98642 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/115295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112208 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95852 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/40433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94752 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27496 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8700 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28848 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9232 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/5422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14854 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48394 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6862 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10781 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->