### PR TITLE
Refactor Content Sniffing Policy

### DIFF
--- a/Source/WebCore/css/StyleRuleImport.cpp
+++ b/Source/WebCore/css/StyleRuleImport.cpp
@@ -138,7 +138,7 @@ void StyleRuleImport::requestStyleSheet()
     if (m_parentStyleSheet->isUserStyleSheet()) {
         ResourceLoaderOptions options {
             SendCallbackPolicy::DoNotSendCallbacks,
-            ContentSniffingPolicy::SniffContent,
+            ContentSniffingPolicy::DefaultForPlatform,
             DataBufferingPolicy::BufferData,
             StoredCredentialsPolicy::Use,
             ClientCredentialPolicy::MayAskClientForCredentials,

--- a/Source/WebCore/loader/ApplicationManifestLoader.cpp
+++ b/Source/WebCore/loader/ApplicationManifestLoader.cpp
@@ -69,7 +69,7 @@ bool ApplicationManifestLoader::startLoading()
     auto credentials = m_useCredentials ? FetchOptions::Credentials::Include : FetchOptions::Credentials::Omit;
     auto options = ResourceLoaderOptions(
         SendCallbackPolicy::SendCallbacks,
-        ContentSniffingPolicy::SniffContent,
+        ContentSniffingPolicy::DefaultForPlatform,
         DataBufferingPolicy::BufferData,
         StoredCredentialsPolicy::DoNotUse,
         ClientCredentialPolicy::CannotAskClientForCredentials,

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -2159,7 +2159,7 @@ void DocumentLoader::loadMainResource(ResourceRequest&& request)
 {
     ResourceLoaderOptions mainResourceLoadOptions(
         SendCallbackPolicy::SendCallbacks,
-        ContentSniffingPolicy::SniffContent,
+        ContentSniffingPolicy::DefaultForPlatform,
         DataBufferingPolicy::BufferData,
         StoredCredentialsPolicy::Use,
         ClientCredentialPolicy::MayAskClientForCredentials,

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -396,7 +396,7 @@ private:
     NetworkStorageSession* storageSession() const final { return nullptr; }
 
 #if PLATFORM(COCOA)
-    bool localFileContentSniffingEnabled() const { return false; }
+    ContentSniffingPolicy localFileContentSniffingPolicy() const { return ContentSniffingPolicy::Disable; }
     SchedulePairHashSet* scheduledRunLoopPairs() const { return nullptr; }
     RetainPtr<CFDataRef> sourceApplicationAuditData() const { return nullptr; };
 #endif

--- a/Source/WebCore/loader/MediaResourceLoader.cpp
+++ b/Source/WebCore/loader/MediaResourceLoader.cpp
@@ -102,7 +102,7 @@ RefPtr<PlatformMediaResource> MediaResourceLoader::requestResource(ResourceReque
     ContentSecurityPolicyImposition contentSecurityPolicyImposition = m_element && m_element->isInUserAgentShadowTree() ? ContentSecurityPolicyImposition::SkipPolicyCheck : ContentSecurityPolicyImposition::DoPolicyCheck;
     ResourceLoaderOptions loaderOptions {
         SendCallbackPolicy::SendCallbacks,
-        ContentSniffingPolicy::DoNotSniffContent,
+        ContentSniffingPolicy::Disable,
         bufferingPolicy,
         StoredCredentialsPolicy::Use,
         ClientCredentialPolicy::MayAskClientForCredentials,

--- a/Source/WebCore/loader/NetscapePlugInStreamLoader.cpp
+++ b/Source/WebCore/loader/NetscapePlugInStreamLoader.cpp
@@ -46,7 +46,7 @@ namespace WebCore {
 NetscapePlugInStreamLoader::NetscapePlugInStreamLoader(Frame& frame, NetscapePlugInStreamLoaderClient& client)
     : ResourceLoader(frame, ResourceLoaderOptions(
         SendCallbackPolicy::SendCallbacks,
-        ContentSniffingPolicy::SniffContent,
+        ContentSniffingPolicy::DefaultForPlatform,
         DataBufferingPolicy::DoNotBufferData,
         StoredCredentialsPolicy::Use,
         ClientCredentialPolicy::MayAskClientForCredentials,

--- a/Source/WebCore/loader/ResourceLoader.cpp
+++ b/Source/WebCore/loader/ResourceLoader.cpp
@@ -262,7 +262,7 @@ void ResourceLoader::start()
 
     bool isMainFrameNavigation = frame() && frame()->isMainFrame() && options().mode == FetchOptions::Mode::Navigate;
 
-    m_handle = ResourceHandle::create(frameLoader()->networkingContext(), m_request, this, m_defersLoading, m_options.sniffContent == ContentSniffingPolicy::SniffContent, m_options.contentEncodingSniffingPolicy, WTFMove(sourceOrigin), isMainFrameNavigation);
+    m_handle = ResourceHandle::create(frameLoader()->networkingContext(), m_request, this, m_defersLoading, m_options.contentSniffingPolicy, m_options.contentEncodingSniffingPolicy, WTFMove(sourceOrigin), isMainFrameNavigation);
 }
 
 void ResourceLoader::setDefersLoading(bool defers)

--- a/Source/WebCore/loader/ResourceLoader.h
+++ b/Source/WebCore/loader/ResourceLoader.h
@@ -129,7 +129,7 @@ public:
     ResourceHandle* handle() const { return m_handle.get(); }
     bool shouldSendResourceLoadCallbacks() const { return m_options.sendLoadCallbacks == SendCallbackPolicy::SendCallbacks; }
     void setSendCallbackPolicy(SendCallbackPolicy sendLoadCallbacks) { m_options.sendLoadCallbacks = sendLoadCallbacks; }
-    bool shouldSniffContent() const { return m_options.sniffContent == ContentSniffingPolicy::SniffContent; }
+    ContentSniffingPolicy contentSniffingPolicy() const { return m_options.contentSniffingPolicy; }
     ContentEncodingSniffingPolicy contentEncodingSniffingPolicy() const { return m_options.contentEncodingSniffingPolicy; }
     WEBCORE_EXPORT bool isAllowedToAskUserForCredentials() const;
     WEBCORE_EXPORT bool shouldIncludeCertificateInfo() const;

--- a/Source/WebCore/loader/ResourceLoaderOptions.h
+++ b/Source/WebCore/loader/ResourceLoaderOptions.h
@@ -51,11 +51,9 @@ enum class SendCallbackPolicy : uint8_t {
 };
 static constexpr unsigned bitWidthOfSendCallbackPolicy = 1;
 
-// FIXME: These options are named poorly. We only implement force disabling content sniffing, not enabling it,
-// and even that only on some platforms.
 enum class ContentSniffingPolicy : bool {
-    SniffContent,
-    DoNotSniffContent
+    DefaultForPlatform,
+    Disable
 };
 static constexpr unsigned bitWidthOfContentSniffingPolicy = 1;
 
@@ -139,7 +137,7 @@ enum class ApplicationCacheMode : uint8_t {
 static constexpr unsigned bitWidthOfApplicationCacheMode = 1;
 
 enum class ContentEncodingSniffingPolicy : bool {
-    Default,
+    DefaultForPlatform,
     Disable
 };
 static constexpr unsigned bitWidthOfContentEncodingSniffingPolicy = 1;
@@ -172,8 +170,8 @@ struct ResourceLoaderOptions : public FetchOptions {
     ResourceLoaderOptions(FetchOptions options)
         : FetchOptions { WTFMove(options) }
         , sendLoadCallbacks(SendCallbackPolicy::DoNotSendCallbacks)
-        , sniffContent(ContentSniffingPolicy::DoNotSniffContent)
-        , contentEncodingSniffingPolicy(ContentEncodingSniffingPolicy::Default)
+        , contentSniffingPolicy(ContentSniffingPolicy::Disable)
+        , contentEncodingSniffingPolicy(ContentEncodingSniffingPolicy::DefaultForPlatform)
         , dataBufferingPolicy(DataBufferingPolicy::BufferData)
         , storedCredentialsPolicy(StoredCredentialsPolicy::DoNotUse)
         , securityCheck(SecurityCheckPolicy::DoSecurityCheck)
@@ -192,10 +190,10 @@ struct ResourceLoaderOptions : public FetchOptions {
         , loadedFromPluginElement(LoadedFromPluginElement::No)
     { }
 
-    ResourceLoaderOptions(SendCallbackPolicy sendLoadCallbacks, ContentSniffingPolicy sniffContent, DataBufferingPolicy dataBufferingPolicy, StoredCredentialsPolicy storedCredentialsPolicy, ClientCredentialPolicy credentialPolicy, FetchOptions::Credentials credentials, SecurityCheckPolicy securityCheck, FetchOptions::Mode mode, CertificateInfoPolicy certificateInfoPolicy, ContentSecurityPolicyImposition contentSecurityPolicyImposition, DefersLoadingPolicy defersLoadingPolicy, CachingPolicy cachingPolicy)
+    ResourceLoaderOptions(SendCallbackPolicy sendLoadCallbacks, ContentSniffingPolicy sniffingPolicy, DataBufferingPolicy dataBufferingPolicy, StoredCredentialsPolicy storedCredentialsPolicy, ClientCredentialPolicy credentialPolicy, FetchOptions::Credentials credentials, SecurityCheckPolicy securityCheck, FetchOptions::Mode mode, CertificateInfoPolicy certificateInfoPolicy, ContentSecurityPolicyImposition contentSecurityPolicyImposition, DefersLoadingPolicy defersLoadingPolicy, CachingPolicy cachingPolicy)
         : sendLoadCallbacks(sendLoadCallbacks)
-        , sniffContent(sniffContent)
-        , contentEncodingSniffingPolicy(ContentEncodingSniffingPolicy::Default)
+        , contentSniffingPolicy(sniffingPolicy)
+        , contentEncodingSniffingPolicy(ContentEncodingSniffingPolicy::DefaultForPlatform)
         , dataBufferingPolicy(dataBufferingPolicy)
         , storedCredentialsPolicy(storedCredentialsPolicy)
         , securityCheck(securityCheck)
@@ -228,7 +226,7 @@ struct ResourceLoaderOptions : public FetchOptions {
     OptionSet<HTTPHeadersToKeepFromCleaning> httpHeadersToKeep;
 
     SendCallbackPolicy sendLoadCallbacks : bitWidthOfSendCallbackPolicy;
-    ContentSniffingPolicy sniffContent : bitWidthOfContentSniffingPolicy;
+    ContentSniffingPolicy contentSniffingPolicy : bitWidthOfContentSniffingPolicy;
     ContentEncodingSniffingPolicy contentEncodingSniffingPolicy : bitWidthOfContentEncodingSniffingPolicy;
     DataBufferingPolicy dataBufferingPolicy : bitWidthOfDataBufferingPolicy;
     StoredCredentialsPolicy storedCredentialsPolicy : bitWidthOfStoredCredentialsPolicy;

--- a/Source/WebCore/loader/ThreadableLoader.cpp
+++ b/Source/WebCore/loader/ThreadableLoader.cpp
@@ -83,7 +83,7 @@ ThreadableLoaderOptions ThreadableLoaderOptions::isolatedCopy() const
 
     // ResourceLoaderOptions
     copy.sendLoadCallbacks = this->sendLoadCallbacks;
-    copy.sniffContent = this->sniffContent;
+    copy.contentSniffingPolicy = this->contentSniffingPolicy;
     copy.contentEncodingSniffingPolicy = this->contentEncodingSniffingPolicy;
     copy.dataBufferingPolicy = this->dataBufferingPolicy;
     copy.storedCredentialsPolicy = this->storedCredentialsPolicy;

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -1746,7 +1746,7 @@ const ResourceLoaderOptions& CachedResourceLoader::defaultCachedResourceOptions(
 {
     static NeverDestroyed<ResourceLoaderOptions> options(
         SendCallbackPolicy::SendCallbacks,
-        ContentSniffingPolicy::SniffContent,
+        ContentSniffingPolicy::DefaultForPlatform,
         DataBufferingPolicy::BufferData,
         StoredCredentialsPolicy::Use,
         ClientCredentialPolicy::MayAskClientForCredentials,

--- a/Source/WebCore/loader/icon/IconLoader.cpp
+++ b/Source/WebCore/loader/icon/IconLoader.cpp
@@ -74,7 +74,7 @@ void IconLoader::startLoading()
 
     CachedResourceRequest request(WTFMove(resourceRequest), ResourceLoaderOptions(
         SendCallbackPolicy::SendCallbacks,
-        ContentSniffingPolicy::SniffContent,
+        ContentSniffingPolicy::DefaultForPlatform,
         DataBufferingPolicy::BufferData,
         StoredCredentialsPolicy::DoNotUse,
         ClientCredentialPolicy::CannotAskClientForCredentials,

--- a/Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
@@ -76,7 +76,7 @@ std::unique_ptr<CachedResourceMediaLoader> CachedResourceMediaLoader::create(Web
     // is in a user-agent shadow tree. See <https://bugs.webkit.org/show_bug.cgi?id=173498>.
     ResourceLoaderOptions loaderOptions(
         SendCallbackPolicy::SendCallbacks,
-        ContentSniffingPolicy::DoNotSniffContent,
+        ContentSniffingPolicy::Disable,
         DataBufferingPolicy::BufferData,
         StoredCredentialsPolicy::DoNotUse,
         ClientCredentialPolicy::CannotAskClientForCredentials,

--- a/Source/WebCore/platform/network/BlobResourceHandle.cpp
+++ b/Source/WebCore/platform/network/BlobResourceHandle.cpp
@@ -155,7 +155,7 @@ void BlobResourceHandle::loadResourceSynchronously(BlobData* blobData, const Res
 }
 
 BlobResourceHandle::BlobResourceHandle(BlobData* blobData, const ResourceRequest& request, ResourceHandleClient* client, bool async)
-    : ResourceHandle { nullptr, request, client, false /* defersLoading */, false /* shouldContentSniff */, ContentEncodingSniffingPolicy::Default, nullptr /* sourceOrigin */, false /* isMainFrameNavigation */ }
+    : ResourceHandle { nullptr, request, client, false /* defersLoading */, ContentSniffingPolicy::Disable, ContentEncodingSniffingPolicy::DefaultForPlatform, nullptr /* sourceOrigin */, false /* isMainFrameNavigation */ }
     , m_blobData { blobData }
     , m_async { async }
 {

--- a/Source/WebCore/platform/network/NetworkingContext.h
+++ b/Source/WebCore/platform/network/NetworkingContext.h
@@ -41,6 +41,8 @@ class NetworkStorageSession;
 class ResourceError;
 class ResourceRequest;
 
+enum class ContentSniffingPolicy : bool;
+
 class NetworkingContext : public StorageSessionProvider {
 public:
     virtual ~NetworkingContext() = default;
@@ -50,7 +52,7 @@ public:
     virtual bool shouldClearReferrerOnHTTPSToHTTPRedirect() const = 0;
 
 #if PLATFORM(COCOA)
-    virtual bool localFileContentSniffingEnabled() const = 0; // FIXME: Reconcile with ResourceHandle::forceContentSniffing().
+    virtual ContentSniffingPolicy localFileContentSniffingPolicy() const = 0; // FIXME: Reconcile with ResourceHandle::forceContentSniffing().
     virtual SchedulePairHashSet* scheduledRunLoopPairs() const { return 0; }
     virtual RetainPtr<CFDataRef> sourceApplicationAuditData() const = 0;
     virtual ResourceError blockedError(const ResourceRequest&) const = 0;

--- a/Source/WebCore/platform/network/ResourceHandle.h
+++ b/Source/WebCore/platform/network/ResourceHandle.h
@@ -96,7 +96,7 @@ class CurlResourceHandleDelegate;
 
 class ResourceHandle : public RefCounted<ResourceHandle>, public AuthenticationClient {
 public:
-    WEBCORE_EXPORT static RefPtr<ResourceHandle> create(NetworkingContext*, const ResourceRequest&, ResourceHandleClient*, bool defersLoading, bool shouldContentSniff, ContentEncodingSniffingPolicy, RefPtr<SecurityOrigin>&& sourceOrigin, bool isMainFrameNavigation);
+    WEBCORE_EXPORT static RefPtr<ResourceHandle> create(NetworkingContext*, const ResourceRequest&, ResourceHandleClient*, bool defersLoading, ContentSniffingPolicy, ContentEncodingSniffingPolicy, RefPtr<SecurityOrigin>&& sourceOrigin, bool isMainFrameNavigation);
     WEBCORE_EXPORT static void loadResourceSynchronously(NetworkingContext*, const ResourceRequest&, StoredCredentialsPolicy, SecurityOrigin*, ResourceError&, ResourceResponse&, Vector<uint8_t>& data);
     WEBCORE_EXPORT virtual ~ResourceHandle();
 
@@ -148,12 +148,11 @@ public:
     static void setClientCertificateInfo(const String&, const String&, const String&);
 #endif
 
-    bool shouldContentSniff() const;
-    static bool shouldContentSniffURL(const URL&);
+    ContentSniffingPolicy contentSniffingPolicy() const;
+    static ContentSniffingPolicy contentSniffingPolicyForURL(const URL&);
+    WEBCORE_EXPORT static void forceContentSniffing();
 
     ContentEncodingSniffingPolicy contentEncodingSniffingPolicy() const;
-
-    WEBCORE_EXPORT static void forceContentSniffing();
 
 #if USE(CURL)
     ResourceHandleInternal* getInternal() { return d.get(); }
@@ -210,7 +209,7 @@ public:
     static void registerBuiltinSynchronousLoader(const AtomString& protocol, BuiltinSynchronousLoader);
 
 protected:
-    ResourceHandle(NetworkingContext*, const ResourceRequest&, ResourceHandleClient*, bool defersLoading, bool shouldContentSniff, ContentEncodingSniffingPolicy, RefPtr<SecurityOrigin>&& sourceOrigin, bool isMainFrameNavigation);
+    ResourceHandle(NetworkingContext*, const ResourceRequest&, ResourceHandleClient*, bool defersLoading, ContentSniffingPolicy, ContentEncodingSniffingPolicy, RefPtr<SecurityOrigin>&& sourceOrigin, bool isMainFrameNavigation);
 
 private:
     enum FailureType {
@@ -240,15 +239,15 @@ private:
 #endif
 
 #if PLATFORM(MAC)
-    void createNSURLConnection(id delegate, bool shouldUseCredentialStorage, bool shouldContentSniff, ContentEncodingSniffingPolicy, SchedulingBehavior);
+    void createNSURLConnection(id delegate, bool shouldUseCredentialStorage, ContentSniffingPolicy, ContentEncodingSniffingPolicy, SchedulingBehavior);
 #endif
 
 #if PLATFORM(IOS_FAMILY)
-    void createNSURLConnection(id delegate, bool shouldUseCredentialStorage, bool shouldContentSniff, ContentEncodingSniffingPolicy, SchedulingBehavior, NSDictionary *connectionProperties);
+    void createNSURLConnection(id delegate, bool shouldUseCredentialStorage, ContentSniffingPolicy, ContentEncodingSniffingPolicy, SchedulingBehavior, NSDictionary *connectionProperties);
 #endif
 
 #if PLATFORM(COCOA)
-    NSURLRequest *applySniffingPoliciesIfNeeded(NSURLRequest *, bool shouldContentSniff, ContentEncodingSniffingPolicy);
+    NSURLRequest *applySniffingPoliciesIfNeeded(NSURLRequest *, ContentSniffingPolicy, ContentEncodingSniffingPolicy);
 #endif
 
 #if USE(CURL)

--- a/Source/WebCore/platform/network/ResourceHandleInternal.h
+++ b/Source/WebCore/platform/network/ResourceHandleInternal.h
@@ -65,14 +65,14 @@ class ResourceHandleInternal {
     WTF_MAKE_NONCOPYABLE(ResourceHandleInternal);
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(ResourceHandleInternal);
 public:
-    ResourceHandleInternal(ResourceHandle* loader, NetworkingContext* context, const ResourceRequest& request, ResourceHandleClient* client, bool defersLoading, bool shouldContentSniff, ContentEncodingSniffingPolicy contentEncodingSniffingPolicy, RefPtr<SecurityOrigin>&& sourceOrigin, bool isMainFrameNavigation)
+    ResourceHandleInternal(ResourceHandle* loader, NetworkingContext* context, const ResourceRequest& request, ResourceHandleClient* client, bool defersLoading, ContentSniffingPolicy contentSniffingPolicy, ContentEncodingSniffingPolicy contentEncodingSniffingPolicy, RefPtr<SecurityOrigin>&& sourceOrigin, bool isMainFrameNavigation)
         : m_context(context)
         , m_client(client)
         , m_firstRequest(request)
         , m_lastHTTPMethod(request.httpMethod())
         , m_partition(request.cachePartition())
         , m_defersLoading(defersLoading)
-        , m_shouldContentSniff(shouldContentSniff)
+        , m_contentSniffingPolicy(contentSniffingPolicy)
         , m_contentEncodingSniffingPolicy(contentEncodingSniffingPolicy)
 #if USE(CFURLCONNECTION)
         , m_currentRequest(request)
@@ -90,7 +90,7 @@ public:
     ~ResourceHandleInternal();
 
     ResourceHandleClient* client() { return m_client; }
-
+    
     RefPtr<NetworkingContext> m_context;
     ResourceHandleClient* m_client;
     ResourceRequest m_firstRequest;
@@ -106,7 +106,7 @@ public:
     int status { 0 };
 
     bool m_defersLoading;
-    bool m_shouldContentSniff;
+    ContentSniffingPolicy m_contentSniffingPolicy;
     ContentEncodingSniffingPolicy m_contentEncodingSniffingPolicy;
 #if USE(CFURLCONNECTION)
     RetainPtr<CFURLConnectionRef> m_connection;

--- a/Source/WebKit/NetworkProcess/NetworkLoadParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkLoadParameters.h
@@ -80,8 +80,8 @@ public:
     std::optional<audit_token_t> networkProcessAuditToken;
 #endif
     WebCore::ResourceRequest request;
-    WebCore::ContentSniffingPolicy contentSniffingPolicy { WebCore::ContentSniffingPolicy::SniffContent };
-    WebCore::ContentEncodingSniffingPolicy contentEncodingSniffingPolicy { WebCore::ContentEncodingSniffingPolicy::Default };
+    WebCore::ContentSniffingPolicy contentSniffingPolicy { WebCore::ContentSniffingPolicy::DefaultForPlatform };
+    WebCore::ContentEncodingSniffingPolicy contentEncodingSniffingPolicy { WebCore::ContentEncodingSniffingPolicy::DefaultForPlatform };
     WebCore::StoredCredentialsPolicy storedCredentialsPolicy { WebCore::StoredCredentialsPolicy::DoNotUse };
     WebCore::ClientCredentialPolicy clientCredentialPolicy { WebCore::ClientCredentialPolicy::CannotAskClientForCredentials };
     bool shouldClearReferrerOnHTTPSToHTTPRedirect { true };

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerSoftUpdateLoader.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerSoftUpdateLoader.cpp
@@ -126,8 +126,8 @@ void ServiceWorkerSoftUpdateLoader::loadFromNetwork(NetworkSession& session, Res
 {
     NetworkLoadParameters parameters;
     parameters.storedCredentialsPolicy = StoredCredentialsPolicy::Use;
-    parameters.contentSniffingPolicy = ContentSniffingPolicy::DoNotSniffContent;
-    parameters.contentEncodingSniffingPolicy = ContentEncodingSniffingPolicy::Default;
+    parameters.contentSniffingPolicy = ContentSniffingPolicy::Disable;
+    parameters.contentEncodingSniffingPolicy = ContentEncodingSniffingPolicy::DefaultForPlatform;
     parameters.needsCertificateInfo = true;
     parameters.request = WTFMove(request);
     m_networkLoad = makeUnique<NetworkLoad>(*this, nullptr, WTFMove(parameters), session);

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoad.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoad.cpp
@@ -64,8 +64,8 @@ SpeculativeLoad::SpeculativeLoad(Cache& cache, const GlobalFrameID& globalFrameI
     parameters.webPageID = globalFrameID.webPageID;
     parameters.webFrameID = globalFrameID.frameID;
     parameters.storedCredentialsPolicy = StoredCredentialsPolicy::Use;
-    parameters.contentSniffingPolicy = ContentSniffingPolicy::DoNotSniffContent;
-    parameters.contentEncodingSniffingPolicy = ContentEncodingSniffingPolicy::Default;
+    parameters.contentSniffingPolicy = ContentSniffingPolicy::Disable;
+    parameters.contentEncodingSniffingPolicy = ContentEncodingSniffingPolicy::DefaultForPlatform;
     parameters.request = m_originalRequest;
     parameters.isNavigatingToAppBoundDomain = isNavigatingToAppBoundDomain;
     parameters.allowPrivacyProxy = allowPrivacyProxy;

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp
@@ -465,8 +465,8 @@ void SpeculativeLoadManager::preconnectForSubresource(const SubresourceInfo& sub
     parameters.webPageID = frameID.webPageID;
     parameters.webFrameID = frameID.frameID;
     parameters.storedCredentialsPolicy = StoredCredentialsPolicy::Use;
-    parameters.contentSniffingPolicy = ContentSniffingPolicy::DoNotSniffContent;
-    parameters.contentEncodingSniffingPolicy = ContentEncodingSniffingPolicy::Default;
+    parameters.contentSniffingPolicy = ContentSniffingPolicy::Disable;
+    parameters.contentEncodingSniffingPolicy = ContentEncodingSniffingPolicy::DefaultForPlatform;
     parameters.shouldPreconnectOnly = PreconnectOnly::Yes;
     parameters.request = constructRevalidationRequest(subresourceInfo.key(), subresourceInfo, entry);
     parameters.isNavigatingToAppBoundDomain = isNavigatingToAppBoundDomain;

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h
@@ -96,7 +96,7 @@ private:
     NetworkDataTaskCocoa(NetworkSession&, NetworkDataTaskClient&, const NetworkLoadParameters&);
 
     bool tryPasswordBasedAuthentication(const WebCore::AuthenticationChallenge&, ChallengeCompletionHandler&);
-    void applySniffingPoliciesAndBindRequestToInferfaceIfNeeded(RetainPtr<NSURLRequest>&, bool shouldContentSniff, WebCore::ContentEncodingSniffingPolicy);
+    void applySniffingPoliciesAndBindRequestToInferfaceIfNeeded(RetainPtr<NSURLRequest>&, WebCore::ContentSniffingPolicy, WebCore::ContentEncodingSniffingPolicy);
 
 #if ENABLE(TRACKING_PREVENTION)
     static NSHTTPCookieStorage *statelessCookieStorage();

--- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
@@ -175,7 +175,7 @@ void NetworkDataTaskSoup::createRequest(ResourceRequest&& request, WasBlockingCo
 #if !USE(SOUP2)
     messageFlags |= SOUP_MESSAGE_COLLECT_METRICS;
 #endif
-    if (m_shouldContentSniff == ContentSniffingPolicy::DoNotSniffContent)
+    if (m_shouldContentSniff == ContentSniffingPolicy::Disable)
         soup_message_disable_feature(m_soupMessage.get(), SOUP_TYPE_CONTENT_SNIFFER);
     if (m_user.isEmpty() && m_password.isEmpty() && m_storedCredentialsPolicy == StoredCredentialsPolicy::DoNotUse) {
 #if SOUP_CHECK_VERSION(2, 57, 1)
@@ -242,7 +242,7 @@ void NetworkDataTaskSoup::createRequest(ResourceRequest&& request, WasBlockingCo
 #endif
     g_signal_connect(m_soupMessage.get(), "restarted", G_CALLBACK(restartedCallback), this);
     g_signal_connect(m_soupMessage.get(), "starting", G_CALLBACK(startingCallback), this);
-    if (m_shouldContentSniff == ContentSniffingPolicy::SniffContent)
+    if (m_shouldContentSniff == ContentSniffingPolicy::DefaultForPlatform)
         g_signal_connect(m_soupMessage.get(), "content-sniffed", G_CALLBACK(didSniffContentCallback), this);
 }
 

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -364,8 +364,6 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
         }
     }
 
-    ContentSniffingPolicy contentSniffingPolicy = resourceLoader.shouldSniffContent() ? ContentSniffingPolicy::SniffContent : ContentSniffingPolicy::DoNotSniffContent;
-    auto contentEncodingSniffingPolicy = resourceLoader.contentEncodingSniffingPolicy();
     StoredCredentialsPolicy storedCredentialsPolicy = resourceLoader.shouldUseCredentialStorage() ? StoredCredentialsPolicy::Use : StoredCredentialsPolicy::DoNotUse;
 
     LOG(NetworkScheduling, "(WebProcess) WebLoaderStrategy::scheduleLoad, url '%s' will be scheduled with the NetworkProcess with priority %d, storedCredentialsPolicy %i", resourceLoader.url().string().latin1().data(), static_cast<int>(resourceLoader.request().priority()), (int)storedCredentialsPolicy);
@@ -380,8 +378,8 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
     loadParameters.networkProcessAuditToken = WebProcess::singleton().ensureNetworkProcessConnection().networkProcessAuditToken();
 #endif
     loadParameters.request = request;
-    loadParameters.contentSniffingPolicy = contentSniffingPolicy;
-    loadParameters.contentEncodingSniffingPolicy = contentEncodingSniffingPolicy;
+    loadParameters.contentSniffingPolicy = resourceLoader.contentSniffingPolicy();
+    loadParameters.contentEncodingSniffingPolicy = resourceLoader.contentEncodingSniffingPolicy();
     loadParameters.storedCredentialsPolicy = storedCredentialsPolicy;
     // If there is no WebFrame then this resource cannot be authenticated with the client.
     loadParameters.clientCredentialPolicy = (loadParameters.webFrameID && loadParameters.webPageID && resourceLoader.isAllowedToAskUserForCredentials()) ? ClientCredentialPolicy::MayAskClientForCredentials : ClientCredentialPolicy::CannotAskClientForCredentials;
@@ -725,8 +723,8 @@ void WebLoaderStrategy::loadResourceSynchronously(FrameLoader& frameLoader, WebC
     loadParameters.networkProcessAuditToken = WebProcess::singleton().ensureNetworkProcessConnection().networkProcessAuditToken();
 #endif
     loadParameters.request = request;
-    loadParameters.contentSniffingPolicy = ContentSniffingPolicy::SniffContent;
-    loadParameters.contentEncodingSniffingPolicy = ContentEncodingSniffingPolicy::Default;
+    loadParameters.contentSniffingPolicy = ContentSniffingPolicy::DefaultForPlatform;
+    loadParameters.contentEncodingSniffingPolicy = ContentEncodingSniffingPolicy::DefaultForPlatform;
     loadParameters.storedCredentialsPolicy = options.credentials == FetchOptions::Credentials::Omit ? StoredCredentialsPolicy::DoNotUse : StoredCredentialsPolicy::Use;
     loadParameters.clientCredentialPolicy = clientCredentialPolicy;
     loadParameters.shouldClearReferrerOnHTTPSToHTTPRedirect = shouldClearReferrerOnHTTPSToHTTPRedirect(webFrame ? webFrame->coreFrame() : nullptr);

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebFrameNetworkingContext.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebFrameNetworkingContext.h
@@ -50,7 +50,7 @@ private:
     {
     }
 
-    bool localFileContentSniffingEnabled() const override;
+    WebCore::ContentSniffingPolicy localFileContentSniffingPolicy() const override;
     SchedulePairHashSet* scheduledRunLoopPairs() const override;
     RetainPtr<CFDataRef> sourceApplicationAuditData() const override;
     String sourceApplicationIdentifier() const override;

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebFrameNetworkingContext.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebFrameNetworkingContext.mm
@@ -42,9 +42,11 @@
 namespace WebKit {
 using namespace WebCore;
 
-bool WebFrameNetworkingContext::localFileContentSniffingEnabled() const
+ContentSniffingPolicy WebFrameNetworkingContext::localFileContentSniffingPolicy() const
 {
-    return frame() && frame()->settings().localFileContentSniffingEnabled();
+    if (frame() && frame()->settings().localFileContentSniffingEnabled())
+        return ContentSniffingPolicy::DefaultForPlatform;
+    return ContentSniffingPolicy::Disable;
 }
 
 SchedulePairHashSet* WebFrameNetworkingContext::scheduledRunLoopPairs() const

--- a/Source/WebKitLegacy/WebCoreSupport/PingHandle.h
+++ b/Source/WebKitLegacy/WebCoreSupport/PingHandle.h
@@ -50,8 +50,7 @@ public:
         , m_completionHandler(WTFMove(completionHandler))
     {
         bool defersLoading = false;
-        bool shouldContentSniff = false;
-        m_handle = WebCore::ResourceHandle::create(networkingContext, request, this, defersLoading, shouldContentSniff, WebCore::ContentEncodingSniffingPolicy::Default, nullptr, false);
+        m_handle = WebCore::ResourceHandle::create(networkingContext, request, this, defersLoading, WebCore::ContentSniffingPolicy::Disable, WebCore::ContentEncodingSniffingPolicy::DefaultForPlatform, nullptr, false);
 
         // If the server never responds, this object will hang around forever.
         // Set a very generous timeout, just in case.

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameNetworkingContext.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameNetworkingContext.h
@@ -44,7 +44,7 @@ private:
     {
     }
 
-    bool localFileContentSniffingEnabled() const override;
+    WebCore::ContentSniffingPolicy localFileContentSniffingPolicy() const override;
     SchedulePairHashSet* scheduledRunLoopPairs() const override;
     RetainPtr<CFDataRef> sourceApplicationAuditData() const override;
     String sourceApplicationIdentifier() const override;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameNetworkingContext.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameNetworkingContext.mm
@@ -57,9 +57,11 @@ void WebFrameNetworkingContext::destroyPrivateBrowsingSession()
     NetworkStorageSessionMap::destroySession(PAL::SessionID::legacyPrivateSessionID());
 }
 
-bool WebFrameNetworkingContext::localFileContentSniffingEnabled() const
+ContentSniffingPolicy WebFrameNetworkingContext::localFileContentSniffingPolicy() const
 {
-    return frame() && frame()->settings().localFileContentSniffingEnabled();
+    if (frame() && frame()->settings().localFileContentSniffingEnabled())
+        return ContentSniffingPolicy::DefaultForPlatform;
+    return ContentSniffingPolicy::Disable;
 }
 
 SchedulePairHashSet* WebFrameNetworkingContext::scheduledRunLoopPairs() const


### PR DESCRIPTION
#### 4477a5ead38074584e7a0ac0143bdd786fc19735
<pre>
Refactor Content Sniffing Policy
<a href="https://bugs.webkit.org/show_bug.cgi?id=251729">https://bugs.webkit.org/show_bug.cgi?id=251729</a>
rdar://105026695

Reviewed by NOBODY (OOPS!).

Content Sniffing Policy is set inconsistently using either an enum class or a boolean.
The enum class is also inconsistently named with how we configure the policy - we either
defer to the platform default behavior or explicitly disable content sniffing. Similar to
what was done for Content Encoding Sniffing Policy we should use an enum with more accurate
names in the code.

This patch renames the enum values to more accurately describe the two states - either
DefaultForPlatform or Disable. We also now use the enum in more places. Finally, rename
the default for Content Encoding Sniffing Policy to DefaultForPlatform instead of simply
Default.

No new behavior.

* Source/WebCore/css/StyleRuleImport.cpp:
(WebCore::StyleRuleImport::requestStyleSheet):
* Source/WebCore/loader/ApplicationManifestLoader.cpp:
(WebCore::ApplicationManifestLoader::startLoading):
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::loadMainResource):
* Source/WebCore/loader/EmptyClients.cpp:
* Source/WebCore/loader/MediaResourceLoader.cpp:
(WebCore::MediaResourceLoader::requestResource):
* Source/WebCore/loader/NetscapePlugInStreamLoader.cpp:
(WebCore::NetscapePlugInStreamLoader::NetscapePlugInStreamLoader):
* Source/WebCore/loader/ResourceLoader.cpp:
(WebCore::ResourceLoader::start):
* Source/WebCore/loader/ResourceLoader.h:
(WebCore::ResourceLoader::contentSniffingPolicy const):
(WebCore::ResourceLoader::shouldSniffContent const): Deleted.
* Source/WebCore/loader/ResourceLoaderOptions.h:
(WebCore::ResourceLoaderOptions::ResourceLoaderOptions):
* Source/WebCore/loader/ThreadableLoader.cpp:
(WebCore::ThreadableLoaderOptions::isolatedCopy const):
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::defaultCachedResourceOptions):
* Source/WebCore/loader/icon/IconLoader.cpp:
(WebCore::IconLoader::startLoading):
* Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm:
(WebCore::CachedResourceMediaLoader::create):
* Source/WebCore/platform/network/BlobResourceHandle.cpp:
(WebCore::BlobResourceHandle::BlobResourceHandle):
* Source/WebCore/platform/network/NetworkingContext.h:
* Source/WebCore/platform/network/ResourceHandle.cpp:
(WebCore::contentSniffingPolicyGivenURL):
(WebCore::ResourceHandle::ResourceHandle):
(WebCore::ResourceHandle::create):
(WebCore::ResourceHandle::contentSniffingPolicy const):
(WebCore::ResourceHandle::contentSniffingPolicyForURL):
(WebCore::ResourceHandle::shouldContentSniff const): Deleted.
(WebCore::ResourceHandle::shouldContentSniffURL): Deleted.
* Source/WebCore/platform/network/ResourceHandle.h:
* Source/WebCore/platform/network/ResourceHandleInternal.h:
(WebCore::ResourceHandleInternal::ResourceHandleInternal):
* Source/WebCore/platform/network/mac/ResourceHandleMac.mm:
(WebCore::ResourceHandle::applySniffingPoliciesIfNeeded):
(WebCore::ResourceHandle::createNSURLConnection):
(WebCore::ResourceHandle::start):
(WebCore::ResourceHandle::platformLoadResourceSynchronously):
* Source/WebKit/NetworkProcess/NetworkLoadParameters.h:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerSoftUpdateLoader.cpp:
(WebKit::ServiceWorkerSoftUpdateLoader::loadFromNetwork):
* Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoad.cpp:
(WebKit::NetworkCache::SpeculativeLoad::SpeculativeLoad):
* Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp:
(WebKit::NetworkCache::SpeculativeLoadManager::preconnectForSubresource):
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::applySniffingPoliciesAndBindRequestToInferfaceIfNeeded):
(WebKit::NetworkDataTaskCocoa::NetworkDataTaskCocoa):
* Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp:
(WebKit::NetworkDataTaskSoup::createRequest):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::scheduleLoadFromNetworkProcess):
(WebKit::WebLoaderStrategy::loadResourceSynchronously):
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebFrameNetworkingContext.h:
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebFrameNetworkingContext.mm:
(WebKit::WebFrameNetworkingContext::localFileContentSniffingPolicy const):
(WebKit::WebFrameNetworkingContext::localFileContentSniffingEnabled const): Deleted.
* Source/WebKitLegacy/WebCoreSupport/PingHandle.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameNetworkingContext.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameNetworkingContext.mm:
(WebFrameNetworkingContext::localFileContentSniffingPolicy const):
(WebFrameNetworkingContext::localFileContentSniffingEnabled const): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4477a5ead38074584e7a0ac0143bdd786fc19735

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106165 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15215 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38996 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115346 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175421 "Hash 4477a5ea for PR 9636 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110068 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16650 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6400 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98367 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115033 "Hash 4477a5ea for PR 9636 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111922 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12672 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95642 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40208 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94545 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27285 "Found 9 new test failures: http/tests/mime/mime-type-sniff.html, http/tests/security/http-0.9/image-on-HTTP-0.9-default-port-page-allowed-ref-test.html, http/tests/security/http-0.9/image-on-HTTP-0.9-default-port-page-allowed.html, http/tests/security/http-0.9/image-on-HTTP-0.9-page-blocked.html, http/tests/security/http-0.9/sandbox-should-not-persist-on-navigation.html, imported/w3c/web-platform-tests/dom/nodes/Document-characterSet-normalization-1.html, imported/w3c/web-platform-tests/dom/nodes/Document-characterSet-normalization-2.html, imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/script-src-module.tentative.html, imported/w3c/web-platform-tests/preload/preload-referrer-policy.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81893 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8461 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28637 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8961 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5195 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14577 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48182 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10497 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->