### PR TITLE
Web Inspector: Don't show `::backdrop` rules for elements without a backdrop

### DIFF
--- a/LayoutTests/inspector/css/getMatchedStylesForNode.html
+++ b/LayoutTests/inspector/css/getMatchedStylesForNode.html
@@ -36,6 +36,7 @@ window.internals.insertUserCSS("div { z-index: 500; }");
     div::-webkit-scrollbar-track-piece { z-index: 11; }
     div::-webkit-scrollbar-corner { z-index: 12; }
     div::-webkit-resizer { z-index: 13; }
+    div::backdrop { z-index: 14; }
 </style>
 <script>
 function test()

--- a/LayoutTests/inspector/css/getMatchedStylesForNodeBackdropPseudoId-expected.txt
+++ b/LayoutTests/inspector/css/getMatchedStylesForNodeBackdropPseudoId-expected.txt
@@ -1,0 +1,11 @@
+Tests for the CSS.getMatchedStyleForNode command and the `::backdrop` CSS rule selector.
+
+
+== Running test suite: CSS.getMatchedStyleForNode.BackdropPseudoId
+-- Running test case: CSS.getMatchedStyleForNode.BackdropPseudoId.Dialog
+PASS: Expected no rules entry for selector `*::backdrop` before showing the dialog.
+PASS: Expected exactly 3 rules for selector `*::backdrop` after showing the dialog.
+
+-- Running test case: CSS.getMatchedStyleForNode.BackdropPseudoId.Div
+PASS: Expected no rules entry for selector `*::backdrop`.
+

--- a/LayoutTests/inspector/css/getMatchedStylesForNodeBackdropPseudoId.html
+++ b/LayoutTests/inspector/css/getMatchedStylesForNodeBackdropPseudoId.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+function openDialog()
+{
+    document.getElementById("test-dialog").showModal();
+}
+
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("CSS.getMatchedStyleForNode.BackdropPseudoId");
+
+    function addTestCase({name, description, selector, domNodeStylesHandler})
+    {
+        suite.addTestCase({
+            name,
+            description,
+            async test() {
+                let documentNode = await WI.domManager.requestDocument();
+                let nodeId = await documentNode.querySelector(selector);
+                let domNode = WI.domManager.nodeForId(nodeId);
+                InspectorTest.assert(domNode, `Should find DOM Node for selector '${selector}'.`);
+
+                let domNodeStyles = WI.cssManager.stylesForNode(domNode);
+                InspectorTest.assert(domNodeStyles, `Should find CSS Styles for DOM Node.`);
+                await domNodeStyles.refreshIfNeeded();
+
+                await domNodeStylesHandler(domNodeStyles);
+            },
+        });
+    }
+
+    async function openDialog()
+    {
+        
+    }
+
+    addTestCase({
+        name: "CSS.getMatchedStyleForNode.BackdropPseudoId.Dialog",
+        description: "A dialog should have both the User Agent and authored `::backdrop` rules.",
+        selector: "#test-dialog",
+        async domNodeStylesHandler(styles) {
+            InspectorTest.expectEqual(styles.pseudoElements.get(WI.CSSManager.PseudoSelectorNames.Backdrop), undefined, "Expected no rules entry for selector `*::backdrop` before showing the dialog.");
+            await InspectorTest.evaluateInPage(`openDialog()`);
+            await styles.refresh();
+            InspectorTest.expectEqual(styles.pseudoElements.get(WI.CSSManager.PseudoSelectorNames.Backdrop).matchedRules.length, 3, "Expected exactly 3 rules for selector `*::backdrop` after showing the dialog.");
+        }
+    });
+
+    addTestCase({
+        name: "CSS.getMatchedStyleForNode.BackdropPseudoId.Div",
+        description: "A non-dialog should have no `::backdrop` rules.",
+        selector: "#test-div",
+        async domNodeStylesHandler(styles) {
+            InspectorTest.expectEqual(styles.pseudoElements.get(WI.CSSManager.PseudoSelectorNames.Marker), undefined, "Expected no rules entry for selector `*::backdrop`.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+<style>
+    ::backdrop {
+        background-color: red;
+    }
+</style>
+</head>
+<body onload="runTest()">
+    <p>Tests for the CSS.getMatchedStyleForNode command and the `::backdrop` CSS rule selector.</p>
+    <dialog id="test-dialog"></dialog>
+    <div id="test-div"></div>
+</body>
+</html>

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
@@ -468,6 +468,10 @@ Protocol::ErrorStringOr<std::tuple<RefPtr<JSON::ArrayOf<Protocol::CSS::RuleMatch
                 // `*::marker` selectors are only applicable to elements with `display: list-item`.
                 if (pseudoId == PseudoId::Marker && element->computedStyle()->display() != DisplayType::ListItem)
                     continue;
+
+                if (pseudoId == PseudoId::Backdrop && !element->isInTopLayer())
+                    continue;
+
                 if (auto protocolPseudoId = protocolValueForPseudoId(pseudoId)) {
                     auto matchedRules = styleResolver.pseudoStyleRulesForElement(element, pseudoId, Style::Resolver::AllCSSRules);
                     if (!matchedRules.isEmpty()) {


### PR DESCRIPTION
#### c5064e5e284d10414bb3d55f3603729687f99260
<pre>
Web Inspector: Don&apos;t show `::backdrop` rules for elements without a backdrop
<a href="https://bugs.webkit.org/show_bug.cgi?id=251466">https://bugs.webkit.org/show_bug.cgi?id=251466</a>
rdar://104889944

Reviewed by Tim Nguyen.

`::backdrop` only applies to elements in the top layer. Like `::marker`, we should not display this selector for elements it can&apos;t apply to.

* LayoutTests/inspector/css/getMatchedStylesForNode.html:
* LayoutTests/inspector/css/getMatchedStylesForNodeBackdropPseudoId-expected.txt: Added.
* LayoutTests/inspector/css/getMatchedStylesForNodeBackdropPseudoId.html: Added.
* Source/WebCore/inspector/agents/InspectorCSSAgent.cpp:
(WebCore::InspectorCSSAgent::getMatchedStylesForNode):

Canonical link: <a href="https://commits.webkit.org/259894@main">https://commits.webkit.org/259894@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab7da9b0a17ebf43260400d278e02321b8cd18e1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106164 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15214 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38995 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115345 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175423 "Failed to checkout and rebase branch from PR 9638") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110067 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16649 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6399 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98366 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115032 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111921 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12665 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95643 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40207 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94538 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27286 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81892 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8460 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28638 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8960 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5192 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14576 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48183 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6840 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10496 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->