### PR TITLE
getDisplayMedia does not require a list of every screen and window

### DIFF
--- a/Source/WebCore/Modules/mediastream/MediaDevices.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.cpp
@@ -179,7 +179,7 @@ static bool hasInvalidGetDisplayMediaConstraint(const MediaConstraints& constrai
     //     2. If value contains a member which in turn is a dictionary containing a member named either min or
     //        exact, return a promise rejected with a newly created TypeError.
     if (!constraints.isValid)
-        return false;
+        return true;
 
     if (!constraints.advancedConstraints.isEmpty())
         return true;

--- a/Source/WebCore/platform/mediastream/DisplayCaptureManager.h
+++ b/Source/WebCore/platform/mediastream/DisplayCaptureManager.h
@@ -38,8 +38,6 @@ public:
         CaptureDevice m_device;
         String m_application;
     };
-
-    virtual void windowDevices(Vector<WindowCaptureDevice>&) { }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
@@ -1019,19 +1019,15 @@ const IntSize RealtimeMediaSource::size() const
     return size;
 }
 
-void RealtimeMediaSource::setIntrinsicSize(const IntSize& size, bool notifyObservers)
+void RealtimeMediaSource::setIntrinsicSize(const IntSize& intrinsicSize, bool notifyObservers)
 {
-    if (m_intrinsicSize == size)
+    if (m_intrinsicSize == intrinsicSize)
         return;
 
-    ALWAYS_LOG_IF(m_logger, LOGIDENTIFIER, size);
-    
-    auto currentSize = this->size();
-    m_intrinsicSize = size;
-    if (!notifyObservers)
-        return;
+    ALWAYS_LOG_IF(m_logger, LOGIDENTIFIER, intrinsicSize);
 
-    if (currentSize != this->size()) {
+    m_intrinsicSize = intrinsicSize;
+    if (notifyObservers) {
         scheduleDeferredTask([this] {
             notifySettingsDidChangeObservers({ RealtimeMediaSourceSettings::Flag::Width, RealtimeMediaSourceSettings::Flag::Height });
         });

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h
@@ -122,10 +122,9 @@ private:
         CaptureDevice device;
     };
 
-    void getDisplayMediaDevices(const MediaStreamRequest&, MediaDeviceHashSalts&&, Vector<DeviceInfo>&, String&);
     void getUserMediaDevices(const MediaStreamRequest&, MediaDeviceHashSalts&&, Vector<DeviceInfo>& audioDevices, Vector<DeviceInfo>& videoDevices, String&);
     void validateRequestConstraintsAfterEnumeration(ValidConstraintsHandler&&, InvalidConstraintsHandler&&, const MediaStreamRequest&, MediaDeviceHashSalts&&);
-    void enumerateDevices(bool shouldEnumerateCamera, bool shouldEnumerateDisplay, bool shouldEnumerateMicrophone, bool shouldEnumerateSpeakers, CompletionHandler<void()>&&);
+    void enumerateDevices(bool shouldEnumerateCamera, bool shouldEnumerateMicrophone, bool shouldEnumerateSpeakers, CompletionHandler<void()>&&);
 
     RealtimeMediaSourceSupportedConstraints m_supportedConstraints;
 

--- a/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp
@@ -205,7 +205,6 @@ Seconds DisplayCaptureSourceCocoa::elapsedTime()
 void DisplayCaptureSourceCocoa::updateFrameSize()
 {
     auto intrinsicSize = this->intrinsicSize();
-
     auto frameSize = size();
     if (!frameSize.height())
         frameSize.setHeight(intrinsicSize.height());
@@ -308,11 +307,13 @@ void DisplayCaptureSourceCocoa::emitFrame()
 void DisplayCaptureSourceCocoa::capturerConfigurationChanged()
 {
     m_currentSettings = { };
+    m_capabilities = { };
     auto capturerIntrinsicSize = m_capturer->intrinsicSize();
-    if (this->intrinsicSize() != capturerIntrinsicSize) {
-        m_capabilities = { };
+    if (this->intrinsicSize() != capturerIntrinsicSize)
         setIntrinsicSize(capturerIntrinsicSize);
-    }
+    forEachObserver([](auto& observer) {
+        observer.sourceConfigurationChanged();
+    });
 }
 
 void DisplayCaptureSourceCocoa::setLogger(const Logger& logger, const void* identifier)

--- a/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h
+++ b/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h
@@ -118,7 +118,6 @@ public:
     static CaptureSourceOrError create(Expected<UniqueRef<Capturer>, String>&&, const CaptureDevice&, MediaDeviceHashSalts&&, const MediaConstraints*, PageIdentifier);
 
     Seconds elapsedTime();
-    void updateFrameSize();
 
 private:
     DisplayCaptureSourceCocoa(UniqueRef<Capturer>&&, const CaptureDevice&, MediaDeviceHashSalts&&, PageIdentifier);
@@ -143,6 +142,7 @@ private:
     void capturerConfigurationChanged() final;
 
     void emitFrame();
+    void updateFrameSize();
 
     UniqueRef<Capturer> m_capturer;
     std::optional<RealtimeMediaSourceCapabilities> m_capabilities;

--- a/Source/WebCore/platform/mediastream/mac/DisplayCaptureManagerCocoa.cpp
+++ b/Source/WebCore/platform/mediastream/mac/DisplayCaptureManagerCocoa.cpp
@@ -55,38 +55,7 @@ DisplayCaptureManagerCocoa& DisplayCaptureManagerCocoa::singleton()
 
 const Vector<CaptureDevice>& DisplayCaptureManagerCocoa::captureDevices()
 {
-    m_devices.clear();
-
-    updateDisplayCaptureDevices();
-    updateWindowCaptureDevices();
-
     return m_devices;
-}
-
-void DisplayCaptureManagerCocoa::updateDisplayCaptureDevices()
-{
-#if PLATFORM(MAC)
-
-#if HAVE(SCREEN_CAPTURE_KIT)
-    if (ScreenCaptureKitCaptureSource::isAvailable()) {
-        ScreenCaptureKitCaptureSource::screenCaptureDevices(m_devices);
-        return;
-    }
-#endif
-
-    CGDisplayStreamScreenCaptureSource::screenCaptureDevices(m_devices);
-
-#elif PLATFORM(IOS)
-    ReplayKitCaptureSource::screenCaptureDevices(m_devices);
-#endif
-}
-
-void DisplayCaptureManagerCocoa::updateWindowCaptureDevices()
-{
-#if HAVE(SCREEN_CAPTURE_KIT)
-    if (ScreenCaptureKitCaptureSource::isAvailable())
-        ScreenCaptureKitCaptureSource::windowCaptureDevices(m_devices);
-#endif
 }
 
 std::optional<CaptureDevice> DisplayCaptureManagerCocoa::screenCaptureDeviceWithPersistentID(const String& deviceID)
@@ -139,16 +108,6 @@ std::optional<CaptureDevice> DisplayCaptureManagerCocoa::captureDeviceWithPersis
     }
 
     return std::nullopt;
-}
-
-void DisplayCaptureManagerCocoa::windowDevices(Vector<DisplayCaptureManager::WindowCaptureDevice>& windowDevices)
-{
-#if HAVE(SCREEN_CAPTURE_KIT)
-    if (ScreenCaptureKitCaptureSource::isAvailable())
-        return ScreenCaptureKitCaptureSource::windowDevices(windowDevices);
-#else
-    UNUSED_PARAM(windowDevices);
-#endif
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/mac/DisplayCaptureManagerCocoa.h
+++ b/Source/WebCore/platform/mediastream/mac/DisplayCaptureManagerCocoa.h
@@ -40,16 +40,11 @@ public:
 private:
     virtual ~DisplayCaptureManagerCocoa() = default;
 
-    void updateDisplayCaptureDevices();
-    void updateWindowCaptureDevices();
-
     const Vector<CaptureDevice>& captureDevices() final;
 
     std::optional<CaptureDevice> captureDeviceWithPersistentID(CaptureDevice::DeviceType, const String&) final;
     std::optional<CaptureDevice> screenCaptureDeviceWithPersistentID(const String&);
     std::optional<CaptureDevice> windowCaptureDeviceWithPersistentID(const String&);
-
-    void windowDevices(Vector<WindowCaptureDevice>&) final;
 
     Vector<CaptureDevice> m_devices;
 };

--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.h
@@ -61,13 +61,7 @@ public:
     WEBCORE_EXPORT static bool isAvailable();
 
     static std::optional<CaptureDevice> screenCaptureDeviceWithPersistentID(const String&);
-    WEBCORE_EXPORT static void screenCaptureDevices(Vector<CaptureDevice>&);
-
-    static void windowCaptureDevices(Vector<CaptureDevice>&);
     static std::optional<CaptureDevice> windowCaptureDeviceWithPersistentID(const String&);
-    WEBCORE_EXPORT static void windowDevices(Vector<DisplayCaptureManager::WindowCaptureDevice>&);
-
-    static void captureDeviceWithPersistentID(CaptureDevice::DeviceType, uint32_t, CompletionHandler<void(std::optional<CaptureDevice>)>&&);
 
     using Content = std::variant<RetainPtr<SCWindow>, RetainPtr<SCDisplay>>;
     void streamFailedWithError(RetainPtr<NSError>&&, const String&);
@@ -114,7 +108,7 @@ private:
     BlockPtr<void(SCStream *, CMSampleBufferRef)> m_frameAvailableHandler;
     CaptureDevice m_captureDevice;
     uint32_t m_deviceID { 0 };
-    std::optional<IntSize> m_intrinsicSize;
+    mutable std::optional<IntSize> m_intrinsicSize;
 
     uint32_t m_width { 0 };
     uint32_t m_height { 0 };

--- a/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
@@ -489,17 +489,6 @@ DisplayCaptureFactory& MockRealtimeMediaSourceCenter::displayCaptureFactory()
     return factory.get();
 }
 
