### PR TITLE
[WebRTC] Insufficient test for back camera canvas in webrtc/video-replace-track.html

### DIFF
--- a/LayoutTests/webrtc/video-replace-track.html
+++ b/LayoutTests/webrtc/video-replace-track.html
@@ -21,9 +21,8 @@ function grabImagePixels()
     canvas.height = video.videoHeight;
     canvas.getContext('2d').drawImage(video, 0, 0, canvas.width, canvas.height);
 
-    imageData = canvas.getContext('2d').getImageData(20, 20, 2, 2);
-    return imageData.data;
- }
+    return canvas.getContext('2d').getImageData(20, 20, 2, 2);
+}
 
 async function testFrontCameraImage(counter)
 {
@@ -42,7 +41,7 @@ async function testFrontCameraImage(counter)
 
 function isBetween100And200(value)
 {
-     return data[0] > 100 && data[0] < 200;
+     return value > 100 && value < 200;
 }
 
 async function testBackCameraImage(counter)
@@ -52,11 +51,13 @@ async function testBackCameraImage(counter)
 
     data = grabImagePixels();
 
-    if(isBetween100And200(data[0]) && isBetween100And200(data[1]) && isBetween100And200(data[2]))
+    var pixel = getImageDataPixel(data, [0, 0]);
+
+    if(isBetween100And200(pixel[0]) && isBetween100And200(pixel[1]) && isBetween100And200(pixel[2]))
         return;
 
     if (counter >= 20)
-        return Promise.reject("testFrontCameraImage timed out");
+        return Promise.reject("testBackCameraImage timed out");
 
     await waitFor(50);
     return testBackCameraImage(++counter);


### PR DESCRIPTION
#### 2c750bfc2d23e727526997bd8327eebf5e6f0bb6
<pre>
[WebRTC] Insufficient test for back camera canvas in webrtc/video-replace-track.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=251677">https://bugs.webkit.org/show_bug.cgi?id=251677</a>

Reviewed by Youenn Fablet.

* LayoutTests/webrtc/video-replace-track.html: Test the pixel R, G and B components instead of
checking the value of the R component three times.

Canonical link: <a href="https://commits.webkit.org/259886@main">https://commits.webkit.org/259886@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c03e68a7494547b0834fded0551619a5a096d383

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106045 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15101 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38877 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115228 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175322 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16525 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6272 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98255 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114950 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111798 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12579 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95553 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40120 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94447 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27195 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81798 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8352 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28547 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8844 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5099 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14465 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48091 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6831 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10388 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->