### PR TITLE
[GTK][WPE] Remove webkit_web_view_new_with_related_view from new API too

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -754,12 +754,20 @@ static void webkitWebViewConstructed(GObject* object)
     WebKitWebView* webView = WEBKIT_WEB_VIEW(object);
     WebKitWebViewPrivate* priv = webView->priv;
     if (priv->relatedView) {
+        if (priv->context)
+            g_critical("WebKitWebView web-context property can't be set when releated-view is set too, passed web-context value is ignored.");
         priv->context = webkit_web_view_get_context(priv->relatedView);
 #if ENABLE(2022_GLIB_API)
+        if (priv->networkSession)
+            g_critical("WebKitWebView network-session property can't be set when releated-view is set too, passed network-session value is ignored.");
         priv->networkSession = webkit_web_view_get_network_session(priv->relatedView);
 #else
+        if (priv->isEphemeral)
+            g_critical("WebKitWebView is-ephemeral property can't be set when releated-view is set too, passed is-ephemeral value is ignored.");
         priv->isEphemeral = webkit_web_view_is_ephemeral(priv->relatedView);
 #endif
+        if (priv->isControlledByAutomation)
+            g_critical("WebKitWebView is-controlled-by-automation can't be set when releated-view is set too, passed is-controlled-by-automation value is ignored.");
         priv->isControlledByAutomation = webkit_web_view_is_controlled_by_automation(priv->relatedView);
     } else if (!priv->context)
         priv->context = webkit_web_context_get_default();
@@ -1107,8 +1115,8 @@ static void webkit_web_view_class_init(WebKitWebViewClass* webViewClass)
      * WebKitWebView:related-view:
      *
      * The related #WebKitWebView used when creating the view to share the
-     * same web process. This property is not readable because the related
-     * web view is only valid during the object construction.
+     * same web process and network session. This property is not readable
+     * because the related web view is only valid during the object construction.
      *
      * Since: 2.4
      */
@@ -1658,7 +1666,7 @@ static void webkit_web_view_class_init(WebKitWebViewClass* webViewClass)
      * navigation action that triggered this signal.
      *
      * The new #WebKitWebView must be related to @web_view, see
-     * webkit_web_view_new_with_related_view() for more details.
+     * #WebKitWebView:related-view for more details.
      *
      * The new #WebKitWebView should not be displayed to the user
      * until the #WebKitWebView::ready-to-show signal is emitted.

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
@@ -434,10 +434,10 @@ webkit_web_view_get_type                             (void);
 WEBKIT_API GtkWidget *
 webkit_web_view_new                                  (void);
 
+#if !ENABLE(2022_GLIB_API)
 WEBKIT_API GtkWidget *
 webkit_web_view_new_with_related_view                (WebKitWebView             *web_view);
 
-#if !ENABLE(2022_GLIB_API)
 WEBKIT_API GtkWidget *
 webkit_web_view_new_with_context                     (WebKitWebContext          *context);
 
@@ -453,11 +453,11 @@ webkit_web_view_new_with_user_content_manager        (WebKitUserContentManager  
 WEBKIT_API WebKitWebView *
 webkit_web_view_new                                  (WebKitWebViewBackend      *backend);
 
+#if !ENABLE(2022_GLIB_API)
 WEBKIT_API WebKitWebView *
 webkit_web_view_new_with_related_view                (WebKitWebViewBackend      *backend,
                                                       WebKitWebView             *web_view);
 
-#if !ENABLE(2022_GLIB_API)
 WEBKIT_API WebKitWebView *
 webkit_web_view_new_with_context                     (WebKitWebViewBackend      *backend,
                                                       WebKitWebContext          *context);

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewGtk.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewGtk.cpp
@@ -360,6 +360,7 @@ GtkWidget* webkit_web_view_new_with_context(WebKitWebContext* context)
 }
 #endif
 
