### PR TITLE
wip: [Xcode] Disable unified build with WK_USE_UNIFIED_BUILD=NO

### DIFF
--- a/Source/JavaScriptCore/Configurations/JavaScriptCore.xcconfig
+++ b/Source/JavaScriptCore/Configurations/JavaScriptCore.xcconfig
@@ -99,7 +99,13 @@ OUTPUT_ALTERNATE_ROOT_PATH_YES_YES = $(DSTROOT)$(ALTERNATE_ROOT_PATH)/$(FULL_PRO
 INSTALLHDRS_SCRIPT_PHASE = YES;
 APPLY_RULES_IN_COPY_HEADERS = $(WK_USE_NEW_BUILD_SYSTEM);
 
-EXCLUDED_SOURCE_FILE_NAMES = $(inherited) $(EXCLUDED_SOURCE_FILE_NAMES_$(WK_WHICH_BUILD_SYSTEM));
+INCLUDED_SOURCE_FILE_NAMES = $(inherited) $(INCLUDED_SOURCE_FILE_NAMES_UNIFIED_$(WK_NOT_$(WK_NOT_$(WK_USE_UNIFIED_SOURCES))));
+EXCLUDED_SOURCE_FILE_NAMES = $(inherited) $(EXCLUDED_SOURCE_FILE_NAMES_UNIFIED_$(WK_NOT_$(WK_NOT_$(WK_USE_UNIFIED_SOURCES)))) $(EXCLUDED_SOURCE_FILE_NAMES_$(WK_WHICH_BUILD_SYSTEM));
 EXCLUDED_SOURCE_FILE_NAMES[sdk=iphone*] = $(inherited) framework.sb;
 // Offset and settings headers are built by separate targets and script phases in the legacy build system, not using build rules.
 EXCLUDED_SOURCE_FILE_NAMES_legacy = *.asm;
+
+WK_USE_UNIFIED_SOURCES = YES;
+EXCLUDED_SOURCE_FILE_NAMES_UNIFIED_YES = *.c *.cpp *.m *.mm;
+INCLUDED_SOURCE_FILE_NAMES_UNIFIED_YES = UnifiedSource* CachedTypes.cpp DFGSpeculativeJIT.cpp DFGSpeculativeJIT32_64.cpp DFGSpeculativeJIT64.cpp FTLLowerDFGToB3.cpp IntlDateTimeFormat.cpp IntlDurationFormat.cpp IntlListFormat.cpp IntlNumberFormat.cpp IntlPluralRules.cpp IntlWorkaround.cpp JSCBuiltins.cpp JSDateMath.cpp LowLevelInterpreter.cpp MacroAssemblerARM64.cpp MacroAssemblerARMv7.cpp MacroAssemblerMIPS.cpp MacroAssemblerRISCV64.cpp MacroAssemblerX86Common.cpp Parser.cpp WasmAirIRGenerator32_64.cpp WasmAirIRGenerator64.cpp ZydisFormatterATT.c ZydisFormatterBase.c ZydisFormatterIntel.c;
+EXCLUDED_SOURCE_FILE_NAMES_UNIFIED_NO = UnifiedSource*;

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1837,8 +1837,6 @@
 		DCF3D56D1CD29476003D5C65 /* LazyPropertyInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = DCF3D5681CD29468003D5C65 /* LazyPropertyInlines.h */; };
 		DCFDFBD91D1F5D9B00FE3D72 /* B3BottomProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = DCFDFBD71D1F5D9800FE3D72 /* B3BottomProvider.h */; };
 		DCFDFBDA1D1F5D9E00FE3D72 /* B3TypeMap.h in Headers */ = {isa = PBXBuildFile; fileRef = DCFDFBD81D1F5D9800FE3D72 /* B3TypeMap.h */; };
-		DD284672291A217E0009A61D /* CachedTypes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14DAFA4521E3B871004B68F7 /* CachedTypes.cpp */; };
-		DD284679291A29900009A61D /* JSCBytecodeCacheVersion.cpp.in in Sources */ = {isa = PBXBuildFile; fileRef = DD284677291A280D0009A61D /* JSCBytecodeCacheVersion.cpp.in */; };
 		DD28467B291A35120009A61D /* JSCBytecodeCacheVersion.h in Headers */ = {isa = PBXBuildFile; fileRef = DD28467A291A35120009A61D /* JSCBytecodeCacheVersion.h */; };
 		DD28467C291AF1B20009A61D /* JSCBuiltins.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7D801A61880D6A80026C39B /* JSCBuiltins.cpp */; };
 		DD41FA8627CDAD3200394D95 /* LowLevelInterpreter.asm in Sources */ = {isa = PBXBuildFile; fileRef = 86A054461556451B00445157 /* LowLevelInterpreter.asm */; };
@@ -1848,6 +1846,1127 @@
 		DDB04F42278E56A2008D3678 /* libWTF.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1498CAD3214656C400710879 /* libWTF.a */; };
 		DDE99310278D087D00F60D26 /* libWebKitAdditions.a in Product Dependencies */ = {isa = PBXBuildFile; fileRef = DDE9930E278D086600F60D26 /* libWebKitAdditions.a */; };
 		DDE99312278D089000F60D26 /* libWebKitAdditions.a in Product Dependencies */ = {isa = PBXBuildFile; fileRef = DDE9930E278D086600F60D26 /* libWebKitAdditions.a */; };
