### PR TITLE
Remove suppressFormNotifications and restoreFormNotifications

### DIFF
--- a/Source/WebCore/loader/EmptyClients.h
+++ b/Source/WebCore/loader/EmptyClients.h
@@ -197,9 +197,6 @@ class EmptyChromeClient : public ChromeClient {
     void didStartOverflowScroll() final { }
     void didEndOverflowScroll() final { }
 
-    void suppressFormNotifications() final { }
-    void restoreFormNotifications() final { }
-
     void addOrUpdateScrollingLayer(Node*, PlatformLayer*, PlatformLayer*, const IntSize&, bool, bool) final { }
     void removeScrollingLayer(Node*, PlatformLayer*, PlatformLayer*) final { }
 

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -319,12 +319,6 @@ public:
     virtual void didStartOverflowScroll() = 0;
     virtual void didEndOverflowScroll() = 0;
 
-    // FIXME: Remove this functionality. This functionality was added to workaround an issue (<rdar://problem/5973875>)
-    // where the unconfirmed text in a text area would be removed when a person clicks in the text area before a
-    // suggestion is shown. We should fix this issue in <rdar://problem/5975559>.
-    virtual void suppressFormNotifications() = 0;
-    virtual void restoreFormNotifications() = 0;
-
     virtual void didFlushCompositingLayers() { }
 
     virtual bool fetchCustomFixedPositionLayoutRect(IntRect&) { return false; }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -184,10 +184,6 @@ private:
     void didEndOverflowScroll() final;
     bool hasStablePageScaleFactor() const final;
 
-    // FIXME: See <rdar://problem/5975559>
-    void suppressFormNotifications() final;
-    void restoreFormNotifications() final;
-
     void addOrUpdateScrollingLayer(WebCore::Node*, PlatformLayer* scrollingLayer, PlatformLayer* contentsLayer, const WebCore::IntSize& scrollSize, bool allowHorizontalScrollbar, bool allowVerticalScrollbar) final;
     void removeScrollingLayer(WebCore::Node*, PlatformLayer* scrollingLayer, PlatformLayer* contentsLayer) final;
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/ios/WebChromeClientIOS.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/ios/WebChromeClientIOS.mm
@@ -110,16 +110,6 @@ bool WebChromeClient::hasStablePageScaleFactor() const
     return protectedPage()->hasStablePageScaleFactor();
 }
 
-void WebChromeClient::suppressFormNotifications()
-{
-    notImplemented();
-}
-
-void WebChromeClient::restoreFormNotifications()
-{
-    notImplemented();
-}
-
 void WebChromeClient::addOrUpdateScrollingLayer(WebCore::Node*, PlatformLayer*, PlatformLayer*, const WebCore::IntSize&, bool, bool)
 {
     notImplemented();

--- a/Source/WebKitLegacy/ios/WebCoreSupport/WebChromeClientIOS.h
+++ b/Source/WebKitLegacy/ios/WebCoreSupport/WebChromeClientIOS.h
@@ -77,9 +77,6 @@ private:
     void didStartOverflowScroll() final;
     void didEndOverflowScroll() final;
 
-    void suppressFormNotifications() final;
-    void restoreFormNotifications() final;
-
     void elementDidFocus(WebCore::Element&, const WebCore::FocusOptions&) final;
     void elementDidBlur(WebCore::Element&) final;
 
@@ -108,8 +105,6 @@ private:
 #if ENABLE(ORIENTATION_EVENTS)
     WebCore::IntDegrees deviceOrientation() const final;
 #endif
-
-    int m_formNotificationSuppressions { 0 };
 };
 
 #endif

--- a/Source/WebKitLegacy/ios/WebCoreSupport/WebChromeClientIOS.mm
+++ b/Source/WebKitLegacy/ios/WebCoreSupport/WebChromeClientIOS.mm
@@ -268,29 +268,14 @@ void WebChromeClientIOS::didEndOverflowScroll()
     [[[webView() _UIKitDelegateForwarder] asyncForwarder] webViewDidEndOverflowScroll:webView()];
 }
 
