### PR TITLE
[web-animations] clean up the keyframe recomputation code on style change

### DIFF
--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -2579,6 +2579,15 @@ public:
     }
 
 private:
+    bool equals(const RenderStyle& a, const RenderStyle& b) const final
+    {
+        if (a.textIndentLine() != b.textIndentLine())
+            return false;
+        if (a.textIndentType() != b.textIndentType())
+            return false;
+        return LengthPropertyWrapper::equals(a, b);
+    }
+
     bool canInterpolate(const RenderStyle& from, const RenderStyle& to, CompositeOperation compositeOperation) const final
     {
         if (from.textIndentLine() != to.textIndentLine())

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -28,9 +28,7 @@
 
 #include "Animation.h"
 #include "CSSAnimation.h"
-#include "CSSCustomPropertyValue.h"
 #include "CSSKeyframeRule.h"
-#include "CSSPrimitiveValue.h"
 #include "CSSPropertyAnimation.h"
 #include "CSSPropertyNames.h"
 #include "CSSPropertyParser.h"
@@ -894,11 +892,6 @@ void KeyframeEffect::updateBlendingKeyframes(RenderStyle& elementStyle, const St
     KeyframeList keyframeList(m_keyframesName);
     auto& styleResolver = m_target->styleResolver();
 
-    m_inheritedProperties.clear();
-    m_currentColorProperties.clear();
-    m_containsCSSVariableReferences = false;
-    m_hasRelativeFontWeight = false;
-
     for (auto& keyframe : m_parsedKeyframes) {
         KeyframeValue keyframeValue(keyframe.computedOffset, nullptr);
         keyframeValue.setTimingFunction(keyframe.timingFunction->clone());
@@ -918,30 +911,9 @@ void KeyframeEffect::updateBlendingKeyframes(RenderStyle& elementStyle, const St
         }
 
         auto keyframeRule = StyleRuleKeyframe::create(keyframe.style->immutableCopyIfNeeded());
-        if (!m_containsCSSVariableReferences)
-            m_containsCSSVariableReferences = keyframeRule->containsCSSVariableReferences();
-
-        for (auto property : keyframeRule->properties()) {
-            if (auto* cssValue = property.value()) {
-                if (cssValue->isPrimitiveValue()) {
-                    auto valueId = downcast<CSSPrimitiveValue>(*cssValue).valueID();
-                    if (valueId == CSSValueInherit)
-                        m_inheritedProperties.add(property.id());
-                    else if (valueId == CSSValueCurrentcolor)
-                        m_currentColorProperties.add(property.id());
-                    else if (property.id() == CSSPropertyFontWeight && (valueId == CSSValueBolder || valueId == CSSValueLighter))
-                        m_hasRelativeFontWeight = true;
-                } else if (auto* customPropertyValue = dynamicDowncast<CSSCustomPropertyValue>(cssValue)) {
-                    if (customPropertyValue->isCurrentColor())
-                        m_currentColorProperties.add(customPropertyValue->name());
-                    else if (customPropertyValue->isInherit())
-                        m_inheritedProperties.add(customPropertyValue->name());
-                }
-            }
-        }
-
         keyframeValue.setStyle(styleResolver.styleForKeyframe(*m_target, elementStyle, resolutionContext, keyframeRule.get(), keyframeValue));
         keyframeList.insert(WTFMove(keyframeValue));
+        keyframeList.updatePropertiesMetadata(keyframeRule->properties());
     }
 
     setBlendingKeyframes(WTFMove(keyframeList));
@@ -987,21 +959,6 @@ bool KeyframeEffect::animatesProperty(AnimatableProperty property) const
             }
         );
     }) != notFound;
-}
-
-bool KeyframeEffect::animatesDirectionAwareProperty() const
-{
-    if (!m_blendingKeyframes.isEmpty())
-        return m_blendingKeyframes.containsDirectionAwareProperty();
-
-    for (auto& keyframe : m_parsedKeyframes) {
-        for (auto property : keyframe.styleStrings.keys()) {
-            if (CSSProperty::isDirectionAwareProperty(property))
-                return true;
-        }
-    }
-
-    return false;
 }
 
 bool KeyframeEffect::forceLayoutIfNeeded()