+		DDF54D60298DA937000410DB /* JSBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1421359A0A677F4F00A8195E /* JSBase.cpp */; };
+		DDF54D61298DA937000410DB /* MarkedJSValueRefArray.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3D3515E241B89CF008DC16E /* MarkedJSValueRefArray.cpp */; };
+		DDF54D62298DA937000410DB /* JSWeakValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7A9774A6206B828C008D03D0 /* JSWeakValue.cpp */; };
+		DDF54D63298DA937000410DB /* JSLockRef.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1486A8BE24ABED3B0073922D /* JSLockRef.cpp */; };
+		DDF54D64298DA937000410DB /* OpaqueJSString.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E124A8F60E555775003091F1 /* OpaqueJSString.cpp */; };
+		DDF54D65298DA937000410DB /* APIIntegrity.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FEF90A8E28AC187A00C14B84 /* APIIntegrity.cpp */; };
+		DDF54D66298DA937000410DB /* JSContextRef.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14BD5A290A3E91F600BAF59C /* JSContextRef.cpp */; };
+		DDF54D67298DA937000410DB /* JSCTestRunnerUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A72028B41797601E0098028C /* JSCTestRunnerUtils.cpp */; };
+		DDF54D68298DA937000410DB /* JSScriptRef.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7C0C4AA167C08CD0017011D /* JSScriptRef.cpp */; };
+		DDF54D69298DA937000410DB /* JSStringRef.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1482B74C0A43032800517CFC /* JSStringRef.cpp */; };
+		DDF54D6A298DA937000410DB /* JSTypedArray.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 53486BBA1C18E84500F6F3AF /* JSTypedArray.cpp */; };
+		DDF54D6B298DA937000410DB /* JSWeakObjectMapRefPrivate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7482B7A1166CDEA003B0712 /* JSWeakObjectMapRefPrivate.cpp */; };
+		DDF54D6C298DA937000410DB /* JSHeapFinalizerPrivate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F0CAEF91EC4DA6200970D12 /* JSHeapFinalizerPrivate.cpp */; };
+		DDF54D6D298DA937000410DB /* JSCallbackFunction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1440F8900A508B100005F061 /* JSCallbackFunction.cpp */; };
+		DDF54D6E298DA937000410DB /* JSCallbackObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14ABDF5E0A437FEF00ECCA01 /* JSCallbackObject.cpp */; };
+		DDF54D6F298DA937000410DB /* JSMarkingConstraintPrivate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F0B28671EB8E6CD000EB5D2 /* JSMarkingConstraintPrivate.cpp */; };
+		DDF54D70298DA937000410DB /* JSAPIGlobalObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 53C3D5E621ED1C050087FDFC /* JSAPIGlobalObject.cpp */; };
+		DDF54D71298DA937000410DB /* JSObjectRef.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1482B7E20A43076000517CFC /* JSObjectRef.cpp */; };
+		DDF54D72298DA937000410DB /* JSClassRef.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1440FCE20A51E46B0005F061 /* JSClassRef.cpp */; };
+		DDF54D73298DA937000410DB /* JSAPIValueWrapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC0894D50FAFBA2D00001865 /* JSAPIValueWrapper.cpp */; };
+		DDF54D74298DA937000410DB /* JSValueRef.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14BD5A2B0A3E91F600BAF59C /* JSValueRef.cpp */; };
+		DDF54D75298DA937000410DB /* JSRemoteInspector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A552C37D1ADDB8FE00139726 /* JSRemoteInspector.cpp */; };
+		DDF54D76298DA937000410DB /* JSCallbackConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1440F8AD0A508D200005F061 /* JSCallbackConstructor.cpp */; };
+		DDF54D77298DA937000410DB /* JSStringRefCF.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 146AAB370B66A94400E55F16 /* JSStringRefCF.cpp */; };
+		DDF54D78298DA937000410DB /* JSWeakPrivate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F0B28691EB8E6CD000EB5D2 /* JSWeakPrivate.cpp */; };
+		DDF54D79298DA94E000410DB /* MacroAssemblerPrinter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE68C6351B90DDD90042BCB3 /* MacroAssemblerPrinter.cpp */; };
+		DDF54D7A298DA94E000410DB /* ProbeStack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE10AAE91F44D510009DEDC5 /* ProbeStack.cpp */; };
+		DDF54D7B298DA94E000410DB /* MacroAssemblerCodeRef.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F6DB7EB1D617D0F00CDBF8E /* MacroAssemblerCodeRef.cpp */; };
+		DDF54D7C298DA94E000410DB /* AssemblerBuffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FA6F39620CCB7A600A03DCD /* AssemblerBuffer.cpp */; };
+		DDF54D7D298DA94E000410DB /* LinkBuffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FF4275615914A20004CB9FF /* LinkBuffer.cpp */; };
+		DDF54D7E298DA94E000410DB /* MacroAssembler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEB3ECE16237F6700AB67AD /* MacroAssembler.cpp */; };
+		DDF54D7F298DA94E000410DB /* Printer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE63DD551EA9BC5D00103A69 /* Printer.cpp */; };
+		DDF54D80298DA94E000410DB /* AbstractMacroAssembler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2C63BF1E660EA500C13839 /* AbstractMacroAssembler.cpp */; };
+		DDF54D81298DA94E000410DB /* AssemblyComments.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4BDF3001289324AB00AE1DE3 /* AssemblyComments.cpp */; };
+		DDF54D82298DA94E000410DB /* CPU.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52335628225EB8E900268BD2 /* CPU.cpp */; };
+		DDF54D83298DA94E000410DB /* SecureARM64EHashPins.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52CAEC732790B8F600DDBAAF /* SecureARM64EHashPins.cpp */; };
+		DDF54D84298DA94E000410DB /* ProbeContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE10AAF31F46826D009DEDC5 /* ProbeContext.cpp */; };
+		DDF54D85298DA94E000410DB /* JITOperationList.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3CA3A4B2527AB2E004802BF /* JITOperationList.cpp */; };
+		DDF54D86298DA95A000410DB /* AirRegLiveness.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FF4B4BA1E88449500DBBE86 /* AirRegLiveness.cpp */; };
+		DDF54D87298DA95A000410DB /* AirPrintSpecial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE5628CB1E99512400C49E45 /* AirPrintSpecial.cpp */; };
+		DDF54D88298DA95A000410DB /* AirCCallingConvention.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F6183201C45BF070072450B /* AirCCallingConvention.cpp */; };
+		DDF54D89298DA95A000410DB /* AirInst.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC855A1BDACDC70080FF74 /* AirInst.cpp */; };
+		DDF54D8A298DA95A000410DB /* AirCustom.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F6183221C45BF070072450B /* AirCustom.cpp */; };
+		DDF54D8B298DA95A000410DB /* AirLogRegisterPressure.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FE34C171C4B39AE0003A512 /* AirLogRegisterPressure.cpp */; };
+		DDF54D8C298DA95A000410DB /* AirPhaseScope.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC855E1BDACDC70080FF74 /* AirPhaseScope.cpp */; };
+		DDF54D8D298DA95A000410DB /* AirBreakCriticalEdges.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F79C7C51E74C93600EB34D1 /* AirBreakCriticalEdges.cpp */; };
+		DDF54D8E298DA95A000410DB /* AirKind.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FDF67D41D9DC43E001B9825 /* AirKind.cpp */; };
+		DDF54D8F298DA95A000410DB /* AirReportUsedRegisters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F45703A1BE45F0A0062A629 /* AirReportUsedRegisters.cpp */; };
+		DDF54D90298DA95A000410DB /* AirCode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC85501BDACDC70080FF74 /* AirCode.cpp */; };
+		DDF54D91298DA95A000410DB /* AirGenerated.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC85921BDB1E100080FF74 /* AirGenerated.cpp */; };
+		DDF54D92298DA95A000410DB /* AirLowerStackArgs.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F5CF9821E9D537500C18692 /* AirLowerStackArgs.cpp */; };
+		DDF54D93298DA95A000410DB /* AirStackSlotKind.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2BBD9B1C5FF4050023EF23 /* AirStackSlotKind.cpp */; };
+		DDF54D94298DA95A000410DB /* AirTmpWidth.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FE0E4AB1C24C94A002E17B6 /* AirTmpWidth.cpp */; };
+		DDF54D95298DA95A000410DB /* AirArg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC854A1BDACDC70080FF74 /* AirArg.cpp */; };
+		DDF54D96298DA95A000410DB /* AirDisassembler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 79ABB17B1E5CCB570045B9A6 /* AirDisassembler.cpp */; };
+		DDF54D97298DA95A000410DB /* AirInsertionSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC85581BDACDC70080FF74 /* AirInsertionSet.cpp */; };
+		DDF54D98298DA95A000410DB /* AirOptimizeBlockOrder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FB3878C1BFBC44D00E3AB1E /* AirOptimizeBlockOrder.cpp */; };
+		DDF54D99298DA95A000410DB /* AirCCallSpecial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC854E1BDACDC70080FF74 /* AirCCallSpecial.cpp */; };
+		DDF54D9A298DA95A000410DB /* AirFixObviousSpills.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F4DE1CC1C4C1B54004D6C11 /* AirFixObviousSpills.cpp */; };
+		DDF54D9B298DA95A000410DB /* AirSpecial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC85621BDACDC70080FF74 /* AirSpecial.cpp */; };
+		DDF54D9C298DA95A000410DB /* AirFixPartialRegisterStalls.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 262D85B41C0D650F006ACB61 /* AirFixPartialRegisterStalls.cpp */; };
+		DDF54D9D298DA95A000410DB /* AirHandleCalleeSaves.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC85561BDACDC70080FF74 /* AirHandleCalleeSaves.cpp */; };
+		DDF54D9E298DA95A000410DB /* AirLowerMacros.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F6183271C45BF070072450B /* AirLowerMacros.cpp */; };
+		DDF54D9F298DA95A000410DB /* AirBasicBlock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC854C1BDACDC70080FF74 /* AirBasicBlock.cpp */; };
+		DDF54DA0298DA95A000410DB /* AirFixSpillsAfterTerminals.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2AC5641E8A0B760001EE3F /* AirFixSpillsAfterTerminals.cpp */; };
+		DDF54DA1298DA95A000410DB /* AirLowerEntrySwitch.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FDF70831D3F2C1F00927449 /* AirLowerEntrySwitch.cpp */; };
+		DDF54DA2298DA95A000410DB /* AirAllocateRegistersByGraphColoring.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7965C2141E5D799600B7591D /* AirAllocateRegistersByGraphColoring.cpp */; };
+		DDF54DA3298DA95A000410DB /* AirAllocateRegistersAndStackByLinearScan.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2AC5681E8A0BD10001EE3F /* AirAllocateRegistersAndStackByLinearScan.cpp */; };
+		DDF54DA4298DA95A000410DB /* AirPhaseInsertionSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2AC56C1E8D7AFF0001EE3F /* AirPhaseInsertionSet.cpp */; };
+		DDF54DA5298DA95A000410DB /* AirGenerate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC85531BDACDC70080FF74 /* AirGenerate.cpp */; };
+		DDF54DA6298DA95A000410DB /* AirPadInterference.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F9CABC61DB54A760008E83B /* AirPadInterference.cpp */; };
+		DDF54DA7298DA95A000410DB /* AirTmp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC85681BDACDC70080FF74 /* AirTmp.cpp */; };
+		DDF54DA8298DA95A000410DB /* AirBlockInsertionSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2C63B91E63440800C13839 /* AirBlockInsertionSet.cpp */; };
+		DDF54DA9298DA95A000410DB /* AirEmitShuffle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F6183231C45BF070072450B /* AirEmitShuffle.cpp */; };
+		DDF54DAA298DA95A000410DB /* AirLowerAfterRegAlloc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F6183251C45BF070072450B /* AirLowerAfterRegAlloc.cpp */; };
+		DDF54DAB298DA95A000410DB /* AirAllocateStackByGraphColoring.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC85481BDACDC70080FF74 /* AirAllocateStackByGraphColoring.cpp */; };
+		DDF54DAC298DA95A000410DB /* AirStackAllocation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F5CF9861E9ED64E00C18692 /* AirStackAllocation.cpp */; };
+		DDF54DAD298DA95A000410DB /* AirSimplifyCFG.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F338DFB1BED51270013C88F /* AirSimplifyCFG.cpp */; };
+		DDF54DAE298DA95A000410DB /* AirAllocateRegistersAndStackAndGenerateCode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 524E9D7122092B4500A6BEEE /* AirAllocateRegistersAndStackAndGenerateCode.cpp */; };
+		DDF54DAF298DA95A000410DB /* AirEliminateDeadCode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F4570361BE44C910062A629 /* AirEliminateDeadCode.cpp */; };
+		DDF54DB0298DA95A000410DB /* AirStackSlot.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC85661BDACDC70080FF74 /* AirStackSlot.cpp */; };
+		DDF54DB1298DA95A000410DB /* AirValidate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC856B1BDACDC70080FF74 /* AirValidate.cpp */; };
+		DDF54DB2298DA966000410DB /* B3PhaseScope.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC84DF1BDACDAC0080FF74 /* B3PhaseScope.cpp */; };
+		DDF54DB3298DA966000410DB /* B3StackmapSpecial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC84E61BDACDAC0080FF74 /* B3StackmapSpecial.cpp */; };
+		DDF54DB4298DA966000410DB /* B3Const64Value.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC84C51BDACDAC0080FF74 /* B3Const64Value.cpp */; };
+		DDF54DB5298DA966000410DB /* B3Effects.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC85C41BE16F5A0080FF74 /* B3Effects.cpp */; };
+		DDF54DB6298DA966000410DB /* B3EliminateCommonSubexpressions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F725CA31C503DED00AD943A /* B3EliminateCommonSubexpressions.cpp */; };
+		DDF54DB7298DA966000410DB /* B3FoldPathConstants.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F725CAD1C506D3B00AD943A /* B3FoldPathConstants.cpp */; };
+		DDF54DB8298DA966000410DB /* B3SSACalculator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F6B8ADA1C4EFAC300969052 /* B3SSACalculator.cpp */; };
+		DDF54DB9298DA966000410DB /* B3VariableLiveness.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FF4B4C81E889D7800DBBE86 /* B3VariableLiveness.cpp */; };
+		DDF54DBA298DA966000410DB /* B3BottomTupleValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E392E6F624D25FA600B20767 /* B3BottomTupleValue.cpp */; };
+		DDF54DBB298DA966000410DB /* B3VariableValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2BBD941C5FF3F50023EF23 /* B3VariableValue.cpp */; };
+		DDF54DBC298DA966000410DB /* B3LowerMacros.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F338E191BF286EA0013C88F /* B3LowerMacros.cpp */; };
+		DDF54DBD298DA966000410DB /* B3LowerMacrosAfterOptimizations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4319DA011C1BE3C1001D260B /* B3LowerMacrosAfterOptimizations.cpp */; };
+		DDF54DBE298DA966000410DB /* B3MoveConstants.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F338E031BF0276C0013C88F /* B3MoveConstants.cpp */; };
+		DDF54DBF298DA966000410DB /* B3WasmBoundsCheckValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5341FC6F1DAC33E500E7E4D7 /* B3WasmBoundsCheckValue.cpp */; };
+		DDF54DC0298DA966000410DB /* B3ExtractValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5318045D22EAAF0F004A7342 /* B3ExtractValue.cpp */; };
+		DDF54DC1298DA966000410DB /* B3ArgumentRegValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC84B41BDACDAC0080FF74 /* B3ArgumentRegValue.cpp */; };
+		DDF54DC2298DA966000410DB /* B3StackmapValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F338DEF1BE93AD10013C88F /* B3StackmapValue.cpp */; };
+		DDF54DC3298DA966000410DB /* B3PhiChildren.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F37308A1C0BD29100052BFA /* B3PhiChildren.cpp */; };
+		DDF54DC4298DA966000410DB /* B3Common.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC84BF1BDACDAC0080FF74 /* B3Common.cpp */; };
+		DDF54DC5298DA966000410DB /* B3ValueKey.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F338E081BF0276C0013C88F /* B3ValueKey.cpp */; };
+		DDF54DC6298DA966000410DB /* B3OriginDump.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F4DE1D01C4D764B004D6C11 /* B3OriginDump.cpp */; };
+		DDF54DC7298DA966000410DB /* B3Const128Value.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B78E09B294427D2003C6682 /* B3Const128Value.cpp */; };
+		DDF54DC8298DA966000410DB /* B3PatchpointSpecial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC84DB1BDACDAC0080FF74 /* B3PatchpointSpecial.cpp */; };
+		DDF54DC9298DA966000410DB /* B3ReduceStrength.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC85B71BE1462F0080FF74 /* B3ReduceStrength.cpp */; };
+		DDF54DCA298DA966000410DB /* B3LowerToAir.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC84D31BDACDAC0080FF74 /* B3LowerToAir.cpp */; };
+		DDF54DCB298DA966000410DB /* B3ReduceDoubleToFloat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43422A641C16221E00E2EB98 /* B3ReduceDoubleToFloat.cpp */; };
+		DDF54DCC298DA966000410DB /* B3HoistLoopInvariantValues.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F5BF1611F2317120029D91D /* B3HoistLoopInvariantValues.cpp */; };
+		DDF54DCD298DA966000410DB /* B3Procedure.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC84E11BDACDAC0080FF74 /* B3Procedure.cpp */; };
+		DDF54DCE298DA966000410DB /* B3Origin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC84D91BDACDAC0080FF74 /* B3Origin.cpp */; };
+		DDF54DCF298DA966000410DB /* B3EnsureLoopPreHeaders.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F5BF16E1F23A5A10029D91D /* B3EnsureLoopPreHeaders.cpp */; };
+		DDF54DD0298DA966000410DB /* B3PureCSE.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F725CA51C503DED00AD943A /* B3PureCSE.cpp */; };
+		DDF54DD1298DA966000410DB /* B3AtomicValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2C63B31E6343E800C13839 /* B3AtomicValue.cpp */; };
+		DDF54DD2298DA966000410DB /* B3Bank.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2C63AB1E60AE3C00C13839 /* B3Bank.cpp */; };
+		DDF54DD3298DA966000410DB /* B3SlotBaseValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC84EA1BDACDAC0080FF74 /* B3SlotBaseValue.cpp */; };
+		DDF54DD4298DA966000410DB /* B3SwitchValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC84EF1BDACDAC0080FF74 /* B3SwitchValue.cpp */; };
+		DDF54DD5298DA966000410DB /* B3Commutativity.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC84C11BDACDAC0080FF74 /* B3Commutativity.cpp */; };
+		DDF54DD6298DA966000410DB /* B3FrequencyClass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC84CB1BDACDAC0080FF74 /* B3FrequencyClass.cpp */; };
+		DDF54DD7298DA966000410DB /* B3UseCounts.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC84F51BDACDAC0080FF74 /* B3UseCounts.cpp */; };
+		DDF54DD8298DA966000410DB /* B3MemoryValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC84D51BDACDAC0080FF74 /* B3MemoryValue.cpp */; };
+		DDF54DD9298DA966000410DB /* B3LegalizeMemoryOffsets.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 436E54511C468E5F00B5AF73 /* B3LegalizeMemoryOffsets.cpp */; };
+		DDF54DDA298DA966000410DB /* B3SIMDValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B78E098294427D2003C6682 /* B3SIMDValue.cpp */; };
+		DDF54DDB298DA966000410DB /* B3ConstrainedValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F338DF31BE93D550013C88F /* B3ConstrainedValue.cpp */; };
+		DDF54DDC298DA966000410DB /* B3CheckSpecial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC84BB1BDACDAC0080FF74 /* B3CheckSpecial.cpp */; };
+		DDF54DDD298DA966000410DB /* B3ConstFloatValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43422A601C15871B00E2EB98 /* B3ConstFloatValue.cpp */; };
+		DDF54DDE298DA966000410DB /* B3CaseCollection.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC9A0C1C1D2D94EF0085124E /* B3CaseCollection.cpp */; };
+		DDF54DDF298DA966000410DB /* B3Width.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2C63AD1E60AE3C00C13839 /* B3Width.cpp */; };
+		DDF54DE0298DA966000410DB /* B3Const32Value.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC84C31BDACDAC0080FF74 /* B3Const32Value.cpp */; };
+		DDF54DE1298DA966000410DB /* B3Generate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC84CE1BDACDAC0080FF74 /* B3Generate.cpp */; };
+		DDF54DE2298DA966000410DB /* B3DataSection.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F338E011BF0276C0013C88F /* B3DataSection.cpp */; };
+		DDF54DE3298DA966000410DB /* B3OptimizeAssociativeExpressionTrees.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 33743649224D79EF00C8C227 /* B3OptimizeAssociativeExpressionTrees.cpp */; };
+		DDF54DE4298DA966000410DB /* B3PatchpointValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC84DD1BDACDAC0080FF74 /* B3PatchpointValue.cpp */; };
+		DDF54DE5298DA966000410DB /* B3DuplicateTails.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F6B8AD61C4EDDA200969052 /* B3DuplicateTails.cpp */; };
+		DDF54DE6298DA966000410DB /* B3InsertionSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC85B41BE1462F0080FF74 /* B3InsertionSet.cpp */; };
+		DDF54DE7298DA966000410DB /* B3Opcode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC84D71BDACDAC0080FF74 /* B3Opcode.cpp */; };
+		DDF54DE8298DA966000410DB /* B3Type.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC84F11BDACDAC0080FF74 /* B3Type.cpp */; };
+		DDF54DE9298DA966000410DB /* B3FenceValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F6971E81D92F42100BA02A5 /* B3FenceValue.cpp */; };
+		DDF54DEA298DA966000410DB /* B3MathExtras.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43AB26C41C1A52F700D82AE6 /* B3MathExtras.cpp */; };
+		DDF54DEB298DA966000410DB /* B3FixSSA.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F6B8AE01C4EFE1700969052 /* B3FixSSA.cpp */; };
+		DDF54DEC298DA966000410DB /* B3BlockInsertionSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F338E171BF286EA0013C88F /* B3BlockInsertionSet.cpp */; };
+		DDF54DED298DA966000410DB /* B3Variable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2BBD921C5FF3F50023EF23 /* B3Variable.cpp */; };
+		DDF54DEE298DA966000410DB /* B3EstimateStaticExecutionCounts.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52E65A1A27682760002B4C0A /* B3EstimateStaticExecutionCounts.cpp */; };
+		DDF54DEF298DA966000410DB /* B3CCallValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F338DF71BE96AA80013C88F /* B3CCallValue.cpp */; };
+		DDF54DF0298DA966000410DB /* B3Compile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 795F099C1E03600500BBE37F /* B3Compile.cpp */; };
+		DDF54DF1298DA966000410DB /* B3ConstDoubleValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC84C71BDACDAC0080FF74 /* B3ConstDoubleValue.cpp */; };
+		DDF54DF2298DA966000410DB /* B3CheckValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC84BD1BDACDAC0080FF74 /* B3CheckValue.cpp */; };
+		DDF54DF3298DA966000410DB /* B3UpsilonValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC84F31BDACDAC0080FF74 /* B3UpsilonValue.cpp */; };
+		DDF54DF4298DA966000410DB /* B3EliminateDeadCode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3395C70422555F6C00BDBFAD /* B3EliminateDeadCode.cpp */; };
+		DDF54DF5298DA966000410DB /* B3SwitchCase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC84ED1BDACDAC0080FF74 /* B3SwitchCase.cpp */; };
+		DDF54DF6298DA966000410DB /* B3StackmapGenerationParams.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F33FCF51C136E2500323F67 /* B3StackmapGenerationParams.cpp */; };
+		DDF54DF7298DA966000410DB /* B3WasmAddressValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 53D444DD1DAF09A000B92784 /* B3WasmAddressValue.cpp */; };
+		DDF54DF8298DA966000410DB /* B3ValueRep.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC84FC1BDACDAC0080FF74 /* B3ValueRep.cpp */; };
+		DDF54DF9298DA966000410DB /* B3BasicBlock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC84B61BDACDAC0080FF74 /* B3BasicBlock.cpp */; };
+		DDF54DFA298DA966000410DB /* B3Kind.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FDF67D01D9C6086001B9825 /* B3Kind.cpp */; };
+		DDF54DFB298DA966000410DB /* B3InferSwitches.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC69B99A1D15F90F002E3C00 /* B3InferSwitches.cpp */; };
+		DDF54DFC298DA966000410DB /* B3Value.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC84F91BDACDAC0080FF74 /* B3Value.cpp */; };
+		DDF54DFD298DA966000410DB /* B3BreakCriticalEdges.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F6B8ADE1C4EFE1700969052 /* B3BreakCriticalEdges.cpp */; };
+		DDF54DFE298DA966000410DB /* B3Validate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC84F71BDACDAC0080FF74 /* B3Validate.cpp */; };
+		DDF54DFF298DA96C000410DB /* ScriptFunctionCall.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A55D93A3185012A800400DED /* ScriptFunctionCall.cpp */; };
+		DDF54E00298DA96C000410DB /* ScriptObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A54CF2F7184EAEDA00237F19 /* ScriptObject.cpp */; };
+		DDF54E01298DA96C000410DB /* ScriptValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A54CF2F2184EAB2400237F19 /* ScriptValue.cpp */; };
+		DDF54E02298DA976000410DB /* BuiltinExecutables.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7D801A11880D66E0026C39B /* BuiltinExecutables.cpp */; };
+		DDF54E03298DA976000410DB /* BuiltinExecutableCreator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DE26E9061CB5DD9600D2BE82 /* BuiltinExecutableCreator.cpp */; };
+		DDF54E04298DA976000410DB /* BuiltinNames.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E380D66B1F19249D00A59095 /* BuiltinNames.cpp */; };
+		DDF54E05298DA990000410DB /* LLIntPrototypeLoadAdaptiveStructureWatchpoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 53FA2AE21CF380390022711D /* LLIntPrototypeLoadAdaptiveStructureWatchpoint.cpp */; };
+		DDF54E06298DA990000410DB /* CheckPrivateBrandStatus.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86281EF525B61B0600367004 /* CheckPrivateBrandStatus.cpp */; };
+		DDF54E07298DA990000410DB /* AccessCase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 534E034F1E4D95ED00213F64 /* AccessCase.cpp */; };
+		DDF54E08298DA990000410DB /* AdaptiveInferredPropertyValueWatchpointBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5370B4F31BF25EA2005C40FC /* AdaptiveInferredPropertyValueWatchpointBase.cpp */; };
+		DDF54E09298DA990000410DB /* BytecodeLivenessAnalysis.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C2FCAE0E17A9C24E0034C735 /* BytecodeLivenessAnalysis.cpp */; };
+		DDF54E0A298DA990000410DB /* ICStatusUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F44A7B520C0BE3F0022B171 /* ICStatusUtils.cpp */; };
+		DDF54E0B298DA990000410DB /* JumpTable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCFD8C900EEB2EE700283848 /* JumpTable.cpp */; };
+		DDF54E0C298DA990000410DB /* Watchpoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F919D2215853CDE004A4E7D /* Watchpoint.cpp */; };
+		DDF54E0D298DA990000410DB /* InstanceOfVariant.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FB399BC20AF6B2A0017E213 /* InstanceOfVariant.cpp */; };
+		DDF54E0E298DA990000410DB /* PolymorphicAccess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FF9CE711B9CD6D0004EDCA6 /* PolymorphicAccess.cpp */; };
+		DDF54E0F298DA990000410DB /* ArrayAllocationProfile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F8335B41639C1E3001443B5 /* ArrayAllocationProfile.cpp */; };
+		DDF54E10298DA990000410DB /* InlineAccess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7905BB661D12050E0019FE57 /* InlineAccess.cpp */; };
+		DDF54E11298DA990000410DB /* CallMode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 627673211B680C1E00FD9F2E /* CallMode.cpp */; };
+		DDF54E12298DA990000410DB /* SetPrivateBrandStatus.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 865DA0C925B8962A00875772 /* SetPrivateBrandStatus.cpp */; };
+		DDF54E13298DA990000410DB /* UnlinkedModuleProgramCodeBlock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14AD912A1DCAAAB00014F9FE /* UnlinkedModuleProgramCodeBlock.cpp */; };
+		DDF54E14298DA990000410DB /* InstanceOfStatus.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FB399BA20AF6B2A0017E213 /* InstanceOfStatus.cpp */; };
+		DDF54E15298DA990000410DB /* ProxyableAccessCase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 53B0BE351E561B0900A8FC29 /* ProxyableAccessCase.cpp */; };
+		DDF54E16298DA990000410DB /* CallVariant.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F3B7E2419A11B8000D9BC56 /* CallVariant.cpp */; };
+		DDF54E17298DA990000410DB /* ObjectPropertyConditionSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FD3E4051B618B6600C80E1E /* ObjectPropertyConditionSet.cpp */; };
+		DDF54E18298DA990000410DB /* SuperSampler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F4A38F71C8E13DF00190318 /* SuperSampler.cpp */; };
+		DDF54E19298DA990000410DB /* BytecodeIndex.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5360DABB2356ADCA003F6AB8 /* BytecodeIndex.cpp */; };
+		DDF54E1A298DA990000410DB /* DirectEvalCodeCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2EBBAA1DEDF94E00990369 /* DirectEvalCodeCache.cpp */; };
+		DDF54E1B298DA990000410DB /* BytecodeUseDef.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 53D35498240D88AD008950DD /* BytecodeUseDef.cpp */; };
+		DDF54E1C298DA990000410DB /* ExitingInlineKind.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F44A7AC20BF685F0022B171 /* ExitingInlineKind.cpp */; };
+		DDF54E1D298DA990000410DB /* DeleteByStatus.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 73190D962400934900F891C9 /* DeleteByStatus.cpp */; };
+		DDF54E1E298DA990000410DB /* UnlinkedFunctionCodeBlock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14AD912B1DCAAAB00014F9FE /* UnlinkedFunctionCodeBlock.cpp */; };
+		DDF54E1F298DA990000410DB /* UnlinkedEvalCodeBlock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14AD91281DCAAAB00014F9FE /* UnlinkedEvalCodeBlock.cpp */; };
+		DDF54E20298DA990000410DB /* ExitingJITType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F0332BF18ADFAE1005F979A /* ExitingJITType.cpp */; };
+		DDF54E21298DA990000410DB /* DeferredSourceDump.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE5068661AE25E280009DAB7 /* DeferredSourceDump.cpp */; };
+		DDF54E22298DA990000410DB /* CallEdge.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F64B2771A7957B2006E4E66 /* CallEdge.cpp */; };
+		DDF54E23298DA990000410DB /* PutByStatus.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F93329914CA7DC10085F3C6 /* PutByStatus.cpp */; };
+		DDF54E24298DA990000410DB /* BytecodeBasicBlock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C2FCAE0C17A9C24E0034C735 /* BytecodeBasicBlock.cpp */; };
+		DDF54E25298DA990000410DB /* InstructionStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14CC3BA12138A238002D58B6 /* InstructionStream.cpp */; };
+		DDF54E26298DA990000410DB /* InByStatus.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A38D5BF92666D3DA00A109A6 /* InByStatus.cpp */; };
+		DDF54E27298DA990000410DB /* UnlinkedCodeBlockGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E36B480123E9573800E4A66E /* UnlinkedCodeBlockGenerator.cpp */; };
+		DDF54E28298DA990000410DB /* CodeBlockJettisoningWatchpoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FC97F2F182020D7002C9B26 /* CodeBlockJettisoningWatchpoint.cpp */; };
+		DDF54E29298DA990000410DB /* ValueRecovery.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F24E55717F74EDB00ABB217 /* ValueRecovery.cpp */; };
+		DDF54E2A298DA990000410DB /* CodeBlock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 969A07900ED1D3AE00F1F681 /* CodeBlock.cpp */; };
+		DDF54E2B298DA990000410DB /* ComplexGetStatus.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F6FC74E196110A800E1D02D /* ComplexGetStatus.cpp */; };
+		DDF54E2C298DA990000410DB /* CodeType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F8F943F1667632D00D61971 /* CodeType.cpp */; };
+		DDF54E2D298DA990000410DB /* StructureStubInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCCF0D0B0EF0B8A500413C8F /* StructureStubInfo.cpp */; };
+		DDF54E2E298DA990000410DB /* VirtualRegister.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F20C2581A8013AB00DA3229 /* VirtualRegister.cpp */; };
+		DDF54E2F298DA990000410DB /* ExitKind.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FB105821675480C00F8AB6E /* ExitKind.cpp */; };
+		DDF54E30298DA990000410DB /* ReduceWhitespace.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FF60ABF16740F8100029779 /* ReduceWhitespace.cpp */; };
+		DDF54E31298DA990000410DB /* PolyProtoAccessChain.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521131F51F82BF11007CCEEE /* PolyProtoAccessChain.cpp */; };
+		DDF54E32298DA990000410DB /* InlineCallFrameSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F24E55317F0B71C00ABB217 /* InlineCallFrameSet.cpp */; };
+		DDF54E33298DA990000410DB /* StructureStubClearingWatchpoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F766D3615AE4A1A008F363E /* StructureStubClearingWatchpoint.cpp */; };
+		DDF54E34298DA990000410DB /* UnlinkedCodeBlock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A79E781E15EECBA80047C855 /* UnlinkedCodeBlock.cpp */; };
+		DDF54E35298DA990000410DB /* ProgramCodeBlock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14AD91141DCA97FD0014F9FE /* ProgramCodeBlock.cpp */; };
+		DDF54E36298DA990000410DB /* DeferredCompilationCallback.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FC712DC17CD8778008CC93C /* DeferredCompilationCallback.cpp */; };
+		DDF54E37298DA990000410DB /* InlineCallFrame.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 148A7BED1B82975A002D9157 /* InlineCallFrame.cpp */; };
+		DDF54E38298DA990000410DB /* ParseHash.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E34E657420668E8E00FB81AC /* ParseHash.cpp */; };
+		DDF54E39298DA990000410DB /* BytecodeDumper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3D877711E65C08900BE945A /* BytecodeDumper.cpp */; };
+		DDF54E3A298DA990000410DB /* GetterSetterAccessCase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 53B0BE331E561AC900A8FC29 /* GetterSetterAccessCase.cpp */; };
+		DDF54E3B298DA990000410DB /* ModuleProgramCodeBlock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14AD91131DCA97FD0014F9FE /* ModuleProgramCodeBlock.cpp */; };
+		DDF54E3C298DA990000410DB /* UnlinkedFunctionExecutable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14142E541B7973C000F4BF4B /* UnlinkedFunctionExecutable.cpp */; };
+		DDF54E3D298DA990000410DB /* DeleteByVariant.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7311FA33240DB249003D48DB /* DeleteByVariant.cpp */; };
+		DDF54E3E298DA990000410DB /* GetByStatus.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F93329514CA7DC10085F3C6 /* GetByStatus.cpp */; };
+		DDF54E3F298DA990000410DB /* BytecodeRewriter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3D264291D38C042000BE174 /* BytecodeRewriter.cpp */; };
+		DDF54E40298DA990000410DB /* ExitFlag.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F44A7A920BF685E0022B171 /* ExitFlag.cpp */; };
+		DDF54E41298DA990000410DB /* ProxyObjectAccessCase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E30D903728B77F27008B2CDC /* ProxyObjectAccessCase.cpp */; };
+		DDF54E42298DA990000410DB /* CallLinkStatus.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F93329314CA7DC10085F3C6 /* CallLinkStatus.cpp */; };
+		DDF54E43298DA990000410DB /* PutByVariant.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F93B4A718B92C4D00178A3F /* PutByVariant.cpp */; };
+		DDF54E44298DA990000410DB /* InstanceOfAccessCase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F49E9A720AB4CFB001CA0AA /* InstanceOfAccessCase.cpp */; };
+		DDF54E45298DA990000410DB /* PutByIdFlags.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F15CD201BA5F9860031FFD3 /* PutByIdFlags.cpp */; };
+		DDF54E46298DA990000410DB /* TrackedReferences.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F952ABA1B487A7700C367C5 /* TrackedReferences.cpp */; };
+		DDF54E47298DA990000410DB /* PreciseJumpTargets.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F98205D16BFE37F00240D02 /* PreciseJumpTargets.cpp */; };
+		DDF54E48298DA990000410DB /* CodeBlockHash.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F8F943D1667632D00D61971 /* CodeBlockHash.cpp */; };
+		DDF54E49298DA990000410DB /* CallLinkInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F0B83AE14BCF71400885B4F /* CallLinkInfo.cpp */; };
+		DDF54E4A298DA990000410DB /* DataFormat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 62E3D5EF1B8D0B7300B868BB /* DataFormat.cpp */; };
+		DDF54E4B298DA990000410DB /* MetadataTable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14F79F6E216EAD5000046D39 /* MetadataTable.cpp */; };
+		DDF54E4C298DA990000410DB /* ExecutionCounter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F56A1D415001CF2002992B1 /* ExecutionCounter.cpp */; };
+		DDF54E4D298DA990000410DB /* MethodOfGettingAValueProfile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FB5467C14F5CFD3002C2989 /* MethodOfGettingAValueProfile.cpp */; };
+		DDF54E4E298DA990000410DB /* LinkTimeConstant.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3637EE8236E56B00096BD0A /* LinkTimeConstant.cpp */; };
+		DDF54E4F298DA990000410DB /* Opcode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 969A07940ED1D3AE00F1F681 /* Opcode.cpp */; };
+		DDF54E50298DA990000410DB /* StubInfoSummary.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FA1265320C8DB98004B0D11 /* StubInfoSummary.cpp */; };
+		DDF54E51298DA990000410DB /* ObjectPropertyCondition.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FD3E4031B618B6600C80E1E /* ObjectPropertyCondition.cpp */; };
+		DDF54E52298DA990000410DB /* LazyOperandValueProfile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FB5467814F5C468002C2989 /* LazyOperandValueProfile.cpp */; };
+		DDF54E53298DA990000410DB /* InByVariant.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3305FB020B0F78700CEB82B /* InByVariant.cpp */; };
+		DDF54E54298DA990000410DB /* DFGExitProfile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FBC0AE41496C7C100D4FBDD /* DFGExitProfile.cpp */; };
+		DDF54E55298DA990000410DB /* PropertyCondition.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FD3E4071B618B6600C80E1E /* PropertyCondition.cpp */; };
+		DDF54E56298DA990000410DB /* RecordedStatuses.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F44A7AD20BF685F0022B171 /* RecordedStatuses.cpp */; };
+		DDF54E57298DA990000410DB /* SpeculatedType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FD82E84141F3FDA00179C94 /* SpeculatedType.cpp */; };
+		DDF54E58298DA990000410DB /* StructureSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FB438A219270B1D00E1FBC9 /* StructureSet.cpp */; };
+		DDF54E59298DA990000410DB /* UnlinkedProgramCodeBlock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14AD91291DCAAAB00014F9FE /* UnlinkedProgramCodeBlock.cpp */; };
+		DDF54E5A298DA990000410DB /* UnlinkedMetadataTable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3060128228F978100FAABDF /* UnlinkedMetadataTable.cpp */; };
+		DDF54E5B298DA990000410DB /* Repatch.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E39E448F2748E3F800EDD2A5 /* Repatch.cpp */; };
+		DDF54E5C298DA990000410DB /* FullCodeOrigin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AD4252521E5D0F22009D2A97 /* FullCodeOrigin.cpp */; };
+		DDF54E5D298DA990000410DB /* ModuleNamespaceAccessCase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20ECB15EFC524624BC2F02D5 /* ModuleNamespaceAccessCase.cpp */; };
+		DDF54E5E298DA990000410DB /* ArithProfile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 79A228331D35D71E00D8E067 /* ArithProfile.cpp */; };
+		DDF54E5F298DA990000410DB /* ArrayProfile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F63945115D07051006A597C /* ArrayProfile.cpp */; };
+		DDF54E60298DA990000410DB /* FunctionCodeBlock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14AD91161DCA97FD0014F9FE /* FunctionCodeBlock.cpp */; };
+		DDF54E61298DA990000410DB /* IntrinsicGetterAccessCase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 53B0BE371E561B2400A8FC29 /* IntrinsicGetterAccessCase.cpp */; };
+		DDF54E62298DA990000410DB /* CodeOrigin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F8F9445166764EE00D61971 /* CodeOrigin.cpp */; };
+		DDF54E63298DA990000410DB /* SetPrivateBrandVariant.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 865DA0C625B8959E00875772 /* SetPrivateBrandVariant.cpp */; };
+		DDF54E64298DA990000410DB /* ICStatusMap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F44A7AB20BF685E0022B171 /* ICStatusMap.cpp */; };
+		DDF54E65298DA990000410DB /* EvalCodeBlock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14AD91121DCA97FD0014F9FE /* EvalCodeBlock.cpp */; };
+		DDF54E66298DA990000410DB /* CheckPrivateBrandVariant.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86281EF125B6165E00367004 /* CheckPrivateBrandVariant.cpp */; };
+		DDF54E67298DA990000410DB /* ToThisStatus.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2D4DE519832DAC007D4B19 /* ToThisStatus.cpp */; };
+		DDF54E68298DA990000410DB /* AccessCaseSnippetParams.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3BFD0B91DAF807C0065DEA2 /* AccessCaseSnippetParams.cpp */; };
+		DDF54E69298DA990000410DB /* VariableWriteFireDetail.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F6C734E1AC9F99F00BE1682 /* VariableWriteFireDetail.cpp */; };
+		DDF54E6A298DA990000410DB /* GetByVariant.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F0332C118B01763005F979A /* GetByVariant.cpp */; };
+		DDF54E6B298DA990000410DB /* BytecodeGeneratorification.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3D264261D38C042000BE174 /* BytecodeGeneratorification.cpp */; };
+		DDF54E6C298DA990000410DB /* BytecodeIntrinsicRegistry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7094C4DC1AE439530041A2EE /* BytecodeIntrinsicRegistry.cpp */; };
+		DDF54E6D298DA995000410DB /* BytecodeGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 969A07200ED1CE3300F1F681 /* BytecodeGenerator.cpp */; };
+		DDF54E6E298DA995000410DB /* NodesCodegen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 655EB29A10CE2581001A990E /* NodesCodegen.cpp */; };
+		DDF54E6F298DA995000410DB /* ProfileTypeBytecodeFlag.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14788EE221501AF700A561C8 /* ProfileTypeBytecodeFlag.cpp */; };
+		DDF54E71298DA9B3000410DB /* BytecodeDumperGenerated.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDF54E70298DA9B3000410DB /* BytecodeDumperGenerated.cpp */; };
+		DDF54E72298DAA0A000410DB /* Breakpoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 91D1578C24E0BE35001F4CED /* Breakpoint.cpp */; };
+		DDF54E73298DAA0A000410DB /* Debugger.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F692A8580255597D01FF60F7 /* Debugger.cpp */; };
+		DDF54E74298DAA0A000410DB /* DebuggerScope.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2D4DDB19832D34007D4B19 /* DebuggerScope.cpp */; };
+		DDF54E75298DAA0A000410DB /* DebuggerCallFrame.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 149559ED0DDCDDF700648087 /* DebuggerCallFrame.cpp */; };
+		DDF54E76298DAA0A000410DB /* DebuggerParseData.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A5A1A0931D8CB337004C2EB8 /* DebuggerParseData.cpp */; };
+		DDF54E77298DAA0A000410DB /* DebuggerLocation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A5FC84B01D1DDAC8006B5C46 /* DebuggerLocation.cpp */; };
+		DDF54E78298DAA43000410DB /* DFGArrayMode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F63948115E48114006A597C /* DFGArrayMode.cpp */; };
+		DDF54E79298DAA43000410DB /* DFGAvailabilityMap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2B9CD619D0BA7D00B1D1B5 /* DFGAvailabilityMap.cpp */; };
+		DDF54E7A298DAA43000410DB /* DFGAdaptiveInferredPropertyValueWatchpoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FD3E3FF1B618AAF00C80E1E /* DFGAdaptiveInferredPropertyValueWatchpoint.cpp */; };
+		DDF54E7B298DAA43000410DB /* DFGLazyJSValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A73A53581799CD5D00170C19 /* DFGLazyJSValue.cpp */; };
+		DDF54E7C298DAA43000410DB /* DFGOSRExitCompilerCommon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F7025A71714B0F800382C0E /* DFGOSRExitCompilerCommon.cpp */; };
+		DDF54E7D298DAA43000410DB /* DFGCommon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FB4B51A16B62772003F696B /* DFGCommon.cpp */; };
+		DDF54E7E298DAA43000410DB /* DFGAbstractValueClobberEpoch.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F4F11E9209D426300709654 /* DFGAbstractValueClobberEpoch.cpp */; };
+		DDF54E7F298DAA43000410DB /* DFGClobberSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A77A423A17A0BBFD00A8DB81 /* DFGClobberSet.cpp */; };
+		DDF54E80298DAA43000410DB /* DFGNodeAbstractValuePair.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2017871DCB942200EA5950 /* DFGNodeAbstractValuePair.cpp */; };
+		DDF54E81298DAA43000410DB /* DFGArgumentsUtilities.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2DD80E1AB3D8BE00BBB8E8 /* DFGArgumentsUtilities.cpp */; };
+		DDF54E82298DAA43000410DB /* DFGClobberize.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A77A423817A0BBFD00A8DB81 /* DFGClobberize.cpp */; };
+		DDF54E83298DAA43000410DB /* DFGPlan.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A78A9772179738B8009DF744 /* DFGPlan.cpp */; };
+		DDF54E84298DAA43000410DB /* DFGCFGSimplificationPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F3B3A241544C991003ED0FF /* DFGCFGSimplificationPhase.cpp */; };
+		DDF54E85298DAA43000410DB /* DFGThunks.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FC0979F146B28C700CF2442 /* DFGThunks.cpp */; };
+		DDF54E86298DAA43000410DB /* DFGRegisteredStructureSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7980C16A1E3A940E00B71615 /* DFGRegisteredStructureSet.cpp */; };
+		DDF54E87298DAA43000410DB /* DFGVirtualRegisterAllocationPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FFFC95314EF909500C72532 /* DFGVirtualRegisterAllocationPhase.cpp */; };
+		DDF54E88298DAA43000410DB /* DFGCriticalEdgeBreakingPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7D89CE617A0B8CC00773AD8 /* DFGCriticalEdgeBreakingPhase.cpp */; };
+		DDF54E89298DAA43000410DB /* DFGObjectAllocationSinkingPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2B9CDA19D0BA7D00B1D1B5 /* DFGObjectAllocationSinkingPhase.cpp */; };
+		DDF54E8A298DAA43000410DB /* DFGToFTLDeferredCompilationCallback.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FD8A32117D51F5700CA2C40 /* DFGToFTLDeferredCompilationCallback.cpp */; };
+		DDF54E8B298DAA43000410DB /* DFGCSEPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FFFC94D14EF909500C72532 /* DFGCSEPhase.cpp */; };
+		DDF54E8C298DAA43000410DB /* DFGFailedFinalizer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A78A976C179738B8009DF744 /* DFGFailedFinalizer.cpp */; };
+		DDF54E8D298DAA43000410DB /* DFGOSRExitBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F235BE717178E7300690C7F /* DFGOSRExitBase.cpp */; };
+		DDF54E8E298DAA43000410DB /* DFGOSREntrypointCreationPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FD8A31D17D51F5700CA2C40 /* DFGOSREntrypointCreationPhase.cpp */; };
+		DDF54E8F298DAA43000410DB /* DFGNode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FB4B51E16B62772003F696B /* DFGNode.cpp */; };
+		DDF54E90298DAA43000410DB /* DFGFrozenValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F69CC86193AC60A0045759E /* DFGFrozenValue.cpp */; };
+		DDF54E91298DAA43000410DB /* DFGAvailability.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F666EC21835672B00D017F1 /* DFGAvailability.cpp */; };
+		DDF54E92298DAA43000410DB /* DFGArgumentsEliminationPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2DD80C1AB3D8BE00BBB8E8 /* DFGArgumentsEliminationPhase.cpp */; };
+		DDF54E93298DAA43000410DB /* DFGNodeFlowProjection.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2017831DCAE14700EA5950 /* DFGNodeFlowProjection.cpp */; };
+		DDF54E94298DAA43000410DB /* DFGVariableAccessData.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F6E845919030BEF00562741 /* DFGVariableAccessData.cpp */; };
+		DDF54E95298DAA43000410DB /* DFGUnificationPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FBE0F6F16C1DB010082C5E8 /* DFGUnificationPhase.cpp */; };
+		DDF54E96298DAA43000410DB /* DFGCombinedLiveness.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F04396B1B03DC0B009598B7 /* DFGCombinedLiveness.cpp */; };
+		DDF54E97298DAA43000410DB /* DFGEpoch.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F8F142F1ADF090100ED792C /* DFGEpoch.cpp */; };
+		DDF54E98298DAA43000410DB /* DFGDisassembler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FF427611591A1C9004CB9FF /* DFGDisassembler.cpp */; };
+		DDF54E99298DAA43000410DB /* DFGDoesGC.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F5A1271192D9FDF008764A3 /* DFGDoesGC.cpp */; };
+		DDF54E9A298DAA43000410DB /* DFGDesiredWeakReferences.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C2981FD617BAEE4B00A3BC98 /* DFGDesiredWeakReferences.cpp */; };
+		DDF54E9B298DAA43000410DB /* DFGLivenessAnalysisPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7D89CEC17A0B8CC00773AD8 /* DFGLivenessAnalysisPhase.cpp */; };
+		DDF54E9C298DAA43000410DB /* DFGDCEPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2FC77016E12F6F0038D976 /* DFGDCEPhase.cpp */; };
+		DDF54E9D298DAA43000410DB /* DFGPromotedHeapLocation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2B9CE019D0BA7D00B1D1B5 /* DFGPromotedHeapLocation.cpp */; };
+		DDF54E9E298DAA43000410DB /* DFGDesiredGlobalProperties.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3BFA5CB21E853A0009C0EBA /* DFGDesiredGlobalProperties.cpp */; };
+		DDF54E9F298DAA43000410DB /* DFGTypeCheckHoistingPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F63943C15C75F14006A597C /* DFGTypeCheckHoistingPhase.cpp */; };
+		DDF54EA0298DAA43000410DB /* DFGEdge.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FB4B51B16B62772003F696B /* DFGEdge.cpp */; };
+		DDF54EA1298DAA43000410DB /* DFGJITCompiler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86EC9DBB1328DF82002B2AD7 /* DFGJITCompiler.cpp */; };
+		DDF54EA2298DAA43000410DB /* DFGCFAPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FFFC94B14EF909500C72532 /* DFGCFAPhase.cpp */; };
+		DDF54EA3298DAA43000410DB /* DFGMayExit.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F5874EB194FEB1200AAB2C1 /* DFGMayExit.cpp */; };
+		DDF54EA4298DAA43000410DB /* DFGSSALoweringPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FC20CB718556A3500C9E954 /* DFGSSALoweringPhase.cpp */; };
+		DDF54EA5298DAA43000410DB /* DFGDesiredIdentifiers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F8F2B97172F04FD007DBDA5 /* DFGDesiredIdentifiers.cpp */; };
+		DDF54EA6298DAA43000410DB /* DFGLICMPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7D9A29217A0BC7400EE2618 /* DFGLICMPhase.cpp */; };
+		DDF54EA7298DAA43000410DB /* DFGConstantHoistingPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FED67B71B26256D0066CE15 /* DFGConstantHoistingPhase.cpp */; };
+		DDF54EA8298DAA43000410DB /* DFGGraphSafepoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2FCCF218A60070001A27F8 /* DFGGraphSafepoint.cpp */; };
+		DDF54EA9298DAA43000410DB /* DFGDesiredWatchpoints.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FE853491723CDA500B618F5 /* DFGDesiredWatchpoints.cpp */; };
+		DDF54EAA298DAA43000410DB /* DFGCapabilities.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FD82E1E14172C2F00179C94 /* DFGCapabilities.cpp */; };
+		DDF54EAB298DAA43000410DB /* DFGAbstractInterpreterClobberState.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F5E0FD7207C72710097F0DE /* DFGAbstractInterpreterClobberState.cpp */; };
+		DDF54EAC298DAA43000410DB /* DFGSSACalculator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F682FB019BCB36400FA3BAD /* DFGSSACalculator.cpp */; };
+		DDF54EAD298DAA43000410DB /* DFGAbstractValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F55C19317276E4600CEABFD /* DFGAbstractValue.cpp */; };
+		DDF54EAE298DAA43000410DB /* DFGInsertionSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F3BD1B61B896A0700598AA6 /* DFGInsertionSet.cpp */; };
+		DDF54EAF298DAA43000410DB /* DFGDriver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FD3C82014115CF800FD81CB /* DFGDriver.cpp */; };
+		DDF54EB0298DAA43000410DB /* DFGPutStackSinkingPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F3A1BF71A9ECB7D000DE01A /* DFGPutStackSinkingPhase.cpp */; };
+		DDF54EB1298DAA43000410DB /* DFGStoreBarrierInsertionPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F9E32611B05AB0400801ED5 /* DFGStoreBarrierInsertionPhase.cpp */; };
+		DDF54EB2298DAA43000410DB /* DFGOSRExitJumpPlaceholder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEFC9A71681A3B000567F53 /* DFGOSRExitJumpPlaceholder.cpp */; };
+		DDF54EB3298DAA43000410DB /* DFGPhiChildren.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2B9CDE19D0BA7D00B1D1B5 /* DFGPhiChildren.cpp */; };
+		DDF54EB4298DAA43000410DB /* DFGOSRExitFuzz.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F392C871B46188400844728 /* DFGOSRExitFuzz.cpp */; };
+		DDF54EB5298DAA43000410DB /* DFGJITCode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEA0A2F170D40BF00BB722C /* DFGJITCode.cpp */; };
+		DDF54EB6298DAA43000410DB /* DFGJumpReplacement.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FC97F3918202119002C9B26 /* DFGJumpReplacement.cpp */; };
+		DDF54EB7298DAA43000410DB /* DFGValueSource.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2BDC4E15228BE700CD8910 /* DFGValueSource.cpp */; };
+		DDF54EB8298DAA43000410DB /* DFGFixupPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2BDC12151C5D4A00CD8910 /* DFGFixupPhase.cpp */; };
+		DDF54EB9298DAA43000410DB /* DFGDoesGCCheck.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FEC3A39F248735BC00395B54 /* DFGDoesGCCheck.cpp */; };
+		DDF54EBA298DAA43000410DB /* DFGOSRExit.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FC0978E146A6F6300CF2442 /* DFGOSRExit.cpp */; };
+		DDF54EBB298DAA43000410DB /* DFGAbstractHeap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A77A423617A0BBFD00A8DB81 /* DFGAbstractHeap.cpp */; };
+		DDF54EBC298DAA43000410DB /* DFGLiveCatchVariablePreservationPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 79C4B15B1BA2158F00FD592E /* DFGLiveCatchVariablePreservationPhase.cpp */; };
+		DDF54EBD298DAA43000410DB /* DFGNodeOrigin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F5D085C1B8CF99D001143B4 /* DFGNodeOrigin.cpp */; };
+		DDF54EBE298DAA43000410DB /* DFGSSAConversionPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7D89CF017A0B8CC00773AD8 /* DFGSSAConversionPhase.cpp */; };
+		DDF54EBF298DAA43000410DB /* DFGTransition.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FE7211B193B9C590031F6ED /* DFGTransition.cpp */; };
+		DDF54EC0298DAA43000410DB /* DFGAdaptiveStructureWatchpoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F18D3CD1B55A6E0002C5C9F /* DFGAdaptiveStructureWatchpoint.cpp */; };
+		DDF54EC1298DAA43000410DB /* DFGPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FFFC94F14EF909500C72532 /* DFGPhase.cpp */; };
+		DDF54EC2298DAA43000410DB /* DFGStoreBarrierClusteringPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F7F98891D9596C300F4F12E /* DFGStoreBarrierClusteringPhase.cpp */; };
+		DDF54EC3298DAA43000410DB /* DFGCodeOriginPool.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E349A77F2491F159001BA336 /* DFGCodeOriginPool.cpp */; };
+		DDF54EC4298DAA43000410DB /* DFGHeapLocation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FB1765C196B8F9E0091052A /* DFGHeapLocation.cpp */; };
+		DDF54EC5298DAA43000410DB /* DFGConstantFoldingPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F3B3A17153E68EF003ED0FF /* DFGConstantFoldingPhase.cpp */; };
+		DDF54EC6298DAA43000410DB /* DFGNodeFlags.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FA581B7150E952A00B9A2D9 /* DFGNodeFlags.cpp */; };
+		DDF54EC7298DAA43000410DB /* DFGJITFinalizer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A78A9770179738B8009DF744 /* DFGJITFinalizer.cpp */; };
+		DDF54EC8298DAA43000410DB /* DFGArithMode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F48531F187750560083B687 /* DFGArithMode.cpp */; };
+		DDF54EC9298DAA43000410DB /* DFGBlockInsertionSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7D89CE417A0B8CC00773AD8 /* DFGBlockInsertionSet.cpp */; };
+		DDF54ECA298DAA43000410DB /* DFGBlockSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FBF158A19B7A53100695DD0 /* DFGBlockSet.cpp */; };
+		DDF54ECB298DAA43000410DB /* DFGMultiGetByOffsetData.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FF2CD591B61A4F8004955A8 /* DFGMultiGetByOffsetData.cpp */; };
+		DDF54ECC298DAA43000410DB /* DFGStackLayoutPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F9FB4F217FCB91700CB67F8 /* DFGStackLayoutPhase.cpp */; };
+		DDF54ECD298DAA43000410DB /* DFGUseKind.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F34B14716D4200E001CDA5A /* DFGUseKind.cpp */; };
+		DDF54ECE298DAA43000410DB /* DFGPredictionPropagationPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FFFC95114EF909500C72532 /* DFGPredictionPropagationPhase.cpp */; };
+		DDF54ECF298DAA43000410DB /* DFGLazyNode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 62A9A29E1B0BED4800BD54CA /* DFGLazyNode.cpp */; };
+		DDF54ED0298DAA43000410DB /* DFGVariableAccessDataDump.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FDDBFB21666EED500C55FEF /* DFGVariableAccessDataDump.cpp */; };
+		DDF54ED1298DAA43000410DB /* DFGStrengthReductionPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FC20CB31852E2C600C9E954 /* DFGStrengthReductionPhase.cpp */; };
+		DDF54ED2298DAA43000410DB /* DFGVariableEventStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2BDC421522801700CD8910 /* DFGVariableEventStream.cpp */; };
+		DDF54ED3298DAA43000410DB /* DFGFinalizer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A78A976E179738B8009DF744 /* DFGFinalizer.cpp */; };
+		DDF54ED4298DAA43000410DB /* DFGTierUpCheckInjectionPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FD8A31F17D51F5700CA2C40 /* DFGTierUpCheckInjectionPhase.cpp */; };
+		DDF54ED5298DAA43000410DB /* DFGIntegerRangeOptimizationPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F898F2F1B27689F0083A33C /* DFGIntegerRangeOptimizationPhase.cpp */; };
+		DDF54ED6298DAA43000410DB /* DFGAtTailAbstractState.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7D9A28F17A0BC7400EE2618 /* DFGAtTailAbstractState.cpp */; };
+		DDF54ED7298DAA43000410DB /* DFGCommonData.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEA0A2D170D40BF00BB722C /* DFGCommonData.cpp */; };
+		DDF54ED8298DAA43000410DB /* DFGCPSRethreadingPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FBE0F6B16C1DB010082C5E8 /* DFGCPSRethreadingPhase.cpp */; };
+		DDF54ED9298DAA43000410DB /* DFGFlushedAt.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F9D339417FFC4E60073C2BC /* DFGFlushedAt.cpp */; };
+		DDF54EDA298DAA43000410DB /* DFGValueStrength.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F0123301944EA1B00843A0C /* DFGValueStrength.cpp */; };
+		DDF54EDB298DAA43000410DB /* DFGVarargsForwardingPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FE254F41ABDDD2200A7C6D2 /* DFGVarargsForwardingPhase.cpp */; };
+		DDF54EDC298DAA43000410DB /* DFGVariableEvent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2BDC5015228FFA00CD8910 /* DFGVariableEvent.cpp */; };
+		DDF54EDD298DAA43000410DB /* DFGValueRepReductionPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52C55564224C2AE70099F5CC /* DFGValueRepReductionPhase.cpp */; };
+		DDF54EDE298DAA43000410DB /* DFGCleanUpPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F9D36921AE9CC33000D4DFB /* DFGCleanUpPhase.cpp */; };
+		DDF54EDF298DAA43000410DB /* DFGObjectMaterializationData.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2B9CDC19D0BA7D00B1D1B5 /* DFGObjectMaterializationData.cpp */; };
+		DDF54EE0298DAA43000410DB /* DFGGraph.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86EC9DB71328DF82002B2AD7 /* DFGGraph.cpp */; };
+		DDF54EE1298DAA43000410DB /* DFGPhantomInsertionPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F6237951AE45CA700D402EA /* DFGPhantomInsertionPhase.cpp */; };
+		DDF54EE2298DAA43000410DB /* DFGFlushFormat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7D89CE817A0B8CC00773AD8 /* DFGFlushFormat.cpp */; };
+		DDF54EE3298DAA43000410DB /* DFGLoopPreHeaderCreationPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A767B5B317A0B9650063D940 /* DFGLoopPreHeaderCreationPhase.cpp */; };
+		DDF54EE4298DAA43000410DB /* DFGClobbersExitState.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F3C1F181B868E7900ABB08B /* DFGClobbersExitState.cpp */; };
+		DDF54EE5298DAA43000410DB /* DFGOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86EC9DBF1328DF82002B2AD7 /* DFGOperations.cpp */; };
+		DDF54EE6298DAA43000410DB /* DFGPureValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FB1765E196B8F9E0091052A /* DFGPureValue.cpp */; };
+		DDF54EE7298DAA43000410DB /* DFGValidateUnlinked.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E379006328F8F4E000206FD8 /* DFGValidateUnlinked.cpp */; };
+		DDF54EE8298DAA43000410DB /* DFGInPlaceAbstractState.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A704D90017A0BAA8006BA554 /* DFGInPlaceAbstractState.cpp */; };
+		DDF54EE9298DAA43000410DB /* DFGValidate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F3B3A2915474FF4003ED0FF /* DFGValidate.cpp */; };
+		DDF54EEA298DAA43000410DB /* DFGPredictionInjectionPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FBE0F6D16C1DB010082C5E8 /* DFGPredictionInjectionPhase.cpp */; };
+		DDF54EEB298DAA43000410DB /* DFGBackwardsPropagationPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F714CA116EA92ED00F3EBEB /* DFGBackwardsPropagationPhase.cpp */; };
+		DDF54EEC298DAA43000410DB /* DFGBasicBlock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7D89CE317A0B8CC00773AD8 /* DFGBasicBlock.cpp */; };
+		DDF54EED298DAA43000410DB /* DFGByteCodeParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86EC9DB41328DF82002B2AD7 /* DFGByteCodeParser.cpp */; };
+		DDF54EEE298DAA43000410DB /* DFGInvalidationPointInjectionPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FC97F3718202119002C9B26 /* DFGInvalidationPointInjectionPhase.cpp */; };
+		DDF54EEF298DAA43000410DB /* DFGOSRAvailabilityAnalysisPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7D89CEE17A0B8CC00773AD8 /* DFGOSRAvailabilityAnalysisPhase.cpp */; };
+		DDF54EF0298DAA43000410DB /* DFGToFTLForOSREntryDeferredCompilationCallback.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FD8A32317D51F5700CA2C40 /* DFGToFTLForOSREntryDeferredCompilationCallback.cpp */; };
+		DDF54EF1298DAA43000410DB /* DFGStructureAbstractValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F893BDA1936E23C001211F4 /* DFGStructureAbstractValue.cpp */; };
+		DDF54EF2298DAA43000410DB /* DFGMinifiedGraph.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F1725FE1B48719A00AC3A55 /* DFGMinifiedGraph.cpp */; };
+		DDF54EF3298DAA43000410DB /* DFGIntegerCheckCombiningPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F300B7918AB1B1400A6D72E /* DFGIntegerCheckCombiningPhase.cpp */; };
+		DDF54EF4298DAA43000410DB /* DFGStaticExecutionCountEstimationPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F4F29DD18B6AD1C0057BC15 /* DFGStaticExecutionCountEstimationPhase.cpp */; };
+		DDF54EF5298DAA43000410DB /* DFGDesiredTransitions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C2C0F7CB17BBFC5B00464FE4 /* DFGDesiredTransitions.cpp */; };
+		DDF54EF6298DAA43000410DB /* DFGSnippetParams.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E322E5A01DA64435006E7709 /* DFGSnippetParams.cpp */; };
+		DDF54EF7298DAA43000410DB /* DFGMinifiedNode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2BDC4C1522818300CD8910 /* DFGMinifiedNode.cpp */; };
+		DDF54EF8298DAA43000410DB /* DFGFlowIndexing.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F20177D1DCADC3000EA5950 /* DFGFlowIndexing.cpp */; };
+		DDF54EF9298DAA43000410DB /* DFGOSREntry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FD82E52141DAEDE00179C94 /* DFGOSREntry.cpp */; };
+		DDF54EFA298DAA52000410DB /* A64DOpcode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 652A3A221651C69700A80AFE /* A64DOpcode.cpp */; };
+		DDF54EFB298DAA52000410DB /* ARM64Disassembler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 652A3A201651C66100A80AFE /* ARM64Disassembler.cpp */; };
+		DDF54EFC298DAA52000410DB /* Disassembler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F9D336E165DBB8D005AD387 /* Disassembler.cpp */; };
+		DDF54EFD298DAA52000410DB /* X86Disassembler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7E5AB361799E4B200D2833D /* X86Disassembler.cpp */; };
+		DDF54EFE298DAA57000410DB /* DOMJITAbstractHeap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E35CA14F1DBC3A5600F83516 /* DOMJITAbstractHeap.cpp */; };
+		DDF54EFF298DAA57000410DB /* DOMJITHeapRange.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E35CA1511DBC3A5600F83516 /* DOMJITHeapRange.cpp */; };
+		DDF54F00298DAA62000410DB /* FTLOSRExitHandle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F9B1DB51C0E42BD00E5BFD2 /* FTLOSRExitHandle.cpp */; };
+		DDF54F01298DAA62000410DB /* FTLCompile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FB387911BFD31A100E3AB1E /* FTLCompile.cpp */; };
+		DDF54F02298DAA62000410DB /* FTLCommonValues.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEA0A251709623B00BB722C /* FTLCommonValues.cpp */; };
+		DDF54F03298DAA62000410DB /* FTLSlowPathCallKey.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F25F1AC181635F300522F39 /* FTLSlowPathCallKey.cpp */; };
+		DDF54F04298DAA62000410DB /* FTLCapabilities.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEA09FE170513DB00BB722C /* FTLCapabilities.cpp */; };
+		DDF54F05298DAA62000410DB /* FTLOutput.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F9B1DB31C0E42A500E5BFD2 /* FTLOutput.cpp */; };
+		DDF54F06298DAA62000410DB /* FTLLink.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F8F2B93172E049E007DBDA5 /* FTLLink.cpp */; };
+		DDF54F07298DAA62000410DB /* FTLRecoveryOpcode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F485325187DFDEC0083B687 /* FTLRecoveryOpcode.cpp */; };
+		DDF54F08298DAA62000410DB /* FTLState.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEA0A151706BB9000BB722C /* FTLState.cpp */; };
+		DDF54F09298DAA62000410DB /* FTLAbstractHeapRepository.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEA0A191708B00700BB722C /* FTLAbstractHeapRepository.cpp */; };
+		DDF54F0A298DAA62000410DB /* FTLExceptionTarget.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F9D4C0A1C3E1C11006CD984 /* FTLExceptionTarget.cpp */; };
+		DDF54F0B298DAA62000410DB /* FTLOSRExitCompiler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F235BC917178E1C00690C7F /* FTLOSRExitCompiler.cpp */; };
+		DDF54F0C298DAA62000410DB /* FTLExitArgumentForOperand.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F235BBF17178E1C00690C7F /* FTLExitArgumentForOperand.cpp */; };
+		DDF54F0D298DAA62000410DB /* FTLExitPropertyValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2B9CEE19D0BAC100B1D1B5 /* FTLExitPropertyValue.cpp */; };
+		DDF54F0E298DAA62000410DB /* FTLJITFinalizer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A78A977D179738D5009DF744 /* FTLJITFinalizer.cpp */; };
+		DDF54F0F298DAA62000410DB /* FTLSaveRestore.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FCEFAA91804C13E00472CE4 /* FTLSaveRestore.cpp */; };
+		DDF54F10298DAA62000410DB /* FTLAvailableRecovery.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F485323187DFDEC0083B687 /* FTLAvailableRecovery.cpp */; };
+		DDF54F11298DAA62000410DB /* FTLExitArgument.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F235BBD17178E1C00690C7F /* FTLExitArgument.cpp */; };
+		DDF54F12298DAA62000410DB /* FTLSlowPathCall.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F25F1AA181635F300522F39 /* FTLSlowPathCall.cpp */; };
+		DDF54F13298DAA62000410DB /* FTLOSREntry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FD8A31717D51F2200CA2C40 /* FTLOSREntry.cpp */; };
+		DDF54F14298DAA62000410DB /* FTLLocation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FCEFADD180738C000472CE4 /* FTLLocation.cpp */; };
+		DDF54F15298DAA62000410DB /* FTLJITCode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEA0A02170513DB00BB722C /* FTLJITCode.cpp */; };
+		DDF54F16298DAA62000410DB /* FTLLazySlowPath.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FB4FB701BC843140025CA5A /* FTLLazySlowPath.cpp */; };
+		DDF54F17298DAA62000410DB /* FTLOSRExit.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F235BC617178E1C00690C7F /* FTLOSRExit.cpp */; };
+		DDF54F18298DAA62000410DB /* FTLThunks.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F235BCB17178E1C00690C7F /* FTLThunks.cpp */; };
+		DDF54F19298DAA62000410DB /* FTLValueRange.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F5A6281188C98D40072C9DF /* FTLValueRange.cpp */; };
+		DDF54F1A298DAA62000410DB /* FTLPatchpointExceptionHandle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F9D4C0E1C3E2C74006CD984 /* FTLPatchpointExceptionHandle.cpp */; };
+		DDF54F1B298DAA62000410DB /* FTLAbstractHeap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEA0A171708B00700BB722C /* FTLAbstractHeap.cpp */; };
+		DDF54F1C298DAA62000410DB /* FTLForOSREntryJITCode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FD8A31517D51F2200CA2C40 /* FTLForOSREntryJITCode.cpp */; };
+		DDF54F1D298DAA62000410DB /* FTLExitValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F235BC417178E1C00690C7F /* FTLExitValue.cpp */; };
+		DDF54F1E298DAA62000410DB /* FTLFail.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7F2996917A0BB670010417A /* FTLFail.cpp */; };
+		DDF54F1F298DAA62000410DB /* FTLSnippetParams.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E322E5A41DA644A4006E7709 /* FTLSnippetParams.cpp */; };
+		DDF54F20298DAA62000410DB /* FTLOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2B9CF219D0BAC100B1D1B5 /* FTLOperations.cpp */; };
+		DDF54F21298DAA62000410DB /* FTLExitTimeObjectMaterialization.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2B9CF019D0BAC100B1D1B5 /* FTLExitTimeObjectMaterialization.cpp */; };
+		DDF54F22298DAA6D000410DB /* StochasticSpaceTimeMutatorScheduler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F4F82891E31B9710075184C /* StochasticSpaceTimeMutatorScheduler.cpp */; };
+		DDF54F23298DAA6D000410DB /* BlockDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C2B916C414DA040C00CBAC86 /* BlockDirectory.cpp */; };
+		DDF54F24298DAA6D000410DB /* HeapCellType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FDCE1201FAE8587006F3901 /* HeapCellType.cpp */; };
+		DDF54F25298DAA6D000410DB /* GCConductor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FD0E5E71E43D3470006AB08 /* GCConductor.cpp */; };
+		DDF54F26298DAA6D000410DB /* Subspace.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F7DF1311E2970D50095951B /* Subspace.cpp */; };
+		DDF54F27298DAA6D000410DB /* EdenGCActivityCallback.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2A83638318D7D0EE0000EBCC /* EdenGCActivityCallback.cpp */; };
+		DDF54F28298DAA6D000410DB /* IsoMemoryAllocatorBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 533699B227A3078700C9561D /* IsoMemoryAllocatorBase.cpp */; };
+		DDF54F29298DAA6D000410DB /* MarkedBlock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 142D6F0613539A2800B02E86 /* MarkedBlock.cpp */; };
+		DDF54F2A298DAA6D000410DB /* HeapSnapshotBuilder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A5311C341C77CEAC00E6B1B6 /* HeapSnapshotBuilder.cpp */; };
+		DDF54F2B298DAA6D000410DB /* GCLogging.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2ADFA26218EF3540004F9FCC /* GCLogging.cpp */; };
+		DDF54F2C298DAA6D000410DB /* IsoCellSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FB4677C1FDDA6D9003FCB09 /* IsoCellSet.cpp */; };
+		DDF54F2D298DAA6D000410DB /* MarkingConstraintSolver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F9DAA061FD1C3C80079C5B2 /* MarkingConstraintSolver.cpp */; };
+		DDF54F2E298DAA6D000410DB /* SlotVisitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C225494215F7DBAA0065E898 /* SlotVisitor.cpp */; };
+		DDF54F2F298DAA6D000410DB /* HeapHelperPool.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F32BD0E1BB34F190093A57F /* HeapHelperPool.cpp */; };
+		DDF54F30298DAA6D000410DB /* ConservativeRoots.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 146B14DB12EB5B12001BEC1B /* ConservativeRoots.cpp */; };
+		DDF54F31298DAA6D000410DB /* SpaceTimeMutatorScheduler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FDE87FA1DFE6E500064C390 /* SpaceTimeMutatorScheduler.cpp */; };
+		DDF54F32298DAA6D000410DB /* HeapProfiler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A5398FA91C750D950060A963 /* HeapProfiler.cpp */; };
+		DDF54F33298DAA6D000410DB /* StopIfNecessaryTimer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F7CF9501DC027D70098CC12 /* StopIfNecessaryTimer.cpp */; };
+		DDF54F34298DAA6D000410DB /* FullGCActivityCallback.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2A83638718D7D0FE0000EBCC /* FullGCActivityCallback.cpp */; };
+		DDF54F35298DAA6D000410DB /* MachineStackMarker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14B7233F12D7D0DA003BD5ED /* MachineStackMarker.cpp */; };
+		DDF54F36298DAA6D000410DB /* CellAttributes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F9630351D4192C3005609D9 /* CellAttributes.cpp */; };
+		DDF54F37298DAA6D000410DB /* RootMarkReason.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE92E1DD25FC031D0018FCF0 /* RootMarkReason.cpp */; };
+		DDF54F38298DAA6D000410DB /* WeakBlock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14E84F9914EE1ACC00D6D5D4 /* WeakBlock.cpp */; };
+		DDF54F39298DAA6D000410DB /* GigacageAlignedMemoryAllocator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC3C581F33A48900F59B6C /* GigacageAlignedMemoryAllocator.cpp */; };
+		DDF54F3A298DAA6D000410DB /* HeapFinalizerCallback.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F0CAEFD1EC4DA8500970D12 /* HeapFinalizerCallback.cpp */; };
+		DDF54F3B298DAA6D000410DB /* HeapSnapshot.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A54C2AAE1C6544D100A18D78 /* HeapSnapshot.cpp */; };
+		DDF54F3C298DAA6D000410DB /* IncrementalSweeper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C25F8BCB157544A900245B71 /* IncrementalSweeper.cpp */; };
+		DDF54F3D298DAA6D000410DB /* AlignedMemoryAllocator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC3C501F33A41600F59B6C /* AlignedMemoryAllocator.cpp */; };
+		DDF54F3E298DAA6D000410DB /* MarkingConstraint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F660E331E0517B70031462C /* MarkingConstraint.cpp */; };
+		DDF54F3F298DAA6D000410DB /* MarkStackMergingConstraint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F6453161FD246A0002432A1 /* MarkStackMergingConstraint.cpp */; };
+		DDF54F40298DAA6D000410DB /* StructureAlignedMemoryAllocator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 537FEECB2742BDE000C9EFEE /* StructureAlignedMemoryAllocator.cpp */; };
+		DDF54F41298DAA6D000410DB /* LocalAllocator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F75A059200D25F00038E2CF /* LocalAllocator.cpp */; };
+		DDF54F42298DAA6D000410DB /* PreciseAllocation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F070A451D543A89006E7232 /* PreciseAllocation.cpp */; };
+		DDF54F43298DAA6D000410DB /* CompleteSubspace.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FDCE1271FAFA859006F3901 /* CompleteSubspace.cpp */; };
+		DDF54F44298DAA6D000410DB /* Synchronousness.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FD79A2B1EBBBDB200DA88D3 /* Synchronousness.cpp */; };
+		DDF54F45298DAA6D000410DB /* WeakSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14E84F9B14EE1ACC00D6D5D4 /* WeakSet.cpp */; };
+		DDF54F46298DAA6D000410DB /* Allocator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F42B3C0201EB50900357031 /* Allocator.cpp */; };
+		DDF54F47298DAA6D000410DB /* CollectionScope.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FA762001DB9242300B7A2FD /* CollectionScope.cpp */; };
+		DDF54F48298DAA6D000410DB /* DeferGC.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2A7A58EE1808A4C40020BDF7 /* DeferGC.cpp */; };
+		DDF54F49298DAA6D000410DB /* GCRequest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F97152E1EB28BE900A1645D /* GCRequest.cpp */; };
+		DDF54F4A298DAA6D000410DB /* IsoHeapCellType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3C8ED4123A1DBC400131958 /* IsoHeapCellType.cpp */; };
+		DDF54F4B298DAA6D000410DB /* IsoSubspacePerVM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F5E0FE62086AD470097F0DE /* IsoSubspacePerVM.cpp */; };
+		DDF54F4C298DAA6D000410DB /* MarkingConstraintSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F660E351E0517B70031462C /* MarkingConstraintSet.cpp */; };
+		DDF54F4D298DAA6D000410DB /* MutatorScheduler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F1FB38C1E173A6200A9BE50 /* MutatorScheduler.cpp */; };
+		DDF54F4E298DAA6D000410DB /* SimpleMarkingConstraint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F4D8C761FCA3CF2001D32AC /* SimpleMarkingConstraint.cpp */; };
+		DDF54F4F298DAA6D000410DB /* VisitRaceKey.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F952A9F1DF7860700E06FBD /* VisitRaceKey.cpp */; };
+		DDF54F50298DAA6D000410DB /* WriteBarrierSupport.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FC8150814043BCA00CFA603 /* WriteBarrierSupport.cpp */; };
+		DDF54F51298DAA6D000410DB /* MarkStack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 142D6F0E13539A4100B02E86 /* MarkStack.cpp */; };
+		DDF54F52298DAA6D000410DB /* GCActivityCallback.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2AACE63A18CA5A0300ED0191 /* GCActivityCallback.cpp */; };
+		DDF54F53298DAA6D000410DB /* SynchronousStopTheWorldMutatorScheduler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F1FB38A1E173A6200A9BE50 /* SynchronousStopTheWorldMutatorScheduler.cpp */; };
+		DDF54F54298DAA6D000410DB /* Weak.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1ACF7376171CA6FB00C9BB1E /* Weak.cpp */; };
+		DDF54F55298DAA6D000410DB /* WeakHandleOwner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14F7256314EE265E00B1652B /* WeakHandleOwner.cpp */; };
+		DDF54F56298DAA6D000410DB /* HandleSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 142E312C134FF0A600AFADB5 /* HandleSet.cpp */; };
+		DDF54F57298DAA6D000410DB /* MarkedSpace.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 33B2A54522651D53005A0F79 /* MarkedSpace.cpp */; };
+		DDF54F58298DAA6D000410DB /* FreeList.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F5513A71D5A68CB00C32BD8 /* FreeList.cpp */; };
+		DDF54F59298DAA6D000410DB /* MutatorState.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FA762021DB9242300B7A2FD /* MutatorState.cpp */; };
+		DDF54F5A298DAA6D000410DB /* IsoAlignedMemoryAllocator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FDCE12F1FB11D9D006F3901 /* IsoAlignedMemoryAllocator.cpp */; };
+		DDF54F5B298DAA6D000410DB /* Heap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14BA7A9513AADFF8005B7C2C /* Heap.cpp */; };
+		DDF54F5C298DAA6D000410DB /* FastMallocAlignedMemoryAllocator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEC3C541F33A45300F59B6C /* FastMallocAlignedMemoryAllocator.cpp */; };
+		DDF54F5D298DAA6D000410DB /* HeapCell.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC3D2B0B1D34376E00BA918C /* HeapCell.cpp */; };
+		DDF54F5E298DAA6D000410DB /* IsoSubspace.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FDCE12C1FAFB4DE006F3901 /* IsoSubspace.cpp */; };
+		DDF54F5F298DAA6D000410DB /* VerifierSlotVisitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE2BD66E25C0DC8200999D3B /* VerifierSlotVisitor.cpp */; };
+		DDF54F60298DAA6D000410DB /* JITStubRoutineSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F766D2915A8CC34008F363E /* JITStubRoutineSet.cpp */; };
+		DDF54F61298DAA6D000410DB /* GCSegmentedArray.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FA6F38C20CC2C9500A03DCD /* GCSegmentedArray.cpp */; };
+		DDF54F62298DAA6D000410DB /* CellContainer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FDE87F81DFD0C6D0064C390 /* CellContainer.cpp */; };
+		DDF54F63298DAA6D000410DB /* CollectorPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FD0E5E51E43D3470006AB08 /* CollectorPhase.cpp */; };
+		DDF54F64298DAA6D000410DB /* CodeBlockSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FD8A31117D4326C00CA2C40 /* CodeBlockSet.cpp */; };
+		DDF54F65298DAA6D000410DB /* DestructionMode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F9630371D4192C3005609D9 /* DestructionMode.cpp */; };
+		DDF54F66298DAA78000410DB /* InspectorConsoleAgent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A5FD007F189B191A00633231 /* InspectorConsoleAgent.cpp */; };
+		DDF54F67298DAA78000410DB /* InspectorScriptProfilerAgent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A55165D01BDEFDBD003B75C1 /* InspectorScriptProfilerAgent.cpp */; };
+		DDF54F68298DAA78000410DB /* InspectorTargetAgent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A555FF3C2159D41E00FCD826 /* InspectorTargetAgent.cpp */; };
+		DDF54F69298DAA78000410DB /* JSGlobalObjectDebuggerAgent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A57D23E71891B0770031C7FA /* JSGlobalObjectDebuggerAgent.cpp */; };
+		DDF54F6A298DAA78000410DB /* JSGlobalObjectAuditAgent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 91278D5721DEDA9500B57184 /* JSGlobalObjectAuditAgent.cpp */; };
+		DDF54F6B298DAA78000410DB /* InspectorAuditAgent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 91278D5221DEB82400B57184 /* InspectorAuditAgent.cpp */; };
+		DDF54F6C298DAA78000410DB /* InspectorHeapAgent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A5339EC41BB399900054F005 /* InspectorHeapAgent.cpp */; };
+		DDF54F6D298DAA78000410DB /* InspectorAgent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A5CEEE12187F3BAD00E55C99 /* InspectorAgent.cpp */; };
+		DDF54F6E298DAA78000410DB /* InspectorDebuggerAgent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A57D23E31890CEBF0031C7FA /* InspectorDebuggerAgent.cpp */; };
+		DDF54F6F298DAA78000410DB /* InspectorRuntimeAgent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A50E4B5D18809DD50068A46D /* InspectorRuntimeAgent.cpp */; };
+		DDF54F70298DAA78000410DB /* JSGlobalObjectRuntimeAgent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A50E4B5F18809DD50068A46D /* JSGlobalObjectRuntimeAgent.cpp */; };
+		DDF54F71298DAA94000410DB /* JSGlobalObjectInspectorController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A51007BE187CC3C600B38879 /* JSGlobalObjectInspectorController.cpp */; };
+		DDF54F72298DAA94000410DB /* ScriptCallFrame.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A5FD0069189B00A900633231 /* ScriptCallFrame.cpp */; };
+		DDF54F73298DAA94000410DB /* ContentSearchUtilities.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A57D23EF1891B5B40031C7FA /* ContentSearchUtilities.cpp */; };
+		DDF54F74298DAA94000410DB /* InspectorFrontendRouter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 99F1A6FC1B8E6D9400463B26 /* InspectorFrontendRouter.cpp */; };
+		DDF54F75298DAA94000410DB /* InjectedScript.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A513E5B5185B8BD3007E95AD /* InjectedScript.cpp */; };
+		DDF54F76298DAA94000410DB /* InspectorAgentRegistry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A593CF84184038CA00BFCE27 /* InspectorAgentRegistry.cpp */; };
+		DDF54F77298DAA94000410DB /* InspectorBackendDispatcher.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A593CF7A1840360300BFCE27 /* InspectorBackendDispatcher.cpp */; };
+		DDF54F78298DAA94000410DB /* JSJavaScriptCallFrame.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A503FA15188E0FB000110F14 /* JSJavaScriptCallFrame.cpp */; };
+		DDF54F79298DAA94000410DB /* ScriptArguments.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A5FD0065189AFE9C00633231 /* ScriptArguments.cpp */; };
+		DDF54F7A298DAA94000410DB /* InjectedScriptManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A513E5C8185F9624007E95AD /* InjectedScriptManager.cpp */; };
+		DDF54F7B298DAA94000410DB /* InjectedScriptModule.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A5840E1E187B7B8600843B10 /* InjectedScriptModule.cpp */; };
+		DDF54F7C298DAA94000410DB /* ScriptCallStack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A5FD006B189B00A900633231 /* ScriptCallStack.cpp */; };
+		DDF54F7D298DAA94000410DB /* JSGlobalObjectConsoleClient.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A5C3A1A318C0490200C9593A /* JSGlobalObjectConsoleClient.cpp */; };
+		DDF54F7E298DAA94000410DB /* ScriptCallStackFactory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A5FD007B189B0B4C00633231 /* ScriptCallStackFactory.cpp */; };
+		DDF54F7F298DAA94000410DB /* InjectedScriptBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A514B2C0185A684400F3C7CB /* InjectedScriptBase.cpp */; };
+		DDF54F80298DAA94000410DB /* JSInjectedScriptHost.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A513E5BA185BFACC007E95AD /* JSInjectedScriptHost.cpp */; };
+		DDF54F81298DAA94000410DB /* JavaScriptCallFrame.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A503FA13188E0FAF00110F14 /* JavaScriptCallFrame.cpp */; };
+		DDF54F82298DAA94000410DB /* ConsoleMessage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A5FD0077189B051000633231 /* ConsoleMessage.cpp */; };
+		DDF54F83298DAA94000410DB /* AsyncStackTrace.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6A38CFA71E32B58B0060206F /* AsyncStackTrace.cpp */; };
+		DDF54F84298DAA94000410DB /* InjectedScriptHost.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A58E35901860DEC7001F24FE /* InjectedScriptHost.cpp */; };
+		DDF54F85298DAA94000410DB /* JSGlobalObjectDebugger.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A503FA27188F105900110F14 /* JSGlobalObjectDebugger.cpp */; };
+		DDF54F86298DAA94000410DB /* InspectorTarget.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F3459D7423973ABD00DCD27A /* InspectorTarget.cpp */; };
+		DDF54F87298DAA94000410DB /* PerGlobalObjectWrapperWorld.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A5AB49DA1BEC8079007020FB /* PerGlobalObjectWrapperWorld.cpp */; };
+		DDF54F88298DAA94000410DB /* JSJavaScriptCallFramePrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A503FA17188E0FB000110F14 /* JSJavaScriptCallFramePrototype.cpp */; };
+		DDF54F89298DAA94000410DB /* IdentifiersFactory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A5FD0072189B038C00633231 /* IdentifiersFactory.cpp */; };
+		DDF54F8A298DAA94000410DB /* JSInjectedScriptHostPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A513E5BC185BFACC007E95AD /* JSInjectedScriptHostPrototype.cpp */; };
+		DDF54F8B298DAA99000410DB /* ShadowChicken.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC17E8131C9C7FD4008A6AB3 /* ShadowChicken.cpp */; };
+		DDF54F8C298DAA99000410DB /* StackVisitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7C1EAEC17987AB600299DB2 /* StackVisitor.cpp */; };
+		DDF54F8D298DAA99000410DB /* Interpreter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1429D7D30ED2128200B89619 /* Interpreter.cpp */; };
+		DDF54F8E298DAA99000410DB /* CallFrame.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1429D8DB0ED2205B00B89619 /* CallFrame.cpp */; };
+		DDF54F8F298DAA99000410DB /* CLoopStack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1429D85B0ED218E900B89619 /* CLoopStack.cpp */; };
+		DDF54F90298DAAA0000410DB /* PolymorphicCallStubRoutine.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FE834151A6EF97B00D04847 /* PolymorphicCallStubRoutine.cpp */; };
+		DDF54F91298DAAA0000410DB /* JITOpcodes32_64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A71236E41195F33C00BD2174 /* JITOpcodes32_64.cpp */; };
+		DDF54F92298DAAA0000410DB /* JITCode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F8F94431667635200D61971 /* JITCode.cpp */; };
+		DDF54F93298DAAA0000410DB /* JITWorklist.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC0184171D10C1870057B053 /* JITWorklist.cpp */; };
+		DDF54F94298DAAA0000410DB /* ExecutableAllocator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7B48DB60EE74CFC00DCBDB6 /* ExecutableAllocator.cpp */; };
+		DDF54F95298DAAA0000410DB /* RegisterAtOffset.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6540C79E1B82D9CE000F6B79 /* RegisterAtOffset.cpp */; };
+		DDF54F96298DAAA0000410DB /* CallFrameShuffleData.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 62EC9BB41B7EB07C00303AD1 /* CallFrameShuffleData.cpp */; };
+		DDF54F97298DAAA0000410DB /* RegisterAtOffsetList.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6540C79C1B82D99D000F6B79 /* RegisterAtOffsetList.cpp */; };
+		DDF54F98298DAAA0000410DB /* JITExceptions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F46807F14BA572700BFE272 /* JITExceptions.cpp */; };
+		DDF54F99298DAAA0000410DB /* TagRegistersMode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC7997811CDE9F9E004D4A09 /* TagRegistersMode.cpp */; };
+		DDF54F9A298DAAA0000410DB /* JITOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F24E54517EE274900ABB217 /* JITOperations.cpp */; };
+		DDF54F9B298DAAA0000410DB /* Reg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FA7A8E918B413C80052371D /* Reg.cpp */; };
+		DDF54F9C298DAAA0000410DB /* SetupVarargsFrame.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEE98421A89227500754E93 /* SetupVarargsFrame.cpp */; };
+		DDF54F9D298DAAA0000410DB /* JITDivGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE187A0A1C0229230038BBCA /* JITDivGenerator.cpp */; };
+		DDF54F9E298DAAA0000410DB /* JITBitOrGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE3A06A31C10B70800390FDD /* JITBitOrGenerator.cpp */; };
+		DDF54F9F298DAAA0000410DB /* JITMulGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE1879FF1BFBC73C0038BBCA /* JITMulGenerator.cpp */; };
+		DDF54FA0298DAAA0000410DB /* JITSizeStatistics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52B5100C265EFCD4008970E7 /* JITSizeStatistics.cpp */; };
+		DDF54FA1298DAAA0000410DB /* JITRightShiftGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE3A06B81C1103D900390FDD /* JITRightShiftGenerator.cpp */; };
+		DDF54FA2298DAAA0000410DB /* JITToDFGDeferredCompilationCallback.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FC712E017CD878F008CC93C /* JITToDFGDeferredCompilationCallback.cpp */; };
+		DDF54FA3298DAAA0000410DB /* JITCompilationMode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 726B91AE26581653008E6F82 /* JITCompilationMode.cpp */; };
+		DDF54FA4298DAAA0000410DB /* ICStats.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC2143051CA32E52000A8869 /* ICStats.cpp */; };
+		DDF54FA5298DAAA0000410DB /* JITNegGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE99B2471C24B6D300C82159 /* JITNegGenerator.cpp */; };
+		DDF54FA6298DAAA0000410DB /* JITWorklistThread.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 726B91AC26581653008E6F82 /* JITWorklistThread.cpp */; };
+		DDF54FA7298DAAA0000410DB /* JITBitXorGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE3A06AF1C10CB6F00390FDD /* JITBitXorGenerator.cpp */; };
+		DDF54FA8298DAAA0000410DB /* GPRInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F93274C1C1F66AA00CF6564 /* GPRInfo.cpp */; };
+		DDF54FA9298DAAA0000410DB /* JITBitAndGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE3A06AD1C10CB6F00390FDD /* JITBitAndGenerator.cpp */; };
+		DDF54FAA298DAAA0000410DB /* GCAwareJITStubRoutine.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F766D2D15A8DCDD008F363E /* GCAwareJITStubRoutine.cpp */; };
+		DDF54FAB298DAAA0000410DB /* CallFrameShuffler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 62D755D01B84FB39001801FA /* CallFrameShuffler.cpp */; };
+		DDF54FAC298DAAA0000410DB /* CallFrameShuffler32_64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 62D755D21B84FB39001801FA /* CallFrameShuffler32_64.cpp */; };
+		DDF54FAD298DAAA0000410DB /* ExecutableAllocationFuzz.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FF054F71AC35B4400E5BE57 /* ExecutableAllocationFuzz.cpp */; };
+		DDF54FAE298DAAA0000410DB /* JITArithmetic.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86A90ECF0EE7D51F00AB350D /* JITArithmetic.cpp */; };
+		DDF54FAF298DAAA0000410DB /* JITStubRoutine.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F766D2615A8CC1B008F363E /* JITStubRoutine.cpp */; };
+		DDF54FB0298DAAA0000410DB /* JITOpcodes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCDD51E90FB8DF74004A8BDC /* JITOpcodes.cpp */; };
+		DDF54FB1298DAAA0000410DB /* CachedRecovery.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 65B8392D1BACA9D30044E824 /* CachedRecovery.cpp */; };
+		DDF54FB2298DAAA0000410DB /* JIT.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1429D92D0ED22D7000B89619 /* JIT.cpp */; };
+		DDF54FB3298DAAA0000410DB /* JITThunks.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F5EF91B16878F78003E5C25 /* JITThunks.cpp */; };
+		DDF54FB4298DAAA0000410DB /* RegisterSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FC3141418146D7000033232 /* RegisterSet.cpp */; };
+		DDF54FB5298DAAA0000410DB /* JITDisassembler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FAF7EFA165BA919000C8455 /* JITDisassembler.cpp */; };
+		DDF54FB6298DAAA0000410DB /* JITSubGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE42388F1BE18C1200514737 /* JITSubGenerator.cpp */; };
+		DDF54FB7298DAAA0000410DB /* JITCompilation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86D446E825B2124800ECAE75 /* JITCompilation.cpp */; };
+		DDF54FB8298DAAA0000410DB /* ThunkGenerators.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7386552118697B400540279 /* ThunkGenerators.cpp */; };
+		DDF54FB9298DAAA0000410DB /* SIMDInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B8F57F32953B29600090D27 /* SIMDInfo.cpp */; };
+		DDF54FBA298DAAA0000410DB /* JITPlan.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 726B91AA26581653008E6F82 /* JITPlan.cpp */; };
+		DDF54FBB298DAAA0000410DB /* BinarySwitch.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F64B26F1A784BAF006E4E66 /* BinarySwitch.cpp */; };
+		DDF54FBC298DAAA0000410DB /* JITCompilationKey.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 726B91B92658263C008E6F82 /* JITCompilationKey.cpp */; };
+		DDF54FBD298DAAA0000410DB /* SlowPathCall.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6B731CC02647A8370014646F /* SlowPathCall.cpp */; };
+		DDF54FBE298DAAA0000410DB /* JITPropertyAccess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86CC85C30EE7A89400288682 /* JITPropertyAccess.cpp */; };
+		DDF54FBF298DAAA0000410DB /* JITSafepoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 72131BF326587EF2007114CF /* JITSafepoint.cpp */; };
+		DDF54FC0298DAAA0000410DB /* BaselineJITPlan.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 723998F6265DBCDB0057867F /* BaselineJITPlan.cpp */; };
+		DDF54FC1298DAAA0000410DB /* AssemblyHelpers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F24E53B17EA9F5900ABB217 /* AssemblyHelpers.cpp */; };
+		DDF54FC2298DAAA0000410DB /* JITInlineCacheGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FB14E1C18124ACE009B6B4D /* JITInlineCacheGenerator.cpp */; };
+		DDF54FC3298DAAA0000410DB /* ScratchRegisterAllocator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FA7A8ED18CE4FD80052371D /* ScratchRegisterAllocator.cpp */; };
+		DDF54FC4298DAAA0000410DB /* Width.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4BDF15B128FF912800D36BA1 /* Width.cpp */; };
+		DDF54FC5298DAAA0000410DB /* CCallHelpers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC17E8161C9C802B008A6AB3 /* CCallHelpers.cpp */; };
+		DDF54FC6298DAAA0000410DB /* BaselineJITCode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52DD000726E039B40054E408 /* BaselineJITCode.cpp */; };
+		DDF54FC7298DAAA0000410DB /* JITCall.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86CC85A20EE79B7400288682 /* JITCall.cpp */; };
+		DDF54FC8298DAAA0000410DB /* PCToCodeOriginMap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 792CB3471C4EED5C00D13AF3 /* PCToCodeOriginMap.cpp */; };
+		DDF54FC9298DAAA0000410DB /* JITAddGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE1220251BE7F5640039E6F2 /* JITAddGenerator.cpp */; };
+		DDF54FCA298DAAA0000410DB /* JITOpaqueByproducts.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86D446E925B2124800ECAE75 /* JITOpaqueByproducts.cpp */; };
+		DDF54FCB298DAAA0000410DB /* IntrinsicEmitter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DE5A09FF1BA3AC3E003D4424 /* IntrinsicEmitter.cpp */; };
+		DDF54FCC298DAAA0000410DB /* CallFrameShuffler64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 62D755D31B84FB39001801FA /* CallFrameShuffler64.cpp */; };
+		DDF54FCD298DAAA0000410DB /* JITLeftShiftGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE3A06B61C1103D900390FDD /* JITLeftShiftGenerator.cpp */; };
+		DDF54FCE298DAAAB000410DB /* LLIntThunks.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F0B839714BCF45A00885B4F /* LLIntThunks.cpp */; };
+		DDF54FCF298DAAAB000410DB /* LLIntEntrypoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F38B00F17CF077F00B144D3 /* LLIntEntrypoint.cpp */; };
+		DDF54FD0298DAAAB000410DB /* LLIntData.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F4680CE14BBB3D100BFE272 /* LLIntData.cpp */; };
+		DDF54FD1298DAAAB000410DB /* LLIntCLoop.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE20CE9B15F04A9500DF3430 /* LLIntCLoop.cpp */; };
+		DDF54FD2298DAAAB000410DB /* LLIntExceptions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F46809D14BA7F8200BFE272 /* LLIntExceptions.cpp */; };
+		DDF54FD3298DAAAB000410DB /* LLIntSlowPaths.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F46809F14BA7F8200BFE272 /* LLIntSlowPaths.cpp */; };
+		DDF54FD4298DAAB2000410DB /* Parser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93F0B3A909BB4DC00068FCE3 /* Parser.cpp */; };
+		DDF54FD5298DAAB2000410DB /* Lexer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F692A8650255597D01FF60F7 /* Lexer.cpp */; };
+		DDF54FD6298DAAB2000410DB /* Nodes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F692A86D0255597D01FF60F7 /* Nodes.cpp */; };
+		DDF54FD7298DAAB2000410DB /* UnlinkedSourceCode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F8F2B9D17306C8B007DBDA5 /* UnlinkedSourceCode.cpp */; };
+		DDF54FD8298DAAB2000410DB /* VariableEnvironment.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 79EE0BFD1B4AFB85000385C9 /* VariableEnvironment.cpp */; };
+		DDF54FD9298DAAB2000410DB /* ParserArena.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93052C320FB792190048FDC3 /* ParserArena.cpp */; };
+		DDF54FDA298DAAB2000410DB /* NodesAnalyzeModule.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3963CEC1B73F75000EB4CE5 /* NodesAnalyzeModule.cpp */; };
+		DDF54FDB298DAAB2000410DB /* ModuleAnalyzer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3794E731B77EB97005543AE /* ModuleAnalyzer.cpp */; };
+		DDF54FDC298DAAB2000410DB /* SourceProvider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F493AF816D0CAD10084508B /* SourceProvider.cpp */; };
+		DDF54FDD298DAAB2000410DB /* SourceProviderCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E49DC15512EF277200184A1F /* SourceProviderCache.cpp */; };
+		DDF54FDE298DAAB7000410DB /* ProfilerUID.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC605B5B1CE26E9800593718 /* ProfilerUID.cpp */; };
+		DDF54FDF298DAAB7000410DB /* ProfilerBytecode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FF72992166AD347000F5BA3 /* ProfilerBytecode.cpp */; };
+		DDF54FE0298DAAB7000410DB /* ProfilerBytecodeSequence.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F13912416771C30009CCB07 /* ProfilerBytecodeSequence.cpp */; };
+		DDF54FE1298DAAB7000410DB /* ProfilerOSRExit.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FB105871675482E00F8AB6E /* ProfilerOSRExit.cpp */; };
+		DDF54FE2298DAAB7000410DB /* ProfilerCompilation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FF72996166AD347000F5BA3 /* ProfilerCompilation.cpp */; };
+		DDF54FE3298DAAB7000410DB /* ProfilerOriginStack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FF729A1166AD347000F5BA3 /* ProfilerOriginStack.cpp */; };
+		DDF54FE4298DAAB7000410DB /* ProfilerProfiledBytecodes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F13912616771C30009CCB07 /* ProfilerProfiledBytecodes.cpp */; };
+		DDF54FE5298DAAB7000410DB /* ProfilerOrigin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FF7299F166AD347000F5BA3 /* ProfilerOrigin.cpp */; };
+		DDF54FE6298DAAB7000410DB /* ProfilerCompiledBytecode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FF7299A166AD347000F5BA3 /* ProfilerCompiledBytecode.cpp */; };
+		DDF54FE7298DAAB7000410DB /* ProfilerDatabase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FF7299C166AD347000F5BA3 /* ProfilerDatabase.cpp */; };
+		DDF54FE8298DAAB7000410DB /* ProfilerCompilationKind.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FF72998166AD347000F5BA3 /* ProfilerCompilationKind.cpp */; };
+		DDF54FE9298DAAB7000410DB /* ProfilerEvent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC605B591CE26E9800593718 /* ProfilerEvent.cpp */; };
+		DDF54FEA298DAAB7000410DB /* ProfilerJettisonReason.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F190CAA189D82F6000AE5F0 /* ProfilerJettisonReason.cpp */; };
+		DDF54FEB298DAAB7000410DB /* ProfilerOSRExitSite.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FB105891675482E00F8AB6E /* ProfilerOSRExitSite.cpp */; };
+		DDF54FEC298DAAB7000410DB /* ProfilerBytecodes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FF72994166AD347000F5BA3 /* ProfilerBytecodes.cpp */; };
+		DDF55144298DAB28000410DB /* IntlRelativeTimeFormatPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A3BF884B24480BDE001B9F35 /* IntlRelativeTimeFormatPrototype.cpp */; };
+		DDF55145298DAB28000410DB /* TemporalPlainDate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 31770C5327B94CE500308091 /* TemporalPlainDate.cpp */; };
+		DDF55146298DAB28000410DB /* JSGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E34F930B2322D881002B8DB4 /* JSGenerator.cpp */; };
+		DDF55147298DAB28000410DB /* AsyncGeneratorPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8BC0648F1E1AD6AC00B2B8CA /* AsyncGeneratorPrototype.cpp */; };
+		DDF55148298DAB28000410DB /* AsyncIteratorPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8BC064931E1D828B00B2B8CA /* AsyncIteratorPrototype.cpp */; };
+		DDF55149298DAB28000410DB /* JSRunLoopTimer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 534638721E70D01500F12AC1 /* JSRunLoopTimer.cpp */; };
+		DDF5514A298DAB28000410DB /* SymbolTable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F919D2715856770004A4E7D /* SymbolTable.cpp */; };
+		DDF5514B298DAB28000410DB /* ISO8601.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A38CA59B26DD84DE00C8D84C /* ISO8601.cpp */; };
+		DDF5514C298DAB28000410DB /* FunctionPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F692A85C0255597D01FF60F7 /* FunctionPrototype.cpp */; };
+		DDF5514D298DAB28000410DB /* TemporalCalendarPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E32D4DE226DAFD4200D4533A /* TemporalCalendarPrototype.cpp */; };
+		DDF5514E298DAB28000410DB /* AtomicsObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F7CF9541DC1258B0098CC12 /* AtomicsObject.cpp */; };
+		DDF5514F298DAB28000410DB /* PropertyDescriptor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7FB60A3103F7DC20017A286 /* PropertyDescriptor.cpp */; };
+		DDF55150298DAB28000410DB /* CatchScope.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE80C1981D775FB4008510C0 /* CatchScope.cpp */; };
+		DDF55151298DAB28000410DB /* TemporalPlainDateConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 31770C5027B94CE400308091 /* TemporalPlainDateConstructor.cpp */; };
+		DDF55152298DAB28000410DB /* NumberConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC2680C20E16D4E900A06E92 /* NumberConstructor.cpp */; };
+		DDF55153298DAB28000410DB /* ScopedArguments.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FE0501E1AA9095600D33B33 /* ScopedArguments.cpp */; };
+		DDF55154298DAB28000410DB /* IntlLocale.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A3AFF92D245A3CFA00C9BA3B /* IntlLocale.cpp */; };
+		DDF55155298DAB28000410DB /* RegExpGlobalData.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E334CBB221FD96A8000EB178 /* RegExpGlobalData.cpp */; };
+		DDF55156298DAB28000410DB /* TemporalTimeZone.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E30E8A4D26DE2E4700DA4915 /* TemporalTimeZone.cpp */; };
+		DDF55157298DAB28000410DB /* RegExpStringIteratorPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 84925A9A22B30CBA00D1DFFF /* RegExpStringIteratorPrototype.cpp */; };
+		DDF55158298DAB28000410DB /* IntlSegmentIteratorPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3F2193524C7882A003AE453 /* IntlSegmentIteratorPrototype.cpp */; };
+		DDF55159298DAB28000410DB /* Identifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 933A349D038AE80F008635CE /* Identifier.cpp */; };
+		DDF5515A298DAB28000410DB /* TypedArrayController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2B66D917B6B5AB00A7AE3F /* TypedArrayController.cpp */; };
+		DDF5515B298DAB28000410DB /* VarOffset.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FE050231AA9095600D33B33 /* VarOffset.cpp */; };
+		DDF5515C298DAB28000410DB /* ReflectObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E33637A31B63220200EE0840 /* ReflectObject.cpp */; };
+		DDF5515D298DAB28000410DB /* IntlDurationFormatConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E319A3EA28DA84EB00DF18C7 /* IntlDurationFormatConstructor.cpp */; };
+		DDF5515E298DAB28000410DB /* SmallStrings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93303FE80E6A72B500786E6A /* SmallStrings.cpp */; };
+		DDF5515F298DAB28000410DB /* CustomGetterSetter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2A111243192FCE79005EE18D /* CustomGetterSetter.cpp */; };
+		DDF55160298DAB28000410DB /* JSSetIterator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A790DD69182F499700588807 /* JSSetIterator.cpp */; };
+		DDF55161298DAB28000410DB /* JSCBytecodeCacheVersion.cpp.in in Sources */ = {isa = PBXBuildFile; fileRef = DD284677291A280D0009A61D /* JSCBytecodeCacheVersion.cpp.in */; };
+		DDF55162298DAB28000410DB /* ScriptExecutable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 147341E01DC2CE9600AA29BA /* ScriptExecutable.cpp */; };
+		DDF55163298DAB28000410DB /* ErrorPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC02E9060E1839DB000F9297 /* ErrorPrototype.cpp */; };
+		DDF55164298DAB28000410DB /* FunctionExecutable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 147341DC1DC2CE9600AA29BA /* FunctionExecutable.cpp */; };
+		DDF55165298DAB28000410DB /* JSSegmentedVariableObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F919D0E157F3327004A4E7D /* JSSegmentedVariableObject.cpp */; };
+		DDF55166298DAB28000410DB /* JSTypedArrayPrototypes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2B66CE17B6B5AB00A7AE3F /* JSTypedArrayPrototypes.cpp */; };
+		DDF55167298DAB28000410DB /* JSCConfig.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE48BD4323245E8700F136D0 /* JSCConfig.cpp */; };
+		DDF55168298DAB28000410DB /* JSWeakMap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7CA3AE117DA41AE006538AF /* JSWeakMap.cpp */; };
+		DDF55169298DAB28000410DB /* EvalExecutable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 147341DB1DC2CE9600AA29BA /* EvalExecutable.cpp */; };
+		DDF5516A298DAB28000410DB /* JSPromise.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C184E1817BEDBD3007CB63A /* JSPromise.cpp */; };
+		DDF5516B298DAB29000410DB /* MapConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A700873717CBE85300C3E643 /* MapConstructor.cpp */; };
+		DDF5516C298DAB29000410DB /* IntlDisplayNamesConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E353C11A24AA4CB6003FBDF3 /* IntlDisplayNamesConstructor.cpp */; };
+		DDF5516D298DAB29000410DB /* AbstractModuleRecord.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AD4937C11DDBE60A0077C807 /* AbstractModuleRecord.cpp */; };
+		DDF5516E298DAB29000410DB /* ArrayConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC7952060E15E8A800A898AB /* ArrayConstructor.cpp */; };
+		DDF5516F298DAB29000410DB /* ConstantMode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F978B3A1AAEA71D007C7369 /* ConstantMode.cpp */; };
+		DDF55170298DAB29000410DB /* JSArrayBufferPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2B66B817B6B5AB00A7AE3F /* JSArrayBufferPrototype.cpp */; };
+		DDF55171298DAB29000410DB /* JSBigInt.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 868921C31F9C2947001159F6 /* JSBigInt.cpp */; };
+		DDF55172298DAB29000410DB /* JSCustomSetterFunction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 84323E7E25D5EC6A00F97776 /* JSCustomSetterFunction.cpp */; };
+		DDF55173298DAB29000410DB /* SamplingCounter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F7700911402FF280078EB39 /* SamplingCounter.cpp */; };
+		DDF55174298DAB29000410DB /* RandomizingFuzzerAgent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E33A94932255322900D42B06 /* RandomizingFuzzerAgent.cpp */; };
+		DDF55175298DAB29000410DB /* WeakMapImpl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3A32BC51FC8312D007D7E76 /* WeakMapImpl.cpp */; };
+		DDF55176298DAB29000410DB /* BytecodeCacheError.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1435952022A521CA00E8086D /* BytecodeCacheError.cpp */; };
+		DDF55177298DAB29000410DB /* CachedBytecode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 148B1419225DD1E900D6E998 /* CachedBytecode.cpp */; };
+		DDF55178298DAB29000410DB /* FunctionConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC2680C00E16D4E900A06E92 /* FunctionConstructor.cpp */; };
+		DDF55179298DAB29000410DB /* AggregateError.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9168BD842447BA4C0080FFB4 /* AggregateError.cpp */; };
+		DDF5517A298DAB29000410DB /* Watchdog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FED94F2B171E3E2300BE77A4 /* Watchdog.cpp */; };
+		DDF5517B298DAB29000410DB /* JSModuleEnvironment.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3D239C61B829C1C00BBEF67 /* JSModuleEnvironment.cpp */; };
+		DDF5517C298DAB29000410DB /* IntlNumberFormatConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A1D792F81B43864B004516F5 /* IntlNumberFormatConstructor.cpp */; };
+		DDF5517D298DAB29000410DB /* Lookup.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F692A8680255597D01FF60F7 /* Lookup.cpp */; };
+		DDF5517E298DAB29000410DB /* JSAsyncFunction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5B70CFD91DB69E5C00EC23F9 /* JSAsyncFunction.cpp */; };
+		DDF5517F298DAB29000410DB /* MapPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A700873B17CBE8D300C3E643 /* MapPrototype.cpp */; };
+		DDF55180298DAB29000410DB /* Operations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F692A8770255597D01FF60F7 /* Operations.cpp */; };
+		DDF55181298DAB29000410DB /* JSStringIterator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 70EC0EBC1AA0D7DA00B6AAFA /* JSStringIterator.cpp */; };
+		DDF55182298DAB29000410DB /* ScopeOffset.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FE050211AA9095600D33B33 /* ScopeOffset.cpp */; };
+		DDF55183298DAB29000410DB /* SyntheticModuleRecord.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3C4131B289E08E5001150F8 /* SyntheticModuleRecord.cpp */; };
+		DDF55184298DAB29000410DB /* ArgList.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCF605110E203EF800B9A64D /* ArgList.cpp */; };
+		DDF55185298DAB29000410DB /* ProxyConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 79B00CB81C6AB07E0088C65D /* ProxyConstructor.cpp */; };
+		DDF55186298DAB29000410DB /* JSWrapperObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 65C7A1710A8EAACB00FA37EA /* JSWrapperObject.cpp */; };
+		DDF55187298DAB29000410DB /* ShadowRealmConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 860295FD26FB552D0078EB62 /* ShadowRealmConstructor.cpp */; };
+		DDF55188298DAB29000410DB /* JSInternalPromise.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E33F507E1B8429A400413856 /* JSInternalPromise.cpp */; };
+		DDF55189298DAB29000410DB /* ExecutableBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 147341E91DC2CF2500AA29BA /* ExecutableBase.cpp */; };
+		DDF5518A298DAB29000410DB /* JSGeneratorFunction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 70B7918C1C024462002481E2 /* JSGeneratorFunction.cpp */; };
+		DDF5518B298DAB29000410DB /* JSMap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A700873F17CBE8EB00C3E643 /* JSMap.cpp */; };
+		DDF5518C298DAB29000410DB /* MatchResult.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC69AA651CF7A1EF00C6272F /* MatchResult.cpp */; };
+		DDF5518D298DAB29000410DB /* DumpContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A70447EB17A0BD7000F5898E /* DumpContext.cpp */; };
+		DDF5518E298DAB29000410DB /* ThrowScope.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE2E6A7A1D6EA5FE0060F896 /* ThrowScope.cpp */; };
+		DDF5518F298DAB29000410DB /* JSDestructibleObjectHeapCellType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F7DF1391E29710E0095951B /* JSDestructibleObjectHeapCellType.cpp */; };
+		DDF55190298DAB29000410DB /* WeakMapConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7CA3ADD17DA41AE006538AF /* WeakMapConstructor.cpp */; };
+		DDF55191298DAB29000410DB /* HashMapImpl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 79A0907D1D768465008B889B /* HashMapImpl.cpp */; };
+		DDF55192298DAB29000410DB /* ArrayIteratorPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7BDAEC217F4EA1400F6140C /* ArrayIteratorPrototype.cpp */; };
+		DDF55193298DAB29000410DB /* JSDataViewPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2B66BF17B6B5AB00A7AE3F /* JSDataViewPrototype.cpp */; };
+		DDF55194298DAB29000410DB /* RegExp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F692A87D0255597D01FF60F7 /* RegExp.cpp */; };
+		DDF55195298DAB29000410DB /* Symbol.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 705B41A31A6E501E00716757 /* Symbol.cpp */; };
+		DDF55196298DAB29000410DB /* SymbolPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 705B41A91A6E501E00716757 /* SymbolPrototype.cpp */; };
+		DDF55197298DAB29000410DB /* JSRemoteFunction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5B40327F2798D1FD00F37939 /* JSRemoteFunction.cpp */; };
+		DDF55198298DAB29000410DB /* CallData.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCA62DFE0E2826230004F30D /* CallData.cpp */; };
+		DDF55199298DAB29000410DB /* Error.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC337BEA0E1B00CB0076918A /* Error.cpp */; };
+		DDF5519A298DAB29000410DB /* JSArrayIterator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 539DD7F323C1BBA900905F13 /* JSArrayIterator.cpp */; };
+		DDF5519B298DAB29000410DB /* ShadowRealmPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 860295FA26FB552C0078EB62 /* ShadowRealmPrototype.cpp */; };
+		DDF5519C298DAB29000410DB /* VMEntryScope.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE5932A5183C5A2600A1ECCC /* VMEntryScope.cpp */; };
+		DDF5519D298DAB29000410DB /* IntlSegments.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3F2193424C7882A003AE453 /* IntlSegments.cpp */; };
+		DDF5519E298DAB29000410DB /* IntlRelativeTimeFormat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A3BF884F24480BE0001B9F35 /* IntlRelativeTimeFormat.cpp */; };
+		DDF5519F298DAB29000410DB /* TemporalPlainTime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E386FD7726E867B700E4C28B /* TemporalPlainTime.cpp */; };
+		DDF551A0298DAB29000410DB /* WeakSetPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 709FB8651AE335C60039D069 /* WeakSetPrototype.cpp */; };
+		DDF551A1298DAB29000410DB /* SamplingProfiler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 79D5CD581C1106A900CECA07 /* SamplingProfiler.cpp */; };
+		DDF551A2298DAB29000410DB /* BigIntPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86976E5B1FA375A800E7C4E1 /* BigIntPrototype.cpp */; };
+		DDF551A3298DAB29000410DB /* DirectArgumentsOffset.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FE0500D1AA9091100D33B33 /* DirectArgumentsOffset.cpp */; };
+		DDF551A4298DAB29000410DB /* EnsureStillAliveHere.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE34EE2224398B8500AA2E7C /* EnsureStillAliveHere.cpp */; };
+		DDF551A5298DAB29000410DB /* JSArrayBuffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2B66B417B6B5AB00A7AE3F /* JSArrayBuffer.cpp */; };
+		DDF551A6298DAB29000410DB /* JSInternalPromiseConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E33F50761B84225700413856 /* JSInternalPromiseConstructor.cpp */; };
+		DDF551A7298DAB29000410DB /* JSGlobalObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14DE0D680D02431400AACCA2 /* JSGlobalObject.cpp */; };
+		DDF551A8298DAB29000410DB /* JSLock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 65EA4C99092AF9E20093D800 /* JSLock.cpp */; };
+		DDF551A9298DAB29000410DB /* JSFinalizationRegistry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5300740C22DD6F6600B9ACB3 /* JSFinalizationRegistry.cpp */; };
+		DDF551AA298DAB29000410DB /* IntlNumberFormatPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A1D792FA1B43864B004516F5 /* IntlNumberFormatPrototype.cpp */; };
+		DDF551AB298DAB29000410DB /* JSObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC22A3980E16E14800AF21C8 /* JSObject.cpp */; };
+		DDF551AC298DAB29000410DB /* LazyClassStructure.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DCF3D5641CD29468003D5C65 /* LazyClassStructure.cpp */; };
+		DDF551AD298DAB29000410DB /* NarrowingNumberPredictionFuzzerAgent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CE27A3D723759BAC0089605E /* NarrowingNumberPredictionFuzzerAgent.cpp */; };
+		DDF551AE298DAB29000410DB /* ResourceExhaustion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE9F3FBA2613C87C0069E89F /* ResourceExhaustion.cpp */; };
+		DDF551AF298DAB29000410DB /* TemporalPlainDateTimePrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A38120B028ADAD4A008064D5 /* TemporalPlainDateTimePrototype.cpp */; };
+		DDF551B0298DAB29000410DB /* WeakObjectRefPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5373B4D322AD8BF700803572 /* WeakObjectRefPrototype.cpp */; };
+		DDF551B1298DAB29000410DB /* BooleanObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F692A8500255597D01FF60F7 /* BooleanObject.cpp */; };
+		DDF551B2298DAB29000410DB /* PropertyTable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AD1CF06816DCAB2D00B97123 /* PropertyTable.cpp */; };
+		DDF551B3298DAB29000410DB /* GetterSetter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC02E9B80E184545000F9297 /* GetterSetter.cpp */; };
+		DDF551B4298DAB29000410DB /* JSPropertyNameEnumerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2A05ABD31961DF2400341750 /* JSPropertyNameEnumerator.cpp */; };
+		DDF551B5298DAB29000410DB /* TypeSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2D4DE319832D91007D4B19 /* TypeSet.cpp */; };
+		DDF551B6298DAB29000410DB /* IntlLocaleConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A3AFF92F245A3CFB00C9BA3B /* IntlLocaleConstructor.cpp */; };
+		DDF551B7298DAB29000410DB /* IntlDateTimeFormatPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A1587D6B1B4DC14100D69849 /* IntlDateTimeFormatPrototype.cpp */; };
+		DDF551B8298DAB29000410DB /* SymbolObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 705B41A71A6E501E00716757 /* SymbolObject.cpp */; };
+		DDF551B9298DAB29000410DB /* ProxyObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 79B00CBA1C6AB07E0088C65D /* ProxyObject.cpp */; };
+		DDF551BA298DAB29000410DB /* MathObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F692A86A0255597D01FF60F7 /* MathObject.cpp */; };
+		DDF551BB298DAB29000410DB /* SetPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7299D9F17D12848005F5FF9 /* SetPrototype.cpp */; };
+		DDF551BC298DAB29000410DB /* Intrinsic.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F275F2C1ECE079600620D47 /* Intrinsic.cpp */; };
+		DDF551BD298DAB29000410DB /* TemporalPlainDateTime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A38120AF28ADAD4A008064D5 /* TemporalPlainDateTime.cpp */; };
+		DDF551BE298DAB29000410DB /* DoublePredictionFuzzerAgent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3FC25102256ECF400583518 /* DoublePredictionFuzzerAgent.cpp */; };
+		DDF551BF298DAB29000410DB /* CachedSpecialPropertyAdaptiveStructureWatchpoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E39EEAF12281244C008474F4 /* CachedSpecialPropertyAdaptiveStructureWatchpoint.cpp */; };
+		DDF551C0298DAB29000410DB /* ArrayBufferView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7A8AF2717ADB5F3005AB174 /* ArrayBufferView.cpp */; };
+		DDF551C1298DAB29000410DB /* ErrorInstance.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC02E98A0E183E38000F9297 /* ErrorInstance.cpp */; };
+		DDF551C2298DAB29000410DB /* JSWeakSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 709FB8611AE335C60039D069 /* JSWeakSet.cpp */; };
+		DDF551C3298DAB29000410DB /* TypeProfiler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52C952B819A28A1C0069B386 /* TypeProfiler.cpp */; };
+		DDF551C4298DAB29000410DB /* IntlPluralRulesConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7D5FB18E20744BF0005DDF64 /* IntlPluralRulesConstructor.cpp */; };
+		DDF551C5298DAB29000410DB /* RegExpCachedResult.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86F75EFB151C062F007C9BA3 /* RegExpCachedResult.cpp */; };
+		DDF551C6298DAB29000410DB /* SimpleTypedArrayController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2B66D617B6B5AB00A7AE3F /* SimpleTypedArrayController.cpp */; };
+		DDF551C7298DAB29000410DB /* StackFrame.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F6DB7E71D6124B200CDBF8E /* StackFrame.cpp */; };
+		DDF551C8298DAB29000410DB /* JSAsyncGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E39FEBE12339C5D400B40AB0 /* JSAsyncGenerator.cpp */; };
+		DDF551C9298DAB29000410DB /* WeakSetConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 709FB8631AE335C60039D069 /* WeakSetConstructor.cpp */; };
+		DDF551CA298DAB29000410DB /* TemporalPlainTimeConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E386FD7426E867B700E4C28B /* TemporalPlainTimeConstructor.cpp */; };
+		DDF551CB298DAB29000410DB /* WideningNumberPredictionFuzzerAgent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CE27A3D623759BAC0089605E /* WideningNumberPredictionFuzzerAgent.cpp */; };
+		DDF551CC298DAB29000410DB /* IntlDurationFormatPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E319A3E828DA84EB00DF18C7 /* IntlDurationFormatPrototype.cpp */; };
+		DDF551CD298DAB29000410DB /* ClonedArguments.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FE0501C1AA9095600D33B33 /* ClonedArguments.cpp */; };
+		DDF551CE298DAB29000410DB /* PropertySlot.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 65621E6B089E859700760F35 /* PropertySlot.cpp */; };
+		DDF551CF298DAB29000410DB /* RuntimeType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 527773DD1AAF83AC00BDE7E8 /* RuntimeType.cpp */; };
+		DDF551D0298DAB29000410DB /* JSImmutableButterfly.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 53F11F422091749800E411A7 /* JSImmutableButterfly.cpp */; };
+		DDF551D1298DAB29000410DB /* Options.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FE228EA1436AB2300196C48 /* Options.cpp */; };
+		DDF551D2298DAB29000410DB /* TypeofType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FFB6C361AF48DDC00DB1BF7 /* TypeofType.cpp */; };
+		DDF551D3298DAB29000410DB /* RegExpConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCD202BD0E1706A7002C7E82 /* RegExpConstructor.cpp */; };
+		DDF551D4298DAB29000410DB /* ConsoleObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A55714BC1CD8048E0004D2C6 /* ConsoleObject.cpp */; };
+		DDF551D5298DAB29000410DB /* ErrorConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC02E9040E1839DB000F9297 /* ErrorConstructor.cpp */; };
+		DDF551D6298DAB29000410DB /* JSCJSValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F692A8870255597D01FF60F7 /* JSCJSValue.cpp */; };
+		DDF551D7298DAB29000410DB /* TemplateObjectDescriptor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BDB4B5E099CD4C1BB3C1CF05 /* TemplateObjectDescriptor.cpp */; };
+		DDF551D8298DAB29000410DB /* BigIntConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86976E581FA3756D00E7C4E1 /* BigIntConstructor.cpp */; };
+		DDF551D9298DAB29000410DB /* IteratorOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 70113D491A8DB093003848C4 /* IteratorOperations.cpp */; };
+		DDF551DA298DAB29000410DB /* JSLexicalEnvironment.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14DA818F0D99FD2000B0A4FB /* JSLexicalEnvironment.cpp */; };
+		DDF551DB298DAB29000410DB /* JSModuleRecord.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E39DA4A41B7E8B7C0084F33A /* JSModuleRecord.cpp */; };
+		DDF551DC298DAB29000410DB /* DateInstance.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC1166000E1997B1008066DD /* DateInstance.cpp */; };
+		DDF551DD298DAB29000410DB /* FinalizationRegistryPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 531EE7BC22DE6EC60030DA81 /* FinalizationRegistryPrototype.cpp */; };
+		DDF551DE298DAB29000410DB /* ShadowRealmObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 860295FB26FB552C0078EB62 /* ShadowRealmObject.cpp */; };
+		DDF551DF298DAB29000410DB /* JSWithScope.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1442565F15EDE98D0066A49B /* JSWithScope.cpp */; };
+		DDF551E0298DAB29000410DB /* ExceptionScope.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE6491381D78F3A300A694D4 /* ExceptionScope.cpp */; };
+		DDF551E1298DAB29000410DB /* TestRunnerUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FA2C17917D7CF84009D015F /* TestRunnerUtils.cpp */; };
+		DDF551E2298DAB29000410DB /* StringObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC18C3C20E16EE3300B34460 /* StringObject.cpp */; };
+		DDF551E3298DAB29000410DB /* ExceptionHelpers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1429D8770ED21ACD00B89619 /* ExceptionHelpers.cpp */; };
+		DDF551E4298DAB29000410DB /* JSTypedArrayConstructors.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2B66CC17B6B5AB00A7AE3F /* JSTypedArrayConstructors.cpp */; };
+		DDF551E5298DAB29000410DB /* JSONObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7F9935E0FD7325100A0B2D0 /* JSONObject.cpp */; };
+		DDF551E6298DAB29000410DB /* ObjectPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC2680C80E16D4E900A06E92 /* ObjectPrototype.cpp */; };
+		DDF551E7298DAB29000410DB /* JSScope.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14874AE115EBDE4A002E3587 /* JSScope.cpp */; };
+		DDF551E8298DAB29000410DB /* BrandedStructure.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8664967A25D1DD1200516B36 /* BrandedStructure.cpp */; };
+		DDF551E9298DAB29000410DB /* DeferredWorkTimer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 534638761E71E06E00F12AC1 /* DeferredWorkTimer.cpp */; };
+		DDF551EA298DAB29000410DB /* MemoryStatistics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 90213E3B123A40C200D422F3 /* MemoryStatistics.cpp */; };
+		DDF551EB298DAB29000410DB /* SparseArrayValueMap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F0CD4C315F6B6B50032F1C0 /* SparseArrayValueMap.cpp */; };
+		DDF551EC298DAB29000410DB /* StrictEvalActivation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A730B6111250068F009D25B1 /* StrictEvalActivation.cpp */; };
+		DDF551ED298DAB29000410DB /* IntlSegmentsPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3F2193224C7882A003AE453 /* IntlSegmentsPrototype.cpp */; };
+		DDF551EE298DAB29000410DB /* JSProxy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 862553CE16136AA5009F17D0 /* JSProxy.cpp */; };
+		DDF551EF298DAB29000410DB /* RegExpMatchesArray.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86F75EFD151C062F007C9BA3 /* RegExpMatchesArray.cpp */; };
+		DDF551F0298DAB29000410DB /* TemporalObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F6F150192693D33E004B98EF /* TemporalObject.cpp */; };
+		DDF551F1298DAB29000410DB /* AsyncGeneratorFunctionPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8BC064851E1A4FD100B2B8CA /* AsyncGeneratorFunctionPrototype.cpp */; };
+		DDF551F2298DAB29000410DB /* JSPromisePrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C184E1C17BEE22E007CB63A /* JSPromisePrototype.cpp */; };
+		DDF551F3298DAB29000410DB /* InternalFunction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC9BB95B0E19680600DF8855 /* InternalFunction.cpp */; };
+		DDF551F4298DAB29000410DB /* RegExpCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A1712B3A11C7B212007A5315 /* RegExpCache.cpp */; };
+		DDF551F5298DAB29000410DB /* SetConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7299DA317D12858005F5FF9 /* SetConstructor.cpp */; };
+		DDF551F6298DAB29000410DB /* ECMAMode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 145FF2C6243BB99A00569E71 /* ECMAMode.cpp */; };
+		DDF551F7298DAB29000410DB /* IntlRelativeTimeFormatConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A3BF884D24480BDF001B9F35 /* IntlRelativeTimeFormatConstructor.cpp */; };
+		DDF551F8298DAB29000410DB /* CommonSlowPaths.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A709F2F117A0AC2A00512E98 /* CommonSlowPaths.cpp */; };
+		DDF551F9298DAB29000410DB /* JSCallee.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 657CF45619BF6662004ACBF2 /* JSCallee.cpp */; };
+		DDF551FA298DAB29000410DB /* IntlSegmenter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E307178024C7824700DF0644 /* IntlSegmenter.cpp */; };
+		DDF551FB298DAB29000410DB /* StringRecursionChecker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93345A8712D838C400302BE3 /* StringRecursionChecker.cpp */; };
+		DDF551FC298DAB29000410DB /* ImportMap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3285D8E28DD8317008E0090 /* ImportMap.cpp */; };
+		DDF551FD298DAB29000410DB /* RegExpPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCD202BF0E1706A7002C7E82 /* RegExpPrototype.cpp */; };
+		DDF551FE298DAB29000410DB /* StructureChain.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7E4EE70E0EBB7A5B005934AA /* StructureChain.cpp */; };
+		DDF551FF298DAB29000410DB /* JSModuleNamespaceObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E318CBBE1B8AEF5100A2929D /* JSModuleNamespaceObject.cpp */; };
+		DDF55200298DAB29000410DB /* AsyncFunctionPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5B70CFDB1DB69E5C00EC23F9 /* AsyncFunctionPrototype.cpp */; };
+		DDF55201298DAB29000410DB /* Exception.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE1C0FFE1B194FD100B53FCA /* Exception.cpp */; };
+		DDF55202298DAB29000410DB /* CachedTypes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14DAFA4521E3B871004B68F7 /* CachedTypes.cpp */; };
+		DDF55203298DAB29000410DB /* IntlCollator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A1B9E2331B4E0D6700BC7FED /* IntlCollator.cpp */; };
+		DDF55204298DAB29000410DB /* JSGlobalObjectDebuggable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A59455901824744700CC3843 /* JSGlobalObjectDebuggable.cpp */; };
+		DDF55205298DAB29000410DB /* FuzzerPredictions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CECFAD352372DAA700291599 /* FuzzerPredictions.cpp */; };
+		DDF55206298DAB29000410DB /* DirectArguments.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FE0500F1AA9091100D33B33 /* DirectArguments.cpp */; };
+		DDF55207298DAB29000410DB /* GeneratorPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 70B791891C024432002481E2 /* GeneratorPrototype.cpp */; };
+		DDF55208298DAB29000410DB /* ConfigFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 658824B01E5CFDF400FB7359 /* ConfigFile.cpp */; };
+		DDF55209298DAB29000410DB /* JSPromiseConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C184E2017BEE240007CB63A /* JSPromiseConstructor.cpp */; };
+		DDF5520A298DAB29000410DB /* PrivateFieldPutKind.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86B8690224B8A20800487C95 /* PrivateFieldPutKind.cpp */; };
+		DDF5520B298DAB29000410DB /* TemporalDurationConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A3C7EDB226B0DB37004C34C5 /* TemporalDurationConstructor.cpp */; };
+		DDF5520C298DAB29000410DB /* TemporalPlainTimePrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E386FD7626E867B700E4C28B /* TemporalPlainTimePrototype.cpp */; };
+		DDF5520D298DAB29000410DB /* DatePrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCD203470E17135E002C7E82 /* DatePrototype.cpp */; };
+		DDF5520E298DAB29000410DB /* CacheableIdentifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE8DE54E23AC3A8E005C9142 /* CacheableIdentifier.cpp */; };
+		DDF5520F298DAB29000410DB /* JSType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14788EE421501B2800A561C8 /* JSType.cpp */; };
+		DDF55210298DAB29000410DB /* TypeProfilerLog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2D4DDF19832D91007D4B19 /* TypeProfilerLog.cpp */; };
+		DDF55211298DAB29000410DB /* BasicBlockLocation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52678F8C1A031009006A306D /* BasicBlockLocation.cpp */; };
+		DDF55212298DAB29000410DB /* GetPutInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14788EE521501B2900A561C8 /* GetPutInfo.cpp */; };
+		DDF55213298DAB29000410DB /* IntlSegmentIterator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3F2193024C78829003AE453 /* IntlSegmentIterator.cpp */; };
+		DDF55214298DAB29000410DB /* IntlSegmenterConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E307178224C7824700DF0644 /* IntlSegmenterConstructor.cpp */; };
+		DDF55215298DAB29000410DB /* DataView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2B66B017B6B5AB00A7AE3F /* DataView.cpp */; };
+		DDF55216298DAB29000410DB /* JSArray.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93ADFCE60CCBD7AC00D30B08 /* JSArray.cpp */; };
+		DDF55217298DAB29000410DB /* JSCell.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC7F8FBA0E19D1EF008632C0 /* JSCell.cpp */; };
+		DDF55218298DAB29000410DB /* TemporalInstant.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F6D67D3926F902E5006E0349 /* TemporalInstant.cpp */; };
+		DDF55219298DAB29000410DB /* VMTraps.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE6F56DC1E64E92000D17801 /* VMTraps.cpp */; };
+		DDF5521A298DAB29000410DB /* TypeLocationCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52B310FE1975B4240080857C /* TypeLocationCache.cpp */; };
+		DDF5521B298DAB29000410DB /* JSSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7299D9B17D12837005F5FF9 /* JSSet.cpp */; };
+		DDF5521C298DAB29000410DB /* PredictionFileCreatingFuzzerAgent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CE20BD02237D3AD40046E520 /* PredictionFileCreatingFuzzerAgent.cpp */; };
+		DDF5521D298DAB29000410DB /* IntlCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E31C31312511AFD600E7A3A0 /* IntlCache.cpp */; };
+		DDF5521E298DAB29000410DB /* CompilationResult.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7E5A3A51797432D00E893C0 /* CompilationResult.cpp */; };
+		DDF5521F298DAB29000410DB /* ProxyRevoke.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 79160DBB1C8E3EC8008C085A /* ProxyRevoke.cpp */; };
+		DDF55220298DAB29000410DB /* ObjectInitializationScope.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE48E6371EB118AD005D7A96 /* ObjectInitializationScope.cpp */; };
+		DDF55221298DAB29000410DB /* WeakMapPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7CA3ADF17DA41AE006538AF /* WeakMapPrototype.cpp */; };
+		DDF55222298DAB29000410DB /* GeneratorFunctionConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 70B791851C024432002481E2 /* GeneratorFunctionConstructor.cpp */; };
+		DDF55223298DAB29000410DB /* AsyncFunctionConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5B70CFDD1DB69E5C00EC23F9 /* AsyncFunctionConstructor.cpp */; };
+		DDF55224298DAB29000410DB /* FileBasedFuzzerAgentBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CE20BD04237D3AD40046E520 /* FileBasedFuzzerAgentBase.cpp */; };
+		DDF55225298DAB29000410DB /* CachePayload.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 148B141B225DD1EA00D6E998 /* CachePayload.cpp */; };
+		DDF55226298DAB29000410DB /* TemporalPlainDatePrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 31770C5427B94CE500308091 /* TemporalPlainDatePrototype.cpp */; };
+		DDF55227298DAB29000410DB /* IntlLocalePrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A3AFF92E245A3CFB00C9BA3B /* IntlLocalePrototype.cpp */; };
+		DDF55228298DAB29000410DB /* StringPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC18C3C50E16EE3300B34460 /* StringPrototype.cpp */; };
+		DDF55229298DAB29000410DB /* Completion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 969A09220ED1E09C00F1F681 /* Completion.cpp */; };
+		DDF5522A298DAB29000410DB /* ControlFlowProfiler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52B717B41A0597E1007AF4F3 /* ControlFlowProfiler.cpp */; };
+		DDF5522B298DAB29000410DB /* TemporalInstantConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F6D67D3B26F902E6006E0349 /* TemporalInstantConstructor.cpp */; };
+		DDF5522C298DAB29000410DB /* MapIteratorPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A74DEF8D182D991400522C22 /* MapIteratorPrototype.cpp */; };
+		DDF5522D298DAB29000410DB /* ModuleProgramExecutable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 147341DD1DC2CE9600AA29BA /* ModuleProgramExecutable.cpp */; };
+		DDF5522E298DAB29000410DB /* NativeErrorConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC02E9080E1839DB000F9297 /* NativeErrorConstructor.cpp */; };
+		DDF5522F298DAB29000410DB /* TemporalInstantPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F6D67D3D26F902E7006E0349 /* TemporalInstantPrototype.cpp */; };
+		DDF55230298DAB29000410DB /* AggregateErrorPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 918E15BE2447B22700447A56 /* AggregateErrorPrototype.cpp */; };
+		DDF55231298DAB29000410DB /* JSFunction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F692A85E0255597D01FF60F7 /* JSFunction.cpp */; };
+		DDF55232298DAB29000410DB /* JSTemplateObjectDescriptor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 70ECA6001AFDBEA200449739 /* JSTemplateObjectDescriptor.cpp */; };
+		DDF55233298DAB29000410DB /* MemoryMode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E320B66B2912298000E87CDB /* MemoryMode.cpp */; };
+		DDF55234298DAB29000410DB /* NumberObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F692A8700255597D01FF60F7 /* NumberObject.cpp */; };
+		DDF55235298DAB29000410DB /* ScopedArgumentsTable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FE0502E1AAA806900D33B33 /* ScopedArgumentsTable.cpp */; };
+		DDF55236298DAB29000410DB /* JSInternalPromisePrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E33F50721B8421C000413856 /* JSInternalPromisePrototype.cpp */; };
+		DDF55237298DAB29000410DB /* ArrayBuffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7A8AF2517ADB5F2005AB174 /* ArrayBuffer.cpp */; };
+		DDF55238298DAB29000410DB /* LiteralParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7E2EA6A0FB460CF00601F06 /* LiteralParser.cpp */; };
+		DDF55239298DAB29000410DB /* FunctionExecutableDump.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FB4B52116B6278D003F696B /* FunctionExecutableDump.cpp */; };
+		DDF5523A298DAB29000410DB /* NativeExecutable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 147341DE1DC2CE9600AA29BA /* NativeExecutable.cpp */; };
+		DDF5523B298DAB29000410DB /* SetIteratorPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A790DD67182F499700588807 /* SetIteratorPrototype.cpp */; };
+		DDF5523C298DAB29000410DB /* CodeSpecializationKind.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F8F943A1667631100D61971 /* CodeSpecializationKind.cpp */; };
+		DDF5523D298DAB29000410DB /* FinalizationRegistryConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 533D074522C2D87F004D2FE2 /* FinalizationRegistryConstructor.cpp */; };
+		DDF5523E298DAB29000410DB /* JSArrayBufferView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2B66BA17B6B5AB00A7AE3F /* JSArrayBufferView.cpp */; };
+		DDF5523F298DAB29000410DB /* StructureRareData.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C2F0F2D016BAEEE900187C19 /* StructureRareData.cpp */; };
+		DDF55240298DAB29000410DB /* JSBoundFunction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86FA9E8F142BBB2D001773B7 /* JSBoundFunction.cpp */; };
+		DDF55241298DAB29000410DB /* JSTypedArrayViewPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 53F256E11B87E28000B4B768 /* JSTypedArrayViewPrototype.cpp */; };
+		DDF55242298DAB29000410DB /* JSString.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC02E9B60E1842FA000F9297 /* JSString.cpp */; };
+		DDF55243298DAB29000410DB /* MathCommon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4340A4821A9051AF00D73CCA /* MathCommon.cpp */; };
+		DDF55244298DAB29000410DB /* PageCount.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E389D851291226BC0085C3DC /* PageCount.cpp */; };
+		DDF55245298DAB29000410DB /* IntlDateTimeFormatConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A1587D691B4DC14100D69849 /* IntlDateTimeFormatConstructor.cpp */; };
+		DDF55246298DAB29000410DB /* WeakObjectRefConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5373B4D422ADB31400803572 /* WeakObjectRefConstructor.cpp */; };
+		DDF55247298DAB29000410DB /* IntlCollatorConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A1B9E2351B4E0D6700BC7FED /* IntlCollatorConstructor.cpp */; };
+		DDF55248298DAB29000410DB /* StructureCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 798694391F8C0AC7009232AE /* StructureCache.cpp */; };
+		DDF55249298DAB29000410DB /* IntlListFormatPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E318CA68254406B5004DC129 /* IntlListFormatPrototype.cpp */; };
+		DDF5524A298DAB29000410DB /* BufferMemoryHandle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3B24858291224530029C08A /* BufferMemoryHandle.cpp */; };
+		DDF5524B298DAB29000410DB /* IntlDisplayNames.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E353C11624AA4CB5003FBDF3 /* IntlDisplayNames.cpp */; };
+		DDF5524C298DAB29000410DB /* BooleanConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC7952320E15EB5600A898AB /* BooleanConstructor.cpp */; };
+		DDF5524D298DAB29000410DB /* JSMapIterator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A74DEF8F182D991400522C22 /* JSMapIterator.cpp */; };
+		DDF5524E298DAB29000410DB /* ProgramExecutable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 147341DF1DC2CE9600AA29BA /* ProgramExecutable.cpp */; };
+		DDF5524F298DAB29000410DB /* JSDataView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2B66BD17B6B5AB00A7AE3F /* JSDataView.cpp */; };
+		DDF55250298DAB29000410DB /* DateConversion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D21202280AD4310C00ED79B6 /* DateConversion.cpp */; };
+		DDF55251298DAB29000410DB /* ObjectConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC2680C60E16D4E900A06E92 /* ObjectConstructor.cpp */; };
+		DDF55252298DAB29000410DB /* CacheUpdate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 148B141A225DD1E900D6E998 /* CacheUpdate.cpp */; };
+		DDF55253298DAB29000410DB /* JSCPtrTag.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE1E2C3C2240C1EF00F6B729 /* JSCPtrTag.cpp */; };
+		DDF55254298DAB29000410DB /* StringIteratorPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 70EC0EC01AA0D7DA00B6AAFA /* StringIteratorPrototype.cpp */; };
+		DDF55255298DAB29000410DB /* GeneratorFunctionPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 70B791871C024432002481E2 /* GeneratorFunctionPrototype.cpp */; };
+		DDF55256298DAB29000410DB /* JSTypedArrays.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2B66D017B6B5AB00A7AE3F /* JSTypedArrays.cpp */; };
+		DDF55257298DAB29000410DB /* NullSetterFunction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 65525FC31A6DD3B3007B5495 /* NullSetterFunction.cpp */; };
+		DDF55258298DAB29000410DB /* JSGlobalObjectFunctions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC756FC60E2031B200DE7D12 /* JSGlobalObjectFunctions.cpp */; };
+		DDF55259298DAB29000410DB /* TemporalDurationPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A3C7EDB526B0DB37004C34C5 /* TemporalDurationPrototype.cpp */; };
+		DDF5525A298DAB29000410DB /* FileBasedFuzzerAgent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CECFAD332372DAA700291599 /* FileBasedFuzzerAgent.cpp */; };
+		DDF5525B298DAB29000410DB /* IndirectEvalExecutable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14386A761DD6989C008652C4 /* IndirectEvalExecutable.cpp */; };
+		DDF5525C298DAB29000410DB /* JSSymbolTableObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F919D09157EE09D004A4E7D /* JSSymbolTableObject.cpp */; };
+		DDF5525D298DAB29000410DB /* NumberPredictionFuzzerAgent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CE27A3D92375A6DC0089605E /* NumberPredictionFuzzerAgent.cpp */; };
+		DDF5525E298DAB29000410DB /* JSMicrotask.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7013CA891B491A9400CAE613 /* JSMicrotask.cpp */; };
+		DDF5525F298DAB29000410DB /* AsyncFromSyncIteratorPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8B6016F31F3E3CC000F9DE6A /* AsyncFromSyncIteratorPrototype.cpp */; };
+		DDF55260298DAB29000410DB /* ConsoleClient.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A5B6A74C18C6DBA600F11E91 /* ConsoleClient.cpp */; };
+		DDF55261298DAB29000410DB /* JSSourceCode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F73926918DC64330AFCDF0D7 /* JSSourceCode.cpp */; };
+		DDF55262298DAB29000410DB /* JSScriptFetcher.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 11C197C2624848EDA84CED7F /* JSScriptFetcher.cpp */; };
+		DDF55263298DAB29000410DB /* NumberPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC2680C40E16D4E900A06E92 /* NumberPrototype.cpp */; };
+		DDF55264298DAB29000410DB /* ErrorType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3EE137521FBD43400D83C4B /* ErrorType.cpp */; };
+		DDF55265298DAB29000410DB /* ArrayPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F692A84D0255597D01FF60F7 /* ArrayPrototype.cpp */; };
+		DDF55266298DAB29000410DB /* DirectEvalExecutable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14386A721DD69895008652C4 /* DirectEvalExecutable.cpp */; };
+		DDF55267298DAB29000410DB /* JSCustomGetterFunction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 84323E7D25D5EC6A00F97776 /* JSCustomGetterFunction.cpp */; };
+		DDF55268298DAB29000410DB /* JSModuleLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1879510614C540FFB561C124 /* JSModuleLoader.cpp */; };
+		DDF55269298DAB29000410DB /* SymbolConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 705B41A51A6E501E00716757 /* SymbolConstructor.cpp */; };
+		DDF5526A298DAB29000410DB /* GlobalExecutable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E355D38E2244686C008F1AD6 /* GlobalExecutable.cpp */; };
+		DDF5526B298DAB29000410DB /* IntlDisplayNamesPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E353C11924AA4CB6003FBDF3 /* IntlDisplayNamesPrototype.cpp */; };
+		DDF5526C298DAB29000410DB /* IntlObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A12BBFF31B044A9800664B69 /* IntlObject.cpp */; };
+		DDF5526D298DAB29000410DB /* IntlPluralRulesPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7D5FB19120744BF1005DDF64 /* IntlPluralRulesPrototype.cpp */; };
+		DDF5526E298DAB29000410DB /* NativeErrorPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC02E90A0E1839DB000F9297 /* NativeErrorPrototype.cpp */; };
+		DDF5526F298DAB29000410DB /* ArrayConventions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FB415831D78F98200DF8D09 /* ArrayConventions.cpp */; };
+		DDF55270298DAB29000410DB /* ErrorHandlingScope.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FEB58C12187B8B160098EF0B /* ErrorHandlingScope.cpp */; };
+		DDF55271298DAB29000410DB /* IndexingType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F13E04C16164A1B00DC8DE7 /* IndexingType.cpp */; };
+		DDF55272298DAB29000410DB /* IntlListFormatConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E318CA6A254406B5004DC129 /* IntlListFormatConstructor.cpp */; };
+		DDF55273298DAB29000410DB /* TemporalPlainDateTimeConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A38120AE28ADAD4A008064D5 /* TemporalPlainDateTimeConstructor.cpp */; };
+		DDF55274298DAB29000410DB /* IntlCollatorPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A1B9E2371B4E0D6700BC7FED /* IntlCollatorPrototype.cpp */; };
+		DDF55275298DAB29000410DB /* JSNativeStdFunction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E33E8D1A1B9013C300346B52 /* JSNativeStdFunction.cpp */; };
+		DDF55276298DAB29000410DB /* JSAsyncGeneratorFunction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8BC064871E1A583F00B2B8CA /* JSAsyncGeneratorFunction.cpp */; };
+		DDF55277298DAB29000410DB /* Structure.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCDE3AB00E6C82CF001453A7 /* Structure.cpp */; };
+		DDF55278298DAB29000410DB /* TemporalNow.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F6F1501B2693D33E004B98EF /* TemporalNow.cpp */; };
+		DDF55279298DAB29000410DB /* FuzzerAgent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E33A94952255322A00D42B06 /* FuzzerAgent.cpp */; };
+		DDF5527A298DAB29000410DB /* TemporalCalendar.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E32D4DE026DAFD4200D4533A /* TemporalCalendar.cpp */; };
+		DDF5527B298DAB29000410DB /* TemporalDuration.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A3C7EDB126B0DB36004C34C5 /* TemporalDuration.cpp */; };
+		DDF5527C298DAB29000410DB /* FunctionRareData.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 62D2D38D1ADF103F000206C1 /* FunctionRareData.cpp */; };
+		DDF5527D298DAB29000410DB /* IntlSegmenterPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E307177E24C7824600DF0644 /* IntlSegmenterPrototype.cpp */; };
+		DDF5527E298DAB29000410DB /* BigIntObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 861816781FB7931300ECC4EC /* BigIntObject.cpp */; };
+		DDF5527F298DAB29000410DB /* JSWeakObjectRef.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 539BFBB122AD3D8C0023F4C0 /* JSWeakObjectRef.cpp */; };
+		DDF55280298DAB29000410DB /* JSGlobalLexicalEnvironment.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 797E07A71B8FCFB9008400BA /* JSGlobalLexicalEnvironment.cpp */; };
+		DDF55281298DAB29000410DB /* ExceptionEventLocation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE80C19A1D7768FD008510C0 /* ExceptionEventLocation.cpp */; };
+		DDF55282298DAB29000410DB /* JSArrayBufferConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2B66B617B6B5AB00A7AE3F /* JSArrayBufferConstructor.cpp */; };
+		DDF55283298DAB29000410DB /* LeafExecutable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 148B141C225DD1EA00D6E998 /* LeafExecutable.cpp */; };
+		DDF55284298DAB29000410DB /* JSScriptFetchParameters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38D060D1F8E814100649CF2 /* JSScriptFetchParameters.cpp */; };
+		DDF55285298DAB29000410DB /* ExceptionFuzz.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F12DE0D1979D5FD0006FF4E /* ExceptionFuzz.cpp */; };
+		DDF55286298DAB29000410DB /* CommonIdentifiers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 65EA73620BAE35D1001BB560 /* CommonIdentifiers.cpp */; };
+		DDF55287298DAB29000410DB /* RegExpObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F692A87B0255597D01FF60F7 /* RegExpObject.cpp */; };
+		DDF55288298DAB29000410DB /* IteratorPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 70DC3E071B2DF2C700054299 /* IteratorPrototype.cpp */; };
+		DDF55289298DAB29000410DB /* DOMAttributeGetterSetter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E31618111EC5FE080006A218 /* DOMAttributeGetterSetter.cpp */; };
+		DDF5528A298DAB29000410DB /* VM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E18E3A570DF9278C00D90B34 /* VM.cpp */; };
+		DDF5528B298DAB29000410DB /* JSStringJoiner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2600B5A4152BAAA70091EE5F /* JSStringJoiner.cpp */; };
+		DDF5528C298DAB29000410DB /* TemporalTimeZonePrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E30E8A4C26DE2E4700DA4915 /* TemporalTimeZonePrototype.cpp */; };
+		DDF5528D298DAB29000410DB /* TemporalTimeZoneConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E30E8A4F26DE2E4700DA4915 /* TemporalTimeZoneConstructor.cpp */; };
+		DDF5528E298DAB29000410DB /* TemporalCalendarConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E32D4DE526DAFD4300D4533A /* TemporalCalendarConstructor.cpp */; };
+		DDF5528F298DAB29000410DB /* WaiterListManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FFB77C2828FF561B00F3C55B /* WaiterListManager.cpp */; };
+		DDF55290298DAB29000410DB /* JSTypedArrayViewConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 534C457D1BC72549007476A7 /* JSTypedArrayViewConstructor.cpp */; };
+		DDF55291298DAB29000410DB /* TypedArrayType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2B66DC17B6B5AB00A7AE3F /* TypedArrayType.cpp */; };
+		DDF55292298DAB29000410DB /* AggregateErrorConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 918E15BC2447B22600447A56 /* AggregateErrorConstructor.cpp */; };
+		DDF55293298DAB29000410DB /* CodeCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A77F181F164088B200640A47 /* CodeCache.cpp */; };
+		DDF55294298DAB29000410DB /* ConstructData.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCA62DFF0E2826310004F30D /* ConstructData.cpp */; };
+		DDF55295298DAB29000410DB /* AsyncGeneratorFunctionConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8BC064831E1A4FD000B2B8CA /* AsyncGeneratorFunctionConstructor.cpp */; };
+		DDF55296298DAB29000410DB /* BooleanPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC7952340E15EB5600A898AB /* BooleanPrototype.cpp */; };
+		DDF55297298DAB29000410DB /* FunctionHasExecutedCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52B310FC1974AE870080857C /* FunctionHasExecutedCache.cpp */; };
+		DDF55298298DAB29000410DB /* DateConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCD203450E17135E002C7E82 /* DateConstructor.cpp */; };
+		DDF55299298DAB29000410DB /* ClassInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E326C4961ECBEF5700A9A905 /* ClassInfo.cpp */; };
+		DDF5529A298DAB29000410DB /* NullGetterFunction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6546F51F1A32A59C006F07D5 /* NullGetterFunction.cpp */; };
+		DDF5529B298DAB29000410DB /* StringConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC18C3C00E16EE3300B34460 /* StringConstructor.cpp */; };
+		DDF5529C298DAB29000410DB /* InitializeThreading.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E178636C0D9BEEC300D74E75 /* InitializeThreading.cpp */; };
+		DDF5529D298DAB30000410DB /* FunctionOverrides.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE4BFF291AD476E700088F87 /* FunctionOverrides.cpp */; };
+		DDF5529E298DAB30000410DB /* Integrity.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FEC5797423105F4200BCA83F /* Integrity.cpp */; };
+		DDF5529F298DAB30000410DB /* JSDollarVM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE384EE11ADDB7AD0055DE2C /* JSDollarVM.cpp */; };
+		DDF552A0298DAB30000410DB /* FunctionAllowlist.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52EED7922492B868008F4C93 /* FunctionAllowlist.cpp */; };
+		DDF552A1298DAB30000410DB /* VMInspector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE3022D41E42856700BAC493 /* VMInspector.cpp */; };
+		DDF552A2298DAB30000410DB /* CompilerTimingScope.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F4F11E7209BCDA100709654 /* CompilerTimingScope.cpp */; };
+		DDF552A3298DAB30000410DB /* CellList.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE1BD01B1E72002100134BC9 /* CellList.cpp */; };
+		DDF552A4298DAB30000410DB /* SigillCrashAnalyzer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE3022D01E3D739600BAC493 /* SigillCrashAnalyzer.cpp */; };
+		DDF552A5298DAB30000410DB /* HeapVerifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE1BD0221E72052F00134BC9 /* HeapVerifier.cpp */; };
+		DDF552A6298DAB3A000410DB /* WasmIndexOrName.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AD8FF3961EB5BD850087FF82 /* WasmIndexOrName.cpp */; };
+		DDF552A7298DAB3A000410DB /* WasmOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E39D8B2C23021E1E00265852 /* WasmOperations.cpp */; };
+		DDF552A8298DAB3A000410DB /* WasmBBQPlan.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 53CA73071EA533D80076049D /* WasmBBQPlan.cpp */; };
+		DDF552A9298DAB3A000410DB /* WasmFaultSignalHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5381B9361E60E9660090F794 /* WasmFaultSignalHandler.cpp */; };
+		DDF552AA298DAB3A000410DB /* WasmMemory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 535557151D9DFA32006D583B /* WasmMemory.cpp */; };
+		DDF552AB298DAB3A000410DB /* WasmSlowPaths.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14AB0C92231747B7000250BC /* WasmSlowPaths.cpp */; };
+		DDF552AC298DAB3A000410DB /* WasmStreamingParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3A0531921342B670022EC14 /* WasmStreamingParser.cpp */; };
+		DDF552AD298DAB3A000410DB /* WasmWorklist.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 530FB3031E7A1146003C19DD /* WasmWorklist.cpp */; };
+		DDF552AE298DAB3A000410DB /* WasmLLIntGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14C5AD6822F33FBF00F1FB83 /* WasmLLIntGenerator.cpp */; };
+		DDF552AF298DAB3A000410DB /* WasmThunks.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5250D2CF1E8DA05A0029A932 /* WasmThunks.cpp */; };
+		DDF552B0298DAB3A000410DB /* WasmFunctionCodeBlockGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14C5AD6722F33FBF00F1FB83 /* WasmFunctionCodeBlockGenerator.cpp */; };
+		DDF552B1298DAB3A000410DB /* WasmModule.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 790081361E95A8EC0052D7CD /* WasmModule.cpp */; };
+		DDF552B2298DAB3A000410DB /* WasmCalleeRegistry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3FB853922F36674008F90ED /* WasmCalleeRegistry.cpp */; };
+		DDF552B3298DAB3A000410DB /* WasmSectionParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3A0531721342B660022EC14 /* WasmSectionParser.cpp */; };
+		DDF552B4298DAB3A000410DB /* WasmStreamingCompiler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E33BBE0725BFA03C0053690F /* WasmStreamingCompiler.cpp */; };
+		DDF552B5298DAB3A000410DB /* WasmInstance.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AD5C36DE1F699EB6000BCAAF /* WasmInstance.cpp */; };
+		DDF552B6298DAB3A000410DB /* WasmTag.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14D01BF226DEEF5200CAE0D0 /* WasmTag.cpp */; };
+		DDF552B7298DAB3A000410DB /* WasmTypeDefinition.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AD7438BE1E04579200FD0C2A /* WasmTypeDefinition.cpp */; };
+		DDF552B8298DAB3A000410DB /* WasmB3IRGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 53F40E8E1D5902820099A1B6 /* WasmB3IRGenerator.cpp */; };
+		DDF552B9298DAB3A000410DB /* WasmTierUpCount.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3C694B223026874006FBE42 /* WasmTierUpCount.cpp */; };
+		DDF552BA298DAB3A000410DB /* WasmOMGPlan.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5311BD481EA581E500525281 /* WasmOMGPlan.cpp */; };
+		DDF552BB298DAB3A000410DB /* WasmGlobal.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38350082390D9370036316D /* WasmGlobal.cpp */; };
+		DDF552BC298DAB3A000410DB /* WasmTable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AD5C36E31F69EC8B000BCAAF /* WasmTable.cpp */; };
+		DDF552BD298DAB3A000410DB /* WasmMachineThreads.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 53E9E0A91EAE83DE00FEE251 /* WasmMachineThreads.cpp */; };
+		DDF552BE298DAB3A000410DB /* WasmNameSectionParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = ADD8FA441EB3077100DF542F /* WasmNameSectionParser.cpp */; };
+		DDF552BF298DAB3A000410DB /* WasmOpcodeOrigin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 53C6FEF01E8AFE0C00B18425 /* WasmOpcodeOrigin.cpp */; };
+		DDF552C0298DAB3A000410DB /* WasmContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3915C062309682900CB2561 /* WasmContext.cpp */; };
+		DDF552C1298DAB3A000410DB /* WasmFormat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AD2FCC321DC4045300B3E736 /* WasmFormat.cpp */; };
+		DDF552C2298DAB3A000410DB /* WasmCompilationMode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E37CFB2D22F27C57009A7B38 /* WasmCompilationMode.cpp */; };
+		DDF552C3298DAB3A000410DB /* WasmHandlerInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 148521D526EAEBDF00CC1D1A /* WasmHandlerInfo.cpp */; };
+		DDF552C4298DAB3A000410DB /* WasmValueLocation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 863FBC5725B093B800F6C930 /* WasmValueLocation.cpp */; };
+		DDF552C5298DAB3A000410DB /* WasmStreamingPlan.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3C73A8F25BFA73400EFE303 /* WasmStreamingPlan.cpp */; };
+		DDF552C6298DAB3A000410DB /* WasmBinding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AD4B1DF71DF244D70071AE32 /* WasmBinding.cpp */; };
+		DDF552C7298DAB3A000410DB /* WasmBranchHintsSectionParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 37AAC090279F124100D64842 /* WasmBranchHintsSectionParser.cpp */; };
+		DDF552C8298DAB3A000410DB /* WasmCallee.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 525C0DD71E935847002184CD /* WasmCallee.cpp */; };
+		DDF552C9298DAB3A000410DB /* WasmCalleeGroup.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526AC4B41E977C5D003500E1 /* WasmCalleeGroup.cpp */; };
+		DDF552CA298DAB3A000410DB /* WasmEntryPlan.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14AB0C91231747B6000250BC /* WasmEntryPlan.cpp */; };
+		DDF552CB298DAB3A000410DB /* WasmLLIntPlan.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14C5AD6A22F33FBF00F1FB83 /* WasmLLIntPlan.cpp */; };
+		DDF552CC298DAB3A000410DB /* WasmLLIntTierUpCounter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1450FA1D2357BEC40093CD4D /* WasmLLIntTierUpCounter.cpp */; };
+		DDF552CD298DAB3A000410DB /* WasmMemoryInformation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 79B759711DFA4C600052174C /* WasmMemoryInformation.cpp */; };
+		DDF552CE298DAB3A000410DB /* WasmModuleInformation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 53E777E11E92E265007CBEC4 /* WasmModuleInformation.cpp */; };
+		DDF552CF298DAB3A000410DB /* WasmOSREntryPlan.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 527E6CEA2772B9C5005E0782 /* WasmOSREntryPlan.cpp */; };
+		DDF552D0298DAB3A000410DB /* WasmPlan.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 531374BE1D5CE95000AF7A0B /* WasmPlan.cpp */; };
+		DDF552D1298DAB3A000410DB /* WasmCallingConvention.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 53FD04D11D7AB187003287D3 /* WasmCallingConvention.cpp */; };
+		DDF552D2298DAB43000410DB /* JSWebAssembly.cpp in Sources */ = {isa = PBXBuildFile; fileRef = ADD09AF21F624829001313C2 /* JSWebAssembly.cpp */; };
+		DDF552D3298DAB43000410DB /* WebAssemblyMemoryPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AD2FCBBA1DB58DA400B3E736 /* WebAssemblyMemoryPrototype.cpp */; };
+		DDF552D4298DAB43000410DB /* WebAssemblyStructConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14D01BE526DEEF38CCCAE0D0 /* WebAssemblyStructConstructor.cpp */; };
+		DDF552D5298DAB43000410DB /* JSWebAssemblyInstance.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AD2FCBA81DB58DA400B3E736 /* JSWebAssemblyInstance.cpp */; };
+		DDF552D6298DAB43000410DB /* JSWebAssemblyRuntimeError.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AD2FCBAC1DB58DA400B3E736 /* JSWebAssemblyRuntimeError.cpp */; };
+		DDF552D7298DAB43000410DB /* JSToWasm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AD8DD6D01F6708A30004EB52 /* JSToWasm.cpp */; };
+		DDF552D8298DAB43000410DB /* WebAssemblyGlobalConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3BF3C4E2390D1FC008BC752 /* WebAssemblyGlobalConstructor.cpp */; };
+		DDF552D9298DAB43000410DB /* JSWebAssemblyStruct.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14CC3BA22138F3700CAE0D0D /* JSWebAssemblyStruct.cpp */; };
+		DDF552DA298DAB43000410DB /* JSWebAssemblyException.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14D01BDC26DEEF3700CAE0D0 /* JSWebAssemblyException.cpp */; };
+		DDF552DB298DAB43000410DB /* WebAssemblyFunctionBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521322431ECBCE8200F65615 /* WebAssemblyFunctionBase.cpp */; };
+		DDF552DC298DAB43000410DB /* WebAssemblyGlobalPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3BF3C4F2390D1FC008BC752 /* WebAssemblyGlobalPrototype.cpp */; };
+		DDF552DD298DAB43000410DB /* WebAssemblyArrayConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 55F5DFAC28DA9A2000595620 /* WebAssemblyArrayConstructor.cpp */; };
+		DDF552DE298DAB43000410DB /* WebAssemblyLinkErrorPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = ADE802961E08F1C90058DE78 /* WebAssemblyLinkErrorPrototype.cpp */; };
+		DDF552DF298DAB43000410DB /* WebAssemblyStructPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14D01BE226DEEF3CFECAE0D0 /* WebAssemblyStructPrototype.cpp */; };
+		DDF552E0298DAB43000410DB /* WebAssemblyExceptionPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14D01BE226DEEF3800CAE0D0 /* WebAssemblyExceptionPrototype.cpp */; };
+		DDF552E1298DAB43000410DB /* WebAssemblyTableConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AD2FCBC01DB58DA400B3E736 /* WebAssemblyTableConstructor.cpp */; };
+		DDF552E2298DAB43000410DB /* WebAssemblyTagPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14D01BDF26DEEF3700CAE0D0 /* WebAssemblyTagPrototype.cpp */; };
+		DDF552E3298DAB43000410DB /* WebAssemblyWrapperFunction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52F6C35B1E71EB080081F4CC /* WebAssemblyWrapperFunction.cpp */; };
+		DDF552E4298DAB43000410DB /* WebAssemblyRuntimeErrorConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AD2FCBBC1DB58DA400B3E736 /* WebAssemblyRuntimeErrorConstructor.cpp */; };
+		DDF552E5298DAB43000410DB /* JSWebAssemblyTag.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14D01BE426DEEF3800CAE0D0 /* JSWebAssemblyTag.cpp */; };
+		DDF552E6298DAB43000410DB /* WebAssemblyModuleRecord.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AD4937C51DDCDCF00077C807 /* WebAssemblyModuleRecord.cpp */; };
+		DDF552E7298DAB43000410DB /* JSWebAssemblyTable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AD2FCBAE1DB58DA400B3E736 /* JSWebAssemblyTable.cpp */; };
+		DDF552E8298DAB43000410DB /* WebAssemblyExceptionConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14D01BE526DEEF3800CAE0D0 /* WebAssemblyExceptionConstructor.cpp */; };
+		DDF552E9298DAB43000410DB /* WebAssemblyFunction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AD4937C91DDD27340077C807 /* WebAssemblyFunction.cpp */; };
+		DDF552EA298DAB43000410DB /* JSWebAssemblyCompileError.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AD2FCBA61DB58DA400B3E736 /* JSWebAssemblyCompileError.cpp */; };
+		DDF552EB298DAB43000410DB /* WebAssemblyLinkErrorConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = ADE8029D1E08F2260058DE78 /* WebAssemblyLinkErrorConstructor.cpp */; };
+		DDF552EC298DAB43000410DB /* WebAssemblyRuntimeErrorPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AD2FCBBE1DB58DA400B3E736 /* WebAssemblyRuntimeErrorPrototype.cpp */; };
+		DDF552ED298DAB43000410DB /* WebAssemblyArrayPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 55579D8F28DD641000153DAE /* WebAssemblyArrayPrototype.cpp */; };
+		DDF552EE298DAB43000410DB /* WebAssemblyModulePrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AD2FCB9A1DB585A600B3E736 /* WebAssemblyModulePrototype.cpp */; };
+		DDF552EF298DAB43000410DB /* WebAssemblyMemoryConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AD2FCBB81DB58DA400B3E736 /* WebAssemblyMemoryConstructor.cpp */; };
+		DDF552F0298DAB43000410DB /* JSWebAssemblyLinkError.cpp in Sources */ = {isa = PBXBuildFile; fileRef = ADE802931E08F1C90058DE78 /* JSWebAssemblyLinkError.cpp */; };
+		DDF552F1298DAB43000410DB /* JSWebAssemblyMemory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AD2FCBAA1DB58DA400B3E736 /* JSWebAssemblyMemory.cpp */; };
+		DDF552F2298DAB43000410DB /* WebAssemblyTablePrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AD2FCBC21DB58DA400B3E736 /* WebAssemblyTablePrototype.cpp */; };
+		DDF552F3298DAB43000410DB /* WasmToJS.cpp in Sources */ = {isa = PBXBuildFile; fileRef = ADD09AEF1F5F623F001313C2 /* WasmToJS.cpp */; };
+		DDF552F4298DAB43000410DB /* WebAssemblyInstancePrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AD2FCBB61DB58DA400B3E736 /* WebAssemblyInstancePrototype.cpp */; };
+		DDF552F5298DAB43000410DB /* WebAssemblyModuleConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AD2FCB981DB585A600B3E736 /* WebAssemblyModuleConstructor.cpp */; };
+		DDF552F6298DAB43000410DB /* WebAssemblyTagConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14D01BDE26DEEF3700CAE0D0 /* WebAssemblyTagConstructor.cpp */; };
+		DDF552F7298DAB43000410DB /* JSWebAssemblyGlobal.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3BF3C4C2390D1E3008BC752 /* JSWebAssemblyGlobal.cpp */; };
+		DDF552F8298DAB43000410DB /* WebAssemblyCompileErrorConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AD2FCBB01DB58DA400B3E736 /* WebAssemblyCompileErrorConstructor.cpp */; };
+		DDF552F9298DAB43000410DB /* JSWebAssemblyArray.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 55F5DFAD28DA9A2000595620 /* JSWebAssemblyArray.cpp */; };
+		DDF552FA298DAB43000410DB /* WebAssemblyCompileErrorPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AD2FCBB21DB58DA400B3E736 /* WebAssemblyCompileErrorPrototype.cpp */; };
+		DDF552FB298DAB43000410DB /* JSWebAssemblyModule.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AD2FCB8C1DB5844000B3E736 /* JSWebAssemblyModule.cpp */; };
+		DDF552FC298DAB43000410DB /* WebAssemblyInstanceConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AD2FCBB41DB58DA400B3E736 /* WebAssemblyInstanceConstructor.cpp */; };
+		DDF552FD298DAB4A000410DB /* YarrJIT.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86704B7F12DBA33700A9FE7B /* YarrJIT.cpp */; };
+		DDF552FE298DAB4A000410DB /* RegularExpression.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A57D23EB1891B5540031C7FA /* RegularExpression.cpp */; };
+		DDF552FF298DAB4A000410DB /* YarrUnicodeProperties.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 659CDA591F67509800D3E53F /* YarrUnicodeProperties.cpp */; };
+		DDF55300298DAB4A000410DB /* YarrSyntaxChecker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86704B4012DB8A8100A9FE7B /* YarrSyntaxChecker.cpp */; };
+		DDF55301298DAB4A000410DB /* YarrCanonicalizeUCS2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 863C6D981521111200585E4E /* YarrCanonicalizeUCS2.cpp */; };
+		DDF55302298DAB4A000410DB /* YarrErrorCode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3282BB91FE930A300EDAF71 /* YarrErrorCode.cpp */; };
+		DDF55303298DAB4A000410DB /* YarrDisassembler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 65C6BEDF21128C3B006849C3 /* YarrDisassembler.cpp */; };
+		DDF55304298DAB4A000410DB /* YarrInterpreter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86704B7D12DBA33700A9FE7B /* YarrInterpreter.cpp */; };
+		DDF55305298DAB4A000410DB /* YarrPattern.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86704B8212DBA33700A9FE7B /* YarrPattern.cpp */; };
+		DDF55306298DAB4A000410DB /* YarrFlags.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A3FF9BC62234746600B1A9AB /* YarrFlags.cpp */; };
+		DDF55307298DAB58000410DB /* YarrCanonicalizeUnicode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 65A946141C8E9F6F00A7209A /* YarrCanonicalizeUnicode.cpp */; };
+		DDF55308298DAB67000410DB /* JSScript.mm in Sources */ = {isa = PBXBuildFile; fileRef = 53EE01B4218F690E00AD1F8D /* JSScript.mm */; };
+		DDF55309298DAB67000410DB /* JSVirtualMachine.mm in Sources */ = {isa = PBXBuildFile; fileRef = 86E3C610167BAB87006D760A /* JSVirtualMachine.mm */; };
+		DDF5530A298DAB67000410DB /* JSValue.mm in Sources */ = {isa = PBXBuildFile; fileRef = 86E3C60D167BAB87006D760A /* JSValue.mm */; };
+		DDF5530B298DAB67000410DB /* JSScriptSourceProvider.mm in Sources */ = {isa = PBXBuildFile; fileRef = 14D01A7521FB350300BC54E9 /* JSScriptSourceProvider.mm */; };
+		DDF5530C298DAB67000410DB /* JSContext.mm in Sources */ = {isa = PBXBuildFile; fileRef = 86E3C608167BAB87006D760A /* JSContext.mm */; };
+		DDF5530D298DAB67000410DB /* JSAPIGlobalObject.mm in Sources */ = {isa = PBXBuildFile; fileRef = 53C4F66C21B1A7CA002FD009 /* JSAPIGlobalObject.mm */; };
+		DDF5530E298DAB67000410DB /* JSAPIWrapperObject.mm in Sources */ = {isa = PBXBuildFile; fileRef = C2CF39BF16E15A8100DD69BE /* JSAPIWrapperObject.mm */; };
+		DDF5530F298DAB67000410DB /* JSManagedValue.mm in Sources */ = {isa = PBXBuildFile; fileRef = C25D709916DE99F400FCA6BC /* JSManagedValue.mm */; };
+		DDF55310298DAB67000410DB /* JSWrapperMap.mm in Sources */ = {isa = PBXBuildFile; fileRef = 86E3C60B167BAB87006D760A /* JSWrapperMap.mm */; };
+		DDF55311298DAB67000410DB /* ObjCCallbackFunction.mm in Sources */ = {isa = PBXBuildFile; fileRef = 86F3EEBA168CCF750077B92A /* ObjCCallbackFunction.mm */; };
+		DDF55312298DAB96000410DB /* RemoteInspectionTarget.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A594558E18245EDE00CC3843 /* RemoteInspectionTarget.cpp */; };
+		DDF55313298DAB96000410DB /* RemoteAutomationTarget.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 992ABCF51BEA94CA006403A0 /* RemoteAutomationTarget.cpp */; };
+		DDF55314298DAB96000410DB /* RemoteControllableTarget.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 998ED6721BED659A00DD8017 /* RemoteControllableTarget.cpp */; };
+		DDF55315298DAB96000410DB /* RemoteInspectorXPCConnection.mm in Sources */ = {isa = PBXBuildFile; fileRef = 992F56B21E4E84790035953B /* RemoteInspectorXPCConnection.mm */; };
+		DDF55316298DAB96000410DB /* RemoteInspector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 995566851E4E8B0700AAE13C /* RemoteInspector.cpp */; };
+		DDF55317298DAB96000410DB /* RemoteInspectorCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 992F56B01E4E84790035953B /* RemoteInspectorCocoa.mm */; };
+		DDF55318298DAB96000410DB /* RemoteConnectionToTargetCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 992F56B31E4E847D0035953B /* RemoteConnectionToTargetCocoa.mm */; };
 		DE26E9031CB5DD0500D2BE82 /* BuiltinExecutableCreator.h in Headers */ = {isa = PBXBuildFile; fileRef = DE26E9021CB5DD0500D2BE82 /* BuiltinExecutableCreator.h */; };
 		DEA7E2451BBC677F00D78440 /* JSTypedArrayViewPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = 53917E7C1B791106000EBD33 /* JSTypedArrayViewPrototype.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DFBC2CA625E6D5B90081BDD1 /* SymbolStubsForSafariCompatibility.mm in Sources */ = {isa = PBXBuildFile; fileRef = DFBC2CA525E6D5790081BDD1 /* SymbolStubsForSafariCompatibility.mm */; };
