### PR TITLE
Distorted audio after getUserMedia when playing with AudioWorkletNode

### DIFF
--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -42,6 +42,7 @@
 #import <pal/SessionID.h>
 #import <wtf/BlockObjCExceptions.h>
 #import <wtf/Function.h>
+#import <wtf/MathExtras.h>
 
 #import "MediaRemoteSoftLink.h"
 
@@ -169,7 +170,7 @@ void MediaSessionManagerCocoa::updateSessionState()
     else if (captureCount || audioMediaStreamTrackCount) {
         // In case of audio capture or audio MediaStreamTrack playing, we want to grab 20 ms chunks to limit the latency so that it is not noticeable by users
         // while having a large enough buffer so that the audio rendering remains stable, hence a computation based on sample rate.
-        bufferSize = AudioSession::sharedSession().sampleRate() / 50;
+        bufferSize = WTF::roundUpToPowerOfTwo(AudioSession::sharedSession().sampleRate() / 50);
     } else if (m_supportedAudioHardwareBufferSizes && DeprecatedGlobalSettings::lowPowerVideoAudioBufferSizeEnabled())
         bufferSize = m_supportedAudioHardwareBufferSizes.nearest(kLowPowerVideoBufferSize);
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.h
@@ -65,7 +65,7 @@ private:
 
     void startRenderingThread();
     void stopRenderingThread();
-    void renderQuantum();
+    void renderAudio(unsigned frameCount);
 
     IPC::Connection* connection();
     IPC::Connection* existingConnection();


### PR DESCRIPTION
#### 87395a602807aca417e72e768bba2404f2e9ff42
<pre>
Distorted audio after getUserMedia when playing with AudioWorkletNode
<a href="https://bugs.webkit.org/show_bug.cgi?id=251091">https://bugs.webkit.org/show_bug.cgi?id=251091</a>
rdar://104870451

Reviewed by Youenn Fablet and Jer Noble.

Our WebAudio rendering logic was trying to deal with buffer sizes greater than
128 by signaling the IPC semaphore multiple times so that the producer on the
WebProcess side would produce enough 128 frames-sized chunks to satisfy the
reader on the GPUProcess side.

This logic isn&apos;t exercised a lot though since
MediaSessionManagerCocoa::updateSessionState() requests a buffer size of 128
whenever WebAudio is in use. However, 246166@main added logic in
RemoteAudioSessionProxyManager::updatePreferredBufferSizeForProcess() that
delays setting the preferred buffer size if we&apos;re currently capturing media.

In the demo case, we&apos;re capturing media so we would end up using WebAudio with
a buffer size of 960. There were multiple issues here:
1. 960 wasn&apos;t a multiple of 128 so the GPUProcess would signal the semaphore
   an inconsistent number of times for each render quantum (sometimes
   requesting 1024 frames, sometimes 896).
2. Because the demo is using an Audio Worklet, we were doing 7 to 8 dispatches
   to the Audio Worklet thread (from the Audio Thread) in order to do the
   rendering on the WebProcess size. This was unnecessarily expensive.

To address the issue, I made 2 changes:
1. MediaSessionManagerCocoa::updateSessionState() now rounds the preferred
   buffer size to the upper power of 2.
2. RemoteAudioDestinationProxy now relies on IPCSemaphore::waitFor(0_s) to
   see if the consumer is requesting more than 128 samples at once. Once it has
   determined the actual number of frames the consumer wants, it calls
   renderQuantum() once with this number. As a result, when an AudioWorklet is
   used, we greatly reduce the number of dispatches to the AudioWorklet thread.
   In the case of the demo, we end up with a buffer size of 1024 and we
   dispatch once per 1024 quantum instead of 7-8 times. We do the splitting
   into 128-frames chunks on the AudioWorklet threads.

* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::MediaSessionManagerCocoa::updateSessionState):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp:
(WebKit::RemoteAudioDestinationProxy::startRenderingThread):
(WebKit::RemoteAudioDestinationProxy::connection):
(WebKit::RemoteAudioDestinationProxy::renderQuantum):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.h:

Canonical link: <a href="https://commits.webkit.org/259964@main">https://commits.webkit.org/259964@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5215395cf57c3d2fcce932e8d250515be1661c41

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106558 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15574 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39367 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115743 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/115385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110467 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17069 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6802 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98751 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112326 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/95941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/40526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94845 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/27585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8802 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/28937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9344 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/5972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14962 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/48485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6889 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10883 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->