### PR TITLE
Reduce Bridging and Runtime Creation of Strings

### DIFF
--- a/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
+++ b/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
@@ -76,17 +76,16 @@ String createTemporaryZipArchive(const String& path)
         CString archivePath([NSTemporaryDirectory() stringByAppendingPathComponent:@"WebKitGeneratedFileXXXXXX"].fileSystemRepresentation);
         if (mkstemp(archivePath.mutableData()) == -1)
             return;
-        
-        NSDictionary *options = @{
-            (__bridge id)kBOMCopierOptionCreatePKZipKey : @YES,
-            (__bridge id)kBOMCopierOptionSequesterResourcesKey : @YES,
-            (__bridge id)kBOMCopierOptionKeepParentKey : @YES,
-            (__bridge id)kBOMCopierOptionCopyResourcesKey : @YES,
-        };
-        
+
+        CFStringRef keys[4] = { kBOMCopierOptionCreatePKZipKey, kBOMCopierOptionSequesterResourcesKey, kBOMCopierOptionKeepParentKey, kBOMCopierOptionCopyResourcesKey };
+        CFBooleanRef vals[4] = { kCFBooleanTrue, kCFBooleanTrue, kCFBooleanTrue, kCFBooleanTrue };
+
+        CFDictionaryRef options = CFDictionaryCreate(kCFAllocatorDefault, (const void **)keys, (const void **)vals, 4, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
         BOMCopier copier = BOMCopierNew();
-        if (!BOMCopierCopyWithOptions(copier, newURL.path.fileSystemRepresentation, archivePath.data(), (__bridge CFDictionaryRef)options))
+        if (!BOMCopierCopyWithOptions(copier, newURL.path.fileSystemRepresentation, archivePath.data(), options))
             temporaryFile = String::fromUTF8(archivePath);
+
+        CFRelease(options);
         BOMCopierFree(copier);
     }];
     

--- a/Source/WebCore/bridge/objc/objc_class.mm
+++ b/Source/WebCore/bridge/objc/objc_class.mm
@@ -167,7 +167,7 @@ Field* ObjcClass::fieldNamed(PropertyName propertyName, Instance* instance) cons
     ClassStructPtr thisClass = _isa;
 
     CString jsName = name.ascii();
-    RetainPtr<CFStringRef> fieldName = adoptCF(CFStringCreateWithCString(NULL, jsName.data(), kCFStringEncodingASCII));
+    auto fieldName = adoptNS([NSString stringWithCString:jsName.data() encoding:NSASCIIStringEncoding]);
     id targetObject = (static_cast<ObjcInstance*>(instance))->getObject();
 #if PLATFORM(IOS_FAMILY)
     IGNORE_WARNINGS_BEGIN("undeclared-selector")