@@ -5322,6 +6441,7 @@
 		DD28467A291A35120009A61D /* JSCBytecodeCacheVersion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSCBytecodeCacheVersion.h; sourceTree = "<group>"; };
 		DD5F74F8283EF4380027A8C6 /* copy-profiling-data.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "copy-profiling-data.sh"; sourceTree = "<group>"; };
 		DDE9930E278D086600F60D26 /* libWebKitAdditions.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libWebKitAdditions.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		DDF54E70298DA9B3000410DB /* BytecodeDumperGenerated.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BytecodeDumperGenerated.cpp; sourceTree = "<group>"; };
 		DE26E9021CB5DD0500D2BE82 /* BuiltinExecutableCreator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BuiltinExecutableCreator.h; sourceTree = "<group>"; };
 		DE26E9061CB5DD9600D2BE82 /* BuiltinExecutableCreator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BuiltinExecutableCreator.cpp; sourceTree = "<group>"; };
 		DE5A09FF1BA3AC3E003D4424 /* IntrinsicEmitter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IntrinsicEmitter.cpp; sourceTree = "<group>"; };
@@ -7386,6 +8506,7 @@
 				E3893A1C2203A7C600E79A74 /* AsyncFromSyncIteratorPrototype.lut.h */,
 				8B3BF5E31E3D365A0076A87A /* AsyncGeneratorPrototype.lut.h */,
 				996B73071BD9FA2C00331B84 /* BooleanPrototype.lut.h */,
