### PR TITLE
Keep track of LocalStorage size in memory for quota computation

### DIFF
--- a/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.cpp
+++ b/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.cpp
@@ -76,6 +76,7 @@ void SQLiteStorageArea::close()
     ASSERT(!isMainRunLoop());
 
     m_cache = std::nullopt;
+    m_cacheSize = std::nullopt;
     commitTransactionIfNecessary();
     for (size_t i = 0; i < static_cast<size_t>(StatementType::Invalid); ++i)
         m_cachedStatements[i] = nullptr;
@@ -155,14 +156,17 @@ bool SQLiteStorageArea::prepareDatabase(ShouldCreateIfNotExists shouldCreateIfNo
         return true;
 
     m_database = nullptr;
-    if (shouldCreateIfNotExists == ShouldCreateIfNotExists::No && !FileSystem::fileExists(m_path))
+    bool databaseExists = FileSystem::fileExists(m_path);
+    if (shouldCreateIfNotExists == ShouldCreateIfNotExists::No && !databaseExists)
         return true;
 
     m_database = makeUnique<WebCore::SQLiteDatabase>();
     FileSystem::makeAllDirectories(FileSystem::parentPath(m_path));
     auto openResult  = m_database->open(m_path);
-    if (!openResult && handleDatabaseCorruptionIfNeeded(m_database->lastError()))
+    if (!openResult && handleDatabaseCorruptionIfNeeded(m_database->lastError())) {
+        databaseExists = false;
         openResult = m_database->open(m_path);
+    }
 
     if (!openResult) {
         RELEASE_LOG_ERROR(Storage, "SQLiteStorageArea::prepareDatabase failed to open database at '%s'", m_path.utf8().data());
@@ -179,10 +183,9 @@ bool SQLiteStorageArea::prepareDatabase(ShouldCreateIfNotExists shouldCreateIfNo
         return false;
     }
 
-    if (quota() != WebCore::StorageMap::noQuota) {
-        // Value is upconverted and stored as blob in database, so we need to make database file limit
-        // bigger than quota.
-        m_database->setMaximumSize(quota() * 2);
+    if (!databaseExists) {
+        m_cache = HashMap<String, Value> { };
+        m_cacheSize = 0;
     }
 
     return true;
@@ -224,10 +227,12 @@ Expected<String, StorageError> SQLiteStorageArea::getItem(const String& key)
     if (m_cache) {
         auto iterator = m_cache->find(key);
         if (iterator == m_cache->end())
-            return String();
+            return makeUnexpected(StorageError::ItemNotFound);
 
-        if (!iterator->value.isNull())
-            return iterator->value;
+        if (auto* valueString = std::get_if<String>(&iterator->value)) {
+            ASSERT(!valueString->isNull());
+            return *valueString;
+        }
     }
 
     return getItemFromDatabase(key);
@@ -271,8 +276,9 @@ HashMap<String, String> SQLiteStorageArea::allItems()
     if (m_cache) {
         items.reserveInitialCapacity(m_cache->size());
         for (auto& [key, value] : *m_cache) {
-            if (!value.isNull()) {
-                items.add(key, value);
+            if (auto* valueString = std::get_if<String>(&value)) {
+                ASSERT(!valueString->isNull());
+                items.add(key, *valueString);
                 continue;
             }
 
@@ -289,14 +295,15 @@ HashMap<String, String> SQLiteStorageArea::allItems()
         return { };
     }
 
-    m_cache = HashMap<String, String> { };
+    m_cache = HashMap<String, Value> { };
+    m_cacheSize = 0;
     auto result = statement->step();
     while (result == SQLITE_ROW) {
         String key = statement->columnText(0);
         String value = statement->columnBlobAsString(1);
         if (!key.isNull() && !value.isNull()) {
-            m_cache->add(key, value.sizeInBytes() > maximumSizeForValuesKeptInMemory ? String() : value);
-            items.add(WTFMove(key), WTFMove(value));
+            items.add(key, value);
+            updateCacheIfNeeded(WTFMove(key), WTFMove(value));
         }
 
         result = statement->step();
@@ -317,6 +324,9 @@ Expected<void, StorageError> SQLiteStorageArea::setItem(IPC::Connection::UniqueI
     if (!prepareDatabase(ShouldCreateIfNotExists::Yes))
         return makeUnexpected(StorageError::Database);
 
+    if (!requestSpace(key, value))
+        return makeUnexpected(StorageError::QuotaExceeded);
+
     startTransactionIfNecessary();
     String oldValue;
     if (auto valueOrError = getItem(key))
@@ -329,18 +339,14 @@ Expected<void, StorageError> SQLiteStorageArea::setItem(IPC::Connection::UniqueI
     }
 
     const auto result = statement->step();
-    if (result == SQLITE_FULL)
-        return makeUnexpected(StorageError::QuotaExceeded);
     if (result != SQLITE_DONE) {
         RELEASE_LOG_ERROR(Storage, "SQLiteStorageArea::setItem failed on stepping statement (%d) - %s", m_database->lastError(), m_database->lastErrorMsg());
         handleDatabaseCorruptionIfNeeded(result);
-
         return makeUnexpected(StorageError::Database);
     }
 
     dispatchEvents(connection, storageAreaImplID, key, oldValue, value, urlString);
-    if (m_cache)
-        m_cache->set(WTFMove(key), value.sizeInBytes() > maximumSizeForValuesKeptInMemory ? String() : WTFMove(value));
+    updateCacheIfNeeded(key, value);
 
     return { };
 }
@@ -377,8 +383,7 @@ Expected<void, StorageError> SQLiteStorageArea::removeItem(IPC::Connection::Uniq
     }
 
     dispatchEvents(connection, storageAreaImplID, key, oldValue, String(), urlString);
-    if (m_cache)
-        m_cache->remove(key);
+    updateCacheIfNeeded(key, { });
 
     return { };
 }
@@ -393,8 +398,10 @@ Expected<void, StorageError> SQLiteStorageArea::clear(IPC::Connection::UniqueID 
     if (m_cache && m_cache->isEmpty())
         return makeUnexpected(StorageError::ItemNotFound);
 
-    if (m_cache)
+    if (m_cache) {
         m_cache->clear();
+        m_cacheSize = 0;
+    }
 
     if (!m_database)
         return makeUnexpected(StorageError::ItemNotFound);
@@ -442,9 +449,93 @@ bool SQLiteStorageArea::handleDatabaseCorruptionIfNeeded(int databaseError)
         return false;
 
     m_database = nullptr;
+    m_cache = std::nullopt;
+    m_cacheSize = std::nullopt;
     RELEASE_LOG(Storage, "SQLiteStorageArea::handleDatabaseCorruption deletes corrupted database file '%s'", m_path.utf8().data());
     WebCore::SQLiteFileSystem::deleteDatabaseFile(m_path);
     return true;
+}
+
+void SQLiteStorageArea::updateCacheIfNeeded(const String& key, const String& value)
+{
+    if (!m_cache)
+        return;
+
+    ASSERT(m_cacheSize);
+    auto iter = m_cache->find(key);
+    bool itemExists = iter != m_cache->end();
+    unsigned oldKeySize = 0;
+    unsigned oldValueSize = 0;
+    unsigned keySize = key.sizeInBytes();
+    unsigned valueSize = value.sizeInBytes();
+    if (itemExists) {
+        oldKeySize = iter->key.sizeInBytes();
+        WTF::switchOn(iter->value, [&](unsigned valueSize) {
+            oldValueSize = valueSize;
+        }, [&](const String& value) {
+            oldValueSize = value.sizeInBytes();
+        });
+    }
+
+    CheckedUint32 newCacheSize = *m_cacheSize;
+    // Null value means to remove.
+    if (value.isNull()) {
+        m_cache->remove(key);
+        newCacheSize -= oldKeySize;
+        newCacheSize -= oldValueSize;
+    } else {
+        if (valueSize > maximumSizeForValuesKeptInMemory)
+            m_cache->set(key, valueSize);
+        else
+            m_cache->set(key, value);
+        newCacheSize -= oldKeySize;
+        newCacheSize -= oldValueSize;
+        newCacheSize += itemExists ? oldKeySize : keySize;
+        newCacheSize += valueSize;
+    }
+
+    if (newCacheSize.hasOverflowed()) {
+        RELEASE_LOG_ERROR(Storage, "SQLiteStorageArea::updateCacheIfNeeded newCacheSize has overflowed: cacheSize - %u, oldKeySize - %u, oldValueSize - %u, keySize - %u, valueSize - %u, will recompute", *m_cacheSize, oldKeySize, oldValueSize, keySize, valueSize);
+        newCacheSize = 0;
+        for (auto& value : m_cache->values()) {
+            WTF::switchOn(value, [&](unsigned size) {
+                newCacheSize += size;
+            }, [&](const String& value) {
+                newCacheSize += value.sizeInBytes();
+            });
+        }
+    }
+
+    m_cacheSize = newCacheSize;
+}
+
+bool SQLiteStorageArea::requestSpace(const String& key, const String& value)
+{
+    ASSERT(m_database && m_database->isOpen());
+    if (!m_cache)
+        return key.sizeInBytes() + value.sizeInBytes() <= quota();
+
+    if (value.isNull())
+        return true;
+
+    ASSERT(m_cacheSize);
+    CheckedUint32 newCacheSize = *m_cacheSize;
+    auto iter = m_cache->find(key);
+    if (iter == m_cache->end())
+        newCacheSize += key.sizeInBytes();
+    else {
+        auto oldValueSize = WTF::switchOn(iter->value, [](unsigned valueSize) {
+            return valueSize;
+        }, [](const String& value) {
+            return value.sizeInBytes();
+        });
+        newCacheSize -= oldValueSize;
+    }
+    newCacheSize += value.sizeInBytes();
+    if (newCacheSize.hasOverflowed())
+        return false;
+
+    return newCacheSize <= quota();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.h
+++ b/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.h
@@ -69,15 +69,18 @@ private:
     WebCore::SQLiteStatementAutoResetScope cachedStatement(StatementType);
     Expected<String, StorageError> getItem(const String& key);
     Expected<String, StorageError> getItemFromDatabase(const String& key);
-
     bool handleDatabaseCorruptionIfNeeded(int databaseError);
+    void updateCacheIfNeeded(const String& key, const String& value);
+    bool requestSpace(const String& key, const String& value);
 
     String m_path;
     Ref<WorkQueue> m_queue;
     std::unique_ptr<WebCore::SQLiteDatabase> m_database;
     std::unique_ptr<WebCore::SQLiteTransaction> m_transaction;
     Vector<std::unique_ptr<WebCore::SQLiteStatement>> m_cachedStatements;
-    std::optional<HashMap<String, String>> m_cache;
+    using Value = std::variant<String, unsigned>;
+    std::optional<HashMap<String, Value>> m_cache;
+    std::optional<unsigned> m_cacheSize;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### e9650775a43554b06d3406b3a9a750451fbdc4a5
<pre>
Keep track of LocalStorage size in memory for quota computation
<a href="https://bugs.webkit.org/show_bug.cgi?id=251800">https://bugs.webkit.org/show_bug.cgi?id=251800</a>
rdar://problem/105085248

Reviewed by Chris Dumez.

As stated in 259571@main, StorageAreaMap in web process performs quota check differently from SQLiteStorageArea in
network process. StorageAreaMap uses item (Strings) size and compares size with quota before write operation, while
SQLiteStorageArea sets size limit of database, and relies on SQLite to perform check of database size on write
operation. Also, SQLiteStorageArea stores item value (String) as blob in database, so characters will be upconverted and
take more space. Because of this difference, the two processes can have different result on quota check. For example,
web process might think a write operation passes quota check and sends request to network process, and network process
thinks it fails quota check.

The problem is SQLiteStorageArea currently tries to batch write operations in transaction for performance and SQLite
could roll back transaction automatically when there is a quota error (see <a href="https://www.sqlite.org/lang_transaction.html">https://www.sqlite.org/lang_transaction.html</a>
and SQLITE_FULL). This means when quota error occurs, we might lose all changes in the same transaction and will need to
read all items from database again (to sync cache in SQLiteStorageArea amd StorageAreaMap), which can be costly and lead
to flakiness in tests like imported/w3c/web-platform-tests/webstorage/storage_local_setitem_quotaexceedederr.window.html.
Therefore, this patch makes makes SQLiteStorageArea perform quota check the same way as StorageAreaMap by keeping track
of items size and use it for quota computation. This will make write request that passes quota check in web process less
likely to fail due to quota error and thus makes transaction less likely to be rolled back.

* Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.cpp:
(WebKit::SQLiteStorageArea::close):
(WebKit::SQLiteStorageArea::prepareDatabase):
(WebKit::SQLiteStorageArea::getItem):
(WebKit::SQLiteStorageArea::allItems):
(WebKit::SQLiteStorageArea::setItem):
(WebKit::SQLiteStorageArea::removeItem):
(WebKit::SQLiteStorageArea::clear):
(WebKit::SQLiteStorageArea::handleDatabaseCorruptionIfNeeded):
(WebKit::SQLiteStorageArea::updateCacheIfNeeded):
(WebKit::SQLiteStorageArea::requestSpace):
* Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.h:

Canonical link: <a href="https://commits.webkit.org/259995@main">https://commits.webkit.org/259995@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d37a4ef373c63f75bd7282ac73e48d229b14954

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106577 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15592 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39385 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115761 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115401 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17087 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6820 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98771 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112345 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12982 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95952 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40542 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94860 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27596 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8818 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28948 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9361 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5984 "Found 1 new test failure: imported/w3c/web-platform-tests/css/selectors/invalidation/media-loading-pseudo-classes-in-has.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14980 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48497 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6911 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10899 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->