### PR TITLE
Opt-in wide-layout attachment style using Shadow DOM tree

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -616,12 +616,28 @@ AsynchronousSpellCheckingEnabled:
 AttachmentElementEnabled:
   type: bool
   status: embedder
+  humanReadableName: "Attachment Element"
+  humanReadableDescription: "Allow the insertion of attachment elements"
   webcoreBinding: DeprecatedGlobalSettings
   condition: ENABLE(ATTACHMENT_ELEMENT)
   defaultValue:
     WebKitLegacy:
       default: WebKit::defaultAttachmentElementEnabled()
     WebKit:
+      default: false
+
+AttachmentWideLayoutEnabled:
+  type: bool
+  status: embedder
+  humanReadableName: "Attachment wide-layout styling"
+  humanReadableDescription: "Use horizontal wide-layout attachment style, requires Attachment Element"
+  condition: ENABLE(ATTACHMENT_ELEMENT)
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
       default: false
 
 AudioDescriptionsEnabled:

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1745,6 +1745,7 @@ set(WebCore_USER_AGENT_STYLE_SHEETS
     ${WEBCORE_DIR}/css/popover.css
     ${WEBCORE_DIR}/css/quirks.css
     ${WEBCORE_DIR}/css/svg.css
+    ${WEBCORE_DIR}/html/shadow/attachmentElementShadow.css
     ${WEBCORE_DIR}/html/shadow/imageOverlay.css
     ${WEBCORE_DIR}/html/shadow/meterElementShadow.css
 )

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1425,6 +1425,7 @@ $(PROJECT_DIR)/html/canvas/WebGLVertexArrayObject.idl
 $(PROJECT_DIR)/html/canvas/WebGLVertexArrayObjectOES.idl
 $(PROJECT_DIR)/html/parser/HTMLEntityNames.in
 $(PROJECT_DIR)/html/parser/create-html-entity-table
+$(PROJECT_DIR)/html/shadow/attachmentElementShadow.css
 $(PROJECT_DIR)/html/shadow/imageOverlay.css
 $(PROJECT_DIR)/html/shadow/mac/imageControlsMac.css
 $(PROJECT_DIR)/html/shadow/meterElementShadow.css

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1874,6 +1874,7 @@ USER_AGENT_STYLE_SHEETS = \
     $(WebCore)/css/quirks.css \
     $(WebCore)/css/svg.css \
     $(WebCore)/html/shadow/mac/imageControlsMac.css \
+    $(WebCore)/html/shadow/attachmentElementShadow.css \
     $(WebCore)/html/shadow/imageOverlay.css \
     $(WebCore)/html/shadow/meterElementShadow.css \
     ModernMediaControls.css \

--- a/Source/WebCore/html/HTMLAttachmentElement.cpp
+++ b/Source/WebCore/html/HTMLAttachmentElement.cpp
@@ -35,12 +35,16 @@
 #include "ElementInlines.h"
 #include "File.h"
 #include "Frame.h"
+#include "HTMLDivElement.h"
+#include "HTMLElementTypeHelpers.h"
 #include "HTMLImageElement.h"
 #include "HTMLNames.h"
+#include "HTMLStyleElement.h"
 #include "MIMETypeRegistry.h"
 #include "RenderAttachment.h"
 #include "ShadowRoot.h"
 #include "SharedBuffer.h"
+#include "UserAgentStyleSheets.h"
 #include <pal/FileSizeFormatter.h>
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/UUID.h>
@@ -71,12 +75,101 @@ HTMLAttachmentElement::~HTMLAttachmentElement() = default;
 
 Ref<HTMLAttachmentElement> HTMLAttachmentElement::create(const QualifiedName& tagName, Document& document)
 {
-    return adoptRef(*new HTMLAttachmentElement(tagName, document));
+    Ref attachment = adoptRef(*new HTMLAttachmentElement(tagName, document));
+    if (document.settings().attachmentWideLayoutEnabled()) {
+        ASSERT(attachment->m_implementation == Implementation::Legacy);
+        ASSERT(!attachment->renderer()); // Switch to modern style *must* be done before renderer is created!
+        attachment->m_implementation = Implementation::Modern;
+        attachment->ensureUserAgentShadowRoot();
+    }
+    return attachment;
 }
 
