### PR TITLE
[GTK] Don't enable favicon database by default

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.cpp
@@ -144,11 +144,6 @@ static void webkitNetworkSessionConstructed(GObject* object)
 
     priv->tlsErrorsPolicy = WEBKIT_TLS_ERRORS_POLICY_FAIL;
     webkitWebsiteDataManagerGetDataStore(priv->websiteDataManager.get()).setIgnoreTLSErrors(false);
-
-#if PLATFORM(GTK)
-    // Enable favicons by default.
-    webkit_website_data_manager_set_favicons_enabled(priv->websiteDataManager.get(), TRUE);
-#endif
 }
 
 static void webkit_network_session_class_init(WebKitNetworkSessionClass* sessionClass)

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.cpp
@@ -1054,8 +1054,8 @@ static String webkitWebsiteDataManagerGetFaviconDatabasePath(WebKitWebsiteDataMa
  * @manager: a #WebKitWebsiteDataManager
  * @enabled: value to set
  *
- * Set whether website icons are enabled. Website icons are enabled by default.
- * When website icons are disabled, the #WebKitFaviconDatabase of @manager is closed
+ * Set whether website icons are enabled. Website icons are disabled by default.
+ * When website icons are disabled, the #WebKitFaviconDatabase of @manager is closed and
  * its reference removed, so webkit_website_data_manager_get_favicon_database() will
  * return %NULL. If website icons are enabled again, a new #WebKitFaviconDatabase will
  * be created.

--- a/Tools/MiniBrowser/gtk/BrowserWindow.c
+++ b/Tools/MiniBrowser/gtk/BrowserWindow.c
@@ -799,7 +799,13 @@ static void openPrivateWindow(GSimpleAction *action, GVariant *parameter, gpoint
 #if GTK_CHECK_VERSION(3, 98, 0)
     WebKitNetworkSession *networkSession = NULL;
     if (!webkit_web_view_is_controlled_by_automation(webView)) {
+        WebKitWebsiteDataManager *manager;
+
         networkSession = webkit_network_session_new_ephemeral();
+
+        manager = webkit_network_session_get_website_data_manager(networkSession);
+        webkit_website_data_manager_set_favicons_enabled(manager, TRUE);
+
         webkit_network_session_set_tls_errors_policy(networkSession, webkit_network_session_get_tls_errors_policy(window->networkSession));
         // FIXME: we need public api to get proxy settings.
     }

--- a/Tools/MiniBrowser/gtk/main.c
+++ b/Tools/MiniBrowser/gtk/main.c
@@ -693,6 +693,11 @@ static void activate(GApplication *application, WebKitSettings *webkitSettings)
     webkit_network_session_set_itp_enabled(networkSession, enableITP);
 
     if (!automationMode) {
+        WebKitWebsiteDataManager *manager;
+
+        manager = webkit_network_session_get_website_data_manager(networkSession);
+        webkit_website_data_manager_set_favicons_enabled(manager, TRUE);
+
         if (proxy) {
             WebKitNetworkProxySettings *webkitProxySettings = webkit_network_proxy_settings_new(proxy, ignoreHosts);
             webkit_network_session_set_proxy_settings(networkSession, WEBKIT_NETWORK_PROXY_MODE_CUSTOM, webkitProxySettings);
@@ -769,7 +774,7 @@ static void activate(GApplication *application, WebKitSettings *webkitSettings)
         webkit_cookie_manager_set_persistent_storage(cookieManager, cookiesFile, storageType);
     }
 
-    // Enable the favicon database. In GTK4 API they are enabled by default.
+    // Enable the favicon database.
     webkit_web_context_set_favicon_database_directory(webContext, NULL);
 #endif
 


### PR DESCRIPTION
#### ac3878ed7421386b7ac87aea6f323552a32f7794
<pre>
[GTK] Don&apos;t enable favicon database by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=251588">https://bugs.webkit.org/show_bug.cgi?id=251588</a>

Reviewed by Adrian Perez de Castro.

* Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.cpp:
(webkitNetworkSessionConstructed):
* Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.cpp:
* Tools/MiniBrowser/gtk/BrowserWindow.c:
(openPrivateWindow):
* Tools/MiniBrowser/gtk/main.c:
(activate):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitFaviconDatabase.cpp:
(testFaviconDatabaseInitialization):
(testFaviconDatabaseGetFavicon):
(testFaviconDatabaseEphemeral):
(testFaviconDatabaseClear):

Canonical link: <a href="https://commits.webkit.org/259888@main">https://commits.webkit.org/259888@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1b7478f8fd569f639ed006dab87fd6ff7a89fc0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106310 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15364 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39149 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115503 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175607 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110220 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16812 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6580 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98526 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115191 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112074 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95770 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/40342 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94667 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27413 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82031 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8604 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/28765 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9114 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5337 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14729 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48311 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10668 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3683 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->