### PR TITLE
[Win] REGRESSION(259818@main) error LNK2019: unresolved external symbol currentStackPointer

### DIFF
--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
@@ -2801,14 +2801,6 @@ _wasm_trampoline_wasm_tail_call_indirect_wide32:
 
 end # WEBASSEMBLY and not X86_64_WIN
 
-if X86_64_WIN
-    global _currentStackPointer
-    _currentStackPointer:
-        move sp, r0
-        addp MachineRegisterSize + 32, r0 # Account for return address and shadow stack
-        ret
-end
-
 include? LowLevelInterpreterAdditions
 
 global _llintPCRangeEnd

--- a/Source/WTF/wtf/StackPointer.h
+++ b/Source/WTF/wtf/StackPointer.h
@@ -49,7 +49,7 @@ ALWAYS_INLINE void* currentStackPointer()
     return stackPointer;
 }
 
-#elif !ENABLE(CLOOP) && !ASAN_ENABLED
+#elif !ENABLE(CLOOP) && !ASAN_ENABLED && !(CPU(X86_64) && OS(WINDOWS))
 
 #define USE_ASM_CURRENT_STACK_POINTER 1
 extern "C" WTF_EXPORT_PRIVATE void* currentStackPointer();


### PR DESCRIPTION
#### 9be772528ff28d90138ee12eebc844be7dce30ae
<pre>
[Win] REGRESSION(259818@main) error LNK2019: unresolved external symbol currentStackPointer
<a href="https://bugs.webkit.org/show_bug.cgi?id=251770">https://bugs.webkit.org/show_bug.cgi?id=251770</a>

Reviewed by Mark Lam.

Linking WTF.dll was failing due to the unresolved external symbol
currentStackPointer in Windows debug builds.
WTF::StackBounds::checkConsistency calls the function only in debug
builds. Restored the original code of currentStackPointer for 64bit
Windows.

* Source/JavaScriptCore/llint/LowLevelInterpreter.asm:
* Source/WTF/wtf/StackPointer.h:

Canonical link: <a href="https://commits.webkit.org/259877@main">https://commits.webkit.org/259877@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47cdd114caeda78b7e8ca89f93932cc8dc253aff

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106292 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15346 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39131 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/115485 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175589 "Failed to checkout and rebase branch from PR 9668") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16788 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6562 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98508 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115170 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112056 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/95754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/40327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/94646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/27397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/95899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/8586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/28749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/95298 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/83/builds/6436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9096 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/5320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/30595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14709 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/48295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/104039 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10632 "Built successfully") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/25784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3678 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->