### PR TITLE
Web Inspector: Console messages may be lost on main frame navigation depending on timing

### DIFF
--- a/LayoutTests/inspector/console/messagesCleared-expected.txt
+++ b/LayoutTests/inspector/console/messagesCleared-expected.txt
@@ -12,5 +12,7 @@ PASS: Cleared event should fire.
 PASS: Cleared event should fire.
 
 -- Running test case: ClearViaPageReload
-PASS: Cleared event should fire.
+Received `WI.ConsoleManager.Event.SessionStarted` event.
+PASS: Expected `WI.ConsoleManager.Event.SessionStarted` to be a reload-based session start.
+Received `WI.ConsoleManager.Event.Cleared` event.
 

--- a/LayoutTests/inspector/console/messagesCleared.html
+++ b/LayoutTests/inspector/console/messagesCleared.html
@@ -52,14 +52,18 @@ function test()
     suite.addTestCase({
         name: "ClearViaPageReload",
         description: "Reloading the page should trigger Console.messagesCleared.",
-        test(resolve, reject) {
-            WI.consoleManager.awaitEvent(WI.ConsoleManager.Event.Cleared)
-            .then((event) => {
-                InspectorTest.expectThat(event, "Cleared event should fire.");
-            })
-            .then(resolve, reject);
+        async test() {
+            let sessionStartedEvent = WI.consoleManager.awaitEvent(WI.ConsoleManager.Event.SessionStarted) // , {timestamp, wasReloaded}
+            let consoleClearedEvent = WI.consoleManager.awaitEvent(WI.ConsoleManager.Event.Cleared);
 
             InspectorTest.reloadPage();
+
+            let sessionStartedEventData = (await sessionStartedEvent).data;
+            InspectorTest.log("Received `WI.ConsoleManager.Event.SessionStarted` event.");
+            InspectorTest.expectTrue(sessionStartedEventData.wasReloaded, "Expected `WI.ConsoleManager.Event.SessionStarted` to be a reload-based session start.");
+
+            await consoleClearedEvent;
+            InspectorTest.log("Received `WI.ConsoleManager.Event.Cleared` event.");
         }
     });
 

--- a/Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.cpp
@@ -96,14 +96,7 @@ Protocol::ErrorStringOr<void> InspectorConsoleAgent::disable()
 
 Protocol::ErrorStringOr<void> InspectorConsoleAgent::clearMessages()
 {
-    m_consoleMessages.clear();
-    m_expiredConsoleMessageCount = 0;
-
-    m_injectedScriptManager.releaseObjectGroup("console"_s);
-
-    if (m_enabled)
-        m_frontendDispatcher->messagesCleared();
-
+    clearMessages(Inspector::Protocol::Console::ClearReason::ConsoleAPI);
     return { };
 }
 
@@ -112,12 +105,23 @@ bool InspectorConsoleAgent::developerExtrasEnabled() const
     return m_injectedScriptManager.inspectorEnvironment().developerExtrasEnabled();
 }
 
-void InspectorConsoleAgent::reset()
+void InspectorConsoleAgent::mainFrameNavigated()
 {
-    clearMessages();
+    clearMessages(Inspector::Protocol::Console::ClearReason::MainFrameNavigation);
 
     m_times.clear();
     m_counts.clear();
+}
+
+void InspectorConsoleAgent::clearMessages(Inspector::Protocol::Console::ClearReason reason)
+{
+    m_consoleMessages.clear();
+    m_expiredConsoleMessageCount = 0;
+
+    m_injectedScriptManager.releaseObjectGroup("console"_s);
+
+    if (m_enabled)
+        m_frontendDispatcher->messagesCleared(reason);
 }
 
 void InspectorConsoleAgent::addMessageToConsole(std::unique_ptr<ConsoleMessage> message)

--- a/Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.h
@@ -70,7 +70,9 @@ public:
 
     bool enabled() const { return m_enabled; }
     bool developerExtrasEnabled() const;
-    void reset();
+
+    // InspectorInstrumentation
+    void mainFrameNavigated();
 
     void addMessageToConsole(std::unique_ptr<ConsoleMessage>);
 
@@ -83,6 +85,7 @@ public:
 
 protected:
     void addConsoleMessage(std::unique_ptr<ConsoleMessage>);
+    void clearMessages(Protocol::Console::ClearReason);
 
     InjectedScriptManager& m_injectedScriptManager;
     std::unique_ptr<ConsoleFrontendDispatcher> m_frontendDispatcher;

