### PR TITLE
HTMLFrameOwnerElement::getSVGDocument should return null rather than throwing

### DIFF
--- a/LayoutTests/fast/dom/getSVGDocument-on-object-crash-expected.txt
+++ b/LayoutTests/fast/dom/getSVGDocument-on-object-crash-expected.txt
@@ -1,2 +1,1 @@
-CONSOLE MESSAGE: NotSupportedError: The operation is not supported.
 PASS if no crash.

--- a/LayoutTests/svg/custom/getsvgdocument-null-expected.txt
+++ b/LayoutTests/svg/custom/getsvgdocument-null-expected.txt
@@ -1,0 +1,12 @@
+This tests that 'getSVGDocument' returns null on elements that don't contain SVG documents.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS document.createElement('object').getSVGDocument() is null
+PASS document.createElement('iframe').getSVGDocument() is null
+PASS document.createElement('embed').getSVGDocument() is null
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/svg/custom/getsvgdocument-null.html
+++ b/LayoutTests/svg/custom/getsvgdocument-null.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="../../resources/js-test.js"></script>
+</head>
+<body>
+    <script>
+        description("This tests that 'getSVGDocument' returns null on elements that don't contain SVG documents.");
+
+        var types = ['object', 'iframe', 'embed'];
+
+        types.forEach(function(type) {
+            shouldBeNull("document.createElement('" + type + "').getSVGDocument()");
+        });
+    </script>
+</body>
+</html>

--- a/Source/WebCore/html/HTMLFrameOwnerElement.cpp
+++ b/Source/WebCore/html/HTMLFrameOwnerElement.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2006-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2013 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -110,13 +111,12 @@ bool HTMLFrameOwnerElement::isKeyboardFocusable(KeyboardEvent* event) const
     return m_contentFrame && HTMLElement::isKeyboardFocusable(event);
 }
 
-ExceptionOr<Document&> HTMLFrameOwnerElement::getSVGDocument() const
+Document* HTMLFrameOwnerElement::getSVGDocument() const
 {
     auto* document = contentDocument();
     if (is<SVGDocument>(document))
-        return *document;
-    // Spec: http://www.w3.org/TR/SVG/struct.html#InterfaceGetSVGDocument
-    return Exception { NotSupportedError };
+        return document;
+    return nullptr;
 }
 
 void HTMLFrameOwnerElement::scheduleInvalidateStyleAndLayerComposition()

--- a/Source/WebCore/html/HTMLFrameOwnerElement.h
+++ b/Source/WebCore/html/HTMLFrameOwnerElement.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2006-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2013 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -50,7 +51,7 @@ public:
     // RenderElement when using fallback content.
     RenderWidget* renderWidget() const;
 
-    ExceptionOr<Document&> getSVGDocument() const;
+    Document* getSVGDocument() const;
 
     virtual ScrollbarMode scrollingMode() const { return ScrollbarMode::Auto; }
 


### PR DESCRIPTION
#### 47f7b571335b97a026780cede91b9232efbbbd44
<pre>
HTMLFrameOwnerElement::getSVGDocument should return null rather than throwing

HTMLFrameOwnerElement::getSVGDocument should return null rather than throwing
<a href="https://bugs.webkit.org/show_bug.cgi?id=250758">https://bugs.webkit.org/show_bug.cgi?id=250758</a>
rdar://problem/104641450

Reviewed by Ryosuke Niwa.

This patch is to align WebKit with Gecko / Firefox and Blink / Chromium.

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/cf7eb89e462b4f8b003025cab9c99a6770ef6c44">https://chromium.googlesource.com/chromium/blink/+/cf7eb89e462b4f8b003025cab9c99a6770ef6c44</a>

If the element&apos;s &apos;contentDocument&apos; is not an SVG document (or does not exist) we currently
throw a NotSupportedError exception. This matches neither the spec[1] nor Firefox&apos;s /
Chrome&apos;s implementation.

This patch drops the exception and matches WebKit with other browser engines.

[1] <a href="https://www.w3.org/TR/SVG/struct.html#InterfaceGetSVGDocument">https://www.w3.org/TR/SVG/struct.html#InterfaceGetSVGDocument</a>

* Source/WebCore/html/HTMLFrameOwnerElement.cpp:
(HTMLFrameOwnerElement::getSVGDocument): Remove &apos;Exception&apos; from function and also return &apos;nullptr&apos; rather than &apos;exception&apos;
* Source/WebCore/html/HTMLFrameOwnerElement.h: Remove &apos;Exception&apos; from &apos;getSVGDocument&apos; function
* LayoutTests/svg/custom/getsvgdocument-null.html: Add Test Case
* LayoutTests/svg/custom/getsvgdocument-null-expected.txt: Add Test Case Expectation
* LayoutTests/fast/dom/getSVGDocument-on-object-crash-expected.txt: Remove &apos;Console&apos; message

Canonical link: <a href="https://commits.webkit.org/259905@main">https://commits.webkit.org/259905@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5e52740e6930ba13c59807c55ab5381d87690e1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106217 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15269 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39053 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115405 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175508 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110125 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16711 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6482 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98423 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115091 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111978 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12716 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95690 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40258 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94590 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27333 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81945 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8513 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28685 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9019 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5256 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14634 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48231 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6844 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10555 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->