### PR TITLE
CachedResource does not need to store a whole ResourceLoaderOptions

### DIFF
--- a/Source/WebCore/Modules/fetch/FetchLoader.cpp
+++ b/Source/WebCore/Modules/fetch/FetchLoader.cpp
@@ -85,7 +85,7 @@ void FetchLoader::startLoadingBlobURL(ScriptExecutionContext& context, const URL
 
 void FetchLoader::start(ScriptExecutionContext& context, const FetchRequest& request, const String& initiator)
 {
-    ResourceLoaderOptions resourceLoaderOptions = request.fetchOptions();
+    ResourceLoaderOptions resourceLoaderOptions { request.fetchOptions() };
     resourceLoaderOptions.preflightPolicy = PreflightPolicy::Consider;
     ThreadableLoaderOptions options(resourceLoaderOptions,
         context.shouldBypassMainWorldContentSecurityPolicy() ? ContentSecurityPolicyEnforcement::DoNotEnforce : ContentSecurityPolicyEnforcement::EnforceConnectSrcDirective,

--- a/Source/WebCore/dom/LoadableClassicScript.cpp
+++ b/Source/WebCore/dom/LoadableClassicScript.cpp
@@ -115,7 +115,7 @@ void LoadableNonModuleScriptBase::notifyFinished(CachedResource& resource, const
         };
     }
 
-    if (!m_error && shouldBlockResponseDueToMIMEType(m_cachedScript->response(), m_cachedScript->options().destination)) {
+    if (!m_error && shouldBlockResponseDueToMIMEType(m_cachedScript->response(), m_cachedScript->fetchDestination())) {
         m_error = Error {
             ErrorType::MIMEType,
             ConsoleMessage {

--- a/Source/WebCore/html/HTMLLinkElement.cpp
+++ b/Source/WebCore/html/HTMLLinkElement.cpp
@@ -418,7 +418,7 @@ void HTMLLinkElement::initializeStyleSheet(Ref<StyleSheetContents>&& styleSheet,
 {
     // FIXME: originClean should be turned to false except if fetch mode is CORS.
     std::optional<bool> originClean;
-    if (cachedStyleSheet.options().mode == FetchOptions::Mode::Cors)
+    if (cachedStyleSheet.fetchMode() == FetchOptions::Mode::Cors)
         originClean = cachedStyleSheet.isCORSSameOrigin();
 
     m_sheet = CSSStyleSheet::create(WTFMove(styleSheet), *this, originClean);

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
@@ -128,7 +128,7 @@ Vector<CachedResource*> InspectorPageAgent::cachedResourcesForFrame(Frame* frame
     Vector<CachedResource*> result;
 
     for (auto& cachedResourceHandle : frame->document()->cachedResourceLoader().allCachedResources().values()) {
-        auto* cachedResource = cachedResourceHandle.get();
+        auto* cachedResource = cachedResourceHandle.first.get();
         if (cachedResource->resourceRequest().hiddenFromInspector())
             continue;
 

--- a/Source/WebCore/loader/COEPInheritenceViolationReportBody.h
+++ b/Source/WebCore/loader/COEPInheritenceViolationReportBody.h
@@ -28,6 +28,7 @@
 #include "CrossOriginEmbedderPolicy.h"
 #include "ReportBody.h"
 #include "ViolationReportType.h"
+#include <wtf/URL.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -1749,7 +1749,8 @@ Vector<Ref<ArchiveResource>> DocumentLoader::subresources() const
         return { };
 
     Vector<Ref<ArchiveResource>> subresources;
-    for (auto& handle : m_cachedResourceLoader->allCachedResources().values()) {
+    for (auto& pair : m_cachedResourceLoader->allCachedResources().values()) {
+        auto& handle = pair.first;
         if (auto subresource = this->subresource(handle->url()))
             subresources.append(subresource.releaseNonNull());
     }
@@ -1974,7 +1975,7 @@ void DocumentLoader::addSubresourceLoader(ResourceLoader& loader)
         case Document::AboutToEnterBackForwardCache: {
             // A page about to enter the BackForwardCache should only be able to start ping loads.
             auto* cachedResource = downcast<SubresourceLoader>(loader).cachedResource();
-            ASSERT(cachedResource && (CachedResource::shouldUsePingLoad(cachedResource->type()) || cachedResource->options().keepAlive));
+            ASSERT(cachedResource && (CachedResource::shouldUsePingLoad(cachedResource->type()) || cachedResource->fetchKeepAlive()));
             break;
         }
         case Document::InBackForwardCache:

--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -221,7 +221,7 @@ void ImageLoader::updateFromElement(RelevantMutation relevantMutation)
             newImage = new CachedImage(WTFMove(request), page->sessionID(), &page->cookieJar());
             newImage->setStatus(CachedResource::Pending);
             newImage->setLoading(true);
-            document.cachedResourceLoader().m_documentResources.set(newImage->url().string(), newImage.get());
+            document.cachedResourceLoader().m_documentResources.set(newImage->url().string(), std::make_pair(newImage.get(), makeUnique<ResourceLoaderOptions>(request.options())));
             document.cachedResourceLoader().setAutoLoadImages(autoLoadOtherImages);
         } else {
 #if !LOG_DISABLED

--- a/Source/WebCore/loader/MediaResourceLoader.cpp
+++ b/Source/WebCore/loader/MediaResourceLoader.cpp
@@ -190,7 +190,7 @@ void MediaResource::responseReceived(CachedResource& resource, const ResourceRes
         return;
     }
 
-    m_didPassAccessControlCheck = m_resource->options().mode == FetchOptions::Mode::Cors;
+    m_didPassAccessControlCheck = m_resource->fetchMode() == FetchOptions::Mode::Cors;
     if (m_client)
         m_client->responseReceived(*this, response, [this, protectedThis = Ref { *this }, completionHandler = completionHandlerCaller.release()] (auto shouldContinue) mutable {
             if (completionHandler)

--- a/Source/WebCore/loader/ResourceLoaderOptions.h
+++ b/Source/WebCore/loader/ResourceLoaderOptions.h
@@ -40,6 +40,8 @@
 #include "StoredCredentialsPolicy.h"
 #include <wtf/EnumTraits.h>
 #include <wtf/HashSet.h>
+#include <wtf/Markable.h>
+#include <wtf/UUID.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
@@ -59,7 +61,7 @@ enum class ContentSniffingPolicy : bool {
 };
 static constexpr unsigned bitWidthOfContentSniffingPolicy = 1;
 
-enum class DataBufferingPolicy : uint8_t {
+enum class DataBufferingPolicy : bool {
     BufferData,
     DoNotBufferData
 };
@@ -164,12 +166,14 @@ enum class LoadedFromPluginElement : bool {
 static constexpr unsigned bitWidthOfLoadedFromPluginElement = 1;
 
 struct ResourceLoaderOptions : public FetchOptions {
+    WTF_MAKE_STRUCT_FAST_ALLOCATED;
+
     ResourceLoaderOptions()
         : ResourceLoaderOptions(FetchOptions())
     {
     }
 
-    ResourceLoaderOptions(FetchOptions options)
+    explicit ResourceLoaderOptions(FetchOptions options)
         : FetchOptions { WTFMove(options) }
         , sendLoadCallbacks(SendCallbackPolicy::DoNotSendCallbacks)
         , sniffContent(ContentSniffingPolicy::DoNotSniffContent)
@@ -212,7 +216,6 @@ struct ResourceLoaderOptions : public FetchOptions {
         , preflightPolicy(PreflightPolicy::Consider)
         , loadedFromOpaqueSource(LoadedFromOpaqueSource::No)
         , loadedFromPluginElement(LoadedFromPluginElement::No)
-
     {
         this->credentials = credentials;
         this->mode = mode;
@@ -249,6 +252,9 @@ struct ResourceLoaderOptions : public FetchOptions {
 
     FetchIdentifier navigationPreloadIdentifier;
     String nonce;
+
+    Markable<UUID> clientIdentifier; // Identifier of https://fetch.spec.whatwg.org/#concept-request-client
+    Markable<UUID> resultingClientIdentifier; // Identifier of https://fetch.spec.whatwg.org/#concept-request-reserved-client
 };
 
 } // namespace WebCore

--- a/Source/WebCore/loader/ResourceTimingInformation.cpp
+++ b/Source/WebCore/loader/ResourceTimingInformation.cpp
@@ -42,7 +42,7 @@ bool ResourceTimingInformation::shouldAddResourceTiming(CachedResource& resource
 {
     return resource.resourceRequest().url().protocolIsInHTTPFamily()
         && !resource.loadFailedOrCanceled()
-        && resource.options().loadedFromOpaqueSource == LoadedFromOpaqueSource::No;
+        && !resource.loadedFromOpaqueSource();
 }
 
 void ResourceTimingInformation::addResourceTiming(CachedResource& resource, Document& document, ResourceTiming&& resourceTiming)

--- a/Source/WebCore/loader/cache/CachedFont.cpp
+++ b/Source/WebCore/loader/cache/CachedFont.cpp
@@ -51,12 +51,13 @@ CachedFont::CachedFont(CachedResourceRequest&& request, PAL::SessionID sessionID
     : CachedResource(WTFMove(request), type, sessionID, cookieJar)
     , m_loadInitiated(false)
     , m_hasCreatedFontDataWrappingResource(false)
+    , m_loaderOptions(makeUnique<ResourceLoaderOptions>(request.options()))
 {
 }
 
 CachedFont::~CachedFont() = default;
 
-void CachedFont::load(CachedResourceLoader&)
+void CachedFont::load(CachedResourceLoader&, const ResourceLoaderOptions&)
 {
     // Don't load the file yet.  Wait for an access before triggering the load.
     setLoading(true);
@@ -110,7 +111,8 @@ void CachedFont::beginLoadIfNeeded(CachedResourceLoader& loader)
 {
     if (!m_loadInitiated) {
         m_loadInitiated = true;
-        CachedResource::load(loader);
+        CachedResource::load(loader, *m_loaderOptions);
+        m_loaderOptions = nullptr;
     }
 }
 

--- a/Source/WebCore/loader/cache/CachedFont.h
+++ b/Source/WebCore/loader/cache/CachedFont.h
@@ -70,7 +70,7 @@ private:
     void checkNotify(const NetworkLoadMetrics&) override;
     bool mayTryReplaceEncodedData() const override;
 
-    void load(CachedResourceLoader&) override;
+    void load(CachedResourceLoader&, const ResourceLoaderOptions&) final;
     NO_RETURN_DUE_TO_ASSERT void setBodyDataFrom(const CachedResource&) final { ASSERT_NOT_REACHED(); }
 
     void didAddClient(CachedResourceClient&) override;
@@ -85,7 +85,7 @@ private:
     bool m_hasCreatedFontDataWrappingResource;
 
     std::unique_ptr<FontCustomPlatformData> m_fontCustomPlatformData;
-
+    std::unique_ptr<ResourceLoaderOptions> m_loaderOptions;
     friend class MemoryCache;
 };
 

--- a/Source/WebCore/loader/cache/CachedImage.cpp
+++ b/Source/WebCore/loader/cache/CachedImage.cpp
@@ -96,7 +96,7 @@ CachedImage::~CachedImage()
     clearImage();
 }
 
-void CachedImage::load(CachedResourceLoader& loader)
+void CachedImage::load(CachedResourceLoader& loader, const ResourceLoaderOptions& options)
 {
     m_skippingRevalidationDocument = loader.document();
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
@@ -104,7 +104,7 @@ void CachedImage::load(CachedResourceLoader& loader)
 #endif
 
     if (loader.shouldPerformImageLoad(url()))
-        CachedResource::load(loader);
+        CachedResource::load(loader, options);
     else
         setLoading(false);
 }
@@ -755,7 +755,7 @@ CachedResource::RevalidationDecision CachedImage::makeRevalidationDecision(Cache
 
 bool CachedImage::canSkipRevalidation(const CachedResourceLoader& loader, const CachedResourceRequest& request) const
 {
-    if (options().mode != request.options().mode || options().credentials != request.options().credentials || resourceRequest().allowCookies() != request.resourceRequest().allowCookies())
+    if (fetchMode() != request.options().mode || fetchCredentials() != request.options().credentials || resourceRequest().allowCookies() != request.resourceRequest().allowCookies())
         return false;
 
     // Skip revalidation as per https://html.spec.whatwg.org/#ignore-higher-layer-caching which defines a per-document image list.

--- a/Source/WebCore/loader/cache/CachedImage.h
+++ b/Source/WebCore/loader/cache/CachedImage.h
@@ -85,7 +85,7 @@ public:
 
     bool isManuallyCached() const { return m_isManuallyCached; }
     RevalidationDecision makeRevalidationDecision(CachePolicy) const override;
-    void load(CachedResourceLoader&) override;
+    void load(CachedResourceLoader&, const ResourceLoaderOptions&) final;
 
     bool isOriginClean(SecurityOrigin*);
 

--- a/Source/WebCore/loader/cache/CachedRawResource.cpp
+++ b/Source/WebCore/loader/cache/CachedRawResource.cpp
@@ -281,7 +281,7 @@ void CachedRawResource::setDefersLoading(bool defers)
 
 void CachedRawResource::setDataBufferingPolicy(DataBufferingPolicy dataBufferingPolicy)
 {
-    m_options.dataBufferingPolicy = dataBufferingPolicy;
+    setDataBufferingPolicyOption(dataBufferingPolicy);
 }
 
 static bool shouldIgnoreHeaderForCacheReuse(HTTPHeaderName name)

--- a/Source/WebCore/loader/cache/CachedResourceLoader.h
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.h
@@ -119,7 +119,7 @@ public:
     WEBCORE_EXPORT CachedResource* cachedResource(const String& url) const;
     CachedResource* cachedResource(const URL& url) const;
 
-    typedef HashMap<String, CachedResourceHandle<CachedResource>> DocumentResourceMap;
+    typedef HashMap<String, std::pair<CachedResourceHandle<CachedResource>, std::unique_ptr<ResourceLoaderOptions>>> DocumentResourceMap;
     const DocumentResourceMap& allCachedResources() const { return m_documentResources; }
 
     void notifyFinished(const CachedResource&);

--- a/Source/WebCore/loader/cache/KeepaliveRequestTracker.cpp
+++ b/Source/WebCore/loader/cache/KeepaliveRequestTracker.cpp
@@ -39,7 +39,7 @@ KeepaliveRequestTracker::~KeepaliveRequestTracker()
 
 bool KeepaliveRequestTracker::tryRegisterRequest(CachedResource& resource)
 {
-    ASSERT(resource.options().keepAlive);
+    ASSERT(resource.fetchKeepAlive());
     auto body = resource.resourceRequest().httpBody();
     if (!body)
         return true;
@@ -54,7 +54,7 @@ bool KeepaliveRequestTracker::tryRegisterRequest(CachedResource& resource)
 
 void KeepaliveRequestTracker::registerRequest(CachedResource& resource)
 {
-    ASSERT(resource.options().keepAlive);
+    ASSERT(resource.fetchKeepAlive());
     auto body = resource.resourceRequest().httpBody();
     if (!body)
         return;
@@ -83,7 +83,7 @@ void KeepaliveRequestTracker::notifyFinished(CachedResource& resource, const Net
 
 void KeepaliveRequestTracker::unregisterRequest(CachedResource& resource)
 {
-    ASSERT(resource.options().keepAlive);
+    ASSERT(resource.fetchKeepAlive());
 
     m_inflightKeepaliveBytes -= resource.resourceRequest().httpBody()->lengthInBytes();
     ASSERT(m_inflightKeepaliveBytes <= maxInflightKeepaliveBytes);

--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -5067,14 +5067,14 @@ void FrameView::checkAndDispatchDidReachVisuallyNonEmptyState()
             if (!resourceLoader.requestCount())
                 return false;
 
-            auto& resources = resourceLoader.allCachedResources();
-            for (auto& resource : resources) {
-                if (resource.value->isLoaded())
+            for (auto& pair : resourceLoader.allCachedResources().values()) {
+                auto& resource = pair.first;
+                if (resource->isLoaded())
                     continue;
                 // ResourceLoadPriority::VeryLow is used for resources that are not needed to render.
-                if (resource.value->loadPriority() == ResourceLoadPriority::VeryLow)
+                if (resource->loadPriority() == ResourceLoadPriority::VeryLow)
                     continue;
-                if (resource.value->type() == CachedResource::Type::CSSStyleSheet || resource.value->type() == CachedResource::Type::FontResource)
+                if (resource->type() == CachedResource::Type::CSSStyleSheet || resource->type() == CachedResource::Type::FontResource)
                     return true;
             }
             return false;

--- a/Source/WebCore/platform/WebCorePersistentCoders.cpp
+++ b/Source/WebCore/platform/WebCorePersistentCoders.cpp
@@ -676,13 +676,13 @@ std::optional<WebCore::ResourceResponse> Coder<WebCore::ResourceResponse>::decod
 
 void Coder<WebCore::FetchOptions>::encode(Encoder& encoder, const WebCore::FetchOptions& instance)
 {
-    instance.encodePersistent(encoder);
+    instance.encode(encoder);
 }
 
 std::optional<WebCore::FetchOptions> Coder<WebCore::FetchOptions>::decode(Decoder& decoder)
 {
     WebCore::FetchOptions options;
-    if (!WebCore::FetchOptions::decodePersistent(decoder, options))
+    if (!WebCore::FetchOptions::decode(decoder, options))
         return std::nullopt;
     return options;
 }

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp
@@ -66,6 +66,8 @@ NetworkResourceLoadParameters::NetworkResourceLoadParameters(
     , std::optional<WebCore::ServiceWorkerRegistrationIdentifier> serviceWorkerRegistrationIdentifier
     , OptionSet<WebCore::HTTPHeadersToKeepFromCleaning> httpHeadersToKeep
     , std::optional<WebCore::FetchIdentifier> navigationPreloadIdentifier
+    , Markable<UUID> clientIdentifier
+    , Markable<UUID> resultingClientIdentifier
 #endif
 #if ENABLE(CONTENT_EXTENSIONS)
     , URL&& mainDocumentURL
@@ -102,6 +104,8 @@ NetworkResourceLoadParameters::NetworkResourceLoadParameters(
         , serviceWorkerRegistrationIdentifier(serviceWorkerRegistrationIdentifier)
         , httpHeadersToKeep(httpHeadersToKeep)
         , navigationPreloadIdentifier(navigationPreloadIdentifier)
+        , clientIdentifier(clientIdentifier)
+        , resultingClientIdentifier(resultingClientIdentifier)
 #endif
 #if ENABLE(CONTENT_EXTENSIONS)
         , mainDocumentURL(WTFMove(mainDocumentURL))

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h
@@ -36,7 +36,9 @@
 #include <WebCore/NavigationRequester.h>
 #include <WebCore/ResourceLoaderIdentifier.h>
 #include <WebCore/SecurityContext.h>
+#include <wtf/Markable.h>
 #include <wtf/Seconds.h>
+#include <wtf/UUID.h>
 
 namespace IPC {
 class Decoder;
@@ -83,6 +85,8 @@ public:
         , std::optional<WebCore::ServiceWorkerRegistrationIdentifier>
         , OptionSet<WebCore::HTTPHeadersToKeepFromCleaning>
         , std::optional<WebCore::FetchIdentifier> navigationPreloadIdentifier
+        , Markable<UUID>
+        , Markable<UUID>
 #endif
 #if ENABLE(CONTENT_EXTENSIONS)
         , URL&& mainDocumentURL
@@ -129,6 +133,8 @@ public:
     std::optional<WebCore::ServiceWorkerRegistrationIdentifier> serviceWorkerRegistrationIdentifier;
     OptionSet<WebCore::HTTPHeadersToKeepFromCleaning> httpHeadersToKeep;
     std::optional<WebCore::FetchIdentifier> navigationPreloadIdentifier;
+    Markable<UUID> clientIdentifier;
+    Markable<UUID> resultingClientIdentifier;
 #endif
 
 #if ENABLE(CONTENT_EXTENSIONS)

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in
@@ -97,6 +97,8 @@ class WebKit::NetworkResourceLoadParameters : WebKit::NetworkLoadParameters {
     std::optional<WebCore::ServiceWorkerRegistrationIdentifier> serviceWorkerRegistrationIdentifier;
     OptionSet<WebCore::HTTPHeadersToKeepFromCleaning> httpHeadersToKeep;
     std::optional<WebCore::FetchIdentifier> navigationPreloadIdentifier;
+    Markable<UUID> clientIdentifier;
+    Markable<UUID> resultingClientIdentifier;
 #endif
 
 #if ENABLE(CONTENT_EXTENSIONS)

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -591,10 +591,10 @@ void NetworkResourceLoader::transferToNewWebProcess(NetworkConnectionToWebProces
     m_parameters.webPageProxyID = parameters.webPageProxyID;
     m_parameters.webPageID = parameters.webPageID;
     m_parameters.webFrameID = parameters.webFrameID;
-    m_parameters.options.clientIdentifier = parameters.options.clientIdentifier;
-    m_parameters.options.resultingClientIdentifier = parameters.options.resultingClientIdentifier;
-
 #if ENABLE(SERVICE_WORKER)
+    m_parameters.clientIdentifier = parameters.clientIdentifier;
+    m_parameters.resultingClientIdentifier = parameters.resultingClientIdentifier;
+
     ASSERT(m_responseCompletionHandler || m_cacheEntryWaitingForContinueDidReceiveResponse || m_serviceWorkerFetchTask);
     if (m_serviceWorkerRegistration) {
         if (auto* swConnection = newConnection.swConnection())

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
@@ -170,7 +170,7 @@ void ServiceWorkerFetchTask::startFetch()
 
     String clientIdentifier;
     if (m_loader.parameters().options.mode != FetchOptions::Mode::Navigate) {
-        if (auto identifier = m_loader.parameters().options.clientIdentifier)
+        if (auto identifier = m_loader.parameters().clientIdentifier)
             clientIdentifier = identifier->toString();
     }
 

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
@@ -174,7 +174,7 @@ void WebSWServerConnection::controlClient(const NetworkResourceLoadParameters& p
     else
         clientType = ServiceWorkerClientType::Window;
 
-    ScriptExecutionContextIdentifier clientIdentifier { *parameters.options.resultingClientIdentifier, webProcessIdentifier };
+    ScriptExecutionContextIdentifier clientIdentifier { *parameters.resultingClientIdentifier, webProcessIdentifier };
     // As per step 12 of https://w3c.github.io/ServiceWorker/#on-fetch-request-algorithm, the active service worker should be controlling the document.
     // We register the service worker client using the identifier provided by DocumentLoader and notify DocumentLoader about it.
     // If notification is successful, DocumentLoader is responsible to unregister the service worker client as needed.
@@ -211,7 +211,7 @@ std::unique_ptr<ServiceWorkerFetchTask> WebSWServerConnection::createFetchTask(N
 
         serviceWorkerRegistrationIdentifier = registration->identifier();
         controlClient(loader.parameters(), *registration, request, loader.connectionToWebProcess().webProcessIdentifier());
-        if (auto resultingClientIdentifier = loader.parameters().options.resultingClientIdentifier)
+        if (auto resultingClientIdentifier = loader.parameters().resultingClientIdentifier)
             loader.setResultingClientIdentifier(resultingClientIdentifier->toString());
         loader.setServiceWorkerRegistration(*registration);
     } else {

--- a/Source/WebKit/NetworkProcess/cache/CacheStorageEngineCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/CacheStorageEngineCache.cpp
@@ -556,7 +556,7 @@ Storage::Record Cache::encode(const RecordInformation& recordInformation, const 
     encoder << recordInformation.size;
     encoder << record.requestHeadersGuard;
     encoder << record.request;
-    record.options.encodePersistent(encoder);
+    record.options.encode(encoder);
     encoder << record.referrer;
 
     encoder << record.responseHeadersGuard;
@@ -590,7 +590,7 @@ static std::optional<WebCore::DOMCacheEngine::Record> decodeDOMCacheRecord(WTF::
         return std::nullopt;
     
     FetchOptions options;
-    if (!FetchOptions::decodePersistent(decoder, options))
+    if (!FetchOptions::decode(decoder, options))
         return std::nullopt;
     
     std::optional<String> referrer;

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp
@@ -230,7 +230,7 @@ static std::optional<RecordHeader> decodeRecordHeader(Span<const uint8_t> header
         return std::nullopt;
 
     WebCore::FetchOptions options;
-    if (!WebCore::FetchOptions::decodePersistent(decoder, options))
+    if (!WebCore::FetchOptions::decode(decoder, options))
         return std::nullopt;
 
     std::optional<String> referrer;
@@ -444,7 +444,7 @@ static Vector<uint8_t> encodeRecordHeader(CacheStorageRecord&& record)
     encoder << record.info.size;
     encoder << record.requestHeadersGuard;
     encoder << record.request;
-    record.options.encodePersistent(encoder);
+    record.options.encode(encoder);
     encoder << record.referrer;
     encoder << record.responseHeadersGuard;
     encoder << WebCore::ResourceResponse::fromCrossThreadData(WTFMove(record.responseData));

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2386,8 +2386,6 @@ struct WebCore::FetchOptions {
     WebCore::ReferrerPolicy referrerPolicy;
     bool keepAlive;
     String integrity;
-    Markable<UUID> clientIdentifier;
-    Markable<UUID> resultingClientIdentifier;
 }
 
 enum class WebCore::FetchHeadersGuard : uint8_t {

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -399,6 +399,8 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
     loadParameters.httpHeadersToKeep = resourceLoader.options().httpHeadersToKeep;
     if (resourceLoader.options().navigationPreloadIdentifier)
         loadParameters.navigationPreloadIdentifier = resourceLoader.options().navigationPreloadIdentifier;
+    loadParameters.clientIdentifier = resourceLoader.options().clientIdentifier;
+    loadParameters.resultingClientIdentifier = resourceLoader.options().resultingClientIdentifier;
 #endif
 
     auto* document = frame ? frame->document() : nullptr;


### PR DESCRIPTION
<pre>
    CachedResource does not need to store a whole ResourceLoaderOptions
    https://bugs.webkit.org/show_bug.cgi?id=251786
    rdar://problem/105077011

    Reviewed by NOBODY (OOPS!).

    Inline useful options directly in CachedResource instead of storing the whole ResourceLoaderOptions.
    For CachedFont, we need to store the whole ResourceLoaderOptions as a unique_ptr to make sure to have these options when actually starting the load.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d4978bf53bd0911d86237320bcf8d3c437fecef2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107146 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16195 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39936 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116322 "Hash d4978bf5 for PR 9683 does not build (failure)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115802 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111048 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17655 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7395 "Built successfully") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99328 "Hash d4978bf5 for PR 9683 does not build (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112911 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13340 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96394 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/99328 "Hash d4978bf5 for PR 9683 does not build (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95240 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28030 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/99328 "Hash d4978bf5 for PR 9683 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9282 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29371 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9891 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6368 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15440 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48950 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11433 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->