### PR TITLE
Fix backwards propagation in try catch blocks

### DIFF
--- a/JSTests/stress/try-catch-backwards-propagation.js
+++ b/JSTests/stress/try-catch-backwards-propagation.js
@@ -1,0 +1,171 @@
+function throwFunction() {
+    throw 2;
+}
+
+let a = [0.1];
+
+// --------- try catch with throw function ---------
+function foo1(i) {
+    let x = a[1];
+    try {
+        throwFunction();
+    } catch { }
+    if (x !== undefined) {
+        throw new Error(`x is ${x} at iteration ${i}`);
+    }
+}
+
+function foo2(i) {
+    let x = a[1];
+    try {
+        throwFunction();
+    } catch {
+        if (x !== undefined) {
+            throw new Error(`x is ${x} at iteration ${i}`);
+        }
+    }
+}
+
+function foo3(i) {
+    let x = a[1];
+    try {
+        if (i % 2)
+            throwFunction();
+    } catch { }
+    if (x !== undefined) {
+        throw new Error(`x is ${x} at iteration ${i}`);
+    }
+}
+
+// --------- try catch with throw ---------
+function foo4(i) {
+    let x = a[1];
+    try {
+        throw new Error();
+    } catch { }
+    if (x !== undefined) {
+        throw new Error(`x is ${x} at iteration ${i}`);
+    }
+}
+
+function foo5(i) {
+    let x = a[1];
+    try {
+        throw new Error();
+    } catch {
+        if (x !== undefined) {
+            throw new Error(`x is ${x} at iteration ${i}`);
+        }
+    }
+}
+
+function foo6(i) {
+    let x = a[1];
+    try {
+        if (i % 2)
+            throw new Error();
+    } catch { }
+    if (x !== undefined) {
+        throw new Error(`x is ${x} at iteration ${i}`);
+    }
+}
+
+// --------- try catch finally with throw function ---------
+function foo7(i) {
+    let x = a[1];
+    try {
+        throw new Error();
+    } catch {
+    } finally { }
+    if (x !== undefined) {
+        throw new Error(`x is ${x} at iteration ${i}`);
+    }
+}
+
+function foo8(i) {
+    let x = a[1];
+    try {
+        throw new Error();
+    } catch {
+    } finally {
+        if (x !== undefined) {
+            throw new Error(`x is ${x} at iteration ${i}`);
+        }
+    }
+}
+
+function foo9(i) {
+    let x = a[1];
+    try {
+        if (i % 2)
+            throw new Error();
+    } catch {
+    } finally { }
+    if (x !== undefined) {
+        throw new Error(`x is ${x} at iteration ${i}`);
+    }
+}
+
+// --------- try catch finally with throw function ---------
+function foo10(i) {
+    let x = a[1];
+    try {
+        throwFunction();
+    } catch {
+    } finally { }
+    if (x !== undefined) {
+        throw new Error(`x is ${x} at iteration ${i}`);
+    }
+}
+
+function foo11(i) {
+    let x = a[1];
+    try {
+        throwFunction();
+    } catch {
+    } finally {
+        if (x !== undefined) {
+            throw new Error(`x is ${x} at iteration ${i}`);
+        }
+    }
+}
+
+function foo12(i) {
+    let x = a[1];
+    try {
+        if (i % 2)
+            throwFunction();
+    } catch {
+    } finally { }
+    if (x !== undefined) {
+        throw new Error(`x is ${x} at iteration ${i}`);
+    }
+}
+
+function opt() {
+    var b = false;
+    var c = -b;
+    try {
+        throw "";
+    } catch (e) {
+    }
+    return c;
+}
+
+for (let i = 0; i < 100000; i++) {
+    foo1(i);
+    foo2(i);
+    foo3(i);
+    foo4(i);
+    foo5(i);
+    foo6(i);
+    foo7(i);
+    foo8(i);
+    foo9(i);
+    foo10(i);
+    foo11(i);
+    foo12(i);
+
+    if (1 / opt() === Infinity)
+        throw Error(`Should be -Infinity`);
+}

--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -725,7 +725,7 @@ void Graph::determineReachability()
     }
 }
 
