### PR TITLE
[GTK4] Make favicon and snapshot API use GdkTexture instead of cairo surfaces

### DIFF
--- a/Source/WebCore/PlatformGTK.cmake
+++ b/Source/WebCore/PlatformGTK.cmake
@@ -51,6 +51,8 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     platform/glib/ApplicationGLib.h
 
+    platform/graphics/gtk/GdkCairoUtilities.h
+
     platform/graphics/x11/PlatformDisplayX11.h
     platform/graphics/x11/XErrorTrapper.h
     platform/graphics/x11/XUniquePtr.h

--- a/Source/WebCore/platform/graphics/gtk/GdkCairoUtilities.cpp
+++ b/Source/WebCore/platform/graphics/gtk/GdkCairoUtilities.cpp
@@ -146,4 +146,19 @@ GdkPixbuf* cairoSurfaceToGdkPixbuf(cairo_surface_t* surface)
     return gdk_pixbuf_get_from_surface(surface, 0, 0, size.width(), size.height());
 }
 
+#if USE(GTK4)
+GdkTexture* cairoSurfaceToGdkTexture(cairo_surface_t* surface)
+{
+    ASSERT(cairo_image_surface_get_format(surface) == CAIRO_FORMAT_ARGB32);
+    auto width = cairo_image_surface_get_width(surface);
+    auto height = cairo_image_surface_get_height(surface);
+    auto stride = cairo_image_surface_get_stride(surface);
+    auto* data = cairo_image_surface_get_data(surface);
+    GRefPtr<GBytes> bytes = adoptGRef(g_bytes_new_with_free_func(data, height * stride, [](gpointer data) {
+        cairo_surface_destroy(static_cast<cairo_surface_t*>(data));
+    }, cairo_surface_reference(surface)));
+    return gdk_memory_texture_new(width, height, GDK_MEMORY_DEFAULT, bytes.get(), stride);
+}
+#endif
+
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/gtk/GdkCairoUtilities.h
+++ b/Source/WebCore/platform/graphics/gtk/GdkCairoUtilities.h
@@ -28,5 +28,7 @@
 namespace WebCore {
 
 GdkPixbuf* cairoSurfaceToGdkPixbuf(cairo_surface_t*);
-
+#if USE(GTK4)
+GdkTexture* cairoSurfaceToGdkTexture(cairo_surface_t*);
+#endif
 }

--- a/Source/WebCore/platform/graphics/gtk/ImageGtk.cpp
+++ b/Source/WebCore/platform/graphics/gtk/ImageGtk.cpp
@@ -66,21 +66,11 @@ GdkPixbuf* BitmapImage::getGdkPixbuf()
 #if USE(GTK4)
 GdkTexture* BitmapImage::gdkTexture()
 {
-    auto nativeImage = nativeImageForCurrentFrame();
-    if (!nativeImage)
-        return nullptr;
-
-    auto& surface = nativeImage->platformImage();
-
-    ASSERT(cairo_image_surface_get_format(surface.get()) == CAIRO_FORMAT_ARGB32);
-    auto width = cairo_image_surface_get_width(surface.get());
-    auto height = cairo_image_surface_get_height(surface.get());
-    auto stride = cairo_image_surface_get_stride(surface.get());
-    auto* data = cairo_image_surface_get_data(surface.get());
-    GRefPtr<GBytes> bytes = adoptGRef(g_bytes_new_with_free_func(data, height * stride, [](gpointer data) {
-        cairo_surface_destroy(static_cast<cairo_surface_t*>(data));
-    }, const_cast<PlatformImagePtr&>(surface).leakRef()));
-    return gdk_memory_texture_new(width, height, GDK_MEMORY_DEFAULT, bytes.get(), stride);
+    if (auto nativeImage = nativeImageForCurrentFrame()) {
+        auto& surface = nativeImage->platformImage();
+        return cairoSurfaceToGdkTexture(surface.get());
+    }
+    return nullptr;
 }
 #endif
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.h.in
@@ -26,7 +26,9 @@
 #include <glib-object.h>
 #include <@API_INCLUDE_PREFIX@/WebKitDefines.h>
 
-#if PLATFORM(GTK)
+#if USE(GTK4)
+#include <gtk/gtk.h>
+#else
 #include <cairo.h>
 #endif
 
@@ -81,13 +83,19 @@ webkit_favicon_database_error_quark        (void);
 WEBKIT_API GType
 webkit_favicon_database_get_type           (void);
 
-#if PLATFORM(GTK)
 WEBKIT_API void
 webkit_favicon_database_get_favicon        (WebKitFaviconDatabase *database,
                                             const gchar           *page_uri,
                                             GCancellable          *cancellable,
                                             GAsyncReadyCallback    callback,
                                             gpointer               user_data);
