### PR TITLE
Add support for `Clear-Site-Data: "executionContext"`

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -430,9 +430,6 @@ imported/w3c/web-platform-tests/server-timing/test_server_timing.https.html [ Sk
 imported/w3c/web-platform-tests/server-timing/navigation_timing_idl.html [ Skip ]
 imported/w3c/web-platform-tests/server-timing/navigation_timing_idl.https.html [ Skip ]
 
-# No support for Clear-Site-Data: "executionContexts".
-imported/w3c/web-platform-tests/clear-site-data/executionContexts.sub.html [ Skip ]
-
 # Console log lines may appear in a different order so we silence them.
 http/tests/security/cookie-module.html [ DumpJSConsoleLogInStdErr ]
 http/tests/security/cookie-module-import-propagate.html [ DumpJSConsoleLogInStdErr ]

--- a/LayoutTests/imported/w3c/web-platform-tests/clear-site-data/executionContexts.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/clear-site-data/executionContexts.sub-expected.txt
@@ -1,8 +1,5 @@
-Blocked access to external URL https://www2.localhost:9443/clear-site-data/support/iframe_executionContexts.html
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT executionContexts triggers the reload of contexts Test timed out
-NOTRUN * triggers the reload of contexts
+PASS executionContexts triggers the reload of contexts
+PASS * triggers the reload of contexts
 

--- a/LayoutTests/imported/w3c/web-platform-tests/clear-site-data/executionContexts.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/clear-site-data/executionContexts.sub.html
@@ -3,6 +3,7 @@
   <head>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
+    <script src="/common/get-host-info.sub.js"></script>
   </head>
 
   <body>
@@ -16,7 +17,7 @@
 
           let ifr = document.createElement('iframe');
           document.body.appendChild(ifr);
-          ifr.src = "https://{{domains[www2]}}:{{ports[https][0]}}/clear-site-data/support/iframe_executionContexts.html";
+          ifr.src = get_host_info().HTTPS_REMOTE_ORIGIN + "/clear-site-data/support/iframe_executionContexts.html";
         });
       }
 
@@ -28,7 +29,7 @@
           }, { once: true });
 
           let image = new Image();
-          image.src = "https://{{domains[www2]}}:{{ports[https][0]}}/clear-site-data/support/echo-clear-site-data.py?" + what;
+          image.src = get_host_info().HTTPS_REMOTE_ORIGIN + "/clear-site-data/support/echo-clear-site-data.py?" + what;
         });
       }
 

--- a/Source/WebCore/page/FrameTree.cpp
+++ b/Source/WebCore/page/FrameTree.cpp
@@ -348,6 +348,28 @@ AbstractFrame* FrameTree::traverseNext(const AbstractFrame* stayWithin) const
     return nullptr;
 }
 
