### PR TITLE
Revert 8c49f9898715b5df8bf06c82b633bf55b009d9ee which may break x86 build

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTForward.h
+++ b/Source/WebGPU/WGSL/AST/ASTForward.h
@@ -105,10 +105,8 @@ class Variable;
 class VariableQualifier;
 
 enum class AccessMode : uint8_t;
-enum class BinaryOperation : uint8_t;
 enum class ParameterRole : uint8_t;
 enum class StorageClass : uint8_t;
 enum class StructureRole : uint8_t;
-enum class UnaryOperation : uint8_t;
 
 } // namespace WGSL::AST

--- a/Source/WebGPU/WGSL/Lexer.cpp
+++ b/Source/WebGPU/WGSL/Lexer.cpp
@@ -41,9 +41,6 @@ Token Lexer<T>::lex()
         return makeToken(TokenType::EndOfFile);
 
     switch (m_current) {
-    case '%':
-        shift();
-        return makeToken(TokenType::Modulo);
     case '(':
         shift();
         return makeToken(TokenType::ParenLeft);
@@ -86,9 +83,6 @@ Token Lexer<T>::lex()
     case '*':
         shift();
         return makeToken(TokenType::Star);
-    case '/':
-        shift();
-        return makeToken(TokenType::Slash);
     case '.': {
         shift();
         unsigned offset = currentOffset();

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -40,9 +40,6 @@ namespace WGSL {
 #define CURRENT_SOURCE_SPAN() \
     SourceSpan(_startOfElementPosition, m_lexer.currentPosition())
 
-#define MAKE_NODE_UNIQUE_REF(type, ...) \
-    makeUniqueRef<AST::type>(CURRENT_SOURCE_SPAN() __VA_OPT__(,) __VA_ARGS__) /* NOLINT */
-
 #define RETURN_NODE(type, ...) \
     do { \
         AST::type astNodeResult(CURRENT_SOURCE_SPAN(), __VA_ARGS__); \
@@ -60,7 +57,7 @@ namespace WGSL {
     return { adoptRef(*new AST::type(CURRENT_SOURCE_SPAN(), __VA_ARGS__)) };
 
 #define RETURN_NODE_UNIQUE_REF(type, ...) \
-    return { MAKE_NODE_UNIQUE_REF(type, __VA_ARGS__) };
+    return { makeUniqueRef<AST::type>(CURRENT_SOURCE_SPAN(), __VA_ARGS__) };
 
 // Passing 0 arguments beyond the type to RETURN_NODE_UNIQUE_REF is invalid because of a stupid limitation of the C preprocessor
 #define RETURN_NODE_UNIQUE_REF_NO_ARGS(type) \
@@ -76,12 +73,6 @@ namespace WGSL {
     if (!name##Expected) \
         return makeUnexpected(name##Expected.error()); \
     auto& name = *name##Expected;
-
-#define PARSE_MOVE(name, element, ...) \
-    auto name##Expected = parse##element(__VA_ARGS__); \
-    if (!name##Expected) \
-        return makeUnexpected(name##Expected.error()); \
-    name = WTFMove(*name##Expected);
 
 // Warning: cannot use the do..while trick because it defines a new identifier named `name`.
 // So do not use after an if/for/while without braces.
@@ -631,69 +622,28 @@ Expected<UniqueRef<AST::Expression>, Error> Parser<Lexer>::parseShiftExpression(
 }
 
 template<typename Lexer>
-Expected<AST::BinaryOperation, Error> Parser<Lexer>::parseAdditiveOperator()
-{
-    START_PARSE();
-
-    switch (current().m_type) {
-    case TokenType::Minus:
-        consume();
-        return AST::BinaryOperation::Subtract;
-    case TokenType::Plus:
-        consume();
-        return AST::BinaryOperation::Add;
-    default:
-        FAIL("Expected one of + or -"_s);
-    }
-}
-
-template<typename Lexer>
 Expected<UniqueRef<AST::Expression>, Error> Parser<Lexer>::parseAdditiveExpression(AST::Expression::Ref&& lhs)
 {
+    // FIXME: fill in
     START_PARSE();
-    PARSE_MOVE(lhs, MultiplicativeExpression, WTFMove(lhs));
-
-    while (current().m_type == TokenType::Plus || current().m_type == TokenType::Minus) {
-        PARSE(op, AdditiveOperator);
-        PARSE(unary, UnaryExpression);
-        PARSE(rhs, MultiplicativeExpression, WTFMove(unary));
-        lhs = MAKE_NODE_UNIQUE_REF(BinaryExpression, WTFMove(lhs), WTFMove(rhs), op);
+    if (current().m_type == TokenType::Plus) {
+        consume();
+        PARSE(rhs, UnaryExpression);
+        RETURN_NODE_UNIQUE_REF(BinaryExpression, WTFMove(lhs), WTFMove(rhs), AST::BinaryOperation::Add);
     }
-
-    return WTFMove(lhs);
-}
-
-template<typename Lexer>
-Expected<AST::BinaryOperation, Error> Parser<Lexer>::parseMultiplicativeOperator()
-{
-    START_PARSE();
-    switch (current().m_type) {
-    case TokenType::Modulo:
-        consume();
-        return AST::BinaryOperation::Modulo;
-    case TokenType::Slash:
-        consume();
-        return AST::BinaryOperation::Divide;
-    case TokenType::Star:
-        consume();
-        return AST::BinaryOperation::Multiply;
-    default:
-        FAIL("Expected one of %, / or *"_s);
-    }
+    return parseMultiplicativeExpression(WTFMove(lhs));
 }
 
 template<typename Lexer>
 Expected<UniqueRef<AST::Expression>, Error> Parser<Lexer>::parseMultiplicativeExpression(AST::Expression::Ref&& lhs)
 {
+    // FIXME: fill in
     START_PARSE();
-    while (current().m_type == TokenType::Modulo
-        || current().m_type == TokenType::Slash
-        || current().m_type == TokenType::Star) {
-        PARSE(op, MultiplicativeOperator)
+    if (current().m_type == TokenType::Star) {
+        consume();
         PARSE(rhs, UnaryExpression);
-        lhs = MAKE_NODE_UNIQUE_REF(BinaryExpression, WTFMove(lhs), WTFMove(rhs), op);
+        RETURN_NODE_UNIQUE_REF(BinaryExpression, WTFMove(lhs), WTFMove(rhs), AST::BinaryOperation::Multiply);
     }
-
     return WTFMove(lhs);
 }
 

--- a/Source/WebGPU/WGSL/ParserPrivate.h
+++ b/Source/WebGPU/WGSL/ParserPrivate.h
@@ -74,9 +74,7 @@ public:
     Expected<AST::Expression::Ref, Error> parseRelationalExpression(AST::Expression::Ref&& lhs);
     Expected<AST::Expression::Ref, Error> parseShiftExpression(AST::Expression::Ref&& lhs);
     Expected<AST::Expression::Ref, Error> parseAdditiveExpression(AST::Expression::Ref&& lhs);
-    Expected<AST::BinaryOperation, Error> parseAdditiveOperator();
     Expected<AST::Expression::Ref, Error> parseMultiplicativeExpression(AST::Expression::Ref&& lhs);
-    Expected<AST::BinaryOperation, Error> parseMultiplicativeOperator();
     Expected<AST::Expression::Ref, Error> parseUnaryExpression();
     Expected<AST::Expression::Ref, Error> parseSingularExpression();
     Expected<AST::Expression::Ref, Error> parsePostfixExpression(AST::Expression::Ref&& base, SourcePosition startPosition);

--- a/Source/WebGPU/WGSL/Token.cpp
+++ b/Source/WebGPU/WGSL/Token.cpp
@@ -113,8 +113,6 @@ String toString(TokenType type)
         return "-"_s;
     case TokenType::MinusMinus:
         return "--"_s;
-    case TokenType::Modulo:
-        return "%"_s;
     case TokenType::Plus:
         return "+"_s;
     case TokenType::PlusPlus:
@@ -127,8 +125,6 @@ String toString(TokenType type)
         return ")"_s;
     case TokenType::Semicolon:
         return ";"_s;
-    case TokenType::Slash:
-        return "/"_s;
     case TokenType::Star:
         return "*"_s;
     }

--- a/Source/WebGPU/WGSL/Token.h
+++ b/Source/WebGPU/WGSL/Token.h
@@ -83,14 +83,12 @@ enum class TokenType: uint32_t {
     LT,
     Minus,
     MinusMinus,
-    Modulo,
     Plus,
     PlusPlus,
     Period,
     ParenLeft,
     ParenRight,
     Semicolon,
-    Slash,
     Star,
     // FIXME: add all the other special tokens
 };

--- a/Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp
@@ -138,13 +138,10 @@ TEST(WGSLLexerTests, SpecialTokens)
     checkSingleToken("<"_s, TokenType::LT);
     checkSingleToken("-"_s, TokenType::Minus);
     checkSingleToken("--"_s, TokenType::MinusMinus);
-    checkSingleToken("%"_s, TokenType::Modulo);
     checkSingleToken("."_s, TokenType::Period);
     checkSingleToken("("_s, TokenType::ParenLeft);
     checkSingleToken(")"_s, TokenType::ParenRight);
     checkSingleToken(";"_s, TokenType::Semicolon);
-    checkSingleToken("/"_s, TokenType::Slash);
-    checkSingleToken("*"_s, TokenType::Star);
 }
 
 TEST(WGSLLexerTests, ComputeShader)

--- a/Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp
@@ -27,7 +27,6 @@
 #include "ASTAttribute.h"
 #include "ASTTypeName.h"
 #include "Parser.h"
-#include "ParserPrivate.h"
 
 #include "AST.h"
 #include "Lexer.h"
@@ -75,14 +74,6 @@ inline Expected<WGSL::AST::ShaderModule, WGSL::Error> parse(const String& wgsl)
     WGSL::Configuration configuration;
     configuration.maxBuffersPlusVertexBuffersForVertexStage = 8;
     return WGSL::parseLChar(wgsl, configuration);
-}
-
-Expected<WGSL::AST::Expression::Ref, WGSL::Error> parseExpression(const String& wgsl)
-{
-    WGSL::Lexer<LChar> lexer(wgsl);
-    WGSL::Parser parser(lexer);
-
-    return parser.parseExpression();
 }
 
 static void testStruct(ASCIILiteral program, const Vector<String>& fieldNames, const Vector<String>& typeNames)
@@ -502,105 +493,6 @@ TEST(WGSLParserTests, BinaryExpression)
         EXPECT_EQ(rhs.identifier(), "y"_s);
     }
 }
-
-TEST(WGSLParserTests, BinaryExpression2)
-{
-    EXPECT_EXPRESSION(expression, parseExpression(R"(x - y + 1)"_s));
-    EXPECT_TRUE(is<WGSL::AST::BinaryExpression>(expression));
-    auto& binaryExpression = downcast<WGSL::AST::BinaryExpression>(expression.get());
-
-    {
-        // op: +
-        EXPECT_EQ(binaryExpression.operation(), WGSL::AST::BinaryOperation::Add);
-        // lhs: x - y
-        EXPECT_TRUE(is<WGSL::AST::BinaryExpression>(binaryExpression.leftExpression()));
-        // rhs: 1
-        EXPECT_TRUE(is<WGSL::AST::AbstractIntegerLiteral>(binaryExpression.rightExpression()));
-        checkIntLiteral(binaryExpression.rightExpression(), 1);
-    }
-
-    {
-        EXPECT_TRUE(is<WGSL::AST::BinaryExpression>(binaryExpression.leftExpression()));
-        auto& binaryExpression2 = downcast<WGSL::AST::BinaryExpression>(binaryExpression.leftExpression());
-        // op: -
-        EXPECT_EQ(binaryExpression2.operation(), WGSL::AST::BinaryOperation::Subtract);
-        // lhs: x
-        EXPECT_TRUE(is<WGSL::AST::IdentifierExpression>(binaryExpression2.leftExpression()));
-        auto& lhs = downcast<WGSL::AST::IdentifierExpression>(binaryExpression2.leftExpression());
-        EXPECT_EQ(lhs.identifier(), "x"_s);
-        // rhs: y
-        EXPECT_TRUE(is<WGSL::AST::IdentifierExpression>(binaryExpression2.rightExpression()));
-        auto& rhs = downcast<WGSL::AST::IdentifierExpression>(binaryExpression2.rightExpression());
-        EXPECT_EQ(rhs.identifier(), "y"_s);
-    }
-}
-
-TEST(WGSLParserTests, BinaryExpression3)
-{
-    EXPECT_EXPRESSION(expression, parseExpression(R"(x + y * z)"_s));
-    EXPECT_TRUE(is<WGSL::AST::BinaryExpression>(expression));
-    auto& binaryExpression = downcast<WGSL::AST::BinaryExpression>(expression.get());
-
-    {
-        // op: +
-        EXPECT_EQ(binaryExpression.operation(), WGSL::AST::BinaryOperation::Add);
-        // lhs: x
-        EXPECT_TRUE(is<WGSL::AST::IdentifierExpression>(binaryExpression.leftExpression()));
-        auto& lhs = downcast<WGSL::AST::IdentifierExpression>(binaryExpression.leftExpression());
-        EXPECT_EQ(lhs.identifier(), "x"_s);
-        // rhs: y * z
-        EXPECT_TRUE(is<WGSL::AST::BinaryExpression>(binaryExpression.rightExpression()));
-    }
-
-    {
-        EXPECT_TRUE(is<WGSL::AST::BinaryExpression>(binaryExpression.rightExpression()));
-        auto& binaryExpression2 = downcast<WGSL::AST::BinaryExpression>(binaryExpression.rightExpression());
-        // op: *
-        EXPECT_EQ(binaryExpression2.operation(), WGSL::AST::BinaryOperation::Multiply);
-        // lhs: y
-        EXPECT_TRUE(is<WGSL::AST::IdentifierExpression>(binaryExpression2.leftExpression()));
-        auto& lhs = downcast<WGSL::AST::IdentifierExpression>(binaryExpression2.leftExpression());
-        EXPECT_EQ(lhs.identifier(), "y"_s);
-        // rhs: z
-        EXPECT_TRUE(is<WGSL::AST::IdentifierExpression>(binaryExpression2.rightExpression()));
-        auto& rhs = downcast<WGSL::AST::IdentifierExpression>(binaryExpression2.rightExpression());
-        EXPECT_EQ(rhs.identifier(), "z"_s);
-    }
-}
-
-TEST(WGSLParserTests, BinaryExpression4)
-{
-    EXPECT_EXPRESSION(expression, parseExpression(R"(x / y + z)"_s));
-    EXPECT_TRUE(is<WGSL::AST::BinaryExpression>(expression));
-    auto& binaryExpression = downcast<WGSL::AST::BinaryExpression>(expression.get());
-
-    {
-        // op: +
-        EXPECT_EQ(binaryExpression.operation(), WGSL::AST::BinaryOperation::Add);
-        // lhs: x * y
-        EXPECT_TRUE(is<WGSL::AST::BinaryExpression>(binaryExpression.leftExpression()));
-        // rhs: z
-        EXPECT_TRUE(is<WGSL::AST::IdentifierExpression>(binaryExpression.rightExpression()));
-        auto& rhs = downcast<WGSL::AST::IdentifierExpression>(binaryExpression.rightExpression());
-        EXPECT_EQ(rhs.identifier(), "z"_s);
-    }
-
-    {
-        EXPECT_TRUE(is<WGSL::AST::BinaryExpression>(binaryExpression.leftExpression()));
-        auto& binaryExpression2 = downcast<WGSL::AST::BinaryExpression>(binaryExpression.leftExpression());
-        // op: /
-        EXPECT_EQ(binaryExpression2.operation(), WGSL::AST::BinaryOperation::Divide);
-        // lhs: x
-        EXPECT_TRUE(is<WGSL::AST::IdentifierExpression>(binaryExpression2.leftExpression()));
-        auto& lhs = downcast<WGSL::AST::IdentifierExpression>(binaryExpression2.leftExpression());
-        EXPECT_EQ(lhs.identifier(), "x"_s);
-        // rhs: y
-        EXPECT_TRUE(is<WGSL::AST::IdentifierExpression>(binaryExpression2.rightExpression()));
-        auto& rhs = downcast<WGSL::AST::IdentifierExpression>(binaryExpression2.rightExpression());
-        EXPECT_EQ(rhs.identifier(), "y"_s);
-    }
-}
-
 #pragma mark -
 #pragma mark WebGPU Example Shaders
 

--- a/Tools/TestWebKitAPI/Tests/WGSL/TestWGSLAPI.h
+++ b/Tools/TestWebKitAPI/Tests/WGSL/TestWGSLAPI.h
@@ -33,14 +33,6 @@
         } \
     } while (false)
 
-#define EXPECT_EXPRESSION(name, expr) \
-    auto name##Expected = expr; \
-    if (!name##Expected) { \
-        ::TestWGSLAPI::logCompilationError(name##Expected.error()); \
-        return; \
-    } \
-    auto& name = *name##Expected;
-
 namespace WGSL {
 class CompilationMessage;
 }


### PR DESCRIPTION
#### e79907de7da0f4f530654dd1c41da861c907ccc0
<pre>
Revert 8c49f9898715b5df8bf06c82b633bf55b009d9ee which may break x86 build
<a href="https://bugs.webkit.org/show_bug.cgi?id=251705">https://bugs.webkit.org/show_bug.cgi?id=251705</a>
&lt;radar://105012824&gt;

Reviewed by NOBODY (OOPS!).

This change seems related to an Intel build failure, going to revert
it if it fixes the x86 build.

* Source/WebGPU/WGSL/AST/ASTForward.h:
* Source/WebGPU/WGSL/Lexer.cpp:
(WGSL::Lexer&lt;T&gt;::lex):
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseAdditiveExpression):
(WGSL::Parser&lt;Lexer&gt;::parseMultiplicativeExpression):
(WGSL::Parser&lt;Lexer&gt;::parseAdditiveOperator): Deleted.
(WGSL::Parser&lt;Lexer&gt;::parseMultiplicativeOperator): Deleted.
* Source/WebGPU/WGSL/ParserPrivate.h:
* Source/WebGPU/WGSL/Token.cpp:
(WGSL::toString):
* Source/WebGPU/WGSL/Token.h:
* Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp:
(TestWGSLAPI::TEST):
* Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp:
(TestWGSLAPI::TEST):
(TestWGSLAPI::parseExpression): Deleted.
* Tools/TestWebKitAPI/Tests/WGSL/TestWGSLAPI.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e79907de7da0f4f530654dd1c41da861c907ccc0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106094 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15147 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/38965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115278 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/175358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109999 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16578 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6319 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98303 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111850 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95589 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/40164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94486 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27232 "Unable to confirm if test failures are introduced by change, retrying build") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8398 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28584 "Unable to confirm if test failures are introduced by change, retrying build") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8892 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/5131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14511 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48128 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10437 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3654 "Commit message contains (OOPS!) and no reviewer found") | | | | 
<!--EWS-Status-Bubble-End-->