+				DDF54E70298DA9B3000410DB /* BytecodeDumperGenerated.cpp */,
 				6514F21718B3E1670098FF8B /* Bytecodes.h */,
 				53696E5720A3A70200D7E01E /* BytecodeStructs.h */,
 				A53243951856A475002ED692 /* CombinedDomains.json */,
@@ -12409,27 +13530,1024 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DD284672291A217E0009A61D /* CachedTypes.cpp in Sources */,
+				DDF54EFA298DAA52000410DB /* A64DOpcode.cpp in Sources */,
+				DDF54D80298DA94E000410DB /* AbstractMacroAssembler.cpp in Sources */,
+				DDF5516D298DAB29000410DB /* AbstractModuleRecord.cpp in Sources */,
+				DDF54E07298DA990000410DB /* AccessCase.cpp in Sources */,
+				DDF54E68298DA990000410DB /* AccessCaseSnippetParams.cpp in Sources */,
+				DDF54E08298DA990000410DB /* AdaptiveInferredPropertyValueWatchpointBase.cpp in Sources */,
+				DDF55179298DAB29000410DB /* AggregateError.cpp in Sources */,
+				DDF55292298DAB29000410DB /* AggregateErrorConstructor.cpp in Sources */,
+				DDF55230298DAB29000410DB /* AggregateErrorPrototype.cpp in Sources */,
+				DDF54DAE298DA95A000410DB /* AirAllocateRegistersAndStackAndGenerateCode.cpp in Sources */,
+				DDF54DA3298DA95A000410DB /* AirAllocateRegistersAndStackByLinearScan.cpp in Sources */,
+				DDF54DA2298DA95A000410DB /* AirAllocateRegistersByGraphColoring.cpp in Sources */,
+				DDF54DAB298DA95A000410DB /* AirAllocateStackByGraphColoring.cpp in Sources */,
+				DDF54D95298DA95A000410DB /* AirArg.cpp in Sources */,
+				DDF54D9F298DA95A000410DB /* AirBasicBlock.cpp in Sources */,
+				DDF54DA8298DA95A000410DB /* AirBlockInsertionSet.cpp in Sources */,
+				DDF54D8D298DA95A000410DB /* AirBreakCriticalEdges.cpp in Sources */,
+				DDF54D88298DA95A000410DB /* AirCCallingConvention.cpp in Sources */,
+				DDF54D99298DA95A000410DB /* AirCCallSpecial.cpp in Sources */,
+				DDF54D90298DA95A000410DB /* AirCode.cpp in Sources */,
+				DDF54D8A298DA95A000410DB /* AirCustom.cpp in Sources */,
+				DDF54D96298DA95A000410DB /* AirDisassembler.cpp in Sources */,
+				DDF54DAF298DA95A000410DB /* AirEliminateDeadCode.cpp in Sources */,
+				DDF54DA9298DA95A000410DB /* AirEmitShuffle.cpp in Sources */,
+				DDF54D9A298DA95A000410DB /* AirFixObviousSpills.cpp in Sources */,
+				DDF54D9C298DA95A000410DB /* AirFixPartialRegisterStalls.cpp in Sources */,
+				DDF54DA0298DA95A000410DB /* AirFixSpillsAfterTerminals.cpp in Sources */,
+				DDF54DA5298DA95A000410DB /* AirGenerate.cpp in Sources */,
+				DDF54D91298DA95A000410DB /* AirGenerated.cpp in Sources */,
+				DDF54D9D298DA95A000410DB /* AirHandleCalleeSaves.cpp in Sources */,
+				DDF54D97298DA95A000410DB /* AirInsertionSet.cpp in Sources */,
+				DDF54D89298DA95A000410DB /* AirInst.cpp in Sources */,
+				DDF54D8E298DA95A000410DB /* AirKind.cpp in Sources */,
+				DDF54D8B298DA95A000410DB /* AirLogRegisterPressure.cpp in Sources */,
+				DDF54DAA298DA95A000410DB /* AirLowerAfterRegAlloc.cpp in Sources */,
+				DDF54DA1298DA95A000410DB /* AirLowerEntrySwitch.cpp in Sources */,
+				DDF54D9E298DA95A000410DB /* AirLowerMacros.cpp in Sources */,
+				DDF54D92298DA95A000410DB /* AirLowerStackArgs.cpp in Sources */,
+				DDF54D98298DA95A000410DB /* AirOptimizeBlockOrder.cpp in Sources */,
+				DDF54DA6298DA95A000410DB /* AirPadInterference.cpp in Sources */,
+				DDF54DA4298DA95A000410DB /* AirPhaseInsertionSet.cpp in Sources */,
+				DDF54D8C298DA95A000410DB /* AirPhaseScope.cpp in Sources */,
+				DDF54D87298DA95A000410DB /* AirPrintSpecial.cpp in Sources */,
+				DDF54D86298DA95A000410DB /* AirRegLiveness.cpp in Sources */,
+				DDF54D8F298DA95A000410DB /* AirReportUsedRegisters.cpp in Sources */,
+				DDF54DAD298DA95A000410DB /* AirSimplifyCFG.cpp in Sources */,
+				DDF54D9B298DA95A000410DB /* AirSpecial.cpp in Sources */,
+				DDF54DAC298DA95A000410DB /* AirStackAllocation.cpp in Sources */,
+				DDF54DB0298DA95A000410DB /* AirStackSlot.cpp in Sources */,
+				DDF54D93298DA95A000410DB /* AirStackSlotKind.cpp in Sources */,
+				DDF54DA7298DA95A000410DB /* AirTmp.cpp in Sources */,
+				DDF54D94298DA95A000410DB /* AirTmpWidth.cpp in Sources */,
+				DDF54DB1298DA95A000410DB /* AirValidate.cpp in Sources */,
+				DDF54F3D298DAA6D000410DB /* AlignedMemoryAllocator.cpp in Sources */,
+				DDF54F46298DAA6D000410DB /* Allocator.cpp in Sources */,
+				DDF54D65298DA937000410DB /* APIIntegrity.cpp in Sources */,
+				DDF55184298DAB29000410DB /* ArgList.cpp in Sources */,
+				DDF54E5E298DA990000410DB /* ArithProfile.cpp in Sources */,
+				DDF54EFB298DAA52000410DB /* ARM64Disassembler.cpp in Sources */,
+				DDF54E0F298DA990000410DB /* ArrayAllocationProfile.cpp in Sources */,
+				DDF55237298DAB29000410DB /* ArrayBuffer.cpp in Sources */,
+				DDF551C0298DAB29000410DB /* ArrayBufferView.cpp in Sources */,
+				DDF5516E298DAB29000410DB /* ArrayConstructor.cpp in Sources */,
+				DDF5526F298DAB29000410DB /* ArrayConventions.cpp in Sources */,
+				DDF55192298DAB29000410DB /* ArrayIteratorPrototype.cpp in Sources */,
+				DDF54E5F298DA990000410DB /* ArrayProfile.cpp in Sources */,
+				DDF55265298DAB29000410DB /* ArrayPrototype.cpp in Sources */,
+				DDF54D7C298DA94E000410DB /* AssemblerBuffer.cpp in Sources */,
+				DDF54D81298DA94E000410DB /* AssemblyComments.cpp in Sources */,
+				DDF54FC1298DAAA0000410DB /* AssemblyHelpers.cpp in Sources */,
+				DDF5525F298DAB29000410DB /* AsyncFromSyncIteratorPrototype.cpp in Sources */,
+				DDF55223298DAB29000410DB /* AsyncFunctionConstructor.cpp in Sources */,
+				DDF55200298DAB29000410DB /* AsyncFunctionPrototype.cpp in Sources */,
+				DDF55295298DAB29000410DB /* AsyncGeneratorFunctionConstructor.cpp in Sources */,
+				DDF551F1298DAB29000410DB /* AsyncGeneratorFunctionPrototype.cpp in Sources */,
+				DDF55147298DAB28000410DB /* AsyncGeneratorPrototype.cpp in Sources */,
+				DDF55148298DAB28000410DB /* AsyncIteratorPrototype.cpp in Sources */,
+				DDF54F83298DAA94000410DB /* AsyncStackTrace.cpp in Sources */,
+				DDF5514E298DAB28000410DB /* AtomicsObject.cpp in Sources */,
+				DDF54DC1298DA966000410DB /* B3ArgumentRegValue.cpp in Sources */,
+				DDF54DD1298DA966000410DB /* B3AtomicValue.cpp in Sources */,
+				DDF54DD2298DA966000410DB /* B3Bank.cpp in Sources */,
+				DDF54DF9298DA966000410DB /* B3BasicBlock.cpp in Sources */,
+				DDF54DEC298DA966000410DB /* B3BlockInsertionSet.cpp in Sources */,
+				DDF54DBA298DA966000410DB /* B3BottomTupleValue.cpp in Sources */,
+				DDF54DFD298DA966000410DB /* B3BreakCriticalEdges.cpp in Sources */,
+				DDF54DDE298DA966000410DB /* B3CaseCollection.cpp in Sources */,
+				DDF54DEF298DA966000410DB /* B3CCallValue.cpp in Sources */,
+				DDF54DDC298DA966000410DB /* B3CheckSpecial.cpp in Sources */,
+				DDF54DF2298DA966000410DB /* B3CheckValue.cpp in Sources */,
+				DDF54DC4298DA966000410DB /* B3Common.cpp in Sources */,
+				DDF54DD5298DA966000410DB /* B3Commutativity.cpp in Sources */,
+				DDF54DF0298DA966000410DB /* B3Compile.cpp in Sources */,
+				DDF54DC7298DA966000410DB /* B3Const128Value.cpp in Sources */,
+				DDF54DE0298DA966000410DB /* B3Const32Value.cpp in Sources */,
+				DDF54DB4298DA966000410DB /* B3Const64Value.cpp in Sources */,
+				DDF54DF1298DA966000410DB /* B3ConstDoubleValue.cpp in Sources */,
+				DDF54DDD298DA966000410DB /* B3ConstFloatValue.cpp in Sources */,
+				DDF54DDB298DA966000410DB /* B3ConstrainedValue.cpp in Sources */,
+				DDF54DE2298DA966000410DB /* B3DataSection.cpp in Sources */,
+				DDF54DE5298DA966000410DB /* B3DuplicateTails.cpp in Sources */,
+				DDF54DB5298DA966000410DB /* B3Effects.cpp in Sources */,
+				DDF54DB6298DA966000410DB /* B3EliminateCommonSubexpressions.cpp in Sources */,
+				DDF54DF4298DA966000410DB /* B3EliminateDeadCode.cpp in Sources */,
+				DDF54DCF298DA966000410DB /* B3EnsureLoopPreHeaders.cpp in Sources */,
+				DDF54DEE298DA966000410DB /* B3EstimateStaticExecutionCounts.cpp in Sources */,
+				DDF54DC0298DA966000410DB /* B3ExtractValue.cpp in Sources */,
+				DDF54DE9298DA966000410DB /* B3FenceValue.cpp in Sources */,
+				DDF54DEB298DA966000410DB /* B3FixSSA.cpp in Sources */,
+				DDF54DB7298DA966000410DB /* B3FoldPathConstants.cpp in Sources */,
+				DDF54DD6298DA966000410DB /* B3FrequencyClass.cpp in Sources */,
+				DDF54DE1298DA966000410DB /* B3Generate.cpp in Sources */,
+				DDF54DCC298DA966000410DB /* B3HoistLoopInvariantValues.cpp in Sources */,
+				DDF54DFB298DA966000410DB /* B3InferSwitches.cpp in Sources */,
+				DDF54DE6298DA966000410DB /* B3InsertionSet.cpp in Sources */,
+				DDF54DFA298DA966000410DB /* B3Kind.cpp in Sources */,
+				DDF54DD9298DA966000410DB /* B3LegalizeMemoryOffsets.cpp in Sources */,
+				DDF54DBC298DA966000410DB /* B3LowerMacros.cpp in Sources */,
+				DDF54DBD298DA966000410DB /* B3LowerMacrosAfterOptimizations.cpp in Sources */,
+				DDF54DCA298DA966000410DB /* B3LowerToAir.cpp in Sources */,
+				DDF54DEA298DA966000410DB /* B3MathExtras.cpp in Sources */,
+				DDF54DD8298DA966000410DB /* B3MemoryValue.cpp in Sources */,
+				DDF54DBE298DA966000410DB /* B3MoveConstants.cpp in Sources */,
+				DDF54DE7298DA966000410DB /* B3Opcode.cpp in Sources */,
+				DDF54DE3298DA966000410DB /* B3OptimizeAssociativeExpressionTrees.cpp in Sources */,
+				DDF54DCE298DA966000410DB /* B3Origin.cpp in Sources */,
+				DDF54DC6298DA966000410DB /* B3OriginDump.cpp in Sources */,
+				DDF54DC8298DA966000410DB /* B3PatchpointSpecial.cpp in Sources */,
+				DDF54DE4298DA966000410DB /* B3PatchpointValue.cpp in Sources */,
+				DDF54DB2298DA966000410DB /* B3PhaseScope.cpp in Sources */,
+				DDF54DC3298DA966000410DB /* B3PhiChildren.cpp in Sources */,
+				DDF54DCD298DA966000410DB /* B3Procedure.cpp in Sources */,
+				DDF54DD0298DA966000410DB /* B3PureCSE.cpp in Sources */,
+				DDF54DCB298DA966000410DB /* B3ReduceDoubleToFloat.cpp in Sources */,
+				DDF54DC9298DA966000410DB /* B3ReduceStrength.cpp in Sources */,
+				DDF54DDA298DA966000410DB /* B3SIMDValue.cpp in Sources */,
+				DDF54DD3298DA966000410DB /* B3SlotBaseValue.cpp in Sources */,
+				DDF54DB8298DA966000410DB /* B3SSACalculator.cpp in Sources */,
+				DDF54DF6298DA966000410DB /* B3StackmapGenerationParams.cpp in Sources */,
+				DDF54DB3298DA966000410DB /* B3StackmapSpecial.cpp in Sources */,
+				DDF54DC2298DA966000410DB /* B3StackmapValue.cpp in Sources */,
+				DDF54DF5298DA966000410DB /* B3SwitchCase.cpp in Sources */,
+				DDF54DD4298DA966000410DB /* B3SwitchValue.cpp in Sources */,
+				DDF54DE8298DA966000410DB /* B3Type.cpp in Sources */,
+				DDF54DF3298DA966000410DB /* B3UpsilonValue.cpp in Sources */,
+				DDF54DD7298DA966000410DB /* B3UseCounts.cpp in Sources */,
+				DDF54DFE298DA966000410DB /* B3Validate.cpp in Sources */,
+				DDF54DFC298DA966000410DB /* B3Value.cpp in Sources */,
+				DDF54DC5298DA966000410DB /* B3ValueKey.cpp in Sources */,
+				DDF54DF8298DA966000410DB /* B3ValueRep.cpp in Sources */,
+				DDF54DED298DA966000410DB /* B3Variable.cpp in Sources */,
+				DDF54DB9298DA966000410DB /* B3VariableLiveness.cpp in Sources */,
+				DDF54DBB298DA966000410DB /* B3VariableValue.cpp in Sources */,
+				DDF54DF7298DA966000410DB /* B3WasmAddressValue.cpp in Sources */,
+				DDF54DBF298DA966000410DB /* B3WasmBoundsCheckValue.cpp in Sources */,
+				DDF54DDF298DA966000410DB /* B3Width.cpp in Sources */,
+				DDF54FC6298DAAA0000410DB /* BaselineJITCode.cpp in Sources */,
+				DDF54FC0298DAAA0000410DB /* BaselineJITPlan.cpp in Sources */,
+				DDF55211298DAB29000410DB /* BasicBlockLocation.cpp in Sources */,
+				DDF551D8298DAB29000410DB /* BigIntConstructor.cpp in Sources */,
+				DDF5527E298DAB29000410DB /* BigIntObject.cpp in Sources */,
+				DDF551A2298DAB29000410DB /* BigIntPrototype.cpp in Sources */,
+				DDF54FBB298DAAA0000410DB /* BinarySwitch.cpp in Sources */,
+				DDF54F23298DAA6D000410DB /* BlockDirectory.cpp in Sources */,
+				DDF5524C298DAB29000410DB /* BooleanConstructor.cpp in Sources */,
+				DDF551B1298DAB29000410DB /* BooleanObject.cpp in Sources */,
+				DDF55296298DAB29000410DB /* BooleanPrototype.cpp in Sources */,
+				DDF551E8298DAB29000410DB /* BrandedStructure.cpp in Sources */,
+				DDF54E72298DAA0A000410DB /* Breakpoint.cpp in Sources */,
+				DDF5524A298DAB29000410DB /* BufferMemoryHandle.cpp in Sources */,
+				DDF54E03298DA976000410DB /* BuiltinExecutableCreator.cpp in Sources */,
+				DDF54E02298DA976000410DB /* BuiltinExecutables.cpp in Sources */,
+				DDF54E04298DA976000410DB /* BuiltinNames.cpp in Sources */,
+				DDF54E24298DA990000410DB /* BytecodeBasicBlock.cpp in Sources */,
+				DDF55176298DAB29000410DB /* BytecodeCacheError.cpp in Sources */,
+				DDF54E39298DA990000410DB /* BytecodeDumper.cpp in Sources */,
+				DDF54E71298DA9B3000410DB /* BytecodeDumperGenerated.cpp in Sources */,
+				DDF54E6D298DA995000410DB /* BytecodeGenerator.cpp in Sources */,
+				DDF54E6B298DA990000410DB /* BytecodeGeneratorification.cpp in Sources */,
+				DDF54E19298DA990000410DB /* BytecodeIndex.cpp in Sources */,
+				DDF54E6C298DA990000410DB /* BytecodeIntrinsicRegistry.cpp in Sources */,
+				DDF54E09298DA990000410DB /* BytecodeLivenessAnalysis.cpp in Sources */,
+				DDF54E3F298DA990000410DB /* BytecodeRewriter.cpp in Sources */,
+				DDF54E1B298DA990000410DB /* BytecodeUseDef.cpp in Sources */,
+				DDF5520E298DAB29000410DB /* CacheableIdentifier.cpp in Sources */,
+				DDF55177298DAB29000410DB /* CachedBytecode.cpp in Sources */,
+				DDF54FB1298DAAA0000410DB /* CachedRecovery.cpp in Sources */,
+				DDF551BF298DAB29000410DB /* CachedSpecialPropertyAdaptiveStructureWatchpoint.cpp in Sources */,
+				DDF55202298DAB29000410DB /* CachedTypes.cpp in Sources */,
+				DDF55225298DAB29000410DB /* CachePayload.cpp in Sources */,
+				DDF55252298DAB29000410DB /* CacheUpdate.cpp in Sources */,
+				DDF55198298DAB29000410DB /* CallData.cpp in Sources */,
+				DDF54E22298DA990000410DB /* CallEdge.cpp in Sources */,
+				DDF54F8E298DAA99000410DB /* CallFrame.cpp in Sources */,
+				DDF54F96298DAAA0000410DB /* CallFrameShuffleData.cpp in Sources */,
+				DDF54FAB298DAAA0000410DB /* CallFrameShuffler.cpp in Sources */,
+				DDF54FAC298DAAA0000410DB /* CallFrameShuffler32_64.cpp in Sources */,
+				DDF54FCC298DAAA0000410DB /* CallFrameShuffler64.cpp in Sources */,
+				DDF54E49298DA990000410DB /* CallLinkInfo.cpp in Sources */,
+				DDF54E42298DA990000410DB /* CallLinkStatus.cpp in Sources */,
+				DDF54E11298DA990000410DB /* CallMode.cpp in Sources */,
+				DDF54E16298DA990000410DB /* CallVariant.cpp in Sources */,
+				DDF55150298DAB28000410DB /* CatchScope.cpp in Sources */,
+				DDF54FC5298DAAA0000410DB /* CCallHelpers.cpp in Sources */,
+				DDF54F36298DAA6D000410DB /* CellAttributes.cpp in Sources */,
+				DDF54F62298DAA6D000410DB /* CellContainer.cpp in Sources */,
+				DDF552A3298DAB30000410DB /* CellList.cpp in Sources */,
+				DDF54E06298DA990000410DB /* CheckPrivateBrandStatus.cpp in Sources */,
+				DDF54E66298DA990000410DB /* CheckPrivateBrandVariant.cpp in Sources */,
+				DDF55299298DAB29000410DB /* ClassInfo.cpp in Sources */,
+				DDF551CD298DAB29000410DB /* ClonedArguments.cpp in Sources */,
+				DDF54F8F298DAA99000410DB /* CLoopStack.cpp in Sources */,
+				DDF54E2A298DA990000410DB /* CodeBlock.cpp in Sources */,
+				DDF54E48298DA990000410DB /* CodeBlockHash.cpp in Sources */,
+				DDF54E28298DA990000410DB /* CodeBlockJettisoningWatchpoint.cpp in Sources */,
+				DDF54F64298DAA6D000410DB /* CodeBlockSet.cpp in Sources */,
+				DDF55293298DAB29000410DB /* CodeCache.cpp in Sources */,
+				DDF54E62298DA990000410DB /* CodeOrigin.cpp in Sources */,
+				DDF5523C298DAB29000410DB /* CodeSpecializationKind.cpp in Sources */,
+				DDF54E2C298DA990000410DB /* CodeType.cpp in Sources */,
+				DDF54F47298DAA6D000410DB /* CollectionScope.cpp in Sources */,
+				DDF54F63298DAA6D000410DB /* CollectorPhase.cpp in Sources */,
+				DDF55286298DAB29000410DB /* CommonIdentifiers.cpp in Sources */,
+				DDF551F8298DAB29000410DB /* CommonSlowPaths.cpp in Sources */,
+				DDF5521E298DAB29000410DB /* CompilationResult.cpp in Sources */,
+				DDF552A2298DAB30000410DB /* CompilerTimingScope.cpp in Sources */,
+				DDF54F43298DAA6D000410DB /* CompleteSubspace.cpp in Sources */,
+				DDF55229298DAB29000410DB /* Completion.cpp in Sources */,
+				DDF54E2B298DA990000410DB /* ComplexGetStatus.cpp in Sources */,
+				DDF55208298DAB29000410DB /* ConfigFile.cpp in Sources */,
+				DDF54F30298DAA6D000410DB /* ConservativeRoots.cpp in Sources */,
+				DDF55260298DAB29000410DB /* ConsoleClient.cpp in Sources */,
+				DDF54F82298DAA94000410DB /* ConsoleMessage.cpp in Sources */,
+				DDF551D4298DAB29000410DB /* ConsoleObject.cpp in Sources */,
+				DDF5516F298DAB29000410DB /* ConstantMode.cpp in Sources */,
+				DDF55294298DAB29000410DB /* ConstructData.cpp in Sources */,
+				DDF54F73298DAA94000410DB /* ContentSearchUtilities.cpp in Sources */,
+				DDF5522A298DAB29000410DB /* ControlFlowProfiler.cpp in Sources */,
+				DDF54D82298DA94E000410DB /* CPU.cpp in Sources */,
+				DDF5515F298DAB28000410DB /* CustomGetterSetter.cpp in Sources */,
+				DDF54E4A298DA990000410DB /* DataFormat.cpp in Sources */,
+				DDF55215298DAB29000410DB /* DataView.cpp in Sources */,
+				DDF55298298DAB29000410DB /* DateConstructor.cpp in Sources */,
+				DDF55250298DAB29000410DB /* DateConversion.cpp in Sources */,
+				DDF551DC298DAB29000410DB /* DateInstance.cpp in Sources */,
+				DDF5520D298DAB29000410DB /* DatePrototype.cpp in Sources */,
+				DDF54E73298DAA0A000410DB /* Debugger.cpp in Sources */,
+				DDF54E75298DAA0A000410DB /* DebuggerCallFrame.cpp in Sources */,
+				DDF54E77298DAA0A000410DB /* DebuggerLocation.cpp in Sources */,
+				DDF54E76298DAA0A000410DB /* DebuggerParseData.cpp in Sources */,
+				DDF54E74298DAA0A000410DB /* DebuggerScope.cpp in Sources */,
+				DDF54F48298DAA6D000410DB /* DeferGC.cpp in Sources */,
+				DDF54E36298DA990000410DB /* DeferredCompilationCallback.cpp in Sources */,
+				DDF54E21298DA990000410DB /* DeferredSourceDump.cpp in Sources */,
+				DDF551E9298DAB29000410DB /* DeferredWorkTimer.cpp in Sources */,
+				DDF54E1D298DA990000410DB /* DeleteByStatus.cpp in Sources */,
+				DDF54E3D298DA990000410DB /* DeleteByVariant.cpp in Sources */,
 				FE05FAFD1FE4CEDA00093230 /* DeprecatedInspectorValues.cpp in Sources */,
