### PR TITLE
Update the Interaction Regions layer tree after UI-side scrolling

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingStateNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateNode.cpp
@@ -173,6 +173,18 @@ void ScrollingStateNode::setLayer(const LayerRepresentation& layerRepresentation
     setPropertyChanged(Property::Layer);
 }
 
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+void ScrollingStateNode::setInteractionRegionsLayer(const LayerRepresentation& layerRepresentation)
+{
+    if (layerRepresentation == m_interactionRegionsLayer)
+        return;
+
+    m_interactionRegionsLayer = layerRepresentation;
+
+    // Piggybacks on other property changed flags: Property::Layer and Property::ScrollContainerLayer.
+}
+#endif
+
 void ScrollingStateNode::dumpProperties(TextStream& ts, OptionSet<ScrollingStateTreeAsTextBehavior> behavior) const
 {
     if (behavior & ScrollingStateTreeAsTextBehavior::IncludeNodeIDs)

--- a/Source/WebCore/page/scrolling/ScrollingStateNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateNode.h
@@ -294,6 +294,11 @@ public:
     const LayerRepresentation& layer() const { return m_layer; }
     WEBCORE_EXPORT void setLayer(const LayerRepresentation&);
 
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    const LayerRepresentation& interactionRegionsLayer() const { return m_interactionRegionsLayer; }
+    WEBCORE_EXPORT void setInteractionRegionsLayer(const LayerRepresentation&);
+#endif
+
     ScrollingStateTree& scrollingStateTree() const { return m_scrollingStateTree; }
 
     ScrollingNodeID scrollingNodeID() const { return m_nodeID; }
@@ -340,6 +345,9 @@ private:
     std::unique_ptr<Vector<RefPtr<ScrollingStateNode>>> m_children;
 
     LayerRepresentation m_layer;
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    LayerRepresentation m_interactionRegionsLayer;
+#endif
 };
 
 inline ScrollingNodeID ScrollingStateNode::parentNodeID() const

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.h
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.h
@@ -51,6 +51,9 @@ private:
     void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const final;
 
     RetainPtr<CALayer> m_layer;
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    RetainPtr<CALayer> m_interactionRegionsLayer;
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.mm
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.mm
@@ -51,8 +51,12 @@ ScrollingTreeFixedNodeCocoa::~ScrollingTreeFixedNodeCocoa() = default;
 void ScrollingTreeFixedNodeCocoa::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
 {
     const ScrollingStateFixedNode& fixedStateNode = downcast<ScrollingStateFixedNode>(stateNode);
-    if (fixedStateNode.hasChangedProperty(ScrollingStateNode::Property::Layer))
+    if (fixedStateNode.hasChangedProperty(ScrollingStateNode::Property::Layer)) {
         m_layer = static_cast<CALayer*>(fixedStateNode.layer());
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+        m_interactionRegionsLayer = static_cast<CALayer*>(fixedStateNode.interactionRegionsLayer());
+#endif
+    }
 
     ScrollingTreeFixedNode::commitStateBeforeChildren(stateNode);
 }
@@ -72,6 +76,9 @@ void ScrollingTreeFixedNodeCocoa::applyLayerPositions()
 #endif
 
     [m_layer _web_setLayerTopLeftPosition:layerPosition - m_constraints.alignmentOffset()];
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    [m_interactionRegionsLayer _web_setLayerTopLeftPosition:layerPosition - m_constraints.alignmentOffset()];
+#endif
 }
 
 void ScrollingTreeFixedNodeCocoa::dumpProperties(TextStream& ts, OptionSet<ScrollingStateTreeAsTextBehavior> behavior) const

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreeOverflowScrollProxyNodeCocoa.h
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreeOverflowScrollProxyNodeCocoa.h
@@ -45,6 +45,9 @@ protected:
     CALayer* layer() const override { return m_layer.get(); }
 
     RetainPtr<CALayer> m_layer;
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    RetainPtr<CALayer> m_interactionRegionsLayer;
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreeOverflowScrollProxyNodeCocoa.mm
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreeOverflowScrollProxyNodeCocoa.mm
@@ -48,8 +48,13 @@ ScrollingTreeOverflowScrollProxyNodeCocoa::~ScrollingTreeOverflowScrollProxyNode
 
 void ScrollingTreeOverflowScrollProxyNodeCocoa::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
 {
-    if (stateNode.hasChangedProperty(ScrollingStateNode::Property::Layer))
+    if (stateNode.hasChangedProperty(ScrollingStateNode::Property::Layer)) {
         m_layer = static_cast<CALayer*>(stateNode.layer());
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+        m_interactionRegionsLayer = static_cast<CALayer*>(stateNode.interactionRegionsLayer());
+#endif
+    }
+
 
     ScrollingTreeOverflowScrollProxyNode::commitStateBeforeChildren(stateNode);
 }
