### PR TITLE
[WebGPU] Address review comments from 259778@main

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUCompositorIntegration.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUCompositorIntegration.cpp
@@ -35,9 +35,9 @@ Vector<MachSendRight> GPUCompositorIntegration::recreateRenderBuffers(int width,
 }
 #endif
 
-void GPUCompositorIntegration::prepareForDisplay()
+void GPUCompositorIntegration::prepareForDisplay(CompletionHandler<void()>&& completionHandler)
 {
-    m_backing->prepareForDisplay();
+    m_backing->prepareForDisplay(WTFMove(completionHandler));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/WebGPU/GPUCompositorIntegration.h
+++ b/Source/WebCore/Modules/WebGPU/GPUCompositorIntegration.h
@@ -45,7 +45,7 @@ public:
     Vector<MachSendRight> recreateRenderBuffers(int width, int height) const;
 #endif
 
-    void prepareForDisplay();
+    void prepareForDisplay(CompletionHandler<void()>&&);
 
     PAL::WebGPU::CompositorIntegration& backing() { return m_backing; }
     const PAL::WebGPU::CompositorIntegration& backing() const { return m_backing; }

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUCompositorIntegrationImpl.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUCompositorIntegrationImpl.cpp
@@ -42,11 +42,12 @@ CompositorIntegrationImpl::CompositorIntegrationImpl(ConvertToBackingContext& co
 
 CompositorIntegrationImpl::~CompositorIntegrationImpl() = default;
 
-void CompositorIntegrationImpl::prepareForDisplay()
+void CompositorIntegrationImpl::prepareForDisplay(CompletionHandler<void()>&& completionHandler)
 {
-    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=250993 Wait for the results to be fully drawn
-
     static_cast<PresentationContext*>(m_presentationContext.get())->present();
+
+    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=250993 Wait for the results to be fully drawn
+    completionHandler();
 }
 
 #if PLATFORM(COCOA)

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUCompositorIntegrationImpl.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUCompositorIntegrationImpl.h
@@ -76,7 +76,7 @@ private:
     CompositorIntegrationImpl& operator=(const CompositorIntegrationImpl&) = delete;
     CompositorIntegrationImpl& operator=(CompositorIntegrationImpl&&) = delete;
 
-    void prepareForDisplay() override;
+    void prepareForDisplay(CompletionHandler<void()>&&) override;
 
 #if PLATFORM(COCOA)
     Vector<MachSendRight> recreateRenderBuffers(int width, int height) override;

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUCompositorIntegration.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUCompositorIntegration.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <optional>
+#include <wtf/CompletionHandler.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
 #include <wtf/text/WTFString.h>
@@ -45,7 +46,7 @@ public:
     virtual Vector<MachSendRight> recreateRenderBuffers(int width, int height) = 0;
 #endif
 
-    virtual void prepareForDisplay() = 0;
+    virtual void prepareForDisplay(CompletionHandler<void()>&&) = 0;
 
 protected:
     CompositorIntegration() = default;

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.cpp
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.cpp
@@ -210,12 +210,12 @@ void GPUCanvasContextCocoa::prepareForDisplay()
 
     ASSERT(m_configuration->frameCount < m_configuration->renderBuffers.size());
 
-    m_compositorIntegration->prepareForDisplay();
-
-    m_layerContentsDisplayDelegate->setDisplayBuffer(m_configuration->renderBuffers[m_configuration->frameCount]);
-    m_compositingResultsNeedsUpdating = false;
-    m_configuration->frameCount = (m_configuration->frameCount + 1) % m_configuration->renderBuffers.size();
-    m_currentTexture = nullptr;
+    m_compositorIntegration->prepareForDisplay([&] {
+        m_layerContentsDisplayDelegate->setDisplayBuffer(m_configuration->renderBuffers[m_configuration->frameCount]);
+        m_compositingResultsNeedsUpdating = false;
+        m_configuration->frameCount = (m_configuration->frameCount + 1) % m_configuration->renderBuffers.size();
+        m_currentTexture = nullptr;
+    });
 }
 
 void GPUCanvasContextCocoa::markContextChangedAndNotifyCanvasObservers()

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.cpp
@@ -60,8 +60,9 @@ void RemoteCompositorIntegration::recreateRenderBuffers(int width, int height, C
 
 void RemoteCompositorIntegration::prepareForDisplay(CompletionHandler<void(bool)>&& completionHandler)
 {
-    m_backing->prepareForDisplay();
-    completionHandler(true);
+    m_backing->prepareForDisplay([completionHandler = WTFMove(completionHandler)]() mutable {
+        completionHandler(true);
+    });
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.messages.in
@@ -27,7 +27,7 @@ messages -> RemoteCompositorIntegration NotRefCounted Stream {
 #if PLATFORM(COCOA)
 void RecreateRenderBuffers(int width, int height) -> (Vector<MachSendRight> renderBuffers) Synchronous NotStreamEncodableReply
 #endif
-void PrepareForDisplay() -> (bool dummy) Synchronous // FIXME: https://bugs.webkit.org/show_bug.cgi?id=250993 Wait for the results to be fully drawn
+void PrepareForDisplay() -> (bool dummy) Synchronous NotStreamEncodableReply // FIXME: https://bugs.webkit.org/show_bug.cgi?id=250993 Wait for the results to be fully drawn
 }
 
 #endif

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp
@@ -55,10 +55,12 @@ Vector<MachSendRight> RemoteCompositorIntegrationProxy::recreateRenderBuffers(in
 }
 #endif
 
-void RemoteCompositorIntegrationProxy::prepareForDisplay()
+void RemoteCompositorIntegrationProxy::prepareForDisplay(CompletionHandler<void()>&& completionHandler)
 {
     auto sendResult = sendSync(Messages::RemoteCompositorIntegration::PrepareForDisplay());
     UNUSED_VARIABLE(sendResult);
+
+    completionHandler();
 }
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.h
@@ -76,7 +76,7 @@ private:
     Vector<MachSendRight> recreateRenderBuffers(int width, int height) override;
 #endif
 
-    void prepareForDisplay() override;
+    void prepareForDisplay(CompletionHandler<void()>&&) override;
 
     WebGPUIdentifier m_backing;
     Ref<ConvertToBackingContext> m_convertToBackingContext;


### PR DESCRIPTION
#### 4c96df92a14a87c66f3d2a0482918710d497698b
<pre>
[WebGPU] Address review comments from 259778@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=251650">https://bugs.webkit.org/show_bug.cgi?id=251650</a>
rdar://104983490

Reviewed by Dean Jackson.

Somehow my updates to the PR that addressed the review comments never got committed...

* Source/WebCore/Modules/WebGPU/GPUCompositorIntegration.cpp:
(WebCore::GPUCompositorIntegration::prepareForDisplay):
* Source/WebCore/Modules/WebGPU/GPUCompositorIntegration.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUCompositorIntegrationImpl.cpp:
(PAL::WebGPU::CompositorIntegrationImpl::prepareForDisplay):
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUCompositorIntegrationImpl.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUCompositorIntegration.h:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.cpp:
(WebCore::GPUCanvasContextCocoa::prepareForDisplay):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.cpp:
(WebKit::RemoteCompositorIntegration::prepareForDisplay):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.messages.in:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp:
(WebKit::WebGPU::RemoteCompositorIntegrationProxy::prepareForDisplay):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.h:

Canonical link: <a href="https://commits.webkit.org/259789@main">https://commits.webkit.org/259789@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18af86d563257dc82b3f6004ed89072f26c7698b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105967 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15031 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38808 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115153 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/175269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109870 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16452 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/6212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/98185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111720 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/95492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/98185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/94387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/27136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/98185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/8288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/28488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/8775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/6212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/14401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/48031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6773 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/10322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->