### PR TITLE
Remove Call to GSFontInitialize()

### DIFF
--- a/Source/WebCore/PAL/pal/spi/ios/GraphicsServicesSPI.h
+++ b/Source/WebCore/PAL/pal/spi/ios/GraphicsServicesSPI.h
@@ -40,7 +40,6 @@ WTF_EXTERN_C_BEGIN
 void GSInitialize(void);
 uint64_t GSCurrentEventTimestamp(void);
 CFStringRef GSSystemRootDirectory(void);
-void GSFontInitialize(void);
 void GSFontPurgeFontCache(void);
 
 typedef struct __GSKeyboard* GSKeyboardRef;

--- a/Source/WebCore/page/cocoa/MemoryReleaseCocoa.mm
+++ b/Source/WebCore/page/cocoa/MemoryReleaseCocoa.mm
@@ -47,8 +47,6 @@ namespace WebCore {
 void platformReleaseMemory(Critical)
 {
 #if PLATFORM(IOS_FAMILY) && !PLATFORM(IOS_FAMILY_SIMULATOR) && !PLATFORM(MACCATALYST)
-    // FIXME: Remove this call to GSFontInitialize() once <rdar://problem/32886715> is fixed.
-    GSFontInitialize();
     GSFontPurgeFontCache();
 #endif
 

--- a/WebKitLibraries/WebKitPrivateFrameworkStubs/appletvos/15/GraphicsServices.framework/GraphicsServices.tbd
+++ b/WebKitLibraries/WebKitPrivateFrameworkStubs/appletvos/15/GraphicsServices.framework/GraphicsServices.tbd
@@ -7,6 +7,6 @@ exports:
   -
     archs:           [ x86_64, arm64 ]
     symbols:         [ _GSCurrentEventTimestamp, _GSEventIsHardwareKeyboardAttached, _GSEventSetHardwareKeyboardAttached,
-                       _GSFontInitialize, _GSFontPurgeFontCache, _GSInitialize, _GSKeyboardGetModifierState,
-                       _GSSystemRootDirectory, _kGSEventHardwareKeyboardAvailabilityChangedNotification]
+                       _GSFontPurgeFontCache, _GSInitialize, _GSKeyboardGetModifierState, _GSSystemRootDirectory,
+                       _kGSEventHardwareKeyboardAvailabilityChangedNotification]
 ...

--- a/WebKitLibraries/WebKitPrivateFrameworkStubs/appletvos/16/GraphicsServices.framework/GraphicsServices.tbd
+++ b/WebKitLibraries/WebKitPrivateFrameworkStubs/appletvos/16/GraphicsServices.framework/GraphicsServices.tbd
@@ -7,6 +7,6 @@ exports:
   -
     archs:           [ x86_64, arm64 ]
     symbols:         [ _GSCurrentEventTimestamp, _GSEventIsHardwareKeyboardAttached, _GSEventSetHardwareKeyboardAttached,
-                       _GSFontInitialize, _GSFontPurgeFontCache, _GSInitialize, _GSKeyboardGetModifierState,
-                       _GSSystemRootDirectory, _kGSEventHardwareKeyboardAvailabilityChangedNotification]
+                       _GSFontPurgeFontCache, _GSInitialize, _GSKeyboardGetModifierState, _GSSystemRootDirectory,
+                       _kGSEventHardwareKeyboardAvailabilityChangedNotification]
 ...

--- a/WebKitLibraries/WebKitPrivateFrameworkStubs/iOS/15/GraphicsServices.framework/GraphicsServices.tbd
+++ b/WebKitLibraries/WebKitPrivateFrameworkStubs/iOS/15/GraphicsServices.framework/GraphicsServices.tbd
@@ -7,6 +7,6 @@ exports:
   -
     archs:           [ x86_64, arm64, arm64e ]
     symbols:         [ _GSCurrentEventTimestamp, _GSEventIsHardwareKeyboardAttached, _GSEventSetHardwareKeyboardAttached,
-                       _GSFontInitialize, _GSFontPurgeFontCache, _GSInitialize, _GSKeyboardGetModifierState,
-                       _GSSystemRootDirectory, _kGSEventHardwareKeyboardAvailabilityChangedNotification]
+                       _GSFontPurgeFontCache, _GSInitialize, _GSKeyboardGetModifierState, _GSSystemRootDirectory,
+                       _kGSEventHardwareKeyboardAvailabilityChangedNotification]
 ...