@@ -60,6 +65,10 @@ void ScrollingTreeOverflowScrollProxyNodeCocoa::applyLayerPositions()
 
     LOG_WITH_STREAM(ScrollingTree, stream << "ScrollingTreeOverflowScrollProxyNodeCocoa " << scrollingNodeID() << " applyLayerPositions: setting bounds origin to " << scrollOffset);
     [m_layer _web_setLayerBoundsOrigin:scrollOffset];
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    [m_interactionRegionsLayer _web_setLayerBoundsOrigin:scrollOffset];
+#endif
+
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreePositionedNodeCocoa.h
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreePositionedNodeCocoa.h
@@ -48,6 +48,9 @@ private:
     CALayer *layer() const override { return m_layer.get(); }
 
     RetainPtr<CALayer> m_layer;
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    RetainPtr<CALayer> m_interactionRegionsLayer;
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreePositionedNodeCocoa.mm
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreePositionedNodeCocoa.mm
@@ -49,8 +49,13 @@ ScrollingTreePositionedNodeCocoa::~ScrollingTreePositionedNodeCocoa() = default;
 void ScrollingTreePositionedNodeCocoa::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
 {
     const ScrollingStatePositionedNode& positionedStateNode = downcast<ScrollingStatePositionedNode>(stateNode);
-    if (positionedStateNode.hasChangedProperty(ScrollingStateNode::Property::Layer))
+    if (positionedStateNode.hasChangedProperty(ScrollingStateNode::Property::Layer)) {
         m_layer = static_cast<CALayer*>(positionedStateNode.layer());
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+        m_interactionRegionsLayer = static_cast<CALayer*>(positionedStateNode.interactionRegionsLayer());
+#endif
+    }
+
 
     ScrollingTreePositionedNode::commitStateBeforeChildren(stateNode);
 }
@@ -63,6 +68,9 @@ void ScrollingTreePositionedNodeCocoa::applyLayerPositions()
     LOG_WITH_STREAM(Scrolling, stream << "ScrollingTreePositionedNode " << scrollingNodeID() << " applyLayerPositions: overflow delta " << delta << " moving layer to " << layerPosition);
 
     [m_layer _web_setLayerTopLeftPosition:layerPosition - m_constraints.alignmentOffset()];
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    [m_interactionRegionsLayer _web_setLayerTopLeftPosition:layerPosition - m_constraints.alignmentOffset()];
+#endif
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.h
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.h
@@ -49,6 +49,9 @@ private:
     CALayer* layer() const final { return m_layer.get(); }
 
     RetainPtr<CALayer> m_layer;
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    RetainPtr<CALayer> m_interactionRegionsLayer;
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.mm
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.mm
@@ -51,8 +51,13 @@ void ScrollingTreeStickyNodeCocoa::commitStateBeforeChildren(const ScrollingStat
 {
     const ScrollingStateStickyNode& stickyStateNode = downcast<ScrollingStateStickyNode>(stateNode);
 
-    if (stickyStateNode.hasChangedProperty(ScrollingStateNode::Property::Layer))
+    if (stickyStateNode.hasChangedProperty(ScrollingStateNode::Property::Layer)) {
         m_layer = static_cast<CALayer*>(stickyStateNode.layer());
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+        m_interactionRegionsLayer = static_cast<CALayer*>(stickyStateNode.interactionRegionsLayer());
+#endif
+    }
+
 
     ScrollingTreeStickyNode::commitStateBeforeChildren(stateNode);
 }
@@ -72,6 +77,9 @@ void ScrollingTreeStickyNodeCocoa::applyLayerPositions()
 #endif
 
     [m_layer _web_setLayerTopLeftPosition:layerPosition - m_constraints.alignmentOffset()];
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    [m_interactionRegionsLayer _web_setLayerTopLeftPosition:layerPosition - m_constraints.alignmentOffset()];
+#endif
 }
 
 FloatPoint ScrollingTreeStickyNodeCocoa::layerTopLeft() const

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -146,7 +146,7 @@ static void updateCustomAppearance(CALayer *layer, GraphicsLayer::CustomAppearan
 #endif
 }
 
