### PR TITLE
JetStream3: add Promise tests

### DIFF
--- a/PerformanceTests/JetStream3/JetStreamDriver.js
+++ b/PerformanceTests/JetStream3/JetStreamDriver.js
@@ -1555,6 +1555,22 @@ let testPlans = [
         ],
         testGroup: SimpleGroup
     },
+    {
+        name: "doxbee-promise",
+        files: [
+            "./simple/doxbee-promise.js",
+        ],
+        benchmarkClass: AsyncBenchmark,
+        testGroup: SimpleGroup,
+    },
+    {
+        name: "doxbee-async",
+        files: [
+            "./simple/doxbee-async.js",
+        ],
+        benchmarkClass: AsyncBenchmark,
+        testGroup: SimpleGroup,
+    },
     // SeaMonster
     {
         name: "ai-astar",

--- a/PerformanceTests/JetStream3/in-depth.html
+++ b/PerformanceTests/JetStream3/in-depth.html
@@ -628,6 +628,25 @@
          Source code: <a href="simple/file-system.js">async-fs.js</a>
         </dd>
 
+        <dt id="doxbee-promise">doxbee-promise</dt>
+        <dd>
+         A typical CRUD method extracted from DoxBee that is called when uploading files. The benchmark emulates a situation where
+         10k requests are being made concurrently to execute some mixed async / sync action with fast I/O response times.
+         Authored by <a href="https://blog.spion.dev/posts/analysis-generators-and-other-async-patterns-node.html">Gorki Kosev</a>,
+         <a href="https://github.com/v8/promise-performance-tests">packed by Benedikt Meurer</a>.
+         Source code: <a href="simple/doxbee-promise.js">doxbee-promise.js</a>
+        </dd>
+
+        <dt id="doxbee-async">doxbee-async</dt>
+        <dd>
+         A typical CRUD method extracted from DoxBee that is called when uploading files. The benchmark emulates a situation where
+         10k requests are being made concurrently to execute some mixed async / sync action with fast I/O response times.
+         Uses async / await instead of plain Promise.
+         Authored by <a href="https://blog.spion.dev/posts/analysis-generators-and-other-async-patterns-node.html">Gorki Kosev</a>,
+         <a href="https://github.com/v8/promise-performance-tests">packed by Benedikt Meurer</a>.
+         Source code: <a href="simple/doxbee-async.js">doxbee-async.js</a>
+        </dd>
+
         <dt id="Air">Air</dt>
         <dd>
          Air is an ES2015 port of the <a href="https://webkit.org/blog/5852/introducing-the-b3-jit-compiler/">WebKit B3 JIT</a>'s <a href="https://trac.webkit.org/changeset/201783">Air::allocateStack phase</a>.

--- a/PerformanceTests/JetStream3/simple/doxbee-async.js
+++ b/PerformanceTests/JetStream3/simple/doxbee-async.js
@@ -1,0 +1,182 @@
+// MIT License
+
+// Copyright (c) 2013 Gorgi Kosev
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Copyright 2018 Google LLC, Benedikt Meurer
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     <https://www.apache.org/licenses/LICENSE-2.0>
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+(function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return c(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}return r})()({1:[function(require,module,exports){
+"use strict";
+
+const fakes = require("../lib/fakes-async.js");
+
+module.exports = async function doxbee(stream, idOrPath) {
+  const blob = fakes.blobManager.create(fakes.account);
+  const tx = fakes.db.begin();
+
+  try {
+    const blobId = await blob.put(stream);
+    const file = await fakes.self.byUuidOrPath(idOrPath).get();
+    const previousId = file ? file.version : null;
+    const version = {
+      userAccountId: fakes.userAccount.id,
+      date: new Date(),
+      blobId: blobId,
+      creatorId: fakes.userAccount.id,
+      previousId: previousId
+    };
+    version.id = fakes.Version.createHash(version);
+    await fakes.Version.insert(version).execWithin(tx);
+
+    let fileId;
+    if (!file) {
+      const splitPath = idOrPath.split("/");
+      const fileName = splitPath[splitPath.length - 1];
+      fileId = fakes.uuid.v1();
+      const q = await fakes.self.createQuery(idOrPath, {
+        id: fileId,
+        userAccountId: fakes.userAccount.id,
+        name: fileName,
+        version: version.id
+      });
+      await q.execWithin(tx);
+    } else {
+      fileId = file.id;
+    }
+    await fakes.FileVersion.insert({
+      fileId: fileId,
+      versionId: version.id
+    }).execWithin(tx);
+
+    await fakes.File.whereUpdate(
+      { id: fileId },
+      { version: version.id }
+    ).execWithin(tx);
+    await tx.commit();
+  } catch (err) {
+    await tx.rollback();
+    throw err;
+  }
+};
+
+},{"../lib/fakes-async.js":2}],2:[function(require,module,exports){
+"use strict";
+
+async function dummy_1() { }
+async function dummy_2(a) { }
+
+// a queryish object with all kinds of functions
+function Queryish() {}
+Queryish.prototype.all = dummy_1;
+Queryish.prototype.exec = dummy_1;
+Queryish.prototype.execWithin = dummy_2;
+Queryish.prototype.get = dummy_1;
+function queryish() {
+  return new Queryish();
+}
+
+class Uuid {
+  v1() {}
+}
+const uuid = new Uuid();
+
+const userAccount = { id: 1 };
+
+const account = {};
+
+function Blob() {}
+Blob.prototype.put = dummy_2;
+class BlobManager {
+  create() {
+    return new Blob();
+  }
+}
+const blobManager = new BlobManager();
+
+var cqQueryish = queryish();
+
+function Self() {}
+Self.prototype.byUuidOrPath = queryish;
+Self.prototype.createQuery = async function createQuery(x, y) { return cqQueryish; };
+const self = new Self();
+
+function File() {}
+File.insert = queryish;
+File.whereUpdate = queryish;
+
+function FileVersion() {}
+FileVersion.insert = queryish;
+
+function Version() {}
+Version.createHash = function createHash(v) {
+  return 1;
+};
+Version.insert = queryish;
+
+function Transaction() {}
+Transaction.prototype.commit = dummy_1;
+Transaction.prototype.rollback = dummy_1;
+
+class Db {
+  begin() {
+    return new Transaction();
+  }
+}
+const db = new Db();
+
+module.exports = {
+  uuid,
+  userAccount,
+  account,
+  blobManager,
+  self,
+  File,
+  FileVersion,
+  Version,
+  db
+};
+
+},{}],3:[function(require,module,exports){
+const doxbee = require("../lib/doxbee-async");
+
+globalThis.Benchmark = class {
+  runIteration() {
+    const promises = new Array(10_000);
+
+    for (var i = 0; i < 10_000; i++)
+      promises[i] = doxbee(i, "foo");
+
+    return Promise.all(promises);
+  }
+};
+
+},{"../lib/doxbee-async":1}]},{},[3]);

