### PR TITLE
[git-webkit] Automatically classify commits

### DIFF
--- a/Tools/Scripts/git-webkit
+++ b/Tools/Scripts/git-webkit
@@ -32,6 +32,8 @@ from webkitscmpy import local, program, remote, Contributor, log
 
 def is_webkit_filter(to_return):
     def callback(repository):
+        if repository is None:
+            return to_return
         if isinstance(repository, local.Scm):
             repository = repository.remote()
         if not isinstance(repository, remote.Scm):
@@ -65,11 +67,23 @@ def additional_setup(args, repository):
     return 0
 
 
+def classifier():
+    from webkitscmpy import CommitClassifier
+
+    root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    classifier = os.path.join(root, 'metadata', 'commit_classes.json')
+    if not os.path.isfile(classifier):
+        return None
+    with open(classifier, 'r') as file:
+        return CommitClassifier.load(file)
+
+
 if '__main__' == __name__:
     sys.exit(program.main(
         identifier_template=is_webkit_filter('Canonical link: https://commits.webkit.org/{}'),
         subversion=is_webkit_filter('https://svn.webkit.org/repository/webkit'),
         additional_setup=is_webkit_filter(additional_setup),
         hooks=os.path.join(os.path.abspath(os.path.join(os.path.dirname(__file__))), 'hooks'),
+        classifier=is_webkit_filter(classifier()),
     ))
 

--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.13.2',
+    version='5.14.0',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 13, 2)
+version = Version(5, 14, 0)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))
@@ -60,6 +60,7 @@ if sys.version_info > (3, 6):
 
 from webkitscmpy.contributor import Contributor
 from webkitscmpy.commit import Commit
+from webkitscmpy.commit_classifier import CommitClassifier
 from webkitscmpy.pull_request import PullRequest
 from webkitscmpy.scm_base import ScmBase
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit_classifier.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit_classifier.py
@@ -1,0 +1,131 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import json
+import os
+import sys
+import re
+
+from webkitcorepy import CallByNeed, string_utils
+
+fuzz = None
+
+if sys.version_info > (3, 6):
+    try:
+        from rapidfuzz import fuzz
+    except ModuleNotFoundError:
+        pass
+
+
+class CommitClassifier(object):
+    class HeaderFilter(object):
+        DEFAULT_FUZZ_RATIO = 90
+
+        @classmethod
+        def fuzzy(cls, string, ratio=None):
+            if not fuzz:
+                return re.compile(string)
+
+            ratio = cls.DEFAULT_FUZZ_RATIO if not ratio else ratio
+            return lambda x: fuzz.partial_ratio(string, x) >= ratio
+
+        def __init__(self, value):
+            if isinstance(value, str) or isinstance(value, string_utils.unicode):
+                self.description = value
+                self.do = lambda x: re.search(value, x)
+            elif isinstance(value, dict) and 'value' in value:
+                self.description = 'fuzz({}, {}%)'.format(value['value'], value.get('ratio', self.DEFAULT_FUZZ_RATIO))
+                self.do = self.fuzzy(value['value'], ratio=value.get('ratio'))
+            else:
+                raise ValueError("'{}' not a valid header filter".format(value))
+
+        def __repr__(self):
+            return self.description
+
+        def __call__(self, string):
+            return bool(self.do(string))
+
+    class CommitClass(object):
+        @classmethod
+        def filter_header(cls, header):
+            if isinstance(header, str):
+                return re.compile(header)
+            return None
+
+        def __init__(self, name, pickable=True, headers=None, paths=None, **kwargs):
+            self.name = name
+            self.pickable = pickable
+            self.headers = [CommitClassifier.HeaderFilter(header) for header in headers or []]
+            self.paths = [re.compile(r'^{}'.format(path)) for path in (paths or [])]
+
+            if not self.headers and not self.paths:
+                raise ValueError('A CommitClass must not match all commits')
+
+            for argument, _ in kwargs.items():
+                sys.stderr.write('{} is not a valid member in CommitClassifier.CommitClass\n'.format(argument))
+
+        def __repr__(self):
+            description = '{}(\n'.format(self.name)
+            description += '    pickable = {}\n'.format(self.pickable)
+            if self.headers:
+                description += '    headers = [\n'
+                for header in self.headers:
+                    description += '        {}\n'.format(header)
+                description += '    ]\n'
+            if self.paths:
+                description += '    paths = [\n'
+                for path in self.paths:
+                    description += '        {}\n'.format(path.pattern)
+                description += '    ]\n'
+            description += ')'
+            return description
+
+    @classmethod
+    def load(cls, file):
+        result = cls()
+        contents = json.load(file)
+        for commit_class in contents:
+            result.classes.append(cls.CommitClass(**commit_class))
+        return result
+
+    def __init__(self, classes=None):
+        self.classes = classes or []
+
+    def classify(self, commit, repository=None):
+        header = commit.message.splitlines()[0]
+        paths_for = CallByNeed(
+            callback=lambda: repository.files_changed(commit.hash or str(commit)),
+            type=list,
+        )
+        for klass in self.classes:
+            can_exclude = bool(klass.headers and header) or bool(klass.paths and paths_for.value)
+            if not can_exclude:
+                continue
+            if klass.headers and header and not any([f(header) for f in klass.headers]):
+                continue
+
+            if klass.paths and paths_for.value and not all([
+                any([c.match(path) for c in klass.paths]) for path in paths_for.value
+            ]):
+                continue
+            return klass
+        return None

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2022 Apple Inc. All rights reserved.
+# Copyright (C) 2020-2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -386,8 +386,23 @@ class Git(Scm):
 
         return result
 
