### PR TITLE
`Clear-Site-Data: "cache"` HTTP header should clear navigation snapshots

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -788,7 +788,7 @@ void NetworkResourceLoader::processClearSiteDataHeader(const WebCore::ResourceRe
     m_connection->networkProcess().deleteWebsiteDataForOrigin(sessionID(), typesToRemove, clientOrigin, [callbackAggregator] { });
 
     if (WebsiteDataStore::computeWebProcessAccessTypeForDataRemoval(typesToRemove, sessionID().isEphemeral()) != WebsiteDataStore::ProcessAccessType::None)
-        m_connection->networkProcess().parentProcessConnection()->sendWithAsyncReply(Messages::NetworkProcessProxy::DeleteWebsiteDataInWebProcessesForOrigin(typesToRemove, clientOrigin, sessionID()), [callbackAggregator] { });
+        m_connection->networkProcess().parentProcessConnection()->sendWithAsyncReply(Messages::NetworkProcessProxy::DeleteWebsiteDataInWebProcessesForOrigin(typesToRemove, clientOrigin, sessionID(), m_parameters.webPageProxyID), [callbackAggregator] { });
 }
 
 static BrowsingContextGroupSwitchDecision toBrowsingContextGroupSwitchDecision(const std::optional<CrossOriginOpenerPolicyEnforcementResult>& currentCoopEnforcementResult)

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -49,6 +49,7 @@
 #include "SandboxExtension.h"
 #include "ShouldGrandfatherStatistics.h"
 #include "StorageAccessStatus.h"
+#include "ViewSnapshotStore.h"
 #include "WebCompiledContentRuleList.h"
 #include "WebNotificationManagerProxy.h"
 #include "WebPageMessages.h"
@@ -1877,11 +1878,11 @@ void NetworkProcessProxy::notifyMediaStreamingActivity(bool activity)
     send(Messages::NetworkProcess::NotifyMediaStreamingActivity(activity), 0);
 }
 