-RenderPtr<RenderElement> HTMLAttachmentElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)
+void HTMLAttachmentElement::didAddUserAgentShadowRoot(ShadowRoot& root)
 {
+    if (m_implementation == Implementation::Modern)
+        ensureModernShadowTree(root);
+}
+
+static const AtomString& attachmentContainerIdentifier()
+{
+    static MainThreadNeverDestroyed<const AtomString> identifier("attachment-container"_s);
+    return identifier;
+}
+
+static const AtomString& attachmentPreviewIdentifier()
+{
+    static MainThreadNeverDestroyed<const AtomString> identifier("attachment-preview"_s);
+    return identifier;
+}
+
+static const AtomString& attachmentTitleIdentifier()
+{
+    static MainThreadNeverDestroyed<const AtomString> identifier("attachment-title"_s);
+    return identifier;
+}
+
+static const AtomString& attachmentSubtitleIdentifier()
+{
+    static MainThreadNeverDestroyed<const AtomString> identifier("attachment-subtitle"_s);
+    return identifier;
+}
+
+void HTMLAttachmentElement::ensureModernShadowTree(ShadowRoot& root)
+{
+    ASSERT(m_implementation == Implementation::Modern);
+    if (m_elementWithTitle)
+        return;
+
+    static MainThreadNeverDestroyed<const String> shadowStyle(StringImpl::createWithoutCopying(attachmentElementShadowUserAgentStyleSheet, sizeof(attachmentElementShadowUserAgentStyleSheet)));
+    auto style = HTMLStyleElement::create(HTMLNames::styleTag, document(), false);
+    style->setTextContent(String { shadowStyle });
+    root.appendChild(WTFMove(style));
+
+    auto container = HTMLDivElement::create(document());
+    container->setIdAttribute(attachmentContainerIdentifier());
+    root.appendChild(container);
+
+    // FIXME: This is using the same HTMLAttachmentElement type, but with different behavior (thanks to m_implementation), to fetch and show
+    // the appropriate image (thumbnail, icon, etc.). In the longer term, this functionality should be folded into the Implementation::Modern
+    // code, and the old Legacy/ImageOnly code should be removed. See rdar://105252742.
+    m_innerLegacyAttachment = adoptRef(*new HTMLAttachmentElement(HTMLNames::attachmentTag, document()));
+    m_innerLegacyAttachment->m_implementation = Implementation::ImageOnly;
+    m_innerLegacyAttachment->cloneAttributesFromElement(*this);
+    m_innerLegacyAttachment->m_file = m_file;
+    m_innerLegacyAttachment->m_thumbnail = WTFMove(m_thumbnail);
+    m_innerLegacyAttachment->m_icon = WTFMove(m_icon);
+    m_innerLegacyAttachment->m_iconSize = m_iconSize;
+    m_innerLegacyAttachment->setIdAttribute(attachmentPreviewIdentifier());
+    container->appendChild(*m_innerLegacyAttachment);
+
+    m_elementWithTitle = HTMLDivElement::create(document());
+    m_elementWithTitle->setIdAttribute(attachmentTitleIdentifier());
+    if (String title = attachmentTitleForDisplay(); !title.isEmpty())
+        m_elementWithTitle->setInnerText(WTFMove(title));
+    container->appendChild(*m_elementWithTitle);
+
+    m_elementWithSubtitle = HTMLDivElement::create(document());
+    m_elementWithSubtitle->setIdAttribute(attachmentSubtitleIdentifier());
+    if (String subtitle = attachmentSubtitleForDisplay(); !subtitle.isEmpty())
+        m_elementWithSubtitle->setInnerText(WTFMove(subtitle));
+    container->appendChild(*m_elementWithSubtitle);
+}
+
+RenderPtr<RenderElement> HTMLAttachmentElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition& position)
+{
+    if (m_implementation == Implementation::Modern)
+        return HTMLElement::createElementRenderer(WTFMove(style), position);
+
     return createRenderer<RenderAttachment>(*this, WTFMove(style));
+}
+
+void HTMLAttachmentElement::invalidateRendering()
+{
+    if (auto* renderer = this->renderer()) {
+        renderer->setNeedsLayout();
+        renderer->repaint();
+    }
 }
 
 const String& HTMLAttachmentElement::getAttachmentIdentifier(HTMLImageElement& image)
@@ -133,8 +226,7 @@ void HTMLAttachmentElement::setFile(RefPtr<File>&& file, UpdateDisplayAttributes
         }
     }
 