-void WebChromeClientIOS::suppressFormNotifications() 
-{
-    m_formNotificationSuppressions++;
-}
-
-void WebChromeClientIOS::restoreFormNotifications() 
-{
-    m_formNotificationSuppressions--;
-    ASSERT(m_formNotificationSuppressions >= 0);
-    if (m_formNotificationSuppressions < 0)
-        m_formNotificationSuppressions = 0;
-}
-
 void WebChromeClientIOS::elementDidFocus(WebCore::Element& element, const WebCore::FocusOptions&)
 {
-    if (m_formNotificationSuppressions <= 0)
-        [[webView() _UIKitDelegateForwarder] webView:webView() elementDidFocusNode:kit(&element)];
+    [[webView() _UIKitDelegateForwarder] webView:webView() elementDidFocusNode:kit(&element)];
 }
 
 void WebChromeClientIOS::elementDidBlur(WebCore::Element& element)
 {
-    if (m_formNotificationSuppressions <= 0)
-        [[webView() _UIKitDelegateForwarder] webView:webView() elementDidBlurNode:kit(&element)];
+    [[webView() _UIKitDelegateForwarder] webView:webView() elementDidBlurNode:kit(&element)];
 }
 
 bool WebChromeClientIOS::selectItemWritingDirectionIsNatural()

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -1615,9 +1615,7 @@ static WebFrameLoadType toWebFrameLoadType(WebCore::FrameLoadType frameLoadType)
         return;
     
     Vector<WebCore::CompositionUnderline> underlines;
-    frame->page()->chrome().client().suppressFormNotifications();
     frame->editor().setComposition(text, underlines, { }, { }, newSelRange.location, NSMaxRange(newSelRange));
-    frame->page()->chrome().client().restoreFormNotifications();
 }
 
 - (void)setMarkedText:(NSString *)text forCandidates:(BOOL)forCandidates
@@ -1636,12 +1634,10 @@ static WebFrameLoadType toWebFrameLoadType(WebCore::FrameLoadType frameLoadType)
     if (!frame || !frame->editor().client())
         return;
     
-    frame->page()->chrome().client().suppressFormNotifications();
     if (text)
         frame->editor().confirmComposition(text);
     else
         frame->editor().confirmMarkedText();
-    frame->page()->chrome().client().restoreFormNotifications();
 }
 
 - (void)setText:(NSString *)text asChildOfElement:(DOMElement *)element


### PR DESCRIPTION
#### de40a8acfe8501f29e91e3d39d79a0cb98254019
<pre>
Remove suppressFormNotifications and restoreFormNotifications
<a href="https://bugs.webkit.org/show_bug.cgi?id=251805">https://bugs.webkit.org/show_bug.cgi?id=251805</a>
&lt;rdar://problem/5975559&gt;

Reviewed by NOBODY (OOPS!).

Given this workaround was added over a decade ago and is no longer
relevant, we can remove this.

*Source/WebCore/loader/EmptyClients.h:
*Source/WebCore/page/ChromeClient.h:
*Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
*Source/WebKit/WebProcess/WebCoreSupport/ios/WebChromeClientIOS.mm:
*Source/WebKitLegacy/ios/WebCoreSupport/WebChromeClientIOS.h:
*Source/WebKitLegacy/ios/WebCoreSupport/WebChromeClientIOS.mm:
*Source/WebKitLegacy/mac/WebView/WebFrame.mm:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf7ba64d4063968aa7d3be7a355bdc776091a415

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/64096 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/43453 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/16693 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/68118 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/14704 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/66216 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/51151 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/14984 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/68118 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/14704 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/67165 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/51151 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/16693 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/68118 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/51151 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/16693 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/13577 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/51151 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/16693 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/69817 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/8043 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/14984 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/69817 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/8076 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/16693 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/69817 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/39273 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/40352 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/41535 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/40095 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->