-    def __init__(self, path, dev_branches=None, prod_branches=None, contributors=None, id=None, cached=sys.version_info > (3, 0)):
-        super(Git, self).__init__(path, dev_branches=dev_branches, prod_branches=prod_branches, contributors=contributors, id=id)
+    def __init__(
+            self, path,
+            dev_branches=None,
+            prod_branches=None,
+            contributors=None,
+            id=None,
+            cached=sys.version_info > (3, 0),
+            classifier=None,
+    ):
+        super(Git, self).__init__(
+            path,
+            dev_branches=dev_branches,
+            prod_branches=prod_branches,
+            contributors=contributors,
+            id=id,
+            classifier=classifier,
+        )
         self._branch = None
         self.cache = self.Cache(self) if self.root_path and cached else None
         self.default_remote = 'origin'

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/scm.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/scm.py
@@ -27,7 +27,7 @@ import six
 
 from webkitbugspy import Tracker, bugzilla, github, radar
 from webkitcorepy import decorators
-from webkitscmpy import ScmBase, Contributor
+from webkitscmpy import ScmBase, Contributor, CommitClassifier
 
 
 class Scm(ScmBase):
@@ -55,12 +55,11 @@ class Scm(ScmBase):
             return local.Svn(path, contributors=contributors, **kwargs)
         raise OSError("'{}' is not a known SCM type".format(path))
 
-    def __init__(self, path, dev_branches=None, prod_branches=None, contributors=None, id=None):
+    def __init__(self, path, dev_branches=None, prod_branches=None, contributors=None, id=None, classifier=None):
         if not isinstance(path, six.string_types):
             raise ValueError("Expected 'path' to be a string type, not '{}'".format(type(path)))
         self.path = path
 
