### PR TITLE
[WebGPU] getBindGroupLayout() is actually supposed to have "create" semantics

### DIFF
--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUComputePipelineImpl.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUComputePipelineImpl.cpp
@@ -47,9 +47,8 @@ ComputePipelineImpl::~ComputePipelineImpl()
 
 Ref<BindGroupLayout> ComputePipelineImpl::getBindGroupLayout(uint32_t index)
 {
-    return m_bindGroupLayouts.ensure(index, [this, index] {
-        return BindGroupLayoutImpl::create(wgpuComputePipelineGetBindGroupLayout(m_backing, index), m_convertToBackingContext);
-    }).iterator->value;
+    // "A new GPUBindGroupLayout wrapper is returned each time"
+    return BindGroupLayoutImpl::create(wgpuComputePipelineGetBindGroupLayout(m_backing, index), m_convertToBackingContext);
 }
 
 void ComputePipelineImpl::setLabelInternal(const String& label)

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUComputePipelineImpl.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUComputePipelineImpl.h
@@ -64,7 +64,6 @@ private:
 
     WGPUComputePipeline m_backing { nullptr };
     Ref<ConvertToBackingContext> m_convertToBackingContext;
-    HashMap<uint32_t, Ref<BindGroupLayoutImpl>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_bindGroupLayouts;
 };
 
 } // namespace PAL::WebGPU

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPURenderPipelineImpl.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPURenderPipelineImpl.cpp
@@ -47,9 +47,8 @@ RenderPipelineImpl::~RenderPipelineImpl()
 
 Ref<BindGroupLayout> RenderPipelineImpl::getBindGroupLayout(uint32_t index)
 {
-    return m_bindGroupLayouts.ensure(index, [this, index] {
-        return BindGroupLayoutImpl::create(wgpuRenderPipelineGetBindGroupLayout(m_backing, index), m_convertToBackingContext);
-    }).iterator->value;
+    // "A new GPUBindGroupLayout wrapper is returned each time"
+    return BindGroupLayoutImpl::create(wgpuRenderPipelineGetBindGroupLayout(m_backing, index), m_convertToBackingContext);
 }
 
 void RenderPipelineImpl::setLabelInternal(const String& label)

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPURenderPipelineImpl.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPURenderPipelineImpl.h
@@ -64,7 +64,6 @@ private:
 
     WGPURenderPipeline m_backing { nullptr };
     Ref<ConvertToBackingContext> m_convertToBackingContext;
-    HashMap<uint32_t, Ref<BindGroupLayoutImpl>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_bindGroupLayouts;
 };
 
 } // namespace PAL::WebGPU

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUComputePipeline.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUComputePipeline.h
@@ -46,6 +46,7 @@ public:
         setLabelInternal(m_label);
     }
 
+    // "A new GPUBindGroupLayout wrapper is returned each time"
     virtual Ref<BindGroupLayout> getBindGroupLayout(uint32_t index) = 0;
 
 protected:

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPURenderPipeline.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPURenderPipeline.h
@@ -46,6 +46,7 @@ public:
         setLabelInternal(m_label);
     }
 
+    // "A new GPUBindGroupLayout wrapper is returned each time"
     virtual Ref<BindGroupLayout> getBindGroupLayout(uint32_t index) = 0;
 
 protected:

--- a/Source/WebGPU/WebGPU/APIConversions.h
+++ b/Source/WebGPU/WebGPU/APIConversions.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Apple Inc. All rights reserved.
+ * Copyright (c) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -184,6 +184,15 @@ template <typename T>
 inline T* releaseToAPI(Ref<T>&& pointer)
 {
     return &pointer.leakRef();
+}
+
+template <typename T>
+inline T* releaseToAPI(RefPtr<T>&& pointer)
+{
+    // FIXME: We shouldn't need this, because invalid objects should be created instead of returning nullptr.
+    if (pointer)
+        return pointer.leakRef();
+    return nullptr;
 }
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/ComputePipeline.h
+++ b/Source/WebGPU/WebGPU/ComputePipeline.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (c) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -59,7 +59,7 @@ public:
 
     ~ComputePipeline();
 
-    BindGroupLayout* getBindGroupLayout(uint32_t groupIndex);
+    RefPtr<BindGroupLayout> getBindGroupLayout(uint32_t groupIndex);
     void setLabel(String&&);
 
     bool isValid() const { return m_computePipelineState; }

