### PR TITLE
WebGL IDL uses DoNotCheckConstants in inconsistent manner

### DIFF
--- a/Source/WebCore/html/canvas/OESStandardDerivatives.idl
+++ b/Source/WebCore/html/canvas/OESStandardDerivatives.idl
@@ -25,7 +25,6 @@
 
 [
     Conditional=WEBGL,
-    DoNotCheckConstants,
     GenerateIsReachable=ImplWebGLRenderingContext,
     LegacyNoInterfaceObject,
 ] interface OESStandardDerivatives {

--- a/Source/WebCore/html/canvas/OESVertexArrayObject.idl
+++ b/Source/WebCore/html/canvas/OESVertexArrayObject.idl
@@ -25,7 +25,6 @@
 
 [
     Conditional=WEBGL, 
-    DoNotCheckConstants,
     GenerateIsReachable=ImplWebGLRenderingContext,
     LegacyNoInterfaceObject,
 ] interface OESVertexArrayObject {

--- a/Source/WebCore/html/canvas/WebGLCompressedTextureASTC.idl
+++ b/Source/WebCore/html/canvas/WebGLCompressedTextureASTC.idl
@@ -25,7 +25,6 @@
 
 [
     Conditional=WEBGL,
-    DoNotCheckConstants,
     GenerateIsReachable=ImplWebGLRenderingContext,
     LegacyNoInterfaceObject,
 ] interface WebGLCompressedTextureASTC {

--- a/Source/WebCore/html/canvas/WebGLCompressedTextureETC.idl
+++ b/Source/WebCore/html/canvas/WebGLCompressedTextureETC.idl
@@ -27,7 +27,6 @@
 
 [
     Conditional=WEBGL,
-    DoNotCheckConstants,
     GenerateIsReachable=ImplWebGLRenderingContext,
     LegacyNoInterfaceObject,
 ] interface WebGLCompressedTextureETC {

--- a/Source/WebCore/html/canvas/WebGLCompressedTextureETC1.idl
+++ b/Source/WebCore/html/canvas/WebGLCompressedTextureETC1.idl
@@ -27,7 +27,6 @@
 
 [
     Conditional=WEBGL,
-    DoNotCheckConstants,
     GenerateIsReachable=ImplWebGLRenderingContext,
     LegacyNoInterfaceObject,
 ] interface WebGLCompressedTextureETC1 {

--- a/Source/WebCore/html/canvas/WebGLCompressedTexturePVRTC.idl
+++ b/Source/WebCore/html/canvas/WebGLCompressedTexturePVRTC.idl
@@ -25,7 +25,6 @@
 
 [
     Conditional=WEBGL,
-    DoNotCheckConstants,
     GenerateIsReachable=ImplWebGLRenderingContext,
     LegacyNoInterfaceObject,
 ] interface WebGLCompressedTexturePVRTC {

--- a/Source/WebCore/html/canvas/WebGLCompressedTextureS3TC.idl
+++ b/Source/WebCore/html/canvas/WebGLCompressedTextureS3TC.idl
@@ -25,7 +25,6 @@
 
 [
     Conditional=WEBGL,
-    DoNotCheckConstants,
     GenerateIsReachable=ImplWebGLRenderingContext,
     LegacyNoInterfaceObject,
 ] interface WebGLCompressedTextureS3TC {

--- a/Source/WebCore/html/canvas/WebGLCompressedTextureS3TCsRGB.idl
+++ b/Source/WebCore/html/canvas/WebGLCompressedTextureS3TCsRGB.idl
@@ -25,7 +25,6 @@
 
 [
     Conditional=WEBGL,
-    DoNotCheckConstants,
     GenerateIsReachable=ImplWebGLRenderingContext,
     LegacyNoInterfaceObject,
 ] interface WebGLCompressedTextureS3TCsRGB {

--- a/Source/WebCore/html/canvas/WebGLDebugRendererInfo.idl
+++ b/Source/WebCore/html/canvas/WebGLDebugRendererInfo.idl
@@ -25,7 +25,6 @@
 
 [
     Conditional=WEBGL,
-    DoNotCheckConstants,
     GenerateIsReachable=ImplWebGLRenderingContext,
     LegacyNoInterfaceObject,
 ] interface WebGLDebugRendererInfo {

--- a/Source/WebCore/html/canvas/WebGLDepthTexture.idl
+++ b/Source/WebCore/html/canvas/WebGLDepthTexture.idl
@@ -25,7 +25,6 @@
 
 [
     Conditional=WEBGL,
-    DoNotCheckConstants,
     GenerateIsReachable=ImplWebGLRenderingContext,
     LegacyNoInterfaceObject,
 ] interface WebGLDepthTexture {

--- a/Source/WebCore/html/canvas/WebGLDrawBuffers.idl
+++ b/Source/WebCore/html/canvas/WebGLDrawBuffers.idl
@@ -29,7 +29,6 @@ typedef unsigned long GLenum;
     LegacyNoInterfaceObject,
     Conditional=WEBGL,
     GenerateIsReachable=ImplWebGLRenderingContext,
-    DoNotCheckConstants,
 ] interface WebGLDrawBuffers {
     const GLenum COLOR_ATTACHMENT0_WEBGL = 0x8CE0;
     const GLenum COLOR_ATTACHMENT1_WEBGL = 0x8CE1;

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.idl
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.idl
@@ -54,7 +54,6 @@ typedef (HTMLCanvasElement) WebGLCanvas;
     Conditional=WEBGL,
     CustomIsReachable,
     CustomToJSObject,
-    DoNotCheckConstants,
     JSCustomMarkFunction,
     ExportMacro=WEBCORE_EXPORT,
 ] interface mixin WebGLRenderingContextBase {


### PR DESCRIPTION
#### 0e0c81a1f2a951af49dcf22f515f5e9d9e0d631f
<pre>
WebGL IDL uses DoNotCheckConstants in inconsistent manner
<a href="https://bugs.webkit.org/show_bug.cgi?id=251501">https://bugs.webkit.org/show_bug.cgi?id=251501</a>

Reviewed by Sam Weinig.

Removed DoNotCheckConstants from WebGL extension
interfaces and WebGLRenderingContextBase mixin;
this attribute has no effect there anyway.

* Source/WebCore/html/canvas/OESStandardDerivatives.idl:
* Source/WebCore/html/canvas/OESVertexArrayObject.idl:
* Source/WebCore/html/canvas/WebGLCompressedTextureASTC.idl:
* Source/WebCore/html/canvas/WebGLCompressedTextureETC.idl:
* Source/WebCore/html/canvas/WebGLCompressedTextureETC1.idl:
* Source/WebCore/html/canvas/WebGLCompressedTexturePVRTC.idl:
* Source/WebCore/html/canvas/WebGLCompressedTextureS3TC.idl:
* Source/WebCore/html/canvas/WebGLCompressedTextureS3TCsRGB.idl:
* Source/WebCore/html/canvas/WebGLDebugRendererInfo.idl:
* Source/WebCore/html/canvas/WebGLDepthTexture.idl:
* Source/WebCore/html/canvas/WebGLDrawBuffers.idl:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.idl:

Canonical link: <a href="https://commits.webkit.org/259880@main">https://commits.webkit.org/259880@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2f164577be3226cdb98538ecba0d815f4ecd53a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106049 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15105 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38881 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115231 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175325 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109952 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16529 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6275 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98258 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114953 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111802 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12583 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95559 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40129 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94451 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27201 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81807 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8356 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28553 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8848 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5101 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14468 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48097 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6827 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10392 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->