### PR TITLE
[WebGPU] Timestamp writes only work in vary specific situations

### DIFF
--- a/Source/WebGPU/WebGPU/CommandEncoder.h
+++ b/Source/WebGPU/WebGPU/CommandEncoder.h
@@ -29,6 +29,7 @@
 #import <wtf/FastMalloc.h>
 #import <wtf/Ref.h>
 #import <wtf/RefCounted.h>
+#import <wtf/Vector.h>
 
 struct WGPUCommandEncoderImpl {
 };
@@ -84,6 +85,7 @@ private:
     bool validateClearBuffer(const Buffer&, uint64_t offset, uint64_t size);
     bool validateFinish() const;
     bool validatePopDebugGroup() const;
+    bool validateComputePassDescriptor(const WGPUComputePassDescriptor&) const;
     bool validateRenderPassDescriptor(const WGPURenderPassDescriptor&) const;
 
     void makeInvalid() { m_commandBuffer = nil; }
@@ -94,6 +96,11 @@ private:
     id<MTLCommandBuffer> m_commandBuffer { nil };
     id<MTLBlitCommandEncoder> m_blitCommandEncoder { nil };
 
+    struct PendingTimestampWrites {
+        Ref<QuerySet> querySet;
+        uint32_t queryIndex;
+    };
+    Vector<PendingTimestampWrites> m_pendingTimestampWrites;
     uint64_t m_debugGroupStackSize { 0 };
 
     const Ref<Device> m_device;

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.h
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (c) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,6 +29,7 @@
 #import <wtf/FastMalloc.h>
 #import <wtf/Ref.h>
 #import <wtf/RefCounted.h>
+#import <wtf/Vector.h>
 
 struct WGPUComputePassEncoderImpl {
 };
