### PR TITLE
[@property] Cache tokens in CSSCustomPropertyValue

### DIFF
--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -3914,7 +3914,7 @@ static std::optional<CSSCustomPropertyValue::SyntaxValueList> blendSyntaxValueLi
     return CSSCustomPropertyValue::SyntaxValueList { blendedSyntaxValues, from.separator };
 }
 
-static Ref<CSSCustomPropertyValue> blendedCSSCustomPropertyValue(const RenderStyle& fromStyle, const RenderStyle& toStyle, const CSSCustomPropertyValue& from, const CSSCustomPropertyValue& to, const CSSPropertyBlendingContext& blendingContext)
+static Ref<const CSSCustomPropertyValue> blendedCSSCustomPropertyValue(const RenderStyle& fromStyle, const RenderStyle& toStyle, const CSSCustomPropertyValue& from, const CSSCustomPropertyValue& to, const CSSPropertyBlendingContext& blendingContext)
 {
     if (std::holds_alternative<CSSCustomPropertyValue::SyntaxValue>(from.value()) && std::holds_alternative<CSSCustomPropertyValue::SyntaxValue>(to.value())) {
         auto& fromSyntaxValue = std::get<CSSCustomPropertyValue::SyntaxValue>(from.value());
@@ -3931,7 +3931,7 @@ static Ref<CSSCustomPropertyValue> blendedCSSCustomPropertyValue(const RenderSty
     }
 
     // Use a discrete interpolation for all other cases.
-    return CSSCustomPropertyValue::create(blendingContext.progress < 0.5 ? from : to);
+    return blendingContext.progress < 0.5 ? from : to;
 }
 
 static std::pair<const CSSCustomPropertyValue*, const CSSCustomPropertyValue*> customPropertyValuesForBlending(const AtomString& customProperty, const RenderStyle& fromStyle, const RenderStyle& toStyle)

--- a/Source/WebCore/css/CSSCustomPropertyValue.h
+++ b/Source/WebCore/css/CSSCustomPropertyValue.h
@@ -96,11 +96,6 @@ public:
         return adoptRef(*new CSSCustomPropertyValue(name, VariantValue { WTFMove(syntaxValueList) }));
     }
 
-    static Ref<CSSCustomPropertyValue> create(const CSSCustomPropertyValue& other)
-    {
-        return adoptRef(*new CSSCustomPropertyValue(other));
-    }
-
     String customCSSText() const;
 
     const AtomString& name() const { return m_name; }
@@ -113,7 +108,8 @@ public:
 
     const VariantValue& value() const { return m_value; }
 
-    Vector<CSSParserToken> tokens() const;
+    const Vector<CSSParserToken>& tokens() const;
+
     bool equals(const CSSCustomPropertyValue&) const;
 
     Ref<const CSSVariableData> asVariableData() const;
@@ -126,17 +122,10 @@ private:
     {
     }
 
-    CSSCustomPropertyValue(const CSSCustomPropertyValue& other)
-        : CSSValue(CustomPropertyClass)
-        , m_name(other.m_name)
-        , m_value(other.m_value)
-        , m_stringValue(other.m_stringValue)
-    {
-    }
-
     const AtomString m_name;
     const VariantValue m_value;
-    mutable String m_stringValue;
+    mutable String m_cachedCSSText;
+    mutable RefPtr<CSSVariableData> m_cachedTokens;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### b63783f818783e6859c645186f4c98a09f4bab2d
<pre>
[@property] Cache tokens in CSSCustomPropertyValue
<a href="https://bugs.webkit.org/show_bug.cgi?id=251672">https://bugs.webkit.org/show_bug.cgi?id=251672</a>
rdar://104997649

Reviewed by Antoine Quint.

We currently generate tokens on every access by tokenizing a (cached) string.

* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::blendedCSSCustomPropertyValue):
* Source/WebCore/css/CSSCustomPropertyValue.cpp:
(WebCore::CSSCustomPropertyValue::customCSSText const):
(WebCore::CSSCustomPropertyValue::tokens const):

Add a token cache for registered custom properties.
Also avoid copying by returning a reference.

* Source/WebCore/css/CSSCustomPropertyValue.h:

Also remove an unneeded copy constructor.

Canonical link: <a href="https://commits.webkit.org/259813@main">https://commits.webkit.org/259813@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a6d0a3cdd1796d1569489e4ec56ec64954f7fb5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106040 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15097 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38873 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115223 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/175320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109943 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16521 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6270 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98250 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111793 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95551 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/40121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94448 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27193 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8348 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28545 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8840 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/5097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14461 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48089 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6791 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10384 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->