### PR TITLE
makeString and makeAtomString shouldn't copy arguments objects

### DIFF
--- a/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
+++ b/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
@@ -834,7 +834,7 @@ String SamplingProfiler::StackFrame::displayName(VM& vm)
     case FrameType::Wasm:
 #if ENABLE(WEBASSEMBLY)
         if (wasmIndexOrName)
-            return makeString(wasmIndexOrName.value());
+            return Wasm::makeString(wasmIndexOrName.value());
 #endif
         return "(wasm)"_s;
 
@@ -878,7 +878,7 @@ String SamplingProfiler::StackFrame::displayNameForJSONTests(VM& vm)
     case FrameType::Wasm: {
 #if ENABLE(WEBASSEMBLY)
         if (wasmIndexOrName)
-            return makeString(wasmIndexOrName.value());
+            return Wasm::makeString(wasmIndexOrName.value());
 #endif
         return "(wasm)"_s;
     }

--- a/Source/WTF/wtf/JSONValues.cpp
+++ b/Source/WTF/wtf/JSONValues.cpp
@@ -468,6 +468,24 @@ inline void appendDoubleQuotedString(StringBuilder& builder, StringView string)
 
 } // anonymous namespace
 
+Value::~Value()
+{
+    switch (m_type) {
+    case Type::Null:
+    case Type::Boolean:
+    case Type::Double:
+    case Type::Integer:
+        break;
+    case Type::String:
+        if (m_value.string)
+            m_value.string->deref();
+        break;
+    case Type::Object:
+    case Type::Array:
+        break;
+    }
+}
+
 Ref<Value> Value::null()
 {
     return adoptRef(*new Value);

--- a/Source/WTF/wtf/JSONValues.h
+++ b/Source/WTF/wtf/JSONValues.h
@@ -50,33 +50,17 @@ class Object;
 class ObjectBase;
 
 // FIXME: unify this JSON parser with JSONParse in JavaScriptCore.
-class WTF_EXPORT_PRIVATE Value : public RefCounted<Value> {
+class Value : public RefCounted<Value> {
 public:
     static constexpr int maxDepth = 1000;
 
-    virtual ~Value()
-    {
-        switch (m_type) {
-        case Type::Null:
-        case Type::Boolean:
-        case Type::Double:
-        case Type::Integer:
-            break;
-        case Type::String:
-            if (m_value.string)
-                m_value.string->deref();
-            break;
-        case Type::Object:
-        case Type::Array:
-            break;
-        }
-    }
+    WTF_EXPORT_PRIVATE virtual ~Value();
 
-    static Ref<Value> null();
-    static Ref<Value> create(bool);
-    static Ref<Value> create(int);
-    static Ref<Value> create(double);
-    static Ref<Value> create(const String&);
+    WTF_EXPORT_PRIVATE static Ref<Value> null();
+    WTF_EXPORT_PRIVATE static Ref<Value> create(bool);
+    WTF_EXPORT_PRIVATE static Ref<Value> create(int);
+    WTF_EXPORT_PRIVATE static Ref<Value> create(double);
+    WTF_EXPORT_PRIVATE static Ref<Value> create(const String&);
     template<class T>
     static Ref<Value> create(T) = delete;
 
@@ -93,27 +77,27 @@ public:
     Type type() const { return m_type; }
     bool isNull() const { return m_type == Type::Null; }
 
-    std::optional<bool> asBoolean() const;
-    std::optional<int> asInteger() const;
-    std::optional<double> asDouble() const;
-    String asString() const;
-    RefPtr<Value> asValue();
-    virtual RefPtr<Object> asObject();
-    virtual RefPtr<const Object> asObject() const;
+    WTF_EXPORT_PRIVATE std::optional<bool> asBoolean() const;
+    WTF_EXPORT_PRIVATE std::optional<int> asInteger() const;
+    WTF_EXPORT_PRIVATE std::optional<double> asDouble() const;
+    WTF_EXPORT_PRIVATE String asString() const;
+    WTF_EXPORT_PRIVATE RefPtr<Value> asValue();
+    WTF_EXPORT_PRIVATE virtual RefPtr<Object> asObject();
+    WTF_EXPORT_PRIVATE virtual RefPtr<const Object> asObject() const;
     virtual RefPtr<Array> asArray();
 
-    static RefPtr<Value> parseJSON(StringView);
+    WTF_EXPORT_PRIVATE static RefPtr<Value> parseJSON(StringView);
     static void escapeString(StringBuilder&, StringView);
 
-    String toJSONString() const;
+    WTF_EXPORT_PRIVATE String toJSONString() const;
     virtual void writeJSON(StringBuilder& output) const;
 
     virtual size_t memoryCost() const;
 
     // FIXME: <http://webkit.org/b/179847> remove these functions when legacy InspectorObject symbols are no longer needed.
-    bool asDouble(double&) const;
-    bool asInteger(int&) const;
-    bool asString(String&) const;
+    WTF_EXPORT_PRIVATE bool asDouble(double&) const;
+    WTF_EXPORT_PRIVATE bool asInteger(int&) const;
+    WTF_EXPORT_PRIVATE bool asString(String&) const;
 
 protected:
     Value()

--- a/Source/WTF/wtf/text/StringConcatenate.h
+++ b/Source/WTF/wtf/text/StringConcatenate.h
@@ -51,8 +51,8 @@ public:
     {
     }
 
-    unsigned length() { return 1; }
-    bool is8Bit() { return true; }
+    unsigned length() const { return 1; }
+    bool is8Bit() const { return true; }
     template<typename CharacterType> void writeTo(CharacterType* destination) const { *destination = m_character; }
 
 private:
@@ -358,12 +358,12 @@ public:
     {
     }
 
-    unsigned length()
+    unsigned length() const
     {
         return m_indentation.value * N;
     }
 
-    bool is8Bit()
+    bool is8Bit() const
     {
         return true;
     }
@@ -481,15 +481,15 @@ String tryMakeStringFromAdapters(StringTypeAdapter adapter, StringTypeAdapters .
 }
 
 template<typename... StringTypes>
-String tryMakeString(StringTypes ...strings)
+String tryMakeString(StringTypes&& ...strings)
 {
-    return tryMakeStringFromAdapters(StringTypeAdapter<StringTypes>(strings)...);
+    return tryMakeStringFromAdapters(StringTypeAdapter<std::decay_t<StringTypes>>(std::forward<StringTypes>(strings))...);
 }
 
 template<typename... StringTypes>
-String makeString(StringTypes... strings)
+String makeString(StringTypes&&... strings)
 {
-    String result = tryMakeString(strings...);
+    String result = tryMakeString(std::forward<StringTypes>(strings)...);
     if (!result)
         CRASH();
     return result;
@@ -524,13 +524,13 @@ AtomString tryMakeAtomStringFromAdapters(StringTypeAdapter adapter, StringTypeAd
 template<typename... StringTypes>
 AtomString tryMakeAtomString(StringTypes ...strings)
 {
-    return tryMakeAtomStringFromAdapters(StringTypeAdapter<StringTypes>(strings)...);
+    return tryMakeAtomStringFromAdapters(StringTypeAdapter<std::decay_t<StringTypes>>(std::forward<StringTypes>(strings))...);
 }
 
 template<typename... StringTypes>
-AtomString makeAtomString(StringTypes... strings)
+AtomString makeAtomString(StringTypes&&... strings)
 {
-    AtomString result = tryMakeAtomString(strings...);
+    AtomString result = tryMakeAtomString(std::forward<StringTypes>(strings)...);
     if (result.isNull())
         CRASH();
     return result;

--- a/Source/WTF/wtf/text/StringOperators.h
+++ b/Source/WTF/wtf/text/StringOperators.h
@@ -46,14 +46,14 @@ public:
         return AtomString(operator String());
     }
 
-    bool is8Bit()
+    bool is8Bit() const
     {
         StringTypeAdapter<StringType1> adapter1(m_string1);
         StringTypeAdapter<StringType2> adapter2(m_string2);
         return adapter1.is8Bit() && adapter2.is8Bit();
     }
 
-    void writeTo(LChar* destination)
+    void writeTo(LChar* destination) const
     {
         ASSERT(is8Bit());
         StringTypeAdapter<StringType1> adapter1(m_string1);
@@ -62,7 +62,7 @@ public:
         adapter2.writeTo(destination + adapter1.length());
     }
 
-    void writeTo(UChar* destination)
+    void writeTo(UChar* destination) const
     {
         StringTypeAdapter<StringType1> adapter1(m_string1);
         StringTypeAdapter<StringType2> adapter2(m_string2);
@@ -70,7 +70,7 @@ public:
         adapter2.writeTo(destination + adapter1.length());
     }
 
-    unsigned length()
+    unsigned length() const
     {
         StringTypeAdapter<StringType1> adapter1(m_string1);
         StringTypeAdapter<StringType2> adapter2(m_string2);
@@ -85,7 +85,7 @@ private:
 template<typename StringType1, typename StringType2>
 class StringTypeAdapter<StringAppend<StringType1, StringType2>> {
 public:
-    StringTypeAdapter(StringAppend<StringType1, StringType2>& buffer)
+    StringTypeAdapter(const StringAppend<StringType1, StringType2>& buffer)
         : m_buffer { buffer }
     {
     }
@@ -95,7 +95,7 @@ public:
     template<typename CharacterType> void writeTo(CharacterType* destination) const { m_buffer.writeTo(destination); }
 
 private:
-    StringAppend<StringType1, StringType2>& m_buffer;
+    const StringAppend<StringType1, StringType2>& m_buffer;
 };
 
 inline StringAppend<const char*, String> operator+(const char* string1, const String& string2)

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h
@@ -109,7 +109,7 @@ public:
 
     // Incrementing this number will delete all existing cache content for everyone. Do you really need to do it?
     // FIXME: When this is incremented, remove LegacyCertificateInfoType.
-    static const unsigned version = 16;
+    static constexpr unsigned version = 16;
 
     String basePathIsolatedCopy() const;
     String versionPath() const;


### PR DESCRIPTION
#### 4a0ea82452c539a67e68e1c8111a4f43e765afa4
<pre>
makeString and makeAtomString shouldn&apos;t copy arguments objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=250017">https://bugs.webkit.org/show_bug.cgi?id=250017</a>

Reviewed by NOBODY (OOPS!).

makeString family unnecessary copied objects passed as arguments. It
caused ref churn of RefCounted objects, for example StringImpl. And,
it prevented to take non-copyable objects. They should take universal
references and pass them to StringTypeAdapter by perfect forwarding.

There are two kinds of specialized StringTypeAdapter constructors.
StringTypeAdapter(T) takes the argument as pass by value,
StringTypeAdapter(const T&amp;) does it as pass by reference,

The above change introduced two strange linkage errors. Linking
JavaScriptCore reported a weak external symbol
WTF::JSONImpl::Value::maxDepth. Linking WebKit reported an undefined
symbols WebKit::NetworkCache::Storage::version.

To fix them, stopped exporting Value::maxDepth by not marking the
whole class as WTF_EXPORT_PRIVATE, and changed Storage::version to
constexpr.

* Source/JavaScriptCore/runtime/SamplingProfiler.cpp:
(JSC::SamplingProfiler::StackFrame::displayName):
(JSC::SamplingProfiler::StackFrame::displayNameForJSONTests):
* Source/WTF/wtf/JSONValues.cpp:
(WTF::JSONImpl::Value::~Value):
* Source/WTF/wtf/JSONValues.h:
* Source/WTF/wtf/text/StringConcatenate.h:
(WTF::tryMakeString):
(WTF::makeString):
(WTF::tryMakeAtomString):
(WTF::makeAtomString):
* Source/WTF/wtf/text/StringOperators.h:
(WTF::StringAppend::is8Bit const):
(WTF::StringAppend::writeTo const):
(WTF::StringAppend::length const):
(WTF::StringAppend::is8Bit): Deleted.
(WTF::StringAppend::writeTo): Deleted.
(WTF::StringAppend::length): Deleted.
* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h:
* Tools/TestWebKitAPI/Tests/WTF/StringConcatenate.cpp:
(TestWebKitAPI::NonCopyable::NonCopyable):
(TestWebKitAPI::NonCopyable::value const):
(TestWebKitAPI::TEST):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a0ea82452c539a67e68e1c8111a4f43e765afa4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106513 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15528 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39321 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115697 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115349 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110421 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17023 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6756 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98704 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112281 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12933 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95900 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40490 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94808 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27544 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82212 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/96085 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8758 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28896 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/95529 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/6655 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9300 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5473 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30646 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14916 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48444 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/104271 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10840 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25836 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->