-void MockRealtimeMediaSourceCenter::MockDisplayCaptureDeviceManager::windowDevices(Vector<DisplayCaptureManager::WindowCaptureDevice>& windowDevices)
-{
-    auto devices = MockRealtimeMediaSourceCenter::displayDevices();
-    for (auto device : devices) {
-        if (!device.enabled() || device.type() != CaptureDevice::DeviceType::Window)
-            continue;
-
-        windowDevices.append({ WTFMove(device), "Mock Application"_s });
-    }
-}
-
 } // namespace WebCore
 
 #endif // ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.h
+++ b/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.h
@@ -90,7 +90,6 @@ private:
     private:
         const Vector<CaptureDevice>& captureDevices() final { return MockRealtimeMediaSourceCenter::displayDevices(); }
         std::optional<CaptureDevice> captureDeviceWithPersistentID(CaptureDevice::DeviceType type, const String& id) final { return MockRealtimeMediaSourceCenter::captureDeviceWithPersistentID(type, id); }
-        void windowDevices(Vector<DisplayCaptureManager::WindowCaptureDevice>&) final;
     };
 
     MockAudioCaptureDeviceManager m_audioCaptureDeviceManager;

--- a/Source/WebKit/UIProcess/API/C/WKUserMediaPermissionRequest.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKUserMediaPermissionRequest.cpp
@@ -94,3 +94,9 @@ WKArrayRef WKUserMediaPermissionRequestAudioDeviceUIDs(WKUserMediaPermissionRequ
 #endif
     return array;
 }
