### PR TITLE
Web Inspector: Show grid/flex overlays when in element selection

### DIFF
--- a/LayoutTests/inspector/dom/showFlexOverlay.html
+++ b/LayoutTests/inspector/dom/showFlexOverlay.html
@@ -142,7 +142,7 @@ function test()
 
             InspectorTest.log("Requesting to show flex overlay for invalid nodeId -1");
             await InspectorTest.expectException(async () => {
-                await DOMAgent.showFlexOverlay(-1, WI.Color.fromString("magenta").toProtocol());
+                await DOMAgent.showFlexOverlay(-1, { flexColor: WI.Color.fromString("magenta").toProtocol() });
             });
 
         await checkFlexOverlayCount(0);

--- a/LayoutTests/inspector/dom/showGridOverlay.html
+++ b/LayoutTests/inspector/dom/showGridOverlay.html
@@ -142,7 +142,7 @@ function test()
 
             InspectorTest.log("Requesting to show grid overlay for invalid nodeId -1");
             await InspectorTest.expectException(async () => {
-                await DOMAgent.showGridOverlay(-1, WI.Color.fromString("magenta").toProtocol());
+                await DOMAgent.showGridOverlay(-1, { gridColor: WI.Color.fromString("magenta").toProtocol() });
             });
 
         await checkGridOverlayCount(0);

