### PR TITLE
Fix linking errors related to WGSL on iOS

### DIFF
--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -617,20 +617,6 @@ Expected<AST::ReturnStatement, Error> Parser<Lexer>::parseReturnStatement()
 }
 
 template<typename Lexer>
-Expected<UniqueRef<AST::Expression>, Error> Parser<Lexer>::parseRelationalExpression(AST::Expression::Ref&& lhs)
-{
-    // FIXME: fill in
-    return parseShiftExpression(WTFMove(lhs));
-}
-
-template<typename Lexer>
-Expected<UniqueRef<AST::Expression>, Error> Parser<Lexer>::parseShiftExpression(AST::Expression::Ref&& lhs)
-{
-    // FIXME: fill in
-    return parseAdditiveExpression(WTFMove(lhs));
-}
-
-template<typename Lexer>
 Expected<AST::BinaryOperation, Error> Parser<Lexer>::parseAdditiveOperator()
 {
     START_PARSE();
@@ -645,22 +631,6 @@ Expected<AST::BinaryOperation, Error> Parser<Lexer>::parseAdditiveOperator()
     default:
         FAIL("Expected one of + or -"_s);
     }
-}
-
-template<typename Lexer>
-Expected<UniqueRef<AST::Expression>, Error> Parser<Lexer>::parseAdditiveExpression(AST::Expression::Ref&& lhs)
-{
-    START_PARSE();
-    PARSE_MOVE(lhs, MultiplicativeExpression, WTFMove(lhs));
-
-    while (current().m_type == TokenType::Plus || current().m_type == TokenType::Minus) {
-        PARSE(op, AdditiveOperator);
-        PARSE(unary, UnaryExpression);
-        PARSE(rhs, MultiplicativeExpression, WTFMove(unary));
-        lhs = MAKE_NODE_UNIQUE_REF(BinaryExpression, WTFMove(lhs), WTFMove(rhs), op);
-    }
-
-    return WTFMove(lhs);
 }
 
 template<typename Lexer>
@@ -823,14 +793,6 @@ Expected<UniqueRef<AST::Expression>, Error> Parser<Lexer>::parsePrimaryExpressio
     }
 
     FAIL("Expected one of '(', a literal, or an identifier"_s);
-}
-
-template<typename Lexer>
-Expected<UniqueRef<AST::Expression>, Error> Parser<Lexer>::parseExpression()
-{
-    // FIXME: Fill in
-    PARSE(lhs, UnaryExpression);
-    return parseRelationalExpression(WTFMove(lhs));
 }
 
 template<typename Lexer>


### PR DESCRIPTION
#### 0210f172fe89d2c731001c5b33296bd53db83197
<pre>
Fix linking errors related to WGSL on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=251711">https://bugs.webkit.org/show_bug.cgi?id=251711</a>
rdar://105015168

Reviewed by NOBODY (OOPS!).

* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseRelationalExpression): Deleted.
(WGSL::Parser&lt;Lexer&gt;::parseShiftExpression): Deleted.
(WGSL::Parser&lt;Lexer&gt;::parseAdditiveExpression): Deleted.
(WGSL::Parser&lt;Lexer&gt;::parseExpression): Deleted.
* Source/WebGPU/WGSL/ParserPrivate.h:
(WGSL::Parser&lt;Lexer&gt;::parseExpression):
(WGSL::Parser&lt;Lexer&gt;::parseAdditiveExpression):
(WGSL::Parser&lt;Lexer&gt;::parseShiftExpression):
(WGSL::Parser&lt;Lexer&gt;::parseRelationalExpression):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0210f172fe89d2c731001c5b33296bd53db83197

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/106106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/15159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/38934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/115290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/16591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/6331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/98315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111862 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/16591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/38934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/98315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/16591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/38934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/98315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/8410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/38934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/8904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/6331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/14523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/38934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/10449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->