### PR TITLE
Web Inspector: `inspectable` API doesn't have a correct Objective-C getter

### DIFF
--- a/Source/JavaScriptCore/API/JSContext.h
+++ b/Source/JavaScriptCore/API/JSContext.h
@@ -179,7 +179,7 @@ JSC_CLASS_AVAILABLE(macos(10.9), ios(7.0))
 @property
 @discussion Controls whether this @link JSContext @/link is inspectable in Web Inspector. The default value is NO.
 */
-@property (nonatomic, setter=setInspectable:) BOOL inspectable JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA)) NS_SWIFT_NAME(isInspectable);
+@property (nonatomic, getter=isInspectable) BOOL inspectable JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA)) NS_SWIFT_NAME(isInspectable);
 
 @end
 

--- a/Source/JavaScriptCore/API/JSContext.mm
+++ b/Source/JavaScriptCore/API/JSContext.mm
@@ -273,7 +273,7 @@
     JSGlobalContextSetName(m_context, OpaqueJSString::tryCreate(name).get());
 }
 
-- (BOOL)inspectable
+- (BOOL)isInspectable
 {
     return JSGlobalContextIsInspectable(m_context);
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.h
@@ -662,7 +662,7 @@ The uniform type identifier kUTTypeWebArchive can be used get the related pasteb
 @abstract Controls whether this @link WKWebView @/link is inspectable in Web Inspector.
 @discussion The default value is NO.
 */
-@property (nonatomic, setter=setInspectable:) BOOL inspectable NS_SWIFT_NAME(isInspectable) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+@property (nonatomic, getter=isInspectable) BOOL inspectable NS_SWIFT_NAME(isInspectable) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -1436,7 +1436,7 @@ inline OptionSet<WebKit::FindOptions> toFindOptions(WKFindConfiguration *configu
     _page->restoreFromSessionState(sessionState, true);
 }
 
-- (BOOL)inspectable
+- (BOOL)isInspectable
 {
 #if ENABLE(REMOTE_INSPECTOR)
     // FIXME: <http://webkit.org/b/246237> Local inspection should be controlled by `inspectable` API.


### PR DESCRIPTION
#### c0769577c02dff910bc63e154e78be226bcf43cc
<pre>
Web Inspector: `inspectable` API doesn&apos;t have a correct Objective-C getter
<a href="https://bugs.webkit.org/show_bug.cgi?id=251702">https://bugs.webkit.org/show_bug.cgi?id=251702</a>
rdar://105012093

Reviewed by Tim Horton.

Boolean getters should have an `is` prefix. Currently `inspectable` is not adhering to this rule. The current getter
also doesn&apos;t match the approved API design. This API has not yet shipped, and there is no internal usage of
`[webView inspectable]`, so this change will not break existing clients. `webView.inspectable` remains correct and
unchanged.

* Source/JavaScriptCore/API/JSContext.h:
* Source/JavaScriptCore/API/JSContext.mm:
(-[JSContext isInspectable]):
(-[JSContext inspectable]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView isInspectable]):
(-[WKWebView inspectable]): Deleted.

Canonical link: <a href="https://commits.webkit.org/259840@main">https://commits.webkit.org/259840@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e7dd9cec8c1a130399767af346595271187b640

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106096 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15149 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38924 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115280 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/175360 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16581 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6321 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98305 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114981 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111852 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95593 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/40169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94488 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/27236 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/95717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8400 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/28588 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/95091 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/6221 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8894 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/5133 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30504 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14513 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48132 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/103837 "Built successfully") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6804 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10439 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25734 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->