### PR TITLE
[ews-build.webkit.org] Convert AnalyzeLayoutTestsResults to new-style

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -3754,8 +3754,8 @@ class AnalyzeLayoutTestsResults(buildstep.BuildStep, BugzillaMixin, GitHubMixin)
     descriptionDone = ['analyze-layout-tests-results']
     NUM_FAILURES_TO_DISPLAY = 10
 
+    @defer.inlineCallbacks
     def report_failure(self, new_failures=None, exceed_failure_limit=False, failure_message=''):
-        self.finished(FAILURE)
         self.build.results = FAILURE
         if not new_failures:
             message = 'Found unexpected failure with change' if not failure_message else failure_message
@@ -3769,7 +3769,7 @@ class AnalyzeLayoutTestsResults(buildstep.BuildStep, BugzillaMixin, GitHubMixin)
             message += ' {} new test failure{}: {}'.format(len(new_failures), pluralSuffix, new_failures_string)
             if len(new_failures) > self.NUM_FAILURES_TO_DISPLAY:
                 message += ' ...'
-            self.send_email_for_new_test_failures(new_failures, exceed_failure_limit)
+            yield self.send_email_for_new_test_failures(new_failures, exceed_failure_limit)
         self.descriptionDone = message
         self.setProperty('build_finish_summary', message)
 
@@ -3778,10 +3778,9 @@ class AnalyzeLayoutTestsResults(buildstep.BuildStep, BugzillaMixin, GitHubMixin)
             self.build.addStepsAfterCurrentStep([LeaveComment(), SetCommitQueueMinusFlagOnPatch()])
         else:
             self.build.addStepsAfterCurrentStep([SetCommitQueueMinusFlagOnPatch(), BlockPullRequest()])
-        return defer.succeed(None)
+        defer.returnValue(FAILURE)
 
     def report_pre_existing_failures(self, clean_tree_failures, flaky_failures):
-        self.finished(SUCCESS)
         self.build.results = SUCCESS
         self.descriptionDone = 'Passed layout tests'
         message = ''
@@ -3804,7 +3803,7 @@ class AnalyzeLayoutTestsResults(buildstep.BuildStep, BugzillaMixin, GitHubMixin)
                 self.send_email_for_flaky_failure(flaky_failure)
 
         self.setProperty('build_summary', message)
-        return defer.succeed(None)
+        return SUCCESS
 
     def retry_build(self, message=''):
         if not message:
@@ -3823,11 +3822,10 @@ class AnalyzeLayoutTestsResults(buildstep.BuildStep, BugzillaMixin, GitHubMixin)
                 pull_request=bool(self.getProperty('github.number')),
             )])
             self.setProperty('build_summary', message)
-            self.finished(SUCCESS)
+            return SUCCESS
         else:
-            self.finished(RETRY)
             self.build.buildFinished([message], RETRY)
-        return defer.succeed(None)
+            return RETRY
 
     def _results_failed_different_tests(self, first_results_failing_tests, second_results_failing_tests):
         return first_results_failing_tests != second_results_failing_tests
@@ -3932,7 +3930,8 @@ class AnalyzeLayoutTestsResults(buildstep.BuildStep, BugzillaMixin, GitHubMixin)
         # TODO: implement this
         pass
 
-    def start(self):
+    @defer.inlineCallbacks
+    def run(self):
         first_results_did_exceed_test_failure_limit = self.getProperty('first_results_exceed_failure_limit')
         first_results_failing_tests = set(self.getProperty('first_run_failures', []))
         second_results_did_exceed_test_failure_limit = self.getProperty('second_results_exceed_failure_limit')
@@ -3948,33 +3947,37 @@ class AnalyzeLayoutTestsResults(buildstep.BuildStep, BugzillaMixin, GitHubMixin)
             # there should have been some test failures. Otherwise there is some unexpected issue.
             clean_tree_run_status = self.getProperty('clean_tree_run_status', FAILURE)
             if clean_tree_run_status == SUCCESS:
-                return self.report_failure(set())
+                rc = yield self.report_failure(set())
+                return defer.returnValue(rc)
             self.send_email_for_infrastructure_issue('Both first and second layout-test runs with patch generated no list of results but exited with error, and the clean_tree without change retry also failed.')
-            return self.retry_build('Unexpected infrastructure issue, retrying build')
+            return defer.returnValue(self.retry_build('Unexpected infrastructure issue, retrying build'))
 
         if first_results_did_exceed_test_failure_limit and second_results_did_exceed_test_failure_limit:
             if (len(first_results_failing_tests) - len(clean_tree_results_failing_tests)) <= 5:
                 # If we've made it here, then many tests are failing with the patch applied, but
                 # if the clean tree is also failing many tests, even if it's not quite as many,
                 # then we can't be certain that the discrepancy isn't due to flakiness, and hence we must defer judgement.
