### PR TITLE
Implement a more accurate currentStackPointer().

### DIFF
--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
@@ -2799,6 +2799,14 @@ _wasm_trampoline_wasm_tail_call_wide32:
 _wasm_trampoline_wasm_tail_call_indirect_wide32:
     crash()
 
+end # WEBASSEMBLY and not X86_64_WIN
+
+if X86_64_WIN
+    global _currentStackPointer
+    _currentStackPointer:
+        move sp, r0
+        addp MachineRegisterSize + 32, r0 # Account for return address and shadow stack
+        ret
 end
 
 include? LowLevelInterpreterAdditions

--- a/Source/WTF/wtf/StackPointer.cpp
+++ b/Source/WTF/wtf/StackPointer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,9 +26,128 @@
 #include "config.h"
 #include "StackPointer.h"
 
+#include "InlineASM.h"
+
 namespace WTF {
 
-#if USE(GENERIC_CURRENT_STACK_POINTER)
+#if USE(ASM_CURRENT_STACK_POINTER)
+
+#if CPU(X86) && COMPILER(MSVC)
+extern "C" __declspec(naked) void currentStackPointer()
+{
+    __asm {
+        mov eax, esp
+        add eax, 4
+        ret
+    }
+}
+
+#elif CPU(X86) & COMPILER(GCC_COMPATIBLE)
+asm (
+    ".text" "\n"
+    ".globl " SYMBOL_STRING(currentStackPointer) "\n"
+    HIDE_SYMBOL(currentStackPointer) "\n"
+    SYMBOL_STRING(currentStackPointer) ":" "\n"
+    "movl %esp, %eax" "\n"
+    "addl $4, %eax" "\n"
+    "ret" "\n"
+    ".previous" "\n"
+);
+
+#elif CPU(X86_64) && OS(WINDOWS)
+
+// The Win64 port will use a hack where we define currentStackPointer in
+// LowLevelInterpreter.asm.
+
+#elif CPU(X86_64) && COMPILER(GCC_COMPATIBLE)
+asm (
+    ".text" "\n"
+    ".globl " SYMBOL_STRING(currentStackPointer) "\n"
+    HIDE_SYMBOL(currentStackPointer) "\n"
+    SYMBOL_STRING(currentStackPointer) ":" "\n"
+
+    "movq  %rsp, %rax" "\n"
+    "addq $8, %rax" "\n" // Account for return address.
+    "ret" "\n"
+    ".previous" "\n"
+);
+
+#elif CPU(ARM64E) && COMPILER(GCC_COMPATIBLE)
+asm (
+    ".text" "\n"
+    ".balign 16" "\n"
+    ".globl " SYMBOL_STRING(currentStackPointer) "\n"
+    HIDE_SYMBOL(currentStackPointer) "\n"
+    SYMBOL_STRING(currentStackPointer) ":" "\n"
+
+    "pacibsp" "\n"
+    "mov x0, sp" "\n"
+    "retab" "\n"
+    ".previous" "\n"
+);
+
+#elif CPU(ARM64) && COMPILER(GCC_COMPATIBLE)
+asm (
+    ".text" "\n"
+    ".balign 16" "\n"
+    ".globl " SYMBOL_STRING(currentStackPointer) "\n"
+    HIDE_SYMBOL(currentStackPointer) "\n"
+    SYMBOL_STRING(currentStackPointer) ":" "\n"
+
+    "mov x0, sp" "\n"
+    "ret" "\n"
+    ".previous" "\n"
+);
+
+#elif CPU(ARM_THUMB2) && COMPILER(GCC_COMPATIBLE)
+asm (
+    ".text" "\n"
+    ".align 2" "\n"
+    ".globl " SYMBOL_STRING(currentStackPointer) "\n"
+    HIDE_SYMBOL(currentStackPointer) "\n"
+    ".thumb" "\n"
+    ".thumb_func " THUMB_FUNC_PARAM(currentStackPointer) "\n"
+    SYMBOL_STRING(currentStackPointer) ":" "\n"
+
+    "mov r0, sp" "\n"
+    "bx  lr" "\n"
+    ".previous" "\n"
+);
+
+#elif CPU(MIPS) && COMPILER(GCC_COMPATIBLE)
+asm (
+    ".text" "\n"
+    ".globl " SYMBOL_STRING(currentStackPointer) "\n"
+    HIDE_SYMBOL(currentStackPointer) "\n"
+    SYMBOL_STRING(currentStackPointer) ":" "\n"
+    ".set push" "\n"
+    ".set noreorder" "\n"
+    ".set noat" "\n"
+
+    "move $v0, $sp" "\n"
+    "jr   $ra" "\n"
+    "nop" "\n"
+    ".set pop" "\n"
+    ".previous" "\n"
+);
+
+#elif CPU(RISCV64) && COMPILER(GCC_COMPATIBLE)
+asm (
+    ".text" "\n"
+    ".globl " SYMBOL_STRING(currentStackPointer) "\n"
+    HIDE_SYMBOL(currentStackPointer) "\n"
+    SYMBOL_STRING(currentStackPointer) ":" "\n"
+
+     "mv x10, sp" "\n"
+     "ret" "\n"
+     ".previous" "\n"
+);
+
+#else
+#error "Unsupported platform: need implementation of currentStackPointer."
+#endif
+
+#elif USE(GENERIC_CURRENT_STACK_POINTER)
 constexpr size_t sizeOfFrameHeader = 2 * sizeof(void*);
 
 SUPPRESS_ASAN NEVER_INLINE

--- a/Source/WTF/wtf/StackPointer.h
+++ b/Source/WTF/wtf/StackPointer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -48,6 +48,11 @@ ALWAYS_INLINE void* currentStackPointer()
 #endif
     return stackPointer;
 }
+
+#elif !ENABLE(CLOOP)
+
+#define USE_ASM_CURRENT_STACK_POINTER 1
+extern "C" WTF_EXPORT_PRIVATE void* currentStackPointer();
 
 #else
 


### PR DESCRIPTION
#### 7dbed20e73b0c8ef5831a07a1bab1135f64b6781
<pre>
Implement a more accurate currentStackPointer().
<a href="https://bugs.webkit.org/show_bug.cgi?id=251667">https://bugs.webkit.org/show_bug.cgi?id=251667</a>
rdar://104993866

Reviewed by Justin Michaud.

currentStackPointer() was already accurate for some ports (the ones that support
inline assembly), but for others or when using a Debug build, we fall back to a C++
runtime function that only gives an approximate value.  This patch implements a
currentStackPointer() that is accurate for all currently support ports even when
using a Debug build.

* Source/JavaScriptCore/llint/LowLevelInterpreter.asm:
* Source/WTF/wtf/StackPointer.cpp:
(WTF::currentStackPointer):
* Source/WTF/wtf/StackPointer.h:

Canonical link: <a href="https://commits.webkit.org/259818@main">https://commits.webkit.org/259818@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f70817008160fee28ef2ccd938dcdfec744ee58c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106005 "7 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15060 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38837 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115188 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175296 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16484 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6244 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98214 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114925 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111758 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12549 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95519 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40093 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94414 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27162 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/95665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8316 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28514 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/94989 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/6129 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8806 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5077 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30488 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14430 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48057 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/103738 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10350 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25718 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3648 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->