### PR TITLE
REGRESSION: [Ventura] 16 TestWebKitAPI.WebPushD tests failing/timing out

### DIFF
--- a/Source/WebKit/Platform/IPC/DaemonCoders.h
+++ b/Source/WebKit/Platform/IPC/DaemonCoders.h
@@ -106,7 +106,6 @@ template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t min
 
 template<typename T> struct Coder<T, typename std::enable_if_t<std::is_enum_v<T>>> : public IPC::ArgumentCoder<T> { };
 template<typename T> struct Coder<std::optional<T>> : public IPC::ArgumentCoder<std::optional<T>> { };
-template<typename T> struct Coder<Markable<T>> : public IPC::ArgumentCoder<Markable<T>> { };
 template<typename ValueType, typename ErrorType> struct Coder<Expected<ValueType, ErrorType>> : IPC::ArgumentCoder<Expected<ValueType, ErrorType>> { };
 template<typename... Elements> struct Coder<std::tuple<Elements...>> : public IPC::ArgumentCoder<std::tuple<Elements...>> { };
 

--- a/Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.h
+++ b/Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.h
@@ -38,7 +38,7 @@ struct WebPushDaemonConnectionConfiguration {
     bool useMockBundlesForTesting { false };
     std::optional<Vector<uint8_t>> hostAppAuditTokenData;
     String pushPartitionString;
-    Markable<UUID> dataStoreIdentifier;
+    std::optional<UUID> dataStoreIdentifier;
 };
 
 template<class Encoder>

--- a/Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.serialization.in
+++ b/Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.serialization.in
@@ -25,5 +25,5 @@ header: "WebPushDaemonConnectionConfiguration.h"
     bool useMockBundlesForTesting;
     std::optional<Vector<uint8_t>> hostAppAuditTokenData;
     String pushPartitionString;
-    Markable<UUID> dataStoreIdentifier;
+    std::optional<UUID> dataStoreIdentifier;
 };


### PR DESCRIPTION
#### 58201f5319e0bbcd10017c5c5676eef5360353e9
<pre>
REGRESSION: [Ventura] 16 TestWebKitAPI.WebPushD tests failing/timing out
<a href="https://bugs.webkit.org/show_bug.cgi?id=251638">https://bugs.webkit.org/show_bug.cgi?id=251638</a>
rdar://104979435

Unreviewed.

This reverts the part having to do with serialization to and from webpushd
which was incorrect.

* Source/WebKit/Platform/IPC/DaemonCoders.h:
* Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.h:
* Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.serialization.in:

Canonical link: <a href="https://commits.webkit.org/259806@main">https://commits.webkit.org/259806@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c805c2aac9485cadf437fc224f27fa3892f67da1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106008 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15063 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38840 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115191 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16487 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/6247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98217 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111761 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95522 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/40092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/94418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27165 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8319 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28517 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8809 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/6247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14433 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48060 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6782 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10353 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->