### PR TITLE
[WK2] Rework message-sending methods on IPC::Connection, IPC::StreamClientConnection et al.

### DIFF
--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -308,7 +308,7 @@ GPUConnectionToWebProcess::GPUConnectionToWebProcess(GPUProcess& gpuProcess, Web
         hasVP9ExtensionSupport
 #endif
     };
-    m_connection->send(Messages::GPUProcessConnection::DidInitialize(info), 0);
+    m_connection->send<Messages::GPUProcessConnection::DidInitialize>({ }, std::make_optional(WTFMove(info)));
     ++gObjectCountForTesting;
 }
 
@@ -663,7 +663,7 @@ void GPUConnectionToWebProcess::updateSupportedRemoteCommands()
 
 void GPUConnectionToWebProcess::didReceiveRemoteControlCommand(PlatformMediaSession::RemoteControlCommandType type, const PlatformMediaSession::RemoteCommandArgument& argument)
 {
-    connection().send(Messages::GPUProcessConnection::DidReceiveRemoteCommand(type, argument), 0);
+    connection().send<Messages::GPUProcessConnection::DidReceiveRemoteCommand>({ }, type, argument);
 }
 
 #if USE(AUDIO_SESSION)

--- a/Source/WebKit/GPUProcess/mac/LocalAudioSessionRoutingArbitrator.cpp
+++ b/Source/WebKit/GPUProcess/mac/LocalAudioSessionRoutingArbitrator.cpp
@@ -55,12 +55,12 @@ void LocalAudioSessionRoutingArbitrator::processDidTerminate()
 
 void LocalAudioSessionRoutingArbitrator::beginRoutingArbitrationWithCategory(AudioSession::CategoryType category, CompletionHandler<void(RoutingArbitrationError, DefaultRouteChanged)>&& callback)
 {
-    m_connectionToWebProcess.connection().sendWithAsyncReply(Messages::GPUProcessConnection::BeginRoutingArbitrationWithCategory(category), WTFMove(callback), 0);
+    m_connectionToWebProcess.connection().sendWithAsyncReply<Messages::GPUProcessConnection::BeginRoutingArbitrationWithCategory>({ }, WTFMove(callback), category);
 }
 
 void LocalAudioSessionRoutingArbitrator::leaveRoutingAbritration()
 {
-    m_connectionToWebProcess.connection().send(Messages::GPUProcessConnection::EndRoutingArbitration(), 0);
+    m_connectionToWebProcess.connection().send<Messages::GPUProcessConnection::EndRoutingArbitration>({ });
 }
 
 }

--- a/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
@@ -179,7 +179,7 @@ void RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit::reset()
         return;
 
     m_canReset = false;
-    m_connection->send(Messages::GPUProcessConnection::ResetAudioMediaStreamTrackRendererInternalUnit { m_identifier }, 0);
+    m_connection->send<Messages::GPUProcessConnection::ResetAudioMediaStreamTrackRendererInternalUnit>(IPC::Connection::AsyncMessageOptions { }, m_identifier);
 }
 
 void RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit::setShouldRegisterAsSpeakerSamplesProducer(bool value)

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.h
@@ -87,7 +87,7 @@ private:
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 
-    template<typename Message> bool sendToServiceWorker(Message&&);
+    template<typename T, typename... ArgumentTypes> bool sendToServiceWorker(ArgumentTypes&&...);
     void didFailDownload(std::optional<WebCore::ResourceError>&& = { });
     void close();
 

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h
@@ -116,7 +116,7 @@ private:
     NetworkSession* session();
     void preloadResponseIsReady();
 
-    template<typename Message> bool sendToServiceWorker(Message&&);
+    template<typename T, typename... ArgumentTypes> bool sendToServiceWorker(ArgumentTypes&&...);
     template<typename Message> bool sendToClient(Message&&);
 
     WeakPtr<WebSWServerConnection> m_swServerConnection;

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWOriginStore.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWOriginStore.cpp
@@ -62,7 +62,7 @@ void WebSWOriginStore::importComplete()
 {
     m_isImported = true;
     for (auto& connection : m_webSWServerConnections)
-        connection.send(Messages::WebSWClientConnection::SetSWOriginTableIsImported());
+        connection.send<Messages::WebSWClientConnection::SetSWOriginTableIsImported>({ });
 }
 
 void WebSWOriginStore::registerSWServerConnection(WebSWServerConnection& connection)
@@ -73,7 +73,7 @@ void WebSWOriginStore::registerSWServerConnection(WebSWServerConnection& connect
         sendStoreHandle(connection);
 
     if (m_isImported)
-        connection.send(Messages::WebSWClientConnection::SetSWOriginTableIsImported());
+        connection.send<Messages::WebSWClientConnection::SetSWOriginTableIsImported>({ });
 }
 
 void WebSWOriginStore::unregisterSWServerConnection(WebSWServerConnection& connection)
@@ -86,7 +86,7 @@ void WebSWOriginStore::sendStoreHandle(WebSWServerConnection& connection)
     auto handle = m_store.createSharedMemoryHandle();
     if (!handle)
         return;