-static void applyGeometryPropertiesToLayer(CALayer *layer, const RemoteLayerTreeTransaction::LayerProperties& properties)
+static void applyCommonPropertiesToLayer(CALayer *layer, const RemoteLayerTreeTransaction::LayerProperties& properties)
 {
     if (properties.changedProperties & LayerChange::PositionChanged) {
         layer.position = CGPointMake(properties.position.x(), properties.position.y());
@@ -177,11 +177,14 @@ static void applyGeometryPropertiesToLayer(CALayer *layer, const RemoteLayerTree
         layer.contentsScale = properties.contentsScale;
         layer.rasterizationScale = properties.contentsScale;
     }
+
+    if (properties.changedProperties & LayerChange::MasksToBoundsChanged)
+        layer.masksToBounds = properties.masksToBounds;
 }
 
 void RemoteLayerTreePropertyApplier::applyPropertiesToLayer(CALayer *layer, RemoteLayerTreeHost* layerTreeHost, const RemoteLayerTreeTransaction::LayerProperties& properties, RemoteLayerBackingStore::LayerContentsType layerContentsType)
 {
-    applyGeometryPropertiesToLayer(layer, properties);
+    applyCommonPropertiesToLayer(layer, properties);
 
     if (properties.changedProperties & LayerChange::NameChanged)
         layer.name = properties.name;
@@ -200,9 +203,6 @@ void RemoteLayerTreePropertyApplier::applyPropertiesToLayer(CALayer *layer, Remo
 
     if (properties.changedProperties & LayerChange::DoubleSidedChanged)
         layer.doubleSided = properties.doubleSided;
-
-    if (properties.changedProperties & LayerChange::MasksToBoundsChanged)
-        layer.masksToBounds = properties.masksToBounds;
 
     if (properties.changedProperties & LayerChange::OpaqueChanged)
         layer.opaque = properties.opaque;
@@ -300,7 +300,7 @@ void RemoteLayerTreePropertyApplier::applyProperties(RemoteLayerTreeNode& node, 
 
     applyPropertiesToLayer(node.layer(), layerTreeHost, properties, layerContentsType);
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    applyGeometryPropertiesToLayer(node.interactionRegionsLayer(), properties);
+    applyCommonPropertiesToLayer(node.interactionRegionsLayer(), properties);
     if (properties.changedProperties & LayerChange::EventRegionChanged)
         updateLayersForInteractionRegions(node.interactionRegionsLayer(), *layerTreeHost, properties);
 #endif

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm
@@ -152,7 +152,8 @@ void updateLayersForInteractionRegions(CALayer *layer, RemoteLayerTreeHost& host
                 setInteractionRegionOcclusion(interactionRegionLayer.get());
 
                 if (applyBackgroundColorForDebugging) {
-                    [interactionRegionLayer setBackgroundColor:cachedCGColor({ WebCore::SRGBA<float>(1, 0, 0, .1) }).get()];
+                    [interactionRegionLayer setBorderColor:cachedCGColor({ WebCore::SRGBA<float>(1, 0, 0, .2) }).get()];
+                    [interactionRegionLayer setBorderWidth:6];
                     [interactionRegionLayer setName:@"Occlusion"];
                 }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
@@ -71,14 +71,15 @@ std::unique_ptr<RemoteLayerTreeNode> RemoteLayerTreeNode::createWithPlainLayer(W
 
 void RemoteLayerTreeNode::detachFromParent()
 {
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    [interactionRegionsLayer() removeFromSuperlayer];
+#endif
+
 #if PLATFORM(IOS_FAMILY)
     if (auto view = uiView()) {
         [view removeFromSuperview];
         return;
     }
-#endif
-#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    [interactionRegionsLayer() removeFromSuperlayer];
 #endif
     [layer() removeFromSuperlayer];
 }
@@ -94,6 +95,7 @@ void RemoteLayerTreeNode::initializeLayer()
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
     m_interactionRegionsLayer = adoptNS([[CALayer alloc] init]);
     [m_interactionRegionsLayer setName:@"InteractionRegions Container"];
+    [m_interactionRegionsLayer setDelegate:[WebActionDisablingCALayerDelegate shared]];
 #endif
 }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
@@ -109,19 +109,33 @@ void RemoteScrollingCoordinatorProxyIOS::connectStateNodeLayers(ScrollingStateTr
     for (auto& currNode : stateTree.nodeMap().values()) {
         if (currNode->hasChangedProperty(ScrollingStateNode::Property::Layer)) {
             auto platformLayerID = PlatformLayerID { currNode->layer() };
-            currNode->setLayer(layerTreeHost.layerForID(platformLayerID));
+            auto remoteLayerTreeNode = layerTreeHost.nodeForID(platformLayerID);
+            if (remoteLayerTreeNode) {
+                currNode->setLayer(remoteLayerTreeNode->layer());
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+                currNode->setInteractionRegionsLayer(remoteLayerTreeNode->interactionRegionsLayer());
+#endif
+            }
 #if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
             if (platformLayerID && (currNode->isFixedNode() || currNode->isStickyNode()))
                 m_fixedScrollingNodeLayerIDs.add(platformLayerID);
 #endif
         }
-        
+
         switch (currNode->nodeType()) {
         case ScrollingNodeType::Overflow: {
             ScrollingStateOverflowScrollingNode& scrollingStateNode = downcast<ScrollingStateOverflowScrollingNode>(*currNode);
 
-            if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollContainerLayer))
-                scrollingStateNode.setScrollContainerLayer(layerTreeHost.layerForID(PlatformLayerID { scrollingStateNode.scrollContainerLayer() }));
+            if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollContainerLayer)) {
+                auto platformLayerID = PlatformLayerID { scrollingStateNode.scrollContainerLayer() };
+                auto remoteLayerTreeNode = layerTreeHost.nodeForID(platformLayerID);
+                if (remoteLayerTreeNode) {
+                    scrollingStateNode.setScrollContainerLayer(remoteLayerTreeNode->layer());
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+                    scrollingStateNode.setInteractionRegionsLayer(remoteLayerTreeNode->interactionRegionsLayer());
+#endif
+                }
+            }
 
             if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrolledContentsLayer))
                 scrollingStateNode.setScrolledContentsLayer(layerTreeHost.layerForID(PlatformLayerID { scrollingStateNode.scrolledContentsLayer() }));
@@ -131,8 +145,16 @@ void RemoteScrollingCoordinatorProxyIOS::connectStateNodeLayers(ScrollingStateTr
         case ScrollingNodeType::Subframe: {
             ScrollingStateFrameScrollingNode& scrollingStateNode = downcast<ScrollingStateFrameScrollingNode>(*currNode);
 
-            if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollContainerLayer))
-                scrollingStateNode.setScrollContainerLayer(layerTreeHost.layerForID(PlatformLayerID { scrollingStateNode.scrollContainerLayer() }));
+            if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollContainerLayer)) {
+                auto platformLayerID = PlatformLayerID { scrollingStateNode.scrollContainerLayer() };
+                auto remoteLayerTreeNode = layerTreeHost.nodeForID(platformLayerID);
+                if (remoteLayerTreeNode) {
+                    scrollingStateNode.setScrollContainerLayer(remoteLayerTreeNode->layer());
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+                    scrollingStateNode.setInteractionRegionsLayer(remoteLayerTreeNode->interactionRegionsLayer());
+#endif
+                }
+            }
 
             if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrolledContentsLayer))
                 scrollingStateNode.setScrolledContentsLayer(layerTreeHost.layerForID(PlatformLayerID { scrollingStateNode.scrolledContentsLayer() }));

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.h
@@ -90,6 +90,9 @@ public:
 
 private:
     RetainPtr<CALayer> m_scrollLayer;
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    RetainPtr<CALayer> m_interactionRegionsLayer;
+#endif
     RetainPtr<CALayer> m_scrolledContentsLayer;
     RetainPtr<WKScrollingNodeScrollViewDelegate> m_scrollViewDelegate;
     OptionSet<WebCore::TouchAction> m_activeTouchActions { };

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
@@ -46,6 +46,10 @@
 #import <wtf/BlockObjCExceptions.h>
 #import <wtf/SetForScope.h>
 
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+#import <WebCore/WebCoreCALayerExtras.h>
+#endif
+
 @implementation WKScrollingNodeScrollViewDelegate
 
 - (instancetype)initWithScrollingTreeNodeDelegate:(WebKit::ScrollingTreeScrollingNodeDelegateIOS*)delegate
