### PR TITLE
Add an explicit method to getUserCTM() to GraphicsContext

### DIFF
--- a/Source/WebCore/html/CustomPaintImage.cpp
+++ b/Source/WebCore/html/CustomPaintImage.cpp
@@ -149,7 +149,7 @@ void CustomPaintImage::drawPattern(GraphicsContext& destContext, const FloatRect
     FloatRect adjustedSrcRect = srcRect;
 
     // Factor in the destination context's scale to generate at the best resolution
-    AffineTransform destContextCTM = destContext.getCTM(GraphicsContext::DefinitelyIncludeDeviceScale);
+    AffineTransform destContextCTM = destContext.getCTM();
     double xScale = fabs(destContextCTM.xScale());
     double yScale = fabs(destContextCTM.yScale());
     AffineTransform adjustedPatternCTM = patternTransform;

--- a/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
@@ -444,9 +444,14 @@ void BifurcatedGraphicsContext::setCTM(const AffineTransform& transform)
     VERIFY_STATE_SYNCHRONIZATION();
 }
 
-AffineTransform BifurcatedGraphicsContext::getCTM(IncludeDeviceScale includeDeviceScale) const
+AffineTransform BifurcatedGraphicsContext::getCTM() const
 {
-    return m_primaryContext.getCTM(includeDeviceScale);
+    return m_primaryContext.getCTM();
+}
+
+AffineTransform BifurcatedGraphicsContext::getUserCTM() const
+{
+    return m_primaryContext.getUserCTM();
 }
 
 void BifurcatedGraphicsContext::drawFocusRing(const Path& path, float outlineWidth, const Color& color)

--- a/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h
+++ b/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h
@@ -117,7 +117,8 @@ public:
     void concatCTM(const AffineTransform&) final;
     void setCTM(const AffineTransform&) final;
 
-    AffineTransform getCTM(IncludeDeviceScale = PossiblyIncludeDeviceScale) const final;
+    AffineTransform getCTM() const final;
+    AffineTransform getUserCTM() const final;
 
     void drawFocusRing(const Path&, float outlineWidth, const Color&) final;
     void drawFocusRing(const Vector<FloatRect>&, float outlineOffset, float outlineWidth, const Color&) final;

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -195,7 +195,7 @@ std::unique_ptr<DisplayList::InMemoryDisplayList> FontCascade::displayListForTex
         return nullptr;
 
     std::unique_ptr<DisplayList::InMemoryDisplayList> displayList = makeUnique<DisplayList::InMemoryDisplayList>();
-    DisplayList::RecorderImpl recordingContext(*displayList, context.state().cloneForRecording(), { }, context.getCTM(GraphicsContext::DefinitelyIncludeDeviceScale), DisplayList::Recorder::DrawGlyphsMode::DeconstructUsingDrawDecomposedGlyphsCommands);
+    DisplayList::RecorderImpl recordingContext(*displayList, context.state().cloneForRecording(), { }, context.getCTM(), DisplayList::Recorder::DrawGlyphsMode::DeconstructUsingDrawDecomposedGlyphsCommands);
 
     FloatPoint startPoint = toFloatPoint(WebCore::size(glyphBuffer.initialAdvance()));
     drawGlyphBuffer(recordingContext, glyphBuffer, startPoint, customFontNotReadyAction);

