### PR TITLE
[WebGPU] Minor cleanup in QuerySet

### DIFF
--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -2080,7 +2080,7 @@ def check_function_body(filename, file_extension, clean_lines, line_number, clas
         max_index = min(function_line_count, i + 4)
         partial_function_body = ' '.join(function_body_view.trimmed_lines[min_index:max_index])
 
-        if search(r'[^_]ASSERT_NOT_REACHED\(\);\s*(continue|return(\s+[^;]+)?);', partial_function_body) \
+        if search(r'[^_]ASSERT_NOT_REACHED\(\);\s*(continue|return|break(\s+[^;]+)?);', partial_function_body) \
                 or search(r'[^_]ASSERT_NOT_REACHED\(\);(\s*#endif)?(\s*})+\s*$', partial_function_body) \
                 or search(r'[^_]ASSERT_NOT_REACHED\(\);(\s*completionHandler[^;]+;)?(\s*})+\s*$', partial_function_body) \
                 or search(r'[^_]ASSERT_NOT_REACHED\(\);(\s*[^;]+;)?\s*return(\s+[^;]+)?;', partial_function_body) \


### PR DESCRIPTION
#### 817f9dbade8cdcb1fecc679eda0d0632a2c1f481
<pre>
[WebGPU] Minor cleanup in QuerySet
<a href="https://bugs.webkit.org/show_bug.cgi?id=251767">https://bugs.webkit.org/show_bug.cgi?id=251767</a>
rdar://105062705

Reviewed by Tadeu Zagallo.

This doesn&apos;t actually change any behavior; I&apos;m just moving stuff around for stylistic reasons.

A few varied cleanups:
1. We have 3 types of queries, so CommandEncoder::resolveQuerySet() should use a switch instead
       of an if statement
2. Instead of the constructor reverse-engineering the number of queries and their type, we can
       just pass them directly as arguments, and remember them
3. isValid() needs to return false after destroy() is called
4. We can set the label of the MTLCounterSampleBuffers / MTLBuffer
5. HardwareCapabilities already found the MTLCommonCounterTimestamp if it exists, so we can just
       use the one that we already have

* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::resolveQuerySet):
* Source/WebGPU/WebGPU/QuerySet.h:
(WebGPU::QuerySet::create):
(WebGPU::QuerySet::isValid const):
(WebGPU::QuerySet::count const):
(WebGPU::QuerySet::type const):
(WebGPU::QuerySet::queryCount const): Deleted.
* Source/WebGPU/WebGPU/QuerySet.mm:
(WebGPU::Device::createQuerySet):
(WebGPU::QuerySet::QuerySet):
(WebGPU::QuerySet::setLabel):
(WebGPU::QuerySet::resolveTimestamps const):
(wgpuQuerySetGetCount):
(wgpuQuerySetGetType):
(WebGPU::QuerySet::queryType const): Deleted.

Canonical link: <a href="https://commits.webkit.org/259951@main">https://commits.webkit.org/259951@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75a7aa5a23f5e0dd8591f4fb2d062933669a479f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106502 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15517 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39310 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115686 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/175776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110410 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17012 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6745 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98693 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/115341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112270 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95892 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/40477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/109987 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94799 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27536 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8748 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28888 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9289 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/5465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14906 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48435 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6878 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10829 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->