### PR TITLE
Range APIs do not construct / move trees in tree order (observable by custom elements)

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/range-and-constructors-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/range-and-constructors-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Range.cloneContents should invoke constructor in tree order assert_array_equals: expected property 0 to be "root-0" but got "root-0-0" (expected array ["root-0", "root-0-0", "root-1"] got ["root-0-0", "root-0", "root-1"])
-FAIL Range.extractContents should invoke constructor in tree order assert_array_equals: expected property 0 to be "root-0" but got "root-0-0" (expected array ["root-0", "root-0-0"] got ["root-0-0", "root-0"])
+PASS Range.cloneContents should invoke constructor in tree order
+PASS Range.extractContents should invoke constructor in tree order
 

--- a/Source/WebCore/dom/CustomElementReactionQueue.h
+++ b/Source/WebCore/dom/CustomElementReactionQueue.h
@@ -57,6 +57,8 @@ public:
     void add(Element&);
     void processQueue(JSC::JSGlobalObject*);
 
+    Vector<GCReachableRef<Element>> takeElements();
+
 private:
     void invokeAll();
 
@@ -98,6 +100,8 @@ public:
 #endif
 
     static void processBackupQueue(CustomElementQueue&);
+
+    static void enqueueElementsOnAppropriateElementQueue(const Vector<Ref<Element>>&);
 
 private:
     static void enqueueElementOnAppropriateElementQueue(Element&);
@@ -176,6 +180,8 @@ public:
             processQueue(m_state);
         s_currentProcessingStack = m_previousProcessingStack;
     }
+
+    Vector<GCReachableRef<Element>> takeElements();
 
 private:
     WEBCORE_EXPORT void processQueue(JSC::JSGlobalObject*);


### PR DESCRIPTION
#### fa5a06a66c96bc6864e684d9f9f07b115f39c60e
<pre>
Range APIs do not construct / move trees in tree order (observable by custom elements)
<a href="https://bugs.webkit.org/show_bug.cgi?id=188279">https://bugs.webkit.org/show_bug.cgi?id=188279</a>

Reviewed by Chris Dumez.

In order to match the spec&apos;ed upgrade order, create a nested custom element reaction stack
which is used as a holding tank of upgrade reactions during Range::processContents.

At the end, we traverse the document fragment top-down and re-enqueue each element to the real
custom element reaction stack in the tree order.

* LayoutTests/imported/w3c/web-platform-tests/custom-elements/range-and-constructors-expected.txt:
* Source/WebCore/dom/CustomElementReactionQueue.cpp:
(WebCore::CustomElementQueue::takeElements): Added.
(WebCore::CustomElementReactionQueue::enqueueElementsOnAppropriateElementQueue): Added.
(WebCore::CustomElementReactionStack::takeElements): Added.
* Source/WebCore/dom/CustomElementReactionQueue.h:
* Source/WebCore/dom/Range.cpp:
(WebCore::Range::processContents):

Canonical link: <a href="https://commits.webkit.org/259987@main">https://commits.webkit.org/259987@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fcd1be1195518d65df5900aaba9f16f71ab35af7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106628 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15625 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39420 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115813 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/115433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110535 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17133 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6858 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98820 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112397 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/95978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/40583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/94891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27623 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8851 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28977 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9403 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/6016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15018 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48523 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10931 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3715 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->