### PR TITLE
[WGSL] Move builtin types into their own class

### DIFF
--- a/Source/WebGPU/WGSL/TypeStore.cpp
+++ b/Source/WebGPU/WGSL/TypeStore.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TypeStore.h"
+
+#include "ASTTypeName.h"
+#include <wtf/EnumTraits.h>
+
+namespace WGSL {
+
+TypeStore::TypeStore()
+    : m_typeConstrutors(AST::ParameterizedTypeName::NumberOfBaseTypes)
+{
+    m_abstractInt = allocateType<Primitive>(Primitive::AbstractInt);
+    m_abstractFloat = allocateType<Primitive>(Primitive::AbstractFloat);
+    m_void = allocateType<Primitive>(Primitive::Void);
+    m_bool = allocateType<Primitive>(Primitive::Bool);
+    m_i32 = allocateType<Primitive>(Primitive::I32);
+    m_u32 = allocateType<Primitive>(Primitive::U32);
+    m_f32 = allocateType<Primitive>(Primitive::F32);
+
+    allocateConstructor<Vector>(AST::ParameterizedTypeName::Base::Vec2, static_cast<uint8_t>(2));
+    allocateConstructor<Vector>(AST::ParameterizedTypeName::Base::Vec3, static_cast<uint8_t>(3));
+    allocateConstructor<Vector>(AST::ParameterizedTypeName::Base::Vec4, static_cast<uint8_t>(4));
+    allocateConstructor<Matrix>(AST::ParameterizedTypeName::Base::Mat2x2, static_cast<uint8_t>(2), static_cast<uint8_t>(2));
+    allocateConstructor<Matrix>(AST::ParameterizedTypeName::Base::Mat2x3, static_cast<uint8_t>(2), static_cast<uint8_t>(3));
+    allocateConstructor<Matrix>(AST::ParameterizedTypeName::Base::Mat2x4, static_cast<uint8_t>(2), static_cast<uint8_t>(4));
+    allocateConstructor<Matrix>(AST::ParameterizedTypeName::Base::Mat3x2, static_cast<uint8_t>(3), static_cast<uint8_t>(2));
+    allocateConstructor<Matrix>(AST::ParameterizedTypeName::Base::Mat3x3, static_cast<uint8_t>(3), static_cast<uint8_t>(3));
+    allocateConstructor<Matrix>(AST::ParameterizedTypeName::Base::Mat3x4, static_cast<uint8_t>(3), static_cast<uint8_t>(4));
+    allocateConstructor<Matrix>(AST::ParameterizedTypeName::Base::Mat4x2, static_cast<uint8_t>(4), static_cast<uint8_t>(2));
+    allocateConstructor<Matrix>(AST::ParameterizedTypeName::Base::Mat4x3, static_cast<uint8_t>(4), static_cast<uint8_t>(3));
+    allocateConstructor<Matrix>(AST::ParameterizedTypeName::Base::Mat4x4, static_cast<uint8_t>(4), static_cast<uint8_t>(4));
+}
+
+Type* TypeStore::structType(const AST::Identifier& name)
+{
+    return allocateType<Struct>(name);
+}
+
+template<typename TypeKind, typename... Arguments>
+Type* TypeStore::allocateType(Arguments&&... arguments)
+{
+    m_types.append(std::unique_ptr<Type>(new Type(TypeKind { std::forward<Arguments>(arguments)... })));
+    return m_types.last().get();
+}
+
+template<typename TargetType, typename Base, typename... Arguments>
+void TypeStore::allocateConstructor(Base base, Arguments&&... arguments)
+{
+    m_typeConstrutors[WTF::enumToUnderlyingType(base)] =
+        TypeConstructor { [this, arguments...](Type* elementType) -> Type* {
+            // FIXME: this should be cached
+            return allocateType<TargetType>(elementType, arguments...);
+        } };
+}
+
+} // namespace WGSL

--- a/Source/WebGPU/WGSL/TypeStore.h
+++ b/Source/WebGPU/WGSL/TypeStore.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Types.h"
+#include <wtf/FixedVector.h>
+#include <wtf/Vector.h>
+
+namespace WGSL {
+
+namespace AST {
+class Identifier;
+}
+
+class TypeStore {
+public:
+    TypeStore();
+
+    Type* voidType() const { return m_i32; }
+    Type* boolType() const { return m_i32; }
+
+    Type* abstractIntType() const { return m_i32; }
+    Type* i32Type() const { return m_i32; }
+    Type* u32Type() const { return m_i32; }
+
+    Type* abstractFloatType() const { return m_i32; }
+    Type* f32Type() const { return m_i32; }
+
+    Type* structType(const AST::Identifier& name);
+
+private:
+    template<typename TypeKind, typename... Arguments>
+    Type* allocateType(Arguments&&...);
+
+    template<typename TargetType, typename Base, typename... Arguments>
+    void allocateConstructor(Base, Arguments&&...);
+
+    WTF::Vector<std::unique_ptr<Type>> m_types;
+    FixedVector<TypeConstructor> m_typeConstrutors;
+
+    Type* m_abstractInt;
+    Type* m_abstractFloat;
+    Type* m_void;
+    Type* m_bool;
+    Type* m_i32;
+    Type* m_u32;
+    Type* m_f32;
+};
+
+} // namespace WGSL