+AbstractFrame* FrameTree::traverseNextSkippingChildren(const AbstractFrame* stayWithin) const
+{
+    if (&m_thisFrame == stayWithin)
+        return nullptr;
+    if (auto* sibling = nextSibling())
+        return sibling;
+    return nextAncestorSibling(stayWithin);
+}
+
+AbstractFrame* FrameTree::nextAncestorSibling(const AbstractFrame* stayWithin) const
+{
+    ASSERT(!nextSibling());
+    ASSERT(&m_thisFrame != stayWithin);
+    for (auto* ancestor = parent(); ancestor; ancestor = ancestor->tree().parent()) {
+        if (ancestor == stayWithin)
+            return nullptr;
+        if (auto ancestorSibling = ancestor->tree().nextSibling())
+            return ancestorSibling;
+    }
+    return nullptr;
+}
+
 AbstractFrame* FrameTree::firstRenderedChild() const
 {
     auto* child = firstChild();

--- a/Source/WebCore/page/FrameTree.h
+++ b/Source/WebCore/page/FrameTree.h
@@ -58,6 +58,7 @@ public:
     WEBCORE_EXPORT bool isDescendantOf(const AbstractFrame* ancestor) const;
     
     WEBCORE_EXPORT AbstractFrame* traverseNext(const AbstractFrame* stayWithin = nullptr) const;
+    AbstractFrame* traverseNextSkippingChildren(const AbstractFrame* stayWithin = nullptr) const;
     // Rendered means being the main frame or having an ownerRenderer. It may not have been parented in the Widget tree yet (see WidgetHierarchyUpdatesSuspensionScope).
     WEBCORE_EXPORT AbstractFrame* traverseNextRendered(const AbstractFrame* stayWithin = nullptr) const;
     WEBCORE_EXPORT AbstractFrame* traverseNext(CanWrap, DidWrap* = nullptr) const;
@@ -86,6 +87,7 @@ public:
 private:
     AbstractFrame* deepFirstChild() const;
     AbstractFrame* deepLastChild() const;
+    AbstractFrame* nextAncestorSibling(const AbstractFrame* stayWithin) const;
 
     bool scopedBy(TreeScope*) const;
     AbstractFrame* scopedChild(unsigned index, TreeScope*) const;

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -293,6 +293,8 @@ public:
     WEBCORE_EXPORT OptionSet<DisabledAdaptations> disabledAdaptations() const;
     WEBCORE_EXPORT ViewportArguments viewportArguments() const;
 
+    WEBCORE_EXPORT void reloadExecutionContextsForOrigin(const ClientOrigin&, std::optional<FrameIdentifier> triggeringFrame) const;
+
     const std::optional<ViewportArguments>& overrideViewportArguments() const { return m_overrideViewportArguments; }
     WEBCORE_EXPORT void setOverrideViewportArguments(const std::optional<ViewportArguments>&);
 

--- a/Source/WebCore/platform/network/HTTPParsers.cpp
+++ b/Source/WebCore/platform/network/HTTPParsers.cpp
@@ -600,10 +600,12 @@ OptionSet<ClearSiteDataValue> parseClearSiteDataHeader(const ResourceResponse& r
             result.add(ClearSiteDataValue::Cache);
         else if (trimmedValue == "\"cookies\""_s)
             result.add(ClearSiteDataValue::Cookies);
+        else if (trimmedValue == "\"executionContexts\""_s)
+            result.add(ClearSiteDataValue::ExecutionContexts);
         else if (trimmedValue == "\"storage\""_s)
             result.add(ClearSiteDataValue::Storage);
         else if (trimmedValue == "\"*\""_s)
-            result.add({ ClearSiteDataValue::Cache, ClearSiteDataValue::Cookies, ClearSiteDataValue::Storage });
+            result.add({ ClearSiteDataValue::Cache, ClearSiteDataValue::Cookies, ClearSiteDataValue::ExecutionContexts, ClearSiteDataValue::Storage });
     }
     return result;
 }

--- a/Source/WebCore/platform/network/HTTPParsers.h
+++ b/Source/WebCore/platform/network/HTTPParsers.h
@@ -73,7 +73,8 @@ enum class CrossOriginResourcePolicy : uint8_t {
 enum class ClearSiteDataValue : uint8_t {
     Cache = 1 << 0,
     Cookies = 1 << 1,
-    Storage = 1 << 2,
+    ExecutionContexts = 1 << 2,
+    Storage = 1 << 3,
 };
 
 bool isValidReasonPhrase(const String&);

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -764,7 +764,8 @@ void NetworkResourceLoader::processClearSiteDataHeader(const WebCore::ResourceRe
 #endif
     }
 
-    if (!typesToRemove)
+    bool shouldReloadExecutionContexts = clearSiteDataValues.contains(ClearSiteDataValue::ExecutionContexts);
+    if (!typesToRemove && !shouldReloadExecutionContexts)
         return completionHandler();
 
     LOADER_RELEASE_LOG("processClearSiteDataHeader: BEGIN");
@@ -785,10 +786,18 @@ void NetworkResourceLoader::processClearSiteDataHeader(const WebCore::ResourceRe
         LOADER_RELEASE_LOG("processClearSiteDataHeader: END");
         completionHandler();
     });