+
+bool WKUserMediaPermissionRequestRequiresDisplayCapture(WKUserMediaPermissionRequestRef userMediaPermissionRequestRef)
+{
+    return toImpl(userMediaPermissionRequestRef)->requiresDisplayCapture();
+}
+

--- a/Source/WebKit/UIProcess/API/C/WKUserMediaPermissionRequest.h
+++ b/Source/WebKit/UIProcess/API/C/WKUserMediaPermissionRequest.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2014 Igalia S.L
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
@@ -42,6 +42,7 @@ typedef uint32_t UserMediaPermissionRequestDenialReason;
 WK_EXPORT void WKUserMediaPermissionRequestAllow(WKUserMediaPermissionRequestRef, WKStringRef audioDeviceUID, WKStringRef videoDeviceUID);
 WK_EXPORT void WKUserMediaPermissionRequestDeny(WKUserMediaPermissionRequestRef, UserMediaPermissionRequestDenialReason);
 
+WK_EXPORT bool WKUserMediaPermissionRequestRequiresDisplayCapture(WKUserMediaPermissionRequestRef);
 WK_EXPORT WKArrayRef WKUserMediaPermissionRequestVideoDeviceUIDs(WKUserMediaPermissionRequestRef);
 WK_EXPORT WKArrayRef WKUserMediaPermissionRequestAudioDeviceUIDs(WKUserMediaPermissionRequestRef);
 

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestProxy.h
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestProxy.h
@@ -60,8 +60,8 @@ public:
 
     bool requiresAudioCapture() const { return m_eligibleAudioDevices.size(); }
     bool requiresVideoCapture() const { return !requiresDisplayCapture() && m_eligibleVideoDevices.size(); }
