### PR TITLE
[run-webkit-tests] Handle diverse WatchOS device types

### DIFF
--- a/Tools/Scripts/webkitpy/xcode/device_type_unittest.py
+++ b/Tools/Scripts/webkitpy/xcode/device_type_unittest.py
@@ -163,3 +163,8 @@ class DeviceTypeTest(unittest.TestCase):
         self.assertEqual(DeviceType.from_string('iPhone SE (1st generation)').standardized_hardware_type, 'SE')
         self.assertTrue(DeviceType.from_string('iPhone SE') == DeviceType.from_string('iPhone SE (1st generation)'))
         self.assertTrue(DeviceType.from_string('iPhone SE') != DeviceType.from_string('iPhone SE (2nd generation)'))
+
+    def test_watch_standardization(self):
+        self.assertEqual(DeviceType.from_string('Apple Watch Series 5 (44mm)').standardized_hardware_type, 'Series 5 - 44mm')
+        self.assertTrue(DeviceType.from_string('Apple Watch Series 5 (44mm)') == DeviceType.from_string('Apple Watch Series 5 - 44mm'))
+        self.assertTrue(DeviceType.from_string('Apple Watch Series 5 (38mm)') != DeviceType.from_string('Apple Watch Series 5 - 44mm'))

--- a/Tools/Scripts/webkitpy/xcode/simulated_device.py
+++ b/Tools/Scripts/webkitpy/xcode/simulated_device.py
@@ -268,9 +268,7 @@ class SimulatedDeviceManager(object):
             ' {}'.format(device_type.standardized_hardware_type.lower()) if device_type.standardized_hardware_type else '',
         )
         for type_id, type_name in SimulatedDeviceManager._device_identifier_to_name.items():
-            if type_name.lower() == type_name_for_request:
-                return type_id
-            if type_name.lower().endswith(DeviceType.FIRST_GENERATION) and type_name.lower()[:-len(DeviceType.FIRST_GENERATION)] == type_name_for_request:
+            if DeviceType.standardize_hardware_type(type_name).lower() == type_name_for_request:
                 return type_id
         return None
 


### PR DESCRIPTION
#### 1b334608e22428bfcb4db180417c93e50c06333f
<pre>
[run-webkit-tests] Handle diverse WatchOS device types
<a href="https://bugs.webkit.org/show_bug.cgi?id=251723">https://bugs.webkit.org/show_bug.cgi?id=251723</a>
rdar://105021853

Reviewed by Ryan Haddad.

* Tools/Scripts/webkitpy/xcode/device_type.py:
(DeviceType.standardize_hardware_type): Refactor to allow invocation without a class instance,
add a check for WatchOS variants.
(DeviceType.standardized_hardware_type): Invoke refactored function
* Tools/Scripts/webkitpy/xcode/device_type_unittest.py:
(DeviceTypeTest.test_watch_standardization):
* Tools/Scripts/webkitpy/xcode/simulated_device.py:
(SimulatedDeviceManager._get_device_identifier_for_type): Invoke DeviceType.standardize_hardware_type
instead of re-implimenting the function.

Canonical link: <a href="https://commits.webkit.org/259848@main">https://commits.webkit.org/259848@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd56341854424cd185ee17a93b744d09844c80b9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106140 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15190 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38971 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115321 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/175396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110043 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16623 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6365 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98343 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/115015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111897 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/95618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/40189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/109604 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94518 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27261 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8439 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28613 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8936 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/5165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14554 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48157 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10477 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3665 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->