### PR TITLE
[TestWebKitAPI] register WebProcessTestRunner only for main frame

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/WebProcessTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/WebProcessTest.cpp
@@ -86,7 +86,7 @@ static void webProcessTestRunnerFinalize(WebKitWebPage* webPage)
 
 static void windowObjectClearedCallback(WebKitScriptWorld* world, WebKitWebPage* webPage, WebKitFrame* frame, WebKitWebExtension* extension)
 {
-    if (g_strcmp0(webkit_web_page_get_uri(webPage), "webprocess://test"))
+    if (g_strcmp0(webkit_web_page_get_uri(webPage), "webprocess://test") || !webkit_frame_is_main_frame(frame))
         return;
 
     GRefPtr<JSCContext> context = adoptGRef(webkit_frame_get_js_context_for_script_world(frame, world));


### PR DESCRIPTION
#### af3682230d4e02cc379762abae2cb116380fb5a9
<pre>
[TestWebKitAPI] register WebProcessTestRunner only for main frame
<a href="https://bugs.webkit.org/show_bug.cgi?id=251684">https://bugs.webkit.org/show_bug.cgi?id=251684</a>

Reviewed by Carlos Garcia Campos.

It fixes the problem with reporting an object leak at the end of the
test:
Leaked objects in WebProcess: WebKitWebPage(0x55f0239978a0)
Bail out! ERROR:/app/webkit/Tools/TestWebKitAPI/Tests/WebKitGLib/WebProcessTest.cpp:49:void checkLeaks(): &apos;s_watchedObjects.isEmpty()&apos; should be TRUE

* Tools/TestWebKitAPI/Tests/WebKitGLib/WebProcessTest.cpp:
(windowObjectClearedCallback):

Canonical link: <a href="https://commits.webkit.org/259883@main">https://commits.webkit.org/259883@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0dd463ac6f674a77df9471343345ede17e1a3811

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106301 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15355 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39140 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115494 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/175598 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110211 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16797 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6571 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98517 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115181 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112065 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/95764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/40334 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/94660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/27407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82024 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8595 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/28759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9105 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5329 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14718 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/48305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10641 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3680 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->