### PR TITLE
Remove Preprocessor Checks for Old LLVM Bugs

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/third_party/abseil-cpp/absl/numeric/int128.cc
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/abseil-cpp/absl/numeric/int128.cc
@@ -111,27 +111,6 @@ uint128 MakeUint128FromFloat(T v) {
   return MakeUint128(0, static_cast<uint64_t>(v));
 }
 
-#if defined(__clang__) && !defined(__SSE3__)
-// Workaround for clang bug: https://bugs.llvm.org/show_bug.cgi?id=38289
-// Casting from long double to uint64_t is miscompiled and drops bits.
-// It is more work, so only use when we need the workaround.
-uint128 MakeUint128FromFloat(long double v) {
-  // Go 50 bits at a time, that fits in a double
-  static_assert(std::numeric_limits<double>::digits >= 50, "");
-  static_assert(std::numeric_limits<long double>::digits <= 150, "");
-  // Undefined behavior if v is not finite or cannot fit into uint128.
-  assert(std::isfinite(v) && v > -1 && v < std::ldexp(1.0L, 128));
-
-  v = std::ldexp(v, -100);
-  uint64_t w0 = static_cast<uint64_t>(static_cast<double>(std::trunc(v)));
-  v = std::ldexp(v - static_cast<double>(w0), 50);
-  uint64_t w1 = static_cast<uint64_t>(static_cast<double>(std::trunc(v)));
-  v = std::ldexp(v - static_cast<double>(w1), 50);
-  uint64_t w2 = static_cast<uint64_t>(static_cast<double>(std::trunc(v)));
-  return (static_cast<uint128>(w0) << 100) | (static_cast<uint128>(w1) << 50) |
-         static_cast<uint128>(w2);
-}
-#endif  // __clang__ && !__SSE3__
 }  // namespace
 
 uint128::uint128(float v) : uint128(MakeUint128FromFloat(v)) {}

--- a/Source/ThirdParty/libwebrtc/Source/third_party/abseil-cpp/absl/strings/internal/str_format/float_conversion.cc
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/abseil-cpp/absl/strings/internal/str_format/float_conversion.cc
@@ -1079,14 +1079,7 @@ void PrintExponent(int exp, char e, Buffer *out) {
 
 template <typename Float, typename Int>
 constexpr bool CanFitMantissa() {
-  return
-#if defined(__clang__) && !defined(__SSE3__)
-      // Workaround for clang bug: https://bugs.llvm.org/show_bug.cgi?id=38289
-      // Casting from long double to uint64_t is miscompiled and drops bits.
-      (!std::is_same<Float, long double>::value ||
-       !std::is_same<Int, uint64_t>::value) &&
-#endif
-      std::numeric_limits<Float>::digits <= std::numeric_limits<Int>::digits;
+  return std::numeric_limits<Float>::digits <= std::numeric_limits<Int>::digits;
 }
 
 template <typename Float>

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/rtc_base/logging.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/rtc_base/logging.cc
@@ -376,8 +376,7 @@ void LogMessage::OutputToDebug(LoggingSeverity severity, const LogLineRef& log_l
   // On the Mac, all stderr output goes to the Console log and causes clutter.
   // So in opt builds, don't log to stderr unless the user specifically sets
   // a preference to do so.
-  CFStringRef key = CFStringCreateWithCString(
-      kCFAllocatorDefault, "logToStdErr", kCFStringEncodingUTF8);
+  CFStringRef key = CFSTR("logToStdErr");
   CFStringRef domain = CFBundleGetIdentifier(CFBundleGetMainBundle());
   if (key != nullptr && domain != nullptr) {
     Boolean exists_and_is_valid;


### PR DESCRIPTION
#### 84250783c571255515d5c97a061c71620cf38570
<pre>
Remove Preprocessor Checks for Old LLVM Bugs
<a href="https://bugs.webkit.org/show_bug.cgi?id=196788">https://bugs.webkit.org/show_bug.cgi?id=196788</a>
&lt;rdar://problem/49792205&gt;

Reviewed by NOBODY (OOPS!).

Given how LLVM and clang have had their respective bugs resolved and
fixed, we do not need these workarounds anymore.

*Source\WTF\wtf\Int128.cpp: Remove clang + SSE3 workaround
*Source\ThirdParty\libwebrtc\Source\third_party\abseil-cpp\absl\numeric\int128.cc: Remove workaround
*Source\ThirdParty\libwebrtc\Source\third_party\abseil-cpp\absl\strings\internal\str_format\float_conversion.cc:
Remove workaround
*Source\ThirdParty\libwebrtc\Source\webrtc\rtc_base\logging.cc: Support
CFSTR macro that clang understands now
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84250783c571255515d5c97a061c71620cf38570

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107927 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16983 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40811 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117060 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18372 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8300 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100114 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113689 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/97088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41686 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/95778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/28725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/97184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9907 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/30073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/38/builds/96559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/83/builds/7982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10614 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/6965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/38/builds/96559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16059 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/49662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-mips~~](https://ews-build.webkit.org/#/builders/37/builds/105564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12186 "Built successfully") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/37/builds/105564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | | | | 
<!--EWS-Status-Bubble-End-->