### PR TITLE
Remove unnecessary masking after wasm LLInt comparison instructions.

### DIFF
--- a/Source/JavaScriptCore/llint/WebAssembly.asm
+++ b/Source/JavaScriptCore/llint/WebAssembly.asm
@@ -1708,7 +1708,6 @@ wasmOp(i32_eq, WasmI32Eq, macro(ctx)
     mloadi(ctx, m_lhs, t0)
     mloadi(ctx, m_rhs, t1)
     cieq t0, t1, t2
-    andi 1, t2
     returni(ctx, t2)
 end)
 
@@ -1716,7 +1715,6 @@ wasmOp(i32_ne, WasmI32Ne, macro(ctx)
     mloadi(ctx, m_lhs, t0)
     mloadi(ctx, m_rhs, t1)
     cineq t0, t1, t2
-    andi 1, t2
     returni(ctx, t2)
 end)
 
@@ -1724,7 +1722,6 @@ wasmOp(i32_lt_s, WasmI32LtS, macro(ctx)
     mloadi(ctx, m_lhs, t0)
     mloadi(ctx, m_rhs, t1)
     cilt t0, t1, t2
-    andi 1, t2
     returni(ctx, t2)
 end)
 
@@ -1732,7 +1729,6 @@ wasmOp(i32_le_s, WasmI32LeS, macro(ctx)
     mloadi(ctx, m_lhs, t0)
     mloadi(ctx, m_rhs, t1)
     cilteq t0, t1, t2
-    andi 1, t2
     returni(ctx, t2)
 end)
 
@@ -1740,7 +1736,6 @@ wasmOp(i32_lt_u, WasmI32LtU, macro(ctx)
     mloadi(ctx, m_lhs, t0)
     mloadi(ctx, m_rhs, t1)
     cib t0, t1, t2
-    andi 1, t2
     returni(ctx, t2)
 end)
 
@@ -1748,7 +1743,6 @@ wasmOp(i32_le_u, WasmI32LeU, macro(ctx)
     mloadi(ctx, m_lhs, t0)
     mloadi(ctx, m_rhs, t1)
     cibeq t0, t1, t2
-    andi 1, t2
     returni(ctx, t2)
 end)
 
@@ -1756,7 +1750,6 @@ wasmOp(i32_gt_s, WasmI32GtS, macro(ctx)
     mloadi(ctx, m_lhs, t0)
     mloadi(ctx, m_rhs, t1)
     cigt t0, t1, t2
-    andi 1, t2
     returni(ctx, t2)
 end)
 
@@ -1764,7 +1757,6 @@ wasmOp(i32_ge_s, WasmI32GeS, macro(ctx)
     mloadi(ctx, m_lhs, t0)
     mloadi(ctx, m_rhs, t1)
     cigteq t0, t1, t2
-    andi 1, t2
     returni(ctx, t2)
 end)
 
@@ -1772,7 +1764,6 @@ wasmOp(i32_gt_u, WasmI32GtU, macro(ctx)
     mloadi(ctx, m_lhs, t0)
     mloadi(ctx, m_rhs, t1)
     cia t0, t1, t2
-    andi 1, t2
     returni(ctx, t2)
 end)
 
@@ -1780,7 +1771,6 @@ wasmOp(i32_ge_u, WasmI32GeU, macro(ctx)
     mloadi(ctx, m_lhs, t0)
     mloadi(ctx, m_rhs, t1)
     ciaeq t0, t1, t2
-    andi 1, t2
     returni(ctx, t2)
 end)
 

--- a/Source/JavaScriptCore/llint/WebAssembly32_64.asm
+++ b/Source/JavaScriptCore/llint/WebAssembly32_64.asm
@@ -1,4 +1,4 @@
-# Copyright (C) 2011-2021 Apple Inc. All rights reserved.
+# Copyright (C) 2011-2023 Apple Inc. All rights reserved.
 # Copyright (C) 2021 Igalia S.L. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -578,7 +578,6 @@ wasmOp(i64_lt_s, WasmI64LtS, macro(ctx)
     move 0, t6
     bigt t1, t3, .return
     cib t0, t2, t6
-    andi 1, t6
 .return:
     returni(ctx, t6)
 end)
@@ -591,7 +590,6 @@ wasmOp(i64_le_s, WasmI64LeS, macro(ctx)
     move 0, t6
     bigt t1, t3, .return
     cibeq t0, t2, t6
-    andi 1, t6
 .return:
     returni(ctx, t6)
 end)
@@ -604,7 +602,6 @@ wasmOp(i64_lt_u, WasmI64LtU, macro(ctx)
     move 0, t6
     bia t1, t3, .return
     cib t0, t2, t6
-    andi 1, t6
 .return:
     returni(ctx, t6)
 end)
@@ -617,7 +614,6 @@ wasmOp(i64_le_u, WasmI64LeU, macro(ctx)
     move 0, t6
     bia t1, t3, .return
     cibeq t0, t2, t6
-    andi 1, t6
 .return:
     returni(ctx, t6)
 end)
@@ -630,7 +626,6 @@ wasmOp(i64_gt_s, WasmI64GtS, macro(ctx)
     move 0, t6
     bilt t1, t3, .return
     cia t0, t2, t6
-    andi 1, t6
 .return:
     returni(ctx, t6)
 end)
@@ -643,7 +638,6 @@ wasmOp(i64_ge_s, WasmI64GeS, macro(ctx)
     move 0, t6
     bilt t1, t3, .return
     ciaeq t0, t2, t6
-    andi 1, t6
 .return:
     returni(ctx, t6)
 end)
