### PR TITLE
SVG text selection has bugs with collapsed whitespace

### DIFF
--- a/LayoutTests/svg/text/resources/SelectionTestCase.js
+++ b/LayoutTests/svg/text/resources/SelectionTestCase.js
@@ -63,16 +63,16 @@ function selectRange(id, start, end, expectedText) {
 
     if (window.eventSender) {
         // Trigger 'partial glyph selection' code, by adjusting the end x position by half glyph width
-        var xOld = endPos.x;
+        var xOldStart = startPos.x;
+        var xOldEnd = endPos.x;
         endPos.x -= endExtent.width / 2 - 1;
-
-        var absStartPos = toAbsoluteCoordinates(startPos, element);
-        var absEndPos = toAbsoluteCoordinates(endPos, element);
 
         // Round the points "inwards" to avoid being affected by the truncation taking place in 
         // eventSender.mouseMoveTo(...).
-        absStartPos.x = Math.ceil(absStartPos.x);
-        absEndPos.x = Math.floor(absEndPos.x);
+        startPos.x = Math.ceil(startPos.x);
+
+        var absStartPos = toAbsoluteCoordinates(startPos, element);
+        var absEndPos = toAbsoluteCoordinates(endPos, element);
 
         // Move to selection origin and hold down mouse
         eventSender.mouseMoveTo(absStartPos.x, absStartPos.y);
@@ -85,7 +85,8 @@ function selectRange(id, start, end, expectedText) {
         eventSender.mouseMoveTo(absEndPos.x, absEndPos.y);
         eventSender.mouseUp();
 
-        endPos.x = xOld;
+        startPos.x = xOldStart;
+        endPos.x = xOldEnd;
     }
 
     // Mark start position using a green line

--- a/LayoutTests/svg/text/select-svg-text-with-collapsed-whitespace-expected.txt
+++ b/LayoutTests/svg/text/select-svg-text-with-collapsed-whitespace-expected.txt
@@ -1,0 +1,8 @@
+This test checks that characters can be selected correctly with collapsed whitespace.
+happy debugging !!
+happy debugging !!
+happy debugging !!
+happy debugging !!
+
+PASS Test for selection with collapsed whitespace
+

--- a/LayoutTests/svg/text/select-svg-text-with-collapsed-whitespace.html
+++ b/LayoutTests/svg/text/select-svg-text-with-collapsed-whitespace.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<title>Test for selection with collapsed whitespace</title>
+<body>
+This test checks that characters can be selected correctly with collapsed whitespace.
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="300" height="300">
+  <text id="text1" x="20" y="20">     happy           debugging       !!</text>
+  <text id="text2" x="20" y="40">     <tspan id="tspan1" style="font-weight: bold;">happy</tspan>           debugging       !!</text>
+  <text id="text3" x="20" y="80">     <tspan id="tspan2" style="font-size: 25px;">happy</tspan>          debugging       !!</text>
+  <text id="text4" x="20" y="230" fill="black" transform="scale(0.5)" font-size="40">     happy           debugging       !!</text>
+</svg>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="resources/SelectionTestCase.js"></script>
+<script>
+test(function() {
+  selectText('text1', 0, 3);
+  verify(5, 9);
+
+  selectText('text1', 0, 8);
+  verify(5, 24);
+
+  selectText('text1', 4, 9);
+  verify(9, 25);
+
+  selectText('text2', 0, 3);
+  verify(0, 4);
+
+  selectText('text2', 0, 8);
+  verify(0, 14);
+
+  selectText('text2', 3, 9);
+  verify(3, 15);
+
+  selectText('text3', 0, 3);
+  verify(0, 4);
+
+  selectText('text3', 0, 10);
+  verify(0, 15);
+
+  selectText('text3', 2, 14);
+  verify(2, 19);
+
+  selectText('text4', 0, 3);
+  verify(5, 9);
+
+  selectText('text4', 0, 8);
+  verify(5, 24);
+
+  selectText('text4', 6, 11);
+  verify(21, 27)
+
+  function verify(start, end) {
+    var range = window.getSelection().getRangeAt(0);
+    assert_equals(range.startOffset, start);
+    assert_equals(range.endOffset, end);
+    if (window.eventSender) {
+      eventSender.mouseMoveTo(0,0);
+      eventSender.mouseDown();
+      eventSender.mouseUp();
+    }
+  }
+
+  function selectText(id, start, end) {
+    var element = document.getElementById(id);
+    var startPos = element.getStartPositionOfChar(start);
+    var endPos = element.getEndPositionOfChar(end);
+    var absStartPos = toAbsoluteCoordinates(startPos, element);
+    var absEndPos = toAbsoluteCoordinates(endPos, element);
+    if (window.eventSender) {
+      eventSender.mouseMoveTo(absStartPos.x, absStartPos.y);
+      eventSender.mouseDown();
+      eventSender.mouseMoveTo(absEndPos.x, absEndPos.y);
+      eventSender.mouseUp();
+    }
+  }
+});
+</script>


### PR DESCRIPTION
<pre>
SVG text selection has bugs with collapsed whitespace
<a href="https://bugs.webkit.org/show_bug.cgi?id=248357">https://bugs.webkit.org/show_bug.cgi?id=248357</a>
rdar://problem/102933142

Reviewed by NOBODY (OOPS!).

Merge - <a href="https://src.chromium.org/viewvc/blink?view=revision&revision=194860">https://src.chromium.org/viewvc/blink?view=revision&revision=194860</a> &
<a href="https://src.chromium.org/viewvc/blink?revision=194744&view=revision">https://src.chromium.org/viewvc/blink?revision=194744&view=revision</a>

This patch introduces helper function 'squaredDistanceToClosestPoint' to calculate the closestPoint distance
and later leverages on to fix SVG text selection bug with collapsed whitespace.
This patch also update 'SelectionTestCase.js' to fix mouse position because of coordinate truncation in 'mouseMoveTo'.

* Source/WebCore/rendering/svg/RenderSVGInlineText.cpp:
(squaredDistanceToClosestPoint): Helper function
(RenderSVGInlineText::positionForPoint):
(1) Add ASSERT on m_scalingFactor
(2) Use 'm_scalingFactor' to divide baseline
(3) Calculate 'distance' based on helper function and update 'if' clause as well
* LayoutTests/svg/text/resources/SelectionTestCases.js: Update to adjust for mouse position event if 'eventSender' truncates coordinates
* LayoutTests/svg/text/select-svg-text-with-collapsed-whitespace.html: Add Test Case
* LayoutTests/svg/texst/select-svg-text-with-collapsed-whitespace-expected.txt: Add Test Case Expectation
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37dc81cfa7c71e0e1ffe10ca3437c4e434f8df90

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106544 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15560 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39353 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115729 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115372 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110453 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17055 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6788 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98736 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112312 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12957 "Found 3 new test failures: fast/dynamic/create-renderer-for-whitespace-only-text.html, http/tests/site-isolation/basic-iframe.html, svg/text/select-svg-text-with-collapsed-whitespace.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95929 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40522 "Found 1 new test failure: svg/text/select-svg-text-with-collapsed-whitespace.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94833 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27573 "Found 2 new test failures: svg/text/select-svg-text-with-collapsed-whitespace.html, svg/text/select-textLength-spacingAndGlyphs-squeeze-3.svg (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82242 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8789 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28925 "Found 4 new test failures: pageoverlay/overlay-small-frame-mouse-events.html, pageoverlay/overlay-small-frame-paints.html, svg/text/select-svg-text-with-collapsed-whitespace.html, svg/text/select-textLength-spacingAndGlyphs-squeeze-3.svg (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9331 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5701 "Found 2 new test failures: svg/text/select-svg-text-with-collapsed-whitespace.html, svg/text/select-textLength-spacingAndGlyphs-squeeze-3.svg (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14948 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48473 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10870 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->