--- a/Source/WebGPU/WebGPU/ComputePipeline.mm
+++ b/Source/WebGPU/WebGPU/ComputePipeline.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (c) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -224,7 +224,7 @@ ComputePipeline::ComputePipeline(Device& device)
 
 ComputePipeline::~ComputePipeline() = default;
 
-BindGroupLayout* ComputePipeline::getBindGroupLayout(uint32_t groupIndex)
+RefPtr<BindGroupLayout> ComputePipeline::getBindGroupLayout(uint32_t groupIndex)
 {
     if (m_pipelineLayout)
         return const_cast<BindGroupLayout*>(&m_pipelineLayout->bindGroupLayout(groupIndex));
@@ -255,6 +255,7 @@ BindGroupLayout* ComputePipeline::getBindGroupLayout(uint32_t groupIndex)
     return bindGroupLayout.ptr();
 #else
     UNUSED_PARAM(groupIndex);
+    // FIXME: Return an invalid object instead of nullptr.
     return nullptr;
 #endif
 }
@@ -275,7 +276,7 @@ void wgpuComputePipelineRelease(WGPUComputePipeline computePipeline)
 
 WGPUBindGroupLayout wgpuComputePipelineGetBindGroupLayout(WGPUComputePipeline computePipeline, uint32_t groupIndex)
 {
-    return WebGPU::fromAPI(computePipeline).getBindGroupLayout(groupIndex);
+    return WebGPU::releaseToAPI(WebGPU::fromAPI(computePipeline).getBindGroupLayout(groupIndex));
 }
 
 void wgpuComputePipelineSetLabel(WGPUComputePipeline computePipeline, const char* label)

--- a/Source/WebGPU/WebGPU/RenderPipeline.h
+++ b/Source/WebGPU/WebGPU/RenderPipeline.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (c) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -60,7 +60,7 @@ public:
 
     ~RenderPipeline();
 
-    BindGroupLayout* getBindGroupLayout(uint32_t groupIndex);
+    RefPtr<BindGroupLayout> getBindGroupLayout(uint32_t groupIndex);
     void setLabel(String&&);
 
     bool isValid() const { return m_renderPipelineState; }

--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -512,7 +512,7 @@ RenderPipeline::RenderPipeline(Device& device)
 
 RenderPipeline::~RenderPipeline() = default;
 
-BindGroupLayout* RenderPipeline::getBindGroupLayout(uint32_t groupIndex)
+RefPtr<BindGroupLayout> RenderPipeline::getBindGroupLayout(uint32_t groupIndex)
 {
     if (m_pipelineLayout)
         return const_cast<BindGroupLayout*>(&m_pipelineLayout->bindGroupLayout(groupIndex));
@@ -553,6 +553,7 @@ BindGroupLayout* RenderPipeline::getBindGroupLayout(uint32_t groupIndex)
     return bindGroupLayout.ptr();
 #else
     UNUSED_PARAM(groupIndex);
+    // FIXME: Return an invalid object instead of nullptr.
     return nullptr;
 #endif
 }
@@ -589,7 +590,7 @@ void wgpuRenderPipelineRelease(WGPURenderPipeline renderPipeline)
 
 WGPUBindGroupLayout wgpuRenderPipelineGetBindGroupLayout(WGPURenderPipeline renderPipeline, uint32_t groupIndex)
 {
-    return WebGPU::fromAPI(renderPipeline).getBindGroupLayout(groupIndex);
+    return WebGPU::releaseToAPI(WebGPU::fromAPI(renderPipeline).getBindGroupLayout(groupIndex));
 }
 
 void wgpuRenderPipelineSetLabel(WGPURenderPipeline renderPipeline, const char* label)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.cpp