-        root_path = self.root_path
         if not contributors and self.metadata:
             for candidate in [
                 os.path.join(self.metadata, 'contributors.json'),
@@ -70,7 +69,22 @@ class Scm(ScmBase):
                 with open(candidate, 'r') as file:
                     contributors = Contributor.Mapping.load(file)
 
-        super(Scm, self).__init__(dev_branches=dev_branches, prod_branches=prod_branches, contributors=contributors, id=id)
+        if not classifier and self.metadata:
+            for candidate in [
+                os.path.join(self.metadata, 'commit_classes.json'),
+            ]:
+                if not os.path.isfile(candidate):
+                    continue
+                with open(candidate, 'r') as file:
+                    classifier = CommitClassifier.load(file)
+
+        super(Scm, self).__init__(
+            dev_branches=dev_branches,
+            prod_branches=prod_branches,
+            contributors=contributors,
+            classifier=classifier,
+            id=id,
+        )
 
         trackers = []
         if self.metadata:

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/svn.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/svn.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020, 2021 Apple Inc. All rights reserved.
+# Copyright (C) 2020-2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -214,13 +214,13 @@ class Svn(Scm):
     def is_checkout(cls, path):
         return run([cls.executable(), 'info'], cwd=path, capture_output=True).returncode == 0
 
-    def __init__(self, path, dev_branches=None, prod_branches=None, contributors=None, id=None, cached=True):
+    def __init__(self, path, dev_branches=None, prod_branches=None, contributors=None, id=None, cached=True, classifier=None,):
         self._root_path = path
         self._root_path = self.info(cached=False).get('Working Copy Root Path')
         if not self.root_path:
             raise OSError('Provided path {} is not a svn repository'.format(path))
 
-        super(Svn, self).__init__(path, dev_branches=dev_branches, prod_branches=prod_branches, contributors=contributors, id=id)
+        super(Svn, self).__init__(path, dev_branches=dev_branches, prod_branches=prod_branches, contributors=contributors, id=id, classifier=classifier,)
         self.cache = self.Cache(self) if cached else None
 
     @decorators.Memoize(cached=False)

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/classify.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/classify.py
@@ -1,0 +1,96 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import sys
+
+from .command import Command
+from webkitcorepy import string_utils
+from webkitscmpy import ScmBase
+
+
+class Classify(Command):
+    name = 'classify'
+
+    @classmethod
+    def help(cls, classifier=None):
+        result = 'Repositories may classify different commits so that automation behaves differently '
+        result += 'for different types of changes. For example, a commit to garden test expectations '
+        result += 'may have less stringent code-review requirements. '
+
+        if classifier and classifier.classes:
+            result += 'This repository support the classifications {}. '.format(
+                string_utils.join(["'{}'".format(klass.name) for klass in classifier.classes]),
+            )
+        result += 'Print the classification of a given commit.'
+        return result
+
+    @classmethod
+    def parser(cls, parser, loggers=None):
+        parser.add_argument(
+            'argument', nargs='?',
+            type=str, default=None,
+            help='String representation of a commit to classify',
+        )
+        parser.add_argument(
+            '--list', '-l',
+            help='List all commit classifications supported in this repository.',
+            action='store_true',
+            dest='list',
+            default=False,
+        )
+
+    @classmethod
+    def main(cls, args, repository, **kwargs):
+        if not repository:
+            sys.stderr.write('No repository provided\n')
+            return 1
+
+        if not repository.classifier:
+            sys.stderr.write('Provided repository has no classifier specified\n')
+            return 255
+        if not repository.classifier.classes:
+            sys.stderr.write('Repository does not specify any commit classifications\n')
+            return 255
+
+        if args.list:
+            for klass in repository.classifier.classes:
+                print(klass.name)
+            return 0
+
+        if not args.argument:
+            args.argument = 'HEAD'
+
+        try:
+            commit = repository.find(args.argument, include_log=True)
+        except (ScmBase.Exception, TypeError, ValueError) as exception:
+            # ValueErrors and Scm exceptions usually contain enough information to be displayed
+            # to the user as an error
+            sys.stderr.write(str(exception) + '\n')
+            return 1
+
+        klass = repository.classifier.classify(commit, repository)
+        if not klass:
+            sys.stderr.write('Provided commit does not match a known class in this repository\n')
+            print('None')
+            return 1
+        print(klass.name)
+        return 0

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py
@@ -313,7 +313,7 @@ class BitBucket(Scm):
     def is_webserver(cls, url):
         return True if cls.URL_RE.match(url) else False
 
-    def __init__(self, url, dev_branches=None, prod_branches=None, contributors=None, id=None):
+    def __init__(self, url, dev_branches=None, prod_branches=None, contributors=None, id=None, classifier=None):
         match = self.URL_RE.match(url)
         if not match:
             raise self.Exception("'{}' is not a valid BitBucket project".format(url))
@@ -326,6 +326,7 @@ class BitBucket(Scm):
             dev_branches=dev_branches, prod_branches=prod_branches,
             contributors=contributors,
             id=id or self.name.lower(),
+            classifier=classifier,
         )
 
         self.pull_requests = self.PRGenerator(self)

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py
@@ -357,7 +357,7 @@ class GitHub(Scm):
     def is_webserver(cls, url):
         return True if cls.URL_RE.match(url) else False
 
-    def __init__(self, url, dev_branches=None, prod_branches=None, contributors=None, id=None, proxies=None):
+    def __init__(self, url, dev_branches=None, prod_branches=None, contributors=None, id=None, proxies=None, classifier=None):
         match = self.URL_RE.match(url)
         if not match:
             raise self.Exception("'{}' is not a valid GitHub project".format(url))