-void NetworkProcessProxy::deleteWebsiteDataInWebProcessesForOrigin(OptionSet<WebsiteDataType> dataTypes, const WebCore::ClientOrigin& origin, PAL::SessionID sessionID, CompletionHandler<void()>&& completionHandler)
+void NetworkProcessProxy::deleteWebsiteDataInWebProcessesForOrigin(OptionSet<WebsiteDataType> dataTypes, const WebCore::ClientOrigin& origin, PAL::SessionID sessionID, WebPageProxyIdentifier webPageProxyID, CompletionHandler<void()>&& completionHandler)
 {
-    RELEASE_LOG(Process, "%p - NetworkProcessProxy::deleteWebsiteDataInWebProcessesForOrigin BEGIN", this);
-    auto callbackAggregator = CallbackAggregator::create([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)]() mutable {
-        RELEASE_LOG(Process, "%p - NetworkProcessProxy::deleteWebsiteDataInWebProcessesForOrigin END", protectedThis.ptr());
+    RELEASE_LOG(Process, "%p - NetworkProcessProxy::deleteWebsiteDataInWebProcessesForOrigin - webPageProxyID=%" PRIu64 " - BEGIN", this, webPageProxyID.toUInt64());
+    auto callbackAggregator = CallbackAggregator::create([protectedThis = Ref { *this }, webPageProxyID, completionHandler = WTFMove(completionHandler)]() mutable {
+        RELEASE_LOG(Process, "%p - NetworkProcessProxy::deleteWebsiteDataInWebProcessesForOrigin - webPageProxyID=%" PRIu64 " - END", protectedThis.ptr(), webPageProxyID.toUInt64());
         completionHandler();
     });
     RefPtr websiteDataStore = websiteDataStoreFromSessionID(sessionID);
@@ -1890,6 +1891,16 @@ void NetworkProcessProxy::deleteWebsiteDataInWebProcessesForOrigin(OptionSet<Web
     for (auto& process : websiteDataStore->processes()) {
         if (process.canSendMessage() && !process.isDummyProcessProxy())
             process.sendWithAsyncReply(Messages::WebProcess::DeleteWebsiteDataForOrigin(dataTypes, origin), [callbackAggregator] { });
+    }
+    bool shouldClearNavigationSnapshots = dataTypes.contains(WebsiteDataType::MemoryCache) && origin.topOrigin == origin.clientOrigin;
+    if (shouldClearNavigationSnapshots) {
+#if PLATFORM(COCOA) || PLATFORM(GTK)
+        ViewSnapshotStore::singleton().discardSnapshotImagesForOrigin(origin.topOrigin);
+#endif
+        // Since this navigation requested that we clear existing navigation snapshots, we shouldn't
+        // create a snapshot for this navigation either.
+        if (auto page = WebProcessProxy::webPage(webPageProxyID))
+            page->suppressNextAutomaticNavigationSnapshot();
     }
 }
 

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -304,7 +304,7 @@ public:
     void dataTaskDidCompleteWithError(DataTaskIdentifier, WebCore::ResourceError&&);
     void cancelDataTask(DataTaskIdentifier, PAL::SessionID);
 
-    void deleteWebsiteDataInWebProcessesForOrigin(OptionSet<WebsiteDataType>, const WebCore::ClientOrigin&, PAL::SessionID, CompletionHandler<void()>&&);
+    void deleteWebsiteDataInWebProcessesForOrigin(OptionSet<WebsiteDataType>, const WebCore::ClientOrigin&, PAL::SessionID, WebPageProxyIdentifier, CompletionHandler<void()>&&);
 
     void terminateRemoteWorkerContextConnectionWhenPossible(RemoteWorkerType, PAL::SessionID, const WebCore::RegistrableDomain&, WebCore::ProcessIdentifier);
 

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.messages.in
@@ -97,7 +97,7 @@ messages -> NetworkProcessProxy LegacyReceiver {
 
     CookiesDidChange(PAL::SessionID sessionID)
 
-    DeleteWebsiteDataInWebProcessesForOrigin(OptionSet<WebKit::WebsiteDataType> websiteDataTypes, struct WebCore::ClientOrigin origin, PAL::SessionID sessionID) -> ()
+    DeleteWebsiteDataInWebProcessesForOrigin(OptionSet<WebKit::WebsiteDataType> websiteDataTypes, struct WebCore::ClientOrigin origin, PAL::SessionID sessionID, WebKit::WebPageProxyIdentifier webPageProxyID) -> ()
 
 #if ENABLE(NETWORK_ISSUE_REPORTING)
     ReportNetworkIssue(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, URL requestURL)

--- a/Source/WebKit/UIProcess/ViewSnapshotStore.cpp
+++ b/Source/WebKit/UIProcess/ViewSnapshotStore.cpp
@@ -100,6 +100,7 @@ void ViewSnapshotStore::recordSnapshot(WebPageProxy& webPageProxy, WebBackForwar
     snapshot->setDeviceScaleFactor(webPageProxy.deviceScaleFactor());
     snapshot->setBackgroundColor(webPageProxy.pageExtendedBackgroundColor());
     snapshot->setViewScrollPosition(WebCore::roundedIntPoint(webPageProxy.viewScrollPosition()));
+    snapshot->setOrigin(WebCore::SecurityOriginData::fromURL(URL(item.url())));
 
     item.setSnapshot(WTFMove(snapshot));
 }
@@ -108,6 +109,16 @@ void ViewSnapshotStore::discardSnapshotImages()
 {
     while (!m_snapshotsWithImages.isEmpty())
         m_snapshotsWithImages.first()->clearImage();
+}
+
+void ViewSnapshotStore::discardSnapshotImagesForOrigin(const WebCore::SecurityOriginData& origin)
+{
+    for (auto it = m_snapshotsWithImages.begin(); it != m_snapshotsWithImages.end();) {
+        auto viewSnapshot = *it;
+        ++it;
+        if (viewSnapshot->origin() == origin)
+            viewSnapshot->clearImage();
+    }
 }
 
 ViewSnapshot::~ViewSnapshot()

--- a/Source/WebKit/UIProcess/ViewSnapshotStore.h
+++ b/Source/WebKit/UIProcess/ViewSnapshotStore.h
@@ -27,6 +27,7 @@
 
 #include <WebCore/Color.h>
 #include <WebCore/IntPoint.h>
+#include <WebCore/SecurityOriginData.h>
 #include <wtf/ListHashSet.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/text/WTFString.h>
@@ -83,6 +84,9 @@ public:
     void setDeviceScaleFactor(float deviceScaleFactor) { m_deviceScaleFactor = deviceScaleFactor; }
     float deviceScaleFactor() const { return m_deviceScaleFactor; }
 
+    void setOrigin(WebCore::SecurityOriginData&& origin) { m_origin = WTFMove(origin); }
+    const WebCore::SecurityOriginData& origin() const { return m_origin; }
+
 #if HAVE(IOSURFACE)
     WebCore::IOSurface* surface() const { return m_surface.get(); }
 
@@ -128,6 +132,7 @@ private:
     float m_deviceScaleFactor;
     WebCore::Color m_backgroundColor;
     WebCore::IntPoint m_viewScrollPosition; // Scroll position at snapshot time. Integral to make comparison reliable.
+    WebCore::SecurityOriginData m_origin;
 };
 
 class ViewSnapshotStore {
@@ -142,6 +147,7 @@ public:
     void recordSnapshot(WebPageProxy&, WebBackForwardListItem&);
 
     void discardSnapshotImages();
+    void discardSnapshotImagesForOrigin(const WebCore::SecurityOriginData&);
 
     void setDisableSnapshotVolatilityForTesting(bool disable) { m_disableSnapshotVolatility = disable; }
     bool disableSnapshotVolatilityForTesting() const { return m_disableSnapshotVolatility; }

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -449,10 +449,13 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
         if (!origin.isNull())
             loadParameters.sourceOrigin = SecurityOrigin::createFromString(origin);
     }
-    if (document) {
+    if (isMainFrameNavigation)
+        loadParameters.topOrigin = SecurityOrigin::create(request.url());
+    else if (document)
         loadParameters.topOrigin = &document->topOrigin();
+
+    if (document)
         loadParameters.documentURL = document->url();
-    }
 
     if (loadParameters.options.mode != FetchOptions::Mode::Navigate) {
         ASSERT(loadParameters.sourceOrigin);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SnapshotStore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SnapshotStore.mm
@@ -28,6 +28,7 @@
 
 #if PLATFORM(MAC)
 
+#import "HTTPServer.h"
 #import "PlatformUtilities.h"
 #import "Test.h"
 #import "TestNavigationDelegate.h"
@@ -82,6 +83,13 @@ static void forceRepaintCallback(WKErrorRef error, void*)
 - (void)synchronouslyLoadTestPageAndForceRepaint:(NSString *)testPageName
 {
     [self synchronouslyLoadTestPageNamed:testPageName];
+    [self synchronouslyForceRepaint];
+    [[self window] display];
+}
+
+- (void)synchronouslyLoadRequestPageAndForceRepaint:(NSURLRequest *)request
+{
+    [self synchronouslyLoadRequestIgnoringSSLErrors:request];
     [self synchronouslyForceRepaint];
     [[self window] display];
 }
@@ -209,6 +217,32 @@ TEST(SnapshotStore, SnapshottingNullBackForwardItemShouldNotCrash)
 {
     RetainPtr<SnapshotTestWKWebView> webView = adoptNS([[SnapshotTestWKWebView alloc] init]);
     [webView _saveBackForwardSnapshotForItem:nil];
+}
+
+TEST(SnapshotStore, ClearSiteDataHeader)
+{
+    HTTPServer server({
+        { "/index1.html"_s, { "foo"_s } },
+        { "/index2.html"_s, { "bar"_s } },
+        { "/logout.html"_s, { { { "Content-Type"_s, "text/html"_s }, { "Clear-Site-Data"_s, "\"cache\""_s } }, "Logged out."_s } },
+    }, HTTPServer::Protocol::Https);
+
+    auto webView = adoptNS([[SnapshotTestWKWebView alloc] init]);
+    for (_WKFeature *feature in [WKPreferences _features]) {
+        if ([feature.key isEqualToString:@"ClearSiteDataHTTPHeaderEnabled"]) {
+            [[[webView configuration] preferences] _setEnabled:YES forFeature:feature];
+            break;
+        }
+    }
+
+    auto *backForwardList = [webView backForwardList];
+    [webView synchronouslyLoadRequestPageAndForceRepaint:server.request("/index1.html"_s)];
+    [webView synchronouslyLoadRequestPageAndForceRepaint:server.request("/index2.html"_s)];
+    EXPECT_TRUE(!!adoptCF([backForwardList.backItem _copySnapshotForTesting]));
+
+    [webView synchronouslyLoadRequestPageAndForceRepaint:server.request("/logout.html"_s)];
+    EXPECT_FALSE(!!adoptCF([backForwardList.backItem _copySnapshotForTesting]));
+    EXPECT_FALSE(!!adoptCF([[backForwardList itemAtIndex:-2] _copySnapshotForTesting]));
 }
 
 #endif // PLATFORM(MAC)

--- a/Tools/TestWebKitAPI/cocoa/TestNavigationDelegate.h
+++ b/Tools/TestWebKitAPI/cocoa/TestNavigationDelegate.h
@@ -56,6 +56,7 @@
 - (void)_test_waitForDidFinishNavigation;
 - (void)_test_waitForDidFinishNavigationWithPreferences:(WKWebpagePreferences *)preferences;
 - (void)_test_waitForDidFinishNavigationWithoutPresentationUpdate;
+- (void)_test_waitForDidFinishNavigationWhileIgnoringSSLErrors;
 - (void)_test_waitForDidFailProvisionalNavigation;
 - (void)_test_waitForWebContentProcessDidTerminate;
 @end

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
@@ -64,6 +64,7 @@
 - (void)synchronouslyLoadHTMLString:(NSString *)html baseURL:(NSURL *)url;
 - (void)synchronouslyLoadHTMLString:(NSString *)html preferences:(WKWebpagePreferences *)preferences;
 - (void)synchronouslyLoadRequest:(NSURLRequest *)request;
+- (void)synchronouslyLoadRequestIgnoringSSLErrors:(NSURLRequest *)request;
 - (void)synchronouslyLoadTestPageNamed:(NSString *)pageName;
 - (BOOL)_synchronouslyExecuteEditCommand:(NSString *)command argument:(NSString *)argument;
 - (void)expectElementTagsInOrder:(NSArray<NSString *> *)tagNames;

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
@@ -87,6 +87,12 @@ static NSString *overrideBundleIdentifier(id, SEL)
     [self _test_waitForDidFinishNavigation];
 }
 
+- (void)synchronouslyLoadRequestIgnoringSSLErrors:(NSURLRequest *)request
+{
+    [self loadRequest:request];
+    [self _test_waitForDidFinishNavigationWhileIgnoringSSLErrors];
+}
+
 - (void)synchronouslyLoadHTMLString:(NSString *)html baseURL:(NSURL *)url
 {
     [self loadHTMLString:html baseURL:url];


### PR DESCRIPTION
#### 17d23e2ec51d99b28ed99a79de5e0319d23565b7
<pre>
`Clear-Site-Data: &quot;cache&quot;` HTTP header should clear navigation snapshots
<a href="https://bugs.webkit.org/show_bug.cgi?id=251766">https://bugs.webkit.org/show_bug.cgi?id=251766</a>

Reviewed by Geoffrey Garen.

`Clear-Site-Data: &quot;cache&quot;` HTTP header already clears the back/forward cache
but it didn&apos;t clear the navigation snapshots yet. This patch fixes this.

Since a common use case is a log out page, we shouldn&apos;t be able to see
&quot;logged in&quot; information when swiping back once you&apos;ve logged out.

* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::processClearSiteDataHeader):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::deleteWebsiteDataInWebProcessesForOrigin):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.messages.in:

Canonical link: <a href="https://commits.webkit.org/259936@main">https://commits.webkit.org/259936@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48aaf496a48e16f7b68dd4474432b10815242684

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106462 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15485 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39277 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115649 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/175748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110370 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16974 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6710 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98659 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/115312 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112228 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95867 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/40451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94774 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27511 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8717 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28863 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9251 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5435 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14871 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48409 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10798 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3696 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->