### PR TITLE
Modernize Objective-C Strings

### DIFF
--- a/Source/JavaScriptCore/API/JSWrapperMap.mm
+++ b/Source/JavaScriptCore/API/JSWrapperMap.mm
@@ -69,7 +69,7 @@ static NSString *selectorToPropertyName(const char* start)
     // Use 'index' to check for colons, if there are none, this is easy!
     const char* firstColon = strchr(start, ':');
     if (!firstColon)
-        return [NSString stringWithUTF8String:start];
+        return @(start);
 
     // 'header' is the length of string up to the first colon.
     size_t header = firstColon - start;
@@ -101,7 +101,7 @@ static NSString *selectorToPropertyName(const char* start)
         // If we get here, we've consumed a ':' - wash, rinse, repeat.
     }
 done:
-    return [NSString stringWithUTF8String:buffer.data()];
+    return @(buffer.data());
 }
 
 static bool constructorHasInstance(JSContextRef ctx, JSObjectRef constructorRef, JSValueRef possibleInstance, JSValueRef*)

--- a/Source/JavaScriptCore/testmem/testmem.mm
+++ b/Source/JavaScriptCore/testmem/testmem.mm
@@ -74,7 +74,7 @@ int main(int argc, char* argv[])
         iterations = iters;
     }
 
-    NSString *path = [NSString stringWithUTF8String:argv[1]];
+    NSString *path = @(argv[1]);
     NSString *script = [[NSString alloc] initWithContentsOfFile:path encoding:NSUTF8StringEncoding error:nil];
     if (!script) {
         printf("Can't open file: %s\n", argv[1]);

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -3238,7 +3238,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     char description[2048];
     formatForDebugger(visiblePositionRange, description, sizeof(description));
 
-    return [NSString stringWithUTF8String:description];
+    return @(description);
 }
 
 - (void)showNodeForTextMarker:(AXTextMarkerRef)textMarker