-                return self.retry_build()
-            return self.report_failure(first_results_failing_tests)
+                return defer.returnValue(self.retry_build())
+            rc = yield self.report_failure(first_results_failing_tests)
+            return defer.returnValue(rc)
 
         if second_results_did_exceed_test_failure_limit:
             if clean_tree_results_did_exceed_test_failure_limit:
-                return self.retry_build()
+                return defer.returnValue(self.retry_build())
             failures_introduced_by_patch = first_results_failing_tests - clean_tree_results_failing_tests
             if failures_introduced_by_patch:
-                return self.report_failure(failures_introduced_by_patch)
-            return self.retry_build()
+                rc = yield self.report_failure(failures_introduced_by_patch)
+                return defer.returnValue(rc)
+            return defer.returnValue(self.retry_build())
 
         if first_results_did_exceed_test_failure_limit:
             if clean_tree_results_did_exceed_test_failure_limit:
-                return self.retry_build()
+                return defer.returnValue(self.retry_build())
             failures_introduced_by_patch = second_results_failing_tests - clean_tree_results_failing_tests
             if failures_introduced_by_patch:
-                return self.report_failure(failures_introduced_by_patch)
-            return self.retry_build()
+                rc = yield self.report_failure(failures_introduced_by_patch)
+                return defer.returnValue(rc)
+            return defer.returnValue(self.retry_build())
 
         # FIXME: Here it could be a good idea to also use the info of results.flaky_tests from the runs
         if self._results_failed_different_tests(first_results_failing_tests, second_results_failing_tests):
@@ -3987,28 +3990,31 @@ class AnalyzeLayoutTestsResults(buildstep.BuildStep, BugzillaMixin, GitHubMixin)
             tests_that_consistently_failed = first_results_failing_tests.intersection(second_results_failing_tests)
             if tests_that_consistently_failed:
                 if clean_tree_results_did_exceed_test_failure_limit:
-                    return self.retry_build()
+                    return defer.returnValue(self.retry_build())
                 failures_introduced_by_patch = tests_that_consistently_failed - clean_tree_results_failing_tests
                 if failures_introduced_by_patch:
-                    return self.report_failure(failures_introduced_by_patch)
+                    rc = yield self.report_failure(failures_introduced_by_patch)
+                    return defer.returnValue(rc)
             elif num_flaky_failures > 10:
-                return self.report_failure(failure_message=f'Too many flaky failures: {flaky_failures_string}')
+                rc = yield self.report_failure(failure_message=f'Too many flaky failures: {flaky_failures_string}')
+                return defer.returnValue(rc)
 
             # At this point we know that at least one test flaked, but no consistent failures
             # were introduced. This is a bit of a grey-zone. It's possible that the patch introduced some flakiness.
             # We still mark the build as SUCCESS.
-            return self.report_pre_existing_failures(clean_tree_results_failing_tests, flaky_failures)
+            return defer.returnValue(self.report_pre_existing_failures(clean_tree_results_failing_tests, flaky_failures))
 
         if clean_tree_results_did_exceed_test_failure_limit:
-            return self.retry_build()
+            return defer.returnValue(self.retry_build())
         failures_introduced_by_patch = first_results_failing_tests - clean_tree_results_failing_tests
         if failures_introduced_by_patch:
-            return self.report_failure(failures_introduced_by_patch)
+            rc = yield self.report_failure(failures_introduced_by_patch)
+            return defer.returnValue(rc)
 
         # At this point, we know that the first and second runs had the exact same failures,
         # and that those failures are all present on the clean tree, so we can say with certainty
         # that the patch is good.
-        return self.report_pre_existing_failures(clean_tree_results_failing_tests, flaky_failures)
+        return defer.returnValue(self.report_pre_existing_failures(clean_tree_results_failing_tests, flaky_failures))
 
 
 class RunWebKit1Tests(RunWebKitTests):
@@ -4192,19 +4198,17 @@ class AnalyzeLayoutTestsResultsRedTree(AnalyzeLayoutTestsResults):
     MAX_RETRY = 3
 
     def report_success(self):
-        self.finished(SUCCESS)
         self.build.results = SUCCESS
         self.descriptionDone = 'Passed layout tests'
         message = ''
         self.setProperty('build_summary', message)
-        return defer.succeed(None)
+        return SUCCESS
 
     def report_warning(self, message):
-        self.finished(WARNINGS)
         self.build.results = WARNINGS
         self.descriptionDone = message
         self.setProperty('build_summary', message)
