### PR TITLE
[WPE] Add support for touch based pointer events

### DIFF
--- a/Source/WebCore/SourcesWPE.txt
+++ b/Source/WebCore/SourcesWPE.txt
@@ -38,6 +38,8 @@ accessibility/atspi/AccessibilityObjectValueAtspi.cpp
 accessibility/atspi/AccessibilityRootAtspi.cpp
 accessibility/atspi/AXObjectCacheAtspi.cpp
 
+dom/wpe/PointerEventWPE.cpp
+
 editing/atspi/FrameSelectionAtspi.cpp
 editing/libwpe/EditorLibWPE.cpp
 

--- a/Source/WebCore/dom/PointerEvent.h
+++ b/Source/WebCore/dom/PointerEvent.h
@@ -35,6 +35,10 @@
 #include "PlatformTouchEventIOS.h"
 #endif
 
+#if ENABLE(TOUCH_EVENTS) && (PLATFORM(IOS_FAMILY) || PLATFORM(WPE))
+#include "PlatformTouchEvent.h"
+#endif
+
 namespace WebCore {
 
 class Node;
@@ -81,7 +85,7 @@ public:
     static Ref<PointerEvent> create(const AtomString& type, short button, const MouseEvent&, PointerID, const String& pointerType);
     static Ref<PointerEvent> create(const AtomString& type, PointerID, const String& pointerType, IsPrimary = IsPrimary::No);
 
-#if ENABLE(TOUCH_EVENTS) && PLATFORM(IOS_FAMILY)
+#if ENABLE(TOUCH_EVENTS) && (PLATFORM(IOS_FAMILY) || PLATFORM(WPE))
     static Ref<PointerEvent> create(const PlatformTouchEvent&, unsigned touchIndex, bool isPrimary, Ref<WindowProxy>&&, const IntPoint& touchDelta = { });
     static Ref<PointerEvent> create(const AtomString& type, const PlatformTouchEvent&, unsigned touchIndex, bool isPrimary, Ref<WindowProxy>&&, const IntPoint& touchDelta = { });
 #endif
@@ -116,12 +120,19 @@ private:
     static CanBubble typeCanBubble(const AtomString& type) { return typeIsEnterOrLeave(type) ? CanBubble::No : CanBubble::Yes; }
     static IsCancelable typeIsCancelable(const AtomString& type) { return typeIsEnterOrLeave(type) ? IsCancelable::No : IsCancelable::Yes; }
     static IsComposed typeIsComposed(const AtomString& type) { return typeIsEnterOrLeave(type) ? IsComposed::No : IsComposed::Yes; }
+    static short buttonForType(const AtomString& type) { return type == eventNames().pointermoveEvent ? -1 : 0; }
+    static unsigned short buttonsForType(const AtomString& type)
+    {
+        // We have contact with the touch surface for most events except when we've released the touch or canceled it.
+        auto& eventNames = WebCore::eventNames();
+        return (type == eventNames.pointerupEvent || type == eventNames.pointeroutEvent || type == eventNames.pointerleaveEvent || type == eventNames.pointercancelEvent) ? 0 : 1;
+    }
 
     PointerEvent();
     PointerEvent(const AtomString&, Init&&);
     PointerEvent(const AtomString& type, short button, const MouseEvent&, PointerID, const String& pointerType);
     PointerEvent(const AtomString& type, PointerID, const String& pointerType, IsPrimary);
-#if ENABLE(TOUCH_EVENTS) && PLATFORM(IOS_FAMILY)
+#if ENABLE(TOUCH_EVENTS) && (PLATFORM(IOS_FAMILY) || PLATFORM(WPE))
     PointerEvent(const AtomString& type, const PlatformTouchEvent&, IsCancelable isCancelable, unsigned touchIndex, bool isPrimary, Ref<WindowProxy>&&, const IntPoint& touchDelta = { });
 #endif
 

--- a/Source/WebCore/dom/wpe/PointerEventWPE.cpp
+++ b/Source/WebCore/dom/wpe/PointerEventWPE.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2023 Pengutronix e.K.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "PointerEvent.h"
+
+#if ENABLE(TOUCH_EVENTS)
+
+#include "EventNames.h"
+#include "PlatformTouchEvent.h"
+
+namespace WebCore {
+
+static const AtomString& pointerEventType(PlatformTouchPoint::State state)
+{
+    switch (state) {
+    case PlatformTouchPoint::State::TouchPressed:
+        return eventNames().pointerdownEvent;
+    case PlatformTouchPoint::State::TouchMoved:
+        return eventNames().pointermoveEvent;
+    case PlatformTouchPoint::State::TouchStationary:
+        return eventNames().pointermoveEvent;
+    case PlatformTouchPoint::State::TouchReleased:
+        return eventNames().pointerupEvent;
+    case PlatformTouchPoint::State::TouchCancelled:
+        return eventNames().pointercancelEvent;
+    case PlatformTouchPoint::State::TouchStateEnd:
+        break;
+    }
+    ASSERT_NOT_REACHED();
+    return nullAtom();
+}
+
+Ref<PointerEvent> PointerEvent::create(const PlatformTouchEvent& event, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const IntPoint& touchDelta)
+{
+    const auto& type = pointerEventType(event.touchPoints().at(index).state());
+    return adoptRef(*new PointerEvent(type, event, typeIsCancelable(type), index, isPrimary, WTFMove(view), touchDelta));
+}
+
+Ref<PointerEvent> PointerEvent::create(const AtomString& type, const PlatformTouchEvent& event, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const IntPoint& touchDelta)
+{
+    return adoptRef(*new PointerEvent(type, event, typeIsCancelable(type), index, isPrimary, WTFMove(view), touchDelta));
+}
+
+PointerEvent::PointerEvent(const AtomString& type, const PlatformTouchEvent& event, IsCancelable isCancelable, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const IntPoint& touchDelta)
+    : MouseEvent(type, typeCanBubble(type), isCancelable, typeIsComposed(type), event.timestamp().approximateMonotonicTime(), WTFMove(view), 0, event.touchPoints().at(index).pos(), event.touchPoints().at(index).pos(), touchDelta.x(), touchDelta.y(), event.modifiers(), buttonForType(type), buttonsForType(type), nullptr, 0, 0, IsSimulated::No, IsTrusted::Yes)
+    , m_pointerId(event.touchPoints().at(index).id())
+    , m_width(2 * event.touchPoints().at(index).radiusX())
+    , m_height(2 * event.touchPoints().at(index).radiusY())
+    , m_pressure(event.touchPoints().at(index).force())
+    , m_pointerType(touchPointerEventType())
+    , m_isPrimary(isPrimary)
+{
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(TOUCH_EVENTS)

--- a/Source/WebCore/page/PointerCaptureController.cpp
+++ b/Source/WebCore/page/PointerCaptureController.cpp
@@ -195,7 +195,7 @@ bool PointerCaptureController::preventsCompatibilityMouseEventsForIdentifier(Poi
     return capturingData && capturingData->preventsCompatibilityMouseEvents;
 }
 
-#if ENABLE(TOUCH_EVENTS) && PLATFORM(IOS_FAMILY)
+#if ENABLE(TOUCH_EVENTS) && (PLATFORM(IOS_FAMILY) || PLATFORM(WPE))
 static bool hierarchyHasCapturingEventListeners(Element* target, const AtomString& eventName)
 {
     for (RefPtr<ContainerNode> currentNode = target; currentNode; currentNode = currentNode->parentInComposedTree()) {
@@ -474,7 +474,7 @@ void PointerCaptureController::cancelPointer(PointerID pointerId, const IntPoint
     capturingData->pendingTargetOverride = nullptr;
     capturingData->state = CapturingData::State::Cancelled;
 
-#if ENABLE(TOUCH_EVENTS) && PLATFORM(IOS_FAMILY)
+#if ENABLE(TOUCH_EVENTS) && (PLATFORM(IOS_FAMILY) || PLATFORM(WPE))
     capturingData->previousTarget = nullptr;
 #endif
 

--- a/Source/WebCore/page/PointerCaptureController.h
+++ b/Source/WebCore/page/PointerCaptureController.h
@@ -57,7 +57,7 @@ public:
 
     RefPtr<PointerEvent> pointerEventForMouseEvent(const MouseEvent&, PointerID, const String& pointerType);
 
-#if ENABLE(TOUCH_EVENTS) && PLATFORM(IOS_FAMILY)
+#if ENABLE(TOUCH_EVENTS) && (PLATFORM(IOS_FAMILY) || PLATFORM(WPE))
     void dispatchEventForTouchAtIndex(EventTarget&, const PlatformTouchEvent&, unsigned, bool isPrimary, WindowProxy&, const IntPoint&);
 #endif
 
@@ -77,12 +77,12 @@ private:
 
         RefPtr<Element> pendingTargetOverride;
         RefPtr<Element> targetOverride;
-#if ENABLE(TOUCH_EVENTS) && PLATFORM(IOS_FAMILY)
+#if ENABLE(TOUCH_EVENTS) && (PLATFORM(IOS_FAMILY) || PLATFORM(WPE))
         RefPtr<Element> previousTarget;
 #endif
         bool hasAnyElement() const {
             return pendingTargetOverride || targetOverride
-#if ENABLE(TOUCH_EVENTS) && PLATFORM(IOS_FAMILY)
+#if ENABLE(TOUCH_EVENTS) && (PLATFORM(IOS_FAMILY) || PLATFORM(WPE))
                 || previousTarget
 #endif
                 ;

--- a/Source/WebCore/platform/PlatformTouchEvent.h
+++ b/Source/WebCore/platform/PlatformTouchEvent.h
@@ -38,6 +38,12 @@ public:
 
     const Vector<PlatformTouchPoint>& touchPoints() const { return m_touchPoints; }
 
+#if PLATFORM(WPE)
+    // FIXME: since WPE currently does not send touch stationary events, we need to be able to set
+    // TouchCancelled touchPoints subsequently
+    void setTouchPoints(Vector<PlatformTouchPoint>& touchPoints) { m_touchPoints = touchPoints; }
+#endif
+
 protected:
     Vector<PlatformTouchPoint> m_touchPoints;
 };

--- a/Source/WebCore/platform/PlatformTouchPoint.h
+++ b/Source/WebCore/platform/PlatformTouchPoint.h
@@ -49,6 +49,18 @@ public:
     {
     }
 
+#if PLATFORM(WPE)
+    // FIXME: since WPE currently does not send touch stationary events, we need to be able to
+    // create a PlatformTouchPoint of type TouchCancelled artificially
+    PlatformTouchPoint(unsigned id, State state, IntPoint screenPos, IntPoint pos)
+        : m_id(id)
+        , m_state(state)
+        , m_screenPos(screenPos)
+        , m_pos(pos)
+    {
+    }
+#endif
+
     unsigned id() const { return m_id; }
     State state() const { return m_state; }
     IntPoint screenPos() const { return m_screenPos; }

--- a/Source/WebKit/Shared/NativeWebMouseEvent.h
+++ b/Source/WebKit/Shared/NativeWebMouseEvent.h
@@ -74,7 +74,7 @@ public:
     NativeWebMouseEvent(WebEventType, WebMouseEventButton, unsigned short buttons, const WebCore::IntPoint& position, const WebCore::IntPoint& globalPosition, float deltaX, float deltaY, float deltaZ, int clickCount, OptionSet<WebEventModifier>, WallTime timestamp, double force, GestureWasCancelled, const String& pointerType);
     NativeWebMouseEvent(const NativeWebMouseEvent&, const WebCore::IntPoint& position, const WebCore::IntPoint& globalPosition, float deltaX, float deltaY, float deltaZ);
 #elif USE(LIBWPE)
-    NativeWebMouseEvent(struct wpe_input_pointer_event*, float deviceScaleFactor);
+    NativeWebMouseEvent(struct wpe_input_pointer_event*, float deviceScaleFactor, WebMouseEventSyntheticClickType = WebMouseEventSyntheticClickType::NoTap);
 #elif PLATFORM(WIN)
     NativeWebMouseEvent(HWND, UINT message, WPARAM, LPARAM, bool);
 #endif

--- a/Source/WebKit/Shared/WebEventConversion.cpp
+++ b/Source/WebKit/Shared/WebEventConversion.cpp
@@ -121,6 +121,8 @@ public:
         m_menuTypeForEvent = webEvent.menuTypeForEvent();
 #elif PLATFORM(GTK)
         m_isTouchEvent = webEvent.isTouchEvent();
+#elif PLATFORM(WPE)
+        m_syntheticClickType = static_cast<WebCore::SyntheticClickType>(webEvent.syntheticClickType());
 #endif
         m_modifierFlags = 0;
         if (webEvent.shiftKey())

--- a/Source/WebKit/Shared/libwpe/NativeWebMouseEventLibWPE.cpp
+++ b/Source/WebKit/Shared/libwpe/NativeWebMouseEventLibWPE.cpp
@@ -30,8 +30,8 @@
 
 namespace WebKit {
 
-NativeWebMouseEvent::NativeWebMouseEvent(struct wpe_input_pointer_event* event, float deviceScaleFactor)
-    : WebMouseEvent(WebEventFactory::createWebMouseEvent(event, deviceScaleFactor))
+NativeWebMouseEvent::NativeWebMouseEvent(struct wpe_input_pointer_event* event, float deviceScaleFactor, WebMouseEventSyntheticClickType syntheticClickType)
+    : WebMouseEvent(WebEventFactory::createWebMouseEvent(event, deviceScaleFactor, syntheticClickType))
 {
 }
 

--- a/Source/WebKit/Shared/libwpe/WebEventFactory.cpp
+++ b/Source/WebKit/Shared/libwpe/WebEventFactory.cpp
@@ -157,7 +157,7 @@ static inline short pressedMouseButtons(uint32_t modifiers)
     return buttons;
 }
 
-WebMouseEvent WebEventFactory::createWebMouseEvent(struct wpe_input_pointer_event* event, float deviceScaleFactor)
+WebMouseEvent WebEventFactory::createWebMouseEvent(struct wpe_input_pointer_event* event, float deviceScaleFactor, WebMouseEventSyntheticClickType syntheticClickType)
 {
     auto type = WebEventType::NoType;
     switch (event->type) {
@@ -192,7 +192,7 @@ WebMouseEvent WebEventFactory::createWebMouseEvent(struct wpe_input_pointer_even
     WebCore::IntPoint position(event->x, event->y);
     position.scale(1 / deviceScaleFactor);
     return WebMouseEvent({ type, modifiersForEventModifiers(event->modifiers), wallTimeForEventTime(event->time) }, button, pressedMouseButtons(event->modifiers), position, position,
-        0, 0, 0, clickCount);
+        0, 0, 0, clickCount, 0, syntheticClickType);
 }
 
 WebWheelEvent WebEventFactory::createWebWheelEvent(struct wpe_input_axis_event* event, float deviceScaleFactor, WebWheelEvent::Phase phase, WebWheelEvent::Phase momentumPhase)

--- a/Source/WebKit/Shared/libwpe/WebEventFactory.h
+++ b/Source/WebKit/Shared/libwpe/WebEventFactory.h
@@ -45,7 +45,7 @@ namespace WebKit {
 class WebEventFactory {
 public:
     static WebKeyboardEvent createWebKeyboardEvent(struct wpe_input_keyboard_event*, const String&, bool isAutoRepeat, bool handledByInputMethod, std::optional<Vector<WebCore::CompositionUnderline>>&&, std::optional<EditingRange>&&);
-    static WebMouseEvent createWebMouseEvent(struct wpe_input_pointer_event*, float deviceScaleFactor);
+    static WebMouseEvent createWebMouseEvent(struct wpe_input_pointer_event*, float deviceScaleFactor, WebMouseEventSyntheticClickType = WebMouseEventSyntheticClickType::NoTap);
     static WebWheelEvent createWebWheelEvent(struct wpe_input_axis_event*, float deviceScaleFactor, WebWheelEvent::Phase, WebWheelEvent::Phase momentumPhase);
 #if ENABLE(TOUCH_EVENTS)
     static WebTouchEvent createWebTouchEvent(struct wpe_input_touch_event*, float deviceScaleFactor);

--- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
@@ -219,7 +219,7 @@ void PageClientImpl::doneWithTouchEvent(const NativeWebTouchEvent& touchEvent, b
 
             // Mouse motion towards the point of the click.
             event->type = wpe_input_pointer_event_type_motion;
-            page.handleMouseEvent(NativeWebMouseEvent(event, page.deviceScaleFactor()));
+            page.handleMouseEvent(NativeWebMouseEvent(event, page.deviceScaleFactor(), WebMouseEventSyntheticClickType::OneFingerTap));
 
             event->type = wpe_input_pointer_event_type_button;
             event->button = 1;
@@ -227,12 +227,12 @@ void PageClientImpl::doneWithTouchEvent(const NativeWebTouchEvent& touchEvent, b
             // Mouse down on the point of the click.
             event->state = 1;
             event->modifiers |= wpe_input_pointer_modifier_button1;
-            page.handleMouseEvent(NativeWebMouseEvent(event, page.deviceScaleFactor()));
+            page.handleMouseEvent(NativeWebMouseEvent(event, page.deviceScaleFactor(), WebMouseEventSyntheticClickType::OneFingerTap));
 
             // Mouse up on the same location.
             event->state = 0;
             event->modifiers &= ~wpe_input_pointer_modifier_button1;
-            page.handleMouseEvent(NativeWebMouseEvent(event, page.deviceScaleFactor()));
+            page.handleMouseEvent(NativeWebMouseEvent(event, page.deviceScaleFactor(), WebMouseEventSyntheticClickType::OneFingerTap));
         },
         [&](TouchGestureController::ContextMenuEvent&) {
             // FIXME: Generate contextmenuevent without accidentally generating mouseup/mousedown events


### PR DESCRIPTION
#### 84e4a4ae1e8936da66c30862be411246417d44fd
<pre>
[WPE] Add support for touch based pointer events
<a href="https://bugs.webkit.org/show_bug.cgi?id=214870">https://bugs.webkit.org/show_bug.cgi?id=214870</a>

Reviewed by Carlos Alberto Lopez Perez and Michael Catanzaro.

Currently all non-Apple ports support only pointer events of type
&quot;mouse&quot; because they a mapped 1:1 to mouse events. This commit adds
the pointer event support for touch events for the WPE port. With
this patch it should be easy for other ports to add pointer event support
as well.

The WPE port creates artificial motion, button down, button up events
for short touch gestures in PageClientImpl::doneWithTouchEvent() to keep
compatibility, see:

<a href="https://w3c.github.io/pointerevents/#compatibility-mapping-with-mouse-events">https://w3c.github.io/pointerevents/#compatibility-mapping-with-mouse-events</a>

These NativeWebMouseEvents are undistinguishable from actual mouse
events and lead to additional pointer events of type mouse being
dispatched.
Fix this by passing the SyntheticClickType down to the WebMouseEvent and
PlatformMouseEvent. With this, WPE can make use of the code path
introduced in <a href="https://bugs.webkit.org/show_bug.cgi?id=205551">https://bugs.webkit.org/show_bug.cgi?id=205551</a> due to the
same issue.

Initial patch version by Marco Felsch &lt;m.felsch@pengutronix.de&gt;. Tested
and improved by Bastian Krause &lt;bst@pengutronix.de&gt;.

* Source/WebCore/SourcesWPE.txt: Add dom/wpe/PointerEventWPE.cpp, see
below.
* Source/WebCore/dom/PointerEvent.h: Enable various pointer event paths
for WPE, move buttonForType() and buttonsForType() generics from
PointerEventIOS.
* Source/WebCore/dom/wpe/PointerEventWPE.cpp: Adapted for WPE from
Source/WebCore/dom/ios/PointerEventIOS.cpp.
(WebCore::pointerEventType): Add a translation function similar to
PointerEventIOS&apos;s pointerEventType().
(WebCore::PointerEvent::create): Add create functions similar to
PointerEventIOS.
(WebCore::PointerEvent::PointerEvent):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::handleTouchEvent): Change point iteration to
make index value accessible. Add pointer target hit tests for
TouchReleased/TouchCancelled/TouchMoved. Implement WPE-specific
workaround to compensate for non-existent touch stationary events.
Finally dispatch pointer events.
* Source/WebCore/page/PointerCaptureController.cpp:
(WebCore::PointerCaptureController::cancelPointer): Enable existing
pointer event code paths for WPE.
* Source/WebCore/page/PointerCaptureController.h:
(WebCore::PointerCaptureController::CapturingData::hasAnyElement const):
* Source/WebCore/platform/PlatformTouchEvent.h:
(WebCore::PlatformTouchEvent::setTouchPoints): Allow setting touchPoints
for WPE to make the above mentioned touch stationary worarkound
possible.
* Source/WebCore/platform/PlatformTouchPoint.h:
(WebCore::PlatformTouchPoint::PlatformTouchPoint): Allow WPE to create
PlatformTouchPoints to make the above mentioned touch stationary
worarkound possible.
* Source/WebKit/Shared/NativeWebMouseEvent.h: Add synthetic click type.
* Source/WebKit/Shared/WebEventConversion.cpp:
(WebKit::WebKit2PlatformMouseEvent::WebKit2PlatformMouseEvent): Pass the
SyntheticClickType to the PlatformMouseEvent, for WPE only because effects
on other ports are unknown at this time.
* Source/WebKit/Shared/libwpe/NativeWebMouseEventLibWPE.cpp:
(WebKit::NativeWebMouseEvent::NativeWebMouseEvent): Add synthetic click
type.
* Source/WebKit/Shared/libwpe/WebEventFactory.cpp: Add synthetic click
type.
(WebKit::WebEventFactory::createWebMouseEvent):
* Source/WebKit/Shared/libwpe/WebEventFactory.h: Pass synthetic click
type to WebMouseEvent.
* Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp:
(WebKit::PageClientImpl::doneWithTouchEvent): Set synthetic click type
for synthetic mouse events to NativeWebMouseEvent.

Canonical link: <a href="https://commits.webkit.org/263969@main">https://commits.webkit.org/263969@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fcef3c978b920c14e6c5a19e6d48056547134a4f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6237 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6430 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6609 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7806 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6568 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6237 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6650 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6380 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9448 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6348 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6363 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5648 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7896 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3836 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5627 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/13536 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5701 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5707 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7973 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6185 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5057 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5597 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1484 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9745 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5964 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->