### PR TITLE
[WebGPU] forceFallbackAdapter CTS test fails (251629)

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPU.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPU.cpp
@@ -57,7 +57,7 @@ void GPU::requestAdapter(const std::optional<GPURequestAdapterOptions>& options,
 {
     m_backing->requestAdapter(convertToBacking(options), [promise = WTFMove(promise)] (RefPtr<PAL::WebGPU::Adapter>&& adapter) mutable {
         if (!adapter) {
-            promise.reject(nullptr);
+            promise.resolve(nullptr);
             return;
         }
         promise.resolve(GPUAdapter::create(adapter.releaseNonNull()).ptr());

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUImpl.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUImpl.cpp
@@ -58,8 +58,11 @@ void GPUImpl::requestAdapter(const RequestAdapterOptions& options, CompletionHan
         options.forceFallbackAdapter,
     };
 
-    wgpuInstanceRequestAdapterWithBlock(m_backing, &backingOptions, makeBlockPtr([convertToBackingContext = m_convertToBackingContext.copyRef(), callback = WTFMove(callback)](WGPURequestAdapterStatus, WGPUAdapter adapter, const char*) mutable {
-        callback(AdapterImpl::create(adapter, convertToBackingContext));
+    wgpuInstanceRequestAdapterWithBlock(m_backing, &backingOptions, makeBlockPtr([convertToBackingContext = m_convertToBackingContext.copyRef(), callback = WTFMove(callback)](WGPURequestAdapterStatus status, WGPUAdapter adapter, const char*) mutable {
+        if (status == WGPURequestAdapterStatus_Success)
+            callback(AdapterImpl::create(adapter, convertToBackingContext));
+        else
+            callback(nullptr);
     }).get());
 }
 


### PR DESCRIPTION
#### 688149b429be877859932aecb386b215a2c60717
<pre>
[WebGPU] forceFallbackAdapter CTS test fails (251629)
<a href="https://bugs.webkit.org/show_bug.cgi?id=251629">https://bugs.webkit.org/show_bug.cgi?id=251629</a>
&lt;radar://104976449&gt;

Reviewed by Myles C. Maxfield.

The spec says to return nullptr from requestAdapter if the
forceFallback adapter is not supported.

Now we get 0 failures (3 skips, 6 passes), on the requestAdapter
CTS tests.

* Source/WebCore/Modules/WebGPU/GPU.cpp:
(WebCore::GPU::requestAdapter):
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUImpl.cpp:
(PAL::WebGPU::GPUImpl::requestAdapter):
* Source/WebGPU/WebGPU/Adapter.mm:
(WebGPU::Adapter::requestDevice):
* Source/WebGPU/WebGPU/Instance.mm:
(WebGPU::Instance::requestAdapter):
(wgpuInstanceRequestAdapter):
(wgpuInstanceRequestAdapterWithBlock):

Canonical link: <a href="https://commits.webkit.org/259844@main">https://commits.webkit.org/259844@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/263717910740905b11f128918f144836bf0239c2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106112 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15165 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38940 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115296 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175373 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110017 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16597 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6337 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98321 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114993 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111868 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95598 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/40179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94494 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27241 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8416 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28593 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8910 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/5141 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14529 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48137 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6810 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10455 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->