@@ -45,9 +46,9 @@ class QuerySet;
 class ComputePassEncoder : public WGPUComputePassEncoderImpl, public RefCounted<ComputePassEncoder>, public CommandsMixin {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<ComputePassEncoder> create(id<MTLComputeCommandEncoder> computeCommandEncoder, Device& device)
+    static Ref<ComputePassEncoder> create(id<MTLComputeCommandEncoder> computeCommandEncoder, const WGPUComputePassDescriptor& descriptor, Device& device)
     {
-        return adoptRef(*new ComputePassEncoder(computeCommandEncoder, device));
+        return adoptRef(*new ComputePassEncoder(computeCommandEncoder, descriptor, device));
     }
     static Ref<ComputePassEncoder> createInvalid(Device& device)
     {
@@ -73,7 +74,7 @@ public:
     bool isValid() const { return m_computeCommandEncoder; }
 
 private:
-    ComputePassEncoder(id<MTLComputeCommandEncoder>, Device&);
+    ComputePassEncoder(id<MTLComputeCommandEncoder>, const WGPUComputePassDescriptor&, Device&);
     ComputePassEncoder(Device&);
 
     bool validatePopDebugGroup() const;
@@ -82,6 +83,11 @@ private:
 
     id<MTLComputeCommandEncoder> m_computeCommandEncoder { nil };
 
+    struct PendingTimestampWrites {
+        Ref<QuerySet> querySet;
+        uint32_t queryIndex;
+    };
+    Vector<PendingTimestampWrites> m_pendingTimestampWrites;
     uint64_t m_debugGroupStackSize { 0 };
 
     const Ref<Device> m_device;

--- a/Source/WebGPU/WebGPU/HardwareCapabilities.h
+++ b/Source/WebGPU/WebGPU/HardwareCapabilities.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (c) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -43,6 +43,11 @@ struct HardwareCapabilities {
         // as all hardware can render to this format. It's unclear whether this should
         // apply to _all_ PresentationContexts or just PresentationContextCoreAnimation.
         bool canPresentRGB10A2PixelFormats { false };
+        enum class CounterSamplingAPI : uint8_t {
+            StageBoundary,
+            CommandBoundary,
+        };
+        CounterSamplingAPI counterSamplingAPI { CounterSamplingAPI::StageBoundary }; // only meaningful if timestampCounterSet is non-nil
     } baseCapabilities;
 };
 

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (c) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -47,9 +47,9 @@ class RenderPipeline;
 class RenderPassEncoder : public WGPURenderPassEncoderImpl, public RefCounted<RenderPassEncoder>, public CommandsMixin {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<RenderPassEncoder> create(id<MTLRenderCommandEncoder> renderCommandEncoder, NSUInteger visibilityResultBufferSize, bool depthReadOnly, bool stencilReadOnly, Device& device)
+    static Ref<RenderPassEncoder> create(id<MTLRenderCommandEncoder> renderCommandEncoder, const WGPURenderPassDescriptor& descriptor, NSUInteger visibilityResultBufferSize, bool depthReadOnly, bool stencilReadOnly, Device& device)
     {
-        return adoptRef(*new RenderPassEncoder(renderCommandEncoder, visibilityResultBufferSize, depthReadOnly, stencilReadOnly, device));
+        return adoptRef(*new RenderPassEncoder(renderCommandEncoder, descriptor, visibilityResultBufferSize, depthReadOnly, stencilReadOnly, device));
     }
     static Ref<RenderPassEncoder> createInvalid(Device& device)
     {
@@ -86,7 +86,7 @@ public:
     bool isValid() const { return m_renderCommandEncoder; }
 
 private:
-    RenderPassEncoder(id<MTLRenderCommandEncoder>, NSUInteger, bool depthReadOnly, bool stencilReadOnly, Device&);
+    RenderPassEncoder(id<MTLRenderCommandEncoder>, const WGPURenderPassDescriptor&, NSUInteger, bool depthReadOnly, bool stencilReadOnly, Device&);
     RenderPassEncoder(Device&);
 
     bool validatePopDebugGroup() const;
@@ -96,6 +96,11 @@ private:
     id<MTLRenderCommandEncoder> m_renderCommandEncoder { nil };
 
     uint64_t m_debugGroupStackSize { 0 };
+    struct PendingTimestampWrites {
+        Ref<QuerySet> querySet;
+        uint32_t queryIndex;
+    };
+    Vector<PendingTimestampWrites> m_pendingTimestampWrites;
 
     const Ref<Device> m_device;
     MTLPrimitiveType m_primitiveType { MTLPrimitiveTypeTriangle };

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (c) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,13 +35,29 @@
 
 namespace WebGPU {
 
-RenderPassEncoder::RenderPassEncoder(id<MTLRenderCommandEncoder> renderCommandEncoder, NSUInteger visibilityResultBufferSize, bool depthReadOnly, bool stencilReadOnly, Device& device)
+RenderPassEncoder::RenderPassEncoder(id<MTLRenderCommandEncoder> renderCommandEncoder, const WGPURenderPassDescriptor& descriptor, NSUInteger visibilityResultBufferSize, bool depthReadOnly, bool stencilReadOnly, Device& device)
     : m_renderCommandEncoder(renderCommandEncoder)
     , m_device(device)
     , m_visibilityResultBufferSize(visibilityResultBufferSize)
     , m_depthReadOnly(depthReadOnly)
     , m_stencilReadOnly(stencilReadOnly)
 {
+    if (m_device->baseCapabilities().counterSamplingAPI == HardwareCapabilities::BaseCapabilities::CounterSamplingAPI::CommandBoundary) {
+        for (uint32_t i = 0; i < descriptor.timestampWriteCount; ++i) {
+            const auto& timestampWrite = descriptor.timestampWrites[i];
+            switch (timestampWrite.location) {
+            case WGPURenderPassTimestampLocation_Beginning:
+                [m_renderCommandEncoder sampleCountersInBuffer:fromAPI(timestampWrite.querySet).counterSampleBuffer() atSampleIndex:timestampWrite.queryIndex withBarrier:NO];
+                break;
+            case WGPURenderPassTimestampLocation_End:
+                m_pendingTimestampWrites.append({ fromAPI(timestampWrite.querySet), timestampWrite.queryIndex });
+                break;
+            case WGPURenderPassTimestampLocation_Force32:
+                ASSERT_NOT_REACHED();
+                break;
+            }
+        }
+    }
 }
 
 RenderPassEncoder::RenderPassEncoder(Device& device)
@@ -104,6 +120,10 @@ void RenderPassEncoder::endOcclusionQuery()
 
 void RenderPassEncoder::endPass()
 {
+    ASSERT(m_pendingTimestampWrites.isEmpty() || m_device->baseCapabilities().counterSamplingAPI == HardwareCapabilities::BaseCapabilities::CounterSamplingAPI::CommandBoundary);
+    for (const auto& pendingTimestampWrite : m_pendingTimestampWrites)
+        [m_renderCommandEncoder sampleCountersInBuffer:pendingTimestampWrite.querySet->counterSampleBuffer() atSampleIndex:pendingTimestampWrite.queryIndex withBarrier:NO];
+    m_pendingTimestampWrites.clear();
     [m_renderCommandEncoder endEncoding];
 }
 

--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -327,7 +327,7 @@ static MTLVertexStepFunction stepFunction(WGPUVertexStepMode stepMode)
 
 static MTLVertexDescriptor *createVertexDescriptor(WGPUVertexState vertexState)
 {
-    MTLVertexDescriptor *vertexDescriptor = [MTLVertexDescriptor vertexDescriptor];
+    MTLVertexDescriptor *vertexDescriptor = [MTLVertexDescriptor new];
 
     for (size_t bufferIndex = 0; bufferIndex < vertexState.bufferCount; ++bufferIndex) {
         auto& buffer = vertexState.buffers[bufferIndex];


### PR DESCRIPTION
#### 7db946a6f19e50aa9ff1243097142c2a46a89e43
<pre>
[WebGPU] Timestamp writes only work in vary specific situations
<a href="https://bugs.webkit.org/show_bug.cgi?id=251773">https://bugs.webkit.org/show_bug.cgi?id=251773</a>
rdar://105067419

Reviewed by Tadeu Zagallo.

Before this patch, the infrastructure for timestamp writes is very specific:
- Only Apple Silicon machines are supported
- CommandEncoder.writeTimestamp() is not supported
- ComputePassDescriptor.timestampWrites are not supported
- RenderPassDescriptor.timestampWrites is supported, but only for the first element,
      and only for specific hardcoded values of queryIndex

This patch generalizes support:

In Metal, different devices support different query set APIs. You have to call
[MTLDevice supportsCounterSampling:] to know which kind of device you&apos;re on. Apple
Silicon devices report that they only support counter sampling on stage boundaries,
via the pass descriptors&apos; sampleBufferAttachments. All other devices (that I&apos;ve
tried) report that they support counter sampling on individual command boundaries.
If a device doesn&apos;t support either of these granularities, then it just won&apos;t
support the timestamp queries feature in the first place.

For pass descriptors&apos; timestampWrites array, if the device is an Apple Silicon device,
we are supposed to be able to naively transform the timestampWrites into
sampleBufferAttachments, which is what this patch does. However, rdar://91371495 is
about how that doesn&apos;t actually work; a follow-up patch is necessary to work around
this. For non-Apple-Silicon devices, we implement the timestampWrites array by just
calling -[CommandEncoder sampleCountersInBuffer:] at the beginning and end of the pass.

For CommandEncoder.writeTimestamp(), we can implement this on Apple Silicon devices by
creating a dummy blit pass, and setting sampleBufferAttachments on it. We want to
coalesce multiple writes into a single blit pass, so we defer doing this as long as
possible - until either we would have had to make a blit pass anyway, we have to start
a new pass, or the command encoder is ending. For non-Apple-Silicon devices,
CommandEncoder.writeTimestamp() directly turns into
-[MTLBlitCommandEncoder sampleCountersInBuffer:].

Because of rdar://91371495, this patch isn&apos;t actually fully-functional; however,
the existing infrastructure wasn&apos;t fully-functional either, so I&apos;m kind of viewing this
patch as not-a-regression. My next patch will work around rdar://91371495.

* Source/WebGPU/WebGPU/CommandEncoder.h:
* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::ensureBlitCommandEncoder):
(WebGPU::CommandEncoder::finalizeBlitCommandEncoder):
(WebGPU::CommandEncoder::validateComputePassDescriptor const):
(WebGPU::CommandEncoder::beginComputePass):
(WebGPU::CommandEncoder::validateRenderPassDescriptor const):
(WebGPU::CommandEncoder::beginRenderPass):
(WebGPU::CommandEncoder::writeTimestamp):
* Source/WebGPU/WebGPU/ComputePassEncoder.h:
(WebGPU::ComputePassEncoder::create):
* Source/WebGPU/WebGPU/ComputePassEncoder.mm:
(WebGPU::ComputePassEncoder::ComputePassEncoder):
(WebGPU::ComputePassEncoder::endPass):
* Source/WebGPU/WebGPU/HardwareCapabilities.h:
* Source/WebGPU/WebGPU/HardwareCapabilities.mm:
(WebGPU::baseCapabilities):
(WebGPU::mergeBaseCapabilities):
* Source/WebGPU/WebGPU/RenderPassEncoder.h:
(WebGPU::RenderPassEncoder::create):
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::RenderPassEncoder):
(WebGPU::RenderPassEncoder::endPass):
* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::createVertexDescriptor):

Canonical link: <a href="https://commits.webkit.org/259914@main">https://commits.webkit.org/259914@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0f9364bf6f7bafdf9403ab01ec6cefc5c689073

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106295 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15349 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39134 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115488 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16791 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6565 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98511 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115175 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112059 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12776 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95757 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40330 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94651 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27400 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82020 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8589 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28752 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9099 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5323 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14712 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48298 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6849 "'git push ...'") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10635 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->