### PR TITLE
RenderLayerScrollableArea::updateResizerStyle should early return if there is no resizer

### DIFF
--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -1,6 +1,7 @@
 /*
- * Copyright (C) 2006-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2019 Adobe. All rights reserved.
+ * Copyright (C) 2014 Google. All rights reserved.
  * Copyright (C) 2020 Igalia S.L.
  *
  * Portions are Copyright (C) 1998 Netscape Communications Corporation.
@@ -1751,6 +1752,9 @@ void RenderLayerScrollableArea::clearScrollCorner()
 
 void RenderLayerScrollableArea::updateResizerStyle()
 {
+    if (!m_resizer && !m_layer.canResize())
+        return;
+
     auto& renderer = m_layer.renderer();
     RenderElement* actualRenderer = rendererForScrollbar(renderer);
     auto resizer = renderer.hasNonVisibleOverflow() ? actualRenderer->getUncachedPseudoStyle({ PseudoId::Resizer }, &actualRenderer->style()) : nullptr;


### PR DESCRIPTION
#### b5f2eee537a0cfdb71b7df4a2070a665b0c24e2b
<pre>
RenderLayerScrollableArea::updateResizerStyle should early return if there is no resizer

RenderLayerScrollableArea::updateResizerStyle should early return if there is no resizer
<a href="https://bugs.webkit.org/show_bug.cgi?id=251676">https://bugs.webkit.org/show_bug.cgi?id=251676</a>

Reviewed by Simon Fraser.

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/1add5ffe5081cf282014bc4cfe04b8637244c607">https://chromium.googlesource.com/chromium/blink/+/1add5ffe5081cf282014bc4cfe04b8637244c607</a>

This is potential optimization by adding early return to &quot;updateResizeStyle&quot; function in case if there is no resizer.

* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(RenderLayerScrollableArea::updateResizerStyle): Add early return

Canonical link: <a href="https://commits.webkit.org/260857@main">https://commits.webkit.org/260857@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d3168a1a3473d1e4210f5ce36389bd99ff3b2b1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107243 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16287 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40256 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116401 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115862 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111143 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17736 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7557 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99401 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113008 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13385 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96630 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40997 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95286 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28257 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82768 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9348 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29609 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9985 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6453 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15503 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49190 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7528 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11518 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->