+				DDF54F65298DAA6D000410DB /* DestructionMode.cpp in Sources */,
+				DDF54EBB298DAA43000410DB /* DFGAbstractHeap.cpp in Sources */,
+				DDF54EAB298DAA43000410DB /* DFGAbstractInterpreterClobberState.cpp in Sources */,
+				DDF54EAD298DAA43000410DB /* DFGAbstractValue.cpp in Sources */,
+				DDF54E7E298DAA43000410DB /* DFGAbstractValueClobberEpoch.cpp in Sources */,
+				DDF54E7A298DAA43000410DB /* DFGAdaptiveInferredPropertyValueWatchpoint.cpp in Sources */,
+				DDF54EC0298DAA43000410DB /* DFGAdaptiveStructureWatchpoint.cpp in Sources */,
+				DDF54E92298DAA43000410DB /* DFGArgumentsEliminationPhase.cpp in Sources */,
+				DDF54E81298DAA43000410DB /* DFGArgumentsUtilities.cpp in Sources */,
+				DDF54EC8298DAA43000410DB /* DFGArithMode.cpp in Sources */,
+				DDF54E78298DAA43000410DB /* DFGArrayMode.cpp in Sources */,
+				DDF54ED6298DAA43000410DB /* DFGAtTailAbstractState.cpp in Sources */,
+				DDF54E91298DAA43000410DB /* DFGAvailability.cpp in Sources */,
+				DDF54E79298DAA43000410DB /* DFGAvailabilityMap.cpp in Sources */,
+				DDF54EEB298DAA43000410DB /* DFGBackwardsPropagationPhase.cpp in Sources */,
+				DDF54EEC298DAA43000410DB /* DFGBasicBlock.cpp in Sources */,
+				DDF54EC9298DAA43000410DB /* DFGBlockInsertionSet.cpp in Sources */,
+				DDF54ECA298DAA43000410DB /* DFGBlockSet.cpp in Sources */,
+				DDF54EED298DAA43000410DB /* DFGByteCodeParser.cpp in Sources */,
+				DDF54EAA298DAA43000410DB /* DFGCapabilities.cpp in Sources */,
+				DDF54EA2298DAA43000410DB /* DFGCFAPhase.cpp in Sources */,
+				DDF54E84298DAA43000410DB /* DFGCFGSimplificationPhase.cpp in Sources */,
+				DDF54EDE298DAA43000410DB /* DFGCleanUpPhase.cpp in Sources */,
+				DDF54E82298DAA43000410DB /* DFGClobberize.cpp in Sources */,
+				DDF54E7F298DAA43000410DB /* DFGClobberSet.cpp in Sources */,
+				DDF54EE4298DAA43000410DB /* DFGClobbersExitState.cpp in Sources */,
+				DDF54EC3298DAA43000410DB /* DFGCodeOriginPool.cpp in Sources */,
+				DDF54E96298DAA43000410DB /* DFGCombinedLiveness.cpp in Sources */,
+				DDF54E7D298DAA43000410DB /* DFGCommon.cpp in Sources */,
+				DDF54ED7298DAA43000410DB /* DFGCommonData.cpp in Sources */,
+				DDF54EC5298DAA43000410DB /* DFGConstantFoldingPhase.cpp in Sources */,
+				DDF54EA7298DAA43000410DB /* DFGConstantHoistingPhase.cpp in Sources */,
+				DDF54ED8298DAA43000410DB /* DFGCPSRethreadingPhase.cpp in Sources */,
+				DDF54E88298DAA43000410DB /* DFGCriticalEdgeBreakingPhase.cpp in Sources */,
+				DDF54E8B298DAA43000410DB /* DFGCSEPhase.cpp in Sources */,
+				DDF54E9C298DAA43000410DB /* DFGDCEPhase.cpp in Sources */,
+				DDF54E9E298DAA43000410DB /* DFGDesiredGlobalProperties.cpp in Sources */,
+				DDF54EA5298DAA43000410DB /* DFGDesiredIdentifiers.cpp in Sources */,
+				DDF54EF5298DAA43000410DB /* DFGDesiredTransitions.cpp in Sources */,
+				DDF54EA9298DAA43000410DB /* DFGDesiredWatchpoints.cpp in Sources */,
+				DDF54E9A298DAA43000410DB /* DFGDesiredWeakReferences.cpp in Sources */,
+				DDF54E98298DAA43000410DB /* DFGDisassembler.cpp in Sources */,
+				DDF54E99298DAA43000410DB /* DFGDoesGC.cpp in Sources */,
+				DDF54EB9298DAA43000410DB /* DFGDoesGCCheck.cpp in Sources */,
+				DDF54EAF298DAA43000410DB /* DFGDriver.cpp in Sources */,
+				DDF54EA0298DAA43000410DB /* DFGEdge.cpp in Sources */,
+				DDF54E97298DAA43000410DB /* DFGEpoch.cpp in Sources */,
+				DDF54E54298DA990000410DB /* DFGExitProfile.cpp in Sources */,
+				DDF54E8C298DAA43000410DB /* DFGFailedFinalizer.cpp in Sources */,
+				DDF54ED3298DAA43000410DB /* DFGFinalizer.cpp in Sources */,
+				DDF54EB8298DAA43000410DB /* DFGFixupPhase.cpp in Sources */,
+				DDF54EF8298DAA43000410DB /* DFGFlowIndexing.cpp in Sources */,
+				DDF54ED9298DAA43000410DB /* DFGFlushedAt.cpp in Sources */,
+				DDF54EE2298DAA43000410DB /* DFGFlushFormat.cpp in Sources */,
+				DDF54E90298DAA43000410DB /* DFGFrozenValue.cpp in Sources */,
+				DDF54EE0298DAA43000410DB /* DFGGraph.cpp in Sources */,
+				DDF54EA8298DAA43000410DB /* DFGGraphSafepoint.cpp in Sources */,
+				DDF54EC4298DAA43000410DB /* DFGHeapLocation.cpp in Sources */,
+				DDF54EE8298DAA43000410DB /* DFGInPlaceAbstractState.cpp in Sources */,
+				DDF54EAE298DAA43000410DB /* DFGInsertionSet.cpp in Sources */,
+				DDF54EF3298DAA43000410DB /* DFGIntegerCheckCombiningPhase.cpp in Sources */,
+				DDF54ED5298DAA43000410DB /* DFGIntegerRangeOptimizationPhase.cpp in Sources */,
+				DDF54EEE298DAA43000410DB /* DFGInvalidationPointInjectionPhase.cpp in Sources */,
+				DDF54EB5298DAA43000410DB /* DFGJITCode.cpp in Sources */,
+				DDF54EA1298DAA43000410DB /* DFGJITCompiler.cpp in Sources */,
+				DDF54EC7298DAA43000410DB /* DFGJITFinalizer.cpp in Sources */,
+				DDF54EB6298DAA43000410DB /* DFGJumpReplacement.cpp in Sources */,
+				DDF54E7B298DAA43000410DB /* DFGLazyJSValue.cpp in Sources */,
+				DDF54ECF298DAA43000410DB /* DFGLazyNode.cpp in Sources */,
+				DDF54EA6298DAA43000410DB /* DFGLICMPhase.cpp in Sources */,
+				DDF54EBC298DAA43000410DB /* DFGLiveCatchVariablePreservationPhase.cpp in Sources */,
+				DDF54E9B298DAA43000410DB /* DFGLivenessAnalysisPhase.cpp in Sources */,
+				DDF54EE3298DAA43000410DB /* DFGLoopPreHeaderCreationPhase.cpp in Sources */,
+				DDF54EA3298DAA43000410DB /* DFGMayExit.cpp in Sources */,
+				DDF54EF2298DAA43000410DB /* DFGMinifiedGraph.cpp in Sources */,
+				DDF54EF7298DAA43000410DB /* DFGMinifiedNode.cpp in Sources */,
+				DDF54ECB298DAA43000410DB /* DFGMultiGetByOffsetData.cpp in Sources */,
+				DDF54E8F298DAA43000410DB /* DFGNode.cpp in Sources */,
+				DDF54E80298DAA43000410DB /* DFGNodeAbstractValuePair.cpp in Sources */,
+				DDF54EC6298DAA43000410DB /* DFGNodeFlags.cpp in Sources */,
+				DDF54E93298DAA43000410DB /* DFGNodeFlowProjection.cpp in Sources */,
+				DDF54EBD298DAA43000410DB /* DFGNodeOrigin.cpp in Sources */,
+				DDF54E89298DAA43000410DB /* DFGObjectAllocationSinkingPhase.cpp in Sources */,
+				DDF54EDF298DAA43000410DB /* DFGObjectMaterializationData.cpp in Sources */,
+				DDF54EE5298DAA43000410DB /* DFGOperations.cpp in Sources */,
+				DDF54EEF298DAA43000410DB /* DFGOSRAvailabilityAnalysisPhase.cpp in Sources */,
+				DDF54EF9298DAA43000410DB /* DFGOSREntry.cpp in Sources */,
+				DDF54E8E298DAA43000410DB /* DFGOSREntrypointCreationPhase.cpp in Sources */,
+				DDF54EBA298DAA43000410DB /* DFGOSRExit.cpp in Sources */,
+				DDF54E8D298DAA43000410DB /* DFGOSRExitBase.cpp in Sources */,
+				DDF54E7C298DAA43000410DB /* DFGOSRExitCompilerCommon.cpp in Sources */,
+				DDF54EB4298DAA43000410DB /* DFGOSRExitFuzz.cpp in Sources */,
+				DDF54EB2298DAA43000410DB /* DFGOSRExitJumpPlaceholder.cpp in Sources */,
+				DDF54EE1298DAA43000410DB /* DFGPhantomInsertionPhase.cpp in Sources */,
+				DDF54EC1298DAA43000410DB /* DFGPhase.cpp in Sources */,
+				DDF54EB3298DAA43000410DB /* DFGPhiChildren.cpp in Sources */,
+				DDF54E83298DAA43000410DB /* DFGPlan.cpp in Sources */,
+				DDF54EEA298DAA43000410DB /* DFGPredictionInjectionPhase.cpp in Sources */,
+				DDF54ECE298DAA43000410DB /* DFGPredictionPropagationPhase.cpp in Sources */,
+				DDF54E9D298DAA43000410DB /* DFGPromotedHeapLocation.cpp in Sources */,
+				DDF54EE6298DAA43000410DB /* DFGPureValue.cpp in Sources */,
+				DDF54EB0298DAA43000410DB /* DFGPutStackSinkingPhase.cpp in Sources */,
+				DDF54E86298DAA43000410DB /* DFGRegisteredStructureSet.cpp in Sources */,
+				DDF54EF6298DAA43000410DB /* DFGSnippetParams.cpp in Sources */,
 				5333BBDC2110F7D9007618EC /* DFGSpeculativeJIT.cpp in Sources */,
 				5333BBDB2110F7D2007618EC /* DFGSpeculativeJIT32_64.cpp in Sources */,
 				5333BBDD2110F7E1007618EC /* DFGSpeculativeJIT64.cpp in Sources */,