@@ -55,15 +55,8 @@ void RemoteComputePipeline::stopListeningForIPC()
 
 void RemoteComputePipeline::getBindGroupLayout(uint32_t index, WebGPUIdentifier identifier)
 {
+    // "A new GPUBindGroupLayout wrapper is returned each time"
     auto bindGroupLayout = m_backing->getBindGroupLayout(index);
-    // We're creating a new resource here, because we don't want the GetBindGroupLayout message to be sync.
-    // If the message is async, then the WebGPUIdentifier goes from the Web process to the GPU Process, which
-    // means the Web Process is going to proceed and interact with the bind group layout as-if it has this identifier.
-    // So we need to make sure the bind group layout has this identifier.
-    // Maybe one day we could add the same bind group layout into the ObjectHeap multiple times under multiple identifiers,
-    // but for now let's just create a new RemoteBindGroupLayout object with the expected identifier, just for simplicity.
-    // The Web Process should already be caching these current bind group layout internally, so it's unlikely that we'll
-    // actually run into a problem here.
     auto remoteBindGroupLayout = RemoteBindGroupLayout::create(bindGroupLayout, m_objectHeap, m_streamConnection.copyRef(), identifier);
     m_objectHeap.addObject(identifier, remoteBindGroupLayout);
 }

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.cpp
@@ -55,15 +55,8 @@ void RemoteRenderPipeline::stopListeningForIPC()
 
 void RemoteRenderPipeline::getBindGroupLayout(uint32_t index, WebGPUIdentifier identifier)
 {
+    // "A new GPUBindGroupLayout wrapper is returned each time"
     auto bindGroupLayout = m_backing->getBindGroupLayout(index);
-    // We're creating a new resource here, because we don't want the GetBindGroupLayout message to be sync.
-    // If the message is async, then the WebGPUIdentifier goes from the Web process to the GPU Process, which
-    // means the Web Process is going to proceed and interact with the bind group layout as-if it has this identifier.
-    // So we need to make sure the bind group layout has this identifier.
-    // Maybe one day we could add the same bind group layout into the ObjectHeap multiple times under multiple identifiers,
-    // but for now let's just create a new RemoteBindGroupLayout object with the expected identifier, just for simplicity.
-    // The Web Process should already be caching these current bind group layout internally, so it's unlikely that we'll
-    // actually run into a problem here.
     auto remoteBindGroupLayout = RemoteBindGroupLayout::create(bindGroupLayout, m_objectHeap, m_streamConnection.copyRef(), identifier);
     m_objectHeap.addObject(identifier, remoteBindGroupLayout);
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.cpp
@@ -47,13 +47,12 @@ RemoteComputePipelineProxy::~RemoteComputePipelineProxy()
 
 Ref<PAL::WebGPU::BindGroupLayout> RemoteComputePipelineProxy::getBindGroupLayout(uint32_t index)
 {
-    return m_bindGroupLayouts.ensure(index, [this, index] {
-        auto identifier = WebGPUIdentifier::generate();
-        auto sendResult = send(Messages::RemoteComputePipeline::GetBindGroupLayout(index, identifier));
-        UNUSED_VARIABLE(sendResult);
+    // "A new GPUBindGroupLayout wrapper is returned each time"
+    auto identifier = WebGPUIdentifier::generate();
+    auto sendResult = send(Messages::RemoteComputePipeline::GetBindGroupLayout(index, identifier));
+    UNUSED_VARIABLE(sendResult);
 
-        return RemoteBindGroupLayoutProxy::create(m_parent, m_convertToBackingContext, identifier);
-    }).iterator->value;
+    return RemoteBindGroupLayoutProxy::create(m_parent, m_convertToBackingContext, identifier);
 }
 
 void RemoteComputePipelineProxy::setLabelInternal(const String& label)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.h
@@ -81,7 +81,6 @@ private:
     WebGPUIdentifier m_backing;
     Ref<ConvertToBackingContext> m_convertToBackingContext;
     Ref<RemoteDeviceProxy> m_parent;
-    HashMap<uint32_t, Ref<RemoteBindGroupLayoutProxy>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_bindGroupLayouts;
 };
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.cpp
@@ -47,13 +47,12 @@ RemoteRenderPipelineProxy::~RemoteRenderPipelineProxy()
 
 Ref<PAL::WebGPU::BindGroupLayout> RemoteRenderPipelineProxy::getBindGroupLayout(uint32_t index)
 {
-    return m_bindGroupLayouts.ensure(index, [this, index] {
-        auto identifier = WebGPUIdentifier::generate();
-        auto sendResult = send(Messages::RemoteRenderPipeline::GetBindGroupLayout(index, identifier));
-        UNUSED_VARIABLE(sendResult);
+    // "A new GPUBindGroupLayout wrapper is returned each time"
+    auto identifier = WebGPUIdentifier::generate();
+    auto sendResult = send(Messages::RemoteRenderPipeline::GetBindGroupLayout(index, identifier));
+    UNUSED_VARIABLE(sendResult);
 
-        return RemoteBindGroupLayoutProxy::create(m_parent, m_convertToBackingContext, identifier);
-    }).iterator->value;
+    return RemoteBindGroupLayoutProxy::create(m_parent, m_convertToBackingContext, identifier);
 }
 
 void RemoteRenderPipelineProxy::setLabelInternal(const String& label)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.h