-    m_connection->networkProcess().deleteWebsiteDataForOrigin(sessionID(), typesToRemove, clientOrigin, [callbackAggregator] { });
+    if (typesToRemove)
+        m_connection->networkProcess().deleteWebsiteDataForOrigin(sessionID(), typesToRemove, clientOrigin, [callbackAggregator] { });
 
     if (WebsiteDataStore::computeWebProcessAccessTypeForDataRemoval(typesToRemove, sessionID().isEphemeral()) != WebsiteDataStore::ProcessAccessType::None)
         m_connection->networkProcess().parentProcessConnection()->sendWithAsyncReply(Messages::NetworkProcessProxy::DeleteWebsiteDataInWebProcessesForOrigin(typesToRemove, clientOrigin, sessionID(), m_parameters.webPageProxyID), [callbackAggregator] { });
+
+    if (shouldReloadExecutionContexts) {
+        std::optional<WebCore::FrameIdentifier> triggeringFrame;
+        if (isMainResource())
+            triggeringFrame = frameID();
+        m_connection->networkProcess().parentProcessConnection()->sendWithAsyncReply(Messages::NetworkProcessProxy::ReloadExecutionContextsForOrigin(clientOrigin, sessionID(), triggeringFrame), [callbackAggregator] { });
+    }
 }
 
 static BrowsingContextGroupSwitchDecision toBrowsingContextGroupSwitchDecision(const std::optional<CrossOriginOpenerPolicyEnforcementResult>& currentCoopEnforcementResult)

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -305,6 +305,7 @@ public:
     void cancelDataTask(DataTaskIdentifier, PAL::SessionID);
 
     void deleteWebsiteDataInWebProcessesForOrigin(OptionSet<WebsiteDataType>, const WebCore::ClientOrigin&, PAL::SessionID, WebPageProxyIdentifier, CompletionHandler<void()>&&);