-    if (auto* renderer = this->renderer())
-        renderer->invalidate();
+    invalidateRendering();
 }
 
 Node::InsertedIntoAncestorResult HTMLAttachmentElement::insertedIntoAncestor(InsertionType type, ContainerNode& ancestor)
@@ -180,12 +272,21 @@ RefPtr<HTMLImageElement> HTMLAttachmentElement::enclosingImageElement() const
 
 void HTMLAttachmentElement::parseAttribute(const QualifiedName& name, const AtomString& value)
 {
-    if (name == progressAttr || name == subtitleAttr || name == titleAttr || name == typeAttr) {
-        if (auto* renderer = this->renderer())
-            renderer->invalidate();
-    }
+    if (name == progressAttr || name == subtitleAttr || name == titleAttr || name == typeAttr)
+        invalidateRendering();
 
     HTMLElement::parseAttribute(name, value);
+
+    if (name == titleAttr) {
+        if (m_elementWithTitle)
+            m_elementWithTitle->setInnerText(String(value.string()));
+    } else if (name == subtitleAttr) {
+        if (m_elementWithSubtitle)
+            m_elementWithSubtitle->setInnerText(String(value.string()));
+    }
+
+    if (m_innerLegacyAttachment)
+        m_innerLegacyAttachment->setAttributeWithoutSynchronization(name, value);
 
 #if ENABLE(SERVICE_CONTROLS)
     if (name == typeAttr && attachmentType() == "application/pdf"_s) {
@@ -205,6 +306,9 @@ String HTMLAttachmentElement::attachmentTitle() const
 
 String HTMLAttachmentElement::attachmentTitleForDisplay() const
 {
+    if (m_implementation == Implementation::ImageOnly)
+        return { };
+
     auto title = attachmentTitle();
     auto indexOfLastDot = title.reverseFind('.');
     if (indexOfLastDot == notFound)
@@ -217,6 +321,14 @@ String HTMLAttachmentElement::attachmentTitleForDisplay() const
         popDirectionalIsolate,
         StringView(title).substring(indexOfLastDot)
     );
+}
+
+String HTMLAttachmentElement::attachmentSubtitleForDisplay() const
+{
+    if (m_implementation == Implementation::ImageOnly)
+        return { };
+
+    return attributeWithoutSynchronization(subtitleAttr);
 }
 
 String HTMLAttachmentElement::attachmentType() const
@@ -251,8 +363,7 @@ void HTMLAttachmentElement::updateAttributes(std::optional<uint64_t>&& newFileSi
     else
         removeAttribute(HTMLNames::subtitleAttr);
 
-    if (auto* renderer = this->renderer())
-        renderer->invalidate();
+    invalidateRendering();
 }
 
 static bool mimeTypeIsSuitableForInlineImageAttachment(const String& mimeType)
@@ -285,17 +396,14 @@ void HTMLAttachmentElement::updateThumbnail(const RefPtr<Image>& thumbnail)
 {
     m_thumbnail = thumbnail;
     removeAttribute(HTMLNames::progressAttr);
-    if (auto* renderer = this->renderer())
-        renderer->invalidate();
+    invalidateRendering();
 }
 
 void HTMLAttachmentElement::updateIcon(const RefPtr<Image>& icon, const WebCore::FloatSize& iconSize)
 {
     m_icon = icon;
     m_iconSize = iconSize;
-
-    if (auto* renderer = this->renderer())
-        renderer->invalidate();
+    invalidateRendering();
 }
 
 void HTMLAttachmentElement::requestIconWithSize(const FloatSize& size) const

--- a/Source/WebCore/html/HTMLAttachmentElement.h
+++ b/Source/WebCore/html/HTMLAttachmentElement.h
@@ -35,6 +35,7 @@ namespace WebCore {
 class File;
 class HTMLImageElement;
 class RenderAttachment;
+class ShadowRoot;
 class ShareableBitmap;
 class FragmentedSharedBuffer;
 
@@ -69,22 +70,28 @@ public:
 
     WEBCORE_EXPORT String attachmentTitle() const;
     String attachmentTitleForDisplay() const;
+    String attachmentSubtitleForDisplay() const;
     WEBCORE_EXPORT String attachmentType() const;
     String attachmentPath() const;
     RefPtr<Image> thumbnail() const { return m_thumbnail; }
     RefPtr<Image> icon() const { return m_icon; }
     void requestIconWithSize(const FloatSize&) const;
     FloatSize iconSize() const { return m_iconSize; }
-    RenderAttachment* renderer() const;
+    void invalidateRendering();
 
 #if ENABLE(SERVICE_CONTROLS)
     bool isImageMenuEnabled() const { return m_isImageMenuEnabled; }
     void setImageMenuEnabled(bool value) { m_isImageMenuEnabled = value; }
 #endif
 
+    bool isImageOnly() const { return m_implementation == Implementation::ImageOnly; }
+
 private:
     HTMLAttachmentElement(const QualifiedName&, Document&);
     virtual ~HTMLAttachmentElement();
+
+    void didAddUserAgentShadowRoot(ShadowRoot&) final;
+    void ensureModernShadowTree(ShadowRoot&);
 
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
     bool shouldSelectOnMouseDown() final {
@@ -101,11 +108,18 @@ private:
     bool childShouldCreateRenderer(const Node&) const final;
 #endif
 
+    enum class Implementation: uint8_t { Legacy, Modern, ImageOnly };
+    Implementation m_implementation { Implementation::Legacy };
+
     RefPtr<File> m_file;
     String m_uniqueIdentifier;
     RefPtr<Image> m_thumbnail;
     RefPtr<Image> m_icon;
     FloatSize m_iconSize;
+
+    RefPtr<HTMLAttachmentElement> m_innerLegacyAttachment;
+    RefPtr<HTMLElement> m_elementWithTitle;
+    RefPtr<HTMLElement> m_elementWithSubtitle;
 
 #if ENABLE(SERVICE_CONTROLS)
     bool m_isImageMenuEnabled { false };

--- a/Source/WebCore/html/shadow/attachmentElementShadow.css
+++ b/Source/WebCore/html/shadow/attachmentElementShadow.css
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2023 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+div#attachment-container {
+    display: grid;
+    max-width: 500px;
+    background-color: lightgray; /* FIXME: Use semantic colors, see rdar://105252500 */
+    border-radius: 8px;
+    font: caption;
+    pointer-events: none;
+    user-select: none;
+    -webkit-user-select: none;
+}
+
+div#attachment-container::selection {
+    background-color: blue; /* FIXME: Use semantic colors, see rdar://105252500 */
+}
+
+attachment#attachment-preview {
+    grid-row: 1 / 4;
+    grid-column: 1;
+    align-self: center;
+}
+
+div#attachment-title {
+    grid-row: 2;
+    grid-column: 2;
+    font-size: small;
+}
+
+div#attachment-subtitle {
+    grid-row: 3;
+    grid-column: 2;
+    font-size: x-small;
+    color: rgb(82, 145, 214); /* FIXME: Use semantic colors, see rdar://105252500 */
+}