--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -131,6 +131,8 @@
 		978A9130298AD3DA00B37E5E /* TypeCheck.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 978A912E298AD3DA00B37E5E /* TypeCheck.cpp */; };
 		978A9133298BBFD300B37E5E /* Types.h in Headers */ = {isa = PBXBuildFile; fileRef = 978A9131298BBFD300B37E5E /* Types.h */; };
 		978A9134298BBFD300B37E5E /* Types.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 978A9132298BBFD300B37E5E /* Types.cpp */; };
+		978A9137298D40F100B37E5E /* TypeStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 978A9135298D40F100B37E5E /* TypeStore.h */; };
+		978A9138298D40F100B37E5E /* TypeStore.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 978A9136298D40F100B37E5E /* TypeStore.cpp */; };
 		979240B6297018290050EA2C /* MetalCodeGenerator.h in Headers */ = {isa = PBXBuildFile; fileRef = 979240B2297018290050EA2C /* MetalCodeGenerator.h */; };
 		979240B7297018290050EA2C /* MetalFunctionWriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 979240B3297018290050EA2C /* MetalFunctionWriter.h */; };
 		979240B8297018290050EA2C /* MetalCodeGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 979240B4297018290050EA2C /* MetalCodeGenerator.cpp */; };
@@ -340,6 +342,8 @@
 		978A912E298AD3DA00B37E5E /* TypeCheck.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TypeCheck.cpp; sourceTree = "<group>"; };
 		978A9131298BBFD300B37E5E /* Types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Types.h; sourceTree = "<group>"; };
 		978A9132298BBFD300B37E5E /* Types.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Types.cpp; sourceTree = "<group>"; };
+		978A9135298D40F100B37E5E /* TypeStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TypeStore.h; sourceTree = "<group>"; };
+		978A9136298D40F100B37E5E /* TypeStore.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TypeStore.cpp; sourceTree = "<group>"; };
 		979240B2297018290050EA2C /* MetalCodeGenerator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MetalCodeGenerator.h; sourceTree = "<group>"; };
 		979240B3297018290050EA2C /* MetalFunctionWriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MetalFunctionWriter.h; sourceTree = "<group>"; };
 		979240B4297018290050EA2C /* MetalCodeGenerator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MetalCodeGenerator.cpp; sourceTree = "<group>"; };
@@ -498,6 +502,8 @@
 				978A912D298AD3DA00B37E5E /* TypeCheck.h */,
 				978A9132298BBFD300B37E5E /* Types.cpp */,
 				978A9131298BBFD300B37E5E /* Types.h */,
+				978A9136298D40F100B37E5E /* TypeStore.cpp */,
+				978A9135298D40F100B37E5E /* TypeStore.h */,
 				1CEBD8022716BF8200A5254D /* WGSL.cpp */,
 				1CEBD7F72716B34400A5254D /* WGSL.h */,
 			);
@@ -718,6 +724,7 @@
 				338BB2CE27B6B60200E066AB /* Token.h in Headers */,
 				978A912F298AD3DA00B37E5E /* TypeCheck.h in Headers */,
 				978A9133298BBFD300B37E5E /* Types.h in Headers */,
+				978A9137298D40F100B37E5E /* TypeStore.h in Headers */,
 				1CEBD7F82716B34400A5254D /* WGSL.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -885,6 +892,7 @@
 				338BB2D027B6B61B00E066AB /* Token.cpp in Sources */,
 				978A9130298AD3DA00B37E5E /* TypeCheck.cpp in Sources */,
 				978A9134298BBFD300B37E5E /* Types.cpp in Sources */,
+				978A9138298D40F100B37E5E /* TypeStore.cpp in Sources */,
 				1CEBD8032716BF8200A5254D /* WGSL.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
#### 3b30d3baaa8fe572c7c167f5ca5224300d598d8e
<pre>
[WGSL] Move builtin types into their own class
<a href="https://bugs.webkit.org/show_bug.cgi?id=251683">https://bugs.webkit.org/show_bug.cgi?id=251683</a>
rdar://105003822

Reviewed by Myles C. Maxfield.

As suggested in #9539, it&apos;s nicer to have the types be managed by their own class
instead of living in the type checker. Ideally this type store should be owned by
the same container that owns the AST, but that container doesn&apos;t exist yet, it&apos;ll
come in a next refactor.

* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::TypeChecker):
(WGSL::TypeChecker::visit):
(WGSL::TypeChecker::allocateType): Deleted.
* Source/WebGPU/WGSL/TypeStore.cpp: Added.
(WGSL::TypeStore::TypeStore):
(WGSL::TypeStore::allocateType):
(WGSL::TypeStore::allocateConstructor):
* Source/WebGPU/WGSL/TypeStore.h: Added.
(WGSL::TypeStore::voidType const):
(WGSL::TypeStore::boolType const):
(WGSL::TypeStore::abstractIntType const):
(WGSL::TypeStore::i32Type const):
(WGSL::TypeStore::u32Type const):
(WGSL::TypeStore::abstractFloatType const):
(WGSL::TypeStore::f32Type const):
* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/259887@main">https://commits.webkit.org/259887@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a94b77b5cb9c606824b72310225c9fefec6e59f5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106309 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15363 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39148 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115502 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16808 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6579 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98525 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115190 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112073 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12789 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95769 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/40341 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94664 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27412 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8603 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28764 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9113 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5335 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14728 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48310 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6830 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10663 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->