### PR TITLE
Simplify bitwise operations

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp
@@ -291,8 +291,7 @@ private:
         case BitURShift:
         case ArithIMul: {
             flags |= NodeBytecodeUsesAsInt;
-            flags &= ~(NodeBytecodeUsesAsNumber | NodeBytecodeNeedsNegZero | NodeBytecodeUsesAsOther);
-            flags &= ~NodeBytecodeUsesAsArrayIndex;
+            flags &= ~(NodeBytecodeUsesAsNumber | NodeBytecodeNeedsNegZero | NodeBytecodeUsesAsOther | NodeBytecodeUsesAsArrayIndex);
             node->child1()->mergeFlags(flags);
             node->child2()->mergeFlags(flags);
             break;
@@ -396,8 +395,7 @@ private:
 
         case Inc:
         case Dec: {
-            flags &= ~NodeBytecodeNeedsNegZero;
-            flags &= ~NodeBytecodeUsesAsOther;
+            flags &= ~(NodeBytecodeNeedsNegZero | NodeBytecodeUsesAsOther);
             if (!isWithinPowerOfTwo<32>(node->child1()))
                 flags |= NodeBytecodeUsesAsNumber;
             if (!m_allowNestedOverflowingAdditions)

--- a/Source/WTF/wtf/WordLock.cpp
+++ b/Source/WTF/wtf/WordLock.cpp
@@ -218,9 +218,7 @@ NEVER_INLINE void WordLock::unlockSlow()
     ASSERT(currentWordValue & isQueueLockedBit);
     ASSERT((currentWordValue & ~queueHeadMask) == bitwise_cast<uintptr_t>(queueHead));
     uintptr_t newWordValue = currentWordValue;
-    newWordValue &= ~isLockedBit; // Release the WordLock.
-    newWordValue &= ~isQueueLockedBit; // Release the queue lock.
-    newWordValue &= queueHeadMask; // Clear out the old queue head.
+    newWordValue &= ~(isLockedBit | isQueueLockedBit | queueHeadMask); // Release the WordLock, queue lock, and clear out the old queue head
     newWordValue |= bitwise_cast<uintptr_t>(newQueueHead); // Install new queue head.
     m_word.store(newWordValue);
 

--- a/Source/WTF/wtf/WordLock.cpp
+++ b/Source/WTF/wtf/WordLock.cpp
@@ -218,7 +218,7 @@ NEVER_INLINE void WordLock::unlockSlow()
     ASSERT(currentWordValue & isQueueLockedBit);
     ASSERT((currentWordValue & ~queueHeadMask) == bitwise_cast<uintptr_t>(queueHead));
     uintptr_t newWordValue = currentWordValue;
-    newWordValue &= ~(isLockedBit | isQueueLockedBit | queueHeadMask); // Release the WordLock, queue lock, and clear out the old queue head
+    newWordValue &= ~(isLockedBit | isQueueLockedBit) | queueHeadMask; // Release the WordLock, queue lock, and clear out the old queue head
     newWordValue |= bitwise_cast<uintptr_t>(newQueueHead); // Install new queue head.
     m_word.store(newWordValue);
 

--- a/Tools/WebKitTestRunner/ios/HIDEventGenerator.mm
+++ b/Tools/WebKitTestRunner/ios/HIDEventGenerator.mm
@@ -414,11 +414,9 @@ static InterpolationType interpolationFromString(NSString *string)
     IOHIDDigitizerEventMask eventMask = kIOHIDDigitizerEventTouch;
     if (eventType == HandEventMoved) {
         eventMask &= ~kIOHIDDigitizerEventTouch;
-        eventMask |= kIOHIDDigitizerEventPosition;
-        eventMask |= kIOHIDDigitizerEventAttribute;
+        eventMask |= (kIOHIDDigitizerEventPosition | kIOHIDDigitizerEventAttribute);
     } else if (eventType == HandEventChordChanged) {
-        eventMask |= kIOHIDDigitizerEventPosition;
-        eventMask |= kIOHIDDigitizerEventAttribute;
+        eventMask |= (kIOHIDDigitizerEventPosition | kIOHIDDigitizerEventAttribute);
     } else if (eventType == HandEventTouched || eventType == HandEventCanceled || eventType == HandEventLifted)
         eventMask |= kIOHIDDigitizerEventIdentity;
 


### PR DESCRIPTION
#### 6d02adcae306876dfc5b046710e693d9b1a163e0
<pre>
Simplify bitwise operations
<a href="https://bugs.webkit.org/show_bug.cgi?id=251704">https://bugs.webkit.org/show_bug.cgi?id=251704</a>

Reviewed by NOBODY (OOPS!).

This will ensure the compiler does all the bitwise operations via one
instruction.

*Source\JavaScriptCore\dfg\DFGBackwardsPropagationPhase.cpp:
*Source\WTF\wtf\WordLock.cpp:
*Tools\WebKitTestRunner\ios\HIDEventGenerator.mm:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6b2e82ef32d16a51127ff07ddcb0a13a4b54ba2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106132 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15183 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39000 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115314 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175439 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110036 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16615 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6357 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98338 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115010 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111888 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12637 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95647 "Found 28 new API test failures: TestWTF.WTF_Condition.TenProducersOneConsumerOneSlot, TestWTF.WTF_Lock.ManyContendedShortSections, TestWTF.WTF_Condition.TenProducersOneConsumerHundredSlotsNotifyAll, TestWTF.WTF_WordLock.ContendedShortSection, TestWTF.WTF_WordLock.ManyContendedShortSections, TestWTF.WTF_Lock.ManyContendedLongerSections, TestWTF.WTF_ParkingLot.UnparkOneHundredFast, TestWTF.WTF_ParkingLot.HundredUnparkAllOne, TestWTF.WTF_WordLock.ContendedLongSection, TestWTF.WTF_WordLock.ManyContendedLongSections ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40183 "Found 6 new test failures: imported/w3c/web-platform-tests/html/cross-origin-opener-policy/iframe-popup-same-origin-allow-popups-to-same-origin.https.html?9-last, imported/w3c/web-platform-tests/html/cross-origin-opener-policy/iframe-popup-same-origin-to-same-origin.https.html?9-last, imported/w3c/web-platform-tests/html/cross-origin-opener-policy/tentative/restrict-properties/iframe-popup-to-so.https.html?9-last, imported/w3c/web-platform-tests/html/cross-origin-opener-policy/tentative/restrict-properties/iframe-popup-to-soap.https.html?9-last, webgl/1.0.3/conformance/uniforms/uniform-default-values.html, webgl/2.0.0/conformance/uniforms/out-of-bounds-uniform-array-access.html (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94510 "Found 8 new API test failures: TestWTF.WTF_Condition.TenProducersOneConsumerHundredSlotsNotifyAll, TestWTF.WTF_WordLock.ContendedShortSection, TestWTF.WTF_WordLock.ManyContendedShortSections, TestWTF.Signals.SignalsWorkOnExit, TestWTF.WTF.ThreadGroupAddCurrentThread, TestWTF.WTF_WordLock.ContendedLongSection, TestWTF.WTF.ThreadGroupAdd, TestWTF.WTF_WordLock.ManyContendedLongSections (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27290 "Found 3 new test failures: fast/workers/dedicated-worker-lifecycle.html, streams/readable-stream-lock-after-worker-terminates-crash.html, workers/bomb.html (failure)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/95797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8434 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28642 "Found 60 new test failures: accessibility/accessibility-crash-focused-element-change.html, compositing/backgrounds/negative-z-index-behind-body-non-propagated.html, compositing/clipping/border-radius-async-overflow-non-stacking.html, compositing/geometry/fixed-transformed.html, editing/deleting/delete-cell-contents.html, editing/pasteboard/copy-backslash-with-euc.html, editing/style/apply-style-join-child-text-nodes-crash.html, editing/style/inverse-color-filter.html, fast/block/basic/007.html, fast/dom/Window/area-rel-noopener.html ... (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/95129 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/83/builds/6327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8929 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5160 "Found 2 new test failures: fetch/fetch-worker-crash.html, imported/w3c/web-platform-tests/fetch/api/basic/mediasource.window.html (failure)") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/30551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14547 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48188 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/103875 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10472 "Built successfully") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/25766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | | | | 
<!--EWS-Status-Bubble-End-->