### PR TITLE
`Clear-Site-Data: "cache"` HTTP header should clear disk cache more efficiently

### DIFF
--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
@@ -598,6 +598,23 @@ void Cache::traverse(Function<void(const TraversalEntry*)>&& traverseHandler)
     });
 }
 
+void Cache::traverse(const String& partition, Function<void(const TraversalEntry*)>&& traverseHandler)
+{
+    m_storage->traverse(resourceType(), partition, { }, [traverseHandler = WTFMove(traverseHandler)] (const Storage::Record* record, const Storage::RecordInfo& recordInfo) mutable {
+        if (!record) {
+            traverseHandler(nullptr);
+            return;
+        }
+
+        auto entry = Entry::decodeStorageRecord(*record);
+        if (!entry)
+            return;
+
+        TraversalEntry traversalEntry { *entry, recordInfo };
+        traverseHandler(&traversalEntry);
+    });
+}
+
 String Cache::dumpFilePath() const
 {
     return pathByAppendingComponent(m_storage->versionPath(), "dump.json"_s);

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.h
@@ -175,6 +175,7 @@ public:
         const Storage::RecordInfo& recordInfo;
     };
     void traverse(Function<void(const TraversalEntry*)>&&);
+    void traverse(const String& partition, Function<void(const TraversalEntry*)>&&);
     void remove(const Key&);
     void remove(const WebCore::ResourceRequest&);
     void remove(const Vector<Key>&, Function<void()>&&);

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheKey.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheKey.cpp
@@ -114,12 +114,22 @@ Key::HashType Key::computeHash(const Salt& salt) const
     return hash;
 }
 
+String Key::partitionToPartitionHashAsString(const String& partition, const Salt& salt)
+{
+    return hashAsString(partitionToPartitionHash(partition, salt));
+}
+
 Key::HashType Key::computePartitionHash(const Salt& salt) const
+{
+    return partitionToPartitionHash(m_partition, salt);
+}
+
+Key::HashType Key::partitionToPartitionHash(const String& partition, const Salt& salt)
 {
     SHA1 sha1;
     sha1.addBytes(salt.data(), salt.size());
 
-    hashString(sha1, m_partition);
+    hashString(sha1, partition);
 
     SHA1::Digest hash;
     sha1.computeHash(hash);

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheKey.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheKey.h
@@ -86,11 +86,14 @@ public:
     bool operator==(const Key&) const;
     bool operator!=(const Key& other) const { return !(*this == other); }
 
+    static String partitionToPartitionHashAsString(const String& partition, const Salt&);
+
 private:
     friend struct WTF::Persistence::Coder<Key>;
     static String hashAsString(const HashType&);
     HashType computeHash(const Salt&) const;
     HashType computePartitionHash(const Salt&) const;
+    static HashType partitionToPartitionHash(const String& partition, const Salt&);
 
     String m_partition;
     String m_type;

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h
@@ -101,6 +101,7 @@ public:
     using TraverseHandler = Function<void (const Record*, const RecordInfo&)>;
     // Null record signals end.
     void traverse(const String& type, OptionSet<TraverseFlag>, TraverseHandler&&);
+    void traverse(const String& type, const String& partition, OptionSet<TraverseFlag>, TraverseHandler&&);
 
     void setCapacity(size_t);
     size_t capacity() const { return m_capacity; }
@@ -126,6 +127,8 @@ private:
     String recordDirectoryPathForKey(const Key&) const;
     String recordPathForKey(const Key&) const;
     String blobPathForKey(const Key&) const;
+
+    void traverseWithinRootPath(const String& rootPath, const String& type, OptionSet<TraverseFlag>, TraverseHandler&&);
 
     void synchronize();
     void deleteOldVersions();


### PR DESCRIPTION
#### 28678cd68b668ca4d14eec8a3a1775374f304804
<pre>
`Clear-Site-Data: &quot;cache&quot;` HTTP header should clear disk cache more efficiently
<a href="https://bugs.webkit.org/show_bug.cgi?id=251768">https://bugs.webkit.org/show_bug.cgi?id=251768</a>

Reviewed by Antti Koivisto.

`Clear-Site-Data: &quot;cache&quot;` HTTP header should clear disk cache more efficiently.
We will only delete cache entries for a given partition so there is no point in
traversing ALL storage entries. Instead, only traverse entries for the given
partition, which is a lot faster.

This patch adds a new NetworkCache::traverse() function overload which takes in
the cache partition as parameter and only calls the traverseHandler for entries
belonging to this partition. This is cheap and easy to do for our disk cache
implementation since our cache entries as grouped by partition via subfolders.

* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::deleteWebsiteDataForOrigin):
* Source/WebKit/NetworkProcess/cache/NetworkCache.cpp:
(WebKit::NetworkCache::Cache::traverse):
* Source/WebKit/NetworkProcess/cache/NetworkCache.h:
* Source/WebKit/NetworkProcess/cache/NetworkCacheKey.cpp:
(WebKit::NetworkCache::Key::partitionToPartitionHashAsString):
(WebKit::NetworkCache::Key::computePartitionHash const):
(WebKit::NetworkCache::Key::partitionToPartitionHash):
* Source/WebKit/NetworkProcess/cache/NetworkCacheKey.h:
* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp:
(WebKit::NetworkCache::Storage::traverseInternal):
(WebKit::NetworkCache::Storage::traverse):
* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h:

Canonical link: <a href="https://commits.webkit.org/259902@main">https://commits.webkit.org/259902@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4196e8fe9988564ee822422e7af0f97ac2727436

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106346 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15400 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39186 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115539 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16877 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6617 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98563 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115226 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112110 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12815 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95799 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40375 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94690 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27442 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8636 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28794 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9148 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5364 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14778 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48340 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10710 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3686 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->