-    connection.send(Messages::WebSWClientConnection::SetSWOriginTableSharedMemory(*handle));
+    connection.send<Messages::WebSWClientConnection::SetSWOriginTableSharedMemory>({ }, WTFMove(*handle));
 }
 
 void WebSWOriginStore::didInvalidateSharedMemory()

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
@@ -100,12 +100,12 @@ void WebSWServerConnection::rejectJobInClient(ServiceWorkerJobIdentifier jobIden
 {
     if (auto completionHandler = m_unregisterJobs.take(jobIdentifier))
         return completionHandler(makeUnexpected(exceptionData));
-    send(Messages::WebSWClientConnection::JobRejectedInServer(jobIdentifier, exceptionData));
+    send<Messages::WebSWClientConnection::JobRejectedInServer>({ }, jobIdentifier, exceptionData);
 }
 
 void WebSWServerConnection::resolveRegistrationJobInClient(ServiceWorkerJobIdentifier jobIdentifier, const ServiceWorkerRegistrationData& registrationData, ShouldNotifyWhenResolved shouldNotifyWhenResolved)
 {
-    send(Messages::WebSWClientConnection::RegistrationJobResolvedInServer(jobIdentifier, registrationData, shouldNotifyWhenResolved));
+    send<Messages::WebSWClientConnection::RegistrationJobResolvedInServer>({ }, jobIdentifier, registrationData, shouldNotifyWhenResolved);
 }
 
 void WebSWServerConnection::resolveUnregistrationJobInClient(ServiceWorkerJobIdentifier jobIdentifier, const ServiceWorkerRegistrationKey& registrationKey, bool unregistrationResult)
@@ -131,37 +131,37 @@ void WebSWServerConnection::resolveUnregistrationJobInClient(ServiceWorkerJobIde
 
 void WebSWServerConnection::startScriptFetchInClient(ServiceWorkerJobIdentifier jobIdentifier, const ServiceWorkerRegistrationKey& registrationKey, FetchOptions::Cache cachePolicy)
 {
-    send(Messages::WebSWClientConnection::StartScriptFetchForServer(jobIdentifier, registrationKey, cachePolicy));
+    send<Messages::WebSWClientConnection::StartScriptFetchForServer>({ }, jobIdentifier, registrationKey, cachePolicy);
 }
 
 void WebSWServerConnection::updateRegistrationStateInClient(ServiceWorkerRegistrationIdentifier identifier, ServiceWorkerRegistrationState state, const std::optional<ServiceWorkerData>& serviceWorkerData)
 {
-    send(Messages::WebSWClientConnection::UpdateRegistrationState(identifier, state, serviceWorkerData));
+    send<Messages::WebSWClientConnection::UpdateRegistrationState>({ }, identifier, state, serviceWorkerData);
 }
 
 void WebSWServerConnection::fireUpdateFoundEvent(ServiceWorkerRegistrationIdentifier identifier)
 {
-    send(Messages::WebSWClientConnection::FireUpdateFoundEvent(identifier));
+    send<Messages::WebSWClientConnection::FireUpdateFoundEvent>(IPC::Connection::AsyncMessageOptions { }, identifier);
 }
 
 void WebSWServerConnection::setRegistrationLastUpdateTime(ServiceWorkerRegistrationIdentifier identifier, WallTime lastUpdateTime)
 {
-    send(Messages::WebSWClientConnection::SetRegistrationLastUpdateTime(identifier, lastUpdateTime));
+    send<Messages::WebSWClientConnection::SetRegistrationLastUpdateTime>({ }, identifier, lastUpdateTime);
 }
 
 void WebSWServerConnection::setRegistrationUpdateViaCache(ServiceWorkerRegistrationIdentifier identifier, ServiceWorkerUpdateViaCache updateViaCache)
 {
-    send(Messages::WebSWClientConnection::SetRegistrationUpdateViaCache(identifier, updateViaCache));
+    send<Messages::WebSWClientConnection::SetRegistrationUpdateViaCache>({ }, identifier, updateViaCache);
 }
 
 void WebSWServerConnection::notifyClientsOfControllerChange(const HashSet<ScriptExecutionContextIdentifier>& contextIdentifiers, const ServiceWorkerData& newController)
 {
-    send(Messages::WebSWClientConnection::NotifyClientsOfControllerChange(contextIdentifiers, newController));
+    send<Messages::WebSWClientConnection::NotifyClientsOfControllerChange>({ }, contextIdentifiers, newController);
 }
 
 void WebSWServerConnection::updateWorkerStateInClient(ServiceWorkerIdentifier worker, ServiceWorkerState state)
 {
-    send(Messages::WebSWClientConnection::UpdateWorkerState(worker, state));
+    send<Messages::WebSWClientConnection::UpdateWorkerState>({ }, worker, state);
 }
 
 void WebSWServerConnection::controlClient(const NetworkResourceLoadParameters& parameters, SWServerRegistration& registration, const ResourceRequest& request, WebCore::ProcessIdentifier webProcessIdentifier)
@@ -178,11 +178,11 @@ void WebSWServerConnection::controlClient(const NetworkResourceLoadParameters& p
     // As per step 12 of https://w3c.github.io/ServiceWorker/#on-fetch-request-algorithm, the active service worker should be controlling the document.
     // We register the service worker client using the identifier provided by DocumentLoader and notify DocumentLoader about it.
     // If notification is successful, DocumentLoader is responsible to unregister the service worker client as needed.
-    sendWithAsyncReply(Messages::WebSWClientConnection::SetServiceWorkerClientIsControlled { clientIdentifier, registration.data() }, [weakThis = WeakPtr { *this }, this, clientIdentifier](bool isSuccess) {
+    sendWithAsyncReply<Messages::WebSWClientConnection::SetServiceWorkerClientIsControlled>({ }, [weakThis = WeakPtr { *this }, this, clientIdentifier](bool isSuccess) {
         if (!weakThis || isSuccess)
             return;
         unregisterServiceWorkerClient(clientIdentifier);
-    });
+    }, clientIdentifier, registration.data());
 
     auto ancestorOrigins = map(parameters.frameAncestorOrigins, [](auto& origin) { return origin->toString(); });
     ServiceWorkerClientData data { clientIdentifier, clientType, ServiceWorkerClientFrameType::None, request.url(), URL(), parameters.webPageID, parameters.webFrameID, request.isAppInitiated() ? WebCore::LastNavigationWasAppInitiated::Yes : WebCore::LastNavigationWasAppInitiated::No, false, false, 0, WTFMove(ancestorOrigins) };
@@ -322,7 +322,7 @@ void WebSWServerConnection::postMessageToServiceWorker(ServiceWorkerIdentifier d
     // It's possible this specific worker cannot be re-run (e.g. its registration has been removed)
     server().runServiceWorkerIfNecessary(destinationIdentifier, [destinationIdentifier, message = WTFMove(message), sourceData = WTFMove(*sourceData)](auto* contextConnection) mutable {
         if (contextConnection)
-            sendToContextProcess(*contextConnection, Messages::WebSWContextManagerConnection::PostMessageToServiceWorker { destinationIdentifier, WTFMove(message), WTFMove(sourceData) });
+            sendToContextProcess<Messages::WebSWContextManagerConnection::PostMessageToServiceWorker>(*contextConnection, destinationIdentifier, WTFMove(message), WTFMove(sourceData));
     });
 }
 
@@ -384,7 +384,7 @@ void WebSWServerConnection::postMessageToServiceWorkerClient(ScriptExecutionCont
     if (!sourceServiceWorker)
         return;
 
-    send(Messages::WebSWClientConnection::PostMessageToServiceWorkerClient { destinationContextIdentifier, message, sourceServiceWorker->data(), sourceOrigin });
+    send<Messages::WebSWClientConnection::PostMessageToServiceWorkerClient>({ }, destinationContextIdentifier, message, sourceServiceWorker->data(), sourceOrigin);
 }
 
 void WebSWServerConnection::matchRegistration(const SecurityOriginData& topOrigin, const URL& clientURL, CompletionHandler<void(std::optional<ServiceWorkerRegistrationData>&&)>&& callback)
@@ -631,9 +631,10 @@ NetworkSession* WebSWServerConnection::session()
     return m_networkProcess->networkSession(sessionID());
 }
 
-template<typename U> void WebSWServerConnection::sendToContextProcess(WebCore::SWServerToContextConnection& connection, U&& message)
+template<typename T, typename... ArgumentTypes>
+void WebSWServerConnection::sendToContextProcess(WebCore::SWServerToContextConnection& connection, ArgumentTypes&&... arguments)
 {
-    static_cast<WebSWServerToContextConnection&>(connection).send(WTFMove(message));
+    static_cast<WebSWServerToContextConnection&>(connection).send<T>({ }, std::forward<ArgumentTypes>(arguments)...);
 }
 
 void WebSWServerConnection::fetchTaskTimedOut(ServiceWorkerIdentifier serviceWorkerIdentifier)
@@ -688,7 +689,7 @@ void WebSWServerConnection::getNavigationPreloadState(WebCore::ServiceWorkerRegi
 
 void WebSWServerConnection::focusServiceWorkerClient(WebCore::ScriptExecutionContextIdentifier clientIdentifier, CompletionHandler<void(std::optional<ServiceWorkerClientData>&&)>&& callback)
 {
-    sendWithAsyncReply(Messages::WebSWClientConnection::FocusServiceWorkerClient { clientIdentifier }, WTFMove(callback));
+    sendWithAsyncReply<Messages::WebSWClientConnection::FocusServiceWorkerClient>({ }, WTFMove(callback), clientIdentifier);
 }
 
 void WebSWServerConnection::transferServiceWorkerLoadToNewWebProcess(NetworkResourceLoader& loader, WebCore::SWServerRegistration& registration, WebCore::ProcessIdentifier webProcessIdentifier)

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h
@@ -148,7 +148,8 @@ private:
     IPC::Connection* messageSenderConnection() const final { return m_contentConnection.ptr(); }
     uint64_t messageSenderDestinationID() const final { return 0; }
     
-    template<typename U> static void sendToContextProcess(WebCore::SWServerToContextConnection&, U&& message);
+    template<typename T, typename... ArgumentTypes>
+    static void sendToContextProcess(WebCore::SWServerToContextConnection&, ArgumentTypes&&...);
 
     Ref<IPC::Connection> m_contentConnection;
     Ref<NetworkProcess> m_networkProcess;

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.cpp
@@ -118,19 +118,19 @@ void WebSharedWorkerServerConnection::resumeForBackForwardCache(WebCore::SharedW
 void WebSharedWorkerServerConnection::fetchScriptInClient(const WebSharedWorker& sharedWorker, WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, CompletionHandler<void(WebCore::WorkerFetchResult&&, WebCore::WorkerInitializationData&&)>&& completionHandler)
 {
     CONNECTION_RELEASE_LOG("fetchScriptInClient: sharedWorkerObjectIdentifier=%" PUBLIC_LOG_STRING, sharedWorkerObjectIdentifier.toString().utf8().data());
-    sendWithAsyncReply(Messages::WebSharedWorkerObjectConnection::FetchScriptInClient { sharedWorker.url(), sharedWorkerObjectIdentifier, sharedWorker.workerOptions() }, WTFMove(completionHandler));
+    sendWithAsyncReply<Messages::WebSharedWorkerObjectConnection::FetchScriptInClient>({ }, WTFMove(completionHandler), sharedWorker.url(), sharedWorkerObjectIdentifier, sharedWorker.workerOptions());
 }
 
 void WebSharedWorkerServerConnection::notifyWorkerObjectOfLoadCompletion(WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, const WebCore::ResourceError& error)
 {
     CONNECTION_RELEASE_LOG("notifyWorkerObjectOfLoadCompletion: sharedWorkerObjectIdentifier=%" PUBLIC_LOG_STRING ", success=%d", sharedWorkerObjectIdentifier.toString().utf8().data(), error.isNull());
-    send(Messages::WebSharedWorkerObjectConnection::NotifyWorkerObjectOfLoadCompletion { sharedWorkerObjectIdentifier, error });
+    send<Messages::WebSharedWorkerObjectConnection::NotifyWorkerObjectOfLoadCompletion>({ }, sharedWorkerObjectIdentifier, error);
 }
 
 void WebSharedWorkerServerConnection::postExceptionToWorkerObject(WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, const String& errorMessage, int lineNumber, int columnNumber, const String& sourceURL)
 {
     CONNECTION_RELEASE_LOG_ERROR("postExceptionToWorkerObject: sharedWorkerObjectIdentifier=%" PUBLIC_LOG_STRING, sharedWorkerObjectIdentifier.toString().utf8().data());
-    send(Messages::WebSharedWorkerObjectConnection::PostExceptionToWorkerObject { sharedWorkerObjectIdentifier, errorMessage, lineNumber, columnNumber, sourceURL });
+    send<Messages::WebSharedWorkerObjectConnection::PostExceptionToWorkerObject>({ }, sharedWorkerObjectIdentifier, errorMessage, lineNumber, columnNumber, sourceURL);
 }
 
 #undef CONNECTION_RELEASE_LOG

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.cpp
@@ -128,7 +128,7 @@ void WebSharedWorkerServerToContextConnection::launchSharedWorker(WebSharedWorke
         }
 #endif
     }
-    send(Messages::WebSharedWorkerContextManagerConnection::LaunchSharedWorker { sharedWorker.origin(), sharedWorker.identifier(), sharedWorker.workerOptions(), sharedWorker.fetchResult(), initializationData });
+    send<Messages::WebSharedWorkerContextManagerConnection::LaunchSharedWorker>({ }, sharedWorker.origin(), sharedWorker.identifier(), sharedWorker.workerOptions(), sharedWorker.fetchResult(), initializationData);
     sharedWorker.forEachSharedWorkerObject([&](auto, auto& port) {
         postConnectEvent(sharedWorker, port, [](bool) { });
     });
@@ -136,24 +136,24 @@ void WebSharedWorkerServerToContextConnection::launchSharedWorker(WebSharedWorke
 
 void WebSharedWorkerServerToContextConnection::suspendSharedWorker(WebCore::SharedWorkerIdentifier identifier)
 {
-    send(Messages::WebSharedWorkerContextManagerConnection::SuspendSharedWorker { identifier });
+    send<Messages::WebSharedWorkerContextManagerConnection::SuspendSharedWorker>(IPC::Connection::AsyncMessageOptions { }, identifier);
 }
 
 void WebSharedWorkerServerToContextConnection::resumeSharedWorker(WebCore::SharedWorkerIdentifier identifier)
 {
-    send(Messages::WebSharedWorkerContextManagerConnection::ResumeSharedWorker { identifier });
+    send<Messages::WebSharedWorkerContextManagerConnection::ResumeSharedWorker>(IPC::Connection::AsyncMessageOptions { }, identifier);
 }
 
 void WebSharedWorkerServerToContextConnection::postConnectEvent(const WebSharedWorker& sharedWorker, const WebCore::TransferredMessagePort& port, CompletionHandler<void(bool)>&& completionHandler)
 {
     CONTEXT_CONNECTION_RELEASE_LOG("postConnectEvent: sharedWorkerIdentifier=%" PRIu64, sharedWorker.identifier().toUInt64());
-    sendWithAsyncReply(Messages::WebSharedWorkerContextManagerConnection::PostConnectEvent { sharedWorker.identifier(), port, sharedWorker.origin().clientOrigin.toString() }, WTFMove(completionHandler));
+    sendWithAsyncReply<Messages::WebSharedWorkerContextManagerConnection::PostConnectEvent>({ }, WTFMove(completionHandler), sharedWorker.identifier(), port, sharedWorker.origin().clientOrigin.toString());
 }
 
 void WebSharedWorkerServerToContextConnection::terminateSharedWorker(const WebSharedWorker& sharedWorker)
 {
     CONTEXT_CONNECTION_RELEASE_LOG("terminateSharedWorker: sharedWorkerIdentifier=%" PRIu64, sharedWorker.identifier().toUInt64());
-    send(Messages::WebSharedWorkerContextManagerConnection::TerminateSharedWorker { sharedWorker.identifier() });
+    send<Messages::WebSharedWorkerContextManagerConnection::TerminateSharedWorker>(IPC::Connection::AsyncMessageOptions { }, sharedWorker.identifier());
 }
 
 void WebSharedWorkerServerToContextConnection::addSharedWorkerObject(WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier)

--- a/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp
+++ b/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp
@@ -170,7 +170,7 @@ void WebUserContentControllerProxy::addContentWorld(API::ContentWorld& world)
 
     world.addAssociatedUserContentControllerProxy(*this);
     for (auto& process : m_processes)
-        process.send(Messages::WebUserContentController::AddContentWorlds({ world.worldData() }), identifier());
+        process.send<Messages::WebUserContentController::AddContentWorlds>({ identifier() }, Vector { world.worldData() });
 }
 
 void WebUserContentControllerProxy::contentWorldDestroyed(API::ContentWorld& world)
@@ -179,7 +179,7 @@ void WebUserContentControllerProxy::contentWorldDestroyed(API::ContentWorld& wor
     ASSERT_UNUSED(result, result);
 
     for (auto& process : m_processes)
-        process.send(Messages::WebUserContentController::RemoveContentWorlds({ world.identifier() }), identifier());
+        process.send<Messages::WebUserContentController::RemoveContentWorlds>({ identifier() }, Vector { world.identifier() });
 }
 
 void WebUserContentControllerProxy::addUserScript(API::UserScript& userScript, InjectUserScriptImmediately immediately)
@@ -191,7 +191,7 @@ void WebUserContentControllerProxy::addUserScript(API::UserScript& userScript, I
     m_userScripts->elements().append(&userScript);
 
     for (auto& process : m_processes)
-        process.send(Messages::WebUserContentController::AddUserScripts({ { userScript.identifier(), world->identifier(), userScript.userScript() } }, immediately), identifier());
+        process.send<Messages::WebUserContentController::AddUserScripts>({ identifier() }, Vector { WebUserScriptData { userScript.identifier(), world->identifier(), userScript.userScript() } }, immediately);
 }
 
 void WebUserContentControllerProxy::removeUserScript(API::UserScript& userScript)
@@ -199,7 +199,7 @@ void WebUserContentControllerProxy::removeUserScript(API::UserScript& userScript
     Ref<API::ContentWorld> world = userScript.contentWorld();
 
     for (auto& process : m_processes)
-        process.send(Messages::WebUserContentController::RemoveUserScript(world->identifier(), userScript.identifier()), identifier());
+        process.send<Messages::WebUserContentController::RemoveUserScript>({ identifier() }, world->identifier(), userScript.identifier());
 
     m_userScripts->elements().removeAll(&userScript);
 }
@@ -207,7 +207,7 @@ void WebUserContentControllerProxy::removeUserScript(API::UserScript& userScript
 void WebUserContentControllerProxy::removeAllUserScripts(API::ContentWorld& world)
 {
     for (auto& process : m_processes)
-        process.send(Messages::WebUserContentController::RemoveAllUserScripts({ world.identifier() }), identifier());
+        process.send<Messages::WebUserContentController::RemoveAllUserScripts>({ identifier() }, Vector { world.identifier() });
 
     m_userScripts->removeAllOfTypeMatching<API::UserScript>([&](const auto& userScript) {
         return &userScript->contentWorld() == &world;
@@ -224,7 +224,7 @@ void WebUserContentControllerProxy::removeAllUserScripts()
         return entry.key->identifier();
     });
     for (auto& process : m_processes)
-        process.send(Messages::WebUserContentController::RemoveAllUserScripts(worldIdentifiers), identifier());
+        process.send<Messages::WebUserContentController::RemoveAllUserScripts>({ identifier() }, worldIdentifiers);
 
     m_userScripts->elements().clear();
 }
@@ -238,7 +238,7 @@ void WebUserContentControllerProxy::addUserStyleSheet(API::UserStyleSheet& userS
     m_userStyleSheets->elements().append(&userStyleSheet);
 
     for (auto& process : m_processes)
-        process.send(Messages::WebUserContentController::AddUserStyleSheets({ { userStyleSheet.identifier(), world->identifier(), userStyleSheet.userStyleSheet() } }), identifier());
+        process.send<Messages::WebUserContentController::AddUserStyleSheets>({ identifier() }, Vector { WebUserStyleSheetData { userStyleSheet.identifier(), world->identifier(), userStyleSheet.userStyleSheet() } });
 }
 
 void WebUserContentControllerProxy::removeUserStyleSheet(API::UserStyleSheet& userStyleSheet)
@@ -246,7 +246,7 @@ void WebUserContentControllerProxy::removeUserStyleSheet(API::UserStyleSheet& us
     Ref<API::ContentWorld> world = userStyleSheet.contentWorld();
 
     for (auto& process : m_processes)
-        process.send(Messages::WebUserContentController::RemoveUserStyleSheet(world->identifier(), userStyleSheet.identifier()), identifier());
+        process.send<Messages::WebUserContentController::RemoveUserStyleSheet>({ identifier() }, world->identifier(), userStyleSheet.identifier());
 
     m_userStyleSheets->elements().removeAll(&userStyleSheet);
 }
@@ -254,7 +254,7 @@ void WebUserContentControllerProxy::removeUserStyleSheet(API::UserStyleSheet& us
 void WebUserContentControllerProxy::removeAllUserStyleSheets(API::ContentWorld& world)
 {
     for (auto& process : m_processes)
-        process.send(Messages::WebUserContentController::RemoveAllUserStyleSheets({ world.identifier() }), identifier());
+        process.send<Messages::WebUserContentController::RemoveAllUserStyleSheets>({ identifier() }, Vector { world.identifier() });
 
     m_userStyleSheets->removeAllOfTypeMatching<API::UserStyleSheet>([&](const auto& userStyleSheet) {
         return &userStyleSheet->contentWorld() == &world;
@@ -271,7 +271,7 @@ void WebUserContentControllerProxy::removeAllUserStyleSheets()
         return entry.key->identifier();
     });
     for (auto& process : m_processes)
-        process.send(Messages::WebUserContentController::RemoveAllUserStyleSheets(worldIdentifiers), identifier());
+        process.send<Messages::WebUserContentController::RemoveAllUserStyleSheets>({ identifier() }, worldIdentifiers);
 
     m_userStyleSheets->elements().clear();
 }
@@ -290,7 +290,7 @@ bool WebUserContentControllerProxy::addUserScriptMessageHandler(WebScriptMessage
     m_scriptMessageHandlers.add(handler.identifier(), &handler);
 
     for (auto& process : m_processes)
-        process.send(Messages::WebUserContentController::AddUserScriptMessageHandlers({ { handler.identifier(), world.identifier(), handler.name() } }), identifier());
+        process.send<Messages::WebUserContentController::AddUserScriptMessageHandlers>({ identifier() }, Vector { WebScriptMessageHandlerData { handler.identifier(), world.identifier(), handler.name() } });
     
     return true;
 }
@@ -300,7 +300,7 @@ void WebUserContentControllerProxy::removeUserMessageHandlerForName(const String
     for (auto it = m_scriptMessageHandlers.begin(), end = m_scriptMessageHandlers.end(); it != end; ++it) {
         if (it->value->name() == name && it->value->world().identifier() == world.identifier()) {
             for (auto& process : m_processes)
-                process.send(Messages::WebUserContentController::RemoveUserScriptMessageHandler(world.identifier(), it->value->identifier()), identifier());
+                process.send<Messages::WebUserContentController::RemoveUserScriptMessageHandler>({ identifier() }, world.identifier(), it->value->identifier());
 
             m_scriptMessageHandlers.remove(it);
 
@@ -312,7 +312,7 @@ void WebUserContentControllerProxy::removeUserMessageHandlerForName(const String
 void WebUserContentControllerProxy::removeAllUserMessageHandlers(API::ContentWorld& world)
 {
     for (auto& process : m_processes)
-        process.send(Messages::WebUserContentController::RemoveAllUserScriptMessageHandlersForWorlds({ world.identifier() }), identifier());
+        process.send<Messages::WebUserContentController::RemoveAllUserScriptMessageHandlersForWorlds>({ identifier() }, Vector { world.identifier() });
 
     m_scriptMessageHandlers.removeIf([&](auto& entry) {
         return entry.value->world().identifier() == world.identifier();
@@ -322,7 +322,7 @@ void WebUserContentControllerProxy::removeAllUserMessageHandlers(API::ContentWor
 void WebUserContentControllerProxy::removeAllUserMessageHandlers()
 {
     for (auto& process : m_processes)
-        process.send(Messages::WebUserContentController::RemoveAllUserScriptMessageHandlers(), identifier());
+        process.send<Messages::WebUserContentController::RemoveAllUserScriptMessageHandlers>({ identifier() });
 
     m_scriptMessageHandlers.clear();
 }
@@ -365,7 +365,7 @@ void WebUserContentControllerProxy::addContentRuleList(API::ContentRuleList& con
     auto& data = contentRuleList.compiledRuleList().data();
 
     for (auto& process : m_processes)
-        process.send(Messages::WebUserContentController::AddContentRuleLists({ { data, extensionBaseURL } }), identifier());
+        process.send<Messages::WebUserContentController::AddContentRuleLists>({ identifier() }, Vector { std::pair { data, extensionBaseURL } });
 
     for (auto& process : m_networkProcesses)
         process.send(Messages::NetworkContentRuleListManager::AddContentRuleLists { identifier(), { { data, extensionBaseURL } } }, 0);
@@ -376,7 +376,7 @@ void WebUserContentControllerProxy::removeContentRuleList(const String& name)
     m_contentRuleLists.remove(name);
 
     for (auto& process : m_processes)
-        process.send(Messages::WebUserContentController::RemoveContentRuleList(name), identifier());
+        process.send<Messages::WebUserContentController::RemoveContentRuleList>({ identifier() }, name);
 
     for (auto& process : m_networkProcesses)
         process.send(Messages::NetworkContentRuleListManager::RemoveContentRuleList { identifier(), name }, 0);
@@ -387,7 +387,7 @@ void WebUserContentControllerProxy::removeAllContentRuleLists()
     m_contentRuleLists.clear();
 
     for (auto& process : m_processes)
-        process.send(Messages::WebUserContentController::RemoveAllContentRuleLists(), identifier());
+        process.send<Messages::WebUserContentController::RemoveAllContentRuleLists>({ identifier() });
 
     for (auto& process : m_networkProcesses)
         process.send(Messages::NetworkContentRuleListManager::RemoveAllContentRuleLists { identifier() }, 0);

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -2030,20 +2030,20 @@ void WebProcessProxy::setRemoteWorkerUserAgent(const String& userAgent)
 {
 #if ENABLE(SERVICE_WORKER)
     if (m_serviceWorkerInformation)
-        send(Messages::WebSWContextManagerConnection::SetUserAgent { userAgent }, 0);
+        send<Messages::WebSWContextManagerConnection::SetUserAgent>({ }, userAgent);
 #endif
     if (m_sharedWorkerInformation)
-        send(Messages::WebSharedWorkerContextManagerConnection::SetUserAgent { userAgent }, 0);
+        send<Messages::WebSharedWorkerContextManagerConnection::SetUserAgent>({ }, userAgent);
 }
 
 void WebProcessProxy::updateRemoteWorkerPreferencesStore(const WebPreferencesStore& store)
 {
 #if ENABLE(SERVICE_WORKER)
     if (m_serviceWorkerInformation)
-        send(Messages::WebSWContextManagerConnection::UpdatePreferencesStore { store }, 0);
+        send<Messages::WebSWContextManagerConnection::UpdatePreferencesStore>({ }, store);
 #endif
     if (m_sharedWorkerInformation)
-        send(Messages::WebSharedWorkerContextManagerConnection::UpdatePreferencesStore { store }, 0);
+        send<Messages::WebSharedWorkerContextManagerConnection::UpdatePreferencesStore>({ }, store);
 }
 
 void WebProcessProxy::updateRemoteWorkerProcessAssertion(RemoteWorkerType workerType)
@@ -2160,11 +2160,11 @@ void WebProcessProxy::disableRemoteWorkers(RemoteWorkerType workerType)
     switch (workerType) {
     case RemoteWorkerType::ServiceWorker:
 #if ENABLE(SERVICE_WORKER)
-        send(Messages::WebSWContextManagerConnection::Close { }, 0);
+        send<Messages::WebSWContextManagerConnection::Close>({ });
 #endif
         break;
     case RemoteWorkerType::SharedWorker:
-        send(Messages::WebSharedWorkerContextManagerConnection::Close { }, 0);
+        send<Messages::WebSharedWorkerContextManagerConnection::Close>({ });
         break;
     }
 

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.messages.in
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.messages.in
@@ -22,7 +22,7 @@
 
 #if ENABLE(GPU_PROCESS)
 
-messages -> GPUProcessConnection WantsDispatchMessage {
+messages -> GPUProcessConnection WantsDispatchMessage ModernMessageConstruction {
     DidInitialize(std::optional<WebKit::GPUProcessConnectionInfo> info)
     DidReceiveRemoteCommand(enum:uint8_t WebCore::PlatformMediaSession::RemoteControlCommandType type, struct WebCore::PlatformMediaSession::RemoteCommandArgument argument)
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
@@ -375,15 +375,15 @@ protected:
     void markContextLost();
 
     static inline Seconds defaultSendTimeout = 30_s;
-    template<typename T>
-    WARN_UNUSED_RETURN bool send(T&& message)
+    template<typename T, typename... ArgumentTypes>
+    WARN_UNUSED_RETURN bool send(ArgumentTypes&&... arguments)
     {
-        return m_streamConnection->send(WTFMove(message), m_graphicsContextGLIdentifier, defaultSendTimeout);
+        return m_streamConnection->send<T>({ m_graphicsContextGLIdentifier, defaultSendTimeout }, std::forward<ArgumentTypes>(arguments)...);
     }
-    template<typename T>
-    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
+    template<typename T, typename... ArgumentTypes>
+    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(ArgumentTypes&&... arguments)
     {
-        return m_streamConnection->sendSync(WTFMove(message), m_graphicsContextGLIdentifier, defaultSendTimeout);
+        return m_streamConnection->sendSync<T>({ m_graphicsContextGLIdentifier, defaultSendTimeout }, std::forward<ArgumentTypes>(arguments)...);
     }
 
     GraphicsContextGLIdentifier m_graphicsContextGLIdentifier { GraphicsContextGLIdentifier::generate() };

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
@@ -34,7 +34,7 @@ bool RemoteGraphicsContextGLProxy::moveErrorsToSyntheticErrorList()
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::MoveErrorsToSyntheticErrorList());
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::MoveErrorsToSyntheticErrorList>();
     if (!sendResult) {
         markContextLost();
         return { };
@@ -47,7 +47,7 @@ void RemoteGraphicsContextGLProxy::activeTexture(GCGLenum texture)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::ActiveTexture(texture));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::ActiveTexture>(texture);
     if (!sendResult) {
         markContextLost();
         return;
@@ -58,7 +58,7 @@ void RemoteGraphicsContextGLProxy::attachShader(PlatformGLObject program, Platfo
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::AttachShader(program, shader));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::AttachShader>(program, shader);
     if (!sendResult) {
         markContextLost();
         return;
@@ -69,7 +69,7 @@ void RemoteGraphicsContextGLProxy::bindAttribLocation(PlatformGLObject arg0, GCG
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BindAttribLocation(arg0, index, name));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::BindAttribLocation>(arg0, index, name);
     if (!sendResult) {
         markContextLost();
         return;
@@ -80,7 +80,7 @@ void RemoteGraphicsContextGLProxy::bindBuffer(GCGLenum target, PlatformGLObject 
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BindBuffer(target, arg1));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::BindBuffer>(target, arg1);
     if (!sendResult) {
         markContextLost();
         return;
@@ -91,7 +91,7 @@ void RemoteGraphicsContextGLProxy::bindFramebuffer(GCGLenum target, PlatformGLOb
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BindFramebuffer(target, arg1));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::BindFramebuffer>(target, arg1);
     if (!sendResult) {
         markContextLost();
         return;
@@ -102,7 +102,7 @@ void RemoteGraphicsContextGLProxy::bindRenderbuffer(GCGLenum target, PlatformGLO
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BindRenderbuffer(target, arg1));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::BindRenderbuffer>(target, arg1);
     if (!sendResult) {
         markContextLost();
         return;
@@ -113,7 +113,7 @@ void RemoteGraphicsContextGLProxy::bindTexture(GCGLenum target, PlatformGLObject
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BindTexture(target, arg1));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::BindTexture>(target, arg1);
     if (!sendResult) {
         markContextLost();
         return;
@@ -124,7 +124,7 @@ void RemoteGraphicsContextGLProxy::blendColor(GCGLclampf red, GCGLclampf green, 
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendColor(red, green, blue, alpha));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::BlendColor>(red, green, blue, alpha);
     if (!sendResult) {
         markContextLost();
         return;
@@ -135,7 +135,7 @@ void RemoteGraphicsContextGLProxy::blendEquation(GCGLenum mode)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendEquation(mode));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::BlendEquation>(mode);
     if (!sendResult) {
         markContextLost();
         return;
@@ -146,7 +146,7 @@ void RemoteGraphicsContextGLProxy::blendEquationSeparate(GCGLenum modeRGB, GCGLe
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendEquationSeparate(modeRGB, modeAlpha));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::BlendEquationSeparate>(modeRGB, modeAlpha);
     if (!sendResult) {
         markContextLost();
         return;
@@ -157,7 +157,7 @@ void RemoteGraphicsContextGLProxy::blendFunc(GCGLenum sfactor, GCGLenum dfactor)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendFunc(sfactor, dfactor));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::BlendFunc>(sfactor, dfactor);
     if (!sendResult) {
         markContextLost();
         return;
@@ -168,7 +168,7 @@ void RemoteGraphicsContextGLProxy::blendFuncSeparate(GCGLenum srcRGB, GCGLenum d
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendFuncSeparate(srcRGB, dstRGB, srcAlpha, dstAlpha));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::BlendFuncSeparate>(srcRGB, dstRGB, srcAlpha, dstAlpha);
     if (!sendResult) {
         markContextLost();
         return;
@@ -179,7 +179,7 @@ GCGLenum RemoteGraphicsContextGLProxy::checkFramebufferStatus(GCGLenum target)
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CheckFramebufferStatus(target));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::CheckFramebufferStatus>(target);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -192,7 +192,7 @@ void RemoteGraphicsContextGLProxy::clear(GCGLbitfield mask)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Clear(mask));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::Clear>(mask);
     if (!sendResult) {
         markContextLost();
         return;
@@ -203,7 +203,7 @@ void RemoteGraphicsContextGLProxy::clearColor(GCGLclampf red, GCGLclampf green, 
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearColor(red, green, blue, alpha));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::ClearColor>(red, green, blue, alpha);
     if (!sendResult) {
         markContextLost();
         return;
@@ -214,7 +214,7 @@ void RemoteGraphicsContextGLProxy::clearDepth(GCGLclampf depth)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearDepth(depth));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::ClearDepth>(depth);
     if (!sendResult) {
         markContextLost();
         return;
@@ -225,7 +225,7 @@ void RemoteGraphicsContextGLProxy::clearStencil(GCGLint s)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearStencil(s));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::ClearStencil>(s);
     if (!sendResult) {
         markContextLost();
         return;
@@ -236,7 +236,7 @@ void RemoteGraphicsContextGLProxy::colorMask(GCGLboolean red, GCGLboolean green,
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::ColorMask(static_cast<bool>(red), static_cast<bool>(green), static_cast<bool>(blue), static_cast<bool>(alpha)));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::ColorMask>(static_cast<bool>(red), static_cast<bool>(green), static_cast<bool>(blue), static_cast<bool>(alpha));
     if (!sendResult) {
         markContextLost();
         return;
@@ -247,7 +247,7 @@ void RemoteGraphicsContextGLProxy::compileShader(PlatformGLObject arg0)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::CompileShader(arg0));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::CompileShader>(arg0);
     if (!sendResult) {
         markContextLost();
         return;
@@ -258,7 +258,7 @@ void RemoteGraphicsContextGLProxy::copyTexImage2D(GCGLenum target, GCGLint level
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::CopyTexImage2D(target, level, internalformat, x, y, width, height, border));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::CopyTexImage2D>(target, level, internalformat, x, y, width, height, border);
     if (!sendResult) {
         markContextLost();
         return;
@@ -269,7 +269,7 @@ void RemoteGraphicsContextGLProxy::copyTexSubImage2D(GCGLenum target, GCGLint le
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::CopyTexSubImage2D(target, level, xoffset, yoffset, x, y, width, height));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::CopyTexSubImage2D>(target, level, xoffset, yoffset, x, y, width, height);
     if (!sendResult) {
         markContextLost();
         return;
@@ -280,7 +280,7 @@ PlatformGLObject RemoteGraphicsContextGLProxy::createBuffer()
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateBuffer());
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::CreateBuffer>();
     if (!sendResult) {
         markContextLost();
         return { };
@@ -293,7 +293,7 @@ PlatformGLObject RemoteGraphicsContextGLProxy::createFramebuffer()
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateFramebuffer());
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::CreateFramebuffer>();
     if (!sendResult) {
         markContextLost();
         return { };
@@ -306,7 +306,7 @@ PlatformGLObject RemoteGraphicsContextGLProxy::createProgram()
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateProgram());
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::CreateProgram>();
     if (!sendResult) {
         markContextLost();
         return { };
@@ -319,7 +319,7 @@ PlatformGLObject RemoteGraphicsContextGLProxy::createRenderbuffer()
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateRenderbuffer());
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::CreateRenderbuffer>();
     if (!sendResult) {
         markContextLost();
         return { };
@@ -332,7 +332,7 @@ PlatformGLObject RemoteGraphicsContextGLProxy::createShader(GCGLenum arg0)
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateShader(arg0));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::CreateShader>(arg0);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -345,7 +345,7 @@ PlatformGLObject RemoteGraphicsContextGLProxy::createTexture()
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateTexture());
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::CreateTexture>();
     if (!sendResult) {
         markContextLost();
         return { };
@@ -358,7 +358,7 @@ void RemoteGraphicsContextGLProxy::cullFace(GCGLenum mode)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::CullFace(mode));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::CullFace>(mode);
     if (!sendResult) {
         markContextLost();
         return;
@@ -369,7 +369,7 @@ void RemoteGraphicsContextGLProxy::deleteBuffer(PlatformGLObject arg0)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteBuffer(arg0));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::DeleteBuffer>(arg0);
     if (!sendResult) {
         markContextLost();
         return;
@@ -380,7 +380,7 @@ void RemoteGraphicsContextGLProxy::deleteFramebuffer(PlatformGLObject arg0)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteFramebuffer(arg0));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::DeleteFramebuffer>(arg0);
     if (!sendResult) {
         markContextLost();
         return;
@@ -391,7 +391,7 @@ void RemoteGraphicsContextGLProxy::deleteProgram(PlatformGLObject arg0)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteProgram(arg0));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::DeleteProgram>(arg0);
     if (!sendResult) {
         markContextLost();
         return;
@@ -402,7 +402,7 @@ void RemoteGraphicsContextGLProxy::deleteRenderbuffer(PlatformGLObject arg0)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteRenderbuffer(arg0));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::DeleteRenderbuffer>(arg0);
     if (!sendResult) {
         markContextLost();
         return;
@@ -413,7 +413,7 @@ void RemoteGraphicsContextGLProxy::deleteShader(PlatformGLObject arg0)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteShader(arg0));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::DeleteShader>(arg0);
     if (!sendResult) {
         markContextLost();
         return;
@@ -424,7 +424,7 @@ void RemoteGraphicsContextGLProxy::deleteTexture(PlatformGLObject arg0)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteTexture(arg0));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::DeleteTexture>(arg0);
     if (!sendResult) {
         markContextLost();
         return;
@@ -435,7 +435,7 @@ void RemoteGraphicsContextGLProxy::depthFunc(GCGLenum func)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DepthFunc(func));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::DepthFunc>(func);
     if (!sendResult) {
         markContextLost();
         return;
@@ -446,7 +446,7 @@ void RemoteGraphicsContextGLProxy::depthMask(GCGLboolean flag)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DepthMask(static_cast<bool>(flag)));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::DepthMask>(static_cast<bool>(flag));
     if (!sendResult) {
         markContextLost();
         return;
@@ -457,7 +457,7 @@ void RemoteGraphicsContextGLProxy::depthRange(GCGLclampf zNear, GCGLclampf zFar)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DepthRange(zNear, zFar));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::DepthRange>(zNear, zFar);
     if (!sendResult) {
         markContextLost();
         return;
@@ -468,7 +468,7 @@ void RemoteGraphicsContextGLProxy::detachShader(PlatformGLObject arg0, PlatformG
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DetachShader(arg0, arg1));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::DetachShader>(arg0, arg1);
     if (!sendResult) {
         markContextLost();
         return;
@@ -479,7 +479,7 @@ void RemoteGraphicsContextGLProxy::disable(GCGLenum cap)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Disable(cap));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::Disable>(cap);
     if (!sendResult) {
         markContextLost();
         return;
@@ -490,7 +490,7 @@ void RemoteGraphicsContextGLProxy::disableVertexAttribArray(GCGLuint index)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DisableVertexAttribArray(index));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::DisableVertexAttribArray>(index);
     if (!sendResult) {
         markContextLost();
         return;
@@ -501,7 +501,7 @@ void RemoteGraphicsContextGLProxy::drawArrays(GCGLenum mode, GCGLint first, GCGL
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawArrays(mode, first, count));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::DrawArrays>(mode, first, count);
     if (!sendResult) {
         markContextLost();
         return;
@@ -512,7 +512,7 @@ void RemoteGraphicsContextGLProxy::drawElements(GCGLenum mode, GCGLsizei count, 
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawElements(mode, count, type, static_cast<uint64_t>(offset)));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::DrawElements>(mode, count, type, static_cast<uint64_t>(offset));
     if (!sendResult) {
         markContextLost();
         return;
@@ -523,7 +523,7 @@ void RemoteGraphicsContextGLProxy::enable(GCGLenum cap)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Enable(cap));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::Enable>(cap);
     if (!sendResult) {
         markContextLost();
         return;
@@ -534,7 +534,7 @@ void RemoteGraphicsContextGLProxy::enableVertexAttribArray(GCGLuint index)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::EnableVertexAttribArray(index));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::EnableVertexAttribArray>(index);
     if (!sendResult) {
         markContextLost();
         return;
@@ -545,7 +545,7 @@ void RemoteGraphicsContextGLProxy::finish()
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Finish());
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::Finish>();
     if (!sendResult) {
         markContextLost();
         return;
@@ -556,7 +556,7 @@ void RemoteGraphicsContextGLProxy::flush()
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Flush());
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::Flush>();
     if (!sendResult) {
         markContextLost();
         return;
@@ -567,7 +567,7 @@ void RemoteGraphicsContextGLProxy::framebufferRenderbuffer(GCGLenum target, GCGL
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::FramebufferRenderbuffer(target, attachment, renderbuffertarget, arg3));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::FramebufferRenderbuffer>(target, attachment, renderbuffertarget, arg3);
     if (!sendResult) {
         markContextLost();
         return;
@@ -578,7 +578,7 @@ void RemoteGraphicsContextGLProxy::framebufferTexture2D(GCGLenum target, GCGLenu
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::FramebufferTexture2D(target, attachment, textarget, arg3, level));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::FramebufferTexture2D>(target, attachment, textarget, arg3, level);
     if (!sendResult) {
         markContextLost();
         return;
@@ -589,7 +589,7 @@ void RemoteGraphicsContextGLProxy::frontFace(GCGLenum mode)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::FrontFace(mode));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::FrontFace>(mode);
     if (!sendResult) {
         markContextLost();
         return;
@@ -600,7 +600,7 @@ void RemoteGraphicsContextGLProxy::generateMipmap(GCGLenum target)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::GenerateMipmap(target));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::GenerateMipmap>(target);
     if (!sendResult) {
         markContextLost();
         return;
@@ -611,7 +611,7 @@ bool RemoteGraphicsContextGLProxy::getActiveAttrib(PlatformGLObject program, GCG
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetActiveAttrib(program, index));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetActiveAttrib>(program, index);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -625,7 +625,7 @@ bool RemoteGraphicsContextGLProxy::getActiveUniform(PlatformGLObject program, GC
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetActiveUniform(program, index));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetActiveUniform>(program, index);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -639,7 +639,7 @@ GCGLint RemoteGraphicsContextGLProxy::getAttribLocation(PlatformGLObject arg0, c
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetAttribLocation(arg0, name));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetAttribLocation>(arg0, name);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -652,7 +652,7 @@ GCGLint RemoteGraphicsContextGLProxy::getBufferParameteri(GCGLenum target, GCGLe
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetBufferParameteri(target, pname));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetBufferParameteri>(target, pname);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -665,7 +665,7 @@ String RemoteGraphicsContextGLProxy::getString(GCGLenum name)
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetString(name));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetString>(name);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -678,7 +678,7 @@ void RemoteGraphicsContextGLProxy::getFloatv(GCGLenum pname, GCGLSpan<GCGLfloat>
 {
     if (isContextLost())
         return;
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetFloatv(pname, value.size()));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetFloatv>(pname, value.size());
     if (!sendResult) {
         markContextLost();
         return;
@@ -691,7 +691,7 @@ void RemoteGraphicsContextGLProxy::getIntegerv(GCGLenum pname, GCGLSpan<GCGLint>
 {
     if (isContextLost())
         return;
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetIntegerv(pname, value.size()));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetIntegerv>(pname, value.size());
     if (!sendResult) {
         markContextLost();
         return;
@@ -704,7 +704,7 @@ void RemoteGraphicsContextGLProxy::getIntegeri_v(GCGLenum pname, GCGLuint index,
 {
     if (isContextLost())
         return;
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetIntegeri_v(pname, index));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetIntegeri_v>(pname, index);
     if (!sendResult) {
         markContextLost();
         return;
@@ -717,7 +717,7 @@ GCGLint64 RemoteGraphicsContextGLProxy::getInteger64(GCGLenum pname)
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetInteger64(pname));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetInteger64>(pname);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -730,7 +730,7 @@ GCGLint64 RemoteGraphicsContextGLProxy::getInteger64i(GCGLenum pname, GCGLuint i
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetInteger64i(pname, index));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetInteger64i>(pname, index);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -743,7 +743,7 @@ GCGLint RemoteGraphicsContextGLProxy::getProgrami(PlatformGLObject program, GCGL
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetProgrami(program, pname));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetProgrami>(program, pname);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -756,7 +756,7 @@ void RemoteGraphicsContextGLProxy::getBooleanv(GCGLenum pname, GCGLSpan<GCGLbool
 {
     if (isContextLost())
         return;
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetBooleanv(pname, value.size()));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetBooleanv>(pname, value.size());
     if (!sendResult) {
         markContextLost();
         return;
@@ -769,7 +769,7 @@ GCGLint RemoteGraphicsContextGLProxy::getFramebufferAttachmentParameteri(GCGLenu
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetFramebufferAttachmentParameteri(target, attachment, pname));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetFramebufferAttachmentParameteri>(target, attachment, pname);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -782,7 +782,7 @@ String RemoteGraphicsContextGLProxy::getProgramInfoLog(PlatformGLObject arg0)
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetProgramInfoLog(arg0));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetProgramInfoLog>(arg0);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -795,7 +795,7 @@ GCGLint RemoteGraphicsContextGLProxy::getRenderbufferParameteri(GCGLenum target,
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetRenderbufferParameteri(target, pname));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetRenderbufferParameteri>(target, pname);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -808,7 +808,7 @@ GCGLint RemoteGraphicsContextGLProxy::getShaderi(PlatformGLObject arg0, GCGLenum
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetShaderi(arg0, pname));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetShaderi>(arg0, pname);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -821,7 +821,7 @@ String RemoteGraphicsContextGLProxy::getShaderInfoLog(PlatformGLObject arg0)
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetShaderInfoLog(arg0));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetShaderInfoLog>(arg0);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -834,7 +834,7 @@ void RemoteGraphicsContextGLProxy::getShaderPrecisionFormat(GCGLenum shaderType,
 {
     if (isContextLost())
         return;
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetShaderPrecisionFormat(shaderType, precisionType));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetShaderPrecisionFormat>(shaderType, precisionType);
     if (!sendResult) {
         markContextLost();
         return;
@@ -849,7 +849,7 @@ String RemoteGraphicsContextGLProxy::getShaderSource(PlatformGLObject arg0)
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetShaderSource(arg0));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetShaderSource>(arg0);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -862,7 +862,7 @@ GCGLfloat RemoteGraphicsContextGLProxy::getTexParameterf(GCGLenum target, GCGLen
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetTexParameterf(target, pname));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetTexParameterf>(target, pname);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -875,7 +875,7 @@ GCGLint RemoteGraphicsContextGLProxy::getTexParameteri(GCGLenum target, GCGLenum
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetTexParameteri(target, pname));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetTexParameteri>(target, pname);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -888,7 +888,7 @@ void RemoteGraphicsContextGLProxy::getUniformfv(PlatformGLObject program, GCGLin
 {
     if (isContextLost())
         return;
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetUniformfv(program, location, value.size()));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetUniformfv>(program, location, value.size());
     if (!sendResult) {
         markContextLost();
         return;
@@ -901,7 +901,7 @@ void RemoteGraphicsContextGLProxy::getUniformiv(PlatformGLObject program, GCGLin
 {
     if (isContextLost())
         return;
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetUniformiv(program, location, value.size()));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetUniformiv>(program, location, value.size());
     if (!sendResult) {
         markContextLost();
         return;
@@ -914,7 +914,7 @@ void RemoteGraphicsContextGLProxy::getUniformuiv(PlatformGLObject program, GCGLi
 {
     if (isContextLost())
         return;
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetUniformuiv(program, location, value.size()));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetUniformuiv>(program, location, value.size());
     if (!sendResult) {
         markContextLost();
         return;
@@ -927,7 +927,7 @@ GCGLint RemoteGraphicsContextGLProxy::getUniformLocation(PlatformGLObject arg0, 
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetUniformLocation(arg0, name));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetUniformLocation>(arg0, name);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -940,7 +940,7 @@ GCGLsizeiptr RemoteGraphicsContextGLProxy::getVertexAttribOffset(GCGLuint index,
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetVertexAttribOffset(index, pname));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetVertexAttribOffset>(index, pname);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -953,7 +953,7 @@ void RemoteGraphicsContextGLProxy::hint(GCGLenum target, GCGLenum mode)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Hint(target, mode));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::Hint>(target, mode);
     if (!sendResult) {
         markContextLost();
         return;
@@ -964,7 +964,7 @@ GCGLboolean RemoteGraphicsContextGLProxy::isBuffer(PlatformGLObject arg0)
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsBuffer(arg0));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::IsBuffer>(arg0);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -977,7 +977,7 @@ GCGLboolean RemoteGraphicsContextGLProxy::isEnabled(GCGLenum cap)
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsEnabled(cap));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::IsEnabled>(cap);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -990,7 +990,7 @@ GCGLboolean RemoteGraphicsContextGLProxy::isFramebuffer(PlatformGLObject arg0)
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsFramebuffer(arg0));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::IsFramebuffer>(arg0);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -1003,7 +1003,7 @@ GCGLboolean RemoteGraphicsContextGLProxy::isProgram(PlatformGLObject arg0)
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsProgram(arg0));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::IsProgram>(arg0);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -1016,7 +1016,7 @@ GCGLboolean RemoteGraphicsContextGLProxy::isRenderbuffer(PlatformGLObject arg0)
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsRenderbuffer(arg0));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::IsRenderbuffer>(arg0);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -1029,7 +1029,7 @@ GCGLboolean RemoteGraphicsContextGLProxy::isShader(PlatformGLObject arg0)
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsShader(arg0));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::IsShader>(arg0);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -1042,7 +1042,7 @@ GCGLboolean RemoteGraphicsContextGLProxy::isTexture(PlatformGLObject arg0)
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsTexture(arg0));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::IsTexture>(arg0);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -1055,7 +1055,7 @@ void RemoteGraphicsContextGLProxy::lineWidth(GCGLfloat arg0)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::LineWidth(arg0));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::LineWidth>(arg0);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1066,7 +1066,7 @@ void RemoteGraphicsContextGLProxy::linkProgram(PlatformGLObject arg0)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::LinkProgram(arg0));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::LinkProgram>(arg0);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1077,7 +1077,7 @@ void RemoteGraphicsContextGLProxy::pixelStorei(GCGLenum pname, GCGLint param)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::PixelStorei(pname, param));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::PixelStorei>(pname, param);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1088,7 +1088,7 @@ void RemoteGraphicsContextGLProxy::polygonOffset(GCGLfloat factor, GCGLfloat uni
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::PolygonOffset(factor, units));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::PolygonOffset>(factor, units);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1099,7 +1099,7 @@ void RemoteGraphicsContextGLProxy::renderbufferStorage(GCGLenum target, GCGLenum
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::RenderbufferStorage(target, internalformat, width, height));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::RenderbufferStorage>(target, internalformat, width, height);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1110,7 +1110,7 @@ void RemoteGraphicsContextGLProxy::sampleCoverage(GCGLclampf value, GCGLboolean 
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::SampleCoverage(value, static_cast<bool>(invert)));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::SampleCoverage>(value, static_cast<bool>(invert));
     if (!sendResult) {
         markContextLost();
         return;
@@ -1121,7 +1121,7 @@ void RemoteGraphicsContextGLProxy::scissor(GCGLint x, GCGLint y, GCGLsizei width
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Scissor(x, y, width, height));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::Scissor>(x, y, width, height);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1132,7 +1132,7 @@ void RemoteGraphicsContextGLProxy::shaderSource(PlatformGLObject arg0, const Str
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::ShaderSource(arg0, arg1));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::ShaderSource>(arg0, arg1);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1143,7 +1143,7 @@ void RemoteGraphicsContextGLProxy::stencilFunc(GCGLenum func, GCGLint ref, GCGLu
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::StencilFunc(func, ref, mask));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::StencilFunc>(func, ref, mask);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1154,7 +1154,7 @@ void RemoteGraphicsContextGLProxy::stencilFuncSeparate(GCGLenum face, GCGLenum f
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::StencilFuncSeparate(face, func, ref, mask));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::StencilFuncSeparate>(face, func, ref, mask);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1165,7 +1165,7 @@ void RemoteGraphicsContextGLProxy::stencilMask(GCGLuint mask)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::StencilMask(mask));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::StencilMask>(mask);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1176,7 +1176,7 @@ void RemoteGraphicsContextGLProxy::stencilMaskSeparate(GCGLenum face, GCGLuint m
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::StencilMaskSeparate(face, mask));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::StencilMaskSeparate>(face, mask);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1187,7 +1187,7 @@ void RemoteGraphicsContextGLProxy::stencilOp(GCGLenum fail, GCGLenum zfail, GCGL
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::StencilOp(fail, zfail, zpass));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::StencilOp>(fail, zfail, zpass);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1198,7 +1198,7 @@ void RemoteGraphicsContextGLProxy::stencilOpSeparate(GCGLenum face, GCGLenum fai
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::StencilOpSeparate(face, fail, zfail, zpass));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::StencilOpSeparate>(face, fail, zfail, zpass);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1209,7 +1209,7 @@ void RemoteGraphicsContextGLProxy::texParameterf(GCGLenum target, GCGLenum pname
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::TexParameterf(target, pname, param));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::TexParameterf>(target, pname, param);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1220,7 +1220,7 @@ void RemoteGraphicsContextGLProxy::texParameteri(GCGLenum target, GCGLenum pname
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::TexParameteri(target, pname, param));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::TexParameteri>(target, pname, param);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1231,7 +1231,7 @@ void RemoteGraphicsContextGLProxy::uniform1f(GCGLint location, GCGLfloat x)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform1f(location, x));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::Uniform1f>(location, x);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1242,7 +1242,7 @@ void RemoteGraphicsContextGLProxy::uniform1fv(GCGLint location, GCGLSpan<const G
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform1fv(location, IPC::ArrayReference<float>(reinterpret_cast<const float*>(v.data()), v.size())));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::Uniform1fv>(location, IPC::ArrayReference<float>(reinterpret_cast<const float*>(v.data()), v.size()));
     if (!sendResult) {
         markContextLost();
         return;
@@ -1253,7 +1253,7 @@ void RemoteGraphicsContextGLProxy::uniform1i(GCGLint location, GCGLint x)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform1i(location, x));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::Uniform1i>(location, x);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1264,7 +1264,7 @@ void RemoteGraphicsContextGLProxy::uniform1iv(GCGLint location, GCGLSpan<const G
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform1iv(location, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(v.data()), v.size())));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::Uniform1iv>(location, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(v.data()), v.size()));
     if (!sendResult) {
         markContextLost();
         return;
@@ -1275,7 +1275,7 @@ void RemoteGraphicsContextGLProxy::uniform2f(GCGLint location, GCGLfloat x, GCGL
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform2f(location, x, y));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::Uniform2f>(location, x, y);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1286,7 +1286,7 @@ void RemoteGraphicsContextGLProxy::uniform2fv(GCGLint location, GCGLSpan<const G
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform2fv(location, IPC::ArrayReference<float>(reinterpret_cast<const float*>(v.data()), v.size())));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::Uniform2fv>(location, IPC::ArrayReference<float>(reinterpret_cast<const float*>(v.data()), v.size()));
     if (!sendResult) {
         markContextLost();
         return;
@@ -1297,7 +1297,7 @@ void RemoteGraphicsContextGLProxy::uniform2i(GCGLint location, GCGLint x, GCGLin
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform2i(location, x, y));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::Uniform2i>(location, x, y);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1308,7 +1308,7 @@ void RemoteGraphicsContextGLProxy::uniform2iv(GCGLint location, GCGLSpan<const G
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform2iv(location, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(v.data()), v.size())));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::Uniform2iv>(location, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(v.data()), v.size()));
     if (!sendResult) {
         markContextLost();
         return;
@@ -1319,7 +1319,7 @@ void RemoteGraphicsContextGLProxy::uniform3f(GCGLint location, GCGLfloat x, GCGL
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform3f(location, x, y, z));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::Uniform3f>(location, x, y, z);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1330,7 +1330,7 @@ void RemoteGraphicsContextGLProxy::uniform3fv(GCGLint location, GCGLSpan<const G
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform3fv(location, IPC::ArrayReference<float>(reinterpret_cast<const float*>(v.data()), v.size())));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::Uniform3fv>(location, IPC::ArrayReference<float>(reinterpret_cast<const float*>(v.data()), v.size()));
     if (!sendResult) {
         markContextLost();
         return;
@@ -1341,7 +1341,7 @@ void RemoteGraphicsContextGLProxy::uniform3i(GCGLint location, GCGLint x, GCGLin
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform3i(location, x, y, z));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::Uniform3i>(location, x, y, z);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1352,7 +1352,7 @@ void RemoteGraphicsContextGLProxy::uniform3iv(GCGLint location, GCGLSpan<const G
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform3iv(location, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(v.data()), v.size())));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::Uniform3iv>(location, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(v.data()), v.size()));
     if (!sendResult) {
         markContextLost();
         return;
@@ -1363,7 +1363,7 @@ void RemoteGraphicsContextGLProxy::uniform4f(GCGLint location, GCGLfloat x, GCGL
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform4f(location, x, y, z, w));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::Uniform4f>(location, x, y, z, w);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1374,7 +1374,7 @@ void RemoteGraphicsContextGLProxy::uniform4fv(GCGLint location, GCGLSpan<const G
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform4fv(location, IPC::ArrayReference<float>(reinterpret_cast<const float*>(v.data()), v.size())));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::Uniform4fv>(location, IPC::ArrayReference<float>(reinterpret_cast<const float*>(v.data()), v.size()));
     if (!sendResult) {
         markContextLost();
         return;
@@ -1385,7 +1385,7 @@ void RemoteGraphicsContextGLProxy::uniform4i(GCGLint location, GCGLint x, GCGLin
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform4i(location, x, y, z, w));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::Uniform4i>(location, x, y, z, w);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1396,7 +1396,7 @@ void RemoteGraphicsContextGLProxy::uniform4iv(GCGLint location, GCGLSpan<const G
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform4iv(location, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(v.data()), v.size())));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::Uniform4iv>(location, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(v.data()), v.size()));
     if (!sendResult) {
         markContextLost();
         return;
@@ -1407,7 +1407,7 @@ void RemoteGraphicsContextGLProxy::uniformMatrix2fv(GCGLint location, GCGLboolea
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix2fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(value.data()), value.size())));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::UniformMatrix2fv>(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(value.data()), value.size()));
     if (!sendResult) {
         markContextLost();
         return;
@@ -1418,7 +1418,7 @@ void RemoteGraphicsContextGLProxy::uniformMatrix3fv(GCGLint location, GCGLboolea
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix3fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(value.data()), value.size())));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::UniformMatrix3fv>(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(value.data()), value.size()));
     if (!sendResult) {
         markContextLost();
         return;
@@ -1429,7 +1429,7 @@ void RemoteGraphicsContextGLProxy::uniformMatrix4fv(GCGLint location, GCGLboolea
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix4fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(value.data()), value.size())));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::UniformMatrix4fv>(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(value.data()), value.size()));
     if (!sendResult) {
         markContextLost();
         return;
@@ -1440,7 +1440,7 @@ void RemoteGraphicsContextGLProxy::useProgram(PlatformGLObject arg0)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::UseProgram(arg0));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::UseProgram>(arg0);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1451,7 +1451,7 @@ void RemoteGraphicsContextGLProxy::validateProgram(PlatformGLObject arg0)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::ValidateProgram(arg0));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::ValidateProgram>(arg0);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1462,7 +1462,7 @@ void RemoteGraphicsContextGLProxy::vertexAttrib1f(GCGLuint index, GCGLfloat x)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib1f(index, x));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::VertexAttrib1f>(index, x);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1473,7 +1473,7 @@ void RemoteGraphicsContextGLProxy::vertexAttrib1fv(GCGLuint index, GCGLSpan<cons
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib1fv(index, IPC::ArrayReference<float, 1>(reinterpret_cast<const float*>(values.data()), values.size())));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::VertexAttrib1fv>(index, IPC::ArrayReference<float, 1>(reinterpret_cast<const float*>(values.data()), values.size()));
     if (!sendResult) {
         markContextLost();
         return;
@@ -1484,7 +1484,7 @@ void RemoteGraphicsContextGLProxy::vertexAttrib2f(GCGLuint index, GCGLfloat x, G
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib2f(index, x, y));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::VertexAttrib2f>(index, x, y);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1495,7 +1495,7 @@ void RemoteGraphicsContextGLProxy::vertexAttrib2fv(GCGLuint index, GCGLSpan<cons
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib2fv(index, IPC::ArrayReference<float, 2>(reinterpret_cast<const float*>(values.data()), values.size())));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::VertexAttrib2fv>(index, IPC::ArrayReference<float, 2>(reinterpret_cast<const float*>(values.data()), values.size()));
     if (!sendResult) {
         markContextLost();
         return;
@@ -1506,7 +1506,7 @@ void RemoteGraphicsContextGLProxy::vertexAttrib3f(GCGLuint index, GCGLfloat x, G
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib3f(index, x, y, z));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::VertexAttrib3f>(index, x, y, z);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1517,7 +1517,7 @@ void RemoteGraphicsContextGLProxy::vertexAttrib3fv(GCGLuint index, GCGLSpan<cons
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib3fv(index, IPC::ArrayReference<float, 3>(reinterpret_cast<const float*>(values.data()), values.size())));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::VertexAttrib3fv>(index, IPC::ArrayReference<float, 3>(reinterpret_cast<const float*>(values.data()), values.size()));
     if (!sendResult) {
         markContextLost();
         return;
@@ -1528,7 +1528,7 @@ void RemoteGraphicsContextGLProxy::vertexAttrib4f(GCGLuint index, GCGLfloat x, G
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib4f(index, x, y, z, w));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::VertexAttrib4f>(index, x, y, z, w);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1539,7 +1539,7 @@ void RemoteGraphicsContextGLProxy::vertexAttrib4fv(GCGLuint index, GCGLSpan<cons
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib4fv(index, IPC::ArrayReference<float, 4>(reinterpret_cast<const float*>(values.data()), values.size())));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::VertexAttrib4fv>(index, IPC::ArrayReference<float, 4>(reinterpret_cast<const float*>(values.data()), values.size()));
     if (!sendResult) {
         markContextLost();
         return;
@@ -1550,7 +1550,7 @@ void RemoteGraphicsContextGLProxy::vertexAttribPointer(GCGLuint index, GCGLint s
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttribPointer(index, size, type, static_cast<bool>(normalized), stride, static_cast<uint64_t>(offset)));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::VertexAttribPointer>(index, size, type, static_cast<bool>(normalized), stride, static_cast<uint64_t>(offset));
     if (!sendResult) {
         markContextLost();
         return;
@@ -1561,7 +1561,7 @@ void RemoteGraphicsContextGLProxy::viewport(GCGLint x, GCGLint y, GCGLsizei widt
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Viewport(x, y, width, height));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::Viewport>(x, y, width, height);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1572,7 +1572,7 @@ void RemoteGraphicsContextGLProxy::bufferData(GCGLenum target, GCGLsizeiptr arg1
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BufferData0(target, static_cast<uint64_t>(arg1), usage));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::BufferData0>(target, static_cast<uint64_t>(arg1), usage);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1583,7 +1583,7 @@ void RemoteGraphicsContextGLProxy::bufferData(GCGLenum target, GCGLSpan<const GC
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BufferData1(target, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size()), usage));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::BufferData1>(target, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size()), usage);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1594,7 +1594,7 @@ void RemoteGraphicsContextGLProxy::bufferSubData(GCGLenum target, GCGLintptr off
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BufferSubData(target, static_cast<uint64_t>(offset), IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size())));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::BufferSubData>(target, static_cast<uint64_t>(offset), IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size()));
     if (!sendResult) {
         markContextLost();
         return;
@@ -1605,7 +1605,7 @@ void RemoteGraphicsContextGLProxy::texImage2D(GCGLenum target, GCGLint level, GC
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::TexImage2D0(target, level, internalformat, width, height, border, format, type, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(pixels.data()), pixels.size())));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::TexImage2D0>(target, level, internalformat, width, height, border, format, type, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(pixels.data()), pixels.size()));
     if (!sendResult) {
         markContextLost();
         return;
@@ -1616,7 +1616,7 @@ void RemoteGraphicsContextGLProxy::texImage2D(GCGLenum target, GCGLint level, GC
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::TexImage2D1(target, level, internalformat, width, height, border, format, type, static_cast<uint64_t>(offset)));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::TexImage2D1>(target, level, internalformat, width, height, border, format, type, static_cast<uint64_t>(offset));
     if (!sendResult) {
         markContextLost();
         return;
@@ -1627,7 +1627,7 @@ void RemoteGraphicsContextGLProxy::texSubImage2D(GCGLenum target, GCGLint level,
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::TexSubImage2D0(target, level, xoffset, yoffset, width, height, format, type, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(pixels.data()), pixels.size())));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::TexSubImage2D0>(target, level, xoffset, yoffset, width, height, format, type, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(pixels.data()), pixels.size()));
     if (!sendResult) {
         markContextLost();
         return;
@@ -1638,7 +1638,7 @@ void RemoteGraphicsContextGLProxy::texSubImage2D(GCGLenum target, GCGLint level,
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::TexSubImage2D1(target, level, xoffset, yoffset, width, height, format, type, static_cast<uint64_t>(offset)));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::TexSubImage2D1>(target, level, xoffset, yoffset, width, height, format, type, static_cast<uint64_t>(offset));
     if (!sendResult) {
         markContextLost();
         return;
@@ -1649,7 +1649,7 @@ void RemoteGraphicsContextGLProxy::compressedTexImage2D(GCGLenum target, GCGLint
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexImage2D0(target, level, internalformat, width, height, border, imageSize, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size())));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::CompressedTexImage2D0>(target, level, internalformat, width, height, border, imageSize, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size()));
     if (!sendResult) {
         markContextLost();
         return;
@@ -1660,7 +1660,7 @@ void RemoteGraphicsContextGLProxy::compressedTexImage2D(GCGLenum target, GCGLint
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexImage2D1(target, level, internalformat, width, height, border, imageSize, static_cast<uint64_t>(offset)));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::CompressedTexImage2D1>(target, level, internalformat, width, height, border, imageSize, static_cast<uint64_t>(offset));
     if (!sendResult) {
         markContextLost();
         return;
@@ -1671,7 +1671,7 @@ void RemoteGraphicsContextGLProxy::compressedTexSubImage2D(GCGLenum target, GCGL
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexSubImage2D0(target, level, xoffset, yoffset, width, height, format, imageSize, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size())));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::CompressedTexSubImage2D0>(target, level, xoffset, yoffset, width, height, format, imageSize, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size()));
     if (!sendResult) {
         markContextLost();
         return;
@@ -1682,7 +1682,7 @@ void RemoteGraphicsContextGLProxy::compressedTexSubImage2D(GCGLenum target, GCGL
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexSubImage2D1(target, level, xoffset, yoffset, width, height, format, imageSize, static_cast<uint64_t>(offset)));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::CompressedTexSubImage2D1>(target, level, xoffset, yoffset, width, height, format, imageSize, static_cast<uint64_t>(offset));
     if (!sendResult) {
         markContextLost();
         return;
@@ -1693,7 +1693,7 @@ void RemoteGraphicsContextGLProxy::drawArraysInstanced(GCGLenum mode, GCGLint fi
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawArraysInstanced(mode, first, count, primcount));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::DrawArraysInstanced>(mode, first, count, primcount);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1704,7 +1704,7 @@ void RemoteGraphicsContextGLProxy::drawElementsInstanced(GCGLenum mode, GCGLsize
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawElementsInstanced(mode, count, type, static_cast<uint64_t>(offset), primcount));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::DrawElementsInstanced>(mode, count, type, static_cast<uint64_t>(offset), primcount);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1715,7 +1715,7 @@ void RemoteGraphicsContextGLProxy::vertexAttribDivisor(GCGLuint index, GCGLuint 
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttribDivisor(index, divisor));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::VertexAttribDivisor>(index, divisor);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1726,7 +1726,7 @@ PlatformGLObject RemoteGraphicsContextGLProxy::createVertexArray()
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateVertexArray());
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::CreateVertexArray>();
     if (!sendResult) {
         markContextLost();
         return { };
@@ -1739,7 +1739,7 @@ void RemoteGraphicsContextGLProxy::deleteVertexArray(PlatformGLObject arg0)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteVertexArray(arg0));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::DeleteVertexArray>(arg0);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1750,7 +1750,7 @@ GCGLboolean RemoteGraphicsContextGLProxy::isVertexArray(PlatformGLObject arg0)
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsVertexArray(arg0));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::IsVertexArray>(arg0);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -1763,7 +1763,7 @@ void RemoteGraphicsContextGLProxy::bindVertexArray(PlatformGLObject arg0)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BindVertexArray(arg0));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::BindVertexArray>(arg0);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1774,7 +1774,7 @@ void RemoteGraphicsContextGLProxy::copyBufferSubData(GCGLenum readTarget, GCGLen
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::CopyBufferSubData(readTarget, writeTarget, static_cast<uint64_t>(readOffset), static_cast<uint64_t>(writeOffset), static_cast<uint64_t>(arg4)));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::CopyBufferSubData>(readTarget, writeTarget, static_cast<uint64_t>(readOffset), static_cast<uint64_t>(writeOffset), static_cast<uint64_t>(arg4));
     if (!sendResult) {
         markContextLost();
         return;
@@ -1785,7 +1785,7 @@ void RemoteGraphicsContextGLProxy::getBufferSubData(GCGLenum target, GCGLintptr 
 {
     if (isContextLost())
         return;
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetBufferSubData(target, static_cast<uint64_t>(offset), data.size()));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetBufferSubData>(target, static_cast<uint64_t>(offset), data.size());
     if (!sendResult) {
         markContextLost();
         return;
@@ -1798,7 +1798,7 @@ void RemoteGraphicsContextGLProxy::blitFramebuffer(GCGLint srcX0, GCGLint srcY0,
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BlitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::BlitFramebuffer>(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1809,7 +1809,7 @@ void RemoteGraphicsContextGLProxy::framebufferTextureLayer(GCGLenum target, GCGL
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::FramebufferTextureLayer(target, attachment, texture, level, layer));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::FramebufferTextureLayer>(target, attachment, texture, level, layer);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1820,7 +1820,7 @@ void RemoteGraphicsContextGLProxy::invalidateFramebuffer(GCGLenum target, GCGLSp
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::InvalidateFramebuffer(target, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(attachments.data()), attachments.size())));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::InvalidateFramebuffer>(target, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(attachments.data()), attachments.size()));
     if (!sendResult) {
         markContextLost();
         return;
@@ -1831,7 +1831,7 @@ void RemoteGraphicsContextGLProxy::invalidateSubFramebuffer(GCGLenum target, GCG
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::InvalidateSubFramebuffer(target, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(attachments.data()), attachments.size()), x, y, width, height));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::InvalidateSubFramebuffer>(target, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(attachments.data()), attachments.size()), x, y, width, height);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1842,7 +1842,7 @@ void RemoteGraphicsContextGLProxy::readBuffer(GCGLenum src)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::ReadBuffer(src));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::ReadBuffer>(src);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1853,7 +1853,7 @@ void RemoteGraphicsContextGLProxy::renderbufferStorageMultisample(GCGLenum targe
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::RenderbufferStorageMultisample(target, samples, internalformat, width, height));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::RenderbufferStorageMultisample>(target, samples, internalformat, width, height);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1864,7 +1864,7 @@ void RemoteGraphicsContextGLProxy::texStorage2D(GCGLenum target, GCGLsizei level
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::TexStorage2D(target, levels, internalformat, width, height));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::TexStorage2D>(target, levels, internalformat, width, height);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1875,7 +1875,7 @@ void RemoteGraphicsContextGLProxy::texStorage3D(GCGLenum target, GCGLsizei level
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::TexStorage3D(target, levels, internalformat, width, height, depth));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::TexStorage3D>(target, levels, internalformat, width, height, depth);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1886,7 +1886,7 @@ void RemoteGraphicsContextGLProxy::texImage3D(GCGLenum target, GCGLint level, GC
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::TexImage3D0(target, level, internalformat, width, height, depth, border, format, type, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(pixels.data()), pixels.size())));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::TexImage3D0>(target, level, internalformat, width, height, depth, border, format, type, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(pixels.data()), pixels.size()));
     if (!sendResult) {
         markContextLost();
         return;
@@ -1897,7 +1897,7 @@ void RemoteGraphicsContextGLProxy::texImage3D(GCGLenum target, GCGLint level, GC
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::TexImage3D1(target, level, internalformat, width, height, depth, border, format, type, static_cast<uint64_t>(offset)));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::TexImage3D1>(target, level, internalformat, width, height, depth, border, format, type, static_cast<uint64_t>(offset));
     if (!sendResult) {
         markContextLost();
         return;
@@ -1908,7 +1908,7 @@ void RemoteGraphicsContextGLProxy::texSubImage3D(GCGLenum target, GCGLint level,
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::TexSubImage3D0(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(pixels.data()), pixels.size())));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::TexSubImage3D0>(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(pixels.data()), pixels.size()));
     if (!sendResult) {
         markContextLost();
         return;
@@ -1919,7 +1919,7 @@ void RemoteGraphicsContextGLProxy::texSubImage3D(GCGLenum target, GCGLint level,
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::TexSubImage3D1(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, static_cast<uint64_t>(offset)));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::TexSubImage3D1>(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, static_cast<uint64_t>(offset));
     if (!sendResult) {
         markContextLost();
         return;
@@ -1930,7 +1930,7 @@ void RemoteGraphicsContextGLProxy::copyTexSubImage3D(GCGLenum target, GCGLint le
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::CopyTexSubImage3D(target, level, xoffset, yoffset, zoffset, x, y, width, height));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::CopyTexSubImage3D>(target, level, xoffset, yoffset, zoffset, x, y, width, height);
     if (!sendResult) {
         markContextLost();
         return;
@@ -1941,7 +1941,7 @@ void RemoteGraphicsContextGLProxy::compressedTexImage3D(GCGLenum target, GCGLint
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexImage3D0(target, level, internalformat, width, height, depth, border, imageSize, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size())));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::CompressedTexImage3D0>(target, level, internalformat, width, height, depth, border, imageSize, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size()));
     if (!sendResult) {
         markContextLost();
         return;
@@ -1952,7 +1952,7 @@ void RemoteGraphicsContextGLProxy::compressedTexImage3D(GCGLenum target, GCGLint
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexImage3D1(target, level, internalformat, width, height, depth, border, imageSize, static_cast<uint64_t>(offset)));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::CompressedTexImage3D1>(target, level, internalformat, width, height, depth, border, imageSize, static_cast<uint64_t>(offset));
     if (!sendResult) {
         markContextLost();
         return;
@@ -1963,7 +1963,7 @@ void RemoteGraphicsContextGLProxy::compressedTexSubImage3D(GCGLenum target, GCGL
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexSubImage3D0(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size())));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::CompressedTexSubImage3D0>(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size()));
     if (!sendResult) {
         markContextLost();
         return;
@@ -1974,7 +1974,7 @@ void RemoteGraphicsContextGLProxy::compressedTexSubImage3D(GCGLenum target, GCGL
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexSubImage3D1(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, static_cast<uint64_t>(offset)));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::CompressedTexSubImage3D1>(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, static_cast<uint64_t>(offset));
     if (!sendResult) {
         markContextLost();
         return;
@@ -1985,7 +1985,7 @@ GCGLint RemoteGraphicsContextGLProxy::getFragDataLocation(PlatformGLObject progr
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetFragDataLocation(program, name));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetFragDataLocation>(program, name);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -1998,7 +1998,7 @@ void RemoteGraphicsContextGLProxy::uniform1ui(GCGLint location, GCGLuint v0)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform1ui(location, v0));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::Uniform1ui>(location, v0);
     if (!sendResult) {
         markContextLost();
         return;
@@ -2009,7 +2009,7 @@ void RemoteGraphicsContextGLProxy::uniform2ui(GCGLint location, GCGLuint v0, GCG
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform2ui(location, v0, v1));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::Uniform2ui>(location, v0, v1);
     if (!sendResult) {
         markContextLost();
         return;
@@ -2020,7 +2020,7 @@ void RemoteGraphicsContextGLProxy::uniform3ui(GCGLint location, GCGLuint v0, GCG
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform3ui(location, v0, v1, v2));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::Uniform3ui>(location, v0, v1, v2);
     if (!sendResult) {
         markContextLost();
         return;
@@ -2031,7 +2031,7 @@ void RemoteGraphicsContextGLProxy::uniform4ui(GCGLint location, GCGLuint v0, GCG
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform4ui(location, v0, v1, v2, v3));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::Uniform4ui>(location, v0, v1, v2, v3);
     if (!sendResult) {
         markContextLost();
         return;
@@ -2042,7 +2042,7 @@ void RemoteGraphicsContextGLProxy::uniform1uiv(GCGLint location, GCGLSpan<const 
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform1uiv(location, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(data.data()), data.size())));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::Uniform1uiv>(location, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(data.data()), data.size()));
     if (!sendResult) {
         markContextLost();
         return;
@@ -2053,7 +2053,7 @@ void RemoteGraphicsContextGLProxy::uniform2uiv(GCGLint location, GCGLSpan<const 
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform2uiv(location, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(data.data()), data.size())));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::Uniform2uiv>(location, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(data.data()), data.size()));
     if (!sendResult) {
         markContextLost();
         return;
@@ -2064,7 +2064,7 @@ void RemoteGraphicsContextGLProxy::uniform3uiv(GCGLint location, GCGLSpan<const 
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform3uiv(location, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(data.data()), data.size())));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::Uniform3uiv>(location, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(data.data()), data.size()));
     if (!sendResult) {
         markContextLost();
         return;
@@ -2075,7 +2075,7 @@ void RemoteGraphicsContextGLProxy::uniform4uiv(GCGLint location, GCGLSpan<const 
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform4uiv(location, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(data.data()), data.size())));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::Uniform4uiv>(location, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(data.data()), data.size()));
     if (!sendResult) {
         markContextLost();
         return;
@@ -2086,7 +2086,7 @@ void RemoteGraphicsContextGLProxy::uniformMatrix2x3fv(GCGLint location, GCGLbool
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix2x3fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size())));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::UniformMatrix2x3fv>(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size()));
     if (!sendResult) {
         markContextLost();
         return;
@@ -2097,7 +2097,7 @@ void RemoteGraphicsContextGLProxy::uniformMatrix3x2fv(GCGLint location, GCGLbool
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix3x2fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size())));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::UniformMatrix3x2fv>(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size()));
     if (!sendResult) {
         markContextLost();
         return;
@@ -2108,7 +2108,7 @@ void RemoteGraphicsContextGLProxy::uniformMatrix2x4fv(GCGLint location, GCGLbool
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix2x4fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size())));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::UniformMatrix2x4fv>(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size()));
     if (!sendResult) {
         markContextLost();
         return;
@@ -2119,7 +2119,7 @@ void RemoteGraphicsContextGLProxy::uniformMatrix4x2fv(GCGLint location, GCGLbool
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix4x2fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size())));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::UniformMatrix4x2fv>(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size()));
     if (!sendResult) {
         markContextLost();
         return;
@@ -2130,7 +2130,7 @@ void RemoteGraphicsContextGLProxy::uniformMatrix3x4fv(GCGLint location, GCGLbool
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix3x4fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size())));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::UniformMatrix3x4fv>(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size()));
     if (!sendResult) {
         markContextLost();
         return;
@@ -2141,7 +2141,7 @@ void RemoteGraphicsContextGLProxy::uniformMatrix4x3fv(GCGLint location, GCGLbool
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix4x3fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size())));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::UniformMatrix4x3fv>(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size()));
     if (!sendResult) {
         markContextLost();
         return;
@@ -2152,7 +2152,7 @@ void RemoteGraphicsContextGLProxy::vertexAttribI4i(GCGLuint index, GCGLint x, GC
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttribI4i(index, x, y, z, w));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::VertexAttribI4i>(index, x, y, z, w);
     if (!sendResult) {
         markContextLost();
         return;
@@ -2163,7 +2163,7 @@ void RemoteGraphicsContextGLProxy::vertexAttribI4iv(GCGLuint index, GCGLSpan<con
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttribI4iv(index, IPC::ArrayReference<int32_t, 4>(reinterpret_cast<const int32_t*>(values.data()), values.size())));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::VertexAttribI4iv>(index, IPC::ArrayReference<int32_t, 4>(reinterpret_cast<const int32_t*>(values.data()), values.size()));
     if (!sendResult) {
         markContextLost();
         return;
@@ -2174,7 +2174,7 @@ void RemoteGraphicsContextGLProxy::vertexAttribI4ui(GCGLuint index, GCGLuint x, 
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttribI4ui(index, x, y, z, w));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::VertexAttribI4ui>(index, x, y, z, w);
     if (!sendResult) {
         markContextLost();
         return;
@@ -2185,7 +2185,7 @@ void RemoteGraphicsContextGLProxy::vertexAttribI4uiv(GCGLuint index, GCGLSpan<co
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttribI4uiv(index, IPC::ArrayReference<uint32_t, 4>(reinterpret_cast<const uint32_t*>(values.data()), values.size())));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::VertexAttribI4uiv>(index, IPC::ArrayReference<uint32_t, 4>(reinterpret_cast<const uint32_t*>(values.data()), values.size()));
     if (!sendResult) {
         markContextLost();
         return;
@@ -2196,7 +2196,7 @@ void RemoteGraphicsContextGLProxy::vertexAttribIPointer(GCGLuint index, GCGLint 
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttribIPointer(index, size, type, stride, static_cast<uint64_t>(offset)));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::VertexAttribIPointer>(index, size, type, stride, static_cast<uint64_t>(offset));
     if (!sendResult) {
         markContextLost();
         return;
@@ -2207,7 +2207,7 @@ void RemoteGraphicsContextGLProxy::drawRangeElements(GCGLenum mode, GCGLuint sta
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawRangeElements(mode, start, end, count, type, static_cast<uint64_t>(offset)));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::DrawRangeElements>(mode, start, end, count, type, static_cast<uint64_t>(offset));
     if (!sendResult) {
         markContextLost();
         return;
@@ -2218,7 +2218,7 @@ void RemoteGraphicsContextGLProxy::drawBuffers(GCGLSpan<const GCGLenum> bufs)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawBuffers(IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(bufs.data()), bufs.size())));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::DrawBuffers>(IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(bufs.data()), bufs.size()));
     if (!sendResult) {
         markContextLost();
         return;
@@ -2229,7 +2229,7 @@ void RemoteGraphicsContextGLProxy::clearBufferiv(GCGLenum buffer, GCGLint drawbu
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearBufferiv(buffer, drawbuffer, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(values.data()), values.size())));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::ClearBufferiv>(buffer, drawbuffer, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(values.data()), values.size()));
     if (!sendResult) {
         markContextLost();
         return;
@@ -2240,7 +2240,7 @@ void RemoteGraphicsContextGLProxy::clearBufferuiv(GCGLenum buffer, GCGLint drawb
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearBufferuiv(buffer, drawbuffer, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(values.data()), values.size())));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::ClearBufferuiv>(buffer, drawbuffer, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(values.data()), values.size()));
     if (!sendResult) {
         markContextLost();
         return;
@@ -2251,7 +2251,7 @@ void RemoteGraphicsContextGLProxy::clearBufferfv(GCGLenum buffer, GCGLint drawbu
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearBufferfv(buffer, drawbuffer, IPC::ArrayReference<float>(reinterpret_cast<const float*>(values.data()), values.size())));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::ClearBufferfv>(buffer, drawbuffer, IPC::ArrayReference<float>(reinterpret_cast<const float*>(values.data()), values.size()));
     if (!sendResult) {
         markContextLost();
         return;
@@ -2262,7 +2262,7 @@ void RemoteGraphicsContextGLProxy::clearBufferfi(GCGLenum buffer, GCGLint drawbu
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearBufferfi(buffer, drawbuffer, depth, stencil));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::ClearBufferfi>(buffer, drawbuffer, depth, stencil);
     if (!sendResult) {
         markContextLost();
         return;
@@ -2273,7 +2273,7 @@ PlatformGLObject RemoteGraphicsContextGLProxy::createQuery()
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateQuery());
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::CreateQuery>();
     if (!sendResult) {
         markContextLost();
         return { };
@@ -2286,7 +2286,7 @@ void RemoteGraphicsContextGLProxy::deleteQuery(PlatformGLObject query)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteQuery(query));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::DeleteQuery>(query);
     if (!sendResult) {
         markContextLost();
         return;
@@ -2297,7 +2297,7 @@ GCGLboolean RemoteGraphicsContextGLProxy::isQuery(PlatformGLObject query)
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsQuery(query));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::IsQuery>(query);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -2310,7 +2310,7 @@ void RemoteGraphicsContextGLProxy::beginQuery(GCGLenum target, PlatformGLObject 
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BeginQuery(target, query));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::BeginQuery>(target, query);
     if (!sendResult) {
         markContextLost();
         return;
@@ -2321,7 +2321,7 @@ void RemoteGraphicsContextGLProxy::endQuery(GCGLenum target)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::EndQuery(target));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::EndQuery>(target);
     if (!sendResult) {
         markContextLost();
         return;
@@ -2332,7 +2332,7 @@ PlatformGLObject RemoteGraphicsContextGLProxy::getQuery(GCGLenum target, GCGLenu
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetQuery(target, pname));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetQuery>(target, pname);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -2345,7 +2345,7 @@ GCGLuint RemoteGraphicsContextGLProxy::getQueryObjectui(PlatformGLObject query, 
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetQueryObjectui(query, pname));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetQueryObjectui>(query, pname);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -2358,7 +2358,7 @@ PlatformGLObject RemoteGraphicsContextGLProxy::createSampler()
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateSampler());
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::CreateSampler>();
     if (!sendResult) {
         markContextLost();
         return { };
@@ -2371,7 +2371,7 @@ void RemoteGraphicsContextGLProxy::deleteSampler(PlatformGLObject sampler)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteSampler(sampler));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::DeleteSampler>(sampler);
     if (!sendResult) {
         markContextLost();
         return;
@@ -2382,7 +2382,7 @@ GCGLboolean RemoteGraphicsContextGLProxy::isSampler(PlatformGLObject sampler)
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsSampler(sampler));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::IsSampler>(sampler);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -2395,7 +2395,7 @@ void RemoteGraphicsContextGLProxy::bindSampler(GCGLuint unit, PlatformGLObject s
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BindSampler(unit, sampler));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::BindSampler>(unit, sampler);
     if (!sendResult) {
         markContextLost();
         return;
@@ -2406,7 +2406,7 @@ void RemoteGraphicsContextGLProxy::samplerParameteri(PlatformGLObject sampler, G
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::SamplerParameteri(sampler, pname, param));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::SamplerParameteri>(sampler, pname, param);
     if (!sendResult) {
         markContextLost();
         return;
@@ -2417,7 +2417,7 @@ void RemoteGraphicsContextGLProxy::samplerParameterf(PlatformGLObject sampler, G
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::SamplerParameterf(sampler, pname, param));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::SamplerParameterf>(sampler, pname, param);
     if (!sendResult) {
         markContextLost();
         return;
@@ -2428,7 +2428,7 @@ GCGLfloat RemoteGraphicsContextGLProxy::getSamplerParameterf(PlatformGLObject sa
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetSamplerParameterf(sampler, pname));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetSamplerParameterf>(sampler, pname);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -2441,7 +2441,7 @@ GCGLint RemoteGraphicsContextGLProxy::getSamplerParameteri(PlatformGLObject samp
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetSamplerParameteri(sampler, pname));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetSamplerParameteri>(sampler, pname);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -2454,7 +2454,7 @@ GCGLsync RemoteGraphicsContextGLProxy::fenceSync(GCGLenum condition, GCGLbitfiel
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::FenceSync(condition, flags));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::FenceSync>(condition, flags);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -2467,7 +2467,7 @@ GCGLboolean RemoteGraphicsContextGLProxy::isSync(GCGLsync arg0)
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsSync(static_cast<uint64_t>(reinterpret_cast<intptr_t>(arg0))));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::IsSync>(static_cast<uint64_t>(reinterpret_cast<intptr_t>(arg0)));
     if (!sendResult) {
         markContextLost();
         return { };
@@ -2480,7 +2480,7 @@ void RemoteGraphicsContextGLProxy::deleteSync(GCGLsync arg0)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteSync(static_cast<uint64_t>(reinterpret_cast<intptr_t>(arg0))));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::DeleteSync>(static_cast<uint64_t>(reinterpret_cast<intptr_t>(arg0)));
     if (!sendResult) {
         markContextLost();
         return;
@@ -2491,7 +2491,7 @@ GCGLenum RemoteGraphicsContextGLProxy::clientWaitSync(GCGLsync arg0, GCGLbitfiel
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::ClientWaitSync(static_cast<uint64_t>(reinterpret_cast<intptr_t>(arg0)), flags, static_cast<uint64_t>(timeout)));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::ClientWaitSync>(static_cast<uint64_t>(reinterpret_cast<intptr_t>(arg0)), flags, static_cast<uint64_t>(timeout));
     if (!sendResult) {
         markContextLost();
         return { };
@@ -2504,7 +2504,7 @@ void RemoteGraphicsContextGLProxy::waitSync(GCGLsync arg0, GCGLbitfield flags, G
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::WaitSync(static_cast<uint64_t>(reinterpret_cast<intptr_t>(arg0)), flags, static_cast<int64_t>(timeout)));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::WaitSync>(static_cast<uint64_t>(reinterpret_cast<intptr_t>(arg0)), flags, static_cast<int64_t>(timeout));
     if (!sendResult) {
         markContextLost();
         return;
@@ -2515,7 +2515,7 @@ GCGLint RemoteGraphicsContextGLProxy::getSynci(GCGLsync arg0, GCGLenum pname)
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetSynci(static_cast<uint64_t>(reinterpret_cast<intptr_t>(arg0)), pname));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetSynci>(static_cast<uint64_t>(reinterpret_cast<intptr_t>(arg0)), pname);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -2528,7 +2528,7 @@ PlatformGLObject RemoteGraphicsContextGLProxy::createTransformFeedback()
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateTransformFeedback());
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::CreateTransformFeedback>();
     if (!sendResult) {
         markContextLost();
         return { };
@@ -2541,7 +2541,7 @@ void RemoteGraphicsContextGLProxy::deleteTransformFeedback(PlatformGLObject id)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteTransformFeedback(id));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::DeleteTransformFeedback>(id);
     if (!sendResult) {
         markContextLost();
         return;
@@ -2552,7 +2552,7 @@ GCGLboolean RemoteGraphicsContextGLProxy::isTransformFeedback(PlatformGLObject i
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsTransformFeedback(id));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::IsTransformFeedback>(id);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -2565,7 +2565,7 @@ void RemoteGraphicsContextGLProxy::bindTransformFeedback(GCGLenum target, Platfo
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BindTransformFeedback(target, id));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::BindTransformFeedback>(target, id);
     if (!sendResult) {
         markContextLost();
         return;
@@ -2576,7 +2576,7 @@ void RemoteGraphicsContextGLProxy::beginTransformFeedback(GCGLenum primitiveMode
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BeginTransformFeedback(primitiveMode));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::BeginTransformFeedback>(primitiveMode);
     if (!sendResult) {
         markContextLost();
         return;
@@ -2587,7 +2587,7 @@ void RemoteGraphicsContextGLProxy::endTransformFeedback()
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::EndTransformFeedback());
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::EndTransformFeedback>();
     if (!sendResult) {
         markContextLost();
         return;
@@ -2598,7 +2598,7 @@ void RemoteGraphicsContextGLProxy::transformFeedbackVaryings(PlatformGLObject pr
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::TransformFeedbackVaryings(program, varyings, bufferMode));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::TransformFeedbackVaryings>(program, varyings, bufferMode);
     if (!sendResult) {
         markContextLost();
         return;
@@ -2609,7 +2609,7 @@ void RemoteGraphicsContextGLProxy::getTransformFeedbackVarying(PlatformGLObject 
 {
     if (isContextLost())
         return;
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetTransformFeedbackVarying(program, index));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetTransformFeedbackVarying>(program, index);
     if (!sendResult) {
         markContextLost();
         return;
@@ -2622,7 +2622,7 @@ void RemoteGraphicsContextGLProxy::pauseTransformFeedback()
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::PauseTransformFeedback());
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::PauseTransformFeedback>();
     if (!sendResult) {
         markContextLost();
         return;
@@ -2633,7 +2633,7 @@ void RemoteGraphicsContextGLProxy::resumeTransformFeedback()
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::ResumeTransformFeedback());
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::ResumeTransformFeedback>();
     if (!sendResult) {
         markContextLost();
         return;
@@ -2644,7 +2644,7 @@ void RemoteGraphicsContextGLProxy::bindBufferBase(GCGLenum target, GCGLuint inde
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BindBufferBase(target, index, buffer));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::BindBufferBase>(target, index, buffer);
     if (!sendResult) {
         markContextLost();
         return;
@@ -2655,7 +2655,7 @@ void RemoteGraphicsContextGLProxy::bindBufferRange(GCGLenum target, GCGLuint ind
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BindBufferRange(target, index, buffer, static_cast<uint64_t>(offset), static_cast<uint64_t>(arg4)));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::BindBufferRange>(target, index, buffer, static_cast<uint64_t>(offset), static_cast<uint64_t>(arg4));
     if (!sendResult) {
         markContextLost();
         return;
@@ -2666,7 +2666,7 @@ Vector<GCGLuint> RemoteGraphicsContextGLProxy::getUniformIndices(PlatformGLObjec
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetUniformIndices(program, uniformNames));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetUniformIndices>(program, uniformNames);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -2679,7 +2679,7 @@ Vector<GCGLint> RemoteGraphicsContextGLProxy::getActiveUniforms(PlatformGLObject
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetActiveUniforms(program, uniformIndices, pname));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetActiveUniforms>(program, uniformIndices, pname);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -2692,7 +2692,7 @@ GCGLuint RemoteGraphicsContextGLProxy::getUniformBlockIndex(PlatformGLObject pro
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetUniformBlockIndex(program, uniformBlockName));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetUniformBlockIndex>(program, uniformBlockName);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -2705,7 +2705,7 @@ String RemoteGraphicsContextGLProxy::getActiveUniformBlockName(PlatformGLObject 
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetActiveUniformBlockName(program, uniformBlockIndex));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetActiveUniformBlockName>(program, uniformBlockIndex);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -2718,7 +2718,7 @@ void RemoteGraphicsContextGLProxy::uniformBlockBinding(PlatformGLObject program,
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformBlockBinding(program, uniformBlockIndex, uniformBlockBinding));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::UniformBlockBinding>(program, uniformBlockIndex, uniformBlockBinding);
     if (!sendResult) {
         markContextLost();
         return;
@@ -2729,7 +2729,7 @@ void RemoteGraphicsContextGLProxy::getActiveUniformBlockiv(GCGLuint program, GCG
 {
     if (isContextLost())
         return;
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetActiveUniformBlockiv(program, uniformBlockIndex, pname, params.size()));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetActiveUniformBlockiv>(program, uniformBlockIndex, pname, params.size());
     if (!sendResult) {
         markContextLost();
         return;
@@ -2742,7 +2742,7 @@ String RemoteGraphicsContextGLProxy::getTranslatedShaderSourceANGLE(PlatformGLOb
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetTranslatedShaderSourceANGLE(arg0));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetTranslatedShaderSourceANGLE>(arg0);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -2755,7 +2755,7 @@ void RemoteGraphicsContextGLProxy::drawBuffersEXT(GCGLSpan<const GCGLenum> bufs)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawBuffersEXT(IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(bufs.data()), bufs.size())));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::DrawBuffersEXT>(IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(bufs.data()), bufs.size()));
     if (!sendResult) {
         markContextLost();
         return;
@@ -2766,7 +2766,7 @@ PlatformGLObject RemoteGraphicsContextGLProxy::createQueryEXT()
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateQueryEXT());
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::CreateQueryEXT>();
     if (!sendResult) {
         markContextLost();
         return { };
@@ -2779,7 +2779,7 @@ void RemoteGraphicsContextGLProxy::deleteQueryEXT(PlatformGLObject query)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteQueryEXT(query));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::DeleteQueryEXT>(query);
     if (!sendResult) {
         markContextLost();
         return;
@@ -2790,7 +2790,7 @@ GCGLboolean RemoteGraphicsContextGLProxy::isQueryEXT(PlatformGLObject query)
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsQueryEXT(query));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::IsQueryEXT>(query);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -2803,7 +2803,7 @@ void RemoteGraphicsContextGLProxy::beginQueryEXT(GCGLenum target, PlatformGLObje
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BeginQueryEXT(target, query));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::BeginQueryEXT>(target, query);
     if (!sendResult) {
         markContextLost();
         return;
@@ -2814,7 +2814,7 @@ void RemoteGraphicsContextGLProxy::endQueryEXT(GCGLenum target)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::EndQueryEXT(target));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::EndQueryEXT>(target);
     if (!sendResult) {
         markContextLost();
         return;
@@ -2825,7 +2825,7 @@ void RemoteGraphicsContextGLProxy::queryCounterEXT(PlatformGLObject query, GCGLe
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::QueryCounterEXT(query, target));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::QueryCounterEXT>(query, target);
     if (!sendResult) {
         markContextLost();
         return;
@@ -2836,7 +2836,7 @@ GCGLint RemoteGraphicsContextGLProxy::getQueryiEXT(GCGLenum target, GCGLenum pna
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetQueryiEXT(target, pname));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetQueryiEXT>(target, pname);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -2849,7 +2849,7 @@ GCGLint RemoteGraphicsContextGLProxy::getQueryObjectiEXT(PlatformGLObject query,
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetQueryObjectiEXT(query, pname));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetQueryObjectiEXT>(query, pname);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -2862,7 +2862,7 @@ GCGLuint64 RemoteGraphicsContextGLProxy::getQueryObjectui64EXT(PlatformGLObject 
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetQueryObjectui64EXT(query, pname));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetQueryObjectui64EXT>(query, pname);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -2875,7 +2875,7 @@ GCGLint64 RemoteGraphicsContextGLProxy::getInteger64EXT(GCGLenum pname)
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetInteger64EXT(pname));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetInteger64EXT>(pname);
     if (!sendResult) {
         markContextLost();
         return { };
@@ -2888,7 +2888,7 @@ void RemoteGraphicsContextGLProxy::enableiOES(GCGLenum target, GCGLuint index)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::EnableiOES(target, index));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::EnableiOES>(target, index);
     if (!sendResult) {
         markContextLost();
         return;
@@ -2899,7 +2899,7 @@ void RemoteGraphicsContextGLProxy::disableiOES(GCGLenum target, GCGLuint index)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DisableiOES(target, index));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::DisableiOES>(target, index);
     if (!sendResult) {
         markContextLost();
         return;
@@ -2910,7 +2910,7 @@ void RemoteGraphicsContextGLProxy::blendEquationiOES(GCGLuint buf, GCGLenum mode
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendEquationiOES(buf, mode));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::BlendEquationiOES>(buf, mode);
     if (!sendResult) {
         markContextLost();
         return;
@@ -2921,7 +2921,7 @@ void RemoteGraphicsContextGLProxy::blendEquationSeparateiOES(GCGLuint buf, GCGLe
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendEquationSeparateiOES(buf, modeRGB, modeAlpha));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::BlendEquationSeparateiOES>(buf, modeRGB, modeAlpha);
     if (!sendResult) {
         markContextLost();
         return;
@@ -2932,7 +2932,7 @@ void RemoteGraphicsContextGLProxy::blendFunciOES(GCGLuint buf, GCGLenum src, GCG
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendFunciOES(buf, src, dst));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::BlendFunciOES>(buf, src, dst);
     if (!sendResult) {
         markContextLost();
         return;
@@ -2943,7 +2943,7 @@ void RemoteGraphicsContextGLProxy::blendFuncSeparateiOES(GCGLuint buf, GCGLenum 
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendFuncSeparateiOES(buf, srcRGB, dstRGB, srcAlpha, dstAlpha));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::BlendFuncSeparateiOES>(buf, srcRGB, dstRGB, srcAlpha, dstAlpha);
     if (!sendResult) {
         markContextLost();
         return;
@@ -2954,7 +2954,7 @@ void RemoteGraphicsContextGLProxy::colorMaskiOES(GCGLuint buf, GCGLboolean red, 
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::ColorMaskiOES(buf, static_cast<bool>(red), static_cast<bool>(green), static_cast<bool>(blue), static_cast<bool>(alpha)));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::ColorMaskiOES>(buf, static_cast<bool>(red), static_cast<bool>(green), static_cast<bool>(blue), static_cast<bool>(alpha));
     if (!sendResult) {
         markContextLost();
         return;
@@ -2965,7 +2965,7 @@ void RemoteGraphicsContextGLProxy::drawArraysInstancedBaseInstanceANGLE(GCGLenum
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawArraysInstancedBaseInstanceANGLE(mode, first, count, instanceCount, baseInstance));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::DrawArraysInstancedBaseInstanceANGLE>(mode, first, count, instanceCount, baseInstance);
     if (!sendResult) {
         markContextLost();
         return;
@@ -2976,7 +2976,7 @@ void RemoteGraphicsContextGLProxy::drawElementsInstancedBaseVertexBaseInstanceAN
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawElementsInstancedBaseVertexBaseInstanceANGLE(mode, count, type, static_cast<uint64_t>(offset), instanceCount, baseVertex, baseInstance));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::DrawElementsInstancedBaseVertexBaseInstanceANGLE>(mode, count, type, static_cast<uint64_t>(offset), instanceCount, baseVertex, baseInstance);
     if (!sendResult) {
         markContextLost();
         return;
@@ -2987,7 +2987,7 @@ void RemoteGraphicsContextGLProxy::provokingVertexANGLE(GCGLenum provokeMode)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::ProvokingVertexANGLE(provokeMode));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::ProvokingVertexANGLE>(provokeMode);
     if (!sendResult) {
         markContextLost();
         return;
@@ -2998,7 +2998,7 @@ void RemoteGraphicsContextGLProxy::getInternalformativ(GCGLenum target, GCGLenum
 {
     if (isContextLost())
         return;
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetInternalformativ(target, internalformat, pname, params.size()));
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::GetInternalformativ>(target, internalformat, pname, params.size());
     if (!sendResult) {
         markContextLost();
         return;
@@ -3011,7 +3011,7 @@ void RemoteGraphicsContextGLProxy::setDrawingBufferColorSpace(const WebCore::Des
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::SetDrawingBufferColorSpace(arg0));
+    auto sendResult = send<Messages::RemoteGraphicsContextGL::SetDrawingBufferColorSpace>(arg0);
     if (!sendResult) {
         markContextLost();
         return;
@@ -3022,7 +3022,7 @@ RefPtr<WebCore::PixelBuffer> RemoteGraphicsContextGLProxy::paintRenderingResults
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::PaintRenderingResultsToPixelBuffer());
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::PaintRenderingResultsToPixelBuffer>();
     if (!sendResult) {
         markContextLost();
         return { };

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/RemoteGraphicsContextGLProxyCocoa.mm
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/RemoteGraphicsContextGLProxyCocoa.mm
@@ -116,7 +116,7 @@ void RemoteGraphicsContextGLProxyCocoa::prepareForDisplay()
 {
     if (isContextLost())
         return;
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::PrepareForDisplay());
+    auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::PrepareForDisplay>();
     if (!sendResult) {
         markContextLost();
         return;

--- a/Source/WebKit/WebProcess/Storage/WebSWClientConnection.messages.in
+++ b/Source/WebKit/WebProcess/Storage/WebSWClientConnection.messages.in
@@ -22,7 +22,7 @@
 
 #if ENABLE(SERVICE_WORKER)
 
-messages -> WebSWClientConnection {
+messages -> WebSWClientConnection ModernMessageConstruction {
     # When possible, these messages can be implemented directly by WebCore::SWServer::Connection
     JobRejectedInServer(WebCore::ServiceWorkerJobIdentifier jobDataIdentifier, struct WebCore::ExceptionData exception)
     RegistrationJobResolvedInServer(WebCore::ServiceWorkerJobIdentifier jobDataIdentifier, struct WebCore::ServiceWorkerRegistrationData registration, enum:bool WebCore::ShouldNotifyWhenResolved shouldNotifyWhenResolved)

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.messages.in
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.messages.in
@@ -22,7 +22,7 @@
 
 #if ENABLE(SERVICE_WORKER)
 
-messages -> WebSWContextManagerConnection {
+messages -> WebSWContextManagerConnection ModernMessageConstruction {
     InstallServiceWorker(struct WebCore::ServiceWorkerContextData contextData, struct WebCore::ServiceWorkerData workerData, String userAgent, enum:bool WebCore::WorkerThreadMode workerThreadMode)
     UpdateAppInitiatedValue(WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, enum:bool WebCore::LastNavigationWasAppInitiated lastNavigationWasAppInitiated)
     StartFetch(WebCore::SWServerConnectionIdentifier serverConnectionIdentifier, WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, WebCore::FetchIdentifier fetchIdentifier, WebCore::ResourceRequest request, struct WebCore::FetchOptions options, IPC::FormDataReference requestBody, String referrer, bool isServiceWorkerNavigationPreloadEnabled, String clientIdentifier, String resutlingClientIdentifier)

--- a/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.messages.in
+++ b/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.messages.in
@@ -20,7 +20,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-messages -> WebSharedWorkerContextManagerConnection NotRefCounted {
+messages -> WebSharedWorkerContextManagerConnection NotRefCounted ModernMessageConstruction {
     LaunchSharedWorker(struct WebCore::ClientOrigin origin, WebCore::SharedWorkerIdentifier sharedWorkerIdentifier, struct WebCore::WorkerOptions workerOptions, struct WebCore::WorkerFetchResult workerFetchResult, struct WebCore::WorkerInitializationData workerInitializationData)
     PostConnectEvent(WebCore::SharedWorkerIdentifier sharedWorkerIdentifier, WebCore::TransferredMessagePort port, String sourceOrigin) -> (bool success)
     TerminateSharedWorker(WebCore::SharedWorkerIdentifier sharedWorkerIdentifier)

--- a/Source/WebKit/WebProcess/Storage/WebSharedWorkerObjectConnection.messages.in
+++ b/Source/WebKit/WebProcess/Storage/WebSharedWorkerObjectConnection.messages.in
@@ -20,7 +20,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-messages -> WebSharedWorkerObjectConnection {
+messages -> WebSharedWorkerObjectConnection ModernMessageConstruction {
     FetchScriptInClient(URL url, WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, struct WebCore::WorkerOptions workerOptions) -> (struct WebCore::WorkerFetchResult fetchResult, struct WebCore::WorkerInitializationData initializationData)
     NotifyWorkerObjectOfLoadCompletion(WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, WebCore::ResourceError error)
     PostExceptionToWorkerObject(WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, String errorMessage, int lineNumber, int columnNumber, String sourceURL)

--- a/Source/WebKit/WebProcess/UserContent/WebUserContentController.messages.in
+++ b/Source/WebKit/WebProcess/UserContent/WebUserContentController.messages.in
@@ -23,7 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-messages -> WebUserContentController {
+messages -> WebUserContentController ModernMessageConstruction {
     AddContentWorlds(Vector<std::pair<WebKit::ContentWorldIdentifier, String>> worlds);
     RemoveContentWorlds(Vector<WebKit::ContentWorldIdentifier> worldIdentifiers);
 

--- a/Tools/Scripts/generate-gpup-webgl
+++ b/Tools/Scripts/generate-gpup-webgl
@@ -620,11 +620,11 @@ class webkit_ipc_cpp_proxy_impl(object):
             self.call_stmts += [ "    return { };"]
         if is_async:
             self.call_stmts += [
-                f"auto sendResult = send(Messages::RemoteGraphicsContextGL::{self.msg_name}({in_exprs}));",
+                f"auto sendResult = send<Messages::RemoteGraphicsContextGL::{self.msg_name}>({in_exprs});",
             ]
         else:
             self.call_stmts += [
-                f"auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::{self.msg_name}({in_exprs}));"
+                f"auto sendResult = sendSync<Messages::RemoteGraphicsContextGL::{self.msg_name}>({in_exprs});"
             ]
         if self.return_type.is_void():
             self.call_stmts += [

--- a/Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
@@ -44,6 +44,7 @@ struct MockTestMessageWithConnection {
         : m_arguments(handle)
     {
     }
+    using Arguments = std::tuple<IPC::Connection::Handle>;
     std::tuple<const IPC::Connection::Handle&> m_arguments;
 };
 

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h
@@ -49,6 +49,7 @@ struct MessageInfo {
 struct MockTestMessage1 {
     static constexpr bool isSync = false;
     static constexpr IPC::MessageName name()  { return static_cast<IPC::MessageName>(123); }
+    using Arguments = std::tuple<>;
     std::tuple<> arguments() { return { }; }
 };
 
@@ -58,6 +59,7 @@ struct MockTestMessageWithAsyncReply1 {
     // Just using WebPage_GetBytecodeProfileReply as something that is async message name.
     // If WebPage_GetBytecodeProfileReply is removed, just use another one.
     static constexpr IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::WebPage_GetBytecodeProfileReply; }
+    using Arguments = std::tuple<>;
     std::tuple<> arguments() { return { }; }
     using ReplyArguments = std::tuple<uint64_t>;
 };

--- a/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp
@@ -55,6 +55,7 @@ struct MockStreamTestMessage1 {
     static constexpr bool isStreamEncodable = true;
     static constexpr bool isStreamBatched = false;
     static constexpr IPC::MessageName name()  { return IPC::MessageName::RemoteRenderingBackend_ReleaseAllResources; }
+    using Arguments = std::tuple<>;
     std::tuple<> arguments() { return { }; }
 };
 
@@ -66,6 +67,7 @@ struct MockStreamTestMessageWithAsyncReply1 {
     // Just using WebPage_GetBytecodeProfileReply as something that is async message name.
     // If WebPage_GetBytecodeProfileReply is removed, just use another one.
     static constexpr IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::WebPage_GetBytecodeProfileReply; }
+    using Arguments = std::tuple<uint64_t>;
     std::tuple<uint64_t> arguments() { return { contents }; }
     using ReplyArguments = std::tuple<uint64_t>;
     MockStreamTestMessageWithAsyncReply1(uint64_t contents)


### PR DESCRIPTION
#### 12bb67cc9203c51f8dd48ff246ab77778ebd4f11
<pre>
[WK2] Rework message-sending methods on IPC::Connection, IPC::StreamClientConnection et al.
<a href="https://bugs.webkit.org/show_bug.cgi?id=251716">https://bugs.webkit.org/show_bug.cgi?id=251716</a>

Reviewed by NOBODY (OOPS!).

WIP.

- Message-options structs as the first parameter,
- CompletionHandler as the following parameter, if necessary,
- Message arguments follow as arguments to the corresponding parameter pack.

CompletionHandler as the second parameter is odd, but it&apos;s the only possibility
when message arguments are assigned to the parameter pack.

ModernMessageConstruction attribute on receivers prevents generation of
constructors and tuple member variables for arguments for each receiver&apos;s
message, forcing these messages to sent through the new-form sending methods.
This attribute would be added to receivers as they are incrementally ported over
to the new form.

* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::m_routingArbitrator):
(WebKit::GPUConnectionToWebProcess::didReceiveRemoteControlCommand):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h:
(getFloatv):
(getIntegerv):
(getBooleanv):
(getUniformfv):
(getUniformiv):
(getUniformuiv):
(getBufferSubData):
(getActiveUniformBlockiv):
(getInternalformativ):
* Source/WebKit/GPUProcess/mac/LocalAudioSessionRoutingArbitrator.cpp:
(WebKit::LocalAudioSessionRoutingArbitrator::beginRoutingArbitrationWithCategory):
(WebKit::LocalAudioSessionRoutingArbitrator::leaveRoutingAbritration):
* Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp:
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit::reset):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.cpp:
(WebKit::ServiceWorkerDownloadTask::sendToServiceWorker):
(WebKit::ServiceWorkerDownloadTask::cancel):
(WebKit::ServiceWorkerDownloadTask::start):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.h:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp:
(WebKit::ServiceWorkerFetchTask::sendToServiceWorker):
(WebKit::ServiceWorkerFetchTask::startFetch):
(WebKit::ServiceWorkerFetchTask::cancelFromClient):
(WebKit::ServiceWorkerFetchTask::continueDidReceiveFetchResponse):
(WebKit::ServiceWorkerFetchTask::preloadResponseIsReady):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWOriginStore.cpp:
(WebKit::WebSWOriginStore::importComplete):
(WebKit::WebSWOriginStore::registerSWServerConnection):
(WebKit::WebSWOriginStore::sendStoreHandle):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp:
(WebKit::WebSWServerConnection::rejectJobInClient):
(WebKit::WebSWServerConnection::resolveRegistrationJobInClient):
(WebKit::WebSWServerConnection::startScriptFetchInClient):
(WebKit::WebSWServerConnection::updateRegistrationStateInClient):
(WebKit::WebSWServerConnection::fireUpdateFoundEvent):
(WebKit::WebSWServerConnection::setRegistrationLastUpdateTime):
(WebKit::WebSWServerConnection::setRegistrationUpdateViaCache):
(WebKit::WebSWServerConnection::notifyClientsOfControllerChange):
(WebKit::WebSWServerConnection::updateWorkerStateInClient):
(WebKit::WebSWServerConnection::controlClient):
(WebKit::WebSWServerConnection::postMessageToServiceWorker):
(WebKit::WebSWServerConnection::postMessageToServiceWorkerClient):
(WebKit::WebSWServerConnection::sendToContextProcess):
(WebKit::WebSWServerConnection::focusServiceWorkerClient):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp:
(WebKit::WebSWServerToContextConnection::skipWaiting):
(WebKit::WebSWServerToContextConnection::close):
(WebKit::WebSWServerToContextConnection::installServiceWorkerContext):
(WebKit::WebSWServerToContextConnection::updateAppInitiatedValue):
(WebKit::WebSWServerToContextConnection::fireInstallEvent):
(WebKit::WebSWServerToContextConnection::fireActivateEvent):
(WebKit::WebSWServerToContextConnection::firePushEvent):
(WebKit::WebSWServerToContextConnection::fireNotificationEvent):
(WebKit::WebSWServerToContextConnection::terminateWorker):
(WebKit::WebSWServerToContextConnection::didSaveScriptsToDisk):
(WebKit::WebSWServerToContextConnection::matchAllCompleted):
(WebKit::WebSWServerToContextConnection::setThrottleState):
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.cpp:
(WebKit::WebSharedWorkerServerConnection::fetchScriptInClient):
(WebKit::WebSharedWorkerServerConnection::notifyWorkerObjectOfLoadCompletion):
(WebKit::WebSharedWorkerServerConnection::postExceptionToWorkerObject):
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.cpp:
(WebKit::WebSharedWorkerServerToContextConnection::launchSharedWorker):
(WebKit::WebSharedWorkerServerToContextConnection::suspendSharedWorker):
(WebKit::WebSharedWorkerServerToContextConnection::resumeSharedWorker):
(WebKit::WebSharedWorkerServerToContextConnection::postConnectEvent):
(WebKit::WebSharedWorkerServerToContextConnection::terminateSharedWorker):
* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::AsyncMessageOptions::AsyncMessageOptions):
(IPC::Connection::AsyncMessageOptions::destinationID const):
(IPC::Connection::AsyncMessageOptions::sendOptions const):
(IPC::Connection::AsyncMessageOptions::qos const):
(IPC::Connection::AsyncMessageOptions::setOption):
(IPC::Connection::SyncMessageOptions::SyncMessageOptions):
(IPC::Connection::SyncMessageOptions::destinationID const):
(IPC::Connection::SyncMessageOptions::sendSyncOptions const):
(IPC::Connection::SyncMessageOptions::timeout const):
(IPC::Connection::SyncMessageOptions::setOption):
(IPC::Connection::send):
(IPC::Connection::sendWithAsyncReply):
(IPC::Connection::sendSync):
* Source/WebKit/Platform/IPC/MessageSender.h:
(IPC::MessageSender::send):
(IPC::MessageSender::sendSync):
(IPC::MessageSender::sendWithAsyncReply):
* Source/WebKit/Platform/IPC/StreamClientConnection.h:
(IPC::StreamClientConnection::send):
(IPC::StreamClientConnection::sendWithAsyncReply):
(IPC::StreamClientConnection::trySendStream):
(IPC::StreamClientConnection::sendSync):
(IPC::StreamClientConnection::trySendSyncStream):
* Source/WebKit/Scripts/webkit/messages.py:
(message_to_struct_declaration):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
(WebKit::AuxiliaryProcessProxy::AsyncMessageOptions::AsyncMessageOptions):
(WebKit::AuxiliaryProcessProxy::AsyncMessageOptions::destinationID const):
(WebKit::AuxiliaryProcessProxy::AsyncMessageOptions::sendOptions const):
(WebKit::AuxiliaryProcessProxy::AsyncMessageOptions::shouldStartProcessThrottlerActivity const):
(WebKit::AuxiliaryProcessProxy::AsyncMessageOptions::setOption):
(WebKit::AuxiliaryProcessProxy::send):
(WebKit::AuxiliaryProcessProxy::sendSync):
(WebKit::AuxiliaryProcessProxy::sendWithAsyncReply):
* Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp:
(WebKit::WebUserContentControllerProxy::addContentWorld):
(WebKit::WebUserContentControllerProxy::contentWorldDestroyed):
(WebKit::WebUserContentControllerProxy::addUserScript):
(WebKit::WebUserContentControllerProxy::removeUserScript):
(WebKit::WebUserContentControllerProxy::removeAllUserScripts):
(WebKit::WebUserContentControllerProxy::addUserStyleSheet):
(WebKit::WebUserContentControllerProxy::removeUserStyleSheet):
(WebKit::WebUserContentControllerProxy::removeAllUserStyleSheets):
(WebKit::WebUserContentControllerProxy::addUserScriptMessageHandler):
(WebKit::WebUserContentControllerProxy::removeUserMessageHandlerForName):
(WebKit::WebUserContentControllerProxy::removeAllUserMessageHandlers):
(WebKit::WebUserContentControllerProxy::addContentRuleList):
(WebKit::WebUserContentControllerProxy::removeContentRuleList):
(WebKit::WebUserContentControllerProxy::removeAllContentRuleLists):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::setRemoteWorkerUserAgent):
(WebKit::WebProcessProxy::updateRemoteWorkerPreferencesStore):
(WebKit::WebProcessProxy::disableRemoteWorkers):
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.messages.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp:
(WebKit::RemoteGraphicsContextGLProxy::markContextChanged):
(WebKit::RemoteGraphicsContextGLProxy::ensureExtensionEnabled):
(WebKit::RemoteGraphicsContextGLProxy::reshape):
(WebKit::RemoteGraphicsContextGLProxy::paintRenderingResultsToCanvas):
(WebKit::RemoteGraphicsContextGLProxy::paintCompositedResultsToCanvas):
(WebKit::RemoteGraphicsContextGLProxy::paintCompositedResultsToVideoFrame):
(WebKit::RemoteGraphicsContextGLProxy::copyTextureFromVideoFrame):
(WebKit::RemoteGraphicsContextGLProxy::synthesizeGLError):
(WebKit::RemoteGraphicsContextGLProxy::getError):
(WebKit::RemoteGraphicsContextGLProxy::simulateEventForTesting):
(WebKit::RemoteGraphicsContextGLProxy::readnPixels):
(WebKit::RemoteGraphicsContextGLProxy::readnPixelsSharedMemory):
(WebKit::RemoteGraphicsContextGLProxy::multiDrawArraysANGLE):
(WebKit::RemoteGraphicsContextGLProxy::multiDrawArraysInstancedANGLE):
(WebKit::RemoteGraphicsContextGLProxy::multiDrawElementsANGLE):
(WebKit::RemoteGraphicsContextGLProxy::multiDrawElementsInstancedANGLE):
(WebKit::RemoteGraphicsContextGLProxy::multiDrawArraysInstancedBaseInstanceANGLE):
(WebKit::RemoteGraphicsContextGLProxy::multiDrawElementsInstancedBaseVertexBaseInstanceANGLE):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h:
(WebKit::RemoteGraphicsContextGLProxy::send):
(WebKit::RemoteGraphicsContextGLProxy::sendSync):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp:
(WebKit::RemoteGraphicsContextGLProxy::moveErrorsToSyntheticErrorList):
(WebKit::RemoteGraphicsContextGLProxy::activeTexture):
(WebKit::RemoteGraphicsContextGLProxy::attachShader):
(WebKit::RemoteGraphicsContextGLProxy::bindAttribLocation):
(WebKit::RemoteGraphicsContextGLProxy::bindBuffer):
(WebKit::RemoteGraphicsContextGLProxy::bindFramebuffer):
(WebKit::RemoteGraphicsContextGLProxy::bindRenderbuffer):
(WebKit::RemoteGraphicsContextGLProxy::bindTexture):
(WebKit::RemoteGraphicsContextGLProxy::blendColor):
(WebKit::RemoteGraphicsContextGLProxy::blendEquation):
(WebKit::RemoteGraphicsContextGLProxy::blendEquationSeparate):
(WebKit::RemoteGraphicsContextGLProxy::blendFunc):
(WebKit::RemoteGraphicsContextGLProxy::blendFuncSeparate):
(WebKit::RemoteGraphicsContextGLProxy::checkFramebufferStatus):
(WebKit::RemoteGraphicsContextGLProxy::clear):
(WebKit::RemoteGraphicsContextGLProxy::clearColor):
(WebKit::RemoteGraphicsContextGLProxy::clearDepth):
(WebKit::RemoteGraphicsContextGLProxy::clearStencil):
(WebKit::RemoteGraphicsContextGLProxy::colorMask):
(WebKit::RemoteGraphicsContextGLProxy::compileShader):
(WebKit::RemoteGraphicsContextGLProxy::copyTexImage2D):
(WebKit::RemoteGraphicsContextGLProxy::copyTexSubImage2D):
(WebKit::RemoteGraphicsContextGLProxy::createBuffer):
(WebKit::RemoteGraphicsContextGLProxy::createFramebuffer):
(WebKit::RemoteGraphicsContextGLProxy::createProgram):
(WebKit::RemoteGraphicsContextGLProxy::createRenderbuffer):
(WebKit::RemoteGraphicsContextGLProxy::createShader):
(WebKit::RemoteGraphicsContextGLProxy::createTexture):
(WebKit::RemoteGraphicsContextGLProxy::cullFace):
(WebKit::RemoteGraphicsContextGLProxy::deleteBuffer):
(WebKit::RemoteGraphicsContextGLProxy::deleteFramebuffer):
(WebKit::RemoteGraphicsContextGLProxy::deleteProgram):
(WebKit::RemoteGraphicsContextGLProxy::deleteRenderbuffer):
(WebKit::RemoteGraphicsContextGLProxy::deleteShader):
(WebKit::RemoteGraphicsContextGLProxy::deleteTexture):
(WebKit::RemoteGraphicsContextGLProxy::depthFunc):
(WebKit::RemoteGraphicsContextGLProxy::depthMask):
(WebKit::RemoteGraphicsContextGLProxy::depthRange):
(WebKit::RemoteGraphicsContextGLProxy::detachShader):
(WebKit::RemoteGraphicsContextGLProxy::disable):
(WebKit::RemoteGraphicsContextGLProxy::disableVertexAttribArray):
(WebKit::RemoteGraphicsContextGLProxy::drawArrays):
(WebKit::RemoteGraphicsContextGLProxy::drawElements):
(WebKit::RemoteGraphicsContextGLProxy::enable):
(WebKit::RemoteGraphicsContextGLProxy::enableVertexAttribArray):
(WebKit::RemoteGraphicsContextGLProxy::finish):
(WebKit::RemoteGraphicsContextGLProxy::flush):
(WebKit::RemoteGraphicsContextGLProxy::framebufferRenderbuffer):
(WebKit::RemoteGraphicsContextGLProxy::framebufferTexture2D):
(WebKit::RemoteGraphicsContextGLProxy::frontFace):
(WebKit::RemoteGraphicsContextGLProxy::generateMipmap):
(WebKit::RemoteGraphicsContextGLProxy::getActiveAttrib):
(WebKit::RemoteGraphicsContextGLProxy::getActiveUniform):
(WebKit::RemoteGraphicsContextGLProxy::getAttribLocation):
(WebKit::RemoteGraphicsContextGLProxy::getBufferParameteri):
(WebKit::RemoteGraphicsContextGLProxy::getString):
(WebKit::RemoteGraphicsContextGLProxy::getFloatv):
(WebKit::RemoteGraphicsContextGLProxy::getIntegerv):
(WebKit::RemoteGraphicsContextGLProxy::getIntegeri_v):
(WebKit::RemoteGraphicsContextGLProxy::getInteger64):
(WebKit::RemoteGraphicsContextGLProxy::getInteger64i):
(WebKit::RemoteGraphicsContextGLProxy::getProgrami):
(WebKit::RemoteGraphicsContextGLProxy::getBooleanv):
(WebKit::RemoteGraphicsContextGLProxy::getFramebufferAttachmentParameteri):
(WebKit::RemoteGraphicsContextGLProxy::getProgramInfoLog):
(WebKit::RemoteGraphicsContextGLProxy::getRenderbufferParameteri):
(WebKit::RemoteGraphicsContextGLProxy::getShaderi):
(WebKit::RemoteGraphicsContextGLProxy::getShaderInfoLog):
(WebKit::RemoteGraphicsContextGLProxy::getShaderPrecisionFormat):
(WebKit::RemoteGraphicsContextGLProxy::getShaderSource):
(WebKit::RemoteGraphicsContextGLProxy::getTexParameterf):
(WebKit::RemoteGraphicsContextGLProxy::getTexParameteri):
(WebKit::RemoteGraphicsContextGLProxy::getUniformfv):
(WebKit::RemoteGraphicsContextGLProxy::getUniformiv):
(WebKit::RemoteGraphicsContextGLProxy::getUniformuiv):
(WebKit::RemoteGraphicsContextGLProxy::getUniformLocation):
(WebKit::RemoteGraphicsContextGLProxy::getVertexAttribOffset):
(WebKit::RemoteGraphicsContextGLProxy::hint):
(WebKit::RemoteGraphicsContextGLProxy::isBuffer):
(WebKit::RemoteGraphicsContextGLProxy::isEnabled):
(WebKit::RemoteGraphicsContextGLProxy::isFramebuffer):
(WebKit::RemoteGraphicsContextGLProxy::isProgram):
(WebKit::RemoteGraphicsContextGLProxy::isRenderbuffer):
(WebKit::RemoteGraphicsContextGLProxy::isShader):
(WebKit::RemoteGraphicsContextGLProxy::isTexture):
(WebKit::RemoteGraphicsContextGLProxy::lineWidth):
(WebKit::RemoteGraphicsContextGLProxy::linkProgram):
(WebKit::RemoteGraphicsContextGLProxy::pixelStorei):
(WebKit::RemoteGraphicsContextGLProxy::polygonOffset):
(WebKit::RemoteGraphicsContextGLProxy::renderbufferStorage):
(WebKit::RemoteGraphicsContextGLProxy::sampleCoverage):
(WebKit::RemoteGraphicsContextGLProxy::scissor):
(WebKit::RemoteGraphicsContextGLProxy::shaderSource):
(WebKit::RemoteGraphicsContextGLProxy::stencilFunc):
(WebKit::RemoteGraphicsContextGLProxy::stencilFuncSeparate):
(WebKit::RemoteGraphicsContextGLProxy::stencilMask):
(WebKit::RemoteGraphicsContextGLProxy::stencilMaskSeparate):
(WebKit::RemoteGraphicsContextGLProxy::stencilOp):
(WebKit::RemoteGraphicsContextGLProxy::stencilOpSeparate):
(WebKit::RemoteGraphicsContextGLProxy::texParameterf):
(WebKit::RemoteGraphicsContextGLProxy::texParameteri):
(WebKit::RemoteGraphicsContextGLProxy::uniform1f):
(WebKit::RemoteGraphicsContextGLProxy::uniform1fv):
(WebKit::RemoteGraphicsContextGLProxy::uniform1i):
(WebKit::RemoteGraphicsContextGLProxy::uniform1iv):
(WebKit::RemoteGraphicsContextGLProxy::uniform2f):
(WebKit::RemoteGraphicsContextGLProxy::uniform2fv):
(WebKit::RemoteGraphicsContextGLProxy::uniform2i):
(WebKit::RemoteGraphicsContextGLProxy::uniform2iv):
(WebKit::RemoteGraphicsContextGLProxy::uniform3f):
(WebKit::RemoteGraphicsContextGLProxy::uniform3fv):
(WebKit::RemoteGraphicsContextGLProxy::uniform3i):
(WebKit::RemoteGraphicsContextGLProxy::uniform3iv):
(WebKit::RemoteGraphicsContextGLProxy::uniform4f):
(WebKit::RemoteGraphicsContextGLProxy::uniform4fv):
(WebKit::RemoteGraphicsContextGLProxy::uniform4i):
(WebKit::RemoteGraphicsContextGLProxy::uniform4iv):
(WebKit::RemoteGraphicsContextGLProxy::uniformMatrix2fv):
(WebKit::RemoteGraphicsContextGLProxy::uniformMatrix3fv):
(WebKit::RemoteGraphicsContextGLProxy::uniformMatrix4fv):
(WebKit::RemoteGraphicsContextGLProxy::useProgram):
(WebKit::RemoteGraphicsContextGLProxy::validateProgram):
(WebKit::RemoteGraphicsContextGLProxy::vertexAttrib1f):
(WebKit::RemoteGraphicsContextGLProxy::vertexAttrib1fv):
(WebKit::RemoteGraphicsContextGLProxy::vertexAttrib2f):
(WebKit::RemoteGraphicsContextGLProxy::vertexAttrib2fv):
(WebKit::RemoteGraphicsContextGLProxy::vertexAttrib3f):
(WebKit::RemoteGraphicsContextGLProxy::vertexAttrib3fv):
(WebKit::RemoteGraphicsContextGLProxy::vertexAttrib4f):
(WebKit::RemoteGraphicsContextGLProxy::vertexAttrib4fv):
(WebKit::RemoteGraphicsContextGLProxy::vertexAttribPointer):
(WebKit::RemoteGraphicsContextGLProxy::viewport):
(WebKit::RemoteGraphicsContextGLProxy::bufferData):
(WebKit::RemoteGraphicsContextGLProxy::bufferSubData):
(WebKit::RemoteGraphicsContextGLProxy::texImage2D):
(WebKit::RemoteGraphicsContextGLProxy::texSubImage2D):
(WebKit::RemoteGraphicsContextGLProxy::compressedTexImage2D):
(WebKit::RemoteGraphicsContextGLProxy::compressedTexSubImage2D):
(WebKit::RemoteGraphicsContextGLProxy::drawArraysInstanced):
(WebKit::RemoteGraphicsContextGLProxy::drawElementsInstanced):
(WebKit::RemoteGraphicsContextGLProxy::vertexAttribDivisor):
(WebKit::RemoteGraphicsContextGLProxy::createVertexArray):
(WebKit::RemoteGraphicsContextGLProxy::deleteVertexArray):
(WebKit::RemoteGraphicsContextGLProxy::isVertexArray):
(WebKit::RemoteGraphicsContextGLProxy::bindVertexArray):
(WebKit::RemoteGraphicsContextGLProxy::copyBufferSubData):
(WebKit::RemoteGraphicsContextGLProxy::getBufferSubData):
(WebKit::RemoteGraphicsContextGLProxy::blitFramebuffer):
(WebKit::RemoteGraphicsContextGLProxy::framebufferTextureLayer):
(WebKit::RemoteGraphicsContextGLProxy::invalidateFramebuffer):
(WebKit::RemoteGraphicsContextGLProxy::invalidateSubFramebuffer):
(WebKit::RemoteGraphicsContextGLProxy::readBuffer):
(WebKit::RemoteGraphicsContextGLProxy::renderbufferStorageMultisample):
(WebKit::RemoteGraphicsContextGLProxy::texStorage2D):
(WebKit::RemoteGraphicsContextGLProxy::texStorage3D):
(WebKit::RemoteGraphicsContextGLProxy::texImage3D):
(WebKit::RemoteGraphicsContextGLProxy::texSubImage3D):
(WebKit::RemoteGraphicsContextGLProxy::copyTexSubImage3D):
(WebKit::RemoteGraphicsContextGLProxy::compressedTexImage3D):
(WebKit::RemoteGraphicsContextGLProxy::compressedTexSubImage3D):
(WebKit::RemoteGraphicsContextGLProxy::getFragDataLocation):
(WebKit::RemoteGraphicsContextGLProxy::uniform1ui):
(WebKit::RemoteGraphicsContextGLProxy::uniform2ui):
(WebKit::RemoteGraphicsContextGLProxy::uniform3ui):
(WebKit::RemoteGraphicsContextGLProxy::uniform4ui):
(WebKit::RemoteGraphicsContextGLProxy::uniform1uiv):
(WebKit::RemoteGraphicsContextGLProxy::uniform2uiv):
(WebKit::RemoteGraphicsContextGLProxy::uniform3uiv):
(WebKit::RemoteGraphicsContextGLProxy::uniform4uiv):
(WebKit::RemoteGraphicsContextGLProxy::uniformMatrix2x3fv):
(WebKit::RemoteGraphicsContextGLProxy::uniformMatrix3x2fv):
(WebKit::RemoteGraphicsContextGLProxy::uniformMatrix2x4fv):
(WebKit::RemoteGraphicsContextGLProxy::uniformMatrix4x2fv):
(WebKit::RemoteGraphicsContextGLProxy::uniformMatrix3x4fv):
(WebKit::RemoteGraphicsContextGLProxy::uniformMatrix4x3fv):
(WebKit::RemoteGraphicsContextGLProxy::vertexAttribI4i):
(WebKit::RemoteGraphicsContextGLProxy::vertexAttribI4iv):
(WebKit::RemoteGraphicsContextGLProxy::vertexAttribI4ui):
(WebKit::RemoteGraphicsContextGLProxy::vertexAttribI4uiv):
(WebKit::RemoteGraphicsContextGLProxy::vertexAttribIPointer):
(WebKit::RemoteGraphicsContextGLProxy::drawRangeElements):
(WebKit::RemoteGraphicsContextGLProxy::drawBuffers):
(WebKit::RemoteGraphicsContextGLProxy::clearBufferiv):
(WebKit::RemoteGraphicsContextGLProxy::clearBufferuiv):
(WebKit::RemoteGraphicsContextGLProxy::clearBufferfv):
(WebKit::RemoteGraphicsContextGLProxy::clearBufferfi):
(WebKit::RemoteGraphicsContextGLProxy::createQuery):
(WebKit::RemoteGraphicsContextGLProxy::deleteQuery):
(WebKit::RemoteGraphicsContextGLProxy::isQuery):
(WebKit::RemoteGraphicsContextGLProxy::beginQuery):
(WebKit::RemoteGraphicsContextGLProxy::endQuery):
(WebKit::RemoteGraphicsContextGLProxy::getQuery):
(WebKit::RemoteGraphicsContextGLProxy::getQueryObjectui):
(WebKit::RemoteGraphicsContextGLProxy::createSampler):
(WebKit::RemoteGraphicsContextGLProxy::deleteSampler):
(WebKit::RemoteGraphicsContextGLProxy::isSampler):
(WebKit::RemoteGraphicsContextGLProxy::bindSampler):
(WebKit::RemoteGraphicsContextGLProxy::samplerParameteri):
(WebKit::RemoteGraphicsContextGLProxy::samplerParameterf):
(WebKit::RemoteGraphicsContextGLProxy::getSamplerParameterf):
(WebKit::RemoteGraphicsContextGLProxy::getSamplerParameteri):
(WebKit::RemoteGraphicsContextGLProxy::fenceSync):
(WebKit::RemoteGraphicsContextGLProxy::isSync):
(WebKit::RemoteGraphicsContextGLProxy::deleteSync):
(WebKit::RemoteGraphicsContextGLProxy::clientWaitSync):
(WebKit::RemoteGraphicsContextGLProxy::waitSync):
(WebKit::RemoteGraphicsContextGLProxy::getSynci):
(WebKit::RemoteGraphicsContextGLProxy::createTransformFeedback):
(WebKit::RemoteGraphicsContextGLProxy::deleteTransformFeedback):
(WebKit::RemoteGraphicsContextGLProxy::isTransformFeedback):
(WebKit::RemoteGraphicsContextGLProxy::bindTransformFeedback):
(WebKit::RemoteGraphicsContextGLProxy::beginTransformFeedback):
(WebKit::RemoteGraphicsContextGLProxy::endTransformFeedback):
(WebKit::RemoteGraphicsContextGLProxy::transformFeedbackVaryings):
(WebKit::RemoteGraphicsContextGLProxy::getTransformFeedbackVarying):
(WebKit::RemoteGraphicsContextGLProxy::pauseTransformFeedback):
(WebKit::RemoteGraphicsContextGLProxy::resumeTransformFeedback):
(WebKit::RemoteGraphicsContextGLProxy::bindBufferBase):
(WebKit::RemoteGraphicsContextGLProxy::bindBufferRange):
(WebKit::RemoteGraphicsContextGLProxy::getUniformIndices):
(WebKit::RemoteGraphicsContextGLProxy::getActiveUniforms):
(WebKit::RemoteGraphicsContextGLProxy::getUniformBlockIndex):
(WebKit::RemoteGraphicsContextGLProxy::getActiveUniformBlockName):
(WebKit::RemoteGraphicsContextGLProxy::uniformBlockBinding):
(WebKit::RemoteGraphicsContextGLProxy::getActiveUniformBlockiv):
(WebKit::RemoteGraphicsContextGLProxy::getTranslatedShaderSourceANGLE):
(WebKit::RemoteGraphicsContextGLProxy::drawBuffersEXT):
(WebKit::RemoteGraphicsContextGLProxy::enableiOES):
(WebKit::RemoteGraphicsContextGLProxy::disableiOES):
(WebKit::RemoteGraphicsContextGLProxy::blendEquationiOES):
(WebKit::RemoteGraphicsContextGLProxy::blendEquationSeparateiOES):
(WebKit::RemoteGraphicsContextGLProxy::blendFunciOES):
(WebKit::RemoteGraphicsContextGLProxy::blendFuncSeparateiOES):
(WebKit::RemoteGraphicsContextGLProxy::colorMaskiOES):
(WebKit::RemoteGraphicsContextGLProxy::drawArraysInstancedBaseInstanceANGLE):
(WebKit::RemoteGraphicsContextGLProxy::drawElementsInstancedBaseVertexBaseInstanceANGLE):
(WebKit::RemoteGraphicsContextGLProxy::provokingVertexANGLE):
(WebKit::RemoteGraphicsContextGLProxy::getInternalformativ):
(WebKit::RemoteGraphicsContextGLProxy::setDrawingBufferColorSpace):
(WebKit::RemoteGraphicsContextGLProxy::paintRenderingResultsToPixelBuffer):
* Source/WebKit/WebProcess/GPU/graphics/cocoa/RemoteGraphicsContextGLProxyCocoa.mm:
* Source/WebKit/WebProcess/Storage/WebSWClientConnection.messages.in:
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.messages.in:
* Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.messages.in:
* Source/WebKit/WebProcess/Storage/WebSharedWorkerObjectConnection.messages.in:
* Source/WebKit/WebProcess/UserContent/WebUserContentController.messages.in:
* Tools/Scripts/generate-gpup-webgl:
* Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp:
* Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h:
* Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12bb67cc9203c51f8dd48ff246ab77778ebd4f11

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108496 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17593 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41346 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117602 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/117806 "Hash 12bb67cc for PR 9621 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112382 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19044 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8871 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100724 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114263 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14272 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97498 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42238 "Passed tests") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/112027 "Found 1 webkitpy python3 test failure: webkit.messages_unittest.GeneratedFileContentsTest.test_receiver") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96250 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29138 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/83946 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10403 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30487 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11160 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7398 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16550 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50083 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12748 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->