### PR TITLE
[curl] CloseEvent has wasClean=true and no error code when the WebSocket connection got terminated from the server side

### DIFF
--- a/LayoutTests/http/tests/websocket/tests/hybi/server-close-2-expected.txt
+++ b/LayoutTests/http/tests/websocket/tests/hybi/server-close-2-expected.txt
@@ -1,0 +1,13 @@
+WebSocket: Test server-initiated close.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Connected
+Closed
+PASS closeEvent.wasClean is false
+PASS closeEvent.code is 1006
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/websocket/tests/hybi/server-close-2.html
+++ b/LayoutTests/http/tests/websocket/tests/hybi/server-close-2.html
@@ -1,0 +1,26 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("WebSocket: Test server-initiated close.");
+
+jsTestIsAsync = true;
+
+const ws = new WebSocket("ws://127.0.0.1:8880/websocket/tests/hybi/server-close-2");
+var closeEvent;
+
+ws.onopen = () => {
+    debug("Connected");
+};
+
+ws.onmessage = (messageEvent) => {
+    debug("Received: " + messageEvent.data);
+};
+
+ws.onclose = (event) => {
+    debug("Closed");
+    closeEvent = event;
+    shouldBeFalse("closeEvent.wasClean");
+    shouldBe("closeEvent.code", "1006");
+    finishJSTest();
+};
+</script>

--- a/LayoutTests/http/tests/websocket/tests/hybi/server-close-2_wsh.py
+++ b/LayoutTests/http/tests/websocket/tests/hybi/server-close-2_wsh.py
@@ -1,0 +1,6 @@
+def web_socket_do_extra_handshake(request):
+    pass
+
+
+def web_socket_transfer_data(request):
+    assert false

--- a/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp
@@ -131,7 +131,7 @@ void WebSocketTask::didReceiveData(WebCore::CurlStreamID, const WebCore::SharedB
         return;
 
     if (!buffer.size()) {
-        didClose(0, { });
+        didClose(WebCore::WebSocketChannel::CloseEventCode::CloseEventCodeAbnormalClosure, { });
         return;
     }
 


### PR DESCRIPTION
#### 42847605cf96636afb6059426edf7c7b3ed9adb5
<pre>
[curl] CloseEvent has wasClean=true and no error code when the WebSocket connection got terminated from the server side
<a href="https://bugs.webkit.org/show_bug.cgi?id=240227">https://bugs.webkit.org/show_bug.cgi?id=240227</a>

Reviewed by Don Olmstead.

It should return a correct error code rather than 0.

* LayoutTests/http/tests/websocket/tests/hybi/server-close-2-expected.txt: Added.
* LayoutTests/http/tests/websocket/tests/hybi/server-close-2.html: Added.
* LayoutTests/http/tests/websocket/tests/hybi/server-close-2_wsh.py: Added.
* Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp:
(WebKit::WebSocketTask::didReceiveData):
Use WebSocketChannel::CloseEventCode::CloseEventCodeAbnormalClosure if
the connection disconnected.

Canonical link: <a href="https://commits.webkit.org/260025@main">https://commits.webkit.org/260025@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/40465c6af651938dbd175e15590ff7f9d59a20ca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106677 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15668 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39465 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115864 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115465 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17181 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6905 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98872 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112446 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13061 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96009 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40618 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94921 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27660 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8892 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29011 "Found 1 new test failure: media/video-playback-quality.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9450 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6057 "Too many flaky failures: css3/masking/mask-svg-script-png-to-none.html, css3/masking/reference-clip-path-bounds.html, fast/css/large-font-size-crash.html, fast/css/last-child-display-change-inverse.html, fast/text/glyph-display-lists/glyph-display-list-scaled-unshared.html, http/tests/appcache/cyrillic-uri.html, imported/w3c/web-platform-tests/css/css-pseudo/first-letter-with-quote.html, imported/w3c/web-platform-tests/css/css-pseudo/first-line-and-placeholder.html, imported/w3c/web-platform-tests/css/selectors/invalidation/lang-pseudo-class-in-has.html, imported/w3c/web-platform-tests/css/selectors/invalidation/media-loading-pseudo-classes-in-has.html, storage/indexeddb/request-with-null-open-db-request.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15064 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48560 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10972 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3734 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->