--- a/WebKitLibraries/WebKitPrivateFrameworkStubs/iOS/16/GraphicsServices.framework/GraphicsServices.tbd
+++ b/WebKitLibraries/WebKitPrivateFrameworkStubs/iOS/16/GraphicsServices.framework/GraphicsServices.tbd
@@ -7,6 +7,6 @@ exports:
   -
     archs:           [ x86_64, arm64, arm64e ]
     symbols:         [ _GSCurrentEventTimestamp, _GSEventIsHardwareKeyboardAttached, _GSEventSetHardwareKeyboardAttached,
-                       _GSFontInitialize, _GSFontPurgeFontCache, _GSInitialize, _GSKeyboardGetModifierState,
-                       _GSSystemRootDirectory, _kGSEventHardwareKeyboardAvailabilityChangedNotification]
+                       _GSFontPurgeFontCache, _GSInitialize, _GSKeyboardGetModifierState, _GSSystemRootDirectory,
+                       _kGSEventHardwareKeyboardAvailabilityChangedNotification]
 ...

--- a/WebKitLibraries/WebKitPrivateFrameworkStubs/watchos/8/GraphicsServices.framework/GraphicsServices.tbd
+++ b/WebKitLibraries/WebKitPrivateFrameworkStubs/watchos/8/GraphicsServices.framework/GraphicsServices.tbd
@@ -7,6 +7,6 @@ exports:
   -
     archs:           [ i386, x86_64, arm64, arm64e, arm64_32, armv7k ]
     symbols:         [ _GSCurrentEventTimestamp, _GSEventIsHardwareKeyboardAttached, _GSEventSetHardwareKeyboardAttached,
-                       _GSFontInitialize, _GSFontPurgeFontCache, _GSInitialize, _GSKeyboardGetModifierState,
-                       _GSSystemRootDirectory, _kGSEventHardwareKeyboardAvailabilityChangedNotification]
+                       _GSFontPurgeFontCache, _GSInitialize, _GSKeyboardGetModifierState, _GSSystemRootDirectory,
+                       _kGSEventHardwareKeyboardAvailabilityChangedNotification]
 ...

--- a/WebKitLibraries/WebKitPrivateFrameworkStubs/watchos/9/GraphicsServices.framework/GraphicsServices.tbd
+++ b/WebKitLibraries/WebKitPrivateFrameworkStubs/watchos/9/GraphicsServices.framework/GraphicsServices.tbd
@@ -7,6 +7,6 @@ exports:
   -
     archs:           [ i386, x86_64, arm64, arm64e, arm64_32, armv7k ]
     symbols:         [ _GSCurrentEventTimestamp, _GSEventIsHardwareKeyboardAttached, _GSEventSetHardwareKeyboardAttached,
-                       _GSFontInitialize, _GSFontPurgeFontCache, _GSInitialize, _GSKeyboardGetModifierState,
-                       _GSSystemRootDirectory, _kGSEventHardwareKeyboardAvailabilityChangedNotification]
+                       _GSFontPurgeFontCache, _GSInitialize, _GSKeyboardGetModifierState, _GSSystemRootDirectory,
+                       _kGSEventHardwareKeyboardAvailabilityChangedNotification]
 ...


### PR DESCRIPTION
#### 508f25c943534cd7a8f46975945d672dbfcdd6fc
<pre>
Remove Call to GSFontInitialize()
<a href="https://bugs.webkit.org/show_bug.cgi?id=251807">https://bugs.webkit.org/show_bug.cgi?id=251807</a>
&lt;rdar://problem/32886715&gt;

Reviewed by NOBODY (OOPS!).

Now that &lt;rdar://problem/32886715&gt; has been addressed, we can remove
this function call. So basically, revert commit
5bea31adfd254b9b192498abdd9852e51442bbd2

*Source\WebCore\PAL\pal\spi\ios\GraphicsServicesSPI.h:
*Source\WebCore\page\cocoa\MemoryReleaseCocoa.mm:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/508f25c943534cd7a8f46975945d672dbfcdd6fc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107176 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16222 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39961 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116348 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115822 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111077 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17679 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7525 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99353 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112941 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13359 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96418 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40965 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95259 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28054 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82730 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9303 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29395 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9916 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6427 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15460 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48974 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11459 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->