### PR TITLE
Reduce 'Internal' flag list by moving mature things out of the category (251801)

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1667,7 +1667,7 @@ DataDetectorTypes:
 # FIXME: This is on by default in WebKit2 (for everything but WatchOS). Perhaps we should consider turning it on for WebKitLegacy as well.
 DataListElementEnabled:
   type: bool
-  status: internal
+  status: embedder
   humanReadableName: "DataList Element"
   humanReadableDescription: "Enable datalist elements"
   condition: ENABLE(DATALIST_ELEMENT)
@@ -5155,7 +5155,7 @@ SelectTrailingWhitespaceEnabled:
 
 SelectionFlippingEnabled:
   type: bool
-  status: internal
+  status: embedder
   humanReadableName: "Selection Flipping"
   humanReadableDescription: "Enable Selection Flipping"
   webcoreBinding: none
@@ -6103,7 +6103,7 @@ UseGPUProcessForDisplayCapture:
 
 UseGPUProcessForMediaEnabled:
   type: bool
-  status: internal
+  status: embedder
   humanReadableName: "GPU Process: Media"
   humanReadableDescription: "Do all media loading and playback in the GPU Process"
   webcoreBinding: none
@@ -6884,7 +6884,7 @@ WebRTCMediaPipelineAdditionalLoggingEnabled:
 # FIXME: This is not relevant for WebKitLegacy, so should be excluded from WebKitLegacy entirely.
 WebRTCPlatformCodecsInGPUProcessEnabled:
   type: bool
-  status: internal
+  status: embedder
   humanReadableName: "GPU Process: WebRTC Platform Codecs"
   humanReadableDescription: "Enable WebRTC Platform Codecs in GPU Process"
   condition: ENABLE(WEB_RTC)
@@ -7115,7 +7115,7 @@ WebXRHandInputModuleEnabled:
 
 WheelEventGesturesBecomeNonBlocking:
   type: bool
-  status: internal
+  status: mature
   humanReadableName: "Wheel Event gestures become non-blocking"
   humanReadableDescription: "preventDefault() is only allowed on the first wheel event in a gesture"
   defaultValue:


### PR DESCRIPTION
#### 9f1c971a3f52ede6915847ec0d781e4b929e9175
<pre>
Reduce &apos;Internal&apos; flag list by moving mature things out of the category (251801)
<a href="https://bugs.webkit.org/show_bug.cgi?id=251801">https://bugs.webkit.org/show_bug.cgi?id=251801</a>
&lt;rdar://problem/105086053&gt;

Reviewed by Elliott Williams.

The WebKit &apos;Internal&apos; debug flag set is very large. We can simplify this by recategorizing
several mature technologies that no longer need a quick toggle to adjust:

The following `internal` flags will move to `embedder`:
* UseGPUProcessForMediaEnabled
* WebRTCPlatformCodecsInGPUProcessEnabled
* DataListElementEnabled
* SelectionFlippingEnabled

The following `internal` flag will move to `mature`:
* WheelEventGesturesBecomeNonBlocking

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:

Canonical link: <a href="https://commits.webkit.org/259921@main">https://commits.webkit.org/259921@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b6341b3f074dd59e6f2ad4ba3da0f251c9221b1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106388 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15431 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39218 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115579 "Built successfully") | [💥 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175681 "An unexpected error occured. Recent messages:Pull request contains relevant changes; Failed to print configuration") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16913 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6652 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98600 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115252 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112154 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12844 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95828 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40406 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94719 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27471 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/95986 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8660 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28823 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/95398 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/6535 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9186 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5395 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30615 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14811 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48369 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/104137 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6854 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10739 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25805 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->