### PR TITLE
Add more heap identifiers for style data

### DIFF
--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -134,7 +134,12 @@ namespace Style {
 class CustomPropertyRegistry;
 }
 
-using PseudoStyleCache = Vector<std::unique_ptr<RenderStyle>, 4>;
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(PseudoStyleCache);
+class PseudoStyleCache {
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(PseudoStyleCache);
+public:
+    Vector<std::unique_ptr<RenderStyle>, 4> styles;
+};
 
 template<typename T, typename U> inline bool compareEqual(const T& t, const U& u) { return t == static_cast<const T&>(u); }
 

--- a/Source/WebCore/rendering/style/SVGRenderStyleDefs.cpp
+++ b/Source/WebCore/rendering/style/SVGRenderStyleDefs.cpp
@@ -78,6 +78,8 @@ bool StyleFillData::operator==(const StyleFillData& other) const
     
 }
 
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleStrokeData);
+
 StyleStrokeData::StyleStrokeData()
     : opacity(SVGRenderStyle::initialStrokeOpacity())
     , paintColor(SVGRenderStyle::initialStrokePaintColor())
@@ -123,6 +125,8 @@ bool StyleStrokeData::operator==(const StyleStrokeData& other) const
         && visitedLinkPaintType == other.visitedLinkPaintType;
 }
 
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleStopData);
+
 StyleStopData::StyleStopData()
     : opacity(SVGRenderStyle::initialStopOpacity())
     , color(SVGRenderStyle::initialStopColor())
@@ -147,6 +151,8 @@ bool StyleStopData::operator==(const StyleStopData& other) const
         && color == other.color;
 }
 
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleTextData);
+
 StyleTextData::StyleTextData()
     : kerning(SVGRenderStyle::initialKerning())
 {
@@ -167,6 +173,8 @@ bool StyleTextData::operator==(const StyleTextData& other) const
 {
     return kerning == other.kerning;
 }
+
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleMiscData);
 
 StyleMiscData::StyleMiscData()
     : floodOpacity(SVGRenderStyle::initialFloodOpacity())
@@ -198,6 +206,8 @@ bool StyleMiscData::operator==(const StyleMiscData& other) const
         && baselineShiftValue == other.baselineShiftValue;
 }
 
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleShadowSVGData);
+
 StyleShadowSVGData::StyleShadowSVGData()
 {
 }
@@ -217,6 +227,8 @@ bool StyleShadowSVGData::operator==(const StyleShadowSVGData& other) const
 {
     return arePointingToEqualData(shadow, other.shadow);
 }
+
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleInheritedResourceData);
 
 StyleInheritedResourceData::StyleInheritedResourceData()
     : markerStart(SVGRenderStyle::initialMarkerStartResource())
@@ -244,6 +256,8 @@ bool StyleInheritedResourceData::operator==(const StyleInheritedResourceData& ot
         && markerMid == other.markerMid
         && markerEnd == other.markerEnd;
 }
+
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleLayoutData);
 
 StyleLayoutData::StyleLayoutData()
     : cx(RenderStyle::initialZeroLength())

