### PR TITLE
[ iOS BigSur+ ] fast/loader/stateobjects/popstate-does-not-fire-with-page-cache.html is a flaky failure.

### DIFF
--- a/LayoutTests/fast/loader/stateobjects/popstate-does-not-fire-with-page-cache-expected.txt
+++ b/LayoutTests/fast/loader/stateobjects/popstate-does-not-fire-with-page-cache-expected.txt
@@ -5,9 +5,10 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 load fired
 pushState with new state object for page 1
 going to page 2
+pageshow fired - persisted=false
 load fired
 going back to page 1 with new state object
-pageshow fired - persisted=false
+pageshow fired - persisted=true
 PASS testWindowPopstateFireCount is 0
 going back to page 1 in initial state
 popstate fired with state null

--- a/LayoutTests/fast/loader/stateobjects/popstate-does-not-fire-with-page-cache.html
+++ b/LayoutTests/fast/loader/stateobjects/popstate-does-not-fire-with-page-cache.html
@@ -53,6 +53,9 @@ function onTestWindowLoad(event)
 function onTestWindowPageShow(event)
 {
     debug("pageshow fired - persisted=" + event.persisted);
+    if (!event.persisted)
+        return;
+
     setTimeout(() => {
         // Should not have fired a popstate event since the navigation wasn't within the same document.
         shouldBe("testWindowPopstateFireCount", "0");

--- a/LayoutTests/fast/loader/stateobjects/resources/popstate-does-not-fire-with-page-cache-1.html
+++ b/LayoutTests/fast/loader/stateobjects/resources/popstate-does-not-fire-with-page-cache-1.html
@@ -1,1 +1,1 @@
-<body onload="opener.onTestWindowLoad(event)" onpopstate="opener.onTestWindowPopState(event)">page 1</body>
+<body onload="opener.onTestWindowLoad(event)" onpageshow="opener.onTestWindowPageShow(event)" onpopstate="opener.onTestWindowPopState(event)">page 1</body>

--- a/LayoutTests/fast/loader/stateobjects/resources/popstate-does-not-fire-with-page-cache-2.html
+++ b/LayoutTests/fast/loader/stateobjects/resources/popstate-does-not-fire-with-page-cache-2.html
@@ -1,1 +1,1 @@
-<body onload="opener.onTestWindowLoad(event)" onpageshow="opener.onTestWindowPageShow(event)" onpopstate="opener.onTestWindowPopState(event)">page 2</body>
+<body onload="opener.onTestWindowLoad(event)" onpopstate="opener.onTestWindowPopState(event)">page 2</body>

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2796,6 +2796,4 @@ webkit.org/b/251099 [ Ventura+ ] fast/images/avif-image-document.html [ Pass Cra
 [ Ventura ] fast/images/avif-as-image.html [ Pass ImageOnlyFailure Crash ]
 [ Ventura ] fast/images/avif-heif-container-as-image.html [ Pass ImageOnlyFailure Crash ]
 
-webkit.org/b/251312 [ BigSur+ ] fast/loader/stateobjects/popstate-does-not-fire-with-page-cache.html [ Pass Failure ]
-
 webkit.org/b/251710 webaudio/AudioBuffer/huge-buffer.html [ Pass Timeout ]


### PR DESCRIPTION
#### 9b11ab322031299fd6af1cc22b20c882818756eb
<pre>
[ iOS BigSur+ ] fast/loader/stateobjects/popstate-does-not-fire-with-page-cache.html is a flaky failure.
<a href="https://bugs.webkit.org/show_bug.cgi?id=251312">https://bugs.webkit.org/show_bug.cgi?id=251312</a>
rdar://104775065

Reviewed by Ryosuke Niwa.

The test would:
1. open a popup and load popstate-does-not-fire-with-page-cache-1.html in it
2. Call history.pushState() to create an extra history item in the popup
   (popstate-does-not-fire-with-page-cache-1.html#)
3. Navigate the popup to popstate-does-not-fire-with-page-cache-2.html
4. Call history.back() to go back to popstate-does-not-fire-with-page-cache-1.html#
5. Since the item would load from the back/forward cache, the test was relying
   on the `pageshow` event inside the popup to determinate when the navigation
   back had occurred (since no load event would fire).
6. When getting the `pageshow` event, the test would call history.back() again
   in the popup to go back to the initial popstate-does-not-fire-with-page-cache-1.html
7. The test would then expect a popstate event to get fired.

The test would flakily fail because the step 6 would trigger at the wrong time.

The issue was that we had set the pageshow event listener on popstate-does-not-fire-with-page-cache-2.html
instead of popstate-does-not-fire-with-page-cache-1.html. Because we would call `history.back()`
in a setTimeout(10), we would sometimes have navigated back to popstate-does-not-fire-with-page-cache-1.html#
but not always. We really wanted to know when the back/forward cache navigation back to
popstate-does-not-fire-with-page-cache-1.html# had occurred so that `pageshow` event listener
needs to be on popstate-does-not-fire-with-page-cache-1.html.

* LayoutTests/fast/loader/stateobjects/popstate-does-not-fire-with-page-cache-expected.txt:
* LayoutTests/fast/loader/stateobjects/popstate-does-not-fire-with-page-cache.html:
* LayoutTests/fast/loader/stateobjects/resources/popstate-does-not-fire-with-page-cache-1.html:
* LayoutTests/fast/loader/stateobjects/resources/popstate-does-not-fire-with-page-cache-2.html:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/259873@main">https://commits.webkit.org/259873@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/873b46b7b6e43dc0bc16efd6d7c29b49db20eac3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106274 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15328 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39113 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115467 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/175572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16770 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6544 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98490 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115152 "Failed to checkout and rebase branch from PR 9637") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/112038 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/95734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/40310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/94628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/27377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8568 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/28729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/9078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/5300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14691 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/48275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10614 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3674 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->