### PR TITLE
<link> elements with media queries that do not affect the current page can be delayed

### DIFF
--- a/LayoutTests/http/tests/css/link-with-non-matching-media-slow-load-expected.html
+++ b/LayoutTests/http/tests/css/link-with-non-matching-media-slow-load-expected.html
@@ -1,0 +1,5 @@
+<style>
+#pass { display:inline; width:200px; height:200px; background-color: green; position: absolute; }
+</style>
+<body>
+<div id=pass>PASS: Non-matching slow stylesheet didn't delay visually non-empty.</div>

--- a/LayoutTests/http/tests/css/link-with-non-matching-media-slow-load.html
+++ b/LayoutTests/http/tests/css/link-with-non-matching-media-slow-load.html
@@ -1,0 +1,18 @@
+<style>
+#pass { display:none; width:200px; height:200px; background-color: green; position: absolute; }
+#fail { display:inline; width:200px; height:200px; background-color: red; position: absolute; }
+</style>
+<body>
+<link rel="stylesheet" href="http://127.0.0.1:8000/local/slow-css-pass.cgi" media="not all" onload="this.media='all'">
+<div id=pass></div>
+<div id=fail></div>
+<script>
+function test() {
+    document.body.offsetLeft;
+
+    if (window.internals)
+        pass.textContent = internals.isVisuallyNonEmpty ? "PASS: Non-matching slow stylesheet didn't delay visually non-empty." : "FAIL: Non-matching slow media delayed visually non-empty.";
+}
+
+setTimeout(test);
+</script>

--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -5069,6 +5069,9 @@ void FrameView::checkAndDispatchDidReachVisuallyNonEmptyState()
             for (auto& resource : resources) {
                 if (resource.value->isLoaded())
                     continue;
+                // ResourceLoadPriority::VeryLow is used for resources that are not needed to render.
+                if (resource.value->loadPriority() == ResourceLoadPriority::VeryLow)
+                    continue;
                 if (resource.value->type() == CachedResource::Type::CSSStyleSheet || resource.value->type() == CachedResource::Type::FontResource)
                     return true;
             }

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -7014,4 +7014,14 @@ Internals::SelectorFilterHashCounts Internals::selectorFilterHashCounts(const St
     return { hashes.ids.size(), hashes.classes.size(), hashes.tags.size(), hashes.attributes.size() };
 }
 
+bool Internals::isVisuallyNonEmpty() const
+{
+    auto* document = contextDocument();
+    if (!document || !document->frame())
+        return false;
+
+    auto* frameView = document->frame()->view();
+    return frameView && frameView->isVisuallyNonEmpty();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1369,6 +1369,8 @@ public:
     };
     SelectorFilterHashCounts selectorFilterHashCounts(const String& selector);
 
+    bool isVisuallyNonEmpty() const;
+
 private:
     explicit Internals(Document&);
     Document* contextDocument() const;

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1194,4 +1194,6 @@ typedef (FetchRequest or FetchResponse) FetchObject;
     boolean consumeTransientActivation();
 
     SelectorFilterHashCounts selectorFilterHashCounts(DOMString selector);
+
+    readonly attribute boolean isVisuallyNonEmpty;
 };


### PR DESCRIPTION
#### 9e31d4e46121e45d2b95bef93b8515877deb57b5
<pre>
&lt;link&gt; elements with media queries that do not affect the current page can be delayed
<a href="https://bugs.webkit.org/show_bug.cgi?id=39455">https://bugs.webkit.org/show_bug.cgi?id=39455</a>
rdar://102178226

Reviewed by Alan Baradlay.

We correctly deprioritize stylesheets with non-matching media attribute and don&apos;t make them
rendering blocking. However they may still delay the visually non-empty milestone. This delay
only comes into play if there is not enough visual content to trigger the milestone otherwise.
This may end up delaying rendering until the non-matching stylesheets are fully loaded on simple
pages.

* LayoutTests/http/tests/css/link-with-non-matching-media-slow-load-expected.html: Added.
* LayoutTests/http/tests/css/link-with-non-matching-media-slow-load.html: Added.
* Source/WebCore/page/FrameView.cpp:
(WebCore::FrameView::checkAndDispatchDidReachVisuallyNonEmptyState):

Ignore &quot;very low&quot; priority resources when determining if everything important is loaded.

* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::isVisuallyNonEmpty const):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Testing support.

Canonical link: <a href="https://commits.webkit.org/259963@main">https://commits.webkit.org/259963@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f30ff979903b91d7565d015489f2f730b0d60e40

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106528 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15544 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39337 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115713 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115362 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110437 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17039 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6772 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98720 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112296 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12945 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95915 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40503 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94820 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27559 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8773 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28911 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9316 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5486 "Found 1 new test failure: media/video-src-blob-replay.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14932 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48459 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6890 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10854 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->