### PR TITLE
Remove setWithoutBarrier

### DIFF
--- a/Source/WebCore/bindings/js/JSValueInWrappedObject.h
+++ b/Source/WebCore/bindings/js/JSValueInWrappedObject.h
@@ -50,10 +50,6 @@ public:
     void setWeakly(JSC::JSValue);
     JSC::JSValue getValue(JSC::JSValue nullValue = JSC::jsUndefined()) const;
 
-    // FIXME: Remove this once IDBRequest semantic bug is fixed.
-    // https://bugs.webkit.org/show_bug.cgi?id=236278
-    void setWithoutBarrier(JSValueInWrappedObject&);
-
 private:
     // Keep in mind that all of these fields are accessed concurrently without lock from concurrent GC thread.
     JSC::JSValue m_nonCell { };
@@ -111,14 +107,6 @@ inline void JSValueInWrappedObject::clear()
 {
     m_nonCell = { };
     m_cell.clear();
-}
-
-inline void JSValueInWrappedObject::setWithoutBarrier(JSValueInWrappedObject& other)
-{
-    JSC::Weak weak { other.m_cell.get() };
-    WTF::storeStoreFence(); // Ensure Weak is fully initialized for concurrent access.
-    m_nonCell = other.m_nonCell;
-    m_cell = WTFMove(weak);
 }
 
 inline JSC::JSValue cachedPropertyValue(JSC::ThrowScope& throwScope, JSC::JSGlobalObject& lexicalGlobalObject, const JSDOMObject& owner, JSValueInWrappedObject& cachedValue, const Function<JSC::JSValue(JSC::ThrowScope&)>& function)


### PR DESCRIPTION
#### 4d3456e83828b7032889c333a8ba7edd25ef2c1f
<pre>
Remove setWithoutBarrier
<a href="https://bugs.webkit.org/show_bug.cgi?id=236278">https://bugs.webkit.org/show_bug.cgi?id=236278</a>

Reviewed by Yusuke Suzuki.

The parsing bug has been fixed. Let&apos;s remove this workaround.

*Source\WebCore\bindings\js\JSValueInWrappedObject.h:

Canonical link: <a href="https://commits.webkit.org/260073@main">https://commits.webkit.org/260073@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62ac9b0a763b4eefe754f64b222c31cf1af2af7f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106931 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15967 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39728 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116111 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115658 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110834 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17451 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7165 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99117 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112696 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13209 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96233 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/40811 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95101 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27877 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9115 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29230 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9692 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/6228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15282 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48787 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6952 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11222 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->