-void Graph::resetReachability()
+void Graph::clearReachability()
 {
     for (BlockIndex blockIndex = m_blocks.size(); blockIndex--;) {
         BasicBlock* block = m_blocks[blockIndex].get();
@@ -734,7 +734,11 @@ void Graph::resetReachability()
         block->isReachable = false;
         block->predecessors.clear();
     }
-    
+}
+
+void Graph::resetReachability()
+{
+    clearReachability();
     determineReachability();
 }
 

--- a/Source/JavaScriptCore/dfg/DFGGraph.h
+++ b/Source/JavaScriptCore/dfg/DFGGraph.h
@@ -547,6 +547,7 @@ public:
     void killUnreachableBlocks();
     
     void determineReachability();
+    void clearReachability();
     void resetReachability();
     
     void computeRefCounts();

--- a/Source/JavaScriptCore/dfg/DFGLiveCatchVariablePreservationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGLiveCatchVariablePreservationPhase.cpp
@@ -36,10 +36,10 @@
 
 namespace JSC { namespace DFG {
 
-class LiveCatchVariablePreservationPhase : public Phase {
+class LiveCatchVariablePreservationPhase {
 public:
     LiveCatchVariablePreservationPhase(Graph& graph)
-        : Phase(graph, "live catch variable preservation phase")
+        : m_graph(graph)
     {
     }
 
@@ -53,8 +53,10 @@ public:
         InsertionSet insertionSet(m_graph);
         if (m_graph.m_hasExceptionHandlers) {
             for (BasicBlock* block : m_graph.blocksInNaturalOrder()) {
-                handleBlockForTryCatch(block, insertionSet);
-                insertionSet.execute(block);
+                if (block->isReachable) {
+                    handleBlockForTryCatch(block, insertionSet);
+                    insertionSet.execute(block);
+                }
             }
         }
 
@@ -221,11 +223,13 @@ public:
         m_graph.m_variableAccessData.append(operand);
         return &m_graph.m_variableAccessData.last();
     }
+
+    Graph& m_graph;
 };
 
 bool performLiveCatchVariablePreservationPhase(Graph& graph)
 {
-    return runPhase<LiveCatchVariablePreservationPhase>(graph);
+    return LiveCatchVariablePreservationPhase(graph).run();
 }
 
 } } // namespace JSC::DFG

--- a/Source/JavaScriptCore/dfg/DFGPlan.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPlan.cpp
@@ -236,8 +236,6 @@ Plan::CompilationPath Plan::compileInThreadImpl()
         dfg.dump();
     }
 
-    RUN_PHASE(performLiveCatchVariablePreservationPhase);
-
     RUN_PHASE(performCPSRethreading);
     RUN_PHASE(performUnification);
     RUN_PHASE(performPredictionInjection);


### PR DESCRIPTION
#### 15c640b7f430b696984e385b86dfbabfb03854fe
<pre>
Fix backwards propagation in try catch blocks
<a href="https://bugs.webkit.org/show_bug.cgi?id=251411">https://bugs.webkit.org/show_bug.cgi?id=251411</a>

Reviewed by NOBODY (OOPS!).

There is no successor and predecessor relationship between try and catch
block in DFG, in other words node flags cannot be passed from catch block
to its `predecessors`. If a variable defined outside the try catch block
but only be used in the catch block, then our compiler would mis-analyze
the liveness of the varible w.r.t the catch block. Therefore,
`LiveCatchVariablePreservationPhase` should be to performed before backwards propagation.