--- a/Source/WebCore/rendering/style/SVGRenderStyleDefs.h
+++ b/Source/WebCore/rendering/style/SVGRenderStyleDefs.h
@@ -168,7 +168,9 @@ private:
     StyleFillData(const StyleFillData&);
 };
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleStrokeData);
 class StyleStrokeData : public RefCounted<StyleStrokeData> {
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(StyleStrokeData);
 public:
     static Ref<StyleStrokeData> create() { return adoptRef(*new StyleStrokeData); }
     Ref<StyleStrokeData> copy() const;
@@ -198,7 +200,9 @@ private:
     StyleStrokeData(const StyleStrokeData&);
 };
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleStopData);
 class StyleStopData : public RefCounted<StyleStopData> {
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(StyleStopData);
 public:
     static Ref<StyleStopData> create() { return adoptRef(*new StyleStopData); }
     Ref<StyleStopData> copy() const;
@@ -217,7 +221,9 @@ private:
     StyleStopData(const StyleStopData&);
 };
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleTextData);
 class StyleTextData : public RefCounted<StyleTextData> {
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(StyleTextData);
 public:
     static Ref<StyleTextData> create() { return adoptRef(*new StyleTextData); }
     Ref<StyleTextData> copy() const;
@@ -236,7 +242,9 @@ private:
 };
 
 // Note: the rule for this class is, *no inheritance* of these props
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleMiscData);
 class StyleMiscData : public RefCounted<StyleMiscData> {
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(StyleMiscData);
 public:
     static Ref<StyleMiscData> create() { return adoptRef(*new StyleMiscData); }
     Ref<StyleMiscData> copy() const;
@@ -259,7 +267,9 @@ private:
     StyleMiscData(const StyleMiscData&);
 };
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleShadowSVGData);
 class StyleShadowSVGData : public RefCounted<StyleShadowSVGData> {
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(StyleShadowSVGData);
 public:
     static Ref<StyleShadowSVGData> create() { return adoptRef(*new StyleShadowSVGData); }
     Ref<StyleShadowSVGData> copy() const;
@@ -278,7 +288,9 @@ private:
 };
 
 // Inherited resources
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleInheritedResourceData);
 class StyleInheritedResourceData : public RefCounted<StyleInheritedResourceData> {
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(StyleInheritedResourceData);
 public:
     static Ref<StyleInheritedResourceData> create() { return adoptRef(*new StyleInheritedResourceData); }
     Ref<StyleInheritedResourceData> copy() const;
@@ -299,7 +311,9 @@ private:
 };
 
 // Positioning and sizing properties.
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleLayoutData);
 class StyleLayoutData : public RefCounted<StyleLayoutData> {
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(StyleLayoutData);
 public:
     static Ref<StyleLayoutData> create() { return adoptRef(*new StyleLayoutData); }
     Ref<StyleLayoutData> copy() const;

--- a/Source/WebCore/rendering/style/StyleBackgroundData.cpp
+++ b/Source/WebCore/rendering/style/StyleBackgroundData.cpp
@@ -27,6 +27,8 @@
 
 namespace WebCore {
 
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleBackgroundData);
+
 StyleBackgroundData::StyleBackgroundData()
     : background(FillLayer::create(FillLayerType::Background))
     , color(RenderStyle::initialBackgroundColor())

--- a/Source/WebCore/rendering/style/StyleBackgroundData.h
+++ b/Source/WebCore/rendering/style/StyleBackgroundData.h
@@ -33,7 +33,9 @@
 
 namespace WebCore {
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleBackgroundData);
 class StyleBackgroundData : public RefCounted<StyleBackgroundData> {
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(StyleBackgroundData);
 public:
     static Ref<StyleBackgroundData> create() { return adoptRef(*new StyleBackgroundData); }
     Ref<StyleBackgroundData> copy() const;

--- a/Source/WebCore/rendering/style/StyleDeprecatedFlexibleBoxData.cpp
+++ b/Source/WebCore/rendering/style/StyleDeprecatedFlexibleBoxData.cpp
@@ -26,6 +26,8 @@
 
 namespace WebCore {
 
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleDeprecatedFlexibleBoxData);
+
 StyleDeprecatedFlexibleBoxData::StyleDeprecatedFlexibleBoxData()
     : flex(RenderStyle::initialBoxFlex())
     , flexGroup(RenderStyle::initialBoxFlexGroup())

--- a/Source/WebCore/rendering/style/StyleDeprecatedFlexibleBoxData.h
+++ b/Source/WebCore/rendering/style/StyleDeprecatedFlexibleBoxData.h
@@ -29,7 +29,9 @@
 
 namespace WebCore {
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleDeprecatedFlexibleBoxData);
 class StyleDeprecatedFlexibleBoxData : public RefCounted<StyleDeprecatedFlexibleBoxData> {
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(StyleDeprecatedFlexibleBoxData);
 public:
     static Ref<StyleDeprecatedFlexibleBoxData> create() { return adoptRef(*new StyleDeprecatedFlexibleBoxData); }
     Ref<StyleDeprecatedFlexibleBoxData> copy() const;

--- a/Source/WebCore/rendering/style/StyleFlexibleBoxData.cpp
+++ b/Source/WebCore/rendering/style/StyleFlexibleBoxData.cpp
@@ -30,6 +30,8 @@
 
 namespace WebCore {
 
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleFlexibleBoxData);
+
 StyleFlexibleBoxData::StyleFlexibleBoxData()
     : flexGrow(RenderStyle::initialFlexGrow())
     , flexShrink(RenderStyle::initialFlexShrink())

--- a/Source/WebCore/rendering/style/StyleFlexibleBoxData.h
+++ b/Source/WebCore/rendering/style/StyleFlexibleBoxData.h
@@ -31,7 +31,9 @@
 
 namespace WebCore {
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleFlexibleBoxData);
 class StyleFlexibleBoxData : public RefCounted<StyleFlexibleBoxData> {
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(StyleFlexibleBoxData);
 public:
     static Ref<StyleFlexibleBoxData> create() { return adoptRef(*new StyleFlexibleBoxData); }
     Ref<StyleFlexibleBoxData> copy() const;

--- a/Source/WebCore/rendering/style/StyleGridData.cpp
+++ b/Source/WebCore/rendering/style/StyleGridData.cpp
@@ -30,6 +30,8 @@
 
 namespace WebCore {
 
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleGridData);
+
 StyleGridData::StyleGridData()
     : implicitNamedGridColumnLines(RenderStyle::initialNamedGridColumnLines())
     , implicitNamedGridRowLines(RenderStyle::initialNamedGridRowLines())

--- a/Source/WebCore/rendering/style/StyleGridData.h
+++ b/Source/WebCore/rendering/style/StyleGridData.h
@@ -94,7 +94,9 @@ typedef Vector<GridTrackEntry> GridTrackList;
 WTF::TextStream& operator<<(WTF::TextStream&, const RepeatEntry& item);
 WTF::TextStream& operator<<(WTF::TextStream&, const GridTrackEntry& item);
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleGridData);
 class StyleGridData : public RefCounted<StyleGridData> {
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(StyleGridData);
 public:
     static Ref<StyleGridData> create() { return adoptRef(*new StyleGridData); }
     Ref<StyleGridData> copy() const;

--- a/Source/WebCore/rendering/style/StyleGridItemData.cpp
+++ b/Source/WebCore/rendering/style/StyleGridItemData.cpp
@@ -35,6 +35,8 @@
 
 namespace WebCore {
 
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleGridItemData);
+
 StyleGridItemData::StyleGridItemData()
     : gridColumnStart(RenderStyle::initialGridItemColumnStart())
     , gridColumnEnd(RenderStyle::initialGridItemColumnEnd())

--- a/Source/WebCore/rendering/style/StyleGridItemData.h
+++ b/Source/WebCore/rendering/style/StyleGridItemData.h
@@ -36,7 +36,9 @@
 
 namespace WebCore {
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleGridItemData);
 class StyleGridItemData : public RefCounted<StyleGridItemData> {
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(StyleGridItemData);
 public:
     static Ref<StyleGridItemData> create() { return adoptRef(*new StyleGridItemData); }
     Ref<StyleGridItemData> copy() const;

--- a/Source/WebCore/rendering/style/StyleMultiColData.cpp
+++ b/Source/WebCore/rendering/style/StyleMultiColData.cpp
@@ -26,6 +26,8 @@
 
 namespace WebCore {
 
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleMultiColData);
+
 StyleMultiColData::StyleMultiColData()
     : count(RenderStyle::initialColumnCount())
     , autoWidth(true)

--- a/Source/WebCore/rendering/style/StyleMultiColData.h
+++ b/Source/WebCore/rendering/style/StyleMultiColData.h
@@ -33,7 +33,9 @@ namespace WebCore {
 
 // CSS3 Multi Column Layout
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleMultiColData);
 class StyleMultiColData : public RefCounted<StyleMultiColData> {
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(StyleMultiColData);
 public:
     static Ref<StyleMultiColData> create() { return adoptRef(*new StyleMultiColData); }
     Ref<StyleMultiColData> copy() const;

--- a/Source/WebCore/rendering/style/StyleVisualData.cpp
+++ b/Source/WebCore/rendering/style/StyleVisualData.cpp
@@ -26,6 +26,8 @@
 
 namespace WebCore {
 
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleVisualData);
+
 StyleVisualData::StyleVisualData()
     : hasClip(false)
     , textDecorationLine(RenderStyle::initialTextDecorationLine().toRaw())

--- a/Source/WebCore/rendering/style/StyleVisualData.h
+++ b/Source/WebCore/rendering/style/StyleVisualData.h
@@ -31,7 +31,9 @@
 
 namespace WebCore {
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleVisualData);
 class StyleVisualData : public RefCounted<StyleVisualData> {
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(StyleVisualData);
 public:
     static Ref<StyleVisualData> create() { return adoptRef(*new StyleVisualData); }
     Ref<StyleVisualData> copy() const;

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -279,7 +279,7 @@ static bool pseudoStyleCacheIsInvalid(RenderElement* renderer, RenderStyle* newS
     if (!pseudoStyleCache)
         return false;
 
-    for (auto& cache : *pseudoStyleCache) {
+    for (auto& cache : pseudoStyleCache->styles) {
         PseudoId pseudoId = cache->styleType();
         std::unique_ptr<RenderStyle> newPseudoStyle = renderer->getUncachedPseudoStyle({ pseudoId }, newStyle, newStyle);
         if (!newPseudoStyle)


### PR DESCRIPTION
#### b1677b518da08dd4da8abf7f9d321f5d4bc8f4e6
<pre>
Add more heap identifiers for style data
<a href="https://bugs.webkit.org/show_bug.cgi?id=251833">https://bugs.webkit.org/show_bug.cgi?id=251833</a>
&lt;rdar://problem/105112049&gt;

Reviewed by Simon Fraser.

* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::copyPseudoElementsFrom):
(WebCore::RenderStyle::hasUniquePseudoStyle const):
(WebCore::RenderStyle::getCachedPseudoStyle const):
(WebCore::RenderStyle::addCachedPseudoStyle):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/SVGRenderStyleDefs.cpp:
* Source/WebCore/rendering/style/SVGRenderStyleDefs.h:
* Source/WebCore/rendering/style/StyleBackgroundData.cpp:
* Source/WebCore/rendering/style/StyleBackgroundData.h:
* Source/WebCore/rendering/style/StyleDeprecatedFlexibleBoxData.cpp:
* Source/WebCore/rendering/style/StyleDeprecatedFlexibleBoxData.h:
* Source/WebCore/rendering/style/StyleFlexibleBoxData.cpp:
* Source/WebCore/rendering/style/StyleFlexibleBoxData.h:
* Source/WebCore/rendering/style/StyleGridData.cpp:
* Source/WebCore/rendering/style/StyleGridData.h:
* Source/WebCore/rendering/style/StyleGridItemData.cpp:
* Source/WebCore/rendering/style/StyleGridItemData.h:
* Source/WebCore/rendering/style/StyleMultiColData.cpp:
* Source/WebCore/rendering/style/StyleMultiColData.h:
* Source/WebCore/rendering/style/StyleVisualData.cpp:
* Source/WebCore/rendering/style/StyleVisualData.h:
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::pseudoStyleCacheIsInvalid):

Canonical link: <a href="https://commits.webkit.org/260030@main">https://commits.webkit.org/260030@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff892f52ac0c936c8859fbce1f3297b751be9ca7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106633 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15628 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39423 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115818 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115436 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110540 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17138 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6862 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98826 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112403 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13015 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95982 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40589 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94893 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27627 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82318 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8854 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28981 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9408 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6018 "Found 1 new test failure: media/video-src-blob-replay.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15023 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48527 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6926 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10934 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->