### PR TITLE
WebGL IDL uses Exposed=Window in inconsistent manner

### DIFF
--- a/Source/WebCore/html/canvas/WebGLActiveInfo.idl
+++ b/Source/WebCore/html/canvas/WebGLActiveInfo.idl
@@ -23,11 +23,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
-// FIXME: This is specified as Exposed=(Window,Worker)
 [
     Conditional=WEBGL,
     EnabledBySetting=WebGLEnabled,
-    Exposed=Window
+    Exposed=(Window,Worker)
 ] interface WebGLActiveInfo {
     readonly attribute long size;
     readonly attribute unsigned long type;

--- a/Source/WebCore/html/canvas/WebGLBuffer.idl
+++ b/Source/WebCore/html/canvas/WebGLBuffer.idl
@@ -23,11 +23,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
-// FIXME: This is specified as Exposed=(Window,Worker)
 [
     Conditional=WEBGL,
     EnabledBySetting=WebGLEnabled,
     GenerateIsReachable=Impl,
-    Exposed=Window
+    Exposed=(Window,Worker)
 ] interface WebGLBuffer {
 };

--- a/Source/WebCore/html/canvas/WebGLContextEvent.idl
+++ b/Source/WebCore/html/canvas/WebGLContextEvent.idl
@@ -26,7 +26,7 @@
 [
     Conditional=WEBGL,
     EnabledBySetting=WebGLEnabled,
-    Exposed=Window
+    Exposed=(Window,Worker)
 ] interface WebGLContextEvent : Event {
     constructor([AtomString] DOMString type, optional WebGLContextEventInit eventInit);
 

--- a/Source/WebCore/html/canvas/WebGLFramebuffer.idl
+++ b/Source/WebCore/html/canvas/WebGLFramebuffer.idl
@@ -23,11 +23,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
-// FIXME: This is specified as Exposed=(Window,Worker)
 [
     Conditional=WEBGL,
     EnabledBySetting=WebGLEnabled,
     GenerateIsReachable=Impl,
-    Exposed=Window
+    Exposed=(Window,Worker)
 ] interface WebGLFramebuffer {
 };

--- a/Source/WebCore/html/canvas/WebGLProgram.idl
+++ b/Source/WebCore/html/canvas/WebGLProgram.idl
@@ -23,11 +23,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
-// FIXME: This is specified as Exposed=(Window,Worker)
 [
     Conditional=WEBGL,
     EnabledBySetting=WebGLEnabled,
     GenerateIsReachable=Impl,
-    Exposed=Window
+    Exposed=(Window,Worker)
 ] interface WebGLProgram {
 };

--- a/Source/WebCore/html/canvas/WebGLQuery.idl
+++ b/Source/WebCore/html/canvas/WebGLQuery.idl
@@ -23,11 +23,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
-// FIXME: This is specified as Exposed=(Window,Worker)
 [
     Conditional=WEBGL,
     EnabledBySetting=WebGLEnabled,
     GenerateIsReachable=Impl,
-    Exposed=Window
+    Exposed=(Window,Worker)
 ] interface WebGLQuery {
 };

--- a/Source/WebCore/html/canvas/WebGLRenderbuffer.idl
+++ b/Source/WebCore/html/canvas/WebGLRenderbuffer.idl
@@ -23,11 +23,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
-// FIXME: This is specified as Exposed=(Window,Worker)
 [
     Conditional=WEBGL,
     EnabledBySetting=WebGLEnabled,
     GenerateIsReachable=Impl,
-    Exposed=Window
+    Exposed=(Window,Worker)
 ] interface WebGLRenderbuffer {
 };

--- a/Source/WebCore/html/canvas/WebGLSampler.idl
+++ b/Source/WebCore/html/canvas/WebGLSampler.idl
@@ -23,11 +23,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
-// FIXME: This is specified as Exposed=(Window,Worker)
 [
     Conditional=WEBGL,
     EnabledBySetting=WebGLEnabled,
     GenerateIsReachable=Impl,
-    Exposed=Window
+    Exposed=(Window,Worker)
 ] interface WebGLSampler {
 };

--- a/Source/WebCore/html/canvas/WebGLShader.idl
+++ b/Source/WebCore/html/canvas/WebGLShader.idl
@@ -23,11 +23,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
-// FIXME: This is specified as Exposed=(Window,Worker)
 [
     Conditional=WEBGL,
     EnabledBySetting=WebGLEnabled,
     GenerateIsReachable=Impl,
-    Exposed=Window
+    Exposed=(Window,Worker)
 ] interface WebGLShader {
 };

--- a/Source/WebCore/html/canvas/WebGLShaderPrecisionFormat.idl
+++ b/Source/WebCore/html/canvas/WebGLShaderPrecisionFormat.idl
@@ -24,11 +24,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// FIXME: This is specified as Exposed=(Window,Worker)
 [
     Conditional=WEBGL,
     EnabledBySetting=WebGLEnabled,
-    Exposed=Window
+    Exposed=(Window,Worker)
 ] interface WebGLShaderPrecisionFormat {
     readonly attribute long rangeMin;
     readonly attribute long rangeMax;

--- a/Source/WebCore/html/canvas/WebGLSync.idl
+++ b/Source/WebCore/html/canvas/WebGLSync.idl
@@ -23,10 +23,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
-// FIXME: This is specified as Exposed=(Window,Worker)
 [
     Conditional=WEBGL,
     EnabledBySetting=WebGLEnabled,
-    Exposed=Window
+    Exposed=(Window,Worker)
 ] interface WebGLSync {
 };

--- a/Source/WebCore/html/canvas/WebGLTexture.idl
+++ b/Source/WebCore/html/canvas/WebGLTexture.idl
@@ -23,11 +23,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
-// FIXME: This is specified as Exposed=(Window,Worker)
 [
     Conditional=WEBGL,
     EnabledBySetting=WebGLEnabled,
     GenerateIsReachable=Impl,
-    Exposed=Window
+    Exposed=(Window,Worker)
 ] interface WebGLTexture {
 };

--- a/Source/WebCore/html/canvas/WebGLTransformFeedback.idl
+++ b/Source/WebCore/html/canvas/WebGLTransformFeedback.idl
@@ -23,11 +23,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
-// FIXME: This is specified as Exposed=(Window,Worker)
 [
     Conditional=WEBGL,
     EnabledBySetting=WebGLEnabled,
     GenerateIsReachable=Impl,
-    Exposed=Window
+    Exposed=(Window,Worker)
 ] interface WebGLTransformFeedback {
 };

--- a/Source/WebCore/html/canvas/WebGLUniformLocation.idl
+++ b/Source/WebCore/html/canvas/WebGLUniformLocation.idl
@@ -24,10 +24,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
-// FIXME: This is specified as Exposed=(Window,Worker)
 [
     Conditional=WEBGL,
     EnabledBySetting=WebGLEnabled,
-    Exposed=Window
+    Exposed=(Window,Worker)
 ] interface WebGLUniformLocation {
 };

--- a/Source/WebCore/html/canvas/WebGLVertexArrayObject.idl
+++ b/Source/WebCore/html/canvas/WebGLVertexArrayObject.idl
@@ -23,11 +23,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
-// FIXME: This is specified as Exposed=(Window,Worker)
 [
     Conditional=WEBGL,
     EnabledBySetting=WebGLEnabled,
     GenerateIsReachable=Impl,
-    Exposed=Window
+    Exposed=(Window,Worker)
 ] interface WebGLVertexArrayObject {
 };

--- a/Source/WebCore/html/canvas/WebGLVertexArrayObjectOES.idl
+++ b/Source/WebCore/html/canvas/WebGLVertexArrayObjectOES.idl
@@ -26,6 +26,8 @@
 [
     LegacyNoInterfaceObject,
     Conditional=WEBGL,
-    GenerateIsReachable=Impl
+    EnabledBySetting=WebGLEnabled,
+    GenerateIsReachable=Impl,
+    Exposed=(Window,Worker)
 ] interface WebGLVertexArrayObjectOES {
 };


### PR DESCRIPTION
#### 58d5509ece2767c36fa45c4e62a26614e7791ff5
<pre>
WebGL IDL uses Exposed=Window in inconsistent manner
<a href="https://bugs.webkit.org/show_bug.cgi?id=251504">https://bugs.webkit.org/show_bug.cgi?id=251504</a>

Reviewed by Kimmo Kinnunen.

Aligned &apos;Exposed&apos; attribute of various WebGL object
interfaces with the main WebGL context interfaces.

Added EnabledBySetting to WebGLVertexArrayObjectOES.

* Source/WebCore/html/canvas/WebGLActiveInfo.idl:
* Source/WebCore/html/canvas/WebGLBuffer.idl:
* Source/WebCore/html/canvas/WebGLContextEvent.idl:
* Source/WebCore/html/canvas/WebGLFramebuffer.idl:
* Source/WebCore/html/canvas/WebGLProgram.idl:
* Source/WebCore/html/canvas/WebGLQuery.idl:
* Source/WebCore/html/canvas/WebGLRenderbuffer.idl:
* Source/WebCore/html/canvas/WebGLSampler.idl:
* Source/WebCore/html/canvas/WebGLShader.idl:
* Source/WebCore/html/canvas/WebGLShaderPrecisionFormat.idl:
* Source/WebCore/html/canvas/WebGLSync.idl:
* Source/WebCore/html/canvas/WebGLTexture.idl:
* Source/WebCore/html/canvas/WebGLTransformFeedback.idl:
* Source/WebCore/html/canvas/WebGLUniformLocation.idl:
* Source/WebCore/html/canvas/WebGLVertexArrayObject.idl:
* Source/WebCore/html/canvas/WebGLVertexArrayObjectOES.idl:

Canonical link: <a href="https://commits.webkit.org/259945@main">https://commits.webkit.org/259945@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1210db7f6a78beef059cf0abf613f29d9b630a7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106331 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15385 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39171 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115524 "Built successfully") | [💥 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175632 "An unexpected error occured. Recent messages:Pull request contains relevant changes; Failed to print configuration") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110241 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16862 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6602 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98548 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115213 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112095 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12807 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95793 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40364 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94682 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27436 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82053 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8624 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28788 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9134 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5357 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14765 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48334 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6874 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10698 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->