@@ -656,7 +650,6 @@ wasmOp(i64_gt_u, WasmI64GtU, macro(ctx)
     move 0, t6
     bib t1, t3, .return
     cia t0, t2, t6
-    andi 1, t6
 .return:
     returni(ctx, t6)
 end)
@@ -669,7 +662,6 @@ wasmOp(i64_ge_u, WasmI64GeU, macro(ctx)
     move 1, t6
     bia t1, t3, .return
     ciaeq t0, t2, t6
-    andi 1, t6
 .return:
     returni(ctx, t6)
 end)

--- a/Source/JavaScriptCore/llint/WebAssembly64.asm
+++ b/Source/JavaScriptCore/llint/WebAssembly64.asm
@@ -1,4 +1,4 @@
-# Copyright (C) 2011-2021 Apple Inc. All rights reserved.
+# Copyright (C) 2011-2023 Apple Inc. All rights reserved.
 # Copyright (C) 2021 Igalia S.L. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -452,7 +452,6 @@ wasmOp(i64_eq, WasmI64Eq, macro(ctx)
     mloadq(ctx, m_lhs, t0)
     mloadq(ctx, m_rhs, t1)
     cqeq t0, t1, t2
-    andi 1, t2
     returni(ctx, t2)
 end)
 
@@ -460,7 +459,6 @@ wasmOp(i64_ne, WasmI64Ne, macro(ctx)
     mloadq(ctx, m_lhs, t0)
     mloadq(ctx, m_rhs, t1)
     cqneq t0, t1, t2
-    andi 1, t2
     returni(ctx, t2)
 end)
 
@@ -468,7 +466,6 @@ wasmOp(i64_lt_s, WasmI64LtS, macro(ctx)
     mloadq(ctx, m_lhs, t0)
     mloadq(ctx, m_rhs, t1)
     cqlt t0, t1, t2
-    andi 1, t2
     returni(ctx, t2)
 end)
 
@@ -476,7 +473,6 @@ wasmOp(i64_le_s, WasmI64LeS, macro(ctx)
     mloadq(ctx, m_lhs, t0)
     mloadq(ctx, m_rhs, t1)
     cqlteq t0, t1, t2
-    andi 1, t2
     returni(ctx, t2)
 end)
 
@@ -484,7 +480,6 @@ wasmOp(i64_lt_u, WasmI64LtU, macro(ctx)
     mloadq(ctx, m_lhs, t0)
     mloadq(ctx, m_rhs, t1)
     cqb t0, t1, t2
-    andi 1, t2
     returni(ctx, t2)
 end)
 
@@ -492,7 +487,6 @@ wasmOp(i64_le_u, WasmI64LeU, macro(ctx)
     mloadq(ctx, m_lhs, t0)
     mloadq(ctx, m_rhs, t1)
     cqbeq t0, t1, t2
-    andi 1, t2
     returni(ctx, t2)
 end)
 
@@ -500,7 +494,6 @@ wasmOp(i64_gt_s, WasmI64GtS, macro(ctx)
     mloadq(ctx, m_lhs, t0)
     mloadq(ctx, m_rhs, t1)
     cqgt t0, t1, t2
-    andi 1, t2
     returni(ctx, t2)
 end)
 
@@ -508,7 +501,6 @@ wasmOp(i64_ge_s, WasmI64GeS, macro(ctx)
     mloadq(ctx, m_lhs, t0)
     mloadq(ctx, m_rhs, t1)
     cqgteq t0, t1, t2
-    andi 1, t2
     returni(ctx, t2)
 end)
 
@@ -516,7 +508,6 @@ wasmOp(i64_gt_u, WasmI64GtU, macro(ctx)
     mloadq(ctx, m_lhs, t0)
     mloadq(ctx, m_rhs, t1)
     cqa t0, t1, t2
-    andi 1, t2
     returni(ctx, t2)
 end)
 
@@ -524,7 +515,6 @@ wasmOp(i64_ge_u, WasmI64GeU, macro(ctx)
     mloadq(ctx, m_lhs, t0)
     mloadq(ctx, m_rhs, t1)
     cqaeq t0, t1, t2
-    andi 1, t2
     returni(ctx, t2)
 end)
 


### PR DESCRIPTION
#### 9354d948240f4a6f2461eaf6a3febaa3424f0967
<pre>
Remove unnecessary masking after wasm LLInt comparison instructions.
<a href="https://bugs.webkit.org/show_bug.cgi?id=251769">https://bugs.webkit.org/show_bug.cgi?id=251769</a>
rdar://105063662

Reviewed by Tadeu Zagallo.

Currently, we always follow a LLInt comparison instructions with an `and with 1` mask.
This is completely unnecessary because the LLInt comparison instructions already always
produce a 1 or a 0.  Hence, the `and with 1` mask is effectively a no-op.  This patch
removes this unnecessary masking.

* Source/JavaScriptCore/llint/WebAssembly.asm:
* Source/JavaScriptCore/llint/WebAssembly32_64.asm:
* Source/JavaScriptCore/llint/WebAssembly64.asm:

Canonical link: <a href="https://commits.webkit.org/259882@main">https://commits.webkit.org/259882@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f256d8e589057c624be57551a80f790b1206a1a4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106286 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15340 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39125 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115479 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175582 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16782 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6556 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98502 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115164 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112050 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12767 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95748 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40320 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94642 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27391 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82010 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/95893 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8580 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28743 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/95292 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/6430 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9090 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5314 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30591 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14703 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48289 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/104033 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10626 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25780 "Passed tests") | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3679 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->