+				DDF54EAC298DAA43000410DB /* DFGSSACalculator.cpp in Sources */,
+				DDF54EBE298DAA43000410DB /* DFGSSAConversionPhase.cpp in Sources */,
+				DDF54EA4298DAA43000410DB /* DFGSSALoweringPhase.cpp in Sources */,
+				DDF54ECC298DAA43000410DB /* DFGStackLayoutPhase.cpp in Sources */,
+				DDF54EF4298DAA43000410DB /* DFGStaticExecutionCountEstimationPhase.cpp in Sources */,
+				DDF54EC2298DAA43000410DB /* DFGStoreBarrierClusteringPhase.cpp in Sources */,
+				DDF54EB1298DAA43000410DB /* DFGStoreBarrierInsertionPhase.cpp in Sources */,
+				DDF54ED1298DAA43000410DB /* DFGStrengthReductionPhase.cpp in Sources */,
+				DDF54EF1298DAA43000410DB /* DFGStructureAbstractValue.cpp in Sources */,
+				DDF54E85298DAA43000410DB /* DFGThunks.cpp in Sources */,
+				DDF54ED4298DAA43000410DB /* DFGTierUpCheckInjectionPhase.cpp in Sources */,
+				DDF54E8A298DAA43000410DB /* DFGToFTLDeferredCompilationCallback.cpp in Sources */,
+				DDF54EF0298DAA43000410DB /* DFGToFTLForOSREntryDeferredCompilationCallback.cpp in Sources */,
+				DDF54EBF298DAA43000410DB /* DFGTransition.cpp in Sources */,
+				DDF54E9F298DAA43000410DB /* DFGTypeCheckHoistingPhase.cpp in Sources */,
+				DDF54E95298DAA43000410DB /* DFGUnificationPhase.cpp in Sources */,
+				DDF54ECD298DAA43000410DB /* DFGUseKind.cpp in Sources */,
+				DDF54EE9298DAA43000410DB /* DFGValidate.cpp in Sources */,
+				DDF54EE7298DAA43000410DB /* DFGValidateUnlinked.cpp in Sources */,
+				DDF54EDD298DAA43000410DB /* DFGValueRepReductionPhase.cpp in Sources */,
+				DDF54EB7298DAA43000410DB /* DFGValueSource.cpp in Sources */,
+				DDF54EDA298DAA43000410DB /* DFGValueStrength.cpp in Sources */,
+				DDF54EDB298DAA43000410DB /* DFGVarargsForwardingPhase.cpp in Sources */,
+				DDF54E94298DAA43000410DB /* DFGVariableAccessData.cpp in Sources */,
+				DDF54ED0298DAA43000410DB /* DFGVariableAccessDataDump.cpp in Sources */,
+				DDF54EDC298DAA43000410DB /* DFGVariableEvent.cpp in Sources */,
+				DDF54ED2298DAA43000410DB /* DFGVariableEventStream.cpp in Sources */,
+				DDF54E87298DAA43000410DB /* DFGVirtualRegisterAllocationPhase.cpp in Sources */,
+				DDF55206298DAB29000410DB /* DirectArguments.cpp in Sources */,
+				DDF551A3298DAB29000410DB /* DirectArgumentsOffset.cpp in Sources */,
+				DDF54E1A298DA990000410DB /* DirectEvalCodeCache.cpp in Sources */,
+				DDF55266298DAB29000410DB /* DirectEvalExecutable.cpp in Sources */,
+				DDF54EFC298DAA52000410DB /* Disassembler.cpp in Sources */,
+				DDF55289298DAB29000410DB /* DOMAttributeGetterSetter.cpp in Sources */,
+				DDF54EFE298DAA57000410DB /* DOMJITAbstractHeap.cpp in Sources */,
+				DDF54EFF298DAA57000410DB /* DOMJITHeapRange.cpp in Sources */,
+				DDF551BE298DAB29000410DB /* DoublePredictionFuzzerAgent.cpp in Sources */,
+				DDF5518D298DAB29000410DB /* DumpContext.cpp in Sources */,
+				DDF551F6298DAB29000410DB /* ECMAMode.cpp in Sources */,
+				DDF54F27298DAA6D000410DB /* EdenGCActivityCallback.cpp in Sources */,
+				DDF551A4298DAB29000410DB /* EnsureStillAliveHere.cpp in Sources */,
+				DDF55199298DAB29000410DB /* Error.cpp in Sources */,
+				DDF551D5298DAB29000410DB /* ErrorConstructor.cpp in Sources */,
+				DDF55270298DAB29000410DB /* ErrorHandlingScope.cpp in Sources */,
+				DDF551C1298DAB29000410DB /* ErrorInstance.cpp in Sources */,
+				DDF55163298DAB28000410DB /* ErrorPrototype.cpp in Sources */,
+				DDF55264298DAB29000410DB /* ErrorType.cpp in Sources */,
+				DDF54E65298DA990000410DB /* EvalCodeBlock.cpp in Sources */,
+				DDF55169298DAB28000410DB /* EvalExecutable.cpp in Sources */,
+				DDF55201298DAB29000410DB /* Exception.cpp in Sources */,
+				DDF55281298DAB29000410DB /* ExceptionEventLocation.cpp in Sources */,
+				DDF55285298DAB29000410DB /* ExceptionFuzz.cpp in Sources */,
+				DDF551E3298DAB29000410DB /* ExceptionHelpers.cpp in Sources */,
+				DDF551E0298DAB29000410DB /* ExceptionScope.cpp in Sources */,
+				DDF54FAD298DAAA0000410DB /* ExecutableAllocationFuzz.cpp in Sources */,
+				DDF54F94298DAAA0000410DB /* ExecutableAllocator.cpp in Sources */,
+				DDF55189298DAB29000410DB /* ExecutableBase.cpp in Sources */,
+				DDF54E4C298DA990000410DB /* ExecutionCounter.cpp in Sources */,
+				DDF54E40298DA990000410DB /* ExitFlag.cpp in Sources */,
+				DDF54E1C298DA990000410DB /* ExitingInlineKind.cpp in Sources */,
+				DDF54E20298DA990000410DB /* ExitingJITType.cpp in Sources */,
+				DDF54E2F298DA990000410DB /* ExitKind.cpp in Sources */,
+				DDF54F5C298DAA6D000410DB /* FastMallocAlignedMemoryAllocator.cpp in Sources */,
+				DDF5525A298DAB29000410DB /* FileBasedFuzzerAgent.cpp in Sources */,
+				DDF55224298DAB29000410DB /* FileBasedFuzzerAgentBase.cpp in Sources */,
+				DDF5523D298DAB29000410DB /* FinalizationRegistryConstructor.cpp in Sources */,
+				DDF551DD298DAB29000410DB /* FinalizationRegistryPrototype.cpp in Sources */,
+				DDF54F58298DAA6D000410DB /* FreeList.cpp in Sources */,
+				DDF54F1B298DAA62000410DB /* FTLAbstractHeap.cpp in Sources */,
+				DDF54F09298DAA62000410DB /* FTLAbstractHeapRepository.cpp in Sources */,
+				DDF54F10298DAA62000410DB /* FTLAvailableRecovery.cpp in Sources */,
+				DDF54F04298DAA62000410DB /* FTLCapabilities.cpp in Sources */,
+				DDF54F02298DAA62000410DB /* FTLCommonValues.cpp in Sources */,
+				DDF54F01298DAA62000410DB /* FTLCompile.cpp in Sources */,
+				DDF54F0A298DAA62000410DB /* FTLExceptionTarget.cpp in Sources */,
+				DDF54F11298DAA62000410DB /* FTLExitArgument.cpp in Sources */,
+				DDF54F0C298DAA62000410DB /* FTLExitArgumentForOperand.cpp in Sources */,
+				DDF54F0D298DAA62000410DB /* FTLExitPropertyValue.cpp in Sources */,
+				DDF54F21298DAA62000410DB /* FTLExitTimeObjectMaterialization.cpp in Sources */,
+				DDF54F1D298DAA62000410DB /* FTLExitValue.cpp in Sources */,
+				DDF54F1E298DAA62000410DB /* FTLFail.cpp in Sources */,
+				DDF54F1C298DAA62000410DB /* FTLForOSREntryJITCode.cpp in Sources */,
+				DDF54F15298DAA62000410DB /* FTLJITCode.cpp in Sources */,
+				DDF54F0E298DAA62000410DB /* FTLJITFinalizer.cpp in Sources */,
+				DDF54F16298DAA62000410DB /* FTLLazySlowPath.cpp in Sources */,
+				DDF54F06298DAA62000410DB /* FTLLink.cpp in Sources */,
+				DDF54F14298DAA62000410DB /* FTLLocation.cpp in Sources */,
 				33B2A548226543BF005A0F79 /* FTLLowerDFGToB3.cpp in Sources */,