--- a/Source/JavaScriptCore/inspector/protocol/Console.json
+++ b/Source/JavaScriptCore/inspector/protocol/Console.json
@@ -35,6 +35,12 @@
             "description": "Level of logging."
         },
         {
+            "id": "ClearReason",
+            "type": "string",
+            "enum": ["console-api", "main-frame-navigation"],
+            "description": "The reason the console is being cleared."
+        },
+        {
             "id": "Channel",
             "description": "Logging channel.",
             "type": "object",
@@ -133,7 +139,10 @@
         },
         {
             "name": "messagesCleared",
-            "description": "Issued when console is cleared. This happens either upon <code>clearMessages</code> command or after page navigation."
+            "description": "Issued when console is cleared. This happens either upon <code>clearMessages</code> command or after page navigation.",
+            "parameters": [
+                { "name": "reason", "$ref": "ClearReason", "description": "The reason the console is being cleared." }
+            ]
         },
         {
             "name": "heapSnapshot",

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -752,11 +752,13 @@ void InspectorInstrumentation::didCommitLoadImpl(InstrumentingAgents& instrument
     ASSERT(loader->frame() == &frame);
 
     if (frame.isMainFrame()) {
-        if (auto* consoleAgent = instrumentingAgents.webConsoleAgent())
-            consoleAgent->reset();
-
         if (auto* networkAgent = instrumentingAgents.enabledNetworkAgent())
             networkAgent->mainFrameNavigated(*loader);
+
+        // The Web Inspector frontend relies on `networkAgent->mainFrameNavigated` being called first to establish the
+        // type of navigation that has occured.
+        if (auto* consoleAgent = instrumentingAgents.webConsoleAgent())
+            consoleAgent->mainFrameNavigated();
 
         if (auto* cssAgent = instrumentingAgents.enabledCSSAgent())
             cssAgent->reset();

--- a/Source/WebInspectorUI/UserInterface/Protocol/ConsoleObserver.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/ConsoleObserver.js
@@ -43,9 +43,9 @@ WI.ConsoleObserver = class ConsoleObserver extends InspectorBackend.Dispatcher
         WI.consoleManager.messageRepeatCountUpdated(count, timestamp);
     }
 
-    messagesCleared()
+    messagesCleared(reason)
     {
-        WI.consoleManager.messagesCleared();
+        WI.consoleManager.messagesCleared(reason);
     }
 
     heapSnapshot(timestamp, snapshotStringData, title)


### PR DESCRIPTION
#### 77830d12bea6680bcd70a3f2c48fe58b6c24a74f
<pre>
Web Inspector: Console messages may be lost on main frame navigation depending on timing
<a href="https://bugs.webkit.org/show_bug.cgi?id=251659">https://bugs.webkit.org/show_bug.cgi?id=251659</a>
rdar://104303833

Reviewed by Devin Rousso.

The existing heuristic to determine if console messages are being cleared as the result of a main frame navigation made
the assumption that console messages won&apos;t be received between the call to clear messages and the next tick in Web
Inspector. This isn&apos;t a safe assumption, and can be observed when logging immediately after a navigation on some
computers/under certain types of loads. Instead of inferring why the console is being cleared, introduce a `reason`
parameter that tells us if the request to clear is the result of a main frame navigation, removing any doubt. For
compatibility with older remote ends, we keep the existing heuristic, since its better than nothing.

* LayoutTests/inspector/console/messagesCleared-expected.txt:
* LayoutTests/inspector/console/messagesCleared.html:
- Ensure that a new session was signalled due to a refresh when the console is cleared.

* Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.cpp:
(Inspector::InspectorConsoleAgent::clearMessages):
(Inspector::InspectorConsoleAgent::mainFrameNavigated):
(Inspector::InspectorConsoleAgent::clearMessages):
(Inspector::InspectorConsoleAgent::reset): Deleted.
- Provide a reason for the clearing of the console.

* Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.h:
* Source/JavaScriptCore/inspector/protocol/Console.json:
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::didCommitLoadImpl):

* Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js:
(WI.ConsoleManager):
(WI.ConsoleManager.prototype.messagesCleared):
- Use the reason to immediately determine how to handle clearing the console, instead of waiting until the next tick.

(WI.ConsoleManager.prototype._clearMessages):
- Extract the common logic that actually clears the console so we can reuse it for both the new reason-based path as
well as the compatibility path.

(WI.ConsoleManager.prototype._delayedMessagesCleared):
* Source/WebInspectorUI/UserInterface/Protocol/ConsoleObserver.js:
(WI.ConsoleObserver.prototype.messagesCleared):

Canonical link: <a href="https://commits.webkit.org/261512@main">https://commits.webkit.org/261512@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e8b0d53eeaf90e313c0fd8399df905c40e40728

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111774 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20903 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/388 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3553 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120488 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115833 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22262 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11981 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/3298 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117539 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16534 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99681 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104771 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98486 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/257 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45507 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/100256 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13373 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/258 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/92324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/11506 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13869 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9780 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/101496 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19313 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52259 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31549 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8018 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15855 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/109535 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26954 "Passed tests") | 
<!--EWS-Status-Bubble-End-->