### PR TITLE
[GTK][WPE] Expose webkit_web_context_get_network_session_for_automation() in new API

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitAutomationSession.cpp
@@ -355,7 +355,7 @@ WebKitAutomationSession* webkitAutomationSessionCreate(WebKitWebContext* webCont
     auto* session = WEBKIT_AUTOMATION_SESSION(g_object_new(WEBKIT_TYPE_AUTOMATION_SESSION, "id", sessionID, nullptr));
     session->priv->webContext = webContext;
 #if ENABLE(2022_GLIB_API)
-    WebKitNetworkSession* networkSession = webkitWebContextGetNetworkSessionForAutomation(webContext);
+    WebKitNetworkSession* networkSession = webkit_web_context_get_network_session_for_automation(webContext);
 #endif
 
     if (capabilities.acceptInsecureCertificates) {

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
@@ -318,20 +318,8 @@ void webkitWebContextWillCloseAutomationSession(WebKitWebContext* webContext)
 {
     webContext->priv->processPool->setAutomationSession(nullptr);
     webContext->priv->automationSession = nullptr;
-#if ENABLE(2022_GLIB_API)
-    webContext->priv->automationNetworkSession = nullptr;
-#endif
-}
-
-#if ENABLE(2022_GLIB_API)
-WebKitNetworkSession* webkitWebContextGetNetworkSessionForAutomation(WebKitWebContext* webContext)
-{
-    if (!webContext->priv->automationNetworkSession && webContext->priv->automationClient)
-        webContext->priv->automationNetworkSession = adoptGRef(webkit_network_session_new_ephemeral());
-    return webContext->priv->automationNetworkSession.get();
 }
 #endif
-#endif // ENABLE(REMOTE_INSPECTOR)
 
 WEBKIT_DEFINE_FINAL_TYPE_IN_2022_API(WebKitWebContext, webkit_web_context, G_TYPE_OBJECT)
 
@@ -911,6 +899,30 @@ void webkit_web_context_set_automation_allowed(WebKitWebContext* context, gboole
 #endif
 }
 
+#if ENABLE(2022_GLIB_API)
+/**
+ * webkit_web_context_get_network_session_for_automation:
+ * @context: the #WebKitWebContext
+ *
+ * Get the #WebKitNetworkSession used for automation sessions started in @context.
+ *
+ * Returns: (transfer none) (nullable): a #WebKitNetworkSession, or %NULL if automation is not enabled
+ *
+ * Since: 2.40
+ */
+WebKitNetworkSession* webkit_web_context_get_network_session_for_automation(WebKitWebContext* context)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_CONTEXT(context), nullptr);
+
+#if ENABLE(REMOTE_INSPECTOR)
+    if (!context->priv->automationNetworkSession && context->priv->automationClient)
+        context->priv->automationNetworkSession = adoptGRef(webkit_network_session_new_ephemeral());
+    return context->priv->automationNetworkSession.get();
+#else
+    return nullptr;
+#endif
+}
+#endif
 /**
  * webkit_web_context_set_cache_model:
  * @context: the #WebKitWebContext

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebContext.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebContext.h.in
@@ -32,6 +32,9 @@
 #endif
 #include <@API_INCLUDE_PREFIX@/WebKitGeolocationManager.h>
 #include <@API_INCLUDE_PREFIX@/WebKitNetworkProxySettings.h>
+#if ENABLE(2022_GLIB_API)
+#include <@API_INCLUDE_PREFIX@/WebKitNetworkSession.h>
+#endif
 #include <@API_INCLUDE_PREFIX@/WebKitSecurityManager.h>
 #include <@API_INCLUDE_PREFIX@/WebKitURISchemeRequest.h>
 #include <@API_INCLUDE_PREFIX@/WebKitUserMessage.h>
@@ -164,6 +167,12 @@ webkit_web_context_is_automation_allowed            (WebKitWebContext           
 WEBKIT_API void
 webkit_web_context_set_automation_allowed           (WebKitWebContext              *context,
                                                      gboolean                       allowed);
+
+#if ENABLE(2022_GLIB_API)
+WEBKIT_API WebKitNetworkSession *
+webkit_web_context_get_network_session_for_automation(WebKitWebContext             *context);
+#endif
+
 WEBKIT_API void
 webkit_web_context_set_cache_model                  (WebKitWebContext              *context,
                                                      WebKitCacheModel               cache_model);

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebContextPrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebContextPrivate.h
@@ -31,10 +31,6 @@
 #include "WebProcessPool.h"
 #include <WebCore/ResourceRequest.h>
 
-#if ENABLE(2022_GLIB_API)
-#include "WebKitNetworkSession.h"
-#endif
-
 WebKit::WebProcessPool& webkitWebContextGetProcessPool(WebKitWebContext*);
 #if !ENABLE(2022_GLIB_API)
 void webkitWebContextDownloadStarted(WebKitWebContext*, WebKitDownload*);
@@ -46,7 +42,4 @@ GVariant* webkitWebContextInitializeWebExtensions(WebKitWebContext*);
 void webkitWebContextInitializeNotificationPermissions(WebKitWebContext*);
 #if ENABLE(REMOTE_INSPECTOR)
 void webkitWebContextWillCloseAutomationSession(WebKitWebContext*);
-#if ENABLE(2022_GLIB_API)
-WebKitNetworkSession* webkitWebContextGetNetworkSessionForAutomation(WebKitWebContext*);
-#endif
 #endif

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -777,7 +777,7 @@ static void webkitWebViewConstructed(GObject* object)
 #if ENABLE(2022_GLIB_API)
 #if ENABLE(REMOTE_INSPECTOR)
     if (priv->isControlledByAutomation)
-        priv->networkSession = webkitWebContextGetNetworkSessionForAutomation(priv->context.get());
+        priv->networkSession = webkit_web_context_get_network_session_for_automation(priv->context.get());
 #endif
     if (!priv->networkSession)
         priv->networkSession = webkit_network_session_get_default();

--- a/Tools/MiniBrowser/gtk/BrowserWindow.c
+++ b/Tools/MiniBrowser/gtk/BrowserWindow.c
@@ -1516,7 +1516,7 @@ GtkWidget *browser_window_new(GtkWindow *parent, WebKitWebContext *webContext)
 
     window->webContext = g_object_ref(webContext);
 #if GTK_CHECK_VERSION(3, 98, 0)
-    window->networkSession = networkSession ? g_object_ref(networkSession) : NULL;
+    window->networkSession = g_object_ref(networkSession);
 #else
     g_signal_connect(window->webContext, "download-started", G_CALLBACK(downloadStarted), window);
 #endif

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestAutomationSession.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestAutomationSession.cpp
@@ -303,11 +303,22 @@ static void testAutomationSessionRequestSession(AutomationTest* test, gconstpoin
     String sessionID = createVersion4UUIDString();
     // WebKitAutomationSession::automation-started is never emitted if automation is not enabled.
     g_assert_false(webkit_web_context_is_automation_allowed(test->m_webContext.get()));
+#if ENABLE(2022_GLIB_API)
+    // Network session for automation is nullptr if automation is not enabled.
+    g_assert_null(webkit_web_context_get_network_session_for_automation(test->m_webContext.get()));
+#endif
     auto* session = test->requestSession(sessionID.utf8().data());
     g_assert_null(session);
 
     webkit_web_context_set_automation_allowed(test->m_webContext.get(), TRUE);
     g_assert_true(webkit_web_context_is_automation_allowed(test->m_webContext.get()));
+#if ENABLE(2022_GLIB_API)
+    auto* networkSession = webkit_web_context_get_network_session_for_automation(test->m_webContext.get());
+    g_assert_nonnull(networkSession);
+    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(networkSession));
+    g_assert_true(webkit_network_session_is_ephemeral(networkSession));
+    g_assert_false(networkSession == test->m_networkSession.get());
+#endif
 
     // There can't be more than one context with automation enabled
     GRefPtr<WebKitWebContext> otherContext = adoptGRef(webkit_web_context_new());
@@ -329,6 +340,9 @@ static void testAutomationSessionRequestSession(AutomationTest* test, gconstpoin
     auto webView = Test::adoptView(Test::createWebView(test->m_webContext.get()));
     g_assert_false(webkit_web_view_is_controlled_by_automation(webView.get()));
     g_assert_false(test->createTopLevelBrowsingContext(webView.get()));
+#if ENABLE(2022_GLIB_API)
+    g_assert_false(webkit_web_view_get_network_session(webView.get()) == networkSession);
+#endif
 
     // And will work with a proper web view.
     webView = Test::adoptView(g_object_new(WEBKIT_TYPE_WEB_VIEW,
@@ -341,10 +355,7 @@ static void testAutomationSessionRequestSession(AutomationTest* test, gconstpoin
     g_assert_true(webkit_web_view_is_controlled_by_automation(webView.get()));
     g_assert_cmpuint(webkit_web_view_get_automation_presentation_type(webView.get()), ==, WEBKIT_AUTOMATION_BROWSING_CONTEXT_PRESENTATION_WINDOW);
 #if ENABLE(2022_GLIB_API)
-    // Automation session has its own ephemeral session.
-    auto* networkSession = webkit_web_view_get_network_session(webView.get());
-    g_assert_false(networkSession == test->m_networkSession.get());
-    g_assert_true(webkit_network_session_is_ephemeral(networkSession));
+    g_assert_true(webkit_web_view_get_network_session(webView.get()) == networkSession);
 #endif
     g_assert_true(test->createTopLevelBrowsingContext(webView.get()));
 


### PR DESCRIPTION
#### be31bad832d7beee44de10e6148eae6f2744fb49
<pre>
[GTK][WPE] Expose webkit_web_context_get_network_session_for_automation() in new API
<a href="https://bugs.webkit.org/show_bug.cgi?id=251682">https://bugs.webkit.org/show_bug.cgi?id=251682</a>

Reviewed by Michael Catanzaro.

It&apos;s currently private. Applications code is simpler if they can access
the automation network session.

* Source/WebKit/UIProcess/API/glib/WebKitAutomationSession.cpp:
(webkitAutomationSessionCreate):
* Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp:
(webkit_web_context_get_network_session_for_automation):
(webkitWebContextGetNetworkSessionForAutomation): Deleted.
* Source/WebKit/UIProcess/API/glib/WebKitWebContext.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitWebContextPrivate.h:
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(webkitWebViewConstructed):
* Tools/MiniBrowser/gtk/BrowserWindow.c:
(browser_window_new):
* Tools/MiniBrowser/gtk/main.c:
(activate):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestAutomationSession.cpp:

Canonical link: <a href="https://commits.webkit.org/259853@main">https://commits.webkit.org/259853@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ad0e78b21a2f1b1fbb342e6a4dae2f4e5228d1d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106051 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15107 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38883 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115233 "Built successfully") | [💥 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175327 "An unexpected error occured. Recent messages:Pull request contains relevant changes; Failed to print configuration") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109954 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16531 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6277 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98260 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114955 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111804 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12587 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95560 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40133 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94456 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27202 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8358 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28554 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8850 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5104 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14470 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48098 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10394 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3669 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->