### PR TITLE
WPT sync css/css-nesting

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6192,6 +6192,9 @@ imported/w3c/web-platform-tests/html/browsers/the-window-object/window-open-noop
 imported/w3c/web-platform-tests/html/browsers/the-window-object/window-open-noopener.html?_parent [ Skip ]
 imported/w3c/web-platform-tests/html/browsers/the-window-object/window-open-noopener.html?_top [ Skip ]
 
+# CSS nesting unsupported yet
+imported/w3c/web-platform-tests/css/css-nesting/nest-containing-forgiving.html [ ImageOnlyFailure ]
+
 # Needs non-zero line gap in 'Arial'
 fast/text/text-edge-no-half-leading-simple.html [ Skip ]
 fast/text/text-edge-no-half-leading-with-line-height-simple.html [ Skip ]

--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -2186,6 +2186,7 @@
         "web-platform-tests/css/css-nesting/conditional-properties-ref.html",
         "web-platform-tests/css/css-nesting/conditional-rules-ref.html",
         "web-platform-tests/css/css-nesting/implicit-nesting-ref.html",
+        "web-platform-tests/css/css-nesting/nest-containing-forgiving-ref.html",
         "web-platform-tests/css/css-nesting/nesting-basic-ref.html",
         "web-platform-tests/css/css-pseudo/active-selection-051-ref.html",
         "web-platform-tests/css/css-pseudo/backdrop-animate-002-ref.html",

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/001-expected.txt
@@ -7,7 +7,6 @@ PASS Rule insertion works in nested @supports rules
 PASS Insertion @supports rules into another @supports rule works
 PASS Deletion of a nested @supports rule works
 PASS Inserting @font-face inside @supports works