-    bool requiresDisplayCapture() const { return (m_request.type == WebCore::MediaStreamRequest::Type::DisplayMedia || m_request.type == WebCore::MediaStreamRequest::Type::DisplayMediaWithAudio) && m_eligibleVideoDevices.size(); }
-    bool requiresDisplayCaptureWithAudio() const { return m_request.type == WebCore::MediaStreamRequest::Type::DisplayMediaWithAudio && m_eligibleVideoDevices.size(); }
+    bool requiresDisplayCapture() const { return m_request.type == WebCore::MediaStreamRequest::Type::DisplayMedia || m_request.type == WebCore::MediaStreamRequest::Type::DisplayMediaWithAudio; }
+    bool requiresDisplayCaptureWithAudio() const { return m_request.type == WebCore::MediaStreamRequest::Type::DisplayMediaWithAudio; }
 
     void setEligibleVideoDeviceUIDs(Vector<WebCore::CaptureDevice>&& devices) { m_eligibleVideoDevices = WTFMove(devices); }
     void setEligibleAudioDeviceUIDs(Vector<WebCore::CaptureDevice>&& devices) { m_eligibleAudioDevices = WTFMove(devices); }

--- a/Source/WebKit/UIProcess/UserMediaProcessManager.h
+++ b/Source/WebKit/UIProcess/UserMediaProcessManager.h
@@ -29,6 +29,7 @@
 
 namespace WebKit {
 
+class UserMediaPermissionRequestProxy;
 class WebProcessProxy;
 
 class UserMediaProcessManager : public WebCore::RealtimeMediaSourceCenter::Observer {
@@ -38,7 +39,7 @@ public:
 
     UserMediaProcessManager();
 
-    bool willCreateMediaStream(UserMediaPermissionRequestManagerProxy&, bool withAudio, bool withVideo);
+    bool willCreateMediaStream(UserMediaPermissionRequestManagerProxy&, const UserMediaPermissionRequestProxy&);
 
     void revokeSandboxExtensionsIfNeeded(WebProcessProxy&);
 

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -2724,7 +2724,7 @@ void TestController::decidePolicyForUserMediaPermissionRequestIfPossible()
         auto audioDeviceUIDs = adoptWK(WKUserMediaPermissionRequestAudioDeviceUIDs(request));
         auto videoDeviceUIDs = adoptWK(WKUserMediaPermissionRequestVideoDeviceUIDs(request));
 
-        if (!WKArrayGetSize(videoDeviceUIDs.get()) && !WKArrayGetSize(audioDeviceUIDs.get())) {
+        if (!WKUserMediaPermissionRequestRequiresDisplayCapture(request) && !WKArrayGetSize(videoDeviceUIDs.get()) && !WKArrayGetSize(audioDeviceUIDs.get())) {
             WKUserMediaPermissionRequestDeny(request, kWKNoConstraints);
             continue;
         }


### PR DESCRIPTION
#### 1ad6bf1f3f6c8122574d79e9ae8bb53a2a61669a
<pre>
getDisplayMedia does not require a list of every screen and window
<a href="https://bugs.webkit.org/show_bug.cgi?id=251719">https://bugs.webkit.org/show_bug.cgi?id=251719</a>
rdar://105018387

Reviewed by Youenn Fablet.

getDisplayMedia always requires a prompt and an explicit user selection, so we will
never need to build a list of every window and screen.

* Source/WebCore/platform/mediastream/DisplayCaptureManager.h:
(WebCore::DisplayCaptureManager::windowDevices): Deleted.
* Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp:
(WebCore::RealtimeMediaSource::setIntrinsicSize):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp:
(WebCore::RealtimeMediaSourceCenter::getMediaStreamDevices):
(WebCore::RealtimeMediaSourceCenter::enumerateDevices):
(WebCore::RealtimeMediaSourceCenter::validateRequestConstraints):
(WebCore::RealtimeMediaSourceCenter::validateRequestConstraintsAfterEnumeration):
(WebCore::RealtimeMediaSourceCenter::getDisplayMediaDevices): Deleted.
* Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h:
* Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp:
(WebCore::DisplayCaptureSourceCocoa::updateFrameSize):
(WebCore::DisplayCaptureSourceCocoa::capturerConfigurationChanged):
* Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h:
* Source/WebCore/platform/mediastream/mac/DisplayCaptureManagerCocoa.cpp:
(WebCore::DisplayCaptureManagerCocoa::captureDevices):
(WebCore::DisplayCaptureManagerCocoa::updateDisplayCaptureDevices): Deleted.
(WebCore::DisplayCaptureManagerCocoa::updateWindowCaptureDevices): Deleted.
(WebCore::DisplayCaptureManagerCocoa::windowDevices): Deleted.
* Source/WebCore/platform/mediastream/mac/DisplayCaptureManagerCocoa.h:
* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.h:
* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm:
(WebCore::ScreenCaptureKitCaptureSource::startContentStream):
(WebCore::ScreenCaptureKitCaptureSource::intrinsicSize const):
(WebCore::ScreenCaptureKitCaptureSource::streamDidOutputSampleBuffer):
(WebCore::ScreenCaptureKitCaptureSource::windowCaptureDeviceWithPersistentID):
(WebCore::ScreenCaptureKitCaptureSource::captureDeviceWithPersistentID): Deleted.
(WebCore::ScreenCaptureKitCaptureSource::screenCaptureDevices): Deleted.
(WebCore::ScreenCaptureKitCaptureSource::windowCaptureDevices): Deleted.
(WebCore::ScreenCaptureKitCaptureSource::windowDevices): Deleted.
(WebCore::forEachNSWindow): Deleted.
* Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp:
(WebCore::MockRealtimeMediaSourceCenter::MockDisplayCaptureDeviceManager::windowDevices): Deleted.
* Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.h:
* Source/WebKit/UIProcess/API/C/WKUserMediaPermissionRequest.cpp:
(WKUserMediaPermissionRequestRequiresDisplayCapture):
* Source/WebKit/UIProcess/API/C/WKUserMediaPermissionRequest.h:
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp:
(WebKit::UserMediaPermissionRequestManagerProxy::finishGrantingRequest):
(WebKit::UserMediaPermissionRequestManagerProxy::getRequestAction):
(WebKit::UserMediaPermissionRequestManagerProxy::processUserMediaPermissionRequest):
(WebKit::UserMediaPermissionRequestManagerProxy::processUserMediaPermissionValidRequest):
* Source/WebKit/UIProcess/UserMediaPermissionRequestProxy.h:
(WebKit::UserMediaPermissionRequestProxy::requiresDisplayCapture const):
(WebKit::UserMediaPermissionRequestProxy::requiresDisplayCaptureWithAudio const):
* Source/WebKit/UIProcess/UserMediaProcessManager.cpp:
(WebKit::UserMediaProcessManager::willCreateMediaStream):
* Source/WebKit/UIProcess/UserMediaProcessManager.h:
* Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm:
(WebKit::DisplayCaptureSessionManager::showWindowPicker):
(WebKit::DisplayCaptureSessionManager::showScreenPicker):
(WebKit::alertForWindowSelection): Deleted.
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::decidePolicyForUserMediaPermissionRequestIfPossible):

Canonical link: <a href="https://commits.webkit.org/259969@main">https://commits.webkit.org/259969@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68fdb74b48f3e50010fc74eca0680668d4385779

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106588 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/15598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/39391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115772 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/115406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110494 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17095 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6828 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98779 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112356 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/39391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/40549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/94867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/39391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/8824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/39391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9368 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/5991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14986 "Failed to checkout and rebase branch from PR 9625") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/39391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6897 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/10904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->