@@ -378,6 +378,7 @@ class GitHub(Scm):
             dev_branches=dev_branches, prod_branches=prod_branches,
             contributors=contributors,
             id=id or self.name.lower(),
+            classifier=classifier,
         )
 
         self.pull_requests = self.PRGenerator(self)

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/scm.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/scm.py
@@ -59,7 +59,7 @@ class Scm(ScmBase):
 
 
     @classmethod
-    def from_url(cls, url, contributors=None):
+    def from_url(cls, url, contributors=None, classifier=None):
         from webkitscmpy import remote
 
         if 'bitbucket' in url or 'stash' in url:
@@ -73,12 +73,18 @@ class Scm(ScmBase):
 
         for candidate in [remote.Svn, remote.GitHub, remote.BitBucket]:
             if candidate.is_webserver(url):
-                return candidate(url, contributors=contributors)
+                return candidate(url, contributors=contributors, classifier=classifier)
 
         raise OSError("'{}' is not a known SCM server".format(url))
 
-    def __init__(self, url, dev_branches=None, prod_branches=None, contributors=None, id=None):
-        super(Scm, self).__init__(dev_branches=dev_branches, prod_branches=prod_branches, contributors=contributors, id=id)
+    def __init__(self, url, dev_branches=None, prod_branches=None, contributors=None, id=None, classifier=None):
+        super(Scm, self).__init__(
+            dev_branches=dev_branches,
+            prod_branches=prod_branches,
+            contributors=contributors,
+            id=id,
+            classifier=classifier,
+        )
 
         if not isinstance(url, six.string_types):
             raise ValueError("Expected 'url' to be a string type, not '{}'".format(type(url)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/svn.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/svn.py
@@ -44,7 +44,7 @@ class Svn(Scm):
     def is_webserver(cls, url):
         return True if cls.URL_RE.match(url) else False
 
-    def __init__(self, url, dev_branches=None, prod_branches=None, contributors=None, id=None, cache_path=None):
+    def __init__(self, url, dev_branches=None, prod_branches=None, contributors=None, id=None, cache_path=None, classifier=None):
         if url[-1] != '/':
             url += '/'
         if not self.is_webserver(url):
@@ -55,6 +55,7 @@ class Svn(Scm):
             dev_branches=dev_branches, prod_branches=prod_branches,
             contributors=contributors,
             id=id or url.split('/')[-2].lower(),
+            classifier=classifier,
         )
 
         if not cache_path:

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/scm_base.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/scm_base.py
@@ -28,7 +28,7 @@ import time
 
 from datetime import datetime
 from logging import NullHandler
-from webkitscmpy import Commit, Contributor, log
+from webkitscmpy import Commit, Contributor, CommitClassifier, log
 
 
 class ScmBase(object):
@@ -50,11 +50,12 @@ class ScmBase(object):
         ts = time.time()
         return int((datetime.fromtimestamp(ts) - datetime.utcfromtimestamp(ts)).total_seconds() * 100 / (60 * 60))
 
-    def __init__(self, dev_branches=None, prod_branches=None, contributors=None, id=None):
+    def __init__(self, dev_branches=None, prod_branches=None, contributors=None, id=None, classifier=None):
         self.dev_branches = dev_branches or self.DEV_BRANCHES
         self.prod_branches = prod_branches or self.PROD_BRANCHES
         self.path = getattr(self, 'path', None)
         self.contributors = Contributor.Mapping() if contributors is None else contributors
+        self.classifier = CommitClassifier() if classifier is None else classifier
 
         if id and not isinstance(id, six.string_types):
             raise ValueError("Expected 'id' to be a string type, not '{}'".format(type(id)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/classify_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/classify_unittest.py
@@ -1,0 +1,115 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+
+from webkitcorepy import OutputCapture, Terminal, testing
+from webkitscmpy import program, mocks, CommitClassifier
+
+
+class TestClassify(testing.PathTestCase):
+    basepath = 'mock/repository'
+
+    def setUp(self):
+        super(TestClassify, self).setUp()
+        os.mkdir(os.path.join(self.path, '.git'))
+        os.mkdir(os.path.join(self.path, '.svn'))
+
+    def test_no_classes(self):
+        with OutputCapture() as captured, mocks.local.Git(self.path), mocks.local.Svn():
+            self.assertEqual(255, program.main(
+                args=('classify',),
+                path=self.path,
+            ))
+        self.assertEqual(captured.stdout.getvalue(), '')
+        self.assertEqual(captured.stderr.getvalue(), 'Repository does not specify any commit classifications\n')
+
+    def test_list_classes(self):
+        with OutputCapture() as captured, mocks.local.Git(self.path), mocks.local.Svn():
+            self.assertEqual(0, program.main(
+                args=('classify', '-l'),
+                path=self.path,
+                classifier=CommitClassifier([CommitClassifier.CommitClass(
+                    name='Versioning',
+                    headers=[r"Versioning\.$", r'^Revert "?[Vv]ersioning\.?"?$'],
+                )])
+            ))
+        self.assertEqual(captured.stdout.getvalue(), 'Versioning\n')
+        self.assertEqual(captured.stderr.getvalue(), '')
+
+    def test_header_success(self):
+        with OutputCapture() as captured, mocks.local.Git(self.path), mocks.local.Svn():
+            self.assertEqual(0, program.main(
+                args=('classify', 'HEAD'),
+                path=self.path,
+                classifier=CommitClassifier([CommitClassifier.CommitClass(
+                    name='Series',
+                    headers=[r'^Patch Series'],
+                )])
+            ))
+        self.assertEqual(captured.stdout.getvalue(), 'Series\n')
+        self.assertEqual(captured.stderr.getvalue(), '')
+
+    def test_header_failure(self):
+        with OutputCapture() as captured, mocks.local.Git(self.path), mocks.local.Svn():
+            self.assertEqual(1, program.main(
+                args=('classify', 'HEAD'),
+                path=self.path,
+                classifier=CommitClassifier([CommitClassifier.CommitClass(
+                    name='Series',
+                    headers=[r'^\?'],
+                )])
+            ))
+        self.assertEqual(captured.stdout.getvalue(), 'None\n')
+        self.assertEqual(
+            captured.stderr.getvalue(),
+            'Provided commit does not match a known class in this repository\n',
+        )
+
+    def test_path_success(self):
+        with OutputCapture() as captured, mocks.local.Git(self.path), mocks.local.Svn():
+            self.assertEqual(0, program.main(
+                args=('classify', 'HEAD'),
+                path=self.path,
+                classifier=CommitClassifier([CommitClassifier.CommitClass(
+                    name='Change',
+                    paths=['Source'],
+                )])
+            ))
+        self.assertEqual(captured.stdout.getvalue(), 'Change\n')
+        self.assertEqual(captured.stderr.getvalue(), '')
+
+    def test_path_failure(self):
+        with OutputCapture() as captured, mocks.local.Git(self.path), mocks.local.Svn():
+            self.assertEqual(1, program.main(
+                args=('classify', 'HEAD'),
+                path=self.path,
+                classifier=CommitClassifier([CommitClassifier.CommitClass(
+                    name='Tools',
+                    paths=['Tests', 'metadata'],
+                )])
+            ))
+        self.assertEqual(captured.stdout.getvalue(), 'None\n')
+        self.assertEqual(
+            captured.stderr.getvalue(),
+            'Provided commit does not match a known class in this repository\n',
+        )

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pickable_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pickable_unittest.py
@@ -28,7 +28,7 @@ from datetime import datetime
 
 from webkitcorepy import OutputCapture, Terminal, testing
 from webkitcorepy.mocks import Time as MockTime
-from webkitscmpy import local, program, mocks, Commit
+from webkitscmpy import local, program, mocks, Commit, CommitClassifier
 
 
 class TestPickable(testing.PathTestCase):
@@ -132,6 +132,11 @@ class TestPickable(testing.PathTestCase):
             self.assertEqual(0, program.main(
                 args=('pickable', 'safari-xxx-branch'),
                 path=self.path,
+                classifier=CommitClassifier([CommitClassifier.CommitClass(
+                    name='Versioning',
+                    headers=[r"Versioning\.$", r'^Revert "?[Vv]ersioning\.?"?$'],
+                    pickable=False,
+                )]),
             ))
 
         self.assertEqual(
@@ -169,6 +174,11 @@ class TestPickable(testing.PathTestCase):
             self.assertEqual(0, program.main(
                 args=('pickable', 'safari-xxx-branch'),
                 path=self.path,
+                classifier=CommitClassifier([CommitClassifier.CommitClass(
+                    name='Versioning',
+                    headers=[r"Versioning\.$", r'^Revert "?[Vv]ersioning\.?"?$'],
+                    pickable=False,
+                )]),
             ))
 
         self.assertEqual(
@@ -193,6 +203,11 @@ class TestPickable(testing.PathTestCase):
             self.assertEqual(1, program.main(
                 args=('pickable', 'safari-xxx-branch'),
                 path=self.path,
+                classifier=CommitClassifier([CommitClassifier.CommitClass(
+                    name='Versioning',
+                    headers=[r"Versioning\.$", r'^Revert "?[Vv]ersioning\.?"?$'],
+                    pickable=False,
+                )]),
             ))
 
         self.assertEqual(captured.stdout.getvalue(), '')
@@ -217,18 +232,23 @@ class TestPickable(testing.PathTestCase):
             self.assertEqual(0, program.main(
                 args=('pickable', 'safari-xxx-branch', '--exclude', 'Cherry-pick'),
                 path=self.path,
+                classifier=CommitClassifier([
+                    CommitClassifier.CommitClass(
+                        name='Versioning',
+                        headers=[r"Versioning\.$", r'^Revert "?[Vv]ersioning\.?"?$'],
+                        pickable=False,
+                    ), CommitClassifier.CommitClass(
+                        name='Cherry-pick',
+                        headers=[r"^[Cc]herry[- ][Pp]ick"],
+                        pickable=True,
+                    ),
+                ]),
             ))
 
         self.assertEqual(captured.stdout.getvalue(), '4.1@safari-xxx-branch | 6eedcf4492c3 | Versioning.\n')
 
     def test_branch_gardening_exclude(self):
         with OutputCapture() as captured, mocks.local.Git(self.path) as repo, mocks.local.Svn(), MockTime, Terminal.override_atty(sys.stdin, isatty=False):
-            project_config = os.path.join(self.path, 'metadata', local.Git.GIT_CONFIG_EXTENSION)
-            os.mkdir(os.path.dirname(project_config))
-            with open(project_config, 'w') as f:
-                f.write('[webkitscmpy "tests"]\n')
-                f.write('    api-tests = Source\n')
-
             repo.commits['safari-xxx-branch'] = [
                 repo.commits['main'][3],
                 Commit(
@@ -243,6 +263,12 @@ class TestPickable(testing.PathTestCase):
             self.assertEqual(1, program.main(
                 args=('pickable', 'safari-xxx-branch'),
                 path=self.path,
+                classifier=CommitClassifier([CommitClassifier.CommitClass(
+                    name='Gardening',
+                    headers=[r"[GARDENING]"],
+                    paths=['Source'],
+                    pickable=False,
+                )]),
             ))
 
         self.assertEqual(captured.stderr.getvalue(), "No commits in specified range are 'pickable'\n")
@@ -264,6 +290,12 @@ class TestPickable(testing.PathTestCase):
             self.assertEqual(0, program.main(
                 args=('pickable', 'safari-xxx-branch'),
                 path=self.path,
+                classifier=CommitClassifier([CommitClassifier.CommitClass(
+                    name='Gardening',
+                    headers=[r"[GARDENING]"],
+                    paths=['LayoutTests/', 'Tools/TestWebKitAPI'],
+                    pickable=False,
+                )]),
             ))
 
         self.assertEqual(

--- a/metadata/commit_classes.json
+++ b/metadata/commit_classes.json
@@ -1,0 +1,60 @@
+[
+	{
+		"name": "Versioning",
+		"pickable": false,
+		"headers": [
+			"^[Vv]ersioning\\.?$",
+			"^Revert \"?[Vv]ersioning\\.?\"?$"
+		]
+	},
+	{
+		"name": "Build-fix",
+		"pickable": false,
+		"headers": [
+			"^Apply build[ -]fix",
+			"^Unreviewed build[ -]fix"
+		]
+	},
+	{
+		"name": "Gardening",
+		"pickable": false,
+		"headers": [
+			{"value": "GARDENING", "ratio": 85},
+			{"value": "gardening", "ratio": 85},
+			{"value": "REBASELINE"},
+			{"value": "rebaseline"},
+			{"value": "is a constant failure"},
+			{"value": "is an almost constant failure"},
+			{"value": "are constant failures"},
+			{"value": "tests consistently failing"}
+		],
+		"paths": [
+			"LayoutTests/",
+			"Tools/TestWebKitAPI"
+		]
+	},
+	{
+		"name": "Apply-Patch",
+		"pickable": false,
+		"headers": ["^Apply patch"]
+	},
+	{
+		"name": "Contributor",
+		"pickable": false,
+		"paths": ["metadata/contributors.json"]
+	},
+	{
+		"name": "Cherry-pick",
+		"pickable": true,
+		"headers": ["^[Cc]herry[- ][Pp]ick"]
+	},
+	{
+		"name": "Tools",
+		"pickable": true,
+		"paths": [
+			"Tools",
+			"LayoutTests",
+			"metadata"
+		]
+	}
+]

--- a/metadata/git_config_extension
+++ b/metadata/git_config_extension
@@ -14,6 +14,3 @@
         security = WebKit/teams/security
 [webkitscmpy "pre-pr"]
         style-checker = python3 Tools/Scripts/check-webkit-style
-[webkitscmpy "tests"]
-        layout-tests = LayoutTests
-        api-tests = Tools/TestWebKitAPI


### PR DESCRIPTION
#### 45adfd10be4108a4331f479ddc809104ca85a45a
<pre>
[git-webkit] Automatically classify commits
<a href="https://bugs.webkit.org/show_bug.cgi?id=251824">https://bugs.webkit.org/show_bug.cgi?id=251824</a>
rdar://105105664

Rubber-stamped by Aakash Jain.

The WebKit project often wants tools to reason about the type of commit they are
dealing with. For example, certain test gardening changes don&apos;t require review.
And many EWS tests don&apos;t need to be run when adding to contributors.json.

* Tools/Scripts/git-webkit: Pass WebKit&apos;s commit classifier as a default.
* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Export CommitClassifier.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit_classifier.py: Added.
(CommitClassifier.HeaderFilter): A string filter which can be a regex or a fuzzy matcher.
(CommitClassifier.CommitClass): Object representing a type of commit in a project.
(CommitClassifier.load): Load a list of commit classes from a json file.
(CommitClassifier.classify): Given a commit and a repository, attempt to assign the
commit a class.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py:
(Git.__init__): Pass classifier.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/scm.py:
(Scm.__init__): Pass classifier.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/svn.py:
(Svn.__init__): Pass classifier.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py:
(main): Pass provisional classifier to parsers and help message generators.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/classify.py: Added.
(Classify.help): Generate a help message including commit class names.
(Classify.parser): Added.
(Classify.main): Classify the specified commit, printing out its classification.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pickable.py:
(Pickable.parser): Generate help message based on a provisional classifier.
(Pickable.pickable): Use CommitClassifier object instead of implementing classification.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py:
(BitBucket.__init__): Pass classifier.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/scm.py:
(Scm.from_url): Pass classifier.
(Scm.__init__): Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/svn.py:
(Svn.__init__): Pass classifier.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/scm_base.py:
(ScmBase.__init__): Pass classifier.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/classify_unittest.py: Added.
(TestClassify.test_no_classes):
(TestClassify.test_list_classes):
(TestClassify.test_header_success):
(TestClassify.test_header_failure):
(TestClassify.test_path_success):
(TestClassify.test_path_failure):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pickable_unittest.py:
(TestPickable.test_branch):
(TestPickable.test_branch_diverged_cherry_pick):
(TestPickable.test_branch_none):
(TestPickable.test_branch_include_versioning):
(TestPickable.test_branch_gardening_exclude):
(TestPickable.test_branch_gardening_include):
* metadata/commit_classes.json: Added.
* metadata/git_config_extension: &quot;Test&quot; commits are now defined by their classifier.

Canonical link: <a href="https://commits.webkit.org/260273@main">https://commits.webkit.org/260273@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7eb28e89a68c9e60ed04d9b8ba67cf8c651f89cc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/107794 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/16850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/40686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/116938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/111684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/18257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/8165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/99973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/113551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/18257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/40686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/99973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/5/builds/111307 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/18257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/40686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/99973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/9806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/40686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/10499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/8165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/20/builds/106615 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/15960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/40686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/12064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3857 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->