### PR TITLE
Shrink StyleRule by reducing padding and moving CSS Nesting fields to a rare data object

### DIFF
--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -55,6 +55,7 @@ struct SameSizeAsStyleRuleBase : public WTF::RefCountedBase {
 static_assert(sizeof(StyleRuleBase) == sizeof(SameSizeAsStyleRuleBase), "StyleRuleBase should stay small");
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleRuleBase);
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleRuleRareData);
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleRule);
 
 Ref<CSSRule> StyleRuleBase::createCSSOMWrapper(CSSStyleSheet& parentSheet) const
@@ -211,6 +212,13 @@ Ref<CSSRule> StyleRuleBase::createCSSOMWrapper(CSSStyleSheet* parentSheet, CSSRu
     return wrapper;
 }
 
+std::unique_ptr<StyleRuleRareData> StyleRuleRareData::createIfNeeded(Vector<Ref<StyleRuleBase>> nestedRules, CSSSelectorList resolvedSelectorList)
+{
+    if (nestedRules.isEmpty() && resolvedSelectorList.isEmpty())
+        return nullptr;
+    return makeUnique<StyleRuleRareData>(StyleRuleRareData { WTFMove(nestedRules), WTFMove(resolvedSelectorList) });
+}
+
 unsigned StyleRule::averageSizeInBytes()
 {
     return sizeof(StyleRule) + sizeof(CSSSelector) + StyleProperties::averageSizeInBytes() + sizeof(Vector<Ref<StyleRuleBase>>);
@@ -220,7 +228,7 @@ StyleRule::StyleRule(Ref<StyleProperties>&& properties, bool hasDocumentSecurity
     : StyleRuleBase(StyleRuleType::Style, hasDocumentSecurityOrigin)
     , m_properties(WTFMove(properties))
     , m_selectorList(WTFMove(selectors))
-    , m_nestedRules(WTFMove(nestedRules))
+    , m_rareData(!nestedRules.isEmpty() ? StyleRuleRareData::createIfNeeded(WTFMove(nestedRules)) : nullptr)
 {
 }
 
@@ -233,12 +241,11 @@ StyleRule::StyleRule(bool hasDocumentSecurityOrigin, CSSSelectorList&& selectors
 
 StyleRule::StyleRule(const StyleRule& o)
     : StyleRuleBase(o)
-    , m_properties(o.properties().mutableCopy())
-    , m_selectorList(o.m_selectorList)
-    , m_resolvedSelectorList(o.m_resolvedSelectorList)
-    , m_nestedRules(o.m_nestedRules)
     , m_isSplitRule(o.m_isSplitRule)
     , m_isLastRuleInSplitRule(o.m_isLastRuleInSplitRule)
+    , m_properties(o.properties().mutableCopy())
+    , m_selectorList(o.m_selectorList)
+    , m_rareData(o.m_rareData ? StyleRuleRareData::createIfNeeded(o.m_rareData->nestedRules, o.m_rareData->resolvedSelectorList) : nullptr)
 {
 }
 
@@ -310,6 +317,44 @@ Vector<RefPtr<StyleRule>> StyleRule::splitIntoMultipleRulesWithMaximumSelectorCo
         rules.last()->markAsLastRuleInSplitRule();
 
     return rules;
+}
+
+StyleRuleRareData& StyleRule::rareData() const
+{
+    if (!m_rareData)
+        m_rareData = makeUnique<StyleRuleRareData>();
+    return *m_rareData;
+}
+
+void StyleRule::setNestedRules(Vector<Ref<StyleRuleBase>> nestedRules)
+{
+    if (!m_rareData && nestedRules.isEmpty())
+        return;
+    rareData().nestedRules = WTFMove(nestedRules);
+}
+
+void StyleRule::setResolvedSelectorList(CSSSelectorList&& resolvedSelectorList) const
+{
+    if (!m_rareData && resolvedSelectorList.isEmpty())
+        return;
+    rareData().resolvedSelectorList = WTFMove(resolvedSelectorList);
+}
+
+static const Vector<Ref<StyleRuleBase>>& emptyRuleVector()
+{
+    static LazyNeverDestroyed<Vector<Ref<StyleRuleBase>>> emptyRuleVector;
+    static std::once_flag onceFlag;
+    std::call_once(onceFlag, [] {
+        emptyRuleVector.construct();
+    });
+    return emptyRuleVector;
+}
+
+const Vector<Ref<StyleRuleBase>>& StyleRule::nestedRules() const
+{
+    if (!m_rareData)
+        return emptyRuleVector();
+    return m_rareData->nestedRules;
 }
 
 StyleRulePage::StyleRulePage(Ref<StyleProperties>&& properties, CSSSelectorList&& selectors)


### PR DESCRIPTION
#### aea4f3f29a7c8f7dbf76e52647c30b6cfc4cc464
<pre>
Shrink StyleRule by reducing padding and moving CSS Nesting fields to a rare data object
<a href="https://bugs.webkit.org/show_bug.cgi?id=251744">https://bugs.webkit.org/show_bug.cgi?id=251744</a>
rdar://105046580

Reviewed by Simon Fraser.

This reduces StyleRule from 64 to 40 bytes.

* Source/WebCore/css/StyleRule.cpp:
(WebCore::StyleRuleRareData::createIfNeeded):
(WebCore::StyleRule::StyleRule):
(WebCore::StyleRule::rareData const):
(WebCore::StyleRule::setNestedRules):
(WebCore::StyleRule::setResolvedSelectorList const):
(WebCore::emptyRuleVector):
(WebCore::StyleRule::nestedRules const):
* Source/WebCore/css/StyleRule.h:
(WebCore::StyleRuleRareData::createIfNeeded):

Canonical link: <a href="https://commits.webkit.org/259875@main">https://commits.webkit.org/259875@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97abf3a4b279edc2113a6a885d6fcb14f19c1bba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106269 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15323 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39108 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115462 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175566 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110179 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16765 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6539 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98485 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115145 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112033 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12759 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95733 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40308 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94634 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27376 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81998 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8563 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28728 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9073 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5297 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14686 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48274 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10609 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3676 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->