+				DDF54F20298DAA62000410DB /* FTLOperations.cpp in Sources */,
+				DDF54F13298DAA62000410DB /* FTLOSREntry.cpp in Sources */,
+				DDF54F17298DAA62000410DB /* FTLOSRExit.cpp in Sources */,
+				DDF54F0B298DAA62000410DB /* FTLOSRExitCompiler.cpp in Sources */,
+				DDF54F00298DAA62000410DB /* FTLOSRExitHandle.cpp in Sources */,
+				DDF54F05298DAA62000410DB /* FTLOutput.cpp in Sources */,
+				DDF54F1A298DAA62000410DB /* FTLPatchpointExceptionHandle.cpp in Sources */,
+				DDF54F07298DAA62000410DB /* FTLRecoveryOpcode.cpp in Sources */,
+				DDF54F0F298DAA62000410DB /* FTLSaveRestore.cpp in Sources */,
+				DDF54F12298DAA62000410DB /* FTLSlowPathCall.cpp in Sources */,
+				DDF54F03298DAA62000410DB /* FTLSlowPathCallKey.cpp in Sources */,
+				DDF54F1F298DAA62000410DB /* FTLSnippetParams.cpp in Sources */,
+				DDF54F08298DAA62000410DB /* FTLState.cpp in Sources */,
+				DDF54F18298DAA62000410DB /* FTLThunks.cpp in Sources */,
+				DDF54F19298DAA62000410DB /* FTLValueRange.cpp in Sources */,
+				DDF54E5C298DA990000410DB /* FullCodeOrigin.cpp in Sources */,
+				DDF54F34298DAA6D000410DB /* FullGCActivityCallback.cpp in Sources */,
+				DDF552A0298DAB30000410DB /* FunctionAllowlist.cpp in Sources */,
+				DDF54E60298DA990000410DB /* FunctionCodeBlock.cpp in Sources */,
+				DDF55178298DAB29000410DB /* FunctionConstructor.cpp in Sources */,
+				DDF55164298DAB28000410DB /* FunctionExecutable.cpp in Sources */,
+				DDF55239298DAB29000410DB /* FunctionExecutableDump.cpp in Sources */,
+				DDF55297298DAB29000410DB /* FunctionHasExecutedCache.cpp in Sources */,
+				DDF5529D298DAB30000410DB /* FunctionOverrides.cpp in Sources */,
+				DDF5514C298DAB28000410DB /* FunctionPrototype.cpp in Sources */,
+				DDF5527C298DAB29000410DB /* FunctionRareData.cpp in Sources */,
+				DDF55279298DAB29000410DB /* FuzzerAgent.cpp in Sources */,
+				DDF55205298DAB29000410DB /* FuzzerPredictions.cpp in Sources */,
+				DDF54F52298DAA6D000410DB /* GCActivityCallback.cpp in Sources */,
+				DDF54FAA298DAAA0000410DB /* GCAwareJITStubRoutine.cpp in Sources */,
+				DDF54F25298DAA6D000410DB /* GCConductor.cpp in Sources */,
+				DDF54F2B298DAA6D000410DB /* GCLogging.cpp in Sources */,
+				DDF54F49298DAA6D000410DB /* GCRequest.cpp in Sources */,
+				DDF54F61298DAA6D000410DB /* GCSegmentedArray.cpp in Sources */,
+				DDF55222298DAB29000410DB /* GeneratorFunctionConstructor.cpp in Sources */,
+				DDF55255298DAB29000410DB /* GeneratorFunctionPrototype.cpp in Sources */,
+				DDF55207298DAB29000410DB /* GeneratorPrototype.cpp in Sources */,
+				DDF54E3E298DA990000410DB /* GetByStatus.cpp in Sources */,
+				DDF54E6A298DA990000410DB /* GetByVariant.cpp in Sources */,
+				DDF55212298DAB29000410DB /* GetPutInfo.cpp in Sources */,
+				DDF551B3298DAB29000410DB /* GetterSetter.cpp in Sources */,
+				DDF54E3A298DA990000410DB /* GetterSetterAccessCase.cpp in Sources */,
+				DDF54F39298DAA6D000410DB /* GigacageAlignedMemoryAllocator.cpp in Sources */,
+				DDF5526A298DAB29000410DB /* GlobalExecutable.cpp in Sources */,
+				DDF54FA8298DAAA0000410DB /* GPRInfo.cpp in Sources */,
+				DDF54F56298DAA6D000410DB /* HandleSet.cpp in Sources */,
+				DDF55191298DAB29000410DB /* HashMapImpl.cpp in Sources */,
+				DDF54F5B298DAA6D000410DB /* Heap.cpp in Sources */,
+				DDF54F5D298DAA6D000410DB /* HeapCell.cpp in Sources */,
+				DDF54F24298DAA6D000410DB /* HeapCellType.cpp in Sources */,
+				DDF54F3A298DAA6D000410DB /* HeapFinalizerCallback.cpp in Sources */,
+				DDF54F2F298DAA6D000410DB /* HeapHelperPool.cpp in Sources */,
+				DDF54F32298DAA6D000410DB /* HeapProfiler.cpp in Sources */,
+				DDF54F3B298DAA6D000410DB /* HeapSnapshot.cpp in Sources */,
+				DDF54F2A298DAA6D000410DB /* HeapSnapshotBuilder.cpp in Sources */,
+				DDF552A5298DAB30000410DB /* HeapVerifier.cpp in Sources */,
+				DDF54FA4298DAAA0000410DB /* ICStats.cpp in Sources */,
+				DDF54E64298DA990000410DB /* ICStatusMap.cpp in Sources */,
+				DDF54E0A298DA990000410DB /* ICStatusUtils.cpp in Sources */,
+				DDF55159298DAB28000410DB /* Identifier.cpp in Sources */,
+				DDF54F89298DAA94000410DB /* IdentifiersFactory.cpp in Sources */,
+				DDF551FC298DAB29000410DB /* ImportMap.cpp in Sources */,
+				DDF54E26298DA990000410DB /* InByStatus.cpp in Sources */,
+				DDF54E53298DA990000410DB /* InByVariant.cpp in Sources */,
+				DDF54F3C298DAA6D000410DB /* IncrementalSweeper.cpp in Sources */,
+				DDF55271298DAB29000410DB /* IndexingType.cpp in Sources */,
+				DDF5525B298DAB29000410DB /* IndirectEvalExecutable.cpp in Sources */,
+				DDF5529C298DAB29000410DB /* InitializeThreading.cpp in Sources */,
+				DDF54F75298DAA94000410DB /* InjectedScript.cpp in Sources */,
+				DDF54F7F298DAA94000410DB /* InjectedScriptBase.cpp in Sources */,
+				DDF54F84298DAA94000410DB /* InjectedScriptHost.cpp in Sources */,
+				DDF54F7A298DAA94000410DB /* InjectedScriptManager.cpp in Sources */,
+				DDF54F7B298DAA94000410DB /* InjectedScriptModule.cpp in Sources */,
+				DDF54E10298DA990000410DB /* InlineAccess.cpp in Sources */,
+				DDF54E37298DA990000410DB /* InlineCallFrame.cpp in Sources */,
+				DDF54E32298DA990000410DB /* InlineCallFrameSet.cpp in Sources */,
+				DDF54F6D298DAA78000410DB /* InspectorAgent.cpp in Sources */,
+				DDF54F76298DAA94000410DB /* InspectorAgentRegistry.cpp in Sources */,
+				DDF54F6B298DAA78000410DB /* InspectorAuditAgent.cpp in Sources */,
+				DDF54F77298DAA94000410DB /* InspectorBackendDispatcher.cpp in Sources */,
+				DDF54F66298DAA78000410DB /* InspectorConsoleAgent.cpp in Sources */,
+				DDF54F6E298DAA78000410DB /* InspectorDebuggerAgent.cpp in Sources */,
+				DDF54F74298DAA94000410DB /* InspectorFrontendRouter.cpp in Sources */,
+				DDF54F6C298DAA78000410DB /* InspectorHeapAgent.cpp in Sources */,
+				DDF54F6F298DAA78000410DB /* InspectorRuntimeAgent.cpp in Sources */,
+				DDF54F67298DAA78000410DB /* InspectorScriptProfilerAgent.cpp in Sources */,
+				DDF54F86298DAA94000410DB /* InspectorTarget.cpp in Sources */,
+				DDF54F68298DAA78000410DB /* InspectorTargetAgent.cpp in Sources */,
+				DDF54E44298DA990000410DB /* InstanceOfAccessCase.cpp in Sources */,
+				DDF54E14298DA990000410DB /* InstanceOfStatus.cpp in Sources */,
+				DDF54E0D298DA990000410DB /* InstanceOfVariant.cpp in Sources */,
+				DDF54E25298DA990000410DB /* InstructionStream.cpp in Sources */,
+				DDF5529E298DAB30000410DB /* Integrity.cpp in Sources */,
+				DDF551F3298DAB29000410DB /* InternalFunction.cpp in Sources */,
+				DDF54F8D298DAA99000410DB /* Interpreter.cpp in Sources */,
+				DDF5521D298DAB29000410DB /* IntlCache.cpp in Sources */,
+				DDF55203298DAB29000410DB /* IntlCollator.cpp in Sources */,
+				DDF55247298DAB29000410DB /* IntlCollatorConstructor.cpp in Sources */,
+				DDF55274298DAB29000410DB /* IntlCollatorPrototype.cpp in Sources */,
 				E399AEC32559457F00B78485 /* IntlDateTimeFormat.cpp in Sources */,
+				DDF55245298DAB29000410DB /* IntlDateTimeFormatConstructor.cpp in Sources */,
+				DDF551B7298DAB29000410DB /* IntlDateTimeFormatPrototype.cpp in Sources */,
+				DDF5524B298DAB29000410DB /* IntlDisplayNames.cpp in Sources */,
+				DDF5516C298DAB29000410DB /* IntlDisplayNamesConstructor.cpp in Sources */,
+				DDF5526B298DAB29000410DB /* IntlDisplayNamesPrototype.cpp in Sources */,
 				E32E1B3128DA8C7A00FCB571 /* IntlDurationFormat.cpp in Sources */,
+				DDF5515D298DAB28000410DB /* IntlDurationFormatConstructor.cpp in Sources */,
+				DDF551CC298DAB29000410DB /* IntlDurationFormatPrototype.cpp in Sources */,
 				E366441E254409B30001876F /* IntlListFormat.cpp in Sources */,
+				DDF55272298DAB29000410DB /* IntlListFormatConstructor.cpp in Sources */,
+				DDF55249298DAB29000410DB /* IntlListFormatPrototype.cpp in Sources */,
+				DDF55154298DAB28000410DB /* IntlLocale.cpp in Sources */,
+				DDF551B6298DAB29000410DB /* IntlLocaleConstructor.cpp in Sources */,
+				DDF55227298DAB29000410DB /* IntlLocalePrototype.cpp in Sources */,
 				E378DC8D2727629400427B0B /* IntlNumberFormat.cpp in Sources */,
+				DDF5517C298DAB29000410DB /* IntlNumberFormatConstructor.cpp in Sources */,
+				DDF551AA298DAB29000410DB /* IntlNumberFormatPrototype.cpp in Sources */,
+				DDF5526C298DAB29000410DB /* IntlObject.cpp in Sources */,
 				E30873E7272559410053B601 /* IntlPluralRules.cpp in Sources */,
+				DDF551C4298DAB29000410DB /* IntlPluralRulesConstructor.cpp in Sources */,
+				DDF5526D298DAB29000410DB /* IntlPluralRulesPrototype.cpp in Sources */,
+				DDF5519E298DAB29000410DB /* IntlRelativeTimeFormat.cpp in Sources */,
+				DDF551F7298DAB29000410DB /* IntlRelativeTimeFormatConstructor.cpp in Sources */,
+				DDF55144298DAB28000410DB /* IntlRelativeTimeFormatPrototype.cpp in Sources */,
+				DDF551FA298DAB29000410DB /* IntlSegmenter.cpp in Sources */,
+				DDF55214298DAB29000410DB /* IntlSegmenterConstructor.cpp in Sources */,
+				DDF5527D298DAB29000410DB /* IntlSegmenterPrototype.cpp in Sources */,
+				DDF55213298DAB29000410DB /* IntlSegmentIterator.cpp in Sources */,
+				DDF55158298DAB28000410DB /* IntlSegmentIteratorPrototype.cpp in Sources */,
+				DDF5519D298DAB29000410DB /* IntlSegments.cpp in Sources */,
+				DDF551ED298DAB29000410DB /* IntlSegmentsPrototype.cpp in Sources */,
 				A3EE8543262514B000FC9B8D /* IntlWorkaround.cpp in Sources */,
+				DDF551BC298DAB29000410DB /* Intrinsic.cpp in Sources */,
+				DDF54FCB298DAAA0000410DB /* IntrinsicEmitter.cpp in Sources */,
+				DDF54E61298DA990000410DB /* IntrinsicGetterAccessCase.cpp in Sources */,
+				DDF5514B298DAB28000410DB /* ISO8601.cpp in Sources */,
+				DDF54F5A298DAA6D000410DB /* IsoAlignedMemoryAllocator.cpp in Sources */,
+				DDF54F2C298DAA6D000410DB /* IsoCellSet.cpp in Sources */,
+				DDF54F4A298DAA6D000410DB /* IsoHeapCellType.cpp in Sources */,
+				DDF54F28298DAA6D000410DB /* IsoMemoryAllocatorBase.cpp in Sources */,
+				DDF54F5E298DAA6D000410DB /* IsoSubspace.cpp in Sources */,
+				DDF54F4B298DAA6D000410DB /* IsoSubspacePerVM.cpp in Sources */,
+				DDF551D9298DAB29000410DB /* IteratorOperations.cpp in Sources */,
+				DDF55288298DAB29000410DB /* IteratorPrototype.cpp in Sources */,
+				DDF54F81298DAA94000410DB /* JavaScriptCallFrame.cpp in Sources */,
+				DDF54FB2298DAAA0000410DB /* JIT.cpp in Sources */,
+				DDF54FC9298DAAA0000410DB /* JITAddGenerator.cpp in Sources */,
+				DDF54FAE298DAAA0000410DB /* JITArithmetic.cpp in Sources */,
+				DDF54FA9298DAAA0000410DB /* JITBitAndGenerator.cpp in Sources */,
+				DDF54F9E298DAAA0000410DB /* JITBitOrGenerator.cpp in Sources */,
+				DDF54FA7298DAAA0000410DB /* JITBitXorGenerator.cpp in Sources */,
+				DDF54FC7298DAAA0000410DB /* JITCall.cpp in Sources */,
+				DDF54F92298DAAA0000410DB /* JITCode.cpp in Sources */,
+				DDF54FB7298DAAA0000410DB /* JITCompilation.cpp in Sources */,
+				DDF54FBC298DAAA0000410DB /* JITCompilationKey.cpp in Sources */,
+				DDF54FA3298DAAA0000410DB /* JITCompilationMode.cpp in Sources */,
+				DDF54FB5298DAAA0000410DB /* JITDisassembler.cpp in Sources */,
+				DDF54F9D298DAAA0000410DB /* JITDivGenerator.cpp in Sources */,
+				DDF54F98298DAAA0000410DB /* JITExceptions.cpp in Sources */,
+				DDF54FC2298DAAA0000410DB /* JITInlineCacheGenerator.cpp in Sources */,
+				DDF54FCD298DAAA0000410DB /* JITLeftShiftGenerator.cpp in Sources */,
+				DDF54F9F298DAAA0000410DB /* JITMulGenerator.cpp in Sources */,
+				DDF54FA5298DAAA0000410DB /* JITNegGenerator.cpp in Sources */,
+				DDF54FCA298DAAA0000410DB /* JITOpaqueByproducts.cpp in Sources */,
+				DDF54FB0298DAAA0000410DB /* JITOpcodes.cpp in Sources */,
+				DDF54F91298DAAA0000410DB /* JITOpcodes32_64.cpp in Sources */,
+				DDF54D85298DA94E000410DB /* JITOperationList.cpp in Sources */,
+				DDF54F9A298DAAA0000410DB /* JITOperations.cpp in Sources */,
+				DDF54FBA298DAAA0000410DB /* JITPlan.cpp in Sources */,
+				DDF54FBE298DAAA0000410DB /* JITPropertyAccess.cpp in Sources */,
+				DDF54FA1298DAAA0000410DB /* JITRightShiftGenerator.cpp in Sources */,
+				DDF54FBF298DAAA0000410DB /* JITSafepoint.cpp in Sources */,
+				DDF54FA0298DAAA0000410DB /* JITSizeStatistics.cpp in Sources */,
+				DDF54FAF298DAAA0000410DB /* JITStubRoutine.cpp in Sources */,
+				DDF54F60298DAA6D000410DB /* JITStubRoutineSet.cpp in Sources */,
+				DDF54FB6298DAAA0000410DB /* JITSubGenerator.cpp in Sources */,
+				DDF54FB3298DAAA0000410DB /* JITThunks.cpp in Sources */,
+				DDF54FA2298DAAA0000410DB /* JITToDFGDeferredCompilationCallback.cpp in Sources */,
+				DDF54F93298DAAA0000410DB /* JITWorklist.cpp in Sources */,
+				DDF54FA6298DAAA0000410DB /* JITWorklistThread.cpp in Sources */,
+				DDF54D70298DA937000410DB /* JSAPIGlobalObject.cpp in Sources */,
+				DDF5530D298DAB67000410DB /* JSAPIGlobalObject.mm in Sources */,
+				DDF54D73298DA937000410DB /* JSAPIValueWrapper.cpp in Sources */,
+				DDF5530E298DAB67000410DB /* JSAPIWrapperObject.mm in Sources */,
+				DDF55216298DAB29000410DB /* JSArray.cpp in Sources */,
+				DDF551A5298DAB29000410DB /* JSArrayBuffer.cpp in Sources */,
+				DDF55282298DAB29000410DB /* JSArrayBufferConstructor.cpp in Sources */,
+				DDF55170298DAB29000410DB /* JSArrayBufferPrototype.cpp in Sources */,
+				DDF5523E298DAB29000410DB /* JSArrayBufferView.cpp in Sources */,
+				DDF5519A298DAB29000410DB /* JSArrayIterator.cpp in Sources */,
+				DDF5517E298DAB29000410DB /* JSAsyncFunction.cpp in Sources */,
+				DDF551C8298DAB29000410DB /* JSAsyncGenerator.cpp in Sources */,
+				DDF55276298DAB29000410DB /* JSAsyncGeneratorFunction.cpp in Sources */,
+				DDF54D60298DA937000410DB /* JSBase.cpp in Sources */,
+				DDF55171298DAB29000410DB /* JSBigInt.cpp in Sources */,
+				DDF55240298DAB29000410DB /* JSBoundFunction.cpp in Sources */,
+				DDF54D76298DA937000410DB /* JSCallbackConstructor.cpp in Sources */,
+				DDF54D6D298DA937000410DB /* JSCallbackFunction.cpp in Sources */,
+				DDF54D6E298DA937000410DB /* JSCallbackObject.cpp in Sources */,
+				DDF551F9298DAB29000410DB /* JSCallee.cpp in Sources */,
 				DD28467C291AF1B20009A61D /* JSCBuiltins.cpp in Sources */,
-				DD284679291A29900009A61D /* JSCBytecodeCacheVersion.cpp.in in Sources */,
+				DDF55161298DAB28000410DB /* JSCBytecodeCacheVersion.cpp.in in Sources */,
+				DDF55167298DAB28000410DB /* JSCConfig.cpp in Sources */,
+				DDF55217298DAB29000410DB /* JSCell.cpp in Sources */,
+				DDF551D6298DAB29000410DB /* JSCJSValue.cpp in Sources */,
+				DDF54D72298DA937000410DB /* JSClassRef.cpp in Sources */,
+				DDF5530C298DAB67000410DB /* JSContext.mm in Sources */,
+				DDF54D66298DA937000410DB /* JSContextRef.cpp in Sources */,
+				DDF55253298DAB29000410DB /* JSCPtrTag.cpp in Sources */,
+				DDF54D67298DA937000410DB /* JSCTestRunnerUtils.cpp in Sources */,
+				DDF55267298DAB29000410DB /* JSCustomGetterFunction.cpp in Sources */,
+				DDF55172298DAB29000410DB /* JSCustomSetterFunction.cpp in Sources */,
+				DDF5524F298DAB29000410DB /* JSDataView.cpp in Sources */,
+				DDF55193298DAB29000410DB /* JSDataViewPrototype.cpp in Sources */,
 				E38E8790254B978400F6F9E4 /* JSDateMath.cpp in Sources */,
+				DDF5518F298DAB29000410DB /* JSDestructibleObjectHeapCellType.cpp in Sources */,
+				DDF5529F298DAB30000410DB /* JSDollarVM.cpp in Sources */,
+				DDF551A9298DAB29000410DB /* JSFinalizationRegistry.cpp in Sources */,
+				DDF55231298DAB29000410DB /* JSFunction.cpp in Sources */,
+				DDF55146298DAB28000410DB /* JSGenerator.cpp in Sources */,
+				DDF5518A298DAB29000410DB /* JSGeneratorFunction.cpp in Sources */,
+				DDF55280298DAB29000410DB /* JSGlobalLexicalEnvironment.cpp in Sources */,
+				DDF551A7298DAB29000410DB /* JSGlobalObject.cpp in Sources */,
+				DDF54F6A298DAA78000410DB /* JSGlobalObjectAuditAgent.cpp in Sources */,
+				DDF54F7D298DAA94000410DB /* JSGlobalObjectConsoleClient.cpp in Sources */,
+				DDF55204298DAB29000410DB /* JSGlobalObjectDebuggable.cpp in Sources */,
+				DDF54F85298DAA94000410DB /* JSGlobalObjectDebugger.cpp in Sources */,
+				DDF54F69298DAA78000410DB /* JSGlobalObjectDebuggerAgent.cpp in Sources */,
+				DDF55258298DAB29000410DB /* JSGlobalObjectFunctions.cpp in Sources */,
+				DDF54F71298DAA94000410DB /* JSGlobalObjectInspectorController.cpp in Sources */,
+				DDF54F70298DAA78000410DB /* JSGlobalObjectRuntimeAgent.cpp in Sources */,
+				DDF54D6C298DA937000410DB /* JSHeapFinalizerPrivate.cpp in Sources */,
+				DDF551D0298DAB29000410DB /* JSImmutableButterfly.cpp in Sources */,
+				DDF54F80298DAA94000410DB /* JSInjectedScriptHost.cpp in Sources */,
+				DDF54F8A298DAA94000410DB /* JSInjectedScriptHostPrototype.cpp in Sources */,
+				DDF55188298DAB29000410DB /* JSInternalPromise.cpp in Sources */,
+				DDF551A6298DAB29000410DB /* JSInternalPromiseConstructor.cpp in Sources */,
+				DDF55236298DAB29000410DB /* JSInternalPromisePrototype.cpp in Sources */,
+				DDF54F78298DAA94000410DB /* JSJavaScriptCallFrame.cpp in Sources */,
+				DDF54F88298DAA94000410DB /* JSJavaScriptCallFramePrototype.cpp in Sources */,
+				DDF551DA298DAB29000410DB /* JSLexicalEnvironment.cpp in Sources */,
+				DDF551A8298DAB29000410DB /* JSLock.cpp in Sources */,
+				DDF54D63298DA937000410DB /* JSLockRef.cpp in Sources */,
+				DDF5530F298DAB67000410DB /* JSManagedValue.mm in Sources */,
+				DDF5518B298DAB29000410DB /* JSMap.cpp in Sources */,
+				DDF5524D298DAB29000410DB /* JSMapIterator.cpp in Sources */,
+				DDF54D6F298DA937000410DB /* JSMarkingConstraintPrivate.cpp in Sources */,
+				DDF5525E298DAB29000410DB /* JSMicrotask.cpp in Sources */,
+				DDF5517B298DAB29000410DB /* JSModuleEnvironment.cpp in Sources */,
+				DDF55268298DAB29000410DB /* JSModuleLoader.cpp in Sources */,
+				DDF551FF298DAB29000410DB /* JSModuleNamespaceObject.cpp in Sources */,
+				DDF551DB298DAB29000410DB /* JSModuleRecord.cpp in Sources */,
+				DDF55275298DAB29000410DB /* JSNativeStdFunction.cpp in Sources */,
+				DDF551AB298DAB29000410DB /* JSObject.cpp in Sources */,
+				DDF54D71298DA937000410DB /* JSObjectRef.cpp in Sources */,
+				DDF551E5298DAB29000410DB /* JSONObject.cpp in Sources */,
+				DDF5516A298DAB28000410DB /* JSPromise.cpp in Sources */,
+				DDF55209298DAB29000410DB /* JSPromiseConstructor.cpp in Sources */,
+				DDF551F2298DAB29000410DB /* JSPromisePrototype.cpp in Sources */,
+				DDF551B4298DAB29000410DB /* JSPropertyNameEnumerator.cpp in Sources */,
+				DDF551EE298DAB29000410DB /* JSProxy.cpp in Sources */,
+				DDF55197298DAB29000410DB /* JSRemoteFunction.cpp in Sources */,
+				DDF54D75298DA937000410DB /* JSRemoteInspector.cpp in Sources */,
+				DDF55149298DAB28000410DB /* JSRunLoopTimer.cpp in Sources */,
+				DDF551E7298DAB29000410DB /* JSScope.cpp in Sources */,
+				DDF55308298DAB67000410DB /* JSScript.mm in Sources */,
+				DDF55262298DAB29000410DB /* JSScriptFetcher.cpp in Sources */,
+				DDF55284298DAB29000410DB /* JSScriptFetchParameters.cpp in Sources */,
+				DDF54D68298DA937000410DB /* JSScriptRef.cpp in Sources */,
+				DDF5530B298DAB67000410DB /* JSScriptSourceProvider.mm in Sources */,
+				DDF55165298DAB28000410DB /* JSSegmentedVariableObject.cpp in Sources */,
+				DDF5521B298DAB29000410DB /* JSSet.cpp in Sources */,
+				DDF55160298DAB28000410DB /* JSSetIterator.cpp in Sources */,
+				DDF55261298DAB29000410DB /* JSSourceCode.cpp in Sources */,
+				DDF55242298DAB29000410DB /* JSString.cpp in Sources */,
+				DDF55181298DAB29000410DB /* JSStringIterator.cpp in Sources */,
+				DDF5528B298DAB29000410DB /* JSStringJoiner.cpp in Sources */,
+				DDF54D69298DA937000410DB /* JSStringRef.cpp in Sources */,
+				DDF54D77298DA937000410DB /* JSStringRefCF.cpp in Sources */,
+				DDF5525C298DAB29000410DB /* JSSymbolTableObject.cpp in Sources */,
+				DDF55232298DAB29000410DB /* JSTemplateObjectDescriptor.cpp in Sources */,
+				DDF552D7298DAB43000410DB /* JSToWasm.cpp in Sources */,
+				DDF5520F298DAB29000410DB /* JSType.cpp in Sources */,
+				DDF54D6A298DA937000410DB /* JSTypedArray.cpp in Sources */,
+				DDF551E4298DAB29000410DB /* JSTypedArrayConstructors.cpp in Sources */,
+				DDF55166298DAB28000410DB /* JSTypedArrayPrototypes.cpp in Sources */,
+				DDF55256298DAB29000410DB /* JSTypedArrays.cpp in Sources */,
+				DDF55290298DAB29000410DB /* JSTypedArrayViewConstructor.cpp in Sources */,
+				DDF55241298DAB29000410DB /* JSTypedArrayViewPrototype.cpp in Sources */,
+				DDF5530A298DAB67000410DB /* JSValue.mm in Sources */,
+				DDF54D74298DA937000410DB /* JSValueRef.cpp in Sources */,
+				DDF55309298DAB67000410DB /* JSVirtualMachine.mm in Sources */,
+				DDF55168298DAB28000410DB /* JSWeakMap.cpp in Sources */,
+				DDF54D6B298DA937000410DB /* JSWeakObjectMapRefPrivate.cpp in Sources */,
+				DDF5527F298DAB29000410DB /* JSWeakObjectRef.cpp in Sources */,
+				DDF54D78298DA937000410DB /* JSWeakPrivate.cpp in Sources */,
+				DDF551C2298DAB29000410DB /* JSWeakSet.cpp in Sources */,
+				DDF54D62298DA937000410DB /* JSWeakValue.cpp in Sources */,
+				DDF552D2298DAB43000410DB /* JSWebAssembly.cpp in Sources */,
+				DDF552F9298DAB43000410DB /* JSWebAssemblyArray.cpp in Sources */,
+				DDF552EA298DAB43000410DB /* JSWebAssemblyCompileError.cpp in Sources */,
+				DDF552DA298DAB43000410DB /* JSWebAssemblyException.cpp in Sources */,
+				DDF552F7298DAB43000410DB /* JSWebAssemblyGlobal.cpp in Sources */,
+				DDF552D5298DAB43000410DB /* JSWebAssemblyInstance.cpp in Sources */,
+				DDF552F0298DAB43000410DB /* JSWebAssemblyLinkError.cpp in Sources */,
+				DDF552F1298DAB43000410DB /* JSWebAssemblyMemory.cpp in Sources */,
+				DDF552FB298DAB43000410DB /* JSWebAssemblyModule.cpp in Sources */,
+				DDF552D6298DAB43000410DB /* JSWebAssemblyRuntimeError.cpp in Sources */,
+				DDF552D9298DAB43000410DB /* JSWebAssemblyStruct.cpp in Sources */,
+				DDF552E7298DAB43000410DB /* JSWebAssemblyTable.cpp in Sources */,
+				DDF552E5298DAB43000410DB /* JSWebAssemblyTag.cpp in Sources */,
+				DDF551DF298DAB29000410DB /* JSWithScope.cpp in Sources */,
+				DDF55310298DAB67000410DB /* JSWrapperMap.mm in Sources */,
+				DDF55186298DAB29000410DB /* JSWrapperObject.cpp in Sources */,
+				DDF54E0B298DA990000410DB /* JumpTable.cpp in Sources */,
+				DDF551AC298DAB29000410DB /* LazyClassStructure.cpp in Sources */,
+				DDF54E52298DA990000410DB /* LazyOperandValueProfile.cpp in Sources */,
+				DDF55283298DAB29000410DB /* LeafExecutable.cpp in Sources */,
+				DDF54FD5298DAAB2000410DB /* Lexer.cpp in Sources */,
+				DDF54D7D298DA94E000410DB /* LinkBuffer.cpp in Sources */,
+				DDF54E4E298DA990000410DB /* LinkTimeConstant.cpp in Sources */,
+				DDF55238298DAB29000410DB /* LiteralParser.cpp in Sources */,
+				DDF54FD1298DAAAB000410DB /* LLIntCLoop.cpp in Sources */,
+				DDF54FD0298DAAAB000410DB /* LLIntData.cpp in Sources */,
+				DDF54FCF298DAAAB000410DB /* LLIntEntrypoint.cpp in Sources */,
+				DDF54FD2298DAAAB000410DB /* LLIntExceptions.cpp in Sources */,
+				DDF54E05298DA990000410DB /* LLIntPrototypeLoadAdaptiveStructureWatchpoint.cpp in Sources */,
+				DDF54FD3298DAAAB000410DB /* LLIntSlowPaths.cpp in Sources */,
+				DDF54FCE298DAAAB000410DB /* LLIntThunks.cpp in Sources */,
+				DDF54F41298DAA6D000410DB /* LocalAllocator.cpp in Sources */,
+				DDF5517D298DAB29000410DB /* Lookup.cpp in Sources */,
 				4BE92D442898522400FA48E1 /* LowLevelInterpreter.asm in Sources */,
 				4BE92D452898522400FA48E1 /* LowLevelInterpreter.cpp in Sources */,
+				DDF54F35298DAA6D000410DB /* MachineStackMarker.cpp in Sources */,
+				DDF54D7E298DA94E000410DB /* MacroAssembler.cpp in Sources */,
 				4B46940328984FA800512FDF /* MacroAssemblerARM64.cpp in Sources */,
+				DDF54D7B298DA94E000410DB /* MacroAssemblerCodeRef.cpp in Sources */,
+				DDF54D79298DA94E000410DB /* MacroAssemblerPrinter.cpp in Sources */,
 				4B46940428984FEE00512FDF /* MacroAssemblerX86Common.cpp in Sources */,