@@ -1081,7 +1038,7 @@ void KeyframeEffect::computeCSSAnimationBlendingKeyframes(const RenderStyle& una
 
     KeyframeList keyframeList(AtomString { backingAnimation.name().string });
     if (auto* styleScope = Style::Scope::forOrdinal(*m_target, backingAnimation.nameStyleScopeOrdinal()))
-        styleScope->resolver().keyframeStylesForAnimation(*m_target, unanimatedStyle, resolutionContext, keyframeList, m_containsCSSVariableReferences, m_hasRelativeFontWeight, m_inheritedProperties, m_currentColorProperties);
+        styleScope->resolver().keyframeStylesForAnimation(*m_target, unanimatedStyle, resolutionContext, keyframeList);
 
     // Ensure resource loads for all the frames.
     for (auto& keyframe : keyframeList) {
@@ -1794,18 +1751,93 @@ void KeyframeEffect::transformRelatedPropertyDidChange()
     addPendingAcceleratedAction(AcceleratedAction::TransformChange);
 }
 
-void KeyframeEffect::propertyAffectingKeyframeResolutionDidChange(RenderStyle& unanimatedStyle, const Style::ResolutionContext& resolutionContext)
+std::optional<KeyframeEffect::RecomputationReason> KeyframeEffect::recomputeKeyframesIfNecessary(const RenderStyle* previousUnanimatedStyle, const RenderStyle& unanimatedStyle, const Style::ResolutionContext& resolutionContext)
 {
-    switch (m_blendingKeyframesSource) {
-    case BlendingKeyframesSource::CSSTransition:
-        return;
-    case BlendingKeyframesSource::CSSAnimation:
-        computeCSSAnimationBlendingKeyframes(unanimatedStyle, resolutionContext);
-        return;
-    case BlendingKeyframesSource::WebAnimation:
-        clearBlendingKeyframes();
-        return;
+    if (m_blendingKeyframesSource == BlendingKeyframesSource::CSSTransition)
+        return { };
+
+    auto fontSizeChanged = [&]() {
+        return previousUnanimatedStyle && previousUnanimatedStyle->computedFontSize() != unanimatedStyle.computedFontSize();
+    };
+
+    auto fontWeightChanged = [&]() {
+        return m_blendingKeyframes.usesRelativeFontWeight() && previousUnanimatedStyle
+        && previousUnanimatedStyle->fontWeight() != unanimatedStyle.fontWeight();
+    };
+
+    auto cssVariableChanged = [&]() {
+        if (previousUnanimatedStyle && m_blendingKeyframes.hasCSSVariableReferences()) {
+            if (!previousUnanimatedStyle->customPropertiesEqual(unanimatedStyle))
+                return true;
+        }
+        return false;
+    };
+
+    auto propertySetToInheritChanged = [&]() {
+        // In the rare case where a non-inherted property was set to "inherit" on a keyframe,
+        // we consider that a property set to "inherit" changed without trying to work out whether
+        // the computed value changed.
+        if (m_hasExplicitlyInheritedKeyframeProperty)
+            return true;
+
+        if (previousUnanimatedStyle) {
+            for (auto property : m_blendingKeyframes.propertiesSetToInherit()) {
+                ASSERT(m_target);
+                if (!CSSPropertyAnimation::propertiesEqual(property, *previousUnanimatedStyle, unanimatedStyle, m_target->document()))
+                    return true;
+            }
+        }
+        return false;
+    };
+
+    auto propertySetToCurrentColorChanged = [&]() {
+        // If the "color" property itself is set to "currentcolor" on a keyframe, we always recompute keyframes.
+        if (m_blendingKeyframes.hasColorSetToCurrentColor())
+            return true;
+        // For all other color-related properties set to "currentcolor" on a keyframe, it's sufficient to check
+        // whether the value "color" resolves to has changed since the last style resolution.
+        return m_blendingKeyframes.hasPropertySetToCurrentColor() && previousUnanimatedStyle
+        && previousUnanimatedStyle->color() != unanimatedStyle.color();
+    };
+
+    auto logicalPropertyChanged = [&]() {
+        if (!previousUnanimatedStyle)
+            return false;
+
+        if (previousUnanimatedStyle->direction() == unanimatedStyle.direction()
+            && previousUnanimatedStyle->writingMode() == unanimatedStyle.writingMode())
+            return false;
+
+        if (!m_blendingKeyframes.isEmpty())
+            return m_blendingKeyframes.containsDirectionAwareProperty();
+
+        for (auto& keyframe : m_parsedKeyframes) {
+            for (auto property : keyframe.styleStrings.keys()) {
+                if (CSSProperty::isDirectionAwareProperty(property))
+                    return true;
+            }
+        }
+
+        return false;
+    }();
+
+    if (logicalPropertyChanged || fontSizeChanged() || fontWeightChanged() || cssVariableChanged() || propertySetToInheritChanged() || propertySetToCurrentColorChanged()) {
+        switch (m_blendingKeyframesSource) {
+        case BlendingKeyframesSource::CSSTransition:
+            ASSERT_NOT_REACHED();
+            break;
+        case BlendingKeyframesSource::CSSAnimation:
+            computeCSSAnimationBlendingKeyframes(unanimatedStyle, resolutionContext);
+            break;
+        case BlendingKeyframesSource::WebAnimation:
+            clearBlendingKeyframes();
+            break;
+        }
+
+        return logicalPropertyChanged ? KeyframeEffect::RecomputationReason::LogicalPropertyChange : KeyframeEffect::RecomputationReason::Other;
     }
+
+    return { };
 }
 
 void KeyframeEffect::animationWasCanceled()
@@ -2415,16 +2447,6 @@ void KeyframeEffect::lastStyleChangeEventStyleDidChange(const RenderStyle* previ
 
     if (hasMotionPath(previousStyle) != hasMotionPath(currentStyle))
         abilityToBeAcceleratedDidChange();
-}
-
-bool KeyframeEffect::hasPropertySetToCurrentColor() const
-{
-    return !m_currentColorProperties.isEmpty();
-}
-
-bool KeyframeEffect::hasColorSetToCurrentColor() const
-{
-    return m_currentColorProperties.contains(CSSPropertyColor);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -126,7 +126,8 @@ public:
 
     void animationTimingDidChange();
     void transformRelatedPropertyDidChange();
-    void propertyAffectingKeyframeResolutionDidChange(RenderStyle&, const Style::ResolutionContext&);
+    enum class RecomputationReason : uint8_t { LogicalPropertyChange, Other };
+    std::optional<RecomputationReason> recomputeKeyframesIfNecessary(const RenderStyle* previousUnanimatedStyle, const RenderStyle& unanimatedStyle, const Style::ResolutionContext&);
     void applyPendingAcceleratedActions();
 
     void willChangeRenderer();
@@ -150,9 +151,7 @@ public:
     void computeDeclarativeAnimationBlendingKeyframes(const RenderStyle* oldStyle, const RenderStyle& newStyle, const Style::ResolutionContext&);
     const KeyframeList& blendingKeyframes() const { return m_blendingKeyframes; }
     const HashSet<AnimatableProperty>& animatedProperties();
-    const HashSet<AnimatableProperty>& inheritedProperties() const { return m_inheritedProperties; }
     bool animatesProperty(AnimatableProperty) const;
-    bool animatesDirectionAwareProperty() const;
 
     bool computeExtentOfTransformAnimation(LayoutRect&) const;
     bool computeTransformedExtentViaTransformList(const FloatRect&, const RenderStyle&, LayoutRect&) const;
@@ -178,12 +177,6 @@ public:
     void lastStyleChangeEventStyleDidChange(const RenderStyle* previousStyle, const RenderStyle* currentStyle);
 
     static String CSSPropertyIDToIDLAttributeName(CSSPropertyID);
-
-    bool containsCSSVariableReferences() const { return m_containsCSSVariableReferences; }
-    bool hasExplicitlyInheritedKeyframeProperty() const { return m_hasExplicitlyInheritedKeyframeProperty; }
-    bool hasPropertySetToCurrentColor() const;
-    bool hasColorSetToCurrentColor() const;
-    bool hasRelativeFontWeight() const { return m_hasRelativeFontWeight; }
 
 private:
     KeyframeEffect(Element*, PseudoId);
@@ -246,8 +239,6 @@ private:
     AtomString m_keyframesName;
     KeyframeList m_blendingKeyframes { emptyAtom() };
     HashSet<AnimatableProperty> m_animatedProperties;
-    HashSet<AnimatableProperty> m_inheritedProperties;
-    HashSet<AnimatableProperty> m_currentColorProperties;
     Vector<ParsedKeyframe> m_parsedKeyframes;
     Vector<AcceleratedAction> m_pendingAcceleratedActions;
     RefPtr<Element> m_target;
@@ -267,9 +258,7 @@ private:
     bool m_someKeyframesUseStepsTimingFunction { false };
     bool m_hasImplicitKeyframeForAcceleratedProperty { false };
     bool m_hasKeyframeComposingAcceleratedProperty { false };
-    bool m_containsCSSVariableReferences { false };
     bool m_hasExplicitlyInheritedKeyframeProperty { false };
-    bool m_hasRelativeFontWeight { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSKeyframeRule.cpp
+++ b/Source/WebCore/css/CSSKeyframeRule.cpp
@@ -96,17 +96,6 @@ String StyleRuleKeyframe::cssText() const
     return makeString(keyText(), " { }");
 }
 
-bool StyleRuleKeyframe::containsCSSVariableReferences() const
-{
-    for (auto property : m_properties.get()) {
-        if (auto* cssValue = property.value()) {
-            if (cssValue->hasVariableReferences())
-                return true;
-        }
-    }
-    return false;
-}
-
 CSSKeyframeRule::CSSKeyframeRule(StyleRuleKeyframe& keyframe, CSSKeyframesRule* parent)
     : CSSRule(nullptr)
     , m_keyframe(keyframe)

--- a/Source/WebCore/css/CSSKeyframeRule.h
+++ b/Source/WebCore/css/CSSKeyframeRule.h
@@ -59,8 +59,6 @@ public:
 
     String cssText() const;
 
-    bool containsCSSVariableReferences() const;
-
 private:
     explicit StyleRuleKeyframe(Ref<StyleProperties>&&);
     StyleRuleKeyframe(Vector<double>&&, Ref<StyleProperties>&&);

--- a/Source/WebCore/rendering/style/KeyframeList.h
+++ b/Source/WebCore/rendering/style/KeyframeList.h
@@ -35,6 +35,7 @@ namespace WebCore {
 
 class KeyframeEffect;
 class RenderStyle;
+class StyleProperties;
 class TimingFunction;
 
 namespace Style {
@@ -84,7 +85,7 @@ public:
     {
     }
     ~KeyframeList();
-        
+
     KeyframeList& operator=(KeyframeList&&) = default;
     bool operator==(const KeyframeList& o) const;
     bool operator!=(const KeyframeList& o) const { return !(*this == o); }
@@ -113,11 +114,22 @@ public:
     auto end() const { return m_keyframes.end(); }
 
     bool usesContainerUnits() const;
+    bool usesRelativeFontWeight() const;
+    bool hasCSSVariableReferences() const;
+    bool hasColorSetToCurrentColor() const;
+    bool hasPropertySetToCurrentColor() const;
+    const HashSet<AnimatableProperty>& propertiesSetToInherit() const;
+
+    void updatePropertiesMetadata(const StyleProperties&);
 
 private:
     AtomString m_animationName;
     Vector<KeyframeValue> m_keyframes; // Kept sorted by key.
     HashSet<AnimatableProperty> m_properties; // The properties being animated.
+    bool m_usesRelativeFontWeight { false };
+    bool m_containsCSSVariableReferences { false };
+    HashSet<AnimatableProperty> m_propertiesSetToInherit;
+    HashSet<AnimatableProperty> m_propertiesSetToCurrentColor;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/style/StyleResolver.h
+++ b/Source/WebCore/style/StyleResolver.h
@@ -95,7 +95,7 @@ public:
 
     ResolvedStyle styleForElement(const Element&, const ResolutionContext&, RuleMatchingBehavior = RuleMatchingBehavior::MatchAllRules);
 
-    void keyframeStylesForAnimation(const Element&, const RenderStyle& elementStyle, const ResolutionContext&, KeyframeList&, bool& containsCSSVariableReferences, bool& hasRelativeFontWeight, HashSet<AnimatableProperty>& inheritedProperties, HashSet<AnimatableProperty>& currentColorProperties);
+    void keyframeStylesForAnimation(const Element&, const RenderStyle& elementStyle, const ResolutionContext&, KeyframeList&);
 
     WEBCORE_EXPORT std::optional<ResolvedStyle> styleForPseudoElement(const Element&, const PseudoElementRequest&, const ResolutionContext&);
 


### PR DESCRIPTION
#### 7a34ce6d991407d4952df999f0e65a8748486389
<pre>
[web-animations] clean up the keyframe recomputation code on style change
<a href="https://bugs.webkit.org/show_bug.cgi?id=251674">https://bugs.webkit.org/show_bug.cgi?id=251674</a>

Reviewed by Antti Koivisto.

We landed a fair few changes recently to recompute keyframes when style changes while animations are
active. The ever-increasing list of parameters passed to Style::Resolver::keyframeStylesForAnimation()
as well as the ever-growing list of change checks made in KeyframeEffectStack::applyKeyframeEffects()
could do with some cleaning up.

We add a new KeyframeList::updatePropertiesMetadata() method which takes in a StyleProperties
and gathers information on the rule&apos;s StyleProperties relevant to keyframe recomputation: whether
&quot;inherit&quot; or &quot;currentcolor&quot; values are set, whether CSS variable values are used, whether a relative
font-weight value is set. This replaces duplicated logic found in Style::Resolver (in the CSS Animations
case) and KeyframeEffect (in the JS-originated case) when computing keyframes.

This method is called in Style::Resolver::keyframeStylesForAnimation() and KeyframeEffect::updateBlendingKeyframes().
This allows us to remove the matching information previously stored on KeyframeEffect.

We move all the logic from KeyframeEffectStack::applyKeyframeEffects() related to checking
whether some properties change to a new KeyframeEffect::recomputeKeyframesIfNecessary() which
will query the KeyframeList.

The code is now clearer and any future change to recompute keyframes will no longer require code
duplication.

Doing this refactor also uncovered a small error in the animation wrapper for text-indent which would
not check for the RenderStyle::textIndentLine() and RenderStyle::textIndentType() bits to determine
whether two text-indent were equal. This was likely due to change in the order of functions we use to check
whether a recomputation is required in the new KeyframeEffect::recomputeKeyframesIfNecessary().

* Source/WebCore/animation/CSSPropertyAnimation.cpp:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::updateBlendingKeyframes):
(WebCore::KeyframeEffect::computeCSSAnimationBlendingKeyframes):
(WebCore::KeyframeEffect::recomputeKeyframesIfNecessary):
(WebCore::KeyframeEffect::animatesDirectionAwareProperty const): Deleted.
(WebCore::KeyframeEffect::propertyAffectingKeyframeResolutionDidChange): Deleted.
(WebCore::KeyframeEffect::hasPropertySetToCurrentColor const): Deleted.
(WebCore::KeyframeEffect::hasColorSetToCurrentColor const): Deleted.
* Source/WebCore/animation/KeyframeEffect.h:
(WebCore::KeyframeEffect::inheritedProperties const): Deleted.
(WebCore::KeyframeEffect::containsCSSVariableReferences const): Deleted.
(WebCore::KeyframeEffect::hasExplicitlyInheritedKeyframeProperty const): Deleted.
(WebCore::KeyframeEffect::hasRelativeFontWeight const): Deleted.
* Source/WebCore/animation/KeyframeEffectStack.cpp:
(WebCore::KeyframeEffectStack::applyKeyframeEffects):
* Source/WebCore/css/CSSKeyframeRule.cpp:
(WebCore::StyleRuleKeyframe::containsCSSVariableReferences const): Deleted.
* Source/WebCore/css/CSSKeyframeRule.h:
* Source/WebCore/rendering/style/KeyframeList.cpp:
(WebCore::KeyframeList::clear):
(WebCore::KeyframeList::usesRelativeFontWeight const):
(WebCore::KeyframeList::hasCSSVariableReferences const):
(WebCore::KeyframeList::hasColorSetToCurrentColor const):
(WebCore::KeyframeList::hasPropertySetToCurrentColor const):
(WebCore::KeyframeList::propertiesSetToInherit const):
(WebCore::KeyframeList::updatePropertiesMetadata):
* Source/WebCore/rendering/style/KeyframeList.h:
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::keyframeStylesForAnimation):
* Source/WebCore/style/StyleResolver.h:

Canonical link: <a href="https://commits.webkit.org/259838@main">https://commits.webkit.org/259838@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/540dab940501ae97be5e668db79b69ec68573456

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106060 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15115 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38891 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115241 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/175334 "Build was cancelled. Recent messages:Pull request contains relevant changes; Deleted stale build files; Encountered some issues during cleanup") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109962 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16540 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6285 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98268 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114961 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111813 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95565 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40137 "Passed tests") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27208 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8366 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28560 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8858 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5109 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14479 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48104 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10402 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3662 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->