--- a/Source/JavaScriptCore/inspector/protocol/DOM.json
+++ b/Source/JavaScriptCore/inspector/protocol/DOM.json
@@ -170,6 +170,28 @@
             ]
         },
         {
+            "id": "GridOverlayConfig",
+            "type": "object",
+            "description": "Configuration data for grid overlays.",
+            "properties": [
+                { "name": "gridColor", "$ref": "RGBAColor", "description": "The primary color to use for the grid overlay." },
+                { "name": "showLineNames", "type": "boolean", "optional": true, "description": "Show labels for grid line names. If not specified, the default value is false." },
+                { "name": "showLineNumbers", "type": "boolean", "optional": true, "description": "Show labels for grid line numbers. If not specified, the default value is false." },
+                { "name": "showExtendedGridLines", "type": "boolean", "optional": true, "description": "Show grid lines that extend beyond the bounds of the grid. If not specified, the default value is false." },
+                { "name": "showTrackSizes", "type": "boolean", "optional": true, "description": "Show grid track size information. If not specified, the default value is false." },
+                { "name": "showAreaNames", "type": "boolean", "optional": true, "description": "Show labels for grid area names. If not specified, the default value is false." }
+            ]
+        },
+        {
+            "id": "FlexOverlayConfig",
+            "type": "object",
+            "description": "Configuration data for flex overlays.",
+            "properties": [
+                { "name": "flexColor", "$ref": "RGBAColor", "description": "The primary color to use for the flex overlay." },
+                { "name": "showOrderNumbers", "type": "boolean", "optional": true, "description": "Show labels for flex order. If not specified, the default value is false." }
+            ]
+        },
+        {
             "id": "Styleable",
             "type": "object",
             "properties": [
@@ -425,7 +447,9 @@
             "condition": "defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY",
             "parameters": [
                 { "name": "enabled", "type": "boolean", "description": "True to enable inspection mode, false to disable it." },
-                { "name": "highlightConfig", "$ref": "HighlightConfig", "optional": true, "description": "A descriptor for the highlight appearance of hovered-over nodes. May be omitted if <code>enabled == false</code>." }
+                { "name": "highlightConfig", "$ref": "HighlightConfig", "optional": true, "description": "A descriptor for the highlight appearance of hovered-over nodes. May be omitted if <code>enabled == false</code>." },
+                { "name": "gridOverlayConfig", "$ref": "GridOverlayConfig", "optional": true, "description": "If provided, used to configure a grid overlay shown during element selection. This overrides DOM.showGridOverlay." },
+                { "name": "flexOverlayConfig", "$ref": "FlexOverlayConfig", "optional": true, "description": "If provided, used to configure a flex overlay shown during element selection. This overrides DOM.showFlexOverlay." }
             ]
         },
         {
@@ -435,6 +459,8 @@
             "parameters": [
                 { "name": "enabled", "type": "boolean", "description": "True to enable inspection mode, false to disable it." },
                 { "name": "highlightConfig", "$ref": "HighlightConfig", "optional": true, "description": "A descriptor for the highlight appearance of hovered-over nodes. May be omitted if <code>enabled == false</code>." },
+                { "name": "gridOverlayConfig", "$ref": "GridOverlayConfig", "optional": true, "description": "If provided, used to configure a grid overlay shown during element selection. This overrides DOM.showGridOverlay." },
+                { "name": "flexOverlayConfig", "$ref": "FlexOverlayConfig", "optional": true, "description": "If provided, used to configure a flex overlay shown during element selection. This overrides DOM.showFlexOverlay." },
                 { "name": "showRulers", "type": "boolean", "optional": true, "description": "Whether the rulers should be shown during element selection. This overrides Page.setShowRulers." }
             ]
         },
@@ -510,12 +536,7 @@
             "targetTypes": ["page"],
             "parameters": [
                 { "name": "nodeId", "$ref": "NodeId", "description": "The node for which a grid overlay should be shown." },
-                { "name": "gridColor", "$ref": "RGBAColor", "description": "The primary color to use for the grid overlay." },
-                { "name": "showLineNames", "type": "boolean", "optional": true, "description": "Show labels for grid line names. If not specified, the default value is false." },
-                { "name": "showLineNumbers", "type": "boolean", "optional": true, "description": "Show labels for grid line numbers. If not specified, the default value is false." },
-                { "name": "showExtendedGridLines", "type": "boolean", "optional": true, "description": "Show grid lines that extend beyond the bounds of the grid. If not specified, the default value is false." },
-                { "name": "showTrackSizes", "type": "boolean", "optional": true, "description": "Show grid track size information. If not specified, the default value is false." },
-                { "name": "showAreaNames", "type": "boolean", "optional": true, "description": "Show labels for grid area names. If not specified, the default value is false." }
+                { "name": "gridOverlayConfig", "$ref": "GridOverlayConfig", "description": "Configuration options for the grid overlay." }
             ]
         },
         {
@@ -532,8 +553,7 @@
             "targetTypes": ["page"],
             "parameters": [
                 { "name": "nodeId", "$ref": "NodeId", "description": "The node for which a flex overlay should be shown." },
-                { "name": "flexColor", "$ref": "RGBAColor", "description": "The primary color to use for the flex overlay." },
-                { "name": "showOrderNumbers", "type": "boolean", "optional": true, "description": "Show labels for flex order. If not specified, the default value is false." }
+                { "name": "flexOverlayConfig", "$ref": "FlexOverlayConfig", "description": "Configuration options for the flex overlay." }
             ]
         },
         {

--- a/Source/JavaScriptCore/inspector/scripts/codegen/generator.py
+++ b/Source/JavaScriptCore/inspector/scripts/codegen/generator.py
@@ -85,6 +85,8 @@ _TYPES_WITH_OPEN_FIELDS = {
     "Timeline.TimelineEvent": [],
     "CSS.CSSProperty": ["priority", "parsedOk", "status"],
     "DOM.HighlightConfig": [],
+    "DOM.GridOverlayConfig": [],
+    "DOM.FlexOverlayConfig": [],
     "DOM.RGBAColor": [],
     "DOMStorage.StorageId": [],
     "Debugger.BreakpointAction": [],

--- a/Source/WebCore/inspector/InspectorOverlay.h
+++ b/Source/WebCore/inspector/InspectorOverlay.h
@@ -222,10 +222,15 @@ public:
 
     // Multiple grid and flex overlays can be active at the same time. These methods
     // will fail if the node is not a grid or if the node has been GC'd.
+
+    void showHighlightGridOverlayForNode(Node&, const InspectorOverlay::Grid::Config&);
+    void hideHighlightGridOverlay();
     Inspector::ErrorStringOr<void> setGridOverlayForNode(Node&, const InspectorOverlay::Grid::Config&);
     Inspector::ErrorStringOr<void> clearGridOverlayForNode(Node&);
     void clearAllGridOverlays();
 
+    void showHighlightFlexOverlayForNode(Node&, const InspectorOverlay::Flex::Config&);
+    void hideHighlightFlexOverlay();
     Inspector::ErrorStringOr<void> setFlexOverlayForNode(Node&, const InspectorOverlay::Flex::Config&);
     Inspector::ErrorStringOr<void> clearFlexOverlayForNode(Node&);
     void clearAllFlexOverlays();
@@ -269,7 +274,10 @@ private:
     Deque<TimeRectPair> m_paintRects;
     Timer m_paintRectUpdateTimer;
 
+    std::optional<InspectorOverlay::Grid> m_highlightGridOverlay;
     Vector<InspectorOverlay::Grid> m_activeGridOverlays;
+
+    std::optional<InspectorOverlay::Flex> m_highlightFlexOverlay;
     Vector<InspectorOverlay::Flex> m_activeFlexOverlays;
 
     bool m_indicating { false };

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -151,9 +151,14 @@ static std::optional<Color> parseColor(RefPtr<JSON::Object>&& colorObject)
     return { makeFromComponentsClampingExceptAlpha<SRGBA<uint8_t>>(*r, *g, *b, convertFloatAlphaTo<uint8_t>(*a)) };
 }
 
-static Color parseConfigColor(const String& fieldName, JSON::Object& configObject)
+static std::optional<Color> parseRequiredConfigColor(const String& fieldName, JSON::Object& configObject)
 {
-    return parseColor(configObject.getObject(fieldName)).value_or(Color::transparentBlack);
+    return parseColor(configObject.getObject(fieldName));
+}
+
+static Color parseOptionalConfigColor(const String& fieldName, JSON::Object& configObject)
+{
+    return parseRequiredConfigColor(fieldName, configObject).value_or(Color::transparentBlack);
 }
 
 static bool parseQuad(Ref<JSON::Array>&& quadArray, FloatQuad* quad)
@@ -329,10 +334,13 @@ void InspectorDOMAgent::willDestroyFrontendAndBackend(Inspector::DisconnectReaso
     m_inspectedNode = nullptr;
 
     Protocol::ErrorString ignored;
-    setSearchingForNode(ignored, false, nullptr, false);
+    setSearchingForNode(ignored, false, nullptr, nullptr, nullptr, false);
     hideHighlight();
 
+    m_overlay->hideHighlightGridOverlay();
     m_overlay->clearAllGridOverlays();
+
+    m_overlay->hideHighlightFlexOverlay();
     m_overlay->clearAllFlexOverlays();
 
     m_instrumentingAgents.setPersistentDOMAgent(nullptr);
@@ -1198,11 +1206,29 @@ bool InspectorDOMAgent::handleTouchEvent(Node& node)
 {
     if (!m_searchingForNode)
         return false;
+
+    bool shouldInspect = false;
+
     if (m_inspectModeHighlightConfig) {
         m_overlay->highlightNode(&node, *m_inspectModeHighlightConfig);
+        shouldInspect = true;
+    }
+
+    if (m_inspectModeGridOverlayConfig) {
+        m_overlay->showHighlightGridOverlayForNode(node, *m_inspectModeGridOverlayConfig);
+        shouldInspect = true;
+    }
+
+    if (m_inspectModeFlexOverlayConfig) {
+        m_overlay->showHighlightFlexOverlayForNode(node, *m_inspectModeFlexOverlayConfig);
+        shouldInspect = true;
+    }
+
+    if (shouldInspect) {
         inspect(&node);
         return true;
     }
+
     return false;
 }
 
@@ -1210,7 +1236,7 @@ void InspectorDOMAgent::inspect(Node* inspectedNode)
 {
     Protocol::ErrorString ignored;
     RefPtr<Node> node = inspectedNode;
-    setSearchingForNode(ignored, false, nullptr, false);
+    setSearchingForNode(ignored, false, nullptr, nullptr, nullptr, false);
 
     if (!node->isElementNode() && !node->isDocumentNode())
         node = node->parentNode();
@@ -1257,11 +1283,18 @@ void InspectorDOMAgent::highlightMousedOverNode()
     Node* node = m_mousedOverNode.get();
     if (node && node->isTextNode())
         node = node->parentNode();
-    if (node && m_inspectModeHighlightConfig)
+    if (!node)
+        return;
+
+    if (m_inspectModeHighlightConfig)
         m_overlay->highlightNode(node, *m_inspectModeHighlightConfig);
+    if (m_inspectModeGridOverlayConfig)
+        m_overlay->showHighlightGridOverlayForNode(*node, *m_inspectModeGridOverlayConfig);
+    if (m_inspectModeFlexOverlayConfig)
+        m_overlay->showHighlightFlexOverlayForNode(*node, *m_inspectModeFlexOverlayConfig);
 }
 
-void InspectorDOMAgent::setSearchingForNode(Protocol::ErrorString& errorString, bool enabled, RefPtr<JSON::Object>&& highlightInspectorObject, bool showRulers)
+void InspectorDOMAgent::setSearchingForNode(Protocol::ErrorString& errorString, bool enabled, RefPtr<JSON::Object>&& highlightInspectorObject, RefPtr<JSON::Object>&& gridOverlayInspectorObject, RefPtr<JSON::Object>&& flexOverlayInspectorObject, bool showRulers)
 {
     if (m_searchingForNode == enabled)
         return;
@@ -1274,9 +1307,27 @@ void InspectorDOMAgent::setSearchingForNode(Protocol::ErrorString& errorString, 
         m_inspectModeHighlightConfig = highlightConfigFromInspectorObject(errorString, WTFMove(highlightInspectorObject));
         if (!m_inspectModeHighlightConfig)
             return;
+
+        if (gridOverlayInspectorObject) {
+            m_inspectModeGridOverlayConfig = gridOverlayConfigFromInspectorObject(errorString, gridOverlayInspectorObject.releaseNonNull());
+            if (!m_inspectModeGridOverlayConfig)
+                return;
+        } else
+            m_inspectModeGridOverlayConfig = std::nullopt;
+
+        if (flexOverlayInspectorObject) {
+            m_inspectModeFlexOverlayConfig = flexOverlayConfigFromInspectorObject(errorString, flexOverlayInspectorObject.releaseNonNull());
+            if (!m_inspectModeFlexOverlayConfig)
+                return;
+        } else
+            m_inspectModeFlexOverlayConfig = std::nullopt;
+
         highlightMousedOverNode();
-    } else
+    } else {
         hideHighlight();
+        m_overlay->hideHighlightGridOverlay();
+        m_overlay->hideHighlightFlexOverlay();
+    }
 
     m_overlay->didSetSearchingForNode(m_searchingForNode);
 
@@ -1293,19 +1344,51 @@ std::unique_ptr<InspectorOverlay::Highlight::Config> InspectorDOMAgent::highligh
 
     auto highlightConfig = makeUnique<InspectorOverlay::Highlight::Config>();
     highlightConfig->showInfo = highlightInspectorObject->getBoolean(Protocol::DOM::HighlightConfig::showInfoKey).value_or(false);
-    highlightConfig->content = parseConfigColor(Protocol::DOM::HighlightConfig::contentColorKey, *highlightInspectorObject);
-    highlightConfig->padding = parseConfigColor(Protocol::DOM::HighlightConfig::paddingColorKey, *highlightInspectorObject);
-    highlightConfig->border = parseConfigColor(Protocol::DOM::HighlightConfig::borderColorKey, *highlightInspectorObject);
-    highlightConfig->margin = parseConfigColor(Protocol::DOM::HighlightConfig::marginColorKey, *highlightInspectorObject);
+    highlightConfig->content = parseOptionalConfigColor(Protocol::DOM::HighlightConfig::contentColorKey, *highlightInspectorObject);
+    highlightConfig->padding = parseOptionalConfigColor(Protocol::DOM::HighlightConfig::paddingColorKey, *highlightInspectorObject);
+    highlightConfig->border = parseOptionalConfigColor(Protocol::DOM::HighlightConfig::borderColorKey, *highlightInspectorObject);
+    highlightConfig->margin = parseOptionalConfigColor(Protocol::DOM::HighlightConfig::marginColorKey, *highlightInspectorObject);
     return highlightConfig;
 }
 
+std::optional<InspectorOverlay::Grid::Config> InspectorDOMAgent::gridOverlayConfigFromInspectorObject(Inspector::Protocol::ErrorString& errorString, Ref<JSON::Object>&& gridOverlayInspectorObject)
+{
+    auto gridColor = parseRequiredConfigColor(Protocol::DOM::GridOverlayConfig::gridColorKey, gridOverlayInspectorObject);
+    if (!gridColor) {
+        errorString = "Internal error: grid color property of grid overlay configuration parameter is missing"_s;
+        return std::nullopt;
+    }
+
+    InspectorOverlay::Grid::Config gridOverlayConfig;
+    gridOverlayConfig.gridColor = *gridColor;
+    gridOverlayConfig.showLineNames = gridOverlayInspectorObject->getBoolean(Protocol::DOM::GridOverlayConfig::showLineNamesKey).value_or(false);
+    gridOverlayConfig.showLineNumbers = gridOverlayInspectorObject->getBoolean(Protocol::DOM::GridOverlayConfig::showLineNumbersKey).value_or(false);
+    gridOverlayConfig.showExtendedGridLines = gridOverlayInspectorObject->getBoolean(Protocol::DOM::GridOverlayConfig::showExtendedGridLinesKey).value_or(false);
+    gridOverlayConfig.showTrackSizes = gridOverlayInspectorObject->getBoolean(Protocol::DOM::GridOverlayConfig::showTrackSizesKey).value_or(false);
+    gridOverlayConfig.showAreaNames = gridOverlayInspectorObject->getBoolean(Protocol::DOM::GridOverlayConfig::showAreaNamesKey).value_or(false);
+    return gridOverlayConfig;
+}
+
+std::optional<InspectorOverlay::Flex::Config> InspectorDOMAgent::flexOverlayConfigFromInspectorObject(Inspector::Protocol::ErrorString& errorString, Ref<JSON::Object>&& flexOverlayInspectorObject)
+{
+    auto flexColor = parseRequiredConfigColor(Protocol::DOM::FlexOverlayConfig::flexColorKey, flexOverlayInspectorObject);
+    if (!flexColor) {
+        errorString = "Internal error: flex color property of flex overlay configuration parameter is missing"_s;
+        return std::nullopt;
+    }
+
+    InspectorOverlay::Flex::Config flexOverlayConfig;
+    flexOverlayConfig.flexColor = *flexColor;
+    flexOverlayConfig.showOrderNumbers = flexOverlayInspectorObject->getBoolean(Protocol::DOM::FlexOverlayConfig::showOrderNumbersKey).value_or(false);
+    return flexOverlayConfig;
+}
+
 #if PLATFORM(IOS_FAMILY)
-Protocol::ErrorStringOr<void> InspectorDOMAgent::setInspectModeEnabled(bool enabled, RefPtr<JSON::Object>&& highlightConfig)
+Protocol::ErrorStringOr<void> InspectorDOMAgent::setInspectModeEnabled(bool enabled, RefPtr<JSON::Object>&& highlightConfig, RefPtr<JSON::Object>&& gridOverlayConfig, RefPtr<JSON::Object>&& flexOverlayConfig)
 {
     Protocol::ErrorString errorString;
 
-    setSearchingForNode(errorString, enabled, WTFMove(highlightConfig), false);
+    setSearchingForNode(errorString, enabled, WTFMove(highlightConfig), WTFMove(gridOverlayConfig), WTFMove(flexOverlayConfig), false);
 
     if (!!errorString)
         return makeUnexpected(errorString);
@@ -1313,11 +1396,11 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::setInspectModeEnabled(bool enab
     return { };
 }
 #else
-Protocol::ErrorStringOr<void> InspectorDOMAgent::setInspectModeEnabled(bool enabled, RefPtr<JSON::Object>&& highlightConfig, std::optional<bool>&& showRulers)
+Protocol::ErrorStringOr<void> InspectorDOMAgent::setInspectModeEnabled(bool enabled, RefPtr<JSON::Object>&& highlightConfig, RefPtr<JSON::Object>&& gridOverlayConfig, RefPtr<JSON::Object>&& flexOverlayConfig, std::optional<bool>&& showRulers)
 {
     Protocol::ErrorString errorString;
 
-    setSearchingForNode(errorString, enabled, WTFMove(highlightConfig), showRulers && *showRulers);
+    setSearchingForNode(errorString, enabled, WTFMove(highlightConfig), WTFMove(gridOverlayConfig), WTFMove(flexOverlayConfig), showRulers && *showRulers);
 
     if (!!errorString)
         return makeUnexpected(errorString);
@@ -1530,26 +1613,18 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::hideHighlight()
     return { };
 }
 
-Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::showGridOverlay(Inspector::Protocol::DOM::NodeId nodeId,  Ref<JSON::Object>&& gridColor, std::optional<bool>&& showLineNames, std::optional<bool>&& showLineNumbers, std::optional<bool>&& showExtendedGridLines, std::optional<bool>&& showTrackSizes, std::optional<bool>&& showAreaNames)
+Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::showGridOverlay(Inspector::Protocol::DOM::NodeId nodeId,  Ref<JSON::Object>&& gridOverlayInspectorObject)
 {
     Protocol::ErrorString errorString;
     Node* node = assertNode(errorString, nodeId);
     if (!node)
         return makeUnexpected(errorString);
 
-    auto parsedColor = parseColor(WTFMove(gridColor));
-    if (!parsedColor)
-        return makeUnexpected("Invalid color could not be parsed."_s);
+    auto config = gridOverlayConfigFromInspectorObject(errorString, WTFMove(gridOverlayInspectorObject));
+    if (!config)
+        return makeUnexpected(errorString);
 
-    InspectorOverlay::Grid::Config config;
-    config.gridColor = *parsedColor;
-    config.showLineNames = showLineNames.value_or(false);
-    config.showLineNumbers = showLineNumbers.value_or(false);
-    config.showExtendedGridLines = showExtendedGridLines.value_or(false);
-    config.showTrackSizes = showTrackSizes.value_or(false);
-    config.showAreaNames = showAreaNames.value_or(false);
-
-    m_overlay->setGridOverlayForNode(*node, config);
+    m_overlay->setGridOverlayForNode(*node, *config);
 
     return { };
 }
@@ -1570,22 +1645,18 @@ Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::hideGridOverlay(std:
     return { };
 }
 
-Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::showFlexOverlay(Inspector::Protocol::DOM::NodeId nodeId, Ref<JSON::Object>&& flexColor, std::optional<bool>&& showOrderNumbers)
+Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::showFlexOverlay(Inspector::Protocol::DOM::NodeId nodeId, Ref<JSON::Object>&& flexOverlayInspectorObject)
 {
     Protocol::ErrorString errorString;
     Node* node = assertNode(errorString, nodeId);
     if (!node)
         return makeUnexpected(errorString);
 
-    auto parsedColor = parseColor(WTFMove(flexColor));
-    if (!parsedColor)
-        return makeUnexpected("Invalid color could not be parsed."_s);
+    auto config = flexOverlayConfigFromInspectorObject(errorString, WTFMove(flexOverlayInspectorObject));
+    if (!config)
+        return makeUnexpected(errorString);
 
-    InspectorOverlay::Flex::Config config;
-    config.flexColor = *parsedColor;
-    config.showOrderNumbers = showOrderNumbers.value_or(false);
-
-    m_overlay->setFlexOverlayForNode(*node, config);
+    m_overlay->setFlexOverlayForNode(*node, *config);
 
     return { };
 }

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.h
@@ -135,9 +135,9 @@ public:
     Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::Runtime::RemoteObject>> resolveNode(Inspector::Protocol::DOM::NodeId, const String& objectGroup);
     Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<String>>> getAttributes(Inspector::Protocol::DOM::NodeId);
 #if PLATFORM(IOS_FAMILY)
-    Inspector::Protocol::ErrorStringOr<void> setInspectModeEnabled(bool, RefPtr<JSON::Object>&& highlightConfig);
+    Inspector::Protocol::ErrorStringOr<void> setInspectModeEnabled(bool, RefPtr<JSON::Object>&& highlightConfig, RefPtr<JSON::Object>&& gridOverlayConfig, RefPtr<JSON::Object>&& flexOverlayConfig);
 #else
-    Inspector::Protocol::ErrorStringOr<void> setInspectModeEnabled(bool, RefPtr<JSON::Object>&& highlightConfig, std::optional<bool>&& showRulers);
+    Inspector::Protocol::ErrorStringOr<void> setInspectModeEnabled(bool, RefPtr<JSON::Object>&& highlightConfig, RefPtr<JSON::Object>&& gridOverlayConfig, RefPtr<JSON::Object>&& flexOverlayConfig, std::optional<bool>&& showRulers);
 #endif
     Inspector::Protocol::ErrorStringOr<Inspector::Protocol::DOM::NodeId> requestNode(const Inspector::Protocol::Runtime::RemoteObjectId&);
     Inspector::Protocol::ErrorStringOr<Inspector::Protocol::DOM::NodeId> pushNodeByPathToFrontend(const String& path);
@@ -148,9 +148,9 @@ public:
     Inspector::Protocol::ErrorStringOr<void> highlightNode(Ref<JSON::Object>&& highlightConfig, std::optional<Inspector::Protocol::DOM::NodeId>&&, const Inspector::Protocol::Runtime::RemoteObjectId&);
     Inspector::Protocol::ErrorStringOr<void> highlightNodeList(Ref<JSON::Array>&& nodeIds, Ref<JSON::Object>&& highlightConfig);
     Inspector::Protocol::ErrorStringOr<void> highlightFrame(const Inspector::Protocol::Network::FrameId&, RefPtr<JSON::Object>&& color, RefPtr<JSON::Object>&& outlineColor);
-    Inspector::Protocol::ErrorStringOr<void> showGridOverlay(Inspector::Protocol::DOM::NodeId, Ref<JSON::Object>&& gridColor, std::optional<bool>&& showLineNames, std::optional<bool>&& showLineNumbers, std::optional<bool>&& showExtendedGridLines, std::optional<bool>&& showTrackSizes, std::optional<bool>&& showAreaNames);
+    Inspector::Protocol::ErrorStringOr<void> showGridOverlay(Inspector::Protocol::DOM::NodeId, Ref<JSON::Object>&& gridOverlayConfig);
     Inspector::Protocol::ErrorStringOr<void> hideGridOverlay(std::optional<Inspector::Protocol::DOM::NodeId>&&);
-    Inspector::Protocol::ErrorStringOr<void> showFlexOverlay(Inspector::Protocol::DOM::NodeId, Ref<JSON::Object>&& flexColor, std::optional<bool>&& showOrderNumbers);
+    Inspector::Protocol::ErrorStringOr<void> showFlexOverlay(Inspector::Protocol::DOM::NodeId, Ref<JSON::Object>&& flexOverlayConfig);
     Inspector::Protocol::ErrorStringOr<void> hideFlexOverlay(std::optional<Inspector::Protocol::DOM::NodeId>&&);
     Inspector::Protocol::ErrorStringOr<Inspector::Protocol::DOM::NodeId> moveTo(Inspector::Protocol::DOM::NodeId nodeId, Inspector::Protocol::DOM::NodeId targetNodeId, std::optional<Inspector::Protocol::DOM::NodeId>&& insertBeforeNodeId);
     Inspector::Protocol::ErrorStringOr<void> undo();
@@ -224,9 +224,10 @@ private:
 #endif
 
     void highlightMousedOverNode();
-    void setSearchingForNode(Inspector::Protocol::ErrorString&, bool enabled, RefPtr<JSON::Object>&& highlightConfig, bool showRulers);
+    void setSearchingForNode(Inspector::Protocol::ErrorString&, bool enabled, RefPtr<JSON::Object>&& highlightConfig, RefPtr<JSON::Object>&& gridOverlayConfig, RefPtr<JSON::Object>&& flexOverlayConfig, bool showRulers);
     std::unique_ptr<InspectorOverlay::Highlight::Config> highlightConfigFromInspectorObject(Inspector::Protocol::ErrorString&, RefPtr<JSON::Object>&& highlightInspectorObject);
-    std::unique_ptr<InspectorOverlay::Grid::Config> gridOverlayConfigFromInspectorObject(Inspector::Protocol::ErrorString&, RefPtr<JSON::Object>&& gridOverlayInspectorObject);
+    std::optional<InspectorOverlay::Grid::Config> gridOverlayConfigFromInspectorObject(Inspector::Protocol::ErrorString&, Ref<JSON::Object>&& gridOverlayInspectorObject);
+    std::optional<InspectorOverlay::Flex::Config> flexOverlayConfigFromInspectorObject(Inspector::Protocol::ErrorString&, Ref<JSON::Object>&& flexOverlayInspectorObject);
 
     // Node-related methods.
     Inspector::Protocol::DOM::NodeId bind(Node&);
@@ -273,6 +274,8 @@ private:
     RefPtr<Node> m_mousedOverNode;
     RefPtr<Node> m_inspectedNode;
     std::unique_ptr<InspectorOverlay::Highlight::Config> m_inspectModeHighlightConfig;
+    std::optional<InspectorOverlay::Grid::Config> m_inspectModeGridOverlayConfig;
+    std::optional<InspectorOverlay::Flex::Config> m_inspectModeFlexOverlayConfig;
     std::unique_ptr<InspectorHistory> m_history;
     std::unique_ptr<DOMEditor> m_domEditor;
     WeakHashMap<RenderObject, Vector<size_t>> m_flexibleBoxRendererCachedItemsAtStartOfLine;

--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -1469,7 +1469,9 @@ localizedStrings["Show changes only for selected node"] = "Show changes only for
 localizedStrings["Show compositing borders"] = "Show compositing borders";
 /* Label for option to toggle the extended lines setting for CSS grid overlays */
 localizedStrings["Show extended lines @ Layout Panel Overlay Options"] = "Extended Grid Lines";
+localizedStrings["Show flexbox overlay"] = "Show flexbox overlay";
 localizedStrings["Show full certificate"] = "Show full certificate";
+localizedStrings["Show grid overlay"] = "Show grid overlay";
 localizedStrings["Show hidden tabs\u2026"] = "Show hidden tabs\u2026";
 /* Settings tab checkbox label for whether the independent styles sidebar should be shown */
 localizedStrings["Show independent Styles sidebar @ Settings Elements Pane"] = "Show independent Styles sidebar";

--- a/Source/WebInspectorUI/UserInterface/Base/Setting.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Setting.js
@@ -217,6 +217,8 @@ WI.settings = {
     showConsoleMessageTimestamps: new WI.Setting("show-console-message-timestamps", false),
     showCSSPropertySyntaxInDocumentationPopover: new WI.Setting("show-css-property-syntax-in-documentation-popover", false),
     showCanvasPath: new WI.Setting("show-canvas-path", false),
+    showFlexOverlayDuringElementSelection: new WI.Setting("show-grid-overlay-during-element-selection", true),
+    showGridOverlayDuringElementSelection: new WI.Setting("show-flex-overlay-during-element-selection", true),
     showImageGrid: new WI.Setting("show-image-grid", true),
     showInvisibleCharacters: new WI.Setting("show-invisible-characters", !!WI.Setting.migrateValue("show-invalid-characters")),
     showJavaScriptTypeInformation: new WI.Setting("show-javascript-type-information", false),

--- a/Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js
@@ -681,11 +681,29 @@ WI.DOMManager = class DOMManager extends WI.Object
             return;
 
         let target = WI.assumingMainTarget();
+
         let commandArguments = {
             enabled,
             highlightConfig: DOMManager.buildHighlightConfig(),
             showRulers: WI.settings.showRulersDuringElementSelection.value,
         };
+        if (WI.settings.showGridOverlayDuringElementSelection.value) {
+            commandArguments.gridOverlayConfig = {
+                gridColor: WI.DOMNode.defaultLayoutOverlayColor.toProtocol(),
+                showLineNames: WI.settings.gridOverlayShowLineNames.value,
+                showLineNumbers: WI.settings.gridOverlayShowLineNumbers.value,
+                showExtendedGridLines: WI.settings.gridOverlayShowExtendedGridLines.value,
+                showTrackSizes: WI.settings.gridOverlayShowTrackSizes.value,
+                showAreaNames: WI.settings.gridOverlayShowAreaNames.value,
+            };
+        }
+        if (WI.settings.showFlexOverlayDuringElementSelection.value) {
+            commandArguments.flexOverlayConfig = {
+                flexColor: WI.DOMNode.defaultLayoutOverlayColor.toProtocol(),
+                showOrderNumbers: WI.settings.flexOverlayShowOrderNumbers.value,
+            };
+        }
+
         target.DOMAgent.setInspectModeEnabled.invoke(commandArguments, (error) => {
             if (error) {
                 WI.reportInternalError(error);

--- a/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
+++ b/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
@@ -170,6 +170,11 @@ WI.DOMNode = class DOMNode extends WI.Object
 
     // Static
 
+    static get defaultLayoutOverlayColor()
+    {
+        return new WI.Color(WI.Color.Format.HSL, WI.DOMNode._defaultLayoutOverlayConfiguration.colors[0]);
+    }
+
     static resetDefaultLayoutOverlayConfiguration()
     {
         let configuration = WI.DOMNode._defaultLayoutOverlayConfiguration;
@@ -648,12 +653,21 @@ WI.DOMNode = class DOMNode extends WI.Object
 
         switch (this.layoutContextType) {
         case WI.DOMNode.LayoutFlag.Grid:
-            agentCommandArguments.gridColor = color.toProtocol();
-            agentCommandArguments.showLineNames = WI.settings.gridOverlayShowLineNames.value;
-            agentCommandArguments.showLineNumbers = WI.settings.gridOverlayShowLineNumbers.value;
-            agentCommandArguments.showExtendedGridLines = WI.settings.gridOverlayShowExtendedGridLines.value;
-            agentCommandArguments.showTrackSizes = WI.settings.gridOverlayShowTrackSizes.value;
-            agentCommandArguments.showAreaNames = WI.settings.gridOverlayShowAreaNames.value;
+            agentCommandArguments.gridOverlayConfig = {
+                gridColor: color.toProtocol(),
+                showLineNames: WI.settings.gridOverlayShowLineNames.value,
+                showLineNumbers: WI.settings.gridOverlayShowLineNumbers.value,
+                showExtendedGridLines: WI.settings.gridOverlayShowExtendedGridLines.value,
+                showTrackSizes: WI.settings.gridOverlayShowTrackSizes.value,
+                showAreaNames: WI.settings.gridOverlayShowAreaNames.value,
+            };
+
+            // COMPATIBILITY (macOS 13.?, iOS 16.?): DOM.GridOverlayConfig did not exist yet.
+            if (!target.hasCommand("DOM.showGridOverlay", "gridOverlayConfig")) {
+                for (let [key, value] in Object.entries(agentCommandArguments.gridOverlayConfig))
+                    agentCommandArguments[key] = value;
+            }
+
             agentCommandFunction = target.DOMAgent.showGridOverlay;
 
             if (!this._layoutOverlayShowing) {
@@ -666,8 +680,17 @@ WI.DOMNode = class DOMNode extends WI.Object
             break;
 
         case WI.DOMNode.LayoutFlag.Flex:
-            agentCommandArguments.flexColor = color.toProtocol();
-            agentCommandArguments.showOrderNumbers = WI.settings.flexOverlayShowOrderNumbers.value;
+            agentCommandArguments.flexOverlayConfig = {
+                flexColor: color.toProtocol(),
+                showOrderNumbers: WI.settings.flexOverlayShowOrderNumbers.value,
+            };
+
+            // COMPATIBILITY (macOS 13.?, iOS 16.?): DOM.FlexOverlayConfig did not exist yet.
+            if (!target.hasCommand("DOM.showFlexOverlay", "flexOverlayConfig")) {
+                for (let [key, value] in Object.entries(agentCommandArguments.flexOverlayConfig))
+                    agentCommandArguments[key] = value;
+            }
+
             agentCommandFunction = target.DOMAgent.showFlexOverlay;
 
             if (!this._layoutOverlayShowing)

--- a/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js
@@ -289,7 +289,10 @@ WI.SettingsTabContentView = class SettingsTabContentView extends WI.TabContentVi
         }
 
         if (InspectorBackend.hasCommand("DOM.setInspectModeEnabled", "showRulers")) {
-            elementsSettingsView.addSetting(WI.UIString("Element Selection:"), WI.settings.showRulersDuringElementSelection, WI.UIString("Show page rulers and node border lines"));
+            let elementSelectionGroup = elementsSettingsView.addGroup(WI.UIString("Element Selection:"));
+            elementSelectionGroup.addSetting(WI.settings.showRulersDuringElementSelection, WI.UIString("Show page rulers and node border lines"));
+            elementSelectionGroup.addSetting(WI.settings.showFlexOverlayDuringElementSelection, WI.UIString("Show grid overlay"));
+            elementSelectionGroup.addSetting(WI.settings.showGridOverlayDuringElementSelection, WI.UIString("Show flexbox overlay"));
 
             elementsSettingsView.addSeparator();
         }


### PR DESCRIPTION
#### f51cad26306748dfdef688967af230eed8484136
<pre>
Web Inspector: Show grid/flex overlays when in element selection
<a href="https://bugs.webkit.org/show_bug.cgi?id=251737">https://bugs.webkit.org/show_bug.cgi?id=251737</a>
&lt;rdar://problem/105041619&gt;

Reviewed by Patrick Angle.

This allows for developers to more easily visually identify the organization of a node&apos;s contents using element select mode (e.g. hovering over a `gap` area will now be more recognizable due to the hatching shown by the flex overlay).

* Source/JavaScriptCore/inspector/protocol/DOM.json:
Move all the configuration options for grid and flex overlays to bespoke protocol objects.

* Source/JavaScriptCore/inspector/scripts/codegen/generator.py:
Ensure that these protocol objects have helper constants for pulling values out of them.

* Source/WebCore/inspector/InspectorOverlay.h:
* Source/WebCore/inspector/InspectorOverlay.cpp:
(WebCore::InspectorOverlay::paint):
(WebCore::InspectorOverlay::getHighlight):
(WebCore::InspectorOverlay::shouldShowOverlay const):
(WebCore::InspectorOverlay::showHighlightGridOverlayForNode): Added.
(WebCore::InspectorOverlay::hideHighlightGridOverlay): Added.
(WebCore::InspectorOverlay::showHighlightFlexOverlayForNode): Added.
(WebCore::InspectorOverlay::hideHighlightFlexOverlay): Added.
In addition to the always-on grid/flex overlay data, have another member variable for a single grid/flex overlay that takes precedence (and is drawn on top) of all other grid/flex overlays.

* Source/WebCore/inspector/agents/InspectorDOMAgent.h:
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::parseRequiredConfigColor): Renamed from `parseConfigColor`.
(WebCore::parseOptionalConfigColor): Added.
(WebCore::InspectorDOMAgent::willDestroyFrontendAndBackend):
(WebCore::InspectorDOMAgent::handleTouchEvent):
(WebCore::InspectorDOMAgent::inspect):
(WebCore::InspectorDOMAgent::highlightMousedOverNode):
(WebCore::InspectorDOMAgent::setSearchingForNode):
(WebCore::InspectorDOMAgent::highlightConfigFromInspectorObject):
(WebCore::InspectorDOMAgent::gridOverlayConfigFromInspectorObject): Added.
(WebCore::InspectorDOMAgent::flexOverlayConfigFromInspectorObject): Added.
(WebCore::InspectorDOMAgent::setInspectModeEnabled):
(WebCore::InspectorDOMAgent::showGridOverlay):
(WebCore::InspectorDOMAgent::showFlexOverlay):
* Source/WebInspectorUI/UserInterface/Models/DOMNode.js:
(WI.DOMNode.get defaultLayoutOverlayColor): Added.
(WI.DOMNode.prototype.showLayoutOverlay):
Handle changes to `DOM.showGridOverlay` and `DOM.showFlexOverlay`.

* Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js:
(WI.DOMManager.prototype.set inspectModeEnabled):
Pass along the current grid/flex overlay configuration when enabling element selection mode.

* Source/WebInspectorUI/UserInterface/Base/Setting.js:
* Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js:
(WI.SettingsTabContentView.prototype._createElementsSettingsView):
Add some on-by-default `WI.Setting` to control this behavior.

* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:

* LayoutTests/inspector/dom/showFlexOverlay.html:
* LayoutTests/inspector/dom/showGridOverlay.html:

Canonical link: <a href="https://commits.webkit.org/259989@main">https://commits.webkit.org/259989@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fbbbf1c530c945d756d7013c18ea2cef03007792

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106492 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15509 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39302 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115677 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115336 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110400 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17003 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6735 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98686 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112260 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12918 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95889 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40474 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94793 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27533 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82191 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/96069 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8741 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28885 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/95508 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/6636 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9279 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5458 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-pseudo/first-letter-with-span.html (failure)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30642 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14897 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48431 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/104250 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6906 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10822 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25831 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->