+
+#if USE(GTK4)
+WEBKIT_API GdkTexture *
+webkit_favicon_database_get_favicon_finish (WebKitFaviconDatabase *database,
+                                            GAsyncResult          *result,
+                                            GError               **error);
+#else
 WEBKIT_API cairo_surface_t *
 webkit_favicon_database_get_favicon_finish (WebKitFaviconDatabase *database,
                                             GAsyncResult          *result,

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -72,6 +72,7 @@
 #include <JavaScriptCore/JSRetainPtr.h>
 #include <WebCore/CertificateInfo.h>
 #include <WebCore/JSDOMExceptionHandling.h>
+#include <WebCore/RefPtrCairo.h>
 #include <WebCore/SharedBuffer.h>
 #include <WebCore/URLSoup.h>
 #include <glib/gi18n-lib.h>
@@ -92,6 +93,7 @@
 #include "WebKitWebInspectorPrivate.h"
 #include "WebKitWebViewBasePrivate.h"
 #include <WebCore/GUniquePtrGtk.h>
+#include <WebCore/GdkCairoUtilities.h>
 #include <WebCore/RefPtrCairo.h>
 #endif
 
@@ -316,7 +318,11 @@ struct _WebKitWebViewPrivate {
 
     GRefPtr<WebKitWebInspector> inspector;
 
+#if USE(GTK4)
+    GRefPtr<GdkTexture> favicon;
+#else
     RefPtr<cairo_surface_t> favicon;
+#endif
     GRefPtr<GCancellable> faviconCancellable;
 
     CString faviconURI;
@@ -614,7 +620,11 @@ static void enableBackForwardNavigationGesturesChanged(WebKitSettings* settings,
     webkitWebViewBaseSetEnableBackForwardNavigationGesture(WEBKIT_WEB_VIEW_BASE(webView), enable);
 }
 
+#if USE(GTK4)
+static void webkitWebViewUpdateFavicon(WebKitWebView* webView, GdkTexture* favicon)
+#else
 static void webkitWebViewUpdateFavicon(WebKitWebView* webView, cairo_surface_t* favicon)
+#endif
 {
     WebKitWebViewPrivate* priv = webView->priv;
     if (priv->favicon.get() == favicon)
@@ -630,13 +640,17 @@ static void webkitWebViewCancelFaviconRequest(WebKitWebView* webView)
         return;
 
     g_cancellable_cancel(webView->priv->faviconCancellable.get());
-    webView->priv->faviconCancellable = 0;
+    webView->priv->faviconCancellable = nullptr;
 }
 
 static void gotFaviconCallback(GObject* object, GAsyncResult* result, gpointer userData)
 {
     GUniqueOutPtr<GError> error;
+#if USE(GTK4)
+    GRefPtr<GdkTexture> favicon = adoptGRef(webkit_favicon_database_get_favicon_finish(WEBKIT_FAVICON_DATABASE(object), result, &error.outPtr()));
+#else
     RefPtr<cairo_surface_t> favicon = adoptRef(webkit_favicon_database_get_favicon_finish(WEBKIT_FAVICON_DATABASE(object), result, &error.outPtr()));
+#endif
     if (g_error_matches(error.get(), G_IO_ERROR, G_IO_ERROR_CANCELLED))
         return;
 
@@ -962,7 +976,11 @@ static void webkitWebViewGetProperty(GObject* object, guint propId, GValue* valu
         break;
 #if PLATFORM(GTK)
     case PROP_FAVICON:
+#if USE(GTK4)
+        g_value_set_object(value, webkit_web_view_get_favicon(webView));
+#else
         g_value_set_pointer(value, webkit_web_view_get_favicon(webView));
+#endif
         break;
 #endif
     case PROP_URI:
@@ -1210,10 +1228,18 @@ static void webkit_web_view_class_init(WebKitWebViewClass* webViewClass)
      * See webkit_web_view_get_favicon() for more details.
      */
     sObjProperties[PROP_FAVICON] =
+#if USE(GTK4)
+        g_param_spec_object(
+            "favicon",
+            nullptr, nullptr,
+            GDK_TYPE_TEXTURE,
+            WEBKIT_PARAM_READABLE);
+#else
         g_param_spec_pointer(
             "favicon",
             nullptr, nullptr,
             WEBKIT_PARAM_READABLE);
+#endif
 #endif
 
     /**
@@ -3564,10 +3590,14 @@ const gchar* webkit_web_view_get_uri(WebKitWebView* webView)
  * connect to notify::favicon signal of @web_view to be notified when
  * the favicon is available.
  *
- * Returns: (transfer none): a pointer to a #cairo_surface_t with the
- *    favicon or %NULL if there's no icon associated with @web_view.
+ * Returns: (transfer none): the favicon image or %NULL if there's no
+ *    icon associated with @web_view.
  */
+#if USE(GTK4)
+GdkTexture* webkit_web_view_get_favicon(WebKitWebView* webView)
+#else
 cairo_surface_t* webkit_web_view_get_favicon(WebKitWebView* webView)
+#endif
 {
     g_return_val_if_fail(WEBKIT_IS_WEB_VIEW(webView), 0);
     if (webView->priv->activeURI.isNull())
@@ -4851,14 +4881,23 @@ void webkit_web_view_get_snapshot(WebKitWebView* webView, WebKitSnapshotRegion r
  *
  * Finishes an asynchronous operation started with webkit_web_view_get_snapshot().
  *
- * Returns: (transfer full): a #cairo_surface_t with the retrieved snapshot or %NULL in error.
+ * Returns: (transfer full): an image with the retrieved snapshot, or %NULL in case of error.
  */
+#if USE(GTK4)
+GdkTexture* webkit_web_view_get_snapshot_finish(WebKitWebView* webView, GAsyncResult* result, GError** error)
+#else
 cairo_surface_t* webkit_web_view_get_snapshot_finish(WebKitWebView* webView, GAsyncResult* result, GError** error)
+#endif
 {
-    g_return_val_if_fail(WEBKIT_IS_WEB_VIEW(webView), 0);
-    g_return_val_if_fail(g_task_is_valid(result, webView), 0);
+    g_return_val_if_fail(WEBKIT_IS_WEB_VIEW(webView), nullptr);
+    g_return_val_if_fail(g_task_is_valid(result, webView), nullptr);
 
+#if USE(GTK4)
+    auto image = adoptRef(static_cast<cairo_surface_t*>(g_task_propagate_pointer(G_TASK(result), error)));
+    return image ? cairoSurfaceToGdkTexture(image.get()) : nullptr;
+#else
     return static_cast<cairo_surface_t*>(g_task_propagate_pointer(G_TASK(result), error));
+#endif
 }
 #endif
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
@@ -581,8 +581,13 @@ WEBKIT_API const gchar *
 webkit_web_view_get_uri                              (WebKitWebView             *web_view);
 
 #if PLATFORM(GTK)
+#if USE(GTK4)
+WEBKIT_API GdkTexture *
+webkit_web_view_get_favicon                          (WebKitWebView             *web_view);
+#else
 WEBKIT_API cairo_surface_t *
 webkit_web_view_get_favicon                          (WebKitWebView             *web_view);
+#endif
 #endif
 
 WEBKIT_API const gchar *
@@ -768,11 +773,17 @@ webkit_web_view_get_snapshot                         (WebKitWebView             
                                                       GCancellable              *cancellable,
                                                       GAsyncReadyCallback        callback,
                                                       gpointer                   user_data);
-
+#if USE(GTK4)
+WEBKIT_API GdkTexture *
+webkit_web_view_get_snapshot_finish                  (WebKitWebView             *web_view,
+                                                      GAsyncResult              *result,
+                                                      GError                   **error);
+#else
 WEBKIT_API cairo_surface_t *
 webkit_web_view_get_snapshot_finish                  (WebKitWebView             *web_view,
                                                       GAsyncResult              *result,
                                                       GError                   **error);
+#endif
 #endif
 
 WEBKIT_API WebKitUserContentManager *

--- a/Tools/MiniBrowser/gtk/BrowserWindow.c
+++ b/Tools/MiniBrowser/gtk/BrowserWindow.c
@@ -641,24 +641,18 @@ static void updateUriEntryIcon(BrowserWindow *window)
 static void faviconChanged(WebKitWebView *webView, GParamSpec *paramSpec, BrowserWindow *window)
 {
 #if GTK_CHECK_VERSION(3, 98, 0)
-    GdkTexture *favicon = NULL;
+    GdkTexture *favicon = webkit_web_view_get_favicon(webView);
 #else
-    GdkPixbuf *favicon = NULL;
-#endif
     cairo_surface_t *surface = webkit_web_view_get_favicon(webView);
+    GdkPixbuf *favicon = NULL;
 
     if (surface) {
         int width = cairo_image_surface_get_width(surface);
         int height = cairo_image_surface_get_height(surface);
-#if GTK_CHECK_VERSION(3, 98, 0)
-        int stride = cairo_image_surface_get_stride(surface);
-        GBytes *bytes = g_bytes_new(cairo_image_surface_get_data(surface), stride * height);
-        favicon = gdk_memory_texture_new(width, height, GDK_MEMORY_DEFAULT, bytes, stride);
-        g_bytes_unref(bytes);
-#else
+
         favicon = gdk_pixbuf_get_from_surface(surface, 0, 0, width, height);
-#endif
     }
+#endif
 
     if (window->favicon)
         g_object_unref(window->favicon);

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitFaviconDatabase.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitFaviconDatabase.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2012, 2017 Igalia S.L.
  *
@@ -54,8 +53,10 @@ public:
 
     ~FaviconDatabaseTest()
     {
+#if !USE(GTK4)
         if (m_favicon)
             cairo_surface_destroy(m_favicon);
+#endif
 
         g_signal_handlers_disconnect_matched(m_database.get(), G_SIGNAL_MATCH_DATA, 0, 0, 0, 0, this);
 #if ENABLE(2022_GLIB_API)
@@ -112,7 +113,11 @@ public:
     {
         g_assert_true(test->m_webView == webView);
         test->m_faviconNotificationReceived = true;
+#if USE(GTK4)
+        test->m_favicon = webkit_web_view_get_favicon(webView);
+#else
         test->m_favicon = cairo_surface_reference(webkit_web_view_get_favicon(webView));
+#endif
         if (test->m_loadFinished)
             test->quitMainLoop();
     }
@@ -131,7 +136,11 @@ public:
     static void getFaviconCallback(GObject* sourceObject, GAsyncResult* result, void* data)
     {
         FaviconDatabaseTest* test = static_cast<FaviconDatabaseTest*>(data);
+#if USE(GTK4)
+        test->m_favicon = adoptGRef(webkit_favicon_database_get_favicon_finish(test->m_database.get(), result, &test->m_error.outPtr()));
+#else
         test->m_favicon = webkit_favicon_database_get_favicon_finish(test->m_database.get(), result, &test->m_error.outPtr());
+#endif
         test->quitMainLoop();
     }
 
@@ -145,10 +154,11 @@ public:
 
     void waitUntilLoadFinishedAndFaviconChanged()
     {
-        if (m_favicon) {
+#if !USE(GTK4)
+        if (m_favicon)
             cairo_surface_destroy(m_favicon);
-            m_favicon = nullptr;
-        }
+#endif
+        m_favicon = nullptr;
         m_faviconNotificationReceived = false;
         m_loadFinished = false;
         unsigned long faviconChangedID = g_signal_connect(m_webView, "notify::favicon", G_CALLBACK(viewFaviconChangedCallback), this);
@@ -160,10 +170,11 @@ public:
 
     void getFaviconForPageURIAndWaitUntilReady(const char* pageURI)
     {
-        if (m_favicon) {
+#if !USE(GTK4)
+        if (m_favicon)
             cairo_surface_destroy(m_favicon);
-            m_favicon = nullptr;
-        }
+#endif
+        m_favicon = nullptr;
 
         webkit_favicon_database_get_favicon(m_database.get(), pageURI, 0, getFaviconCallback, this);
         g_main_loop_run(m_mainLoop);
@@ -179,7 +190,11 @@ public:
     }
 
     GRefPtr<WebKitFaviconDatabase> m_database;
+#if USE(GTK4)
+    GRefPtr<GdkTexture> m_favicon;
+#else
     cairo_surface_t* m_favicon { nullptr };
+#endif
     CString m_faviconURI;
     GUniqueOutPtr<GError> m_error;
     bool m_faviconNotificationReceived { false };
@@ -260,11 +275,17 @@ static void testFaviconDatabaseGetFavicon(FaviconDatabaseTest* test, gconstpoint
 
     test->getFaviconForPageURIAndWaitUntilReady(kServer->getURIForPath("/foo").data());
     g_assert_nonnull(test->m_favicon);
+#if USE(GTK4)
+    g_assert_cmpint(gdk_texture_get_width(test->m_favicon.get()), ==, 16);
+    g_assert_cmpint(gdk_texture_get_height(test->m_favicon.get()), ==, 16);
+#else
     g_assert_cmpint(cairo_image_surface_get_width(test->m_favicon), ==, 16);
     g_assert_cmpint(cairo_image_surface_get_height(test->m_favicon), ==, 16);
+#endif
     g_assert_cmpstr(test->m_faviconURI.data(), ==, faviconURI.data());
     g_assert_no_error(test->m_error.get());
 
+#if !USE(GTK4)
     // Check that another page with the same favicon returns the same icon.
     cairo_surface_t* favicon = cairo_surface_reference(test->m_favicon);
     test->loadURI(kServer->getURIForPath("/bar").data());
@@ -278,6 +299,7 @@ static void testFaviconDatabaseGetFavicon(FaviconDatabaseTest* test, gconstpoint
     g_assert_cmpstr(test->m_faviconURI.data(), ==, faviconURI.data());
     g_assert_no_error(test->m_error.get());
     cairo_surface_destroy(favicon);
+#endif
 
     faviconURI = kServer->getURIForPath("/favicon.ico");
     test->loadURI(kServer->getURIForPath("/nofavicon").data());

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebView.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebView.cpp
@@ -1065,20 +1065,68 @@ class SnapshotWebViewTest: public WebViewTest {
 public:
     MAKE_GLIB_TEST_FIXTURE(SnapshotWebViewTest);
 
-    static void onSnapshotCancelledReady(WebKitWebView* web_view, GAsyncResult* res, SnapshotWebViewTest* test)
+#if !USE(GTK4)
+    ~SnapshotWebViewTest()
+    {
+        if (m_snapshot)
+            cairo_surface_destroy(m_snapshot);
+    }
+#endif
+
+    static void onSnapshotReady(WebKitWebView* webView, GAsyncResult* result, SnapshotWebViewTest* test)
     {
         GUniqueOutPtr<GError> error;
-        test->m_surface = webkit_web_view_get_snapshot_finish(web_view, res, &error.outPtr());
-        g_assert_null(test->m_surface);
+#if USE(GTK4)
+        test->m_snapshot = adoptGRef(webkit_web_view_get_snapshot_finish(webView, result, &error.outPtr()));
+#else
+        test->m_snapshot = webkit_web_view_get_snapshot_finish(webView, result, &error.outPtr());
+#endif
+        g_assert_true(!test->m_snapshot || !error.get());
+        if (error)
+            g_assert_error(error.get(), WEBKIT_SNAPSHOT_ERROR, WEBKIT_SNAPSHOT_ERROR_FAILED_TO_CREATE);
+        test->quitMainLoop();
+    }
+
+#if USE(GTK4)
+    GdkTexture* getSnapshotAndWaitUntilReady(WebKitSnapshotRegion region, WebKitSnapshotOptions options)
+#else
+    cairo_surface_t* getSnapshotAndWaitUntilReady(WebKitSnapshotRegion region, WebKitSnapshotOptions options)
+#endif
+    {
+#if !USE(GTK4)
+        if (m_snapshot)
+            cairo_surface_destroy(m_snapshot);
+#endif
+        m_snapshot = nullptr;
+        webkit_web_view_get_snapshot(m_webView, region, options, nullptr, reinterpret_cast<GAsyncReadyCallback>(onSnapshotReady), this);
+        g_main_loop_run(m_mainLoop);
+#if USE(GTK4)
+        return m_snapshot.get();
+#else
+        return m_snapshot;
+#endif
+    }
+
+    static void onSnapshotCancelledReady(WebKitWebView* webView, GAsyncResult* result, SnapshotWebViewTest* test)
+    {
+        GUniqueOutPtr<GError> error;
+#if USE(GTK4)
+        test->m_snapshot = adoptGRef(webkit_web_view_get_snapshot_finish(webView, result, &error.outPtr()));
+#else
+        test->m_snapshot = webkit_web_view_get_snapshot_finish(webView, result, &error.outPtr());
+#endif
+        g_assert_null(test->m_snapshot);
         g_assert_error(error.get(), G_IO_ERROR, G_IO_ERROR_CANCELLED);
         test->quitMainLoop();
     }
 
     gboolean getSnapshotAndCancel()
     {
-        if (m_surface)
-            cairo_surface_destroy(m_surface);
-        m_surface = 0;
+#if !USE(GTK4)
+        if (m_snapshot)
+            cairo_surface_destroy(m_snapshot);
+#endif
+        m_snapshot = nullptr;
         GRefPtr<GCancellable> cancellable = adoptGRef(g_cancellable_new());
         webkit_web_view_get_snapshot(m_webView, WEBKIT_SNAPSHOT_REGION_VISIBLE, WEBKIT_SNAPSHOT_OPTIONS_NONE, cancellable.get(), reinterpret_cast<GAsyncReadyCallback>(onSnapshotCancelledReady), this);
         g_cancellable_cancel(cancellable.get());
@@ -1087,6 +1135,26 @@ public:
         return true;
     }
 
+#if USE(GTK4)
+    static cairo_surface_t* snapshotToSurface(GdkTexture* snapshot)
+    {
+        cairo_surface_t* surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, gdk_texture_get_width(snapshot), gdk_texture_get_height(snapshot));
+        gdk_texture_download(snapshot, cairo_image_surface_get_data(surface), cairo_image_surface_get_stride(surface));
+        cairo_surface_mark_dirty(surface);
+        return surface;
+    }
+#else
+    static cairo_surface_t* snapshotToSurface(cairo_surface_t* snapshot)
+    {
+        return cairo_surface_reference(snapshot);
+    }
+#endif
+
+#if USE(GTK4)
+    GRefPtr<GdkTexture> m_snapshot;
+#else
+    cairo_surface_t* m_snapshot { nullptr };
+#endif
 };
 
 static void testWebViewSnapshot(SnapshotWebViewTest* test, gconstpointer)
@@ -1094,45 +1162,79 @@ static void testWebViewSnapshot(SnapshotWebViewTest* test, gconstpointer)
     test->loadHtml("<html><head><style>html { width: 200px; height: 100px; } ::-webkit-scrollbar { display: none; }</style></head><body><p>Whatever</p></body></html>", nullptr);
     test->waitUntilLoadFinished();
 
-    // WEBKIT_SNAPSHOT_REGION_VISIBLE returns a null surface when the view is not visible.
-    cairo_surface_t* surface1 = test->getSnapshotAndWaitUntilReady(WEBKIT_SNAPSHOT_REGION_VISIBLE, WEBKIT_SNAPSHOT_OPTIONS_NONE);
-    g_assert_null(surface1);
+    // WEBKIT_SNAPSHOT_REGION_VISIBLE returns a null snapshot when the view is not visible.
+    auto* snapshot1 = test->getSnapshotAndWaitUntilReady(WEBKIT_SNAPSHOT_REGION_VISIBLE, WEBKIT_SNAPSHOT_OPTIONS_NONE);
+    g_assert_null(snapshot1);
 
     // WEBKIT_SNAPSHOT_REGION_FULL_DOCUMENT works even if the window is not visible.
-    surface1 = test->getSnapshotAndWaitUntilReady(WEBKIT_SNAPSHOT_REGION_FULL_DOCUMENT, WEBKIT_SNAPSHOT_OPTIONS_NONE);
-    g_assert_nonnull(surface1);
-    g_assert_cmpuint(cairo_surface_get_type(surface1), ==, CAIRO_SURFACE_TYPE_IMAGE);
-    g_assert_cmpint(cairo_image_surface_get_width(surface1), ==, 200);
-    g_assert_cmpint(cairo_image_surface_get_height(surface1), ==, 100);
+    snapshot1 = test->getSnapshotAndWaitUntilReady(WEBKIT_SNAPSHOT_REGION_FULL_DOCUMENT, WEBKIT_SNAPSHOT_OPTIONS_NONE);
+    g_assert_nonnull(snapshot1);
+#if USE(GTK4)
+    g_assert_true(GDK_IS_MEMORY_TEXTURE(snapshot1));
+    g_assert_cmpint(gdk_texture_get_width(snapshot1), ==, 200);
+    g_assert_cmpint(gdk_texture_get_height(snapshot1), ==, 100);
+#else
+    g_assert_cmpuint(cairo_surface_get_type(snapshot1), ==, CAIRO_SURFACE_TYPE_IMAGE);
+    g_assert_cmpint(cairo_image_surface_get_width(snapshot1), ==, 200);
+    g_assert_cmpint(cairo_image_surface_get_height(snapshot1), ==, 100);
+#endif
 
     // Show the WebView in a popup widow of 50x50 and try again with WEBKIT_SNAPSHOT_REGION_VISIBLE.
     test->showInWindow(50, 50);
-    surface1 = cairo_surface_reference(test->getSnapshotAndWaitUntilReady(WEBKIT_SNAPSHOT_REGION_VISIBLE, WEBKIT_SNAPSHOT_OPTIONS_NONE));
-    g_assert_nonnull(surface1);
-    g_assert_cmpuint(cairo_surface_get_type(surface1), ==, CAIRO_SURFACE_TYPE_IMAGE);
-    g_assert_cmpint(cairo_image_surface_get_width(surface1), ==, 50);
-    g_assert_cmpint(cairo_image_surface_get_height(surface1), ==, 50);
+    snapshot1 = test->getSnapshotAndWaitUntilReady(WEBKIT_SNAPSHOT_REGION_VISIBLE, WEBKIT_SNAPSHOT_OPTIONS_NONE);
+    g_assert_nonnull(snapshot1);
+    auto* surface1 = SnapshotWebViewTest::snapshotToSurface(snapshot1);
+#if USE(GTK4)
+    GRefPtr<GdkTexture> protectSnapshot1 = snapshot1;
+    g_assert_true(GDK_IS_MEMORY_TEXTURE(snapshot1));
+    g_assert_cmpint(gdk_texture_get_width(snapshot1), ==, 50);
+    g_assert_cmpint(gdk_texture_get_height(snapshot1), ==, 50);
+#else
+    g_assert_cmpuint(cairo_surface_get_type(snapshot1), ==, CAIRO_SURFACE_TYPE_IMAGE);
+    g_assert_cmpint(cairo_image_surface_get_width(snapshot1), ==, 50);
+    g_assert_cmpint(cairo_image_surface_get_height(snapshot1), ==, 50);
+#endif
 
     // Select all text in the WebView, request a snapshot ignoring selection.
     test->selectAll();
-    cairo_surface_t* surface2 = test->getSnapshotAndWaitUntilReady(WEBKIT_SNAPSHOT_REGION_VISIBLE, WEBKIT_SNAPSHOT_OPTIONS_NONE);
-    g_assert_nonnull(surface2);
+    auto* snapshot2 = test->getSnapshotAndWaitUntilReady(WEBKIT_SNAPSHOT_REGION_VISIBLE, WEBKIT_SNAPSHOT_OPTIONS_NONE);
+    g_assert_nonnull(snapshot2);
+    auto* surface2 = SnapshotWebViewTest::snapshotToSurface(snapshot2);
     g_assert_true(Test::cairoSurfacesEqual(surface1, surface2));
+    cairo_surface_destroy(surface2);
 
     // Request a new snapshot, including the selection this time. The size should be the same but the result
     // must be different to the one previously obtained.
-    surface2 = test->getSnapshotAndWaitUntilReady(WEBKIT_SNAPSHOT_REGION_VISIBLE, WEBKIT_SNAPSHOT_OPTIONS_INCLUDE_SELECTION_HIGHLIGHTING);
-    g_assert_cmpuint(cairo_surface_get_type(surface2), ==, CAIRO_SURFACE_TYPE_IMAGE);
-    g_assert_cmpint(cairo_image_surface_get_width(surface1), ==, cairo_image_surface_get_width(surface2));
-    g_assert_cmpint(cairo_image_surface_get_height(surface1), ==, cairo_image_surface_get_height(surface2));
+    snapshot2 = test->getSnapshotAndWaitUntilReady(WEBKIT_SNAPSHOT_REGION_VISIBLE, WEBKIT_SNAPSHOT_OPTIONS_INCLUDE_SELECTION_HIGHLIGHTING);
+    g_assert_nonnull(snapshot2);
+    surface2 = SnapshotWebViewTest::snapshotToSurface(snapshot2);
+#if USE(GTK4)
+    g_assert_true(GDK_IS_MEMORY_TEXTURE(snapshot2));
+    g_assert_cmpint(gdk_texture_get_width(snapshot1), ==, gdk_texture_get_width(snapshot2));
+    g_assert_cmpint(gdk_texture_get_height(snapshot1), ==, gdk_texture_get_height(snapshot2));
+#else
+    g_assert_cmpuint(cairo_surface_get_type(snapshot2), ==, CAIRO_SURFACE_TYPE_IMAGE);
+    g_assert_cmpint(cairo_image_surface_get_width(snapshot1), ==, cairo_image_surface_get_width(snapshot2));
+    g_assert_cmpint(cairo_image_surface_get_height(snapshot1), ==, cairo_image_surface_get_height(snapshot2));
+#endif
     g_assert_false(Test::cairoSurfacesEqual(surface1, surface2));
+    cairo_surface_destroy(surface2);
 
     // Get a snpashot with a transparent background, the result must be different.
-    surface2 = test->getSnapshotAndWaitUntilReady(WEBKIT_SNAPSHOT_REGION_VISIBLE, WEBKIT_SNAPSHOT_OPTIONS_TRANSPARENT_BACKGROUND);
-    g_assert_cmpuint(cairo_surface_get_type(surface2), ==, CAIRO_SURFACE_TYPE_IMAGE);
-    g_assert_cmpint(cairo_image_surface_get_width(surface1), ==, cairo_image_surface_get_width(surface2));
-    g_assert_cmpint(cairo_image_surface_get_height(surface1), ==, cairo_image_surface_get_height(surface2));
+    snapshot2 = test->getSnapshotAndWaitUntilReady(WEBKIT_SNAPSHOT_REGION_VISIBLE, WEBKIT_SNAPSHOT_OPTIONS_TRANSPARENT_BACKGROUND);
+    g_assert_nonnull(snapshot2);
+    surface2 = SnapshotWebViewTest::snapshotToSurface(snapshot2);
+#if USE(GTK4)
+    g_assert_true(GDK_IS_MEMORY_TEXTURE(snapshot2));
+    g_assert_cmpint(gdk_texture_get_width(snapshot1), ==, gdk_texture_get_width(snapshot2));
+    g_assert_cmpint(gdk_texture_get_height(snapshot1), ==, gdk_texture_get_height(snapshot2));
+#else
+    g_assert_cmpuint(cairo_surface_get_type(snapshot2), ==, CAIRO_SURFACE_TYPE_IMAGE);
+    g_assert_cmpint(cairo_image_surface_get_width(snapshot1), ==, cairo_image_surface_get_width(snapshot2));
+    g_assert_cmpint(cairo_image_surface_get_height(snapshot1), ==, cairo_image_surface_get_height(snapshot2));
+#endif
     g_assert_false(Test::cairoSurfacesEqual(surface1, surface2));
+    cairo_surface_destroy(surface2);
     cairo_surface_destroy(surface1);
 
     // Test that cancellation works.

--- a/Tools/TestWebKitAPI/glib/WebKitGLib/WebViewTest.cpp
+++ b/Tools/TestWebKitAPI/glib/WebKitGLib/WebViewTest.cpp
@@ -41,8 +41,6 @@ WebViewTest::~WebViewTest()
     platformDestroy();
     if (m_javascriptResult)
         webkit_javascript_result_unref(m_javascriptResult);
-    if (m_surface)
-        cairo_surface_destroy(m_surface);
     s_dbusConnectionPageMap.remove(webkit_web_view_get_page_id(m_webView));
     g_object_unref(m_webView);
     g_main_loop_unref(m_mainLoop);
@@ -439,28 +437,6 @@ bool WebViewTest::javascriptResultIsUndefined(WebKitJavascriptResult* javascript
     g_assert_true(JSC_IS_VALUE(value));
     return jsc_value_is_undefined(value);
 }
-
-#if PLATFORM(GTK)
-static void onSnapshotReady(WebKitWebView* web_view, GAsyncResult* res, WebViewTest* test)
-{
-    GUniqueOutPtr<GError> error;
-    test->m_surface = webkit_web_view_get_snapshot_finish(web_view, res, &error.outPtr());
-    g_assert_true(!test->m_surface || !error.get());
-    if (error)
-        g_assert_error(error.get(), WEBKIT_SNAPSHOT_ERROR, WEBKIT_SNAPSHOT_ERROR_FAILED_TO_CREATE);
-    test->quitMainLoop();
-}
-
-cairo_surface_t* WebViewTest::getSnapshotAndWaitUntilReady(WebKitSnapshotRegion region, WebKitSnapshotOptions options)
-{
-    if (m_surface)
-        cairo_surface_destroy(m_surface);
-    m_surface = 0;
-    webkit_web_view_get_snapshot(m_webView, region, options, 0, reinterpret_cast<GAsyncReadyCallback>(onSnapshotReady), this);
-    g_main_loop_run(m_mainLoop);
-    return m_surface;
-}
-#endif
 
 bool WebViewTest::runWebProcessTest(const char* suiteName, const char* testName, const char* contents, const char* contentType)
 {

--- a/Tools/TestWebKitAPI/glib/WebKitGLib/WebViewTest.h
+++ b/Tools/TestWebKitAPI/glib/WebKitGLib/WebViewTest.h
@@ -111,7 +111,6 @@ public:
     GError** m_javascriptError { nullptr };
     GUniquePtr<char> m_resourceData { nullptr };
     size_t m_resourceDataSize { 0 };
-    cairo_surface_t* m_surface { nullptr };
     bool m_expectedWebProcessCrash { false };
 
 #if PLATFORM(GTK)


### PR DESCRIPTION
#### d15c97f78b0303aabe2cecbb9e1e7f67ab69a028
<pre>
[GTK4] Make favicon and snapshot API use GdkTexture instead of cairo surfaces
<a href="https://bugs.webkit.org/show_bug.cgi?id=226333">https://bugs.webkit.org/show_bug.cgi?id=226333</a>

Reviewed by Adrian Perez de Castro.

* Source/WebCore/PlatformGTK.cmake:
* Source/WebCore/platform/graphics/gtk/GdkCairoUtilities.cpp:
(WebCore::cairoSurfaceToGdkTexture):
* Source/WebCore/platform/graphics/gtk/GdkCairoUtilities.h:
* Source/WebCore/platform/graphics/gtk/ImageGtk.cpp:
(WebCore::BitmapImage::gdkTexture):
* Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp:
(webkitFaviconDatabaseSetIconForPageURL):
(webkit_favicon_database_get_favicon_finish):
* Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(webkitWebViewUpdateFavicon):
(webkitWebViewCancelFaviconRequest):
(gotFaviconCallback):
(webkitWebViewGetProperty):
(webkit_web_view_class_init):
(webkit_web_view_get_favicon):
* Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in:
* Tools/MiniBrowser/gtk/BrowserWindow.c:
(faviconChanged):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitFaviconDatabase.cpp:
(testFaviconDatabaseGetFavicon):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitFindController.cpp:
(testFindControllerHide):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebView.cpp:
(testWebViewSnapshot):
* Tools/TestWebKitAPI/glib/WebKitGLib/WebViewTest.cpp:
(WebViewTest::~WebViewTest):
(onSnapshotReady): Deleted.
(WebViewTest::getSnapshotAndWaitUntilReady): Deleted.
* Tools/TestWebKitAPI/glib/WebKitGLib/WebViewTest.h:

Canonical link: <a href="https://commits.webkit.org/259997@main">https://commits.webkit.org/259997@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca9517266cad4f181001645e21d056d5e40092b1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106536 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15552 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39345 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115721 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115366 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110445 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17047 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6780 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98728 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112304 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95921 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40508 "Passed tests") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27565 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82231 "Found 1 new API test failure: /WebKitGTK/TestDownloads:/webkit/Downloads/local-file-error (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8781 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28917 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9324 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5636 "Found 1 new test failure: fast/text/glyph-display-lists/glyph-display-list-scaled-unshared.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14940 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48465 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10862 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3718 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->