-        return defer.succeed(None)
+        return WARNINGS
 
     def report_infrastructure_issue_and_maybe_retry_build(self, message):
         retry_count = int(self.getProperty('retry_count', 0))
@@ -4263,7 +4267,8 @@ class AnalyzeLayoutTestsResultsRedTree(AnalyzeLayoutTestsResults):
         except Exception as e:
             print('Error in sending email for flaky failure: {}'.format(e))
 
-    def start(self):
+    @defer.inlineCallbacks
+    def run(self):
         # Run with change, running the whole layout test suite
         first_results_exceed_failure_limit = self.getProperty('first_results_exceed_failure_limit', False)
         first_run_failures = set(self.getProperty('first_run_failures', []))
@@ -4286,7 +4291,7 @@ class AnalyzeLayoutTestsResultsRedTree(AnalyzeLayoutTestsResults):
             # If we are not on the last retry, then try to retry the whole testing with the hope it was a random infrastructure error.
             retry_count = int(self.getProperty('retry_count', 0))
             if retry_count < self.MAX_RETRY:
-                return self.report_infrastructure_issue_and_maybe_retry_build('The layout-test run with change generated no list of results and exited with error, retrying with the hope it was a random infrastructure error.')
+                return defer.returnValue(self.report_infrastructure_issue_and_maybe_retry_build('The layout-test run with change generated no list of results and exited with error, retrying with the hope it was a random infrastructure error.'))
             # Otherwise (last retry) report and error or a warning, since we already gave it enough retries for the issue to not be caused by a random infrastructure error.
             # The clean tree run that only happens when the first run gives an error code without generating a list of failures or flakies.
             clean_tree_run_failures = set(self.getProperty('clean_tree_run_failures', []))
@@ -4294,15 +4299,16 @@ class AnalyzeLayoutTestsResultsRedTree(AnalyzeLayoutTestsResults):
             clean_tree_run_status = self.getProperty('clean_tree_run_status', FAILURE)
             # If the clean-tree run generated some results then we assume this change broke the script run-webkit-tests or something like that.
             if (clean_tree_run_status in [SUCCESS, WARNINGS]) or clean_tree_run_failures or clean_tree_run_flakies:
-                return self.report_failure(set(), first_results_exceed_failure_limit)
+                rc = yield self.report_failure(set(), first_results_exceed_failure_limit)
+                return defer.returnValue(rc)
             # This will end the testing as retry_count will be now self.MAX_RETRY and a warning will be reported.
-            return self.report_infrastructure_issue_and_maybe_retry_build('The layout-test run with change generated no list of results and exited with error, and the clean_tree without change run did the same thing.')
+            return defer.returnValue(self.report_infrastructure_issue_and_maybe_retry_build('The layout-test run with change generated no list of results and exited with error, and the clean_tree without change run did the same thing.'))
 
         if with_change_repeat_failures_results_exceed_failure_limit or without_change_repeat_failures_results_exceed_failure_limit:
-            return self.report_infrastructure_issue_and_maybe_retry_build('One of the steps for retrying the failed tests has exited early, but this steps should run without "--exit-after-n-failures" switch, so they should not exit early.')
+            return defer.returnValue(self.report_infrastructure_issue_and_maybe_retry_build('One of the steps for retrying the failed tests has exited early, but this steps should run without "--exit-after-n-failures" switch, so they should not exit early.'))
 
         if without_change_repeat_failures_timedout:
-            return self.report_infrastructure_issue_and_maybe_retry_build('The step "layout-tests-repeat-failures-without-change" was interrumped because it reached the timeout.')
+            return defer.returnValue(self.report_infrastructure_issue_and_maybe_retry_build('The step "layout-tests-repeat-failures-without-change" was interrumped because it reached the timeout.'))
 
         if with_change_repeat_failures_timedout:
             # The change is causing the step 'layout-tests-repeat-failures-with-change' to timeout, likely the change is adding many failures or long timeouts needing lot of time to test the repeats.
@@ -4310,20 +4316,21 @@ class AnalyzeLayoutTestsResultsRedTree(AnalyzeLayoutTestsResults):
             # There is no point in repeating this run, it would happen the same on next runs and consume lot of time.
             likely_new_non_flaky_failures = first_run_failures - without_change_repeat_failures_results_nonflaky_failures.union(without_change_repeat_failures_results_flakies)
             self.send_email_for_infrastructure_issue('The step "layout-tests-repeat-failures-with-change" reached the timeout but the step "layout-tests-repeat-failures-without-change" ended. Not trying to repeat this. Reporting {} failures from the first run.'.format(len(likely_new_non_flaky_failures)))