+#if !ENABLE(2022_GLIB_API)
 /**
  * webkit_web_view_new_with_related_view: (constructor)
  * @web_view: the related #WebKitWebView
@@ -392,7 +393,6 @@ GtkWidget* webkit_web_view_new_with_related_view(WebKitWebView* webView)
         nullptr));
 }
 
-#if !ENABLE(2022_GLIB_API)
 /**
  * webkit_web_view_new_with_settings:
  * @settings: a #WebKitSettings

--- a/Source/WebKit/UIProcess/API/wpe/WebKitWebViewWPE.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WebKitWebViewWPE.cpp
@@ -118,6 +118,7 @@ WebKitWebView* webkit_web_view_new_with_context(WebKitWebViewBackend* backend, W
 }
 #endif
 
+#if !ENABLE(2022_GLIB_API)
 /**
  * webkit_web_view_new_with_related_view: (constructor)
  * @backend: (transfer full) (not nullable): wrapped WPE view backend which
@@ -149,7 +150,6 @@ WebKitWebView* webkit_web_view_new_with_related_view(WebKitWebViewBackend* backe
         nullptr));
 }
 
-#if !ENABLE(2022_GLIB_API)
 /**
  * webkit_web_view_new_with_settings:
  * @backend: (transfer full) (not nullable): wrapped WPE view backend which

--- a/Tools/MiniBrowser/gtk/BrowserWindow.c
+++ b/Tools/MiniBrowser/gtk/BrowserWindow.c
@@ -462,8 +462,12 @@ static void webViewReadyToShow(WebKitWebView *webView, BrowserWindow *window)
 
 static GtkWidget *webViewCreate(WebKitWebView *webView, WebKitNavigationAction *navigation, BrowserWindow *window)
 {
-    WebKitWebView *newWebView = WEBKIT_WEB_VIEW(webkit_web_view_new_with_related_view(webView));
-    webkit_web_view_set_settings(newWebView, webkit_web_view_get_settings(webView));
+    WebKitWebView *newWebView = WEBKIT_WEB_VIEW(g_object_new(WEBKIT_TYPE_WEB_VIEW,
+        "related-view", webView,
+        "settings", webkit_web_view_get_settings(webView),
+        "user-content-manager", webkit_web_view_get_user_content_manager(webView),
+        "website-policies", webkit_web_view_get_website_policies(webView),
+        NULL));
 
 #if GTK_CHECK_VERSION(3, 98, 0)
     GtkWidget *newWindow = browser_window_new(GTK_WINDOW(window), window->webContext, window->networkSession);

--- a/Tools/MiniBrowser/wpe/main.cpp
+++ b/Tools/MiniBrowser/wpe/main.cpp
@@ -172,8 +172,12 @@ static WebKitWebView* createWebView(WebKitWebView* webView, WebKitNavigationActi
             delete static_cast<WPEToolingBackends::ViewBackend*>(data);
         }, backend.release());
 
-    auto* newWebView = webkit_web_view_new_with_related_view(viewBackend, webView);
-    webkit_web_view_set_settings(newWebView, webkit_web_view_get_settings(webView));
+    auto* newWebView = WEBKIT_WEB_VIEW(g_object_new(WEBKIT_TYPE_WEB_VIEW,
+        "backend", viewBackend,
+        "related-view", webView,
+        "settings", webkit_web_view_get_settings(webView),
+        "user-content-manager", webkit_web_view_get_user_content_manager(webView),
+        nullptr));
 
     g_signal_connect(newWebView, "create", G_CALLBACK(createWebView), nullptr);
     g_signal_connect(newWebView, "close", G_CALLBACK(webViewClose), nullptr);

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebView.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebView.cpp
@@ -85,6 +85,7 @@ static void testWebViewWebContext(WebViewTest* test, gconstpointer)
     g_assert_true(webkit_web_view_get_context(webView.get()) == test->m_webContext.get());
 
     // Check that a web context given as construct parameter is ignored if a related view is also provided.
+    Test::removeLogFatalFlag(G_LOG_LEVEL_CRITICAL);
     webView = Test::adoptView(g_object_new(WEBKIT_TYPE_WEB_VIEW,
 #if PLATFORM(WPE)
         "backend", Test::createWebViewBackend(),
@@ -92,6 +93,7 @@ static void testWebViewWebContext(WebViewTest* test, gconstpointer)
         "web-context", webkit_web_context_get_default(),
         "related-view", test->m_webView,
         nullptr));
+    Test::addLogFatalFlag(G_LOG_LEVEL_CRITICAL);
     g_assert_true(webkit_web_view_get_context(webView.get()) == test->m_webContext.get());
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitGtk/TestPrinting.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGtk/TestPrinting.cpp
@@ -227,7 +227,9 @@ public:
 
     GtkWidget* createWebView()
     {
-        GtkWidget* newWebView = webkit_web_view_new_with_related_view(m_webView);
+        GtkWidget* newWebView = GTK_WIDGET(g_object_new(WEBKIT_TYPE_WEB_VIEW,
+            "related-view", m_webView,
+            nullptr));
         g_object_ref_sink(newWebView);
 
         assertObjectIsDeletedWhenTestFinishes(G_OBJECT(newWebView));

--- a/Tools/TestWebKitAPI/glib/WebKitGLib/TestMain.h
+++ b/Tools/TestWebKitAPI/glib/WebKitGLib/TestMain.h
@@ -206,11 +206,12 @@ public:
 
     static WebKitWebView* createWebView(WebKitWebView* relatedView)
     {
-#if PLATFORM(GTK)
-        return WEBKIT_WEB_VIEW(webkit_web_view_new_with_related_view(relatedView));
-#elif PLATFORM(WPE)
-        return webkit_web_view_new_with_related_view(createWebViewBackend(), relatedView);
+        return WEBKIT_WEB_VIEW(g_object_new(WEBKIT_TYPE_WEB_VIEW,
+#if PLATFORM(WPE)
+            "backend", createWebViewBackend(),
 #endif
+            "related-view", relatedView,
+            nullptr));
     }
 
     static WebKitWebView* createWebView(WebKitUserContentManager* contentManager)


### PR DESCRIPTION
#### 57a26786ef09798e808a70a8e6e2da499326b8e2
<pre>
[GTK][WPE] Remove webkit_web_view_new_with_related_view from new API too
<a href="https://bugs.webkit.org/show_bug.cgi?id=251426">https://bugs.webkit.org/show_bug.cgi?id=251426</a>

Reviewed by Adrian Perez de Castro.

It&apos;s confusing because it&apos;s not equivalent to just calling
g_object_new() with releated-view property set.

* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(webkit_web_view_class_init):
* Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in:
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewGtk.cpp:
* Source/WebKit/UIProcess/API/wpe/WebKitWebViewWPE.cpp:
* Tools/TestWebKitAPI/Tests/WebKitGtk/TestPrinting.cpp:
* Tools/TestWebKitAPI/glib/WebKitGLib/TestMain.h:
(Test::createWebView):

Canonical link: <a href="https://commits.webkit.org/259885@main">https://commits.webkit.org/259885@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4cdee52097171b9249ad4c39c37360af36672f70

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106303 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15357 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39142 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115496 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175600 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110213 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16799 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6573 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98519 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115183 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112067 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12782 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95767 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/40335 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94657 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27410 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82025 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8597 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28762 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9107 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5331 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14720 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48308 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10643 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3682 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->