* JSTests/stress/try-catch-backwards-propagation.js: Added.
(throwFunction):
(foo1):
(foo2):
(foo3):
(foo4):
(foo5):
(foo6):
(foo7):
(foo8):
(foo9):
(foo10):
(foo11):
(foo12):
(opt):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::parse):
* Source/JavaScriptCore/dfg/DFGLiveCatchVariablePreservationPhase.cpp:
(JSC::DFG::LiveCatchVariablePreservationPhase::LiveCatchVariablePreservationPhase):
(JSC::DFG::LiveCatchVariablePreservationPhase::handleBlockForTryCatch):
(JSC::DFG::performLiveCatchVariablePreservationPhase):
* Source/JavaScriptCore/dfg/DFGPlan.cpp:
(JSC::DFG::Plan::compileInThreadImpl):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15c640b7f430b696984e385b86dfbabfb03854fe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105983 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15042 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38819 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115166 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175342 "Found 60 new test failures: accessibility/aria-roles.html, css3/flexbox/flex-flow-margins.html, css3/flexbox/multiline-align-content-horizontal-column.html, css3/flexbox/multiline-align-self.html, css3/flexbox/multiline-justify-content.html, css3/flexbox/multiline.html, css3/flexbox/position-absolute-child.html, cssom/cssvalue-comparison.html, editing/execCommand/insert-list-nested-with-orphaned-live-range.html, fast/css/css-selector-text.html ... (failure)") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16466 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6228 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98196 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114909 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111736 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12536 "Found 60 new test failures: compositing/reflections/mask-and-reflection.html, contact-picker/contacts-select-after-dismissing-picker.html, contentfiltering/allow-media-document.html, crypto/subtle/ec-import-key-malformed-parameters.html, crypto/subtle/rsa-import-key-malformed-parameters.html, css3/flexbox/flex-flow-margins.html, css3/flexbox/multiline-align-self.html, css3/flexbox/multiline-justify-content.html, css3/flexbox/multiline.html, css3/flexbox/position-absolute-child.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95506 "Found 9 new API test failures: TestWebKitAPI.WKInspectorExtension.CanEvaluateScriptInExtensionTab, TestWebKitAPI.WKInspectorExtensionDelegate.ExtensionTabNavigatedCallbacks, TestWebKitAPI.AsyncFunction.Promise, TestWebKitAPI.WKInspectorExtensionDelegate.InspectedPageNavigatedCallbacks, TestWebKitAPI.WKInspectorExtension.ExtensionTabIsPersistent, TestWebKitAPI.WebKit.WebAudioAndGetUserMedia, TestWebKitAPI.WKInspectorExtensionHost.UnregisterExtension, TestWebKitAPI.WKInspectorExtension.EvaluateScriptInExtensionTabCanReturnPromises, TestWebKitAPI.WKInspectorExtension.EvaluateScriptOnPage (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40075 "Found 335 new test failures: css3/flexbox/multiline-align-self.html, css3/flexbox/multiline-justify-content.html, css3/flexbox/multiline.html, css3/flexbox/position-absolute-child.html, cssom/cssvalue-comparison.html, fast/canvas/webgl/webgl2-buffers.html, fast/css/parsing-css-is-2.html, fast/css/pseudo-active-on-labeled-element-not-canceled-by-focus.html, fast/css/pseudo-active-style-sharing-1.html, fast/css/pseudo-active-style-sharing-2.html ... (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94401 "Found 7 new API test failures: TestWebKitAPI.AppPrivacyReport.RestoreFromInteractionStateIsAppInitiated, TestWebKitAPI.WebKit2.CaptureStop, TestWebKitAPI.AppPrivacyReport.RestoreFromSessionStateIsAppInitiated, TestWebKitAPI.AppPrivacyReport.RestoreFromSessionStateIsNonAppInitiated, TestWebKitAPI.WebKit2.CrashGPUProcessWhileCapturingAndCalling, TestWebKitAPI.AppPrivacyReport.RestoreFromInteractionStateIsNonAppInitiated, TestWebKitAPI.AsyncFunction.Promise (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27149 "Found 60 new test failures: crypto/subtle/ec-import-key-malformed-parameters.html, crypto/subtle/rsa-import-key-malformed-parameters.html, css3/flexbox/flex-flow-margins.html, css3/flexbox/multiline-align-self.html, css3/flexbox/multiline-justify-content.html, css3/flexbox/multiline.html, css3/flexbox/position-absolute-child.html, cssom/cssvalue-comparison.html, editing/mac/attributed-string/attrib-string-colors-with-color-filter.html, editing/mac/attributed-string/basic.html ... (failure)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/95648 "Found 9034 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/ControlFlow/forInArrayAdd.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInObjectAdd.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInObjectWithPrototype.js.default, ChakraCore.yaml/ChakraCore/test/Function/argumentsResolution.js.default, ChakraCore.yaml/ChakraCore/test/Function/callmissingtgt.js.default, ChakraCore.yaml/ChakraCore/test/JSON/jx1.js.default, ChakraCore.yaml/ChakraCore/test/JSON/jx2.js.default, ChakraCore.yaml/ChakraCore/test/Math/round.js.default, ChakraCore.yaml/ChakraCore/test/Object/defineProperty.js.default, ChakraCore.yaml/ChakraCore/test/UnifiedRegex/acid.js.default ... (failure)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8298 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28501 "Found 60 new test failures: compositing/clipping/border-radius-async-overflow-non-stacking.html, crypto/subtle/ec-import-key-malformed-parameters.html, crypto/subtle/rsa-import-key-malformed-parameters.html, css3/filters/backdrop/backdropfilter-property-parsing.html, css3/flexbox/flex-flow-margins.html, css3/flexbox/multiline-align-self.html, css3/flexbox/multiline-justify-content.html, css3/flexbox/multiline.html, css3/flexbox/position-absolute-child.html, cssom/cssvalue-comparison.html ... (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/94968 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/6109 "Found 9204 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/ControlFlow/forInArrayAdd.js.default, ChakraCore.yaml/ChakraCore/test/Function/argumentsResolution.js.default, ChakraCore.yaml/ChakraCore/test/Function/callmissingtgt.js.default, ChakraCore.yaml/ChakraCore/test/JSON/jx2.js.default, ChakraCore.yaml/ChakraCore/test/Math/round.js.default, ChakraCore.yaml/ChakraCore/test/Number/boundaries.js.default, ChakraCore.yaml/ChakraCore/test/UnifiedRegex/NoBacktrackingChomp.js.default, ChakraCore.yaml/ChakraCore/test/UnifiedRegex/acid.js.default, ChakraCore.yaml/ChakraCore/test/UnifiedRegex/captures.js.default, ChakraCore.yaml/ChakraCore/test/UnifiedRegex/class-case.js.default ... (failure)") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8786 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5068 "Found 60 new test failures: crypto/subtle/rsa-import-key-malformed-parameters.html, css3/filters/backdrop/backdropfilter-property-parsing.html, css3/filters/filter-property-parsing.html, css3/flexbox/flex-flow-margins.html, css3/flexbox/multiline-align-self.html, css3/flexbox/multiline-justify-content.html, css3/flexbox/multiline.html, css3/flexbox/position-absolute-child.html, cssom/cssvalue-comparison.html, editing/execCommand/change-list-type.html ... (failure)") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30484 "Found 3361 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_fastinit.js.default, ChakraCore.yaml/ChakraCore/test/Array/nativearray_gen2.js.default, ChakraCore.yaml/ChakraCore/test/Array/nativearray_gen7.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInArrayAdd.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInObjectAdd.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInObjectWithPrototype.js.default, ChakraCore.yaml/ChakraCore/test/Error/validate_line_column.js.default, ChakraCore.yaml/ChakraCore/test/Function/argumentsResolution.js.default, ChakraCore.yaml/ChakraCore/test/Function/callmissingtgt.js.default, ChakraCore.yaml/ChakraCore/test/JSON/jx1.js.default ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14412 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48044 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/103716 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10332 "Built successfully") | | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25714 "Found 3170 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_fastinit.js.default, ChakraCore.yaml/ChakraCore/test/Array/nativearray_gen2.js.default, ChakraCore.yaml/ChakraCore/test/Array/nativearray_gen7.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInArrayAdd.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInObjectAdd.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInObjectWithPrototype.js.default, ChakraCore.yaml/ChakraCore/test/Error/validate_line_column.js.default, ChakraCore.yaml/ChakraCore/test/Function/argumentsResolution.js.default, ChakraCore.yaml/ChakraCore/test/Function/callmissingtgt.js.default, ChakraCore.yaml/ChakraCore/test/JSON/jx1.js.default ... (failure)") | 
| | | | | 
<!--EWS-Status-Bubble-End-->