### PR TITLE
[JSC] Fix currentStackPointer

### DIFF
--- a/Source/WTF/wtf/PlatformWin.cmake
+++ b/Source/WTF/wtf/PlatformWin.cmake
@@ -1,3 +1,15 @@
+if (WTF_CPU_X86_64)
+    if (MSVC)
+        add_custom_command(
+            OUTPUT ${WTF_DERIVED_SOURCES_DIR}/AsmStubsMSVC64.obj
+            MAIN_DEPENDENCY ${WTF_DIR}/wtf/win/AsmStubsMSVC64.asm
+            COMMAND ml64 -nologo -c -Fo ${WTF_DERIVED_SOURCES_DIR}/AsmStubsMSVC64.obj ${WTF_DIR}/wtf/win/AsmStubsMSVC64.asm
+            VERBATIM)
+
+        list(APPEND WTF_SOURCES ${WTF_DERIVED_SOURCES_DIR}/AsmStubsMSVC64.obj)
+    endif ()
+endif ()
+
 list(APPEND WTF_PUBLIC_HEADERS
     text/win/WCharStringExtras.h
 

--- a/Source/WTF/wtf/StackPointer.cpp
+++ b/Source/WTF/wtf/StackPointer.cpp
@@ -46,7 +46,6 @@ extern "C" __declspec(naked) void currentStackPointer()
 asm (
     ".text" "\n"
     ".globl " SYMBOL_STRING(currentStackPointer) "\n"
-    HIDE_SYMBOL(currentStackPointer) "\n"
     SYMBOL_STRING(currentStackPointer) ":" "\n"
     "movl %esp, %eax" "\n"
     "addl $4, %eax" "\n"
@@ -63,7 +62,6 @@ asm (
 asm (
     ".text" "\n"
     ".globl " SYMBOL_STRING(currentStackPointer) "\n"
-    HIDE_SYMBOL(currentStackPointer) "\n"
     SYMBOL_STRING(currentStackPointer) ":" "\n"
 
     "movq  %rsp, %rax" "\n"
@@ -77,7 +75,6 @@ asm (
     ".text" "\n"
     ".balign 16" "\n"
     ".globl " SYMBOL_STRING(currentStackPointer) "\n"
-    HIDE_SYMBOL(currentStackPointer) "\n"
     SYMBOL_STRING(currentStackPointer) ":" "\n"
 
     "pacibsp" "\n"
@@ -91,7 +88,6 @@ asm (
     ".text" "\n"
     ".balign 16" "\n"
     ".globl " SYMBOL_STRING(currentStackPointer) "\n"
-    HIDE_SYMBOL(currentStackPointer) "\n"
     SYMBOL_STRING(currentStackPointer) ":" "\n"
 
     "mov x0, sp" "\n"
@@ -104,7 +100,6 @@ asm (
     ".text" "\n"
     ".align 2" "\n"
     ".globl " SYMBOL_STRING(currentStackPointer) "\n"
-    HIDE_SYMBOL(currentStackPointer) "\n"
     ".thumb" "\n"
     ".thumb_func " THUMB_FUNC_PARAM(currentStackPointer) "\n"
     SYMBOL_STRING(currentStackPointer) ":" "\n"
@@ -118,7 +113,6 @@ asm (
 asm (
     ".text" "\n"
     ".globl " SYMBOL_STRING(currentStackPointer) "\n"
-    HIDE_SYMBOL(currentStackPointer) "\n"
     SYMBOL_STRING(currentStackPointer) ":" "\n"
     ".set push" "\n"
     ".set noreorder" "\n"
@@ -135,7 +129,6 @@ asm (
 asm (
     ".text" "\n"
     ".globl " SYMBOL_STRING(currentStackPointer) "\n"
-    HIDE_SYMBOL(currentStackPointer) "\n"
     SYMBOL_STRING(currentStackPointer) ":" "\n"
 
      "mv x10, sp" "\n"

--- a/Source/WTF/wtf/StackPointer.h
+++ b/Source/WTF/wtf/StackPointer.h
@@ -49,10 +49,10 @@ ALWAYS_INLINE void* currentStackPointer()
     return stackPointer;
 }
 
-#elif !ENABLE(CLOOP) && !ASAN_ENABLED && !(CPU(X86_64) && OS(WINDOWS))
+#elif !ENABLE(CLOOP)
 
 #define USE_ASM_CURRENT_STACK_POINTER 1
-extern "C" WTF_EXPORT_PRIVATE void* currentStackPointer();
+extern "C" WTF_EXPORT_PRIVATE void* currentStackPointer(void);
 
 #else
 

--- a/Source/WTF/wtf/win/AsmStubsMSVC64.asm
+++ b/Source/WTF/wtf/win/AsmStubsMSVC64.asm
@@ -1,0 +1,38 @@
+;/*
+; Copyright (C) 2023 Apple Inc. All rights reserved.
+;
+; Redistribution and use in source and binary forms, with or without
+; modification, are permitted provided that the following conditions
+; are met:
+; 1. Redistributions of source code must retain the above copyright
+;    notice, this list of conditions and the following disclaimer.
+; 2. Redistributions in binary form must reproduce the above copyright
+;    notice, this list of conditions and the following disclaimer in the
+;    documentation and/or other materials provided with the distribution.
+;
+; THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+; EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+; PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+; CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+; EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+; PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+; PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+; OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+; (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+; OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+;*/
+
+PUBLIC currentStackPointer
+
+_TEXT   SEGMENT
+
+currentStackPointer PROC EXPORT
+    mov rax, rsp
+    add rax, 40 ; Account for return address and shadow stack
+    ret
+currentStackPointer ENDP
+
+_TEXT   ENDS
+
+END


### PR DESCRIPTION
#### 8ef2a6e11652f78d13e5e9256a5a523cdee84bd2
<pre>
[JSC] Fix currentStackPointer
<a href="https://bugs.webkit.org/show_bug.cgi?id=251780">https://bugs.webkit.org/show_bug.cgi?id=251780</a>
rdar://105073142

Reviewed by Mark Lam.

1. Do not use HIDE_SYMBOL since we would like to actually expose them (WTF_EXPORT_PRIVATE).
2. Add AsmStubsMSVC64.asm for MSVC x64 to implement asm stubs in WTF

* Source/WTF/wtf/PlatformWin.cmake:
* Source/WTF/wtf/StackPointer.cpp:
* Source/WTF/wtf/StackPointer.h:
* Source/WTF/wtf/win/AsmStubsMSVC64.asm: Added.

Canonical link: <a href="https://commits.webkit.org/259907@main">https://commits.webkit.org/259907@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95d7a30716030e76c63245e170404fa387cdd864

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106313 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15367 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39152 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115506 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175625 "Too many flaky failures: accessibility/aria-roles.html, css3/filters/change-filter-style.html, editing/execCommand/insert-list-nested-with-orphaned-live-range.html, fast/forms/shadow-tree-exposure-live-range.html, fast/inline/trailing-inline-box-soft-wrap-opportunity.html, fast/repaint/leftover-after-shrinking-content.html, fast/repaint/rtl-content-selection-hairline-gap.html, fast/text/international/bdo-bidi-width.html, fast/text/text-edge-property-parsing.html, fast/text/text-edge-with-margin-padding-border-simple.html, http/wpt/clear-site-data/clear-back-forward-cache.html (failure)") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16844 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6583 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98529 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115196 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112077 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12794 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95774 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40346 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94669 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27417 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82036 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/95919 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8607 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28769 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/95319 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/6457 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9117 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5340 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30598 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14732 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48315 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/104060 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10684 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25787 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3690 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->