--- a/Source/WebCore/page/DragController.cpp
+++ b/Source/WebCore/page/DragController.cpp
@@ -1210,7 +1210,6 @@ bool DragController::startDrag(Frame& src, const DragState& state, OptionSet<Dra
 #if ENABLE(ATTACHMENT_ELEMENT)
     if (is<HTMLAttachmentElement>(element) && m_dragSourceAction.contains(DragSourceAction::Attachment)) {
         auto& attachment = downcast<HTMLAttachmentElement>(element);
-        auto* attachmentRenderer = attachment.renderer();
 
         src.editor().setIgnoreSelectionChanges(true);
         auto previousSelection = src.selection().selection();
@@ -1234,6 +1233,7 @@ bool DragController::startDrag(Frame& src, const DragState& state, OptionSet<Dra
         
         if (!dragImage) {
             TextIndicatorData textIndicator;
+            auto* attachmentRenderer = dynamicDowncast<RenderAttachment>(attachment.renderer());
             if (attachmentRenderer)
                 attachmentRenderer->setShouldDrawBorder(false);
             dragImage = DragImage { dissolveDragImageToFraction(createDragImageForSelection(src, textIndicator), DragImageAlpha) };

--- a/Source/WebCore/rendering/AttachmentLayout.mm
+++ b/Source/WebCore/rendering/AttachmentLayout.mm
@@ -135,7 +135,7 @@ void AttachmentLayout::layOutTitle(const RenderAttachment& attachment)
 
 void AttachmentLayout::layOutSubtitle(const RenderAttachment& attachment)
 {
-    auto& subtitleText = attachment.attachmentElement().attributeWithoutSynchronization(HTMLNames::subtitleAttr);
+    String subtitleText = attachment.attachmentElement().attachmentSubtitleForDisplay();
     if (subtitleText.isEmpty())
         return;
     auto subtitleColor = attachment.style().colorByApplyingColorFilter(attachmentSubtitleTextColor);
@@ -276,7 +276,7 @@ AttachmentLayout::AttachmentLayout(const RenderAttachment& attachment, Attachmen
     hasProgress = getAttachmentProgress(attachment, progress);
     String title = attachment.attachmentElement().attachmentTitleForDisplay();
     String action = attachment.attachmentElement().attributeWithoutSynchronization(HTMLNames::actionAttr);
-    String subtitle = attachment.attachmentElement().attributeWithoutSynchronization(HTMLNames::subtitleAttr);
+    String subtitle = attachment.attachmentElement().attachmentSubtitleForDisplay();
 
     CGFloat yOffset = 0;
 

--- a/Source/WebCore/rendering/RenderAttachment.cpp
+++ b/Source/WebCore/rendering/RenderAttachment.cpp
@@ -73,12 +73,6 @@ void RenderAttachment::layout()
         layoutShadowContent(newIntrinsicSize);
 }
 
-void RenderAttachment::invalidate()
-{
-    setNeedsLayout();
-    repaint();
-}
-
 LayoutUnit RenderAttachment::baselinePosition(FontBaseline, bool, LineDirectionMode, LinePositionMode) const
 {
     return theme().attachmentBaseline(*this);

--- a/Source/WebCore/rendering/RenderAttachment.h
+++ b/Source/WebCore/rendering/RenderAttachment.h
@@ -42,7 +42,6 @@ public:
     void setShouldDrawBorder(bool drawBorder) { m_shouldDrawBorder = drawBorder; }
     bool shouldDrawBorder() const;
 
-    void invalidate();
     bool hasShadowContent() const { return m_hasShadowControls; }
     void setHasShadowControls(bool hasShadowControls) { m_hasShadowControls = hasShadowControls; }
     bool canHaveGeneratedChildren() const override { return m_hasShadowControls; }
@@ -65,11 +64,6 @@ private:
     bool m_shouldDrawBorder { true };
     bool m_hasShadowControls { false };
 };
-
-inline RenderAttachment* HTMLAttachmentElement::renderer() const
-{
-    return downcast<RenderAttachment>(HTMLElement::renderer());
-}
 
 } // namespace WebCore
 

--- a/Source/WebCore/rendering/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/RenderThemeMac.mm
@@ -1559,6 +1559,7 @@ bool RenderThemeMac::paintAttachment(const RenderObject& renderer, const PaintIn
         return false;
 
     const RenderAttachment& attachment = downcast<RenderAttachment>(renderer);
+    HTMLAttachmentElement& element = attachment.attachmentElement();
 
     auto layoutStyle = AttachmentLayoutStyle::NonSelected;
     if (attachment.selectionState() != RenderObject::HighlightState::None && paintInfo.phase != PaintPhase::Selection)
@@ -1566,7 +1567,7 @@ bool RenderThemeMac::paintAttachment(const RenderObject& renderer, const PaintIn
 
     AttachmentLayout layout(attachment, layoutStyle);
 
-    auto& progressString = attachment.attachmentElement().attributeWithoutSynchronization(progressAttr);
+    auto& progressString = element.attributeWithoutSynchronization(progressAttr);
     bool validProgress = false;
     float progress = 0;
     if (!progressString.isEmpty())
@@ -1581,14 +1582,18 @@ bool RenderThemeMac::paintAttachment(const RenderObject& renderer, const PaintIn
 
     bool usePlaceholder = validProgress && !progress;
 
-    paintAttachmentIconBackground(attachment, context, layout);
+    if (!element.isImageOnly())
+        paintAttachmentIconBackground(attachment, context, layout);
+
     if (usePlaceholder)
         paintAttachmentIconPlaceholder(attachment, context, layout);
     else
         paintAttachmentIcon(attachment, context, layout);
 
-    paintAttachmentTitleBackground(attachment, context, layout);
-    paintAttachmentText(context, &layout);
+    if (!element.isImageOnly()) {
+        paintAttachmentTitleBackground(attachment, context, layout);
+        paintAttachmentText(context, &layout);
+    }
 
     if (validProgress && progress)
         paintAttachmentProgress(attachment, context, layout, progress);


### PR DESCRIPTION
#### d706e84b583afba61b95a266f34c5059df7e1d54
<pre>
Opt-in wide-layout attachment style using Shadow DOM tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=251830">https://bugs.webkit.org/show_bug.cgi?id=251830</a>
rdar://105103464

Reviewed by Aditya Keerthi.

Note that the modern attachment element uses an inner legacy attachment just to display the correct thumbnail or icon.

* Source/WebCore/html/HTMLAttachmentElement.cpp:
(WebCore::HTMLAttachmentElement::HTMLAttachmentElement):
(WebCore::HTMLAttachmentElement::ensureModernShadowRoot):
(WebCore::HTMLAttachmentElement::didAddUserAgentShadowRoot):
(WebCore::HTMLAttachmentElement::ensureModernShadowTree):
(WebCore::HTMLAttachmentElement::createElementRenderer): Deleted.
(WebCore::HTMLAttachmentElement::getAttachmentIdentifier): Deleted.
(WebCore::HTMLAttachmentElement::copyNonAttributePropertiesFromElement): Deleted.
(WebCore::HTMLAttachmentElement::archiveResourceURL): Deleted.
(WebCore::HTMLAttachmentElement::file const): Deleted.
(WebCore::HTMLAttachmentElement::blobURL const): Deleted.
(WebCore::HTMLAttachmentElement::setFile): Deleted.
(WebCore::HTMLAttachmentElement::insertedIntoAncestor): Deleted.
(WebCore::HTMLAttachmentElement::removedFromAncestor): Deleted.
(WebCore::HTMLAttachmentElement::ensureUniqueIdentifier): Deleted.
(WebCore::HTMLAttachmentElement::setUniqueIdentifier): Deleted.
(WebCore::HTMLAttachmentElement::enclosingImageElement const): Deleted.
(WebCore::HTMLAttachmentElement::parseAttribute): Deleted.
(WebCore::HTMLAttachmentElement::attachmentTitle const): Deleted.
(WebCore::HTMLAttachmentElement::attachmentTitleForDisplay const): Deleted.
(WebCore::HTMLAttachmentElement::attachmentType const): Deleted.
(WebCore::HTMLAttachmentElement::attachmentPath const): Deleted.
(WebCore::HTMLAttachmentElement::updateAttributes): Deleted.
(WebCore::mimeTypeIsSuitableForInlineImageAttachment): Deleted.
(WebCore::HTMLAttachmentElement::updateEnclosingImageWithData): Deleted.
(WebCore::HTMLAttachmentElement::updateThumbnail): Deleted.
(WebCore::HTMLAttachmentElement::updateIcon): Deleted.
(WebCore::HTMLAttachmentElement::requestIconWithSize const): Deleted.
(WebCore::HTMLAttachmentElement::childShouldCreateRenderer const): Deleted.
* Source/WebCore/html/HTMLAttachmentElement.h:
* Source/WebCore/rendering/AttachmentLayout.mm:
(WebCore::AttachmentLayout::layOutSubtitle):
(WebCore::AttachmentLayout::AttachmentLayout):

Canonical link: <a href="https://commits.webkit.org/260296@main">https://commits.webkit.org/260296@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2440ed660b7dd90e4823f522bb4299e7b6cf1164

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107464 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16526 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40367 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116627 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116048 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111362 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17951 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7768 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99628 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113225 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13552 "Found 5 new test failures: imported/w3c/web-platform-tests/css/css-counter-styles/devanagari/css3-counter-styles-119.html, imported/w3c/web-platform-tests/css/css-counter-styles/devanagari/css3-counter-styles-120.html, imported/w3c/web-platform-tests/css/css-counter-styles/devanagari/css3-counter-styles-121.html, imported/w3c/web-platform-tests/html/cross-origin-opener-policy/header-parsing-failures.https.html?12-last, webgl/webgl-ext-norm16-texture-texsubimage-nocrash.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96733 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41179 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95457 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28359 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82950 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/96801 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9532 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29712 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/96223 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/7531 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10189 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6611 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30807 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15688 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49293 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/105071 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7123 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11749 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26059 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->