-PASS Inserting an @supports inside a style rule should fail
 PASS 'and' arguments in @supports serialize in the correct order and with extra parentheses
 PASS 'or' arguments in @supports serialize in the correct order and with extra parentheses
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/001.html
@@ -197,12 +197,6 @@
 	}, "Inserting @font-face inside @supports works");
 
 	test(function(){
-		var style_rule = document.styleSheets[0].cssRules[0].cssRules[1];
-
-		assert_throws_js(TypeError, function() { style_rule.insertRule("@supports (width: 0) { ol { width: 0; } }", 0);} );
-
-	}, "Inserting an @supports inside a style rule should fail");
-	test(function(){
 		var rule = document.styleSheets[0].cssRules[1];
 		assert_equals_normalized(rule.cssText,
 		              "@supports (border: black) and (padding: 0) and (width: 0) {\n"

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/cssom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/cssom-expected.txt
@@ -8,4 +8,6 @@ FAIL Simple CSSOM manipulation of subrules 5 assert_throws_dom: function "() => 
 FAIL Simple CSSOM manipulation of subrules 6 undefined is not an object (evaluating 'ss.cssRules[0].cssRules[1]')
 FAIL Simple CSSOM manipulation of subrules 7 ss.cssRules[0].insertRule is not a function. (In 'ss.cssRules[0].insertRule('@supports selector(&) { & div { font-size: 10px; }}', 1)', 'ss.cssRules[0].insertRule' is undefined)
 FAIL Simple CSSOM manipulation of subrules 8 assert_equals: color is changed, new rule is ignored expected ".a {\n  color: olivedrab;\n  & .b { color: green; }\n  & .c { color: blue; }\n}" but got ".a {\n  color: olivedrab;& .b { color: green; }\n}& .c { color: blue; }\n}"
+FAIL Simple CSSOM manipulation of subrules 9 undefined is not an object (evaluating 'ss.cssRules[0].cssRules[0]')
+FAIL Simple CSSOM manipulation of subrules 10 assert_equals: invalid rule containing ampersand is kept in serialization expected ".a {\n  :is(!& .foo, .b) { color: green; }\n}" but got ".a {\n  :is(.b) { color: green; }\n}"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/cssom.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/cssom.html
@@ -124,4 +124,34 @@
   & .c { color: blue; }
 }`, 'color is changed, new rule is ignored');
   });
+
+  // We cannot insert anything starting with an tag, as that would cause
+  // the serialized rule not to parse back. Compounds starting with a tag
+  // that are _not_ the first compound in a complex selector are OK, though,
+  // as are complex selectors that are not the first in the list.
+  test(() => {
+    document.getElementById('ss').innerHTML = sampleSheetText;
+    let [ss] = document.styleSheets;
+    ss.cssRules[0].cssRules[0].selectorText = 'div.b .c &';  // Ignored.
+    ss.cssRules[0].cssRules[1].selectorText = '.c div.b &, div &';  // Allowed.
+    assert_throws_dom('SyntaxError', () => { ss.cssRules[0].insertRule('div & {}'); });
+    assert_equals(ss.cssRules[0].cssText,
+`.a {
+  color: red;
+  & .b { color: green; }
+  .c div.b &, div & { color: blue; }
+}`, 'one rule is kept unchanged, the other is changed');
+  });
+
+  // Rules that are dropped in forgiving parsing but that contain &,
+  // must still be serialized out as they were.
+  test(() => {
+    const text = '.a { :is(!& .foo, .b) { color: green; } }';
+    document.getElementById('ss').innerHTML = text;
+    let [ss] = document.styleSheets;
+    assert_equals(ss.cssRules[0].cssText,
+`.a {
+  :is(!& .foo, .b) { color: green; }
+}`, 'invalid rule containing ampersand is kept in serialization');
+  });
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/delete-other-rule-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/delete-other-rule-crash.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<body>
+<title>Crash with lazy parsing child rules and stylesheet copy-on-write</title>
+<link rel="help" href="https://crbug.com/1404879">
+<link href="../support/delete-other-rule-crash.css" rel="stylesheet">
+<script src="/common/gc.js"></script>
+<script>
+addEventListener('DOMContentLoaded', async () => {
+  requestAnimationFrame(async () => {
+    document.styleSheets[0].deleteRule(0);
+    await garbageCollect();
+    document.styleSheets[0].cssRules[0].cssText;
+  });
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/invalid-inner-rules-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/invalid-inner-rules-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Simple CSSOM manipulation of subrules assert_equals: expected "div {\n  @media screen {\n  &.a { color: red; }\n}\n}" but got "div {\n  @layer {\n  &.a { font-size: 10px; }\n}\n}@media screen {\n  &.a { color: red; }\n  @layer {\n  &.a { font-size: 10px; }\n}\n}\n}"
-FAIL Simple CSSOM manipulation of subrules 1 assert_throws_dom: function "() => { ss.cssRules[0].cssRules[0].insertRule('@layer {}', 0); }" threw object "TypeError: undefined is not an object (evaluating 'ss.cssRules[0].cssRules[0]')" that is not a DOMException HierarchyRequestError: property "code" is equal to undefined, expected 3
+PASS Simple CSSOM manipulation of subrules
+FAIL Simple CSSOM manipulation of subrules 1 assert_throws_dom: function "() => { ss.cssRules[0].cssRules[0].insertRule('@font-face {}', 0); }" threw object "TypeError: undefined is not an object (evaluating 'ss.cssRules[0].cssRules[0]')" that is not a DOMException HierarchyRequestError: property "code" is equal to undefined, expected 3
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/invalid-inner-rules.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/invalid-inner-rules.html
@@ -8,7 +8,7 @@
 <style id="ss">
 div {
   /* This is not a conditional rule, and thus cannot be in nesting context. */
-  @layer {
+  @font-face {
     &.a { font-size: 10px; }
   }
 
@@ -16,7 +16,7 @@ div {
     &.a { color: red; }
 
     /* Same. */
-    @layer {
+    @font-face {
       &.a { font-size: 10px; }
     }
   }
@@ -41,11 +41,11 @@ div {
     let [ss] = document.styleSheets;
     assert_equals(ss.cssRules.length, 1);
     assert_throws_dom('HierarchyRequestError',
-      () => { ss.cssRules[0].cssRules[0].insertRule('@layer {}', 0); });
+      () => { ss.cssRules[0].cssRules[0].insertRule('@font-face {}', 0); });
     assert_throws_dom('HierarchyRequestError',
-      () => { ss.cssRules[0].insertRule('@layer {}', 0); });
+      () => { ss.cssRules[0].insertRule('@font-face {}', 0); });
 
-    // The @layer rules should be ignored (again).
+    // The @font-face rules should be ignored (again).
     assert_equals(ss.cssRules[0].cssText,
 `div {
   @media screen {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nest-containing-forgiving-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nest-containing-forgiving-expected.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<title>Nest-containing in forgiving parsing</title>
+<style>
+  .test {
+    background-color: green;
+    width: 100px;
+    height: 100px;
+    display: grid;
+  }
+
+  body * + * {
+    margin-top: 8px;
+  }
+</style>
+<body>
+  <p>Tests pass if <strong>block is green</strong></p>
+  <div class="test"></div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nest-containing-forgiving-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nest-containing-forgiving-ref.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<title>Nest-containing in forgiving parsing</title>
+<style>
+  .test {
+    background-color: green;
+    width: 100px;
+    height: 100px;
+    display: grid;
+  }
+
+  body * + * {
+    margin-top: 8px;
+  }
+</style>
+<body>
+  <p>Tests pass if <strong>block is green</strong></p>
+  <div class="test"></div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nest-containing-forgiving.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nest-containing-forgiving.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<title>Nest-containing in forgiving parsing</title>
+<link rel="author" title="Steinar H. Gunderson" href="mailto:sesse@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-nesting-1/">
+<link rel="match" href="nest-containing-forgiving-ref.html">
+<style>
+  .test {
+    background-color: red;
+    width: 100px;
+    height: 100px;
+    display: grid;
+  }
+
+  .does-not-exist {
+    :is(.test-1, !&) {
+      background-color: green;
+    }
+  }
+
+  body * + * {
+    margin-top: 8px;
+  }
+</style>
+<body>
+  <p>Tests pass if <strong>block is green</strong></p>
+  <div class="test test-1"></div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic-expected.html
@@ -13,10 +13,6 @@
   body * + * {
     margin-top: 8px;
   }
-
-  .fail {
-    background-color: red;
-  }
 </style>
 <body>
   <p>Tests pass if <strong>block is green</strong></p>
@@ -30,5 +26,5 @@
   <div class="test"></div>
   <div class="test"></div>
   <div class="test"></div>
-  <div class="test fail"></div>
+  <div class="test"></div>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic-ref.html
@@ -26,4 +26,5 @@
   <div class="test"></div>
   <div class="test"></div>
   <div class="test"></div>
+  <div class="test"></div>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic.html
@@ -80,10 +80,12 @@
     background-color: green !important;
   }
 
-  & {
-    :not(&).test-12 {
-      background-color: green;
-    }
+  /* & at top level counts as :scope, i.e. the root element here */
+  & .test-12 {
+    background-color: green;
+  }
+  & > .test-12 {
+    background-color: red !important;
   }
 
   body * + * {
@@ -106,5 +108,5 @@
   <div class="test test-9 t9-- t9-"><div></div></div>
   <div class="test test-10"><div></div></div>
   <div class="test test-11"><div></div></div>
-  <div class="test test-12"><div></div></div>
+  <div class="test test-12"></div>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parsing-expected.txt
@@ -1,7 +1,5 @@
 
-PASS .foo {
-  & { color: green; }
-}
+FAIL .foo { & { color: green; } } assert_equals: expected ".foo { color: green; }" but got ".foo {\n  & { color: green; }\n}"
 PASS .foo { //color: red; color: green; }
 PASS .foo {
   &.bar { color: green; }
@@ -11,6 +9,15 @@ PASS .foo {
 }
 PASS .foo {
   & > .bar { color: green; }
+}
+PASS .foo {
+  > .bar { color: green; }
+}
+PASS .foo {
+  > & .bar { color: green; }
+}
+PASS .foo {
+  + .bar & { color: green; }
 }
 PASS .foo {
   .test > & .bar { color: green; }
@@ -60,9 +67,9 @@ PASS .foo {
 PASS .foo {
  color: red; ident { color: green; }
 }
-PASS .foo {
+FAIL .foo {
  //color: comment; & { color: green; }
-}
+} assert_equals: expected ".foo { color: green; }" but got ".foo {\n  & { color: green; }\n}"
 PASS .foo {
  .bar {
   functionalnotation(div) { color: green; }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parsing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parsing.html
@@ -15,14 +15,17 @@
   }
 
   const testRules = [
-    `.foo {\n  & { color: green; }\n}`, // 🐰
+    [`.foo { & { color: green; } }`, `.foo { color: green; }`], // 🐰
     // nesting should not mess with single line comment legacy special case
     [`.foo { //color: red; color: green; }`,`.foo { color: green; }`],
     `.foo {\n  &.bar { color: green; }\n}`,
     `.foo {\n  & .bar { color: green; }\n}`,
     `.foo {\n  & > .bar { color: green; }\n}`,
+    [`.foo {\n  > .bar { color: green; }\n}`, `.foo {\n  & > .bar { color: green; }\n}`],
+    [`.foo {\n  > & .bar { color: green; }\n}`, `.foo {\n  & > & .bar { color: green; }\n}`],
+    [`.foo {\n  + .bar & { color: green; }\n}`, `.foo {\n  & + .bar & { color: green; }\n}`],
     `.foo {\n  .test > & .bar { color: green; }\n}`,
-    [`.foo {\n  + .bar, .foo, > .lol { color: green; }\n}`,'.foo {\n  & + .bar, .foo, & > .lol { color: green; }\n}'],
+    [`.foo {\n  + .bar, .foo, > .lol { color: green; }\n}`,`.foo {\n  & + .bar, .foo, & > .lol { color: green; }\n}`],
     `.foo {\n  &:is(.bar, &.baz) { color: green; }\n}`,
     `.foo {\n  .bar& { color: green; }\n}`,
     `.foo {\n  .bar & { color: green; }\n}`,
@@ -36,7 +39,7 @@
     `.foo {\n  :has(div) { color: green; }\n}`,
     `.foo {\n  .bar {\n  && { color: green; }\n}\n}`,
     [`.foo {\n color: red; ident { color: green; }\n}`, `.foo { color: red; }`],
-    [`.foo {\n //color: comment; & { color: green; }\n}`, `.foo {\n  & { color: green; }\n}`],
+    [`.foo {\n //color: comment; & { color: green; }\n}`, `.foo { color: green; }`],
     [`.foo {\n .bar {\n  functionalnotation(div) { color: green; }\n\n}`, `.foo {\n  .bar { }\n}`],
   ]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/serialize-group-rules-with-decls.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/serialize-group-rules-with-decls.tentative-expected.txt
@@ -2,6 +2,6 @@
 FAIL Serialization of declarations in group rules assert_equals: expected "div {\n  @media screen { color: red; background-color: green; }\n}" but got "div {\n  @media screen {\n  & { color: red; background-color: green; }\n}\n}"
 FAIL Serialization of declarations in group rules 1 assert_equals: expected "div {\n  @supports selector(&) {\n  color: red; background-color: green;\n  &:hover { color: navy; }\n}\n}" but got "div {\n  @supports selector(&) {\n  & { color: red; background-color: green; }\n  &:hover { color: navy; }\n}\n}"
 FAIL Serialization of declarations in group rules 2 assert_equals: expected "div {\n  @media screen { color: red; }\n}" but got "div {\n  @media screen {\n  & { color: red; }\n}\n}"
-FAIL Serialization of declarations in group rules 3 assert_equals: expected "div {\n & { color: red; }\n}" but got "div {\n  & { color: red; }\n}"
+FAIL Serialization of declarations in group rules 3 assert_equals: expected "div { color: red; }" but got "div {\n  & { color: red; }\n}"
 PASS Serialization of declarations in group rules 4
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/serialize-group-rules-with-decls.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/serialize-group-rules-with-decls.tentative.html
@@ -53,9 +53,9 @@
                    "div {\n  @media screen {\n  &, p > & { color: blue; }\n}\n}");
   });
 
-  // They are not removed from regular rules.
+  //They are removed from regular rules.
   test(() => {
-    assert_becomes("div { & { color: red; } }", "div {\n & { color: red; }\n}");
+    assert_becomes("div { & { color: red; } }", "div { color: red; }");
   });
 
   // Empty rules (confusingly?) serialize different between style rules

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/top-level-is-scope-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/top-level-is-scope-expected.txt
@@ -1,0 +1,4 @@
+
+FAIL & as direct ancestor The string did not match the expected pattern.
+FAIL & matches scoped element only, not everything The string did not match the expected pattern.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/top-level-is-scope.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/top-level-is-scope.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<title>Top-level & is treated like :scope</title>
+<link rel="author" title="Steinar H. Gunderson" href="mailto:sesse@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-nesting-1/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div id="p">
+  <div class="match" id="level1">
+    <div class="match" id="level2"></div>
+  </div>
+</div>
+
+<script>
+  test(() => {
+    let matched = [];
+    for (const elem of p.querySelectorAll('& .match')) {
+      matched.push(elem.getAttribute('id'));
+    }
+    assert_array_equals(matched, ['level1', 'level2']);
+  }, '& as direct ancestor');
+
+  test(() => {
+    let matched = [];
+    for (const elem of p.querySelectorAll('& > .match')) {
+      matched.push(elem.getAttribute('id'));
+    }
+    assert_array_equals(matched, ['level1']);
+  }, '& matches scoped element only, not everything');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/w3c-import.log
@@ -21,6 +21,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/conditional-rules-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/conditional-rules.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/cssom.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/delete-other-rule-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/implicit-nesting-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/implicit-nesting-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/implicit-nesting.html
@@ -30,9 +31,13 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/invalidation-002.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/invalidation-003.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/invalidation-004.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nest-containing-forgiving-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nest-containing-forgiving-ref.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nest-containing-forgiving.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parsing.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/pseudo-part-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/serialize-group-rules-with-decls.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/top-level-is-scope.html


### PR DESCRIPTION
#### db9f7df159c1a83466a4459466b70625e89c4212
<pre>
WPT sync css/css-nesting
<a href="https://bugs.webkit.org/show_bug.cgi?id=251652">https://bugs.webkit.org/show_bug.cgi?id=251652</a>
rdar://104984047

Reviewed by Tim Nguyen.

WPT @ c82c735

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/resources/resource-files.json:
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/cssom-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/cssom.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/delete-other-rule-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/invalid-inner-rules-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/invalid-inner-rules.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nest-containing-forgiving-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nest-containing-forgiving-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nest-containing-forgiving.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parsing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parsing.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/serialize-group-rules-with-decls.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/serialize-group-rules-with-decls.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/top-level-is-scope-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/top-level-is-scope.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/259816@main">https://commits.webkit.org/259816@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/523fb0e7ab0692f85ca3c12e9b85d6dccb7f85ed

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106033 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15089 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38865 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115215 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/175317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16513 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6266 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98242 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111786 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95538 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/40111 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94432 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27181 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8342 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28533 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8833 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/5094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14455 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48076 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6793 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10377 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->