--- a/Source/WebCore/platform/graphics/GradientImage.cpp
+++ b/Source/WebCore/platform/graphics/GradientImage.cpp
@@ -62,7 +62,7 @@ void GradientImage::drawPattern(GraphicsContext& destContext, const FloatRect& d
     m_gradient->adjustParametersForTiledDrawing(adjustedSize, adjustedSrcRect, spacing);
 
     // Factor in the destination context's scale to generate at the best resolution
-    AffineTransform destContextCTM = destContext.getCTM(GraphicsContext::DefinitelyIncludeDeviceScale);
+    AffineTransform destContextCTM = destContext.getCTM();
     double xScale = fabs(destContextCTM.xScale());
     double yScale = fabs(destContextCTM.yScale());
     AffineTransform adjustedPatternCTM = patternTransform;

--- a/Source/WebCore/platform/graphics/GraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContext.cpp
@@ -497,13 +497,13 @@ void GraphicsContext::adjustLineToPixelBoundaries(FloatPoint& p1, FloatPoint& p2
 
 FloatSize GraphicsContext::scaleFactor() const
 {
-    AffineTransform transform = getCTM(GraphicsContext::DefinitelyIncludeDeviceScale);
+    AffineTransform transform = getCTM();
     return FloatSize(transform.xScale(), transform.yScale());
 }
     
 FloatSize GraphicsContext::scaleFactorForDrawing(const FloatRect& destRect, const FloatRect& srcRect) const
 {
-    AffineTransform transform = getCTM(GraphicsContext::DefinitelyIncludeDeviceScale);
+    AffineTransform transform = getCTM();
     auto transformedDestRect = transform.mapRect(destRect);
     return transformedDestRect.size() / srcRect.size();
 }
@@ -546,7 +546,7 @@ FloatRect GraphicsContext::computeLineBoundsAndAntialiasingModeForText(const Flo
     if (printing)
         return FloatRect(origin, FloatSize(rect.width(), thickness));
 
-    AffineTransform transform = getCTM(GraphicsContext::DefinitelyIncludeDeviceScale);
+    AffineTransform transform = getCTM();
     // Just compute scale in x dimension, assuming x and y scales are equal.
     float scale = transform.b() ? std::hypot(transform.a(), transform.b()) : transform.a();
     if (scale < 1.0) {

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -333,8 +333,8 @@ public:
     virtual void concatCTM(const AffineTransform&) = 0;
     virtual void setCTM(const AffineTransform&) = 0;
 
-    enum IncludeDeviceScale { DefinitelyIncludeDeviceScale, PossiblyIncludeDeviceScale };
-    virtual AffineTransform getCTM(IncludeDeviceScale = PossiblyIncludeDeviceScale) const = 0;
+    virtual AffineTransform getCTM() const = 0;
+    virtual AffineTransform getUserCTM() const { return getCTM(); }
 
     // This function applies the device scale factor to the context, making the context capable of
     // acting as a base-level context for a HiDPI environment.

--- a/Source/WebCore/platform/graphics/NullGraphicsContext.h
+++ b/Source/WebCore/platform/graphics/NullGraphicsContext.h
@@ -100,7 +100,7 @@ private:
     void translate(float, float) final { }
     void concatCTM(const AffineTransform&) final { }
     void setCTM(const AffineTransform&) final { }
-    AffineTransform getCTM(IncludeDeviceScale = PossiblyIncludeDeviceScale) const final { return { }; }
+    AffineTransform getCTM() const final { return { }; }
     void clearRect(const FloatRect&) final { }
     void clip(const FloatRect&) final { }
     void clipOut(const FloatRect&) final { }

--- a/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.cpp
@@ -87,9 +87,8 @@ bool GraphicsContextCairo::hasPlatformContext() const
     return true;
 }
 
-AffineTransform GraphicsContextCairo::getCTM(IncludeDeviceScale includeScale) const
+AffineTransform GraphicsContextCairo::getCTM() const
 {
-    UNUSED_PARAM(includeScale);
     return Cairo::State::getCTM(*platformContext());
 }
 

--- a/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.h
+++ b/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.h
@@ -92,7 +92,7 @@ public:
     void scale(const FloatSize&) final;
     void concatCTM(const AffineTransform&) final;
     void setCTM(const AffineTransform&) final;
-    AffineTransform getCTM(GraphicsContext::IncludeDeviceScale) const final;
+    AffineTransform getCTM() const final;
 
     void beginTransparencyLayer(float) final;
     void endTransparencyLayer() final;

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
@@ -102,7 +102,8 @@ public:
     void concatCTM(const AffineTransform&) final;
     void setCTM(const AffineTransform&) override;
 
-    AffineTransform getCTM(IncludeDeviceScale = PossiblyIncludeDeviceScale) const override;
+    AffineTransform getCTM() const override;
+    AffineTransform getUserCTM() const override;
 
     void drawFocusRing(const Path&, float outlineWidth, const Color&) final;
     void drawFocusRing(const Vector<FloatRect>&, float outlineOffset, float outlineWidth, const Color&) final;

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
@@ -313,9 +313,16 @@ void Recorder::setCTM(const AffineTransform& transform)
     recordSetCTM(transform);
 }
 
-AffineTransform Recorder::getCTM(GraphicsContext::IncludeDeviceScale) const
+AffineTransform Recorder::getCTM() const
 {
     return currentState().ctm;
+}
+
+AffineTransform Recorder::getUserCTM() const
+{
+    auto ctm = currentState().ctm;
+    ctm.scale(1 / m_initialScale);
+    return ctm;
 }
 
 void Recorder::beginTransparencyLayer(float opacity)

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
@@ -255,7 +255,8 @@ private:
     WEBCORE_EXPORT void scale(const FloatSize&) final;
     WEBCORE_EXPORT void concatCTM(const AffineTransform&) final;
     WEBCORE_EXPORT void setCTM(const AffineTransform&) final;
-    WEBCORE_EXPORT AffineTransform getCTM(GraphicsContext::IncludeDeviceScale = PossiblyIncludeDeviceScale) const final;
+    WEBCORE_EXPORT AffineTransform getCTM() const final;
+    WEBCORE_EXPORT AffineTransform getUserCTM() const final;
 
     WEBCORE_EXPORT void beginTransparencyLayer(float opacity) final;
     WEBCORE_EXPORT void endTransparencyLayer() final;

--- a/Source/WebCore/platform/graphics/mac/controls/ControlMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlMac.mm
@@ -222,8 +222,7 @@ static void drawCellOrFocusRing(GraphicsContext& context, const FloatRect& rect,
 
 void ControlMac::drawCell(GraphicsContext& context, const FloatRect& rect, float deviceScaleFactor, const ControlStyle& style, NSCell *cell, NSView *view, bool drawCell)
 {
-    auto platformContext = context.platformContext();
-    auto userCTM = AffineTransform(CGAffineTransformConcat(CGContextGetCTM(platformContext), CGAffineTransformInvert(CGContextGetBaseCTM(platformContext))));
+    auto userCTM = context.getUserCTM();
     bool useImageBuffer = userCTM.xScale() != 1.0 || userCTM.yScale() != 1.0;
 
     if (!useImageBuffer) {

--- a/Source/WebCore/platform/graphics/nicosia/cairo/NicosiaCairoOperationRecorder.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/cairo/NicosiaCairoOperationRecorder.cpp
@@ -1001,7 +1001,7 @@ void CairoOperationRecorder::setCTM(const AffineTransform& transform)
     state.ctmInverse = inverse.value();
 }
 
-AffineTransform CairoOperationRecorder::getCTM(GraphicsContext::IncludeDeviceScale) const
+AffineTransform CairoOperationRecorder::getCTM() const
 {
     return m_stateStack.last().ctm;
 }

--- a/Source/WebCore/platform/graphics/nicosia/cairo/NicosiaCairoOperationRecorder.h
+++ b/Source/WebCore/platform/graphics/nicosia/cairo/NicosiaCairoOperationRecorder.h
@@ -88,7 +88,7 @@ private:
     void scale(const WebCore::FloatSize&) override;
     void concatCTM(const WebCore::AffineTransform&) override;
     void setCTM(const WebCore::AffineTransform&) override;
-    WebCore::AffineTransform getCTM(WebCore::GraphicsContext::IncludeDeviceScale) const override;
+    WebCore::AffineTransform getCTM() const override;
 
     void beginTransparencyLayer(float) override;
     void endTransparencyLayer() override;

--- a/Source/WebCore/rendering/svg/RenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGImage.cpp
@@ -370,14 +370,14 @@ bool RenderSVGImage::bufferForeground(PaintInfo& paintInfo, const LayoutPoint& p
     repaintBoundingBox.moveBy(paintOffset);
 
     // Invalidate an existing buffer if the scale is not correct.
-    const auto& absoluteTransform = destinationContext.getCTM(GraphicsContext::DefinitelyIncludeDeviceScale);
+    const auto& absoluteTransform = destinationContext.getCTM();
 
     auto absoluteTargetRect = enclosingIntRect(absoluteTransform.mapRect(repaintBoundingBox));
     if (m_bufferedForeground) {
         if (absoluteTargetRect.size() != m_bufferedForeground->backendSize())
             m_bufferedForeground = nullptr;
         else {
-            const auto& absoluteTransformBuffer = m_bufferedForeground->context().getCTM(GraphicsContext::DefinitelyIncludeDeviceScale);
+            const auto& absoluteTransformBuffer = m_bufferedForeground->context().getCTM();
             if (absoluteTransformBuffer != absoluteTransform)
                 m_bufferedForeground = nullptr;
         }

--- a/Source/WebCore/rendering/svg/SVGRenderingContext.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderingContext.cpp
@@ -273,7 +273,7 @@ bool SVGRenderingContext::bufferForeground(RefPtr<ImageBuffer>& imageBuffer)
 
     // Invalidate an existing buffer if the scale is not correct.
     if (imageBuffer) {
-        AffineTransform transform = m_paintInfo->context().getCTM(GraphicsContext::DefinitelyIncludeDeviceScale);
+        AffineTransform transform = m_paintInfo->context().getCTM();
         IntSize expandedBoundingBox = expandedIntSize(boundingBox.size());
         IntSize bufferSize(static_cast<int>(ceil(expandedBoundingBox.width() * transform.xScale())), static_cast<int>(ceil(expandedBoundingBox.height() * transform.yScale())));
         if (bufferSize != imageBuffer->backendSize())

--- a/Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.mm
@@ -74,9 +74,9 @@ public:
         GraphicsContextCG::setCTM(m_inverseImmutableBaseTransform * transform);
     }
 
-    WebCore::AffineTransform getCTM(IncludeDeviceScale includeDeviceScale) const final
+    WebCore::AffineTransform getCTM() const final
     {
-        return m_immutableBaseTransform * GraphicsContextCG::getCTM(includeDeviceScale);
+        return m_immutableBaseTransform * GraphicsContextCG::getCTM();
     }
 
     WebCore::FloatRect roundToDevicePixels(const WebCore::FloatRect& rect, RoundingMode = RoundAllSides) const final

--- a/Tools/TestWebKitAPI/Tests/WebCore/cg/BifurcatedGraphicsContextTestsCG.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cg/BifurcatedGraphicsContextTestsCG.cpp
@@ -294,8 +294,8 @@ TEST(BifurcatedGraphicsContextTests, ApplyDeviceScaleFactor)
 
     ctx.applyDeviceScaleFactor(2);
 
-    auto primaryCTM = primaryContext.getCTM(GraphicsContext::IncludeDeviceScale::DefinitelyIncludeDeviceScale);
-    auto secondaryCTM = secondaryContext.getCTM(GraphicsContext::IncludeDeviceScale::DefinitelyIncludeDeviceScale);
+    auto primaryCTM = primaryContext.getCTM();
+    auto secondaryCTM = secondaryContext.getCTM();
 
     EXPECT_EQ(primaryCTM.xScale(), secondaryCTM.xScale());
     EXPECT_EQ(primaryCTM.yScale(), secondaryCTM.yScale());


### PR DESCRIPTION
#### e54cbab28e2b19fbcfc7548fda4e4181ba91fc94
<pre>
Add an explicit method to getUserCTM() to GraphicsContext
<a href="https://bugs.webkit.org/show_bug.cgi?id=251839">https://bugs.webkit.org/show_bug.cgi?id=251839</a>
rdar://105115245

Reviewed by NOBODY (OOPS!).

Make getCTM return the effective scale factor which is the multiplication of the
baseCTM and the userCTM. Remove the input argument IncludeDeviceScale since it is
confusing. Make another explicit method which returns the userCTM.

* Source/WebCore/html/CustomPaintImage.cpp:
(WebCore::CustomPaintImage::drawPattern):
* Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp:
(WebCore::BifurcatedGraphicsContext::getCTM const):
(WebCore::BifurcatedGraphicsContext::getUserCTM const):
* Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h:
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::displayListForTextRun const):
* Source/WebCore/platform/graphics/GradientImage.cpp:
(WebCore::GradientImage::drawPattern):
* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::GraphicsContext::scaleFactor const):
(WebCore::GraphicsContext::scaleFactorForDrawing const):
(WebCore::GraphicsContext::computeLineBoundsAndAntialiasingModeForText):
* Source/WebCore/platform/graphics/GraphicsContext.h:
(WebCore::GraphicsContext::getUserCTM const):
* Source/WebCore/platform/graphics/NullGraphicsContext.h:
* Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.cpp:
(WebCore::GraphicsContextCairo::getCTM const):
* Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.h:
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::applyStrokePattern):
(WebCore::GraphicsContextCG::applyFillPattern):
(WebCore::GraphicsContextCG::setCGShadow):
(WebCore::GraphicsContextCG::getCTM const):
(WebCore::GraphicsContextCG::getUserCTM const):
(WebCore::getUserToBaseCTM): Deleted.
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp:
(WebCore::DisplayList::Recorder::getCTM const):
(WebCore::DisplayList::Recorder::getUserCTM const):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h:
* Source/WebCore/platform/graphics/mac/controls/ControlMac.mm:
(WebCore::ControlMac::drawCell):
* Source/WebCore/platform/graphics/nicosia/cairo/NicosiaCairoOperationRecorder.cpp:
(Nicosia::CairoOperationRecorder::getCTM const):
* Source/WebCore/platform/graphics/nicosia/cairo/NicosiaCairoOperationRecorder.h:
* Source/WebCore/rendering/svg/RenderSVGImage.cpp:
(WebCore::RenderSVGImage::bufferForeground):
* Source/WebCore/rendering/svg/SVGRenderingContext.cpp:
(WebCore::SVGRenderingContext::bufferForeground):
* Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.mm:
* Tools/TestWebKitAPI/Tests/WebCore/cg/BifurcatedGraphicsContextTestsCG.cpp:
(TestWebKitAPI::TEST):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e54cbab28e2b19fbcfc7548fda4e4181ba91fc94

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106993 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16043 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39790 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116171 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115701 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110894 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17511 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7246 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99174 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112758 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13247 "Found 60 new test failures: compositing/reflections/mask-and-reflection.html, compositing/video/video-border-radius-clipping.html, editing/async-clipboard/clipboard-change-data-while-reading.html, fast/box-shadow/image-box-shadow.html, fast/canvas/canvas-blending-color-over-pattern.html, fast/canvas/canvas-blending-gradient-over-pattern.html, fast/canvas/canvas-blending-image-over-pattern.html, fast/canvas/canvas-blending-pattern-over-color.html, fast/canvas/canvas-blending-pattern-over-gradient.html, fast/canvas/canvas-blending-pattern-over-image.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96276 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40850 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95139 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27918 "Found 60 new test failures: animations/additive-transform-animations.html, animations/stacking-context-fill-forwards.html, compositing/filters/drop-shadow.html, compositing/hidpi-absolute-subpixel-positioned-transformed-elements.html, compositing/hidpi-box-positioned-off-by-one-when-non-compositing-transform-is-present.html, compositing/reflections/nested-reflection-opacity2.html, compositing/reflections/opacity-in-reflection.html, compositing/video/video-border-radius-clipping.html, css3/filters/backdrop/backdrop-filter-with-reflection-remove-backdrop.html, css3/filters/reference-filter-outsets.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82599 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9166 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29270 "Found 60 new test failures: animations/additive-transform-animations.html, animations/stacking-context-fill-forwards.html, compositing/filters/drop-shadow.html, compositing/hidpi-absolute-subpixel-positioned-transformed-elements.html, compositing/hidpi-box-positioned-off-by-one-when-non-compositing-transform-is-present.html, compositing/reflections/nested-reflection-opacity2.html, compositing/reflections/opacity-in-reflection.html, compositing/video/video-border-radius-clipping.html, css3/filters/backdrop/backdrop-filter-with-reflection-remove-backdrop.html, css3/filters/reference-filter-outsets.html ... (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9755 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6267 "Found 60 new test failures: accessibility/video-element-url-attribute.html, animations/additive-transform-animations.html, animations/stacking-context-fill-forwards.html, animations/stop-animation-on-suspend.html, compositing/filters/drop-shadow.html, compositing/hidpi-absolute-subpixel-positioned-transformed-elements.html, compositing/hidpi-box-positioned-off-by-one-when-non-compositing-transform-is-present.html, compositing/reflections/nested-reflection-opacity2.html, compositing/reflections/opacity-in-reflection.html, compositing/video/video-border-radius-clipping.html ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15330 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48829 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11293 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->