@@ -81,7 +81,6 @@ private:
     WebGPUIdentifier m_backing;
     Ref<ConvertToBackingContext> m_convertToBackingContext;
     Ref<RemoteDeviceProxy> m_parent;
-    HashMap<uint32_t, Ref<RemoteBindGroupLayoutProxy>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_bindGroupLayouts;
 };
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -51,7 +51,7 @@ void RemoteShaderModuleProxy::compilationInfo(CompletionHandler<void(Ref<PAL::We
     auto sendResult = sendSync(Messages::RemoteShaderModule::CompilationInfo());
     auto [messages] = sendResult.takeReplyOr(Vector<CompilationMessage> { });
 
-    auto backingMessages = messages.map([] (CompilationMessage compilationMessage) {
+    auto backingMessages = messages.map([](CompilationMessage compilationMessage) {
         return PAL::WebGPU::CompilationMessage::create(WTFMove(compilationMessage.message), compilationMessage.type, compilationMessage.lineNum, compilationMessage.linePos, compilationMessage.offset, compilationMessage.length);
     });
     callback(PAL::WebGPU::CompilationInfo::create(WTFMove(backingMessages)));


### PR DESCRIPTION
#### 15c8024a15bf3339de61e0100b9d1317f108d30e
<pre>
[WebGPU] getBindGroupLayout() is actually supposed to have &quot;create&quot; semantics
<a href="https://bugs.webkit.org/show_bug.cgi?id=251732">https://bugs.webkit.org/show_bug.cgi?id=251732</a>
rdar://105030025

Reviewed by Dean Jackson.

This is a partial revert of 259609@main. You would think that, because the name of &quot;getBindGroupLayout()&quot;
starts with the word &quot;get,&quot; that it would have &quot;get&quot; semantics. However, the spec actually explicitly
describes that it has &quot;create&quot; semantics. This patch updates the implementation to have those semantics.

The spec specifically says &quot;A new GPUBindGroupLayout wrapper is returned each time.&quot;

<a href="https://github.com/gpuweb/gpuweb/pull/3804">https://github.com/gpuweb/gpuweb/pull/3804</a> is a PR to the spec to rename the functions, to be more clear
about their behavior.

* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUComputePipelineImpl.cpp:
(PAL::WebGPU::ComputePipelineImpl::getBindGroupLayout):
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUComputePipelineImpl.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPURenderPipelineImpl.cpp:
(PAL::WebGPU::RenderPipelineImpl::getBindGroupLayout):
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPURenderPipelineImpl.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUComputePipeline.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/WebGPURenderPipeline.h:
* Source/WebGPU/WebGPU/APIConversions.h:
(WebGPU::releaseToAPI):
* Source/WebGPU/WebGPU/ComputePipeline.h:
* Source/WebGPU/WebGPU/ComputePipeline.mm:
(WebGPU::ComputePipeline::getBindGroupLayout):
(wgpuComputePipelineGetBindGroupLayout):
* Source/WebGPU/WebGPU/RenderPipeline.h:
* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::RenderPipeline::getBindGroupLayout):
(wgpuRenderPipelineGetBindGroupLayout):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.cpp:
(WebKit::RemoteComputePipeline::getBindGroupLayout):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.cpp:
(WebKit::RemoteRenderPipeline::getBindGroupLayout):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.cpp:
(WebKit::WebGPU::RemoteComputePipelineProxy::getBindGroupLayout):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.cpp:
(WebKit::WebGPU::RemoteRenderPipelineProxy::getBindGroupLayout):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.cpp:
(WebKit::WebGPU::RemoteShaderModuleProxy::compilationInfo):

Canonical link: <a href="https://commits.webkit.org/259866@main">https://commits.webkit.org/259866@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44c34279f6c5a5010c35e65874c118436630e359

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106168 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15219 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39001 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115350 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175426 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110072 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16660 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6404 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98371 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115036 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111926 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12675 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95646 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40211 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94548 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27289 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81896 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8465 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28641 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8965 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5197 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14581 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48187 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6819 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10501 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->