+    void reloadExecutionContextsForOrigin(const WebCore::ClientOrigin&, PAL::SessionID, std::optional<WebCore::FrameIdentifier> triggeringFrame, CompletionHandler<void()>&&);
 
     void terminateRemoteWorkerContextConnectionWhenPossible(RemoteWorkerType, PAL::SessionID, const WebCore::RegistrableDomain&, WebCore::ProcessIdentifier);
 

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.messages.in
@@ -98,6 +98,7 @@ messages -> NetworkProcessProxy LegacyReceiver {
     CookiesDidChange(PAL::SessionID sessionID)
 
     DeleteWebsiteDataInWebProcessesForOrigin(OptionSet<WebKit::WebsiteDataType> websiteDataTypes, struct WebCore::ClientOrigin origin, PAL::SessionID sessionID, WebKit::WebPageProxyIdentifier webPageProxyID) -> ()
+    ReloadExecutionContextsForOrigin(struct WebCore::ClientOrigin origin, PAL::SessionID sessionID, std::optional<WebCore::FrameIdentifier> triggeringFrame) -> ()
 
 #if ENABLE(NETWORK_ISSUE_REPORTING)
     ReportNetworkIssue(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, URL requestURL)

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1459,6 +1459,15 @@ void WebProcess::deleteWebsiteDataForOrigin(OptionSet<WebsiteDataType> websiteDa
     completionHandler();
 }
 
+void WebProcess::reloadExecutionContextsForOrigin(const ClientOrigin& origin, std::optional<FrameIdentifier> triggeringFrame, CompletionHandler<void()>&& completionHandler)
+{
+    for (auto& page : m_pageMap.values()) {
+        if (auto* corePage = page->corePage())
+            corePage->reloadExecutionContextsForOrigin(origin, triggeringFrame);
+    }
+    completionHandler();
+}
+
 void WebProcess::deleteWebsiteDataForOrigins(OptionSet<WebsiteDataType> websiteDataTypes, const Vector<WebCore::SecurityOriginData>& originDatas, CompletionHandler<void()>&& completionHandler)
 {
     if (websiteDataTypes.contains(WebsiteDataType::MemoryCache)) {

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -388,6 +388,7 @@ public:
     bool hadMainFrameMainResourcePrivateRelayed() const { return m_hadMainFrameMainResourcePrivateRelayed; }
 
     void deleteWebsiteDataForOrigin(OptionSet<WebsiteDataType>, const WebCore::ClientOrigin&, CompletionHandler<void()>&&);
+    void reloadExecutionContextsForOrigin(const WebCore::ClientOrigin&, std::optional<WebCore::FrameIdentifier> triggeringFrame, CompletionHandler<void()>&&);
 
     void setAppBadge(std::optional<WebPageProxyIdentifier>, const WebCore::SecurityOriginData&, std::optional<uint64_t>);
     void setClientBadge(WebPageProxyIdentifier, const WebCore::SecurityOriginData&, std::optional<uint64_t>);

--- a/Source/WebKit/WebProcess/WebProcess.messages.in
+++ b/Source/WebKit/WebProcess/WebProcess.messages.in
@@ -76,6 +76,7 @@ messages -> WebProcess LegacyReceiver NotRefCounted {
     DeleteWebsiteData(OptionSet<WebKit::WebsiteDataType> websiteDataTypes, WallTime modifiedSince) -> ()
     DeleteWebsiteDataForOrigins(OptionSet<WebKit::WebsiteDataType> websiteDataTypes, Vector<WebCore::SecurityOriginData> origins) -> ()
     DeleteWebsiteDataForOrigin(OptionSet<WebKit::WebsiteDataType> websiteDataTypes, struct WebCore::ClientOrigin origin) -> ()
+    ReloadExecutionContextsForOrigin(struct WebCore::ClientOrigin origin, std::optional<WebCore::FrameIdentifier> triggeringFrame) -> ()
     DeleteAllCookies() -> ()
 
     SetHiddenPageDOMTimerThrottlingIncreaseLimit(int milliseconds)


### PR DESCRIPTION
#### 35591d243359e99fdc75cfe21c70c999d34d985d
<pre>
Add support for `Clear-Site-Data: &quot;executionContext&quot;`
<a href="https://bugs.webkit.org/show_bug.cgi?id=251821">https://bugs.webkit.org/show_bug.cgi?id=251821</a>

Reviewed by Geoffrey Garen.

Add support for `Clear-Site-Data: &quot;executionContext&quot;`:
- <a href="https://w3c.github.io/webappsec-clear-site-data/#grammardef-executioncontexts">https://w3c.github.io/webappsec-clear-site-data/#grammardef-executioncontexts</a>

* LayoutTests/TestExpectations:
Unskip WPT test that is now passing.

* LayoutTests/imported/w3c/web-platform-tests/clear-site-data/executionContexts.sub-expected.txt:
Rebaseline WPT test that is now passing.

* LayoutTests/imported/w3c/web-platform-tests/clear-site-data/executionContexts.sub.html:
Fix WPT test to work with the WebKit test infrastructure (will make an upstream PR).

* Source/WebCore/page/FrameTree.cpp:
(WebCore::FrameTree::traverseNextSkippingChildren const):
(WebCore::FrameTree::nextAncestorSibling const):
* Source/WebCore/page/FrameTree.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::reloadExecutionContextsForOrigin const):
* Source/WebCore/page/Page.h:
(WebCore::Page::overrideViewportArguments const):
* Source/WebCore/platform/network/HTTPParsers.cpp:
(WebCore::parseClearSiteDataHeader):
* Source/WebCore/platform/network/HTTPParsers.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::processClearSiteDataHeader):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::reloadExecutionContextsForOrigin):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.messages.in:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::reloadExecutionContextsForOrigin):
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/WebProcess.messages.in:

Canonical link: <a href="https://commits.webkit.org/259940@main">https://commits.webkit.org/259940@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a53084cab1de569d813328d1656dbd23d9dfab09

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106506 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15521 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39314 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115690 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/175781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110414 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17016 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6749 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98697 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/115345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112274 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95896 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/40484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/94804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27540 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8752 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/28892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9293 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/5469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14910 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48440 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6866 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10833 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->