@@ -178,8 +178,8 @@ Field* ObjcClass::fieldNamed(PropertyName propertyName, Instance* instance) cons
 #endif
     if (attributes) {
         // Class overrides attributeKeys, use that array of key names.
-        unsigned count = [attributes count];
-        for (unsigned i = 0; i < count; i++) {
+        NSUInteger count = [attributes count];
+        for (NSUInteger i = 0; i < count; i++) {
             NSString* keyName = [attributes objectAtIndex:i];
             const char* UTF8KeyName = [keyName UTF8String]; // ObjC actually only supports ASCII names.
 
@@ -195,7 +195,7 @@ Field* ObjcClass::fieldNamed(PropertyName propertyName, Instance* instance) cons
             if ([thisClass respondsToSelector:@selector(webScriptNameForKey:)])
                 mappedName = [thisClass webScriptNameForKey:UTF8KeyName];
 
-            if ((mappedName && [mappedName isEqual:(__bridge NSString *)fieldName.get()]) || [keyName isEqual:(__bridge NSString *)fieldName.get()]) {
+            if ((mappedName && [mappedName isEqual:fieldName.get()]) || [keyName isEqual:fieldName.get()]) {
                 auto newField = makeUnique<ObjcField>((__bridge CFStringRef)keyName);
                 field = newField.get();
                 m_fieldCache.add(name.impl(), WTFMove(newField));
@@ -226,7 +226,7 @@ Field* ObjcClass::fieldNamed(PropertyName propertyName, Instance* instance) cons
                 if ([thisClass respondsToSelector:@selector(webScriptNameForKey:)])
                     mappedName = [thisClass webScriptNameForKey:objcIvarName];
 
-                if ((mappedName && [mappedName isEqual:(__bridge NSString *)fieldName.get()]) || !strcmp(objcIvarName, jsName.data())) {
+                if ((mappedName && [mappedName isEqual:fieldName.get()]) || !strcmp(objcIvarName, jsName.data())) {
                     auto newField = makeUnique<ObjcField>(objcIVar);
                     field = newField.get();
                     m_fieldCache.add(name.impl(), WTFMove(newField));

--- a/Source/WebCore/platform/cocoa/MIMETypeRegistryCocoa.mm
+++ b/Source/WebCore/platform/cocoa/MIMETypeRegistryCocoa.mm
@@ -60,17 +60,18 @@ static MemoryCompactLookupOnlyRobinHoodHashMap<String, MemoryCompactLookupOnlyRo
 
         auto allUTIs = adoptCF(_UTCopyDeclaredTypeIdentifiers());
 
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        for (NSString *uti in (__bridge NSArray<NSString *> *)allUTIs.get()) {
-            auto type = adoptCF(UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)uti, kUTTagClassMIMEType));
+        for (CFIndex i = 0, size = CFArrayGetCount(allUTIs.get()); i < size; i++) {
+            CFStringRef uti = static_cast<CFStringRef>(CFArrayGetValueAtIndex(allUTIs.get(), i));
+            ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+            auto type = adoptCF(UTTypeCopyPreferredTagWithClass(uti, kUTTagClassMIMEType));
             if (!type)
                 continue;
-            auto extensions = adoptCF(UTTypeCopyAllTagsWithClass((__bridge CFStringRef)uti, kUTTagClassFilenameExtension));
+            auto extensions = adoptCF(UTTypeCopyAllTagsWithClass(uti, kUTTagClassFilenameExtension));
+            ALLOW_DEPRECATED_DECLARATIONS_END
             if (!extensions || !CFArrayGetCount(extensions.get()))
                 continue;
             addExtensions(type.get(), (__bridge NSArray<NSString *> *)extensions.get());
         }
-ALLOW_DEPRECATED_DECLARATIONS_END
 
         return map;
     }();

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.mm
@@ -94,8 +94,8 @@ void GameControllerGamepadProvider::controllerDidConnect(GCController *controlle
         if (!serviceInfo.service)
             continue;
 
-        auto cfVendorID = adoptCF((CFNumberRef)IOHIDServiceClientCopyProperty(serviceInfo.service, (__bridge CFStringRef)@(kIOHIDVendorIDKey)));
-        auto cfProductID = adoptCF((CFNumberRef)IOHIDServiceClientCopyProperty(serviceInfo.service, (__bridge CFStringRef)@(kIOHIDProductIDKey)));
+        auto cfVendorID = adoptCF((CFNumberRef)IOHIDServiceClientCopyProperty(serviceInfo.service, CFSTR(kIOHIDVendorIDKey)));
+        auto cfProductID = adoptCF((CFNumberRef)IOHIDServiceClientCopyProperty(serviceInfo.service, CFSTR(kIOHIDProductIDKey)));
 
         int vendorID, productID;
         CFNumberGetValue(cfVendorID.get(), kCFNumberIntType, &vendorID);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -398,9 +398,9 @@ static void hardwareKeyboardAvailabilityChangedCallback(CFNotificationCenterRef,
 
     _page->contentSizeCategoryDidChange([self _contentSizeCategory]);
 
-    auto notificationName = adoptNS([[NSString alloc] initWithCString:kGSEventHardwareKeyboardAvailabilityChangedNotification encoding:NSUTF8StringEncoding]);
+    auto notificationName = adoptCF(CFStringCreateWithCString(kCFAllocatorDefault, kGSEventHardwareKeyboardAvailabilityChangedNotification, kCFStringEncodingUTF8));
     auto notificationBehavior = static_cast<CFNotificationSuspensionBehavior>(CFNotificationSuspensionBehaviorCoalesce | _CFNotificationObserverIsObjC);
-    CFNotificationCenterAddObserver(CFNotificationCenterGetDarwinNotifyCenter(), (__bridge const void *)(self), hardwareKeyboardAvailabilityChangedCallback, (__bridge CFStringRef)notificationName.get(), nullptr, notificationBehavior);
+    CFNotificationCenterAddObserver(CFNotificationCenterGetDarwinNotifyCenter(), (__bridge const void *)(self), hardwareKeyboardAvailabilityChangedCallback, notificationName.get(), nullptr, notificationBehavior);
 #endif // PLATFORM(IOS_FAMILY)
 
 #if ENABLE(META_VIEWPORT)
@@ -667,8 +667,8 @@ static void hardwareKeyboardAvailabilityChangedCallback(CFNotificationCenterRef,
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     [_scrollView setInternalDelegate:nil];
 
-    auto notificationName = adoptNS([[NSString alloc] initWithCString:kGSEventHardwareKeyboardAvailabilityChangedNotification encoding:NSUTF8StringEncoding]);
-    CFNotificationCenterRemoveObserver(CFNotificationCenterGetDarwinNotifyCenter(), (__bridge const void *)(self), (__bridge CFStringRef)notificationName.get(), nullptr);
+    auto notificationName = adoptCF(CFStringCreateWithCString(kCFAllocatorDefault, kGSEventHardwareKeyboardAvailabilityChangedNotification, kCFStringEncodingUTF8));
+    CFNotificationCenterRemoveObserver(CFNotificationCenterGetDarwinNotifyCenter(), (__bridge const void *)(self), notificationName.get(), nullptr);
 #endif
 
 #if HAVE(UIKIT_RESIZABLE_WINDOWS)

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKSystemPreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKSystemPreferences.mm
@@ -40,8 +40,7 @@ constexpr auto CaptivePortalConfigurationIgnoreFileName = @"com.apple.WebKit.cpm
     if (preferenceValue.get() == kCFBooleanTrue)
         return true;
 
-    key = adoptCF(CFStringCreateWithCString(kCFAllocatorDefault, LDMEnabledKey, kCFStringEncodingUTF8));
-    preferenceValue = adoptCF(CFPreferencesCopyValue(key.get(), kCFPreferencesAnyApplication, kCFPreferencesCurrentUser, kCFPreferencesAnyHost));
+    preferenceValue = adoptCF(CFPreferencesCopyValue(LDMEnabledKey, kCFPreferencesAnyApplication, kCFPreferencesCurrentUser, kCFPreferencesAnyHost));
     return preferenceValue.get() == kCFBooleanTrue;
 }
 
@@ -50,7 +49,7 @@ constexpr auto CaptivePortalConfigurationIgnoreFileName = @"com.apple.WebKit.cpm
     auto key = adoptCF(CFStringCreateWithCString(kCFAllocatorDefault, WKLockdownModeEnabledKey.characters(), kCFStringEncodingUTF8));
     CFPreferencesSetValue(key.get(), enabled ? kCFBooleanTrue : kCFBooleanFalse, kCFPreferencesAnyApplication, kCFPreferencesCurrentUser, kCFPreferencesAnyHost);
     CFPreferencesSynchronize(kCFPreferencesAnyApplication, kCFPreferencesCurrentUser, kCFPreferencesAnyHost);
-    CFNotificationCenterPostNotification(CFNotificationCenterGetDarwinNotifyCenter(), (__bridge CFStringRef)WKLockdownModeContainerConfigurationChangedNotification, nullptr, nullptr, true);
+    CFNotificationCenterPostNotification(CFNotificationCenterGetDarwinNotifyCenter(), WKLockdownModeContainerConfigurationChangedNotification, nullptr, nullptr, true);
 }
 
 + (BOOL)isCaptivePortalModeIgnored:(NSString *)containerPath
@@ -84,7 +83,7 @@ constexpr auto CaptivePortalConfigurationIgnoreFileName = @"com.apple.WebKit.cpm
     else
         [[NSFileManager defaultManager] removeItemAtPath:cpmconfigIgnoreFilePath error:NULL];
 
-    CFNotificationCenterPostNotification(CFNotificationCenterGetDarwinNotifyCenter(), (__bridge CFStringRef)WKLockdownModeContainerConfigurationChangedNotification, nullptr, nullptr, true);
+    CFNotificationCenterPostNotification(CFNotificationCenterGetDarwinNotifyCenter(), WKLockdownModeContainerConfigurationChangedNotification, nullptr, nullptr, true);
 #endif
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKSystemPreferencesInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKSystemPreferencesInternal.h
@@ -25,7 +25,7 @@
 
 #import "_WKSystemPreferences.h"
 
-constexpr auto LDMEnabledKey = "LDMGlobalEnabled";
+const auto LDMEnabledKey = CFSTR("LDMGlobalEnabled");
 constexpr auto WKLockdownModeEnabledKey = "WKLockdownModeEnabled"_s;
 // This string must remain consistent with the lockdown mode notification name in privacy settings.
-constexpr auto WKLockdownModeContainerConfigurationChangedNotification = @"WKCaptivePortalModeContainerConfigurationChanged";
+const auto WKLockdownModeContainerConfigurationChangedNotification = CFSTR("WKCaptivePortalModeContainerConfigurationChanged");

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -172,12 +172,8 @@ static NSString * const WebKitSuppressMemoryPressureHandlerDefaultsKey = @"WebKi
 
 static NSString * const WebKitMediaStreamingActivity = @"WebKitMediaStreamingActivity";
 
-#if ENABLE(TRACKING_PREVENTION) && !RELEASE_LOG_DISABLED
-static NSString * const WebKitLogCookieInformationDefaultsKey = @"WebKitLogCookieInformation";
-#endif
-
 #if HAVE(POWERLOG_TASK_MODE_QUERY) && ENABLE(GPU_PROCESS)
-static NSString * const kPLTaskingStartNotificationGlobal = @"kPLTaskingStartNotificationGlobal";
+static CFStringRef const kPLTaskingStartNotificationGlobal = CFSTR("kPLTaskingStartNotificationGlobal");
 #endif
 
 #if PLATFORM(IOS_FAMILY) && !PLATFORM(MACCATALYST)
@@ -468,7 +464,7 @@ void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process
 #endif
 
 #if ENABLE(TRACKING_PREVENTION) && !RELEASE_LOG_DISABLED
-    parameters.shouldLogUserInteraction = [defaults boolForKey:WebKitLogCookieInformationDefaultsKey];
+    parameters.shouldLogUserInteraction = [defaults boolForKey:@"WebKitLogCookieInformation"];
 #endif
 
     auto screenProperties = WebCore::collectScreenProperties();
@@ -824,7 +820,7 @@ void WebProcessPool::registerNotificationObservers()
     });
 
 #if PLATFORM(COCOA)
-    addCFNotificationObserver(lockdownModeConfigurationUpdateCallback, (__bridge CFStringRef)WKLockdownModeContainerConfigurationChangedNotification);
+    addCFNotificationObserver(lockdownModeConfigurationUpdateCallback, WKLockdownModeContainerConfigurationChangedNotification);
 #endif
 
 #if HAVE(PER_APP_ACCESSIBILITY_PREFERENCES)
@@ -842,7 +838,7 @@ void WebProcessPool::registerNotificationObservers()
     addCFNotificationObserver(mediaAccessibilityPreferencesChangedCallback, kMAXCaptionAppearanceSettingsChangedNotification);
 #endif
 #if HAVE(POWERLOG_TASK_MODE_QUERY) && ENABLE(GPU_PROCESS)
-    addCFNotificationObserver(powerLogTaskModeStartedCallback, (__bridge CFStringRef)kPLTaskingStartNotificationGlobal);
+    addCFNotificationObserver(powerLogTaskModeStartedCallback, kPLTaskingStartNotificationGlobal);
 #endif // HAVE(POWERLOG_TASK_MODE_QUERY) && ENABLE(GPU_PROCESS)
 }
 
@@ -881,7 +877,7 @@ void WebProcessPool::unregisterNotificationObservers()
     m_powerSourceNotifier = nullptr;
     
 #if PLATFORM(COCOA)
-    removeCFNotificationObserver((__bridge CFStringRef)WKLockdownModeContainerConfigurationChangedNotification);
+    removeCFNotificationObserver(WKLockdownModeContainerConfigurationChangedNotification);
 #endif
 
 #if HAVE(PER_APP_ACCESSIBILITY_PREFERENCES)
@@ -895,7 +891,7 @@ void WebProcessPool::unregisterNotificationObservers()
     removeCFNotificationObserver(kMAXCaptionAppearanceSettingsChangedNotification);
 #endif
 #if HAVE(POWERLOG_TASK_MODE_QUERY) && ENABLE(GPU_PROCESS)
-    removeCFNotificationObserver((__bridge CFStringRef)kPLTaskingStartNotificationGlobal);
+    removeCFNotificationObserver(kPLTaskingStartNotificationGlobal);
 #endif
     m_weakObserver = nil;
 }

--- a/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
@@ -918,13 +918,13 @@ String WebInspectorUIProxy::inspectorTestPageURL()
 
 DebuggableInfoData WebInspectorUIProxy::infoForLocalDebuggable()
 {
-    NSDictionary *plist = adoptCF(_CFCopySystemVersionDictionary()).bridgingAutorelease();
+    CFDictionaryRef plist = static_cast<CFDictionaryRef>(CFAutorelease(_CFCopySystemVersionDictionary()));
 
     DebuggableInfoData result;
     result.debuggableType = Inspector::DebuggableType::WebPage;
     result.targetPlatformName = "macOS"_s;
-    result.targetBuildVersion = plist[static_cast<NSString *>(_kCFSystemVersionBuildVersionKey)];
-    result.targetProductVersion = plist[static_cast<NSString *>(_kCFSystemVersionProductUserVisibleVersionKey)];
+    result.targetBuildVersion = static_cast<CFStringRef>(CFDictionaryGetValue(plist, _kCFSystemVersionBuildVersionKey));
+    result.targetProductVersion = static_cast<CFStringRef>(CFDictionaryGetValue(plist, _kCFSystemVersionProductUserVisibleVersionKey));
     result.targetIsSimulator = false;
 
     return result;

--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
@@ -155,8 +155,7 @@ void WebsiteDataStore::platformSetNetworkParameters(WebsiteDataStoreParameters& 
             resourceLoadStatisticsManualPrevalentResource = WebCore::RegistrableDomain { url };
     }
 #if !RELEASE_LOG_DISABLED
-    static NSString * const WebKitLogCookieInformationDefaultsKey = @"WebKitLogCookieInformation";
-    shouldLogCookieInformation = [defaults boolForKey:WebKitLogCookieInformationDefaultsKey];
+    shouldLogCookieInformation = [defaults boolForKey:@"WebKitLogCookieInformation"];
 #endif
 #endif // ENABLE(TRACKING_PREVENTION)
 

--- a/Source/WebKitLegacy/mac/Misc/WebNSDataExtras.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebNSDataExtras.mm
@@ -37,18 +37,15 @@
 
 - (NSString *)_web_capitalizeRFC822HeaderFieldName
 {
-    CFStringRef name = (__bridge CFStringRef)self;
-    NSString *result = nil;
-
-    CFIndex len = CFStringGetLength(name);
+    NSUInteger len = [self length];
     char* charPtr = nullptr;
     UniChar* uniCharPtr = nullptr;
     Boolean useUniCharPtr = FALSE;
     Boolean shouldCapitalize = TRUE;
     Boolean somethingChanged = FALSE;
 
-    for (CFIndex i = 0; i < len; i ++) {
-        UniChar ch = CFStringGetCharacterAtIndex(name, i);
+    for (NSUInteger i = 0; i < len; i++) {
+        UniChar ch = [self characterAtIndex:i];
         Boolean replace = FALSE;
         if (shouldCapitalize && ch >= 'a' && ch <= 'z') {
             ch = ch + 'A' - 'a';
@@ -60,15 +57,16 @@
         if (replace) {
             if (!somethingChanged) {
                 somethingChanged = TRUE;
-                if (CFStringGetBytes(name, CFRangeMake(0, len), kCFStringEncodingISOLatin1, 0, FALSE, NULL, 0, NULL) == len) {
+                NSRange range = NSMakeRange(0, len);
+                if ([self getBytes:NULL maxLength:0 usedLength:nil encoding:NSISOLatin1StringEncoding options:NSStringEncodingConversionExternalRepresentation range:range remainingRange:NULL]) {
                     // Can be encoded in ISOLatin1
                     useUniCharPtr = FALSE;
-                    charPtr = static_cast<char*>(CFAllocatorAllocate(kCFAllocatorDefault, len + 1, 0));
-                    CFStringGetCString(name, charPtr, len+1, kCFStringEncodingISOLatin1);
+                    charPtr = static_cast<char *>(malloc(len + 1));
+                    [self getCString:charPtr maxLength:len + 1 encoding:NSISOLatin1StringEncoding];
                 } else {
                     useUniCharPtr = TRUE;
-                    uniCharPtr = static_cast<UniChar*>(CFAllocatorAllocate(kCFAllocatorDefault, len * sizeof(UniChar), 0));
-                    CFStringGetCharacters(name, CFRangeMake(0, len), uniCharPtr);
+                    uniCharPtr = static_cast<UniChar *>(malloc(len * sizeof(UniChar)));
+                    [self getCharacters:uniCharPtr range:range];
                 }
             }
             if (useUniCharPtr)
@@ -82,14 +80,24 @@
             shouldCapitalize = FALSE;
     }
     if (somethingChanged) {
-        if (useUniCharPtr)
-            result = adoptCF(CFStringCreateWithCharactersNoCopy(kCFAllocatorDefault, uniCharPtr, len, nullptr)).bridgingAutorelease();
-        else
-            result = adoptCF(CFStringCreateWithCStringNoCopy(kCFAllocatorDefault, charPtr, kCFStringEncodingISOLatin1, nullptr)).bridgingAutorelease();
-    } else
-        result = self;
+        NSString *result;
+        if (useUniCharPtr) {
+            result = [[NSString alloc] initWithCharactersNoCopy:uniCharPtr length:len freeWhenDone:YES];
+            if (!result) {
+                free(uniCharPtr);
+                return self;
+            }
+        } else {
+            result = [[NSString alloc] initWithBytesNoCopy:charPtr length:len encoding:NSISOLatin1StringEncoding freeWhenDone:YES];
+            if (!result) {
+                free(charPtr);
+                return self;
+            }
+        }
+        return adoptNS(result).autorelease();
+    }
 
-    return result;
+    return self;
 }
 
 @end
@@ -99,16 +107,17 @@
 - (NSString *)_webkit_guessedMIMETypeForXML
 {
     NSUInteger length = [self length];
-    const UInt8* bytes = static_cast<const UInt8*>([self bytes]);
+    if (!length)
+        return nil;
+    const char *p = static_cast<const char *>([self bytes]);
 
 #define CHANNEL_TAG_LENGTH 7
 
-    const char* p = reinterpret_cast<const char*>(bytes);
-    int remaining = std::min<NSUInteger>(length, WEB_GUESS_MIME_TYPE_PEEK_LENGTH) - (CHANNEL_TAG_LENGTH - 1);
+    NSUInteger remaining = std::min<NSUInteger>(length, WEB_GUESS_MIME_TYPE_PEEK_LENGTH) - (CHANNEL_TAG_LENGTH - 1);
 
     BOOL foundRDF = false;
 
-    while (remaining > 0) {
+    while (true) {
         // Look for a "<".
         const char* hit = static_cast<const char*>(memchr(p, '<', remaining));
         if (!hit)
@@ -136,6 +145,8 @@
             return nil;
 
         // Skip the "<" and continue.
+        if (p + remaining <= (hit + 1))
+            break;
         remaining -= (hit + 1) - p;
         p = hit + 1;
     }
@@ -151,16 +162,19 @@
 #define VCARD_HEADER_LENGTH 11
 #define VCAL_HEADER_LENGTH 15
 
+    NSUInteger length = [self length];
+    if (!length)
+        return @"text/plain"; // File is empty. Treat it as an empty text file.
+
     NSString *MIMEType = [self _webkit_guessedMIMETypeForXML];
     if ([MIMEType length])
         return MIMEType;
 
-    NSUInteger length = [self length];
     const char* bytes = static_cast<const char*>([self bytes]);
 
     const char* p = bytes;
-    int remaining = std::min<NSUInteger>(length, WEB_GUESS_MIME_TYPE_PEEK_LENGTH) - (SCRIPT_TAG_LENGTH - 1);
-    while (remaining > 0) {
+    NSUInteger remaining = std::min<NSUInteger>(length, WEB_GUESS_MIME_TYPE_PEEK_LENGTH) - (SCRIPT_TAG_LENGTH - 1);
+    while (true) {
         // Look for a "<".
         const char* hit = static_cast<const char*>(memchr(p, '<', remaining));
         if (!hit)
@@ -175,6 +189,8 @@
         }
 
         // Skip the "<" and continue.
+        if (p + remaining <= (hit + 1))
+            break;
         remaining -= (hit + 1) - p;
         p = hit + 1;
     }
@@ -183,7 +199,7 @@
     // This code could be improved to look for other mime types.
     p = bytes;
     remaining = std::min<NSUInteger>(length, WEB_GUESS_MIME_TYPE_PEEK_LENGTH) - (TEXT_HTML_LENGTH - 1);
-    while (remaining > 0) {
+    while (true) {
         // Look for a "t" or "T".
         const char* hit = nullptr;
         const char* lowerhit = static_cast<const char*>(memchr(p, 't', remaining));
@@ -203,6 +219,8 @@
             return @"text/html";
 
         // Skip the "t/T" and continue.
+        if (p + remaining <= (hit + 1))
+            break;
         remaining -= (hit + 1) - p;
         p = hit + 1;
     }
@@ -251,7 +269,7 @@
     return !strncasecmp(bytes, string, [self length]);
 }
 
-static const UInt8 *_findEOL(const UInt8 *bytes, CFIndex len)
+static const UInt8 *_findEOL(const UInt8 *bytes, NSUInteger len)
 {
     // According to the HTTP specification EOL is defined as
     // a CRLF pair. Unfortunately, some servers will use LF
@@ -262,7 +280,7 @@ static const UInt8 *_findEOL(const UInt8 *bytes, CFIndex len)
     //
     // It returns NULL if EOL is not found or it will return
     // a pointer to the first terminating character.
-    for (CFIndex i = 0;  i < len; i++) {
+    for (NSUInteger i = 0; i < len; i++) {
         UInt8 c = bytes[i];
         if ('\n' == c)
             return bytes + i;
@@ -292,7 +310,7 @@ static const UInt8 *_findEOL(const UInt8 *bytes, CFIndex len)
     // Loop over lines until we're past the header, or we can't find any more end-of-lines
     while ((eol = _findEOL(bytes, length))) {
         const UInt8 *line = bytes;
-        SInt32 lineLength = eol - bytes;
+        UInt32 lineLength = eol - line;
 
         // Move bytes to the character after the terminator as returned by _findEOL.
         bytes = eol + 1;
@@ -342,15 +360,15 @@ static const UInt8 *_findEOL(const UInt8 *bytes, CFIndex len)
 
 - (BOOL)_web_startsWithBlankLine
 {
-    return [self length] > 0 && ((const char *)[self bytes])[0] == '\n';
+    return [self length] > 0 && (static_cast<const char *>([self bytes]))[0] == '\n';
 }
 
 - (NSInteger)_web_locationAfterFirstBlankLine
 {
-    const char *bytes = (const char *)[self bytes];
+    const char *bytes = static_cast<const char *>([self bytes]);
     NSUInteger length = [self length];
 
-    unsigned i;
+    NSUInteger i;
     for (i = 0; i < length - 4; i++) {
 
         //  Support for Acrobat. It sends "\n\n".


### PR DESCRIPTION
#### 3969767bf564ae0d40cd2d6ec2f22fac8c83034e
<pre>
Reduce Bridging and Runtime Creation of Strings
<a href="https://bugs.webkit.org/show_bug.cgi?id=251687">https://bugs.webkit.org/show_bug.cgi?id=251687</a>

Reviewed by NOBODY (OOPS!).

In many places, we needlessly bridge for the sake of calling
Objective-C methods and Core Foundation functions where the native
functions/methods work just fine. This PR replaces the bridging with
calling the functions associated with the variable type. This is focused
primarily on strings but some fixes required changing other variables to
CF types or Objective-C NS types.

*Source\WTF\wtf\cocoa\FileSystemCocoa.mm:
*Source\WebCore\bridge\objc\objc_class.mm:
*Source\WebCore\platform\cocoa\MIMETypeRegistryCocoa.mm:
*Source\WebCore\platform\gamepad\cocoa\GameControllerGamepadProvider.mm:
*Source\WebKit\UIProcess\API\Cocoa\WKWebView.mm:
*Source\WebKit\UIProcess\API\Cocoa\_WKSystemPreferences.mm:
*Source\WebKit\UIProcess\API\Cocoa\_WKSystemPreferencesInternal.h:
*Source\WebKit\UIProcess\Cocoa\WebProcessPoolCocoa.mm:
*Source\WebKit\UIProcess\Inspector\mac\WebInspectorUIProxyMac.mm:
*Source\WebKit\UIProcess\WebsiteData\Cocoa\WebsiteDataStoreCocoa.mm:
*Source\WebKit\UIProcess\mac\WKPrintingView.mm:
*Source\WebKitLegacy\mac\Misc\WebNSDataExtras.mm:(_web_capitalizeRFC822HeaderFieldName):
This function was heavily rewritten to call Objective-C functions with
minimal bridging. In addition, unlike the way the function was written
previously, this function frees the backing buffer. However, as a
caveat, and because we cannot change this, said buffer MUST use
malloc/free instead of the standard and established way we allocate and
free temporary buffers.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3969767bf564ae0d40cd2d6ec2f22fac8c83034e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109492 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18615 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42252 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/990 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118651 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113376 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20082 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9813 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101769 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115247 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98187 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43163 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29840 "Found 60 new test failures: accessibility/file-upload-button-stringvalue.html, accessibility/mac/editable-webarea-context-menu-point.html, accessibility/mac/focus-setting-selection-syncronizing-not-clearing.html, animations/restart-after-scroll-nested.html, animations/restart-after-scroll.html, compositing/fixed-with-fixed-layout.html, compositing/fixed-with-main-thread-scrolling.html, compositing/iframes/layout-on-compositing-change.html, compositing/layer-creation/zoomed-clip-intersection.html, compositing/no-compositing-when-full-screen-is-present.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84927 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/98401 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11356 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31183 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/38/builds/99284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/9381 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12019 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8115 "Passed tests") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/38/builds/99284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17385 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50787 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/107267 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13751 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26483 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->