-            return self.report_failure(likely_new_non_flaky_failures, first_results_exceed_failure_limit)
+            rc = yield self.report_failure(likely_new_non_flaky_failures, first_results_exceed_failure_limit)
+            return defer.returnValue(rc)
 
         # The checks below need to be after the timeout ones (above) because when a timeout is trigerred no results will be generated for the step.
         # The step with_change_repeat_failures generated no list of failures or flakies, which should only happen when the return code of the step is SUCESS or WARNINGS.
         if not with_change_repeat_failures_results_nonflaky_failures and not with_change_repeat_failures_results_flakies:
             with_change_repeat_failures_retcode = self.getProperty('with_change_repeat_failures_retcode', FAILURE)
             if with_change_repeat_failures_retcode not in [SUCCESS, WARNINGS]:
-                return self.report_infrastructure_issue_and_maybe_retry_build('The step "layout-tests-repeat-failures" failed to generate any list of failures or flakies and returned an error code.')
+                return defer.returnValue(self.report_infrastructure_issue_and_maybe_retry_build('The step "layout-tests-repeat-failures" failed to generate any list of failures or flakies and returned an error code.'))
 
         # Check the same for the step without_change_repeat_failures
         if not without_change_repeat_failures_results_nonflaky_failures and not without_change_repeat_failures_results_flakies:
             without_change_repeat_failures_retcode = self.getProperty('without_change_repeat_failures_retcode', FAILURE)
             if without_change_repeat_failures_retcode not in [SUCCESS, WARNINGS]:
-                return self.report_infrastructure_issue_and_maybe_retry_build('The step "layout-tests-repeat-failures-without-change" failed to generate any list of failures or flakies and returned an error code.')
+                return defer.returnValue(self.report_infrastructure_issue_and_maybe_retry_build('The step "layout-tests-repeat-failures-without-change" failed to generate any list of failures or flakies and returned an error code.'))
 
         # Warn EWS bot watchers about flakies so they can garden those. Include the step where the flaky was found in the e-mail to know if it was found with change or without it.
         # Due to the way this class works most of the flakies are filtered on the step with change even when those were pre-existent issues (so this is also useful for bot watchers).
@@ -4348,9 +4355,10 @@ class AnalyzeLayoutTestsResultsRedTree(AnalyzeLayoutTestsResults):
         # Finally check if there are new consistent (non-flaky) failures caused by the change and warn the change author stetting the status for the build.
         new_non_flaky_failures = with_change_repeat_failures_results_nonflaky_failures - without_change_repeat_failures_results_nonflaky_failures.union(without_change_repeat_failures_results_flakies)
         if new_non_flaky_failures:
-            return self.report_failure(new_non_flaky_failures, first_results_exceed_failure_limit)
+            rc = yield self.report_failure(new_non_flaky_failures, first_results_exceed_failure_limit)
+            return defer.returnValue(rc)
 
-        return self.report_success()
+        return defer.returnValue(self.report_success())
 
 
 class ArchiveBuiltProduct(shell.ShellCommand):


### PR DESCRIPTION
#### f80c4133ba61ea386ed66e9964d12fa3de84ff26
<pre>
[ews-build.webkit.org] Convert AnalyzeLayoutTestsResults to new-style
<a href="https://bugs.webkit.org/show_bug.cgi?id=251736">https://bugs.webkit.org/show_bug.cgi?id=251736</a>
rdar://105041006

Reviewed by Aakash Jain.

* Tools/CISupport/ews-build/steps.py:
(AnalyzeLayoutTestsResults.report_failure): Return deferred value since
_addToLog is asynchronous.
(AnalyzeLayoutTestsResults.report_pre_existing_failures): Return exit code.
(AnalyzeLayoutTestsResults.retry_build): Ditto.
(AnalyzeLayoutTestsResults.send_email_for_new_test_failures): Ditto.
(AnalyzeLayoutTestsResults.run): Renamed from start.
(AnalyzeLayoutTestsResults.start): Renamed to run.
(AnalyzeLayoutTestsResultsRedTree.report_success): Return exit code.
(AnalyzeLayoutTestsResultsRedTree.report_warning): Ditto.
(AnalyzeLayoutTestsResultsRedTree.run):Renamed from start.
(AnalyzeLayoutTestsResultsRedTree.start): Renamed to run.

Canonical link: <a href="https://commits.webkit.org/262104@main">https://commits.webkit.org/262104@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbbdde5801c7cf105c76a884305c9bc7c869c71d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106185 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15237 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39020 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115369 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115056 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110091 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16677 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6459 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111945 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12692 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95664 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98390 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94566 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27307 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40226 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8483 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28659 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81909 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8984 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5242 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/104994 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14600 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48205 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10520 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/68 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->