### PR TITLE
REGRESSION (iOS 16): sina.cn: Find on Page highlights obscure the text behind them

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
@@ -298,9 +298,7 @@ void WebFoundTextRangeController::drawRect(WebCore::PageOverlay&, WebCore::Graph
     for (auto& path : foundFramePaths)
         graphicsContext.fillPath(path);
 
-    if (m_textIndicator) {
-        graphicsContext.setCompositeOperation(WebCore::CompositeOperator::SourceOver);
-
+    if (m_textIndicator && !m_textIndicator->selectionRectInRootViewCoordinates().isEmpty()) {
         auto* indicatorImage = m_textIndicator->contentImage();
         if (!indicatorImage)
             return;
@@ -315,6 +313,7 @@ void WebFoundTextRangeController::drawRect(WebCore::PageOverlay&, WebCore::Graph
 
         auto paths = WebCore::PathUtilities::pathsWithShrinkWrappedRects(textRectsInRootViewCoordinates, indicatorRadius);
 
+        graphicsContext.setCompositeOperation(WebCore::CompositeOperator::SourceOver);
         graphicsContext.setFillColor(highlightColor);
         for (const auto& path : paths)
             graphicsContext.fillPath(path);


### PR DESCRIPTION
#### ed56087035ea16b403123ce455cadf354c161988
<pre>
REGRESSION (iOS 16): sina.cn: Find on Page highlights obscure the text behind them
<a href="https://bugs.webkit.org/show_bug.cgi?id=251707">https://bugs.webkit.org/show_bug.cgi?id=251707</a>
rdar://102302792

Reviewed by Wenson Hsieh.

sina.cn contains elements with &quot;-webkit-user-select: none&quot;. Prior to iOS 16,
any text found within these elements would count towards the number of results,
but would not be highlighted.

Find-in-page logic was refactored in iOS 16 to support UIKit&apos;s new Find &amp; Replace
API. As part of these changes, find-in-page began storing/restoring ranges, rather
than simply updating selection. Consequently, the `TextIndicator` used to draw
highlights is created from a `SimpleRange`, rather than the current selection.
The previously used constructor would early return if the selection was empty
(as is the case when attempting to select a &quot;-webkit-user-select: none&quot; element),
resulting the the pre-iOS 16 behavior described above.

`TextIndicator` does not know how to take snapshots of &quot;-webkit-user-select: none&quot;
content. Consequently, the highlight is painted without any text, leading to
found text getting obscured.

For now, restore the pre-iOS 16 behavior, and do not draw highlights if the
selection is empty. In the longer term, `TextIndicator` should be taught to
draw this content (tracked in webkit.org/b/251709). Note that following this
change, there is still a net progression over pre-iOS 16 behavior, where
WebKit will indicate found results with &quot;-webkit-user-select: none&quot; by drawing
&quot;holes&quot;.

* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp:
(WebKit::WebFoundTextRangeController::drawRect):

Additionally, move the use of `GraphicsContext` closer to the painting logic to
avoid running unnecessary code.

Canonical link: <a href="https://commits.webkit.org/259857@main">https://commits.webkit.org/259857@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99057c53aa66e669b764a73c024104f938d597ef

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106108 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15161 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38936 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115292 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16661 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6391 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98317 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114989 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111864 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12678 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95597 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40170 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94551 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27240 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81849 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8412 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28592 "Found 1 new test failure: media/video-seek-have-nothing.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8906 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5184 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14525 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48136 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10451 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3670 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->