-				FE770390298CD40F009634C7 /* Parser.cpp in Sources */,
+				DDF5516B298DAB29000410DB /* MapConstructor.cpp in Sources */,
+				DDF5522C298DAB29000410DB /* MapIteratorPrototype.cpp in Sources */,
+				DDF5517F298DAB29000410DB /* MapPrototype.cpp in Sources */,
+				DDF54F29298DAA6D000410DB /* MarkedBlock.cpp in Sources */,
+				DDF54D61298DA937000410DB /* MarkedJSValueRefArray.cpp in Sources */,
+				DDF54F57298DAA6D000410DB /* MarkedSpace.cpp in Sources */,
+				DDF54F3E298DAA6D000410DB /* MarkingConstraint.cpp in Sources */,
+				DDF54F4C298DAA6D000410DB /* MarkingConstraintSet.cpp in Sources */,
+				DDF54F2D298DAA6D000410DB /* MarkingConstraintSolver.cpp in Sources */,
+				DDF54F51298DAA6D000410DB /* MarkStack.cpp in Sources */,
+				DDF54F3F298DAA6D000410DB /* MarkStackMergingConstraint.cpp in Sources */,
+				DDF5518C298DAB29000410DB /* MatchResult.cpp in Sources */,
+				DDF55243298DAB29000410DB /* MathCommon.cpp in Sources */,
+				DDF551BA298DAB29000410DB /* MathObject.cpp in Sources */,
+				DDF55233298DAB29000410DB /* MemoryMode.cpp in Sources */,
+				DDF551EA298DAB29000410DB /* MemoryStatistics.cpp in Sources */,
+				DDF54E4B298DA990000410DB /* MetadataTable.cpp in Sources */,
+				DDF54E4D298DA990000410DB /* MethodOfGettingAValueProfile.cpp in Sources */,
+				DDF54FDB298DAAB2000410DB /* ModuleAnalyzer.cpp in Sources */,
+				DDF54E5D298DA990000410DB /* ModuleNamespaceAccessCase.cpp in Sources */,
+				DDF54E3B298DA990000410DB /* ModuleProgramCodeBlock.cpp in Sources */,
+				DDF5522D298DAB29000410DB /* ModuleProgramExecutable.cpp in Sources */,
+				DDF54F4D298DAA6D000410DB /* MutatorScheduler.cpp in Sources */,
+				DDF54F59298DAA6D000410DB /* MutatorState.cpp in Sources */,
+				DDF551AD298DAB29000410DB /* NarrowingNumberPredictionFuzzerAgent.cpp in Sources */,
+				DDF5522E298DAB29000410DB /* NativeErrorConstructor.cpp in Sources */,
+				DDF5526E298DAB29000410DB /* NativeErrorPrototype.cpp in Sources */,
+				DDF5523A298DAB29000410DB /* NativeExecutable.cpp in Sources */,
+				DDF54FD6298DAAB2000410DB /* Nodes.cpp in Sources */,
+				DDF54FDA298DAAB2000410DB /* NodesAnalyzeModule.cpp in Sources */,
+				DDF54E6E298DA995000410DB /* NodesCodegen.cpp in Sources */,
+				DDF5529A298DAB29000410DB /* NullGetterFunction.cpp in Sources */,
+				DDF55257298DAB29000410DB /* NullSetterFunction.cpp in Sources */,
+				DDF55152298DAB28000410DB /* NumberConstructor.cpp in Sources */,
+				DDF55234298DAB29000410DB /* NumberObject.cpp in Sources */,
+				DDF5525D298DAB29000410DB /* NumberPredictionFuzzerAgent.cpp in Sources */,
+				DDF55263298DAB29000410DB /* NumberPrototype.cpp in Sources */,
+				DDF55311298DAB67000410DB /* ObjCCallbackFunction.mm in Sources */,
+				DDF55251298DAB29000410DB /* ObjectConstructor.cpp in Sources */,
+				DDF55220298DAB29000410DB /* ObjectInitializationScope.cpp in Sources */,
+				DDF54E51298DA990000410DB /* ObjectPropertyCondition.cpp in Sources */,
+				DDF54E17298DA990000410DB /* ObjectPropertyConditionSet.cpp in Sources */,
+				DDF551E6298DAB29000410DB /* ObjectPrototype.cpp in Sources */,
+				DDF54D64298DA937000410DB /* OpaqueJSString.cpp in Sources */,
+				DDF54E4F298DA990000410DB /* Opcode.cpp in Sources */,
+				DDF55180298DAB29000410DB /* Operations.cpp in Sources */,
+				DDF551D1298DAB29000410DB /* Options.cpp in Sources */,
+				DDF55244298DAB29000410DB /* PageCount.cpp in Sources */,
+				DDF54E38298DA990000410DB /* ParseHash.cpp in Sources */,
+				DDF54FD4298DAAB2000410DB /* Parser.cpp in Sources */,
+				DDF54FD9298DAAB2000410DB /* ParserArena.cpp in Sources */,
+				DDF54FC8298DAAA0000410DB /* PCToCodeOriginMap.cpp in Sources */,
+				DDF54F87298DAA94000410DB /* PerGlobalObjectWrapperWorld.cpp in Sources */,
+				DDF54E0E298DA990000410DB /* PolymorphicAccess.cpp in Sources */,
+				DDF54F90298DAAA0000410DB /* PolymorphicCallStubRoutine.cpp in Sources */,
+				DDF54E31298DA990000410DB /* PolyProtoAccessChain.cpp in Sources */,
+				DDF54F42298DAA6D000410DB /* PreciseAllocation.cpp in Sources */,
+				DDF54E47298DA990000410DB /* PreciseJumpTargets.cpp in Sources */,
+				DDF5521C298DAB29000410DB /* PredictionFileCreatingFuzzerAgent.cpp in Sources */,
+				DDF54D7F298DA94E000410DB /* Printer.cpp in Sources */,
+				DDF5520A298DAB29000410DB /* PrivateFieldPutKind.cpp in Sources */,
+				DDF54D84298DA94E000410DB /* ProbeContext.cpp in Sources */,
+				DDF54D7A298DA94E000410DB /* ProbeStack.cpp in Sources */,
+				DDF54FDF298DAAB7000410DB /* ProfilerBytecode.cpp in Sources */,
+				DDF54FEC298DAAB7000410DB /* ProfilerBytecodes.cpp in Sources */,
+				DDF54FE0298DAAB7000410DB /* ProfilerBytecodeSequence.cpp in Sources */,
+				DDF54FE2298DAAB7000410DB /* ProfilerCompilation.cpp in Sources */,
+				DDF54FE8298DAAB7000410DB /* ProfilerCompilationKind.cpp in Sources */,
+				DDF54FE6298DAAB7000410DB /* ProfilerCompiledBytecode.cpp in Sources */,
+				DDF54FE7298DAAB7000410DB /* ProfilerDatabase.cpp in Sources */,
+				DDF54FE9298DAAB7000410DB /* ProfilerEvent.cpp in Sources */,
+				DDF54FEA298DAAB7000410DB /* ProfilerJettisonReason.cpp in Sources */,
+				DDF54FE5298DAAB7000410DB /* ProfilerOrigin.cpp in Sources */,
+				DDF54FE3298DAAB7000410DB /* ProfilerOriginStack.cpp in Sources */,
+				DDF54FE1298DAAB7000410DB /* ProfilerOSRExit.cpp in Sources */,
+				DDF54FEB298DAAB7000410DB /* ProfilerOSRExitSite.cpp in Sources */,
+				DDF54FE4298DAAB7000410DB /* ProfilerProfiledBytecodes.cpp in Sources */,
+				DDF54FDE298DAAB7000410DB /* ProfilerUID.cpp in Sources */,
+				DDF54E6F298DA995000410DB /* ProfileTypeBytecodeFlag.cpp in Sources */,
+				DDF54E35298DA990000410DB /* ProgramCodeBlock.cpp in Sources */,
+				DDF5524E298DAB29000410DB /* ProgramExecutable.cpp in Sources */,
+				DDF54E55298DA990000410DB /* PropertyCondition.cpp in Sources */,
+				DDF5514F298DAB28000410DB /* PropertyDescriptor.cpp in Sources */,
+				DDF551CE298DAB29000410DB /* PropertySlot.cpp in Sources */,
+				DDF551B2298DAB29000410DB /* PropertyTable.cpp in Sources */,
+				DDF54E15298DA990000410DB /* ProxyableAccessCase.cpp in Sources */,
+				DDF55185298DAB29000410DB /* ProxyConstructor.cpp in Sources */,
+				DDF551B9298DAB29000410DB /* ProxyObject.cpp in Sources */,
+				DDF54E41298DA990000410DB /* ProxyObjectAccessCase.cpp in Sources */,
+				DDF5521F298DAB29000410DB /* ProxyRevoke.cpp in Sources */,
+				DDF54E45298DA990000410DB /* PutByIdFlags.cpp in Sources */,
+				DDF54E23298DA990000410DB /* PutByStatus.cpp in Sources */,
+				DDF54E43298DA990000410DB /* PutByVariant.cpp in Sources */,
+				DDF55174298DAB29000410DB /* RandomizingFuzzerAgent.cpp in Sources */,
+				DDF54E56298DA990000410DB /* RecordedStatuses.cpp in Sources */,
+				DDF54E30298DA990000410DB /* ReduceWhitespace.cpp in Sources */,
+				DDF5515C298DAB28000410DB /* ReflectObject.cpp in Sources */,
+				DDF54F9B298DAAA0000410DB /* Reg.cpp in Sources */,
+				DDF55194298DAB29000410DB /* RegExp.cpp in Sources */,
+				DDF551F4298DAB29000410DB /* RegExpCache.cpp in Sources */,
+				DDF551C5298DAB29000410DB /* RegExpCachedResult.cpp in Sources */,
+				DDF551D3298DAB29000410DB /* RegExpConstructor.cpp in Sources */,
+				DDF55155298DAB28000410DB /* RegExpGlobalData.cpp in Sources */,
+				DDF551EF298DAB29000410DB /* RegExpMatchesArray.cpp in Sources */,
+				DDF55287298DAB29000410DB /* RegExpObject.cpp in Sources */,
+				DDF551FD298DAB29000410DB /* RegExpPrototype.cpp in Sources */,
+				DDF55157298DAB28000410DB /* RegExpStringIteratorPrototype.cpp in Sources */,
+				DDF54F95298DAAA0000410DB /* RegisterAtOffset.cpp in Sources */,
+				DDF54F97298DAAA0000410DB /* RegisterAtOffsetList.cpp in Sources */,
+				DDF54FB4298DAAA0000410DB /* RegisterSet.cpp in Sources */,
+				DDF552FE298DAB4A000410DB /* RegularExpression.cpp in Sources */,
+				DDF55313298DAB96000410DB /* RemoteAutomationTarget.cpp in Sources */,
+				DDF55318298DAB96000410DB /* RemoteConnectionToTargetCocoa.mm in Sources */,
+				DDF55314298DAB96000410DB /* RemoteControllableTarget.cpp in Sources */,
+				DDF55312298DAB96000410DB /* RemoteInspectionTarget.cpp in Sources */,
+				DDF55316298DAB96000410DB /* RemoteInspector.cpp in Sources */,
+				DDF55317298DAB96000410DB /* RemoteInspectorCocoa.mm in Sources */,
+				DDF55315298DAB96000410DB /* RemoteInspectorXPCConnection.mm in Sources */,
+				DDF54E5B298DA990000410DB /* Repatch.cpp in Sources */,
+				DDF551AE298DAB29000410DB /* ResourceExhaustion.cpp in Sources */,
+				DDF54F37298DAA6D000410DB /* RootMarkReason.cpp in Sources */,
+				DDF551CF298DAB29000410DB /* RuntimeType.cpp in Sources */,
+				DDF55173298DAB29000410DB /* SamplingCounter.cpp in Sources */,
+				DDF551A1298DAB29000410DB /* SamplingProfiler.cpp in Sources */,
+				DDF55153298DAB28000410DB /* ScopedArguments.cpp in Sources */,
+				DDF55235298DAB29000410DB /* ScopedArgumentsTable.cpp in Sources */,
+				DDF55182298DAB29000410DB /* ScopeOffset.cpp in Sources */,
+				DDF54FC3298DAAA0000410DB /* ScratchRegisterAllocator.cpp in Sources */,
+				DDF54F79298DAA94000410DB /* ScriptArguments.cpp in Sources */,
+				DDF54F72298DAA94000410DB /* ScriptCallFrame.cpp in Sources */,
+				DDF54F7C298DAA94000410DB /* ScriptCallStack.cpp in Sources */,
+				DDF54F7E298DAA94000410DB /* ScriptCallStackFactory.cpp in Sources */,
+				DDF55162298DAB28000410DB /* ScriptExecutable.cpp in Sources */,
+				DDF54DFF298DA96C000410DB /* ScriptFunctionCall.cpp in Sources */,
+				DDF54E00298DA96C000410DB /* ScriptObject.cpp in Sources */,
+				DDF54E01298DA96C000410DB /* ScriptValue.cpp in Sources */,
+				DDF54D83298DA94E000410DB /* SecureARM64EHashPins.cpp in Sources */,
+				DDF551F5298DAB29000410DB /* SetConstructor.cpp in Sources */,
+				DDF5523B298DAB29000410DB /* SetIteratorPrototype.cpp in Sources */,
+				DDF54E12298DA990000410DB /* SetPrivateBrandStatus.cpp in Sources */,
+				DDF54E63298DA990000410DB /* SetPrivateBrandVariant.cpp in Sources */,
+				DDF551BB298DAB29000410DB /* SetPrototype.cpp in Sources */,
+				DDF54F9C298DAAA0000410DB /* SetupVarargsFrame.cpp in Sources */,
+				DDF54F8B298DAA99000410DB /* ShadowChicken.cpp in Sources */,
+				DDF55187298DAB29000410DB /* ShadowRealmConstructor.cpp in Sources */,
+				DDF551DE298DAB29000410DB /* ShadowRealmObject.cpp in Sources */,
+				DDF5519B298DAB29000410DB /* ShadowRealmPrototype.cpp in Sources */,
+				DDF552A4298DAB30000410DB /* SigillCrashAnalyzer.cpp in Sources */,
+				DDF54FB9298DAAA0000410DB /* SIMDInfo.cpp in Sources */,
+				DDF54F4E298DAA6D000410DB /* SimpleMarkingConstraint.cpp in Sources */,
+				DDF551C6298DAB29000410DB /* SimpleTypedArrayController.cpp in Sources */,
+				DDF54F2E298DAA6D000410DB /* SlotVisitor.cpp in Sources */,
+				DDF54FBD298DAAA0000410DB /* SlowPathCall.cpp in Sources */,
+				DDF5515E298DAB28000410DB /* SmallStrings.cpp in Sources */,
+				DDF54FDC298DAAB2000410DB /* SourceProvider.cpp in Sources */,
+				DDF54FDD298DAAB2000410DB /* SourceProviderCache.cpp in Sources */,
+				DDF54F31298DAA6D000410DB /* SpaceTimeMutatorScheduler.cpp in Sources */,
+				DDF551EB298DAB29000410DB /* SparseArrayValueMap.cpp in Sources */,
+				DDF54E57298DA990000410DB /* SpeculatedType.cpp in Sources */,
+				DDF551C7298DAB29000410DB /* StackFrame.cpp in Sources */,
+				DDF54F8C298DAA99000410DB /* StackVisitor.cpp in Sources */,
+				DDF54F22298DAA6D000410DB /* StochasticSpaceTimeMutatorScheduler.cpp in Sources */,
+				DDF54F33298DAA6D000410DB /* StopIfNecessaryTimer.cpp in Sources */,
+				DDF551EC298DAB29000410DB /* StrictEvalActivation.cpp in Sources */,
+				DDF5529B298DAB29000410DB /* StringConstructor.cpp in Sources */,
+				DDF55254298DAB29000410DB /* StringIteratorPrototype.cpp in Sources */,
+				DDF551E2298DAB29000410DB /* StringObject.cpp in Sources */,
+				DDF55228298DAB29000410DB /* StringPrototype.cpp in Sources */,
+				DDF551FB298DAB29000410DB /* StringRecursionChecker.cpp in Sources */,
+				DDF55277298DAB29000410DB /* Structure.cpp in Sources */,
+				DDF54F40298DAA6D000410DB /* StructureAlignedMemoryAllocator.cpp in Sources */,
+				DDF55248298DAB29000410DB /* StructureCache.cpp in Sources */,
+				DDF551FE298DAB29000410DB /* StructureChain.cpp in Sources */,
+				DDF5523F298DAB29000410DB /* StructureRareData.cpp in Sources */,
+				DDF54E58298DA990000410DB /* StructureSet.cpp in Sources */,
+				DDF54E33298DA990000410DB /* StructureStubClearingWatchpoint.cpp in Sources */,
+				DDF54E2D298DA990000410DB /* StructureStubInfo.cpp in Sources */,
+				DDF54E50298DA990000410DB /* StubInfoSummary.cpp in Sources */,
+				DDF54F26298DAA6D000410DB /* Subspace.cpp in Sources */,
+				DDF54E18298DA990000410DB /* SuperSampler.cpp in Sources */,
+				DDF55195298DAB29000410DB /* Symbol.cpp in Sources */,
+				DDF55269298DAB29000410DB /* SymbolConstructor.cpp in Sources */,
+				DDF551B8298DAB29000410DB /* SymbolObject.cpp in Sources */,
+				DDF55196298DAB29000410DB /* SymbolPrototype.cpp in Sources */,
 				DFBC2CA625E6D5B90081BDD1 /* SymbolStubsForSafariCompatibility.mm in Sources */,
+				DDF5514A298DAB28000410DB /* SymbolTable.cpp in Sources */,
+				DDF54F44298DAA6D000410DB /* Synchronousness.cpp in Sources */,
+				DDF54F53298DAA6D000410DB /* SynchronousStopTheWorldMutatorScheduler.cpp in Sources */,
+				DDF55183298DAB29000410DB /* SyntheticModuleRecord.cpp in Sources */,
+				DDF54F99298DAAA0000410DB /* TagRegistersMode.cpp in Sources */,
+				DDF551D7298DAB29000410DB /* TemplateObjectDescriptor.cpp in Sources */,
+				DDF5527A298DAB29000410DB /* TemporalCalendar.cpp in Sources */,
+				DDF5528E298DAB29000410DB /* TemporalCalendarConstructor.cpp in Sources */,
+				DDF5514D298DAB28000410DB /* TemporalCalendarPrototype.cpp in Sources */,
+				DDF5527B298DAB29000410DB /* TemporalDuration.cpp in Sources */,
+				DDF5520B298DAB29000410DB /* TemporalDurationConstructor.cpp in Sources */,
+				DDF55259298DAB29000410DB /* TemporalDurationPrototype.cpp in Sources */,
+				DDF55218298DAB29000410DB /* TemporalInstant.cpp in Sources */,
+				DDF5522B298DAB29000410DB /* TemporalInstantConstructor.cpp in Sources */,
+				DDF5522F298DAB29000410DB /* TemporalInstantPrototype.cpp in Sources */,
+				DDF55278298DAB29000410DB /* TemporalNow.cpp in Sources */,
+				DDF551F0298DAB29000410DB /* TemporalObject.cpp in Sources */,
+				DDF55145298DAB28000410DB /* TemporalPlainDate.cpp in Sources */,
+				DDF55151298DAB28000410DB /* TemporalPlainDateConstructor.cpp in Sources */,
+				DDF55226298DAB29000410DB /* TemporalPlainDatePrototype.cpp in Sources */,
+				DDF551BD298DAB29000410DB /* TemporalPlainDateTime.cpp in Sources */,
+				DDF55273298DAB29000410DB /* TemporalPlainDateTimeConstructor.cpp in Sources */,
+				DDF551AF298DAB29000410DB /* TemporalPlainDateTimePrototype.cpp in Sources */,
+				DDF5519F298DAB29000410DB /* TemporalPlainTime.cpp in Sources */,
+				DDF551CA298DAB29000410DB /* TemporalPlainTimeConstructor.cpp in Sources */,
+				DDF5520C298DAB29000410DB /* TemporalPlainTimePrototype.cpp in Sources */,
+				DDF55156298DAB28000410DB /* TemporalTimeZone.cpp in Sources */,
+				DDF5528D298DAB29000410DB /* TemporalTimeZoneConstructor.cpp in Sources */,
+				DDF5528C298DAB29000410DB /* TemporalTimeZonePrototype.cpp in Sources */,
+				DDF551E1298DAB29000410DB /* TestRunnerUtils.cpp in Sources */,
+				DDF5518E298DAB29000410DB /* ThrowScope.cpp in Sources */,
+				DDF54FB8298DAAA0000410DB /* ThunkGenerators.cpp in Sources */,
+				DDF54E67298DA990000410DB /* ToThisStatus.cpp in Sources */,
+				DDF54E46298DA990000410DB /* TrackedReferences.cpp in Sources */,
+				DDF5515A298DAB28000410DB /* TypedArrayController.cpp in Sources */,
+				DDF55291298DAB29000410DB /* TypedArrayType.cpp in Sources */,
+				DDF5521A298DAB29000410DB /* TypeLocationCache.cpp in Sources */,
+				DDF551D2298DAB29000410DB /* TypeofType.cpp in Sources */,
+				DDF551C3298DAB29000410DB /* TypeProfiler.cpp in Sources */,
+				DDF55210298DAB29000410DB /* TypeProfilerLog.cpp in Sources */,
+				DDF551B5298DAB29000410DB /* TypeSet.cpp in Sources */,
 				E32F713F281B3C6600AFD21D /* UnifiedSource1-c.c in Sources */,
 				536B319A1F735E780037FC33 /* UnifiedSource1-mm.mm in Sources */,
 				536B315F1F71C5990037FC33 /* UnifiedSource1.cpp in Sources */,
@@ -12595,8 +14713,129 @@
 				538F15ED268FBBB600D601C4 /* UnifiedSource153.cpp in Sources */,
 				538F15EA268FBBB600D601C4 /* UnifiedSource154.cpp in Sources */,
 				538F15EF268FBBB600D601C4 /* UnifiedSource155.cpp in Sources */,
+				DDF54E34298DA990000410DB /* UnlinkedCodeBlock.cpp in Sources */,
+				DDF54E27298DA990000410DB /* UnlinkedCodeBlockGenerator.cpp in Sources */,
+				DDF54E1F298DA990000410DB /* UnlinkedEvalCodeBlock.cpp in Sources */,
+				DDF54E1E298DA990000410DB /* UnlinkedFunctionCodeBlock.cpp in Sources */,
+				DDF54E3C298DA990000410DB /* UnlinkedFunctionExecutable.cpp in Sources */,
+				DDF54E5A298DA990000410DB /* UnlinkedMetadataTable.cpp in Sources */,
+				DDF54E13298DA990000410DB /* UnlinkedModuleProgramCodeBlock.cpp in Sources */,
+				DDF54E59298DA990000410DB /* UnlinkedProgramCodeBlock.cpp in Sources */,
+				DDF54FD7298DAAB2000410DB /* UnlinkedSourceCode.cpp in Sources */,
+				DDF54E29298DA990000410DB /* ValueRecovery.cpp in Sources */,
+				DDF54FD8298DAAB2000410DB /* VariableEnvironment.cpp in Sources */,
+				DDF54E69298DA990000410DB /* VariableWriteFireDetail.cpp in Sources */,
+				DDF5515B298DAB28000410DB /* VarOffset.cpp in Sources */,
+				DDF54F5F298DAA6D000410DB /* VerifierSlotVisitor.cpp in Sources */,
+				DDF54E2E298DA990000410DB /* VirtualRegister.cpp in Sources */,
+				DDF54F4F298DAA6D000410DB /* VisitRaceKey.cpp in Sources */,
+				DDF5528A298DAB29000410DB /* VM.cpp in Sources */,
+				DDF5519C298DAB29000410DB /* VMEntryScope.cpp in Sources */,
+				DDF552A1298DAB30000410DB /* VMInspector.cpp in Sources */,
+				DDF55219298DAB29000410DB /* VMTraps.cpp in Sources */,
+				DDF5528F298DAB29000410DB /* WaiterListManager.cpp in Sources */,
 				467DC2F12906EE3600726988 /* WasmAirIRGenerator32_64.cpp in Sources */,
 				467DC2EF2906EE3600726988 /* WasmAirIRGenerator64.cpp in Sources */,
+				DDF552B8298DAB3A000410DB /* WasmB3IRGenerator.cpp in Sources */,
+				DDF552A8298DAB3A000410DB /* WasmBBQPlan.cpp in Sources */,
+				DDF552C6298DAB3A000410DB /* WasmBinding.cpp in Sources */,
+				DDF552C7298DAB3A000410DB /* WasmBranchHintsSectionParser.cpp in Sources */,
+				DDF552C8298DAB3A000410DB /* WasmCallee.cpp in Sources */,
+				DDF552C9298DAB3A000410DB /* WasmCalleeGroup.cpp in Sources */,
+				DDF552B2298DAB3A000410DB /* WasmCalleeRegistry.cpp in Sources */,
+				DDF552D1298DAB3A000410DB /* WasmCallingConvention.cpp in Sources */,
+				DDF552C2298DAB3A000410DB /* WasmCompilationMode.cpp in Sources */,
+				DDF552C0298DAB3A000410DB /* WasmContext.cpp in Sources */,
+				DDF552CA298DAB3A000410DB /* WasmEntryPlan.cpp in Sources */,
+				DDF552A9298DAB3A000410DB /* WasmFaultSignalHandler.cpp in Sources */,
+				DDF552C1298DAB3A000410DB /* WasmFormat.cpp in Sources */,
+				DDF552B0298DAB3A000410DB /* WasmFunctionCodeBlockGenerator.cpp in Sources */,
+				DDF552BB298DAB3A000410DB /* WasmGlobal.cpp in Sources */,
+				DDF552C3298DAB3A000410DB /* WasmHandlerInfo.cpp in Sources */,
+				DDF552A6298DAB3A000410DB /* WasmIndexOrName.cpp in Sources */,
+				DDF552B5298DAB3A000410DB /* WasmInstance.cpp in Sources */,
+				DDF552AE298DAB3A000410DB /* WasmLLIntGenerator.cpp in Sources */,
+				DDF552CB298DAB3A000410DB /* WasmLLIntPlan.cpp in Sources */,
+				DDF552CC298DAB3A000410DB /* WasmLLIntTierUpCounter.cpp in Sources */,
+				DDF552BD298DAB3A000410DB /* WasmMachineThreads.cpp in Sources */,
+				DDF552AA298DAB3A000410DB /* WasmMemory.cpp in Sources */,
+				DDF552CD298DAB3A000410DB /* WasmMemoryInformation.cpp in Sources */,
+				DDF552B1298DAB3A000410DB /* WasmModule.cpp in Sources */,
+				DDF552CE298DAB3A000410DB /* WasmModuleInformation.cpp in Sources */,
+				DDF552BE298DAB3A000410DB /* WasmNameSectionParser.cpp in Sources */,
+				DDF552BA298DAB3A000410DB /* WasmOMGPlan.cpp in Sources */,
+				DDF552BF298DAB3A000410DB /* WasmOpcodeOrigin.cpp in Sources */,
+				DDF552A7298DAB3A000410DB /* WasmOperations.cpp in Sources */,
+				DDF552CF298DAB3A000410DB /* WasmOSREntryPlan.cpp in Sources */,
+				DDF552D0298DAB3A000410DB /* WasmPlan.cpp in Sources */,
+				DDF552B3298DAB3A000410DB /* WasmSectionParser.cpp in Sources */,
+				DDF552AB298DAB3A000410DB /* WasmSlowPaths.cpp in Sources */,
+				DDF552B4298DAB3A000410DB /* WasmStreamingCompiler.cpp in Sources */,
+				DDF552AC298DAB3A000410DB /* WasmStreamingParser.cpp in Sources */,
+				DDF552C5298DAB3A000410DB /* WasmStreamingPlan.cpp in Sources */,
+				DDF552BC298DAB3A000410DB /* WasmTable.cpp in Sources */,
+				DDF552B6298DAB3A000410DB /* WasmTag.cpp in Sources */,
+				DDF552AF298DAB3A000410DB /* WasmThunks.cpp in Sources */,
+				DDF552B9298DAB3A000410DB /* WasmTierUpCount.cpp in Sources */,
+				DDF552F3298DAB43000410DB /* WasmToJS.cpp in Sources */,
+				DDF552B7298DAB3A000410DB /* WasmTypeDefinition.cpp in Sources */,
+				DDF552C4298DAB3A000410DB /* WasmValueLocation.cpp in Sources */,
+				DDF552AD298DAB3A000410DB /* WasmWorklist.cpp in Sources */,
+				DDF5517A298DAB29000410DB /* Watchdog.cpp in Sources */,
+				DDF54E0C298DA990000410DB /* Watchpoint.cpp in Sources */,
+				DDF54F54298DAA6D000410DB /* Weak.cpp in Sources */,
+				DDF54F38298DAA6D000410DB /* WeakBlock.cpp in Sources */,
+				DDF54F55298DAA6D000410DB /* WeakHandleOwner.cpp in Sources */,
+				DDF55190298DAB29000410DB /* WeakMapConstructor.cpp in Sources */,
+				DDF55175298DAB29000410DB /* WeakMapImpl.cpp in Sources */,
+				DDF55221298DAB29000410DB /* WeakMapPrototype.cpp in Sources */,
+				DDF55246298DAB29000410DB /* WeakObjectRefConstructor.cpp in Sources */,
+				DDF551B0298DAB29000410DB /* WeakObjectRefPrototype.cpp in Sources */,
+				DDF54F45298DAA6D000410DB /* WeakSet.cpp in Sources */,
+				DDF551C9298DAB29000410DB /* WeakSetConstructor.cpp in Sources */,
+				DDF551A0298DAB29000410DB /* WeakSetPrototype.cpp in Sources */,
+				DDF552DD298DAB43000410DB /* WebAssemblyArrayConstructor.cpp in Sources */,
+				DDF552ED298DAB43000410DB /* WebAssemblyArrayPrototype.cpp in Sources */,
+				DDF552F8298DAB43000410DB /* WebAssemblyCompileErrorConstructor.cpp in Sources */,
+				DDF552FA298DAB43000410DB /* WebAssemblyCompileErrorPrototype.cpp in Sources */,
+				DDF552E8298DAB43000410DB /* WebAssemblyExceptionConstructor.cpp in Sources */,
+				DDF552E0298DAB43000410DB /* WebAssemblyExceptionPrototype.cpp in Sources */,
+				DDF552E9298DAB43000410DB /* WebAssemblyFunction.cpp in Sources */,
+				DDF552DB298DAB43000410DB /* WebAssemblyFunctionBase.cpp in Sources */,
+				DDF552D8298DAB43000410DB /* WebAssemblyGlobalConstructor.cpp in Sources */,
+				DDF552DC298DAB43000410DB /* WebAssemblyGlobalPrototype.cpp in Sources */,
+				DDF552FC298DAB43000410DB /* WebAssemblyInstanceConstructor.cpp in Sources */,
+				DDF552F4298DAB43000410DB /* WebAssemblyInstancePrototype.cpp in Sources */,
+				DDF552EB298DAB43000410DB /* WebAssemblyLinkErrorConstructor.cpp in Sources */,
+				DDF552DE298DAB43000410DB /* WebAssemblyLinkErrorPrototype.cpp in Sources */,
+				DDF552EF298DAB43000410DB /* WebAssemblyMemoryConstructor.cpp in Sources */,
+				DDF552D3298DAB43000410DB /* WebAssemblyMemoryPrototype.cpp in Sources */,
+				DDF552F5298DAB43000410DB /* WebAssemblyModuleConstructor.cpp in Sources */,
+				DDF552EE298DAB43000410DB /* WebAssemblyModulePrototype.cpp in Sources */,
+				DDF552E6298DAB43000410DB /* WebAssemblyModuleRecord.cpp in Sources */,
+				DDF552E4298DAB43000410DB /* WebAssemblyRuntimeErrorConstructor.cpp in Sources */,
+				DDF552EC298DAB43000410DB /* WebAssemblyRuntimeErrorPrototype.cpp in Sources */,
+				DDF552D4298DAB43000410DB /* WebAssemblyStructConstructor.cpp in Sources */,
+				DDF552DF298DAB43000410DB /* WebAssemblyStructPrototype.cpp in Sources */,
+				DDF552E1298DAB43000410DB /* WebAssemblyTableConstructor.cpp in Sources */,
+				DDF552F2298DAB43000410DB /* WebAssemblyTablePrototype.cpp in Sources */,
+				DDF552F6298DAB43000410DB /* WebAssemblyTagConstructor.cpp in Sources */,
+				DDF552E2298DAB43000410DB /* WebAssemblyTagPrototype.cpp in Sources */,
+				DDF552E3298DAB43000410DB /* WebAssemblyWrapperFunction.cpp in Sources */,
+				DDF551CB298DAB29000410DB /* WideningNumberPredictionFuzzerAgent.cpp in Sources */,
+				DDF54FC4298DAAA0000410DB /* Width.cpp in Sources */,
+				DDF54F50298DAA6D000410DB /* WriteBarrierSupport.cpp in Sources */,
+				DDF54EFD298DAA52000410DB /* X86Disassembler.cpp in Sources */,
+				DDF55301298DAB4A000410DB /* YarrCanonicalizeUCS2.cpp in Sources */,
+				DDF55307298DAB58000410DB /* YarrCanonicalizeUnicode.cpp in Sources */,
+				DDF55303298DAB4A000410DB /* YarrDisassembler.cpp in Sources */,
+				DDF55302298DAB4A000410DB /* YarrErrorCode.cpp in Sources */,
+				DDF55306298DAB4A000410DB /* YarrFlags.cpp in Sources */,
+				DDF55304298DAB4A000410DB /* YarrInterpreter.cpp in Sources */,
+				DDF552FD298DAB4A000410DB /* YarrJIT.cpp in Sources */,
+				DDF55305298DAB4A000410DB /* YarrPattern.cpp in Sources */,
+				DDF55300298DAB4A000410DB /* YarrSyntaxChecker.cpp in Sources */,
+				DDF552FF298DAB4A000410DB /* YarrUnicodeProperties.cpp in Sources */,
 				E31135C9281B5B0000C1A4A9 /* ZydisFormatterATT.c in Sources */,
 				E31135CA281B5B0300C1A4A9 /* ZydisFormatterBase.c in Sources */,
 				E31135CB281B5B0500C1A4A9 /* ZydisFormatterIntel.c in Sources */,

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -1226,7 +1226,7 @@ bool Heap::shouldCollectInCollectorThread(const AbstractLocker&)
     RELEASE_ASSERT(m_requests.isEmpty() == (m_lastServedTicket == m_lastGrantedTicket));
     RELEASE_ASSERT(m_lastServedTicket <= m_lastGrantedTicket);
     
-    if (false)
+    if ((false))
         dataLog("Mutator has the conn = ", !!(m_worldState.load() & mutatorHasConnBit), "\n");
     
     return !m_requests.isEmpty() && !(m_worldState.load() & mutatorHasConnBit);
@@ -1280,7 +1280,7 @@ auto Heap::runCurrentPhase(GCConductor conn, CurrentThreadState* currentThreadSt
     if (!finishChangingPhase(conn)) {
         // A mischevious mutator could repeatedly relinquish the conn back to us. We try to avoid doing
         // this, but it's probably not the end of the world if it did happen.
-        if (false)
+        if ((false))
             dataLog("Conn bounce-back.\n");
         return RunCurrentPhaseResult::Finished;
     }
@@ -1630,7 +1630,7 @@ NEVER_INLINE bool Heap::runEndPhase(GCConductor conn)
     if (m_currentRequest.didFinishEndPhase)
         m_currentRequest.didFinishEndPhase->run();
     
-    if (false) {
+    if ((false)) {
         dataLog("Heap state after GC:\n");
         m_objectSpace.dumpBits();
     }
@@ -1676,7 +1676,7 @@ NEVER_INLINE bool Heap::finishChangingPhase(GCConductor conn)
     if (m_nextPhase == m_currentPhase)
         return true;
 
-    if (false)
+    if ((false))
         dataLog(conn, ": Going to phase: ", m_nextPhase, " (from ", m_currentPhase, ")\n");
     
     m_phaseVersion++;
@@ -1700,7 +1700,7 @@ NEVER_INLINE bool Heap::finishChangingPhase(GCConductor conn)
             if (conn == GCConductor::Collector) {
                 waitWhileNeedFinalize();
                 if (!stopTheMutator()) {
-                    if (false)
+                    if ((false))
                         dataLog("Returning false.\n");
                     return false;
                 }
@@ -1832,7 +1832,7 @@ bool Heap::stopTheMutator()
         RELEASE_ASSERT(!(oldState & stoppedBit));
         unsigned newState = (oldState | mutatorHasConnBit) & ~mutatorWaitingBit;
         if (m_worldState.compareExchangeWeak(oldState, newState)) {
-            if (false)
+            if ((false))
                 dataLog("Handed off the conn.\n");
             m_stopIfNecessaryTimer->scheduleSoon();
             ParkingLot::unparkAll(&m_worldState);
@@ -1843,7 +1843,7 @@ bool Heap::stopTheMutator()
 
 NEVER_INLINE void Heap::resumeTheMutator()
 {
-    if (false)
+    if ((false))
         dataLog("Resuming the mutator.\n");
     for (;;) {
         unsigned oldState = m_worldState.load();
@@ -1857,13 +1857,13 @@ NEVER_INLINE void Heap::resumeTheMutator()
         }
         
         if (!(oldState & stoppedBit)) {
-            if (false)
+            if ((false))
                 dataLog("Returning because not stopped.\n");
             return;
         }
         
         if (m_worldState.compareExchangeWeak(oldState, oldState & ~stoppedBit)) {
-            if (false)
+            if ((false))
                 dataLog("CASing and returning.\n");
             ParkingLot::unparkAll(&m_worldState);
             return;
@@ -2061,7 +2061,7 @@ bool Heap::relinquishConn(unsigned oldState)
 
 void Heap::finishRelinquishingConn()
 {
-    if (false)
+    if ((false))
         dataLog("Relinquished the conn.\n");
     
     sanitizeStackForVM(vm());
@@ -2186,7 +2186,7 @@ Heap::Ticket Heap::requestCollection(GCRequest request)
     // cases.
     ASSERT(m_lastServedTicket <= m_lastGrantedTicket);
     if ((m_lastServedTicket == m_lastGrantedTicket) && !m_collectorThreadIsRunning) {
-        if (false)
+        if ((false))
             dataLog("Taking the conn.\n");
         m_worldState.exchangeOr(mutatorHasConnBit);
     }

--- a/Source/JavaScriptCore/heap/SlotVisitor.cpp
+++ b/Source/JavaScriptCore/heap/SlotVisitor.cpp
@@ -348,7 +348,7 @@ ALWAYS_INLINE void SlotVisitor::visitChildren(const JSCell* cell)
     
     SetCurrentCellScope currentCellScope(*this, cell);
     
-    if (false) {
+    if ((false)) {
         dataLog("Visiting ", RawPointer(cell));
         if (!m_isFirstVisit)
             dataLog(" (subsequent)");

--- a/Source/JavaScriptCore/runtime/CodeCache.h
+++ b/Source/JavaScriptCore/runtime/CodeCache.h
@@ -54,10 +54,6 @@ class VM;
 
 using TDZEnvironment = HashSet<RefPtr<UniquedStringImpl>, IdentifierRepHash>;
 
-namespace CodeCacheInternal {
-static constexpr bool verbose = false;
-} // namespace CodeCacheInternal
-
 struct SourceCodeValue {
     SourceCodeValue()
     {

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
@@ -68,10 +68,6 @@
 
 namespace JSC {
 
-namespace JSGenericTypedArrayViewPrototypeFunctionsInternal {
-static constexpr bool verbose = false;
-}
-
 template<typename ViewClass>
 ALWAYS_INLINE bool speciesWatchpointIsValid(JSGlobalObject* globalObject, ViewClass* thisObject)
 {

--- a/Source/JavaScriptCore/runtime/LiteralParser.cpp
+++ b/Source/JavaScriptCore/runtime/LiteralParser.cpp
@@ -165,16 +165,6 @@ ALWAYS_INLINE JSString* LiteralParser<CharType>::makeJSString(VM& vm, typename L
     return jsString(vm, Identifier::fromString(vm, token->stringToken16, token->stringLength).string());
 }
 
-static ALWAYS_INLINE bool cannotBeIdentPartOrEscapeStart(LChar)
-{
-    RELEASE_ASSERT_NOT_REACHED();
-}
-
-static ALWAYS_INLINE bool cannotBeIdentPartOrEscapeStart(UChar)
-{
-    RELEASE_ASSERT_NOT_REACHED();
-}
-
 // 256 Latin-1 codes
 // The JSON RFC 4627 defines a list of allowed characters to be considered
 // insignificant white space: http://www.ietf.org/rfc/rfc4627.txt (2. JSON Grammar).


### PR DESCRIPTION
#### 9fa5fcce66bc849a55226df7f5dd27b1215cc389
<pre>
wip: [Xcode] Disable unified build with WK_USE_UNIFIED_BUILD=NO
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

-- WIP: Done in JSC as a proof of concept only! --

With some mechanical changes to Xcode projects, it&apos;s possible to support
a &quot;deunified&quot; build, without comprimising our ability to build with
unified sources by default.

The process done manually is:

1. Add target membership for every source file that&apos;s included as a
   unified source file (i.e. everything in a target&apos;s Sources.txt).

2. Use EXCLUDED_SOURCE_FILE_NAMES and INCLUDED_SOURCE_FILE_NAMES to
   control which sources are actually compiled.

   When WK_USE_UNIFIED_BUILD is YES, all source code files are excluded,
   but the unified files plus any one-off deunified files are opted in.

   Otherwise, all UnifiedSource* files are excluded.

The challenge to this approach is that we have to maintain a second list
of which files should always be deunified, in
INCLUDED_SOURCE_FILE_NAMES_UNIFIED_YES. Additionally, it&apos;s no longer
possible to add a source file to the Xcode build by just updating
Sources.txt: you must always give the file target membership in the
project. Both of these issues will only be visible to someone trying to
build with WK_USE_UNIFIED_BUILD=NO.

* Source/JavaScriptCore/Configurations/JavaScriptCore.xcconfig:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:

Some source files have unused `verbose` flags revealed by the deunified
build; remove them:

* Source/JavaScriptCore/runtime/CodeCache.h:
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h:
* Source/JavaScriptCore/runtime/TemporalPlainDate.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7def5bd15d0040197437a596e41b541d067bc12e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106163 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15213 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38994 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115344 "Hash 7def5bd1 for PR 9633 does not build (failure)") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175419 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16647 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6398 "Built successfully") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98365 "Hash 7def5bd1 for PR 9633 does not build (failure)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115031 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111920 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12668 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95641 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/98365 "Hash 7def5bd1 for PR 9633 does not build (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94541 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27284 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/98365 "Hash 7def5bd1 for PR 9633 does not build (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/95770 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8459 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28636 "Passed tests") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/95162 "Hash 7def5bd1 for PR 9633 does not build (failure)") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/6288 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8959 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5194 "Passed tests") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/38/builds/95162 "Hash 7def5bd1 for PR 9633 does not build (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14575 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48181 "Passed tests") | [❌ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/103908 "Hash 7def5bd1 for PR 9633 does not build (failure)") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10495 "Built successfully") | | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/37/builds/103908 "Hash 7def5bd1 for PR 9633 does not build (failure)") | 
| | | | | 
<!--EWS-Status-Bubble-End-->