### PR TITLE
[WGSL] Replace m_emptySourceSpan with SourceSpan::empty

### DIFF
--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -224,7 +224,7 @@ void RewriteGlobalVariables::insertStructs()
         }
 
         m_callGraph.ast().structures().append(makeUniqueRef<AST::Structure>(
-            SourceSpan(0, 0, 0, 0),
+            SourceSpan::empty(),
             WTFMove(structName),
             WTFMove(structMembers),
             AST::Attribute::List { },


### PR DESCRIPTION
#### 718d6e1306d2ac0d5ee5b4e9095c7f2cfb420b03
<pre>
[WGSL] Replace m_emptySourceSpan with SourceSpan::empty
<a href="https://bugs.webkit.org/show_bug.cgi?id=251840">https://bugs.webkit.org/show_bug.cgi?id=251840</a>
rdar://105118434

Reviewed by Myles C. Maxfield.

Given that `SourceSpan::empty` was recently added, use it in favor of
EntryPointRewriter::m_emptySourceSpan and an explicit allocation of an
empty SourceSpan in RewriteGlobalVariables.

* Source/WebGPU/WGSL/EntryPointRewriter.cpp:
(WGSL::EntryPointRewriter::EntryPointRewriter):
(WGSL::EntryPointRewriter::rewrite):
(WGSL::EntryPointRewriter::constructInputStruct):
(WGSL::EntryPointRewriter::materialize):
(WGSL::EntryPointRewriter::visit):
(WGSL::EntryPointRewriter::appendBuiltins):
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::insertStructs):

Canonical link: <a href="https://commits.webkit.org/260188@main">https://commits.webkit.org/260188@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ce1014c7e9db013f8c1d590d12b61d4ff86c56e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107480 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16542 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40383 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116643 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116064 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17967 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7784 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99644 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113241 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13566 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96745 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41186 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95471 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28371 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82955 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9548 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29724 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10205 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6625 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15704 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49305 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7046 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11765 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->