### PR TITLE
[WGSL] Implement bitwise expression parsing

### DIFF
--- a/Source/WebGPU/WGSL/Lexer.cpp
+++ b/Source/WebGPU/WGSL/Lexer.cpp
@@ -44,6 +44,9 @@ Token Lexer<T>::lex()
     case '%':
         shift();
         return makeToken(TokenType::Modulo);
+    case '&':
+        shift();
+        return makeToken(TokenType::And);
     case '(':
         shift();
         return makeToken(TokenType::ParenLeft);
@@ -131,6 +134,12 @@ Token Lexer<T>::lex()
             return makeToken(TokenType::PlusPlus);
         }
         return makeToken(TokenType::Plus);
+    case '^':
+        shift();
+        return makeToken(TokenType::Xor);
+    case '|':
+        shift();
+        return makeToken(TokenType::Or);
     case '0': {
         shift();
         double literalValue = 0;

--- a/Source/WebGPU/WGSL/ParserPrivate.h
+++ b/Source/WebGPU/WGSL/ParserPrivate.h
@@ -76,6 +76,7 @@ public:
     Expected<AST::Expression::Ref, Error> parseRelationalExpressionPostUnary(AST::Expression::Ref&& lhs);
     Expected<AST::Expression::Ref, Error> parseShiftExpressionPostUnary(AST::Expression::Ref&& lhs);
     Expected<AST::Expression::Ref, Error> parseAdditiveExpressionPostUnary(AST::Expression::Ref&& lhs);
+    Expected<AST::Expression::Ref, Error> parseBitwiseExpressionPostUnary(AST::Expression::Ref&& lhs);
     Expected<AST::Expression::Ref, Error> parseMultiplicativeExpressionPostUnary(AST::Expression::Ref&& lhs);
     Expected<AST::Expression::Ref, Error> parseUnaryExpression();
     Expected<AST::Expression::Ref, Error> parseSingularExpression();

--- a/Source/WebGPU/WGSL/Token.cpp
+++ b/Source/WebGPU/WGSL/Token.cpp
@@ -87,6 +87,8 @@ String toString(TokenType type)
         return "true"_s;
     case TokenType::LiteralFalse:
         return "false"_s;
+    case TokenType::And:
+        return "&"_s;
     case TokenType::Arrow:
         return "->"_s;
     case TokenType::Attribute:
@@ -119,6 +121,8 @@ String toString(TokenType type)
         return "--"_s;
     case TokenType::Modulo:
         return "%"_s;
+    case TokenType::Or:
+        return "|"_s;
     case TokenType::Plus:
         return "+"_s;
     case TokenType::PlusPlus:
@@ -135,6 +139,8 @@ String toString(TokenType type)
         return "/"_s;
     case TokenType::Star:
         return "*"_s;
+    case TokenType::Xor:
+        return "^"_s;
     }
 }
 

--- a/Source/WebGPU/WGSL/Token.h
+++ b/Source/WebGPU/WGSL/Token.h
@@ -70,6 +70,7 @@ enum class TokenType: uint32_t {
     LiteralFalse,
     // FIXME: add all the other keywords: see #keyword-summary in the WGSL spec
 
+    And,
     Arrow,
     Attribute,
     BraceLeft,
@@ -86,14 +87,16 @@ enum class TokenType: uint32_t {
     Minus,
     MinusMinus,
     Modulo,
-    Plus,
-    PlusPlus,
-    Period,
+    Or,
     ParenLeft,
     ParenRight,
+    Period,
+    Plus,
+    PlusPlus,
     Semicolon,
     Slash,
     Star,
+    Xor,
     // FIXME: add all the other special tokens
 };
 

--- a/Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp
@@ -147,6 +147,9 @@ TEST(WGSLLexerTests, SpecialTokens)
     checkSingleToken(";"_s, TokenType::Semicolon);
     checkSingleToken("/"_s, TokenType::Slash);
     checkSingleToken("*"_s, TokenType::Star);
+    checkSingleToken("&"_s, TokenType::And);
+    checkSingleToken("|"_s, TokenType::Or);
+    checkSingleToken("^"_s, TokenType::Xor);
 }
 
 TEST(WGSLLexerTests, ComputeShader)


### PR DESCRIPTION
#### dbe54de0044f94bf3d6a7fbf07fc29ace272bb58
<pre>
[WGSL] Implement bitwise expression parsing
<a href="https://bugs.webkit.org/show_bug.cgi?id=251670">https://bugs.webkit.org/show_bug.cgi?id=251670</a>
rdar://104997452

Reviewed by Tadeu Zagallo.

Handle parsing of expression involving &amp;, ^ and | according to the WGSL spec.

Canonical link: <a href="https://commits.webkit.org/260167@main">https://commits.webkit.org/260167@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a4bac691821682506706e7159312997eff6a84f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107387 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16448 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40265 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116547 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115972 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111287 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17871 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7687 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99549 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113150 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13483 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96642 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41106 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95386 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/28268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82871 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9458 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29621 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10112 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/6539 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15614 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49202 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7032 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11670 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->