### PR TITLE
[WK2] Clean up fixed-length data encoding in Encoder, StreamConnectionEncoder

### DIFF
--- a/Source/WebKit/Platform/IPC/Encoder.cpp
+++ b/Source/WebKit/Platform/IPC/Encoder.cpp
@@ -193,14 +193,6 @@ uint8_t* Encoder::grow(size_t alignment, size_t size)
     return m_buffer + alignedSize;
 }
 
-void Encoder::encodeFixedLengthData(const uint8_t* data, size_t size, size_t alignment)
-{
-    ASSERT(!(reinterpret_cast<uintptr_t>(data) % alignment));
-
-    uint8_t* buffer = grow(alignment, size);
-    memcpy(buffer, data, size);
-}
-
 void Encoder::addAttachment(Attachment&& attachment)
 {
     m_attachments.append(WTFMove(attachment));

--- a/Source/WebKit/Platform/IPC/Encoder.h
+++ b/Source/WebKit/Platform/IPC/Encoder.h
@@ -67,7 +67,6 @@ public:
 
     void wrapForTesting(UniqueRef<Encoder>&&);
 
-    void encodeFixedLengthData(const uint8_t* data, size_t, size_t alignment);
     template<typename T, size_t Extent>
     void encodeSpan(const Span<T, Extent>&);
     template<typename T>
@@ -113,9 +112,15 @@ private:
 };
 
 template<typename T, size_t Extent>
-inline void Encoder::encodeSpan(const Span<T, Extent>& data)
+inline void Encoder::encodeSpan(const Span<T, Extent>& span)
 {
-    encodeFixedLengthData(reinterpret_cast<const uint8_t*>(data.data()), data.size_bytes(), alignof(T));
+    auto* data = reinterpret_cast<const uint8_t*>(span.data());
+    size_t size = span.size_bytes();
+    constexpr size_t alignment = alignof(T);
+    ASSERT(!(reinterpret_cast<uintptr_t>(data) % alignment));
+
+    uint8_t* buffer = grow(alignment, size);
+    memcpy(buffer, data, size);
 }
 
 template<typename T>

--- a/Source/WebKit/Platform/IPC/StreamConnectionEncoder.h
+++ b/Source/WebKit/Platform/IPC/StreamConnectionEncoder.h
@@ -54,10 +54,13 @@ public:
 
     ~StreamConnectionEncoder() = default;
 
-    bool encodeFixedLengthData(const uint8_t* data, size_t size, size_t alignment)
+    template<typename T, size_t Extent>
+    bool encodeSpan(const Span<T, Extent>& span)
     {
+        auto* data = reinterpret_cast<const uint8_t*>(span.data());
+        size_t size = span.size_bytes();
         size_t bufferPointer = static_cast<size_t>(reinterpret_cast<intptr_t>(m_buffer + m_encodedSize));
-        size_t newBufferPointer = roundUpToMultipleOf(alignment, bufferPointer);
+        size_t newBufferPointer = roundUpToMultipleOf<alignof(T)>(bufferPointer);
         if (newBufferPointer < bufferPointer)
             return false;
         intptr_t alignedSize = m_encodedSize + (newBufferPointer - bufferPointer);
@@ -67,12 +70,6 @@ public:
         memcpy(buffer, data, size);
         m_encodedSize = alignedSize + size;
         return true;
-    }
-
-    template<typename T, size_t Extent>
-    bool encodeSpan(const Span<T, Extent>& data)
-    {
-        return encodeFixedLengthData(reinterpret_cast<const uint8_t*>(data.data()), data.size_bytes(), alignof(T));
     }
 
     template<typename T>

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -1884,7 +1884,7 @@ static bool encodeTypedArray(IPC::Encoder& encoder, JSContextRef context, JSValu
     if (!data.buffer)
         return false;
 
-    encoder.encodeFixedLengthData(reinterpret_cast<const uint8_t*>(data.buffer), data.length, 1);
+    encoder.encodeSpan(Span { reinterpret_cast<const uint8_t*>(data.buffer), data.length });
     return true;
 }
 


### PR DESCRIPTION
#### 534e11ed95f096c59f8745a9caeaa3cc451670a7
<pre>
[WK2] Clean up fixed-length data encoding in Encoder, StreamConnectionEncoder
<a href="https://bugs.webkit.org/show_bug.cgi?id=251671">https://bugs.webkit.org/show_bug.cgi?id=251671</a>

Reviewed by Kimmo Kinnunen.

Remove the encodeFixedLengthData() methods on the Encoder and
StreamConnectionEncoder classes, moving the logic into the corresponding
encodeSpan() methods.

One remaining encodeFixedLengthData() call-site in IPCTestingAPI is amended.

* Source/WebKit/Platform/IPC/Encoder.cpp:
(IPC::Encoder::encodeFixedLengthData): Deleted.
* Source/WebKit/Platform/IPC/Encoder.h:
(IPC::Encoder::encodeSpan):
* Source/WebKit/Platform/IPC/StreamConnectionEncoder.h:
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::encodeTypedArray):

Canonical link: <a href="https://commits.webkit.org/260253@main">https://commits.webkit.org/260253@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44807082bc78dcfffecb081aaa6abdd1b6afa1f8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106020 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15076 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38853 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115202 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114936 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16500 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6255 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98229 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111773 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12562 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95532 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40102 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94427 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27175 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81773 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8329 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28527 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8820 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5086 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14443 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48070 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7087 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10364 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->