--- a/PerformanceTests/JetStream3/simple/doxbee-promise.js
+++ b/PerformanceTests/JetStream3/simple/doxbee-promise.js
@@ -1,0 +1,202 @@
+// MIT License
+
+// Copyright (c) 2013 Gorgi Kosev
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Copyright 2018 Google LLC, Benedikt Meurer
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     <https://www.apache.org/licenses/LICENSE-2.0>
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+(function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return c(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}return r})()({1:[function(require,module,exports){
+"use strict";
+
+const fakes = require("../lib/fakes-promises.js");
+
+module.exports = function doxbee(stream, idOrPath) {
+  const blob = fakes.blobManager.create(fakes.account);
+  const tx = fakes.db.begin();
+  let version, blobId, fileId, file;
+
+  return blob
+    .put(stream)
+    .then(blobIdV => {
+      blobId = blobIdV;
+      return fakes.self.byUuidOrPath(idOrPath).get();
+    })
+    .then(fileV => {
+      file = fileV;
+      const previousId = file ? file.version : null;
+      version = {
+        userAccountId: fakes.userAccount.id,
+        date: new Date(),
+        blobId: blobId,
+        creatorId: fakes.userAccount.id,
+        previousId: previousId
+      };
+      version.id = fakes.Version.createHash(version);
+      return fakes.Version.insert(version).execWithin(tx);
+    })
+    .then(_ => {
+      if (!file) {
+        const splitPath = idOrPath.split("/");
+        const fileName = splitPath[splitPath.length - 1];
+        const newId = fakes.uuid.v1();
+        return fakes.self
+          .createQuery(idOrPath, {
+            id: newId,
+            userAccountId: fakes.userAccount.id,
+            name: fileName,
+            version: version.id
+          })
+          .then(q => {
+            return q.execWithin(tx);
+          })
+          .then(_ => {
+            return newId;
+          });
+      } else {
+        return file.id;
+      }
+    })
+    .then(fileIdV => {
+      fileId = fileIdV;
+      return fakes.FileVersion.insert({
+        fileId: fileId,
+        versionId: version.id
+      }).execWithin(tx);
+    })
+    .then(_ => {
+      return fakes.File.whereUpdate(
+        { id: fileId },
+        { version: version.id }
+      ).execWithin(tx);
+    })
+    .then(_ => {
+      return tx.commit();
+    })
+    .catch(err => {
+      return tx.rollback().then(_ => Promise.reject(err));
+    });
+};
+
+},{"../lib/fakes-promises.js":2}],2:[function(require,module,exports){
+"use strict";
+
+function dummy_1() { return Promise.resolve(undefined); }
+function dummy_2(a) { return Promise.resolve(undefined); }
+
+// a queryish object with all kinds of functions
+function Queryish() {}
+Queryish.prototype.all = dummy_1;
+Queryish.prototype.exec = dummy_1;
+Queryish.prototype.execWithin = dummy_2;
+Queryish.prototype.get = dummy_1;
+function queryish() {
+  return new Queryish();
+}
+
+class Uuid {
+  v1() {}
+}
+const uuid = new Uuid();
+
+const userAccount = { id: 1 };
+
+const account = {};
+
+function Blob() {}
+Blob.prototype.put = dummy_2;
+class BlobManager {
+  create() {
+    return new Blob();
+  }
+}
+const blobManager = new BlobManager();
+
+var cqQueryish = queryish();
+
+function Self() {}
+Self.prototype.byUuidOrPath = queryish;
+Self.prototype.createQuery = function createQuery(x, y) {
+  return Promise.resolve(cqQueryish);
+};
+const self = new Self();
+
+function File() {}
+File.insert = queryish;
+File.whereUpdate = queryish;
+
+function FileVersion() {}
+FileVersion.insert = queryish;
+
+function Version() {}
+Version.createHash = function createHash(v) {
+  return 1;
+};
+Version.insert = queryish;
+
+function Transaction() {}
+Transaction.prototype.commit = dummy_1;
+Transaction.prototype.rollback = dummy_1;
+
+class Db {
+  begin() {
+    return new Transaction();
+  }
+}
+const db = new Db();
+
+module.exports = {
+  uuid,
+  userAccount,
+  account,
+  blobManager,
+  self,
+  File,
+  FileVersion,
+  Version,
+  db
+};
+
+},{}],3:[function(require,module,exports){
+const doxbee = require("../lib/doxbee-promises");
+
+globalThis.Benchmark = class {
+  runIteration() {
+    const promises = new Array(10_000);
+
+    for (var i = 0; i < 10_000; i++)
+      promises[i] = doxbee(i, "foo");
+
+    return Promise.all(promises);
+  }
+};
+
+},{"../lib/doxbee-promises":1}]},{},[3]);


