### PR TITLE
[Flatpak SDK] Enable SoundTouch GStreamer plugin

### DIFF
--- a/Tools/buildstream/elements/freedesktop-sdk.bst
+++ b/Tools/buildstream/elements/freedesktop-sdk.bst
@@ -18,6 +18,8 @@ sources:
   path: patches/fdo-0004-gst-plugins-ugly-Enable-x264-encoder.patch
 - kind: patch
   path: patches/fdo-0005-GStreamer-Bump-to-1.22.0.patch
+- kind: patch
+  path: patches/fdo-0006-gst-plugins-bad-Enable-soundtouch.patch
 config:
   options:
     target_arch: '%{arch}'

--- a/Tools/buildstream/patches/fdo-0006-gst-plugins-bad-Enable-soundtouch.patch
+++ b/Tools/buildstream/patches/fdo-0006-gst-plugins-bad-Enable-soundtouch.patch
@@ -1,0 +1,52 @@
+From d528e843e3f952b443137786a8def7bc3a17ae37 Mon Sep 17 00:00:00 2001
+From: ChangSeok Oh <changseok@gnome.org>
+Date: Sat, 4 Feb 2023 02:14:01 -0800
+Subject: [PATCH] Enable soundtouch
+
+---
+ elements/components/gstreamer-plugins-bad.bst |  2 ++
+ elements/components/libsoundtouch.bst         | 12 ++++++++++++
+ 2 files changed, 14 insertions(+)
+ create mode 100644 elements/components/libsoundtouch.bst
+
+diff --git a/elements/components/gstreamer-plugins-bad.bst b/elements/components/gstreamer-plugins-bad.bst
+index 90314b0e2..b3d0ab932 100644
+--- a/elements/components/gstreamer-plugins-bad.bst
++++ b/elements/components/gstreamer-plugins-bad.bst
+@@ -12,6 +12,7 @@ depends:
+ - components/libfdk-aac.bst
+ - components/libglvnd.bst
+ - components/libnice.bst
++- components/libsoundtouch.bst
+ - components/librsvg.bst
+ - components/libva.bst
+ - components/openal.bst
+@@ -51,6 +52,7 @@ variables:
+     -Dpackage-origin="freedesktop-sdk"
+     -Drsvg=enabled
+     -Dsndfile=enabled
++    -Dsoundtouch=enabled
+     -Dva=enabled
+     -Dvulkan=enabled
+     -Dwayland=enabled
+diff --git a/elements/components/libsoundtouch.bst b/elements/components/libsoundtouch.bst
+new file mode 100644
+index 000000000..b62b20fe8
+--- /dev/null
++++ b/elements/components/libsoundtouch.bst
+@@ -0,0 +1,12 @@
++kind: autotools
++
++build-depends:
++- public-stacks/buildsystem-autotools.bst
++
++depends:
++- bootstrap-import.bst
++
++sources:
++- kind: tar
++  url: https://codeberg.org/soundtouch/soundtouch/archive/2.3.2.tar.gz
++  ref: ed714f84a3e748de87b24f385ec69d3bdc51ca47b7f4710d2048b84b2761e7ff
+-- 
+2.39.1
+


### PR DESCRIPTION
#### 24c8ac498e698b2407b4230048dc2bd9424492a1
<pre>
[Flatpak SDK] Enable SoundTouch GStreamer plugin
<a href="https://bugs.webkit.org/show_bug.cgi?id=251739">https://bugs.webkit.org/show_bug.cgi?id=251739</a>

Reviewed by Philippe Normand.

To control the pitch of web speech, we use the SoundTouch GStreamer plugin.
This change enables the SoundTouch support for GStreamer and adds the libsoundtouch build
to Flatpak SDK.

* Tools/buildstream/elements/freedesktop-sdk.bst:
* Tools/buildstream/patches/fdo-0006-gst-plugins-bad-Enable-soundtouch.patch: Added.

Canonical link: <a href="https://commits.webkit.org/259870@main">https://commits.webkit.org/259870@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ff8e15fe9b8d1615f013ad5398e413ead9a3fd3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106248 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15302 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39085 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115438 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175537 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110156 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16744 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6518 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98461 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115120 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112010 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12734 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95712 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40281 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94608 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27355 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81970 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8542 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28707 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9049 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5279 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14664 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48253 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6822 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10585 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->