### PR TITLE
Use `isControlCharacter()` helper

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1996,6 +1996,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/sql/SQLiteStatementAutoResetScope.h
     platform/sql/SQLiteTransaction.h
 
+    platform/text/CharacterProperties.h
     platform/text/BidiContext.h
     platform/text/FontRenderingMode.h
     platform/text/StringWithDirection.h

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -24,7 +24,6 @@
 #include "config.h"
 #include "FontCascade.h"
 
-#include "CharacterProperties.h"
 #include "ComplexTextController.h"
 #include "DisplayListRecorderImpl.h"
 #include "FloatRect.h"

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include "CharacterProperties.h"
 #include "DashArray.h"
 #include "Font.h"
 #include "FontCascadeDescription.h"
@@ -263,10 +264,9 @@ public:
     {
         // https://drafts.csswg.org/css-text-3/#white-space-processing
         // "Unsupported Default_ignorable characters must be ignored for text rendering."
-        return (character >= nullCharacter && character < space)
-            || (character >= deleteCharacter && character < noBreakSpace)
-            || character == objectReplacementCharacter
-            || u_hasBinaryProperty(character, UCHAR_DEFAULT_IGNORABLE_CODE_POINT);
+        return (character == objectReplacementCharacter
+            || isControlCharacter(character)
+            || isDefaultIgnorableCodePoint(character));
     }
     // FIXME: Callers of treatAsZeroWidthSpace() and treatAsZeroWidthSpaceInComplexScript() should probably be calling isCharacterWhoseGlyphsShouldBeDeletedForTextRendering() instead.
     static bool treatAsZeroWidthSpace(UChar32 c) { return treatAsZeroWidthSpaceInComplexScript(c) || c == zeroWidthNonJoiner || c == zeroWidthJoiner; }

--- a/Source/WebCore/platform/graphics/WidthIterator.cpp
+++ b/Source/WebCore/platform/graphics/WidthIterator.cpp
@@ -541,10 +541,7 @@ bool WidthIterator::characterCanUseSimplifiedTextMeasuring(UChar character, bool
         break;
     }
 
-    if (character >= HiraganaLetterSmallA
-        || u_charType(character) == U_CONTROL_CHAR
-        || (character >= nullCharacter && character < space)
-        || (character >= deleteCharacter && character < noBreakSpace))
+    if (character >= HiraganaLetterSmallA || isControlCharacter(character))
         return false;
 
     return true;
@@ -619,8 +616,7 @@ void WidthIterator::applyCSSVisibilityRules(GlyphBuffer& glyphBuffer, unsigned g
         // https://www.w3.org/TR/css-text-3/#white-space-processing
         // "Control characters (Unicode category Cc)—other than tabs (U+0009), line feeds (U+000A), carriage returns (U+000D) and sequences that form a segment break—must be rendered as a visible glyph"
         // Also, we're omitting NULL (U+0000) from this set because Chrome and Firefox do so and it's needed for compat. See https://github.com/w3c/csswg-drafts/pull/6983.
-        if (characterResponsibleForThisGlyph != nullCharacter
-            && u_charType(characterResponsibleForThisGlyph) == U_CONTROL_CHAR) {
+        if (characterResponsibleForThisGlyph != nullCharacter && isControlCharacter(characterResponsibleForThisGlyph)) {
             // Let's assume that .notdef is visible.
             GlyphBufferGlyph visibleGlyph = 0;
             clobberGlyph(i, visibleGlyph);

--- a/Source/WebCore/platform/text/CharacterProperties.h
+++ b/Source/WebCore/platform/text/CharacterProperties.h
@@ -95,7 +95,7 @@ inline bool isDefaultIgnorableCodePoint(UChar32 character)
 
 inline bool isControlCharacter(UChar32 character)
 {
-    return u_getIntPropertyValue(character, UCHAR_GENERAL_CATEGORY) == U_CONTROL_CHAR;
+    return u_charType(character) == U_CONTROL_CHAR;
 }
 
 }


### PR DESCRIPTION
#### 8e48e89eb72f9b3a25ae0921da0f0d2f7ad2ba16
<pre>
Use `isControlCharacter()` helper
<a href="https://bugs.webkit.org/show_bug.cgi?id=251691">https://bugs.webkit.org/show_bug.cgi?id=251691</a>

Reviewed by Myles C. Maxfield.

Several ways to check whether a character is a Unicode control character
are used throughout the codebase. Such as:
```
u_charType(character) == U_CONTROL_CHAR
```
or
```
(character &gt;= nullCharacter &amp;&amp; character &lt; space) || (character &gt;= deleteCharacter &amp;&amp; character &lt; noBreakSpace)
```

We have a nice helper for this in `CharacterProperties.h` - `isControlCharacter()`.
It would be nice to use it since it is shorter and describes the intent
better.

* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::isCharacterWhoseGlyphsShouldBeDeletedForTextRendering):
* Source/WebCore/platform/graphics/FontCascade.h:
(WebCore::FontCascade::isCharacterWhoseGlyphsShouldBeDeletedForTextRendering): Deleted.
* Source/WebCore/platform/graphics/WidthIterator.cpp:
(WebCore::WidthIterator::characterCanUseSimplifiedTextMeasuring):
(WebCore::WidthIterator::applyCSSVisibilityRules):
* Source/WebCore/platform/text/CharacterProperties.h:
(WebCore::isControlCharacter):

Canonical link: <a href="https://commits.webkit.org/260081@main">https://commits.webkit.org/260081@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/955c98d510c3edd9cd926eb1051d99cd67f8050f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106922 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15958 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39719 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116102 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115649 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110824 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17442 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7156 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99108 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112687 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13201 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96224 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40802 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95093 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27868 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9106 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29221 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9683 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6220 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15273 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48778 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6961 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11213 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->