### PR DESCRIPTION
#### 331a0522f70c2667c339a71fc3e98918544062ec
<pre>
JetStream3: add Promise tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=251727">https://bugs.webkit.org/show_bug.cgi?id=251727</a>

Reviewed by NOBODY (OOPS!).

Adds DoxBee benchmark, which is extraced from real-world codebase and emulates a situation where 10k
requests are being made concurrently to execute some mixed async / sync action with fast I/O response times.

Although it has been used by the V8 team and maintainers of bluebird.js, a highly performant Promise implementation,
there are much better real-world examples like Crank.js framework and <a href="https://github.com/fastify/benchmarks">https://github.com/fastify/benchmarks</a>,
yet both of which, unfortunately, are very dependent on browser and Node.js APIs respectively.

* PerformanceTests/JetStream3/JetStreamDriver.js:
* PerformanceTests/JetStream3/in-depth.html:
* PerformanceTests/JetStream3/simple/doxbee-async.js: Added.
* PerformanceTests/JetStream3/simple/doxbee-promise.js: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/331a0522f70c2667c339a71fc3e98918544062ec

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106160 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15210 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38991 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115341 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16643 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6392 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98362 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115029 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111917 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12660 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95638 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40203 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94533 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27281 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81888 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8456 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28633 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8956 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5187 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14572 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48178 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10492 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->