### PR TITLE
Remove pre-Mojave fallback in run-leaks

### DIFF
--- a/Tools/Scripts/run-leaks
+++ b/Tools/Scripts/run-leaks
@@ -124,19 +124,7 @@ sub runLeaks($$)
         $target = $memgraphPath;
     }
 
-    # To get a result we can parse, we need to pass --list to all versions of the leaks tool
-    # that recognize it, but there is no certain way to tell in advance (the version of the
-    # tool is not always tied to OS version, and --help doesn't document the option in some
-    # of the tool versions where it's supported and needed).
-    my @leaksOutput = `/usr/bin/leaks \"$target\" --list`;
-
-    # FIXME: Remove the fallback once macOS Mojave is the oldest supported version.
-    my $leaksExitCode = $? >> 8;
-    if ($leaksExitCode > 1) {
-        @leaksOutput = `/usr/bin/leaks \"$target\"`;
-    }
-
-    return \@leaksOutput;
+    return `/usr/bin/leaks \"$target\" --list`;
 }
 
 # Returns a list of hash references with the keys { address, size, type, callStack, leaksOutput }


### PR DESCRIPTION
#### c751bfa134b07b98a646ddf307211e4b407d0f46
<pre>
Remove pre-Mojave fallback in run-leaks
<a href="https://bugs.webkit.org/show_bug.cgi?id=251799">https://bugs.webkit.org/show_bug.cgi?id=251799</a>

Reviewed by Alexey Proskuryakov and Jonathan Bedard.

Mojave is not supported anymore. We can revert this workaround.

*Tools\Scripts\run-leaks:

Canonical link: <a href="https://commits.webkit.org/259929@main">https://commits.webkit.org/259929@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9badb7818149601c73d4432fb6895939fc973bbc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106411 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15446 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39236 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115602 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175706 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110321 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16932 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6670 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98618 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115269 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112177 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12856 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95838 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40418 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94731 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27482 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8678 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28834 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9206 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5406 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14830 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48380 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6861 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10757 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->