### PR TITLE
Make some minor adjustments when getting screenX/screenY in headless mode

### DIFF
--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -135,6 +135,15 @@
 
 #if USE(APPLE_INTERNAL_SDK)
 #include <WebKitAdditions/DocumentLoaderAdditions.cpp>
+#else
+namespace WebCore {
+
+bool DocumentLoader::isLoadingInHeadlessMode() const
+{
+    return false;
+}
+
+} // namespace WebCore
 #endif
 
 namespace WebCore {

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -312,6 +312,8 @@ public:
     bool isLoadingMainResource() const { return m_loadingMainResource; }
     bool isLoadingMultipartContent() const { return m_isLoadingMultipartContent; }
 
+    bool isLoadingInHeadlessMode() const;
+
     void stopLoadingPlugIns();
     void stopLoadingSubresources();
     WEBCORE_EXPORT void stopLoadingAfterXFrameOptionsOrContentSecurityPolicyDenied(ResourceLoaderIdentifier, const ResourceResponse&);

--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -1335,6 +1335,16 @@ int DOMWindow::innerWidth() const
     return view->mapFromLayoutToCSSUnits(static_cast<int>(view->unobscuredContentRectIncludingScrollbars().width()));
 }
 
+static bool isLoadingInHeadlessMode(const Page& page)
+{
+    RefPtr document = page.mainFrame().document();
+    if (!document)
+        return false;
+
+    RefPtr loader = document->loader();
+    return loader && loader->isLoadingInHeadlessMode();
+}
+
 int DOMWindow::screenX() const
 {
     RefPtr frame = this->frame();
@@ -1342,7 +1352,7 @@ int DOMWindow::screenX() const
         return 0;
 
     Page* page = frame->page();
-    if (!page)
+    if (!page || isLoadingInHeadlessMode(*page))
         return 0;
 
     return static_cast<int>(page->chrome().windowRect().x());
@@ -1355,7 +1365,7 @@ int DOMWindow::screenY() const
         return 0;
 
     Page* page = frame->page();
-    if (!page)
+    if (!page || isLoadingInHeadlessMode(*page))
         return 0;
 
     return static_cast<int>(page->chrome().windowRect().y());

--- a/Tools/TestWebKitAPI/cocoa/TestUIDelegate.h
+++ b/Tools/TestWebKitAPI/cocoa/TestUIDelegate.h
@@ -31,6 +31,7 @@
 @property (nonatomic, copy) void (^runJavaScriptAlertPanelWithMessage)(WKWebView *, NSString *, WKFrameInfo *, void (^)(void));
 #if PLATFORM(MAC)
 @property (nonatomic, copy) void (^getContextMenuFromProposedMenu)(NSMenu *, _WKContextMenuElementInfo *, id <NSSecureCoding>, void (^)(NSMenu *));
+@property (nonatomic, copy) void (^getWindowFrameWithCompletionHandler)(WKWebView *, void(^)(CGRect));
 #endif
 @property (nonatomic, copy) void (^saveDataToFile)(WKWebView *, NSData *, NSString *, NSString *, NSURL *);
 @property (nonatomic, copy) void (^focusWebView)(WKWebView *);

--- a/Tools/TestWebKitAPI/cocoa/TestUIDelegate.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestUIDelegate.mm
@@ -58,6 +58,14 @@
         completionHandler(menu);
 }
 
+- (void)_webView:(WKWebView *)webView getWindowFrameWithCompletionHandler:(void (^)(CGRect))completionHandler
+{
+    if (_getWindowFrameWithCompletionHandler)
+        _getWindowFrameWithCompletionHandler(webView, completionHandler);
+    else
+        completionHandler(CGRectZero);
+}
+
 - (void)_focusWebView:(WKWebView *)webView
 {
     if (_focusWebView)


### PR DESCRIPTION
#### d33463727a4a61def19c0671960e5a51f6ecff80
<pre>
Make some minor adjustments when getting screenX/screenY in headless mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=251825">https://bugs.webkit.org/show_bug.cgi?id=251825</a>
rdar://105105306

Reviewed by Aditya Keerthi.

Return a sensible fallback value for `window.screenX` and `window.screenY`, when
`isLoadingInHeadlessMode()` returns `true`.

* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::isLoadingInHeadlessMode const):
* Source/WebCore/loader/DocumentLoader.h:
* Source/WebCore/page/DOMWindow.cpp:
(WebCore::isLoadingInHeadlessMode):
(WebCore::DOMWindow::screenX const):
(WebCore::DOMWindow::screenY const):
* Tools/TestWebKitAPI/cocoa/TestUIDelegate.h:
* Tools/TestWebKitAPI/cocoa/TestUIDelegate.mm:

Additionally add support for an API test for this change, by exposing this delegate method via an
ObjC block property.

(-[TestUIDelegate _webView:getWindowFrameWithCompletionHandler:]):

Canonical link: <a href="https://commits.webkit.org/259983@main">https://commits.webkit.org/259983@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92cc431432956fd3ea00cff5d47382c8c12af4e1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106473 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15493 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39286 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115658 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115320 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110381 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16985 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6719 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98669 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112241 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12904 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95872 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40459 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94779 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27516 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82172 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8725 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28868 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9260 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5442 "Found 1 new test failure: http/tests/media/fairplay/fps-mse-unmuxed-same-key.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14880 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48414 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6902 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10806 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->