--- a/Source/WebCore/platform/audio/mac/AudioBusMac.mm
+++ b/Source/WebCore/platform/audio/mac/AudioBusMac.mm
@@ -42,7 +42,7 @@ RefPtr<AudioBus> AudioBus::loadPlatformResource(const char* name, float sampleRa
 {
     @autoreleasepool {
         NSBundle *bundle = [NSBundle bundleForClass:[WebCoreAudioBundleClass class]];
-        NSURL *audioFileURL = [bundle URLForResource:[NSString stringWithUTF8String:name] withExtension:@"wav" subdirectory:@"audio"];
+        NSURL *audioFileURL = [bundle URLForResource:@(name) withExtension:@"wav" subdirectory:@"audio"];
         if (NSData *audioData = [NSData dataWithContentsOfURL:audioFileURL options:NSDataReadingMappedIfSafe error:nil])
             return createBusFromInMemoryAudioFile([audioData bytes], [audioData length], false, sampleRate);
     }

--- a/Source/WebCore/platform/graphics/mac/ImageMac.mm
+++ b/Source/WebCore/platform/graphics/mac/ImageMac.mm
@@ -59,7 +59,7 @@ void BitmapImage::invalidatePlatformData()
 Ref<Image> Image::loadPlatformResource(const char *name)
 {
     NSBundle *bundle = [NSBundle bundleForClass:[WebCoreBundleFinder class]];
-    NSString *imagePath = [bundle pathForResource:[NSString stringWithUTF8String:name] ofType:@"png"];
+    NSString *imagePath = [bundle pathForResource:@(name) ofType:@"png"];
     NSData *namedImageData = [NSData dataWithContentsOfFile:imagePath];
     if (namedImageData) {
         auto image = BitmapImage::create();

--- a/Source/WebCore/platform/ios/WebAVPlayerController.mm
+++ b/Source/WebCore/platform/ios/WebAVPlayerController.mm
@@ -130,7 +130,7 @@ static double WebAVPlayerControllerLiveStreamSeekableTimeRangeMinimumDuration = 
 
     for (unsigned i = 0; i < count; i++) {
         objc_property_t property = properties[i];
-        NSString *propertyName = [NSString stringWithUTF8String:property_getName(property)];
+        NSString *propertyName = @(property_getName(property));
         if ([propertyNameFromKeyPath isEqualToString:propertyName]) {
             target = _playerController.get();
             break;

--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
@@ -155,8 +155,7 @@ void WebsiteDataStore::platformSetNetworkParameters(WebsiteDataStoreParameters& 
             resourceLoadStatisticsManualPrevalentResource = WebCore::RegistrableDomain { url };
     }
 #if !RELEASE_LOG_DISABLED
-    static NSString * const WebKitLogCookieInformationDefaultsKey = @"WebKitLogCookieInformation";
-    shouldLogCookieInformation = [defaults boolForKey:WebKitLogCookieInformationDefaultsKey];
+    shouldLogCookieInformation = [defaults boolForKey:@"WebKitLogCookieInformation"];
 #endif
 #endif // ENABLE(TRACKING_PREVENTION)
 

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -614,16 +614,14 @@ RetainPtr<NSDictionary> WebProcess::additionalStateForDiagnosticReport() const
     {
         auto memoryUsageStats = adoptNS([[NSMutableDictionary alloc] init]);
         for (auto& it : PerformanceLogging::memoryUsageStatistics(ShouldIncludeExpensiveComputations::Yes)) {
-            auto keyString = adoptNS([[NSString alloc] initWithUTF8String:it.key]);
-            [memoryUsageStats setObject:@(it.value) forKey:keyString.get()];
+            [memoryUsageStats setObject:@(it.value) forKey:@(it.key)];
         }
         [stateDictionary setObject:memoryUsageStats.get() forKey:@"Memory Usage Stats"];
     }
     {
         auto jsObjectCounts = adoptNS([[NSMutableDictionary alloc] init]);
         for (auto& it : PerformanceLogging::javaScriptObjectCounts()) {
-            auto keyString = adoptNS([[NSString alloc] initWithUTF8String:it.key]);
-            [jsObjectCounts setObject:@(it.value) forKey:keyString.get()];
+            [jsObjectCounts setObject:@(it.value) forKey:@(it.key)];
         }
         [stateDictionary setObject:jsObjectCounts.get() forKey:@"JavaScript Object Counts"];
     }

--- a/Source/WebKitLegacy/mac/Misc/WebCoreStatistics.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebCoreStatistics.mm
@@ -84,7 +84,7 @@ static RetainPtr<NSCountedSet> createNSCountedSet(const HashCountedSet<const cha
 {
     auto result = adoptNS([[NSCountedSet alloc] initWithCapacity:set.size()]);
     for (auto& entry : set) {
-        auto key = [NSString stringWithUTF8String:entry.key];
+        NSString *key = @(entry.key);
         for (unsigned i = 0; i < entry.value; ++i)
             [result addObject:key];
     }

--- a/Source/WebKitLegacy/mac/Misc/WebLocalizableStrings.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebLocalizableStrings.mm
@@ -49,7 +49,7 @@ NSString *WebLocalizedString(WebLocalizableStringsBundle *stringsBundle, const c
     } else {
         bundle = stringsBundle->bundle;
         if (bundle == nil) {
-            bundle = [NSBundle bundleWithIdentifier:[NSString stringWithUTF8String:stringsBundle->identifier]];
+            bundle = [NSBundle bundleWithIdentifier:@(stringsBundle->identifier)];
             ASSERT(bundle);
             stringsBundle->bundle = bundle;
         }

--- a/Tools/DumpRenderTree/mac/DumpRenderTree.mm
+++ b/Tools/DumpRenderTree/mac/DumpRenderTree.mm
@@ -133,7 +133,7 @@ extern "C" {
 
 static RetainPtr<NSString> toNS(const std::string& string)
 {
-    return adoptNS([[NSString alloc] initWithUTF8String:string.c_str()]);
+    return @(string.c_str());
 }
 
 #if !PLATFORM(IOS_FAMILY)
@@ -1046,7 +1046,7 @@ static void initializeGlobalsFromCommandLineOptions(int argc, const char *argv[]
 static void addTestPluginsToPluginSearchPath(const char* executablePath)
 {
 #if !PLATFORM(IOS_FAMILY)
-    NSString *pwd = [[NSString stringWithUTF8String:executablePath] stringByDeletingLastPathComponent];
+    NSString *pwd = [@(executablePath) stringByDeletingLastPathComponent];
     [WebPluginDatabase setAdditionalWebPlugInPaths:@[pwd]];
     [[WebPluginDatabase sharedDatabase] refresh];
 #endif
@@ -1148,7 +1148,7 @@ static void prepareConsistentTestingEnvironment()
 #endif
 
     if (webCoreLogging.length())
-        [[NSUserDefaults standardUserDefaults] setValue:[NSString stringWithUTF8String:webCoreLogging.c_str()] forKey:@"WebCoreLogging"];
+        [[NSUserDefaults standardUserDefaults] setValue:@(webCoreLogging.c_str()) forKey:@"WebCoreLogging"];
 }
 
 const char crashedMessage[] = "#CRASHED\n";
@@ -1200,11 +1200,11 @@ void dumpRenderTree(int argc, const char *argv[])
     [NSURLRequest setAllowsAnyHTTPSCertificate:YES forHost:@"localhost"];
     [NSURLRequest setAllowsAnyHTTPSCertificate:YES forHost:@"127.0.0.1"];
     for (auto& localhostAlias : localhostAliases)
-        [NSURLRequest setAllowsAnyHTTPSCertificate:YES forHost:[NSString stringWithUTF8String:localhostAlias.c_str()]];
+        [NSURLRequest setAllowsAnyHTTPSCertificate:YES forHost:@(localhostAlias.c_str())];
 
     if (allowAnyHTTPSCertificateForAllowedHosts) {
         for (auto& host : allowedHosts)
-            [NSURLRequest setAllowsAnyHTTPSCertificate:YES forHost:[NSString stringWithUTF8String:host.c_str()]];
+            [NSURLRequest setAllowsAnyHTTPSCertificate:YES forHost:@(host.c_str())];
     }
 
     if (threaded)
@@ -1896,7 +1896,7 @@ static void runTest(const std::string& inputLine)
     auto pathOrURL = command.pathOrURL;
     dumpPixelsForCurrentTest = command.shouldDumpPixels || dumpPixelsForAllTests;
 
-    NSString *pathOrURLString = [NSString stringWithUTF8String:pathOrURL.c_str()];
+    NSString *pathOrURLString = @(pathOrURL.c_str());
     if (!pathOrURLString) {
         fprintf(stderr, "Failed to parse \"%s\" as UTF-8\n", pathOrURL.c_str());
         return;

--- a/Tools/DumpRenderTree/mac/ResourceLoadDelegate.mm
+++ b/Tools/DumpRenderTree/mac/ResourceLoadDelegate.mm
@@ -168,7 +168,7 @@ BOOL canAuthenticateServerTrustAgainstProtectionSpace(NSString *host)
     NSURL *url = [request URL];
     NSString *host = [url host];
     if (host && (NSOrderedSame == [[url scheme] caseInsensitiveCompare:@"http"] || NSOrderedSame == [[url scheme] caseInsensitiveCompare:@"https"])) {
-        NSString *testURL = [NSString stringWithUTF8String:gTestRunner->testURL().c_str()];
+        NSString *testURL = @(gTestRunner->testURL().c_str());
         NSString *lowercaseTestURL = [testURL lowercaseString];
         NSString *testHost = 0;
         if ([lowercaseTestURL hasPrefix:@"http:"] || [lowercaseTestURL hasPrefix:@"https:"])
@@ -188,11 +188,10 @@ BOOL canAuthenticateServerTrustAgainstProtectionSpace(NSString *host)
     auto newRequest = adoptNS([request mutableCopy]);
     const set<string>& clearHeaders = gTestRunner->willSendRequestClearHeaders();
     for (set<string>::const_iterator header = clearHeaders.begin(); header != clearHeaders.end(); ++header) {
-        auto nsHeader = adoptNS([[NSString alloc] initWithUTF8String:header->c_str()]);
-        [newRequest setValue:nil forHTTPHeaderField:nsHeader.get()];
+        [newRequest setValue:nil forHTTPHeaderField:@(header->c_str())];
     }
     if (auto* destination = gTestRunner->redirectionDestinationForURL([[url absoluteString] UTF8String]))
-        [newRequest setURL:[NSURL URLWithString:[NSString stringWithUTF8String:destination]]];
+        [newRequest setURL:[NSURL URLWithString:@(destination)]];
 
     return newRequest.autorelease();
 }

--- a/Tools/DumpRenderTree/mac/UIDelegate.mm
+++ b/Tools/DumpRenderTree/mac/UIDelegate.mm
@@ -383,13 +383,13 @@ static NSString *addLeadingSpaceStripTrailingSpaces(NSString *string)
         return;
     }
 
-    NSURL *baseURL = [NSURL URLWithString:[NSString stringWithUTF8String:gTestRunner->testURL().c_str()]];
-    auto filePaths = createNSArray(openPanelFiles, [&] (const std::string& filePath) {
-        return [NSURL fileURLWithPath:[NSString stringWithUTF8String:filePath.c_str()] relativeToURL:baseURL].path;
+    NSURL *baseURL = [NSURL URLWithString:@(gTestRunner->testURL().c_str())];
+    auto filePaths = createNSArray(openPanelFiles, [&](const std::string &filePath) {
+        return [NSURL fileURLWithPath:@(filePath.c_str()) relativeToURL:baseURL].path;
     });
 
 #if PLATFORM(IOS_FAMILY)
-    NSURL *firstURL = [NSURL fileURLWithPath:[NSString stringWithUTF8String:openPanelFiles[0].c_str()] relativeToURL:baseURL];
+    NSURL *firstURL = [NSURL fileURLWithPath:@(openPanelFiles[0].c_str()) relativeToURL:baseURL];
     NSString *displayString = firstURL.lastPathComponent;
     auto& iconData = gTestRunner->openPanelFilesMediaIcon();
     CGImageRef imageRef = nullptr;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FTP.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FTP.mm
@@ -108,7 +108,7 @@ TEST(WKWebView, FTPSubresource)
     setInjectedBundleClient(webView.get());
     
     consoleMessages = [NSMutableArray arrayWithCapacity:2];
-    [webView synchronouslyLoadHTMLString:[NSString stringWithUTF8String:subresourceBytes]];
+    [webView synchronouslyLoadHTMLString:@(subresourceBytes)];
 
     EXPECT_EQ([consoleMessages count], 2u);
     EXPECT_TRUE([consoleMessages.get()[0] isEqualToString:@"FTP URLs are disabled"]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ShouldOpenExternalURLsInNewWindowActions.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ShouldOpenExternalURLsInNewWindowActions.mm
@@ -280,9 +280,9 @@ TEST(WebKit, IFrameWithSameOriginAsMainFramePropagates)
         
         NSString *responseText = nil;
         if ([[task request].URL.absoluteString containsString:@"iframe.html"])
-            responseText = [NSString stringWithUTF8String:iframeBytes];
+            responseText = @(iframeBytes);
         else if ([[task request].URL.absoluteString containsString:@"mainframe.html"])
-            responseText = [NSString stringWithUTF8String:mainFrameBytes];
+            responseText = @(mainFrameBytes);
 
         auto response = adoptNS([[NSURLResponse alloc] initWithURL:requestURL MIMEType:@"text/html" expectedContentLength:[responseText length] textEncodingName:nil]);
         [task didReceiveResponse:response.get()];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKURLSchemeHandler-1.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKURLSchemeHandler-1.mm
@@ -718,7 +718,7 @@ TEST(URLSchemeHandler, XHRPost)
             EXPECT_FALSE(reached);
             reached = true;
             // The length of this is variable
-            auto *formDataString = [NSString stringWithUTF8String:static_cast<const char*>(task.request.HTTPBody.bytes)];
+            auto *formDataString = @(static_cast<const char *>(task.request.HTTPBody.bytes));
             EXPECT_TRUE([formDataString containsString:@"Content-Disposition: form-data; name=\"foo\""]);
             EXPECT_TRUE([formDataString containsString:@"baz"]);
             EXPECT_TRUE([formDataString containsString:@"WebKitFormBoundary"]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
@@ -275,7 +275,7 @@ TEST(WebPushD, BasicCommunication)
         if (!debugMessage)
             return;
 
-        NSString *nsMessage = [NSString stringWithUTF8String:debugMessage];
+        NSString *nsMessage = @(debugMessage);
 
         // Ignore possible connections/messages from webpushtool
         if ([nsMessage hasPrefix:@"[webpushtool "])

--- a/Tools/TestWebKitAPI/cocoa/DaemonTestUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/DaemonTestUtilities.mm
@@ -50,14 +50,7 @@ namespace TestWebKitAPI {
 
 static RetainPtr<NSURL> currentExecutableLocation()
 {
-    uint32_t size { 0 };
-    _NSGetExecutablePath(nullptr, &size);
-    Vector<char> buffer;
-    buffer.resize(size + 1);
-    _NSGetExecutablePath(buffer.data(), &size);
-    buffer[size] = '\0';
-    auto pathString = adoptNS([[NSString alloc] initWithUTF8String:buffer.data()]);
-    return adoptNS([[NSURL alloc] initFileURLWithPath:pathString.get() isDirectory:NO]);
+    return [NSBundle mainBundle].executableURL;
 }
 
 RetainPtr<NSURL> currentExecutableDirectory()

--- a/Tools/TestWebKitAPI/cocoa/PlatformUtilitiesCocoa.mm
+++ b/Tools/TestWebKitAPI/cocoa/PlatformUtilitiesCocoa.mm
@@ -42,7 +42,7 @@ NSString *toNS(WKStringRef string)
     size_t stringLength = WKStringGetUTF8CString(string, buffer.get(), bufferSize);
     buffer[stringLength] = '\0';
 
-    return [NSString stringWithUTF8String:buffer.get()];
+    return @(buffer.get());
 }
 
 NSString *toNS(WKRetainPtr<WKStringRef> string)

--- a/Tools/TestWebKitAPI/mac/JavaScriptTestMac.mm
+++ b/Tools/TestWebKitAPI/mac/JavaScriptTestMac.mm
@@ -35,7 +35,7 @@ namespace TestWebKitAPI {
 
 ::testing::AssertionResult runJSTest(const char*, const char*, const char*, WebView *webView, const char* script, const char* expectedResult)
 {
-    NSString *actualResult = [webView stringByEvaluatingJavaScriptFromString:[NSString stringWithUTF8String:script]];
+    NSString *actualResult = [webView stringByEvaluatingJavaScriptFromString:@(script)];
     return compareJSResult(script, [actualResult UTF8String], expectedResult);
 }
 

--- a/Tools/TestWebKitAPI/mac/PlatformUtilitiesMac.mm
+++ b/Tools/TestWebKitAPI/mac/PlatformUtilitiesMac.mm
@@ -44,7 +44,7 @@ WKStringRef createInjectedBundlePath()
 
 WKURLRef createURLForResource(const char* resource, const char* extension)
 {
-    NSURL *nsURL = [[NSBundle mainBundle] URLForResource:[NSString stringWithUTF8String:resource] withExtension:[NSString stringWithUTF8String:extension] subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *nsURL = [[NSBundle mainBundle] URLForResource:@(resource) withExtension:@(extension) subdirectory:@"TestWebKitAPI.resources"];
     return WKURLCreateWithCFURL((__bridge CFURLRef)nsURL);
 }
 

--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -118,10 +118,10 @@ void TestController::cocoaPlatformInitialize(const Options& options)
         WTFCrash();
     
     if (options.webCoreLogChannels.length())
-        [[NSUserDefaults standardUserDefaults] setValue:[NSString stringWithUTF8String:options.webCoreLogChannels.c_str()] forKey:@"WebCoreLogging"];
+        [[NSUserDefaults standardUserDefaults] setValue:@(options.webCoreLogChannels.c_str()) forKey:@"WebCoreLogging"];
 
     if (options.webKitLogChannels.length())
-        [[NSUserDefaults standardUserDefaults] setValue:[NSString stringWithUTF8String:options.webKitLogChannels.c_str()] forKey:@"WebKit2Logging"];
+        [[NSUserDefaults standardUserDefaults] setValue:@(options.webKitLogChannels.c_str()) forKey:@"WebKit2Logging"];
 }
 
 WKContextRef TestController::platformContext()
@@ -155,7 +155,7 @@ void TestController::platformInitializeDataStore(WKPageConfigurationRef, const T
         if (!useEphemeralSession)
             configureWebsiteDataStoreTemporaryDirectories((WKWebsiteDataStoreConfigurationRef)websiteDataStoreConfig.get());
         if (standaloneWebApplicationURL.length())
-            [websiteDataStoreConfig setStandaloneApplicationURL:[NSURL URLWithString:[NSString stringWithUTF8String:standaloneWebApplicationURL.c_str()]]];
+            [websiteDataStoreConfig setStandaloneApplicationURL:[NSURL URLWithString:@(standaloneWebApplicationURL.c_str())]];
 #if PLATFORM(IOS_FAMILY)
         if (options.enableInAppBrowserPrivacy())
             [websiteDataStoreConfig setEnableInAppBrowserPrivacyForTesting:YES];
@@ -200,7 +200,7 @@ void TestController::platformCreateWebView(WKPageConfigurationRef, const TestOpt
 
     auto applicationManifest = options.applicationManifest();
     if (applicationManifest.length()) {
-        auto manifestPath = [NSString stringWithUTF8String:applicationManifest.c_str()];
+        auto manifestPath = @(applicationManifest.c_str());
         NSString *text = [NSString stringWithContentsOfFile:manifestPath usedEncoding:nullptr error:nullptr];
         [copiedConfiguration _setApplicationManifest:[_WKApplicationManifest applicationManifestFromJSON:text manifestURL:nil documentURL:nil]];
     }


### PR DESCRIPTION
#### 2fe6e434a10b8a482998d1b512b122be1559ace8
<pre>
Modernize Objective-C Strings
<a href="https://bugs.webkit.org/show_bug.cgi?id=251694">https://bugs.webkit.org/show_bug.cgi?id=251694</a>

Reviewed by NOBODY (OOPS!).

There are places where we can replace the stringWithUTFString method with the
shorthand version of @. This makes the code more clear and concise.

*Source\JavaScriptCore\API\JSWrapperMap.mm:
*Source\JavaScriptCore\testmem\testmem.mm:
*Source\WebCore\accessibility\mac\WebAccessibilityObjectWrapperMac.mm:
*Source\WebCore\platform\audio\mac\AudioBusMac.mm:
*Source\WebCore\platform\graphics\mac\ImageMac.mm:
*Source\WebCore\platform\ios\WebAVPlayerController.mm:
*Source\WebKit\UIProcess\WebsiteData\Cocoa\WebsiteDataStoreCocoa.mm:
*Source\WebKit\WebProcess\cocoa\WebProcessCocoa.mm:
*Source\WebKitLegacy\mac\Misc\WebCoreStatistics.mm:
*Source\WebKitLegacy\mac\Misc\WebLocalizableStrings.mm:
*Tools\DumpRenderTree\mac\DumpRenderTree.mm:
*Tools\DumpRenderTree\mac\ResourceLoadDelegate.mm:
*Tools\DumpRenderTree\mac\UIDelegate.mm:
*Tools\TestWebKitAPI\Tests\WebKitCocoa\FTP.mm:
*Tools\TestWebKitAPI\Tests\WebKitCocoa\ShouldOpenExternalURLsInNewWindowActions.mm:
*Tools\TestWebKitAPI\Tests\WebKitCocoa\WKURLSchemeHandler-1.mm:
*Tools\TestWebKitAPI\Tests\WebKitCocoa\WebPushDaemon.mm:
*Tools\TestWebKitAPI\cocoa\DaemonTestUtilities.mm:
*Tools\TestWebKitAPI\cocoa\PlatformUtilitiesCocoa.mm:
*Tools\TestWebKitAPI\mac\JavaScriptTestMac.mm:
*Tools\TestWebKitAPI\mac\PlatformUtilitiesMac.mm:
*Tools\WebKitTestRunner\cocoa\TestControllerCocoa.mm:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5920b0d2d5c0fca430db1548567c11b859dcb9c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107371 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16431 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40293 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116530 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115957 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111271 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17854 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7670 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99532 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113135 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13467 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96665 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41093 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95371 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28291 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82857 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/96716 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9443 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29644 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/96141 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/7439 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10097 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6521 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30781 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15599 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49225 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/104981 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11654 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26027 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->