@@ -218,8 +222,12 @@ void ScrollingTreeScrollingNodeDelegateIOS::resetScrollViewDelegate()
 
 void ScrollingTreeScrollingNodeDelegateIOS::commitStateBeforeChildren(const ScrollingStateScrollingNode& scrollingStateNode)
 {
-    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollContainerLayer))
+    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollContainerLayer)) {
         m_scrollLayer = static_cast<CALayer*>(scrollingStateNode.scrollContainerLayer());
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+        m_interactionRegionsLayer = static_cast<CALayer*>(scrollingStateNode.interactionRegionsLayer());
+#endif
+    }
 }
 
 void ScrollingTreeScrollingNodeDelegateIOS::updateScrollViewForOverscrollBehavior(UIScrollView *scrollView, const WebCore::OverscrollBehavior horizontalOverscrollBehavior, WebCore::OverscrollBehavior verticalOverscrollBehavior, AllowOverscrollToPreventScrollPropagation allowPropogation)
@@ -347,6 +355,10 @@ void ScrollingTreeScrollingNodeDelegateIOS::repositionScrollingLayers()
 
     [scrollView() setContentOffset:scrollingNode().currentScrollOffset()];
     END_BLOCK_OBJC_EXCEPTIONS
+
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    [m_interactionRegionsLayer _web_setLayerBoundsOrigin:scrollingNode().currentScrollOffset()];
+#endif
 }
 
 void ScrollingTreeScrollingNodeDelegateIOS::scrollWillStart() const


