### PR TITLE
[WGSL] Enable deferred compilation of compute shaders

### DIFF
--- a/Source/WebGPU/WGSL/EntryPointRewriter.cpp
+++ b/Source/WebGPU/WGSL/EntryPointRewriter.cpp
@@ -30,20 +30,16 @@
 #include "ASTVisitor.h"
 #include "CallGraph.h"
 #include "ShaderModule.h"
+#include "WGSL.h"
 
 namespace WGSL {
 
 class EntryPointRewriter {
 public:
-    EntryPointRewriter(ShaderModule& shaderModule, AST::Function& functionDecl, AST::StageAttribute::Stage stage)
-        : m_stage(stage)
-        , m_shaderModule(shaderModule)
-        , m_functionDecl(functionDecl)
-        , m_emptySourceSpan(0, 0, 0, 0)
-    {
-    }
+    EntryPointRewriter(ShaderModule&, AST::Function&, AST::StageAttribute::Stage);
 
     void rewrite();
+    Reflection::EntryPointInformation takeEntryPointInformation();
 
 private:
     struct MemberOrParameter {
@@ -68,7 +64,7 @@ private:
 
     AST::StageAttribute::Stage m_stage;
     ShaderModule& m_shaderModule;
-    AST::Function& m_functionDecl;
+    AST::Function& m_function;
 
     const SourceSpan m_emptySourceSpan;
     Vector<MemberOrParameter> m_builtins;
@@ -76,7 +72,27 @@ private:
     AST::Statement::List m_materializations;
     String m_structTypeName;
     String m_structParameterName;
+    Reflection::EntryPointInformation m_information;
 };
+
+EntryPointRewriter::EntryPointRewriter(ShaderModule& shaderModule, AST::Function& function, AST::StageAttribute::Stage stage)
+    : m_stage(stage)
+    , m_shaderModule(shaderModule)
+    , m_function(function)
+    , m_emptySourceSpan(0, 0, 0, 0)
+{
+    switch (m_stage) {
+    case AST::StageAttribute::Stage::Compute:
+        m_information.typedEntryPoint = Reflection::Compute { 1, 1, 1 };
+        break;
+    case AST::StageAttribute::Stage::Vertex:
+        m_information.typedEntryPoint = Reflection::Vertex { false };
+        break;
+    case AST::StageAttribute::Stage::Fragment:
+        m_information.typedEntryPoint = Reflection::Fragment { };
+        break;
+    }
+}
 
 AST::TypeName& EntryPointRewriter::getResolvedType(AST::TypeName& type)
 {
@@ -90,8 +106,8 @@ AST::TypeName& EntryPointRewriter::getResolvedType(AST::TypeName& type)
 
 void EntryPointRewriter::rewrite()
 {
-    m_structTypeName = makeString("__", m_functionDecl.name(), "_inT");
-    m_structParameterName = makeString("__", m_functionDecl.name(), "_in");
+    m_structTypeName = makeString("__", m_function.name(), "_inT");
+    m_structParameterName = makeString("__", m_function.name(), "_in");
 
     collectParameters();
     checkReturnType();
@@ -106,7 +122,7 @@ void EntryPointRewriter::rewrite()
     appendBuiltins();
 
     // add parameter to builtins: ${structName} : ${structType}
-    m_functionDecl.parameters().append(makeUniqueRef<AST::ParameterValue>(
+    m_function.parameters().append(makeUniqueRef<AST::ParameterValue>(
         m_emptySourceSpan,
         AST::Identifier::make(m_structParameterName),
         adoptRef(*new AST::NamedTypeName(m_emptySourceSpan, AST::Identifier::make(m_structTypeName))),
@@ -115,13 +131,18 @@ void EntryPointRewriter::rewrite()
     ));
 
     while (m_materializations.size())
-        m_functionDecl.body().statements().insert(0, m_materializations.takeLast());
+        m_function.body().statements().insert(0, m_materializations.takeLast());
+}
+
+Reflection::EntryPointInformation EntryPointRewriter::takeEntryPointInformation()
+{
+    return WTFMove(m_information);
 }
 
 void EntryPointRewriter::collectParameters()
 {
-    while (m_functionDecl.parameters().size()) {
-        auto parameter = m_functionDecl.parameters().takeLast();
+    while (m_function.parameters().size()) {
+        auto parameter = m_function.parameters().takeLast();
         Vector<String> path;
         visit(path, MemberOrParameter { parameter->name(), parameter->typeName(), WTFMove(parameter->attributes()) });
     }
@@ -133,7 +154,7 @@ void EntryPointRewriter::checkReturnType()
         return;
 
     // FIXME: we might have to duplicate this struct if it has other uses
-    if (auto* maybeReturnType = m_functionDecl.maybeReturnType()) {
+    if (auto* maybeReturnType = m_function.maybeReturnType()) {
         auto& returnType = getResolvedType(*maybeReturnType);
         if (is<AST::StructTypeName>(returnType)) {
             auto& structDecl = downcast<AST::StructTypeName>(returnType).structure();
@@ -275,7 +296,7 @@ void EntryPointRewriter::visit(Vector<String>& path, MemberOrParameter&& data)
 void EntryPointRewriter::appendBuiltins()
 {
     for (auto& data : m_builtins) {
-        m_functionDecl.parameters().append(makeUniqueRef<AST::ParameterValue>(
+        m_function.parameters().append(makeUniqueRef<AST::ParameterValue>(
             m_emptySourceSpan,
             AST::Identifier::make(data.m_name),
             WTFMove(data.m_type),
@@ -285,10 +306,14 @@ void EntryPointRewriter::appendBuiltins()
     }
 }
 
-void rewriteEntryPoints(CallGraph& callGraph)
+void rewriteEntryPoints(CallGraph& callGraph, PrepareResult& result)
 {
-    for (auto& entryPoint : callGraph.entrypoints())
-        EntryPointRewriter(callGraph.ast(), entryPoint.m_function, entryPoint.m_stage).rewrite();
+    for (auto& entryPoint : callGraph.entrypoints()) {
+        EntryPointRewriter rewriter(callGraph.ast(), entryPoint.m_function, entryPoint.m_stage);
+        rewriter.rewrite();
+        auto addResult = result.entryPoints.add(entryPoint.m_function.name().id(), rewriter.takeEntryPointInformation());
+        ASSERT_UNUSED(addResult, addResult.isNewEntry);
+    }
 }
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/EntryPointRewriter.h
+++ b/Source/WebGPU/WGSL/EntryPointRewriter.h
@@ -28,7 +28,8 @@
 namespace WGSL {
 
 class CallGraph;
+struct PrepareResult;
 
-void rewriteEntryPoints(CallGraph&);
+void rewriteEntryPoints(CallGraph&, PrepareResult&);
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/MangleNames.cpp
+++ b/Source/WebGPU/WGSL/MangleNames.cpp
@@ -69,12 +69,13 @@ class NameManglerVisitor : public AST::Visitor, public ContextProvider<MangledNa
     using ContextProvider = ContextProvider<MangledName>;
 
 public:
-    NameManglerVisitor(const CallGraph& callGraph)
+    NameManglerVisitor(const CallGraph& callGraph, PrepareResult& result)
         : m_callGraph(callGraph)
+        , m_result(result)
     {
     }
 
-    HashMap<String, String> run();
+    void run();
 
     void visit(AST::Function&) override;
     void visit(AST::VariableStatement&) override;
@@ -96,19 +97,19 @@ private:
     void visitFunctionBody(AST::Function&);
 
     const CallGraph& m_callGraph;
+    PrepareResult& m_result;
     HashMap<AST::Structure*, NameMap> m_structFieldMapping;
     uint32_t m_indexPerType[MangledName::numberOfKinds] { 0 };
 };
 
-HashMap<String, String> NameManglerVisitor::run()
+void NameManglerVisitor::run()
 {
-    HashMap<String, String> entryPointMap;
-
     for (const auto& entrypoint : m_callGraph.entrypoints()) {
         String originalName = entrypoint.m_function.name();
         introduceVariable(entrypoint.m_function.name(), MangledName::Function);
-        auto result = entryPointMap.add(originalName, entrypoint.m_function.name());
-        ASSERT_UNUSED(result, result.isNewEntry);
+        auto it = m_result.entryPoints.find(originalName);
+        RELEASE_ASSERT(it != m_result.entryPoints.end());
+        it->value.mangledName = entrypoint.m_function.name();
     }
 
     auto& module = m_callGraph.ast();
@@ -120,8 +121,6 @@ HashMap<String, String> NameManglerVisitor::run()
 
     for (auto& function : module.functions())
         visitFunctionBody(function);
-
-    return entryPointMap;
 }
 
 void NameManglerVisitor::visit(AST::Function& function)
@@ -212,9 +211,9 @@ void NameManglerVisitor::readVariable(AST::Identifier& name) const
         name = AST::Identifier::makeWithSpan(name.span(), mangledName->toString());
 }
 
-HashMap<String, String> mangleNames(CallGraph& callGraph)
+void mangleNames(CallGraph& callGraph, PrepareResult& result)
 {
-    return NameManglerVisitor(callGraph).run();
+    NameManglerVisitor(callGraph, result).run();
 }
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/MangleNames.h
+++ b/Source/WebGPU/WGSL/MangleNames.h
@@ -25,12 +25,11 @@
 
 #pragma once
 
-#include <wtf/text/WTFString.h>
-
 namespace WGSL {
 
 class CallGraph;
+struct PrepareResult;
 
-HashMap<String, String> mangleNames(CallGraph&);
+void mangleNames(CallGraph&, PrepareResult&);
 
 } // namespace WGSL

--- a/Source/WebGPU/WebGPU/ShaderModule.mm
+++ b/Source/WebGPU/WebGPU/ShaderModule.mm
@@ -109,9 +109,7 @@ Ref<ShaderModule> Device::createShaderModule(const WGPUShaderModuleDescriptor& d
 
     auto checkResult = WGSL::staticCheck(fromAPI(shaderModuleParameters->wgsl.code), std::nullopt, { maxBuffersPlusVertexBuffersForVertexStage() });
 
-    // FIXME: we shouldn't compile early unless hints were passed in. Remove this
-    // once we have wired up the deferred compilation.
-    if (std::holds_alternative<WGSL::SuccessfulCheck>(checkResult)) {
+    if (std::holds_alternative<WGSL::SuccessfulCheck>(checkResult) && shaderModuleParameters->hints && descriptor.hintCount) {
         if (auto result = earlyCompileShaderModule(*this, WTFMove(checkResult), descriptor, fromAPI(descriptor.label)))
             return result.releaseNonNull();
     } else {


### PR DESCRIPTION
#### f96ecde0824ff7694d781bb8e3324bee9f24e04c
<pre>
[WGSL] Enable deferred compilation of compute shaders
<a href="https://bugs.webkit.org/show_bug.cgi?id=251785">https://bugs.webkit.org/show_bug.cgi?id=251785</a>
&lt;rdar://problem/105075787&gt;

Reviewed by Myles C. Maxfield.

In #9441 we allowed early compilation of shaders even when no hints were provided.
That was a workaround to start passing some of the CTS tests and unblock testing
the API. Now we remove that workaround and add the necessary functionality to defer
the compilation until the pipeline creation if no hints were provided.

* Source/WebGPU/WGSL/EntryPointRewriter.cpp:
(WGSL::EntryPointRewriter::EntryPointRewriter):
(WGSL::EntryPointRewriter::rewrite):
(WGSL::EntryPointRewriter::takeEntryPointInformation):
(WGSL::EntryPointRewriter::collectParameters):
(WGSL::EntryPointRewriter::checkReturnType):
(WGSL::EntryPointRewriter::appendBuiltins):
(WGSL::rewriteEntryPoints):
* Source/WebGPU/WGSL/EntryPointRewriter.h:
* Source/WebGPU/WGSL/MangleNames.cpp:
(WGSL::NameManglerVisitor::NameManglerVisitor):
(WGSL::NameManglerVisitor::run):
(WGSL::mangleNames):
* Source/WebGPU/WGSL/MangleNames.h:
* Source/WebGPU/WGSL/WGSL.cpp:
(WGSL::prepareImpl):
(WGSL::prepare):
* Source/WebGPU/WGSL/WGSL.h:
* Source/WebGPU/WebGPU/ShaderModule.mm:
(WebGPU::Device::createShaderModule):

Canonical link: <a href="https://commits.webkit.org/259954@main">https://commits.webkit.org/259954@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bca7548c95d8734f77db0a7e409698e8a4ebd2e8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106521 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15537 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39330 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115706 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/115355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17032 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6765 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98713 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112289 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95905 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/40496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/94814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27549 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8766 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28901 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9309 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/5480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14925 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48449 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6882 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10847 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->