### PR DESCRIPTION
#### 8f2972ef9f74c7f00d74077697c4028a1121773e
<pre>
Update the Interaction Regions layer tree after UI-side scrolling
<a href="https://bugs.webkit.org/show_bug.cgi?id=251696">https://bugs.webkit.org/show_bug.cgi?id=251696</a>
&lt;rdar://104964643&gt;

Reviewed by Simon Fraser.

UI-side scrolling changes need to be reflected on the Interaction
Regions layer side. Otherwise the in-layer coordinates of the regions
will be offset.

We connect ScrollingStateNodes to their respective Interaction Regions
layers and relay all bounds/position changes.

The root interaction regions layer is not impacted as it is parented to
the root node&apos;s main layer.

* Source/WebCore/page/scrolling/ScrollingStateNode.cpp:
(WebCore::ScrollingStateNode::setInteractionRegionsLayer):
* Source/WebCore/page/scrolling/ScrollingStateNode.h:
(WebCore::ScrollingStateNode::interactionRegionsLayer const):
Add an `interactionRegionsLayer` property.

* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm:
(WebKit::RemoteScrollingCoordinatorProxyIOS::connectStateNodeLayers):
Set Interaction Regions layers on ScrollingStateNodes.

* Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.h:
* Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.mm:
(WebCore::ScrollingTreeFixedNodeCocoa::commitStateBeforeChildren):
(WebCore::ScrollingTreeFixedNodeCocoa::applyLayerPositions):
* Source/WebCore/page/scrolling/cocoa/ScrollingTreeOverflowScrollProxyNodeCocoa.h:
* Source/WebCore/page/scrolling/cocoa/ScrollingTreeOverflowScrollProxyNodeCocoa.mm:
(WebCore::ScrollingTreeOverflowScrollProxyNodeCocoa::commitStateBeforeChildren):
(WebCore::ScrollingTreeOverflowScrollProxyNodeCocoa::applyLayerPositions):
* Source/WebCore/page/scrolling/cocoa/ScrollingTreePositionedNodeCocoa.h:
* Source/WebCore/page/scrolling/cocoa/ScrollingTreePositionedNodeCocoa.mm:
(WebCore::ScrollingTreePositionedNodeCocoa::commitStateBeforeChildren):
(WebCore::ScrollingTreePositionedNodeCocoa::applyLayerPositions):
* Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.h:
* Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.mm:
(WebCore::ScrollingTreeStickyNodeCocoa::commitStateBeforeChildren):
(WebCore::ScrollingTreeStickyNodeCocoa::applyLayerPositions):
Apply all layer positions changes to the ScrollNode&apos;s corresponding
Interaction Regions Layer.

* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm:
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::commitStateBeforeChildren):
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::repositionScrollingLayers):
Apply the ScrollView&apos;s contentOffset to the corresponding Interaction
Regions layer.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::applyCommonPropertiesToLayer):
(WebKit::RemoteLayerTreePropertyApplier::applyPropertiesToLayer):
(WebKit::RemoteLayerTreePropertyApplier::applyProperties):
(WebKit::applyGeometryPropertiesToLayer): Deleted.
Apply the masksToBounds property to Interaction Regions layers.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm:
(WebKit::RemoteLayerTreeNode::detachFromParent):
Remove the Interaction Regions layer from superlayer on detach even for
UIView based nodes.
(WebKit::RemoteLayerTreeNode::initializeLayer):
Disable implicit position animations for Interaction Regions layers.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm:
(WebKit::updateLayersForInteractionRegions):
Improve the debug style for occlusion layers.

Canonical link: <a href="https://commits.webkit.org/260598@main">https://commits.webkit.org/260598@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2114dad570657fdb364fc2cf12076a95e1d5700a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108680 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17781 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41532 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117790 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/117986 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112562 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19232 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9058 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100913 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114447 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14427 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97652 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42404 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96400 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29290 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84138 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10586 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30640 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11346 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7557 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16735 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50236 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12934 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3991 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->