### PR TITLE
Pin wasmMemoryBasePointer on BBQ/ARM

### DIFF
--- a/Source/JavaScriptCore/jit/GPRInfo.h
+++ b/Source/JavaScriptCore/jit/GPRInfo.h
@@ -593,7 +593,7 @@ public:
     static constexpr GPRReg wasmScratchGPR0 = regT5;
     static constexpr GPRReg wasmScratchGPR1 = regT6;
     static constexpr GPRReg wasmContextInstancePointer = regCS0;
-    static constexpr GPRReg wasmBaseMemoryPointer = InvalidGPRReg;
+    static constexpr GPRReg wasmBaseMemoryPointer = ARMRegisters::r9;
     static constexpr GPRReg wasmBoundsCheckingSizeRegister = InvalidGPRReg;
 
     static GPRReg toRegister(unsigned index)

--- a/Source/JavaScriptCore/llint/WebAssembly.asm
+++ b/Source/JavaScriptCore/llint/WebAssembly.asm
@@ -54,7 +54,7 @@ if X86_64 or ARM64 or ARM64E or RISCV64
     const boundsCheckingSize = csr4
 elsif ARMv7
     const wasmInstance = csr0
-    const memoryBase = invalidGPR
+    const memoryBase = t7
     const boundsCheckingSize = invalidGPR
 else
     error
@@ -188,6 +188,10 @@ end
 
             restoreCalleeSavesUsedByWasm()
             restoreCallerPCAndCFR()
+if ARMv7
+            # BBQ pins baseMemory in t7, so reload it just before tiering up.
+            reloadMemoryRegistersFromInstance(wasmInstance, ws0, ws1)
+end
             if ARM64E
                 leap _g_config, ws1
                 jmp JSCConfigGateMapOffset + (constexpr Gate::wasmOSREntry) * PtrSize[ws1], NativeToJITGatePtrTag # WasmEntryPtrTag
@@ -214,6 +218,10 @@ macro checkSwitchToJITForLoop()
             btpz r1, .recover
             restoreCalleeSavesUsedByWasm()
             restoreCallerPCAndCFR()
+if ARMv7
+            # BBQ pins baseMemory in t7, so reload it just before tiering up.
+            reloadMemoryRegistersFromInstance(wasmInstance, ws0, ws1)
+end
             move r0, a0
             if ARM64E
                 move r1, ws0
@@ -321,6 +329,8 @@ if not ARMv7
     loadp Wasm::Instance::m_cachedMemory[instance], memoryBase
     loadp Wasm::Instance::m_cachedBoundsCheckingSize[instance], boundsCheckingSize
     cagedPrimitiveMayBeNull(memoryBase, boundsCheckingSize, scratch1, scratch2) # If boundsCheckingSize is 0, pointer can be a nullptr.
+else
+    loadp Wasm::Instance::m_cachedMemory[instance], memoryBase
 end
 end
 
@@ -366,7 +376,6 @@ macro wasmPrologue()
     # Set up the call frame and check if we should OSR.
     preserveCallerPCAndCFR()
     preserveCalleeSavesUsedByWasm()
-    reloadMemoryRegistersFromInstance(wasmInstance, ws0, ws1)
 
     storep wasmInstance, CodeBlock[cfr]
     loadp Callee[cfr], ws0
@@ -442,6 +451,7 @@ end
     storep 0, [ws0, ws1]
     btpnz ws1, .zeroInitializeLocalsLoop
 .zeroInitializeLocalsDone:
+    reloadMemoryRegistersFromInstance(wasmInstance, ws0, ws1)
 end
 
 macro forEachVectorArgument(fn)
@@ -736,6 +746,10 @@ macro jump(ctx, target)
 end
 
 macro doReturn()
+if ARMv7
+    # ARMv7 pins baseMemory on BBQ, but not in llint.
+    reloadMemoryRegistersFromInstance(wasmInstance, ws0, ws1)
+end
     restoreCalleeSavesUsedByWasm()
     restoreCallerPCAndCFR()
     if ARM64E

--- a/Source/JavaScriptCore/wasm/WasmAirIRGenerator32_64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmAirIRGenerator32_64.cpp
@@ -156,7 +156,7 @@ public:
 
     static constexpr bool tierSupportsSIMD = false;
     static constexpr bool generatesB3OriginData = false;
-    static constexpr bool supportsPinnedStateRegisters = false;
+    static constexpr bool supportsPinnedBoundsCheckingSizeRegister = false;
 
     bool useSignalingMemory() const { return false; }
 
@@ -523,9 +523,6 @@ auto AirIRGenerator32::addRefIsNull(ExpressionType value, ExpressionType& result
 
 auto AirIRGenerator32::emitCheckAndPreparePointer(ExpressionType pointer, uint32_t offset, uint32_t sizeOfOperation) -> ExpressionType
 {
-    auto memoryBase = gPtr();
-    append(Move, Arg::addr(instanceValue(), Instance::offsetOfCachedMemory()), memoryBase);
-
     auto result = gPtr();
     append(Move32, pointer, result);
 
@@ -569,7 +566,7 @@ auto AirIRGenerator32::emitCheckAndPreparePointer(ExpressionType pointer, uint32
     }
     }
 
-    append(AddPtr, memoryBase, result);
+    append(AddPtr, Tmp(GPRInfo::wasmBaseMemoryPointer), result);
     return result;
 }
 inline bool isFPLoadOp(LoadOpType op)

--- a/Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp
@@ -96,7 +96,7 @@ public:
 
     static constexpr bool tierSupportsSIMD = true;
     static constexpr bool generatesB3OriginData = true;
-    static constexpr bool supportsPinnedStateRegisters = true;
+    static constexpr bool supportsPinnedBoundsCheckingSizeRegister = true;
 
     void emitMaterializeConstant(Type, uint64_t value, TypedTmp& dest);
     void emitMaterializeConstant(BasicBlock*, Type, uint64_t value, TypedTmp& dest);

--- a/Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h
+++ b/Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h
@@ -937,7 +937,7 @@ public:
     ////////////////////////////////////////////////////////////////////////////////
     // parameters for shared code
     static constexpr bool generatesB3OriginData = true;
-    static constexpr bool supportsPinnedStateRegisters = true;
+    static constexpr bool supportsPinnedBoundsCheckingSizeRegister = true;
 };
 
 // Memory accesses in WebAssembly have unsigned 32-bit offsets, whereas they have signed 32-bit offsets in B3.
@@ -992,12 +992,12 @@ AirIRGeneratorBase<Derived, ExpressionType>::AirIRGeneratorBase(const ModuleInfo
     // FIXME we don't really need to pin registers here if there's no memory. It makes wasm -> wasm thunks simpler for now. https://bugs.webkit.org/show_bug.cgi?id=166623
     m_code.pinRegister(GPRInfo::wasmContextInstancePointer);
 
-    if constexpr (Derived::supportsPinnedStateRegisters) {
-        m_code.pinRegister(GPRInfo::wasmBaseMemoryPointer);
+    m_code.pinRegister(GPRInfo::wasmBaseMemoryPointer);
+
+    if constexpr (Derived::supportsPinnedBoundsCheckingSizeRegister) {
         if (mode == MemoryMode::BoundsChecking)
             m_code.pinRegister(GPRInfo::wasmBoundsCheckingSizeRegister);
     } else {
-        ASSERT(InvalidGPRReg == GPRInfo::wasmBaseMemoryPointer);
         ASSERT(InvalidGPRReg == GPRInfo::wasmBoundsCheckingSizeRegister);
     }
 
@@ -1144,10 +1144,11 @@ void AirIRGeneratorBase<Derived, ExpressionType>::restoreWebAssemblyGlobalState(
 {
     restoreWasmContextInstance(block, instance);
 
-    if (!!memory && Derived::supportsPinnedStateRegisters) {
+    if (!!memory) {
         RegisterSetBuilder clobbers;
         clobbers.add(GPRInfo::wasmBaseMemoryPointer, IgnoreVectors);
-        clobbers.add(GPRInfo::wasmBoundsCheckingSizeRegister, IgnoreVectors);
+        if (Derived::supportsPinnedBoundsCheckingSizeRegister)
+            clobbers.add(GPRInfo::wasmBoundsCheckingSizeRegister, IgnoreVectors);
         clobbers.merge(RegisterSetBuilder::macroClobberedRegisters());
 
         auto* patchpoint = addPatchpoint(B3::Void);
@@ -1161,8 +1162,11 @@ void AirIRGeneratorBase<Derived, ExpressionType>::restoreWebAssemblyGlobalState(
         patchpoint->setGenerator([](CCallHelpers& jit, const B3::StackmapGenerationParams& params) {
             AllowMacroScratchRegisterUsage allowScratch(jit);
             GPRReg scratch = params.gpScratch(0);
-            jit.loadPairPtr(params[0].gpr(), CCallHelpers::TrustedImm32(Instance::offsetOfCachedMemory()), GPRInfo::wasmBaseMemoryPointer, GPRInfo::wasmBoundsCheckingSizeRegister);
-            jit.cageConditionallyAndUntag(Gigacage::Primitive, GPRInfo::wasmBaseMemoryPointer, GPRInfo::wasmBoundsCheckingSizeRegister, scratch, /* validateAuth */ true, /* mayBeNull */ false);
+            if (Derived::supportsPinnedBoundsCheckingSizeRegister) {
+                jit.loadPairPtr(params[0].gpr(), CCallHelpers::TrustedImm32(Instance::offsetOfCachedMemory()), GPRInfo::wasmBaseMemoryPointer, GPRInfo::wasmBoundsCheckingSizeRegister);
+                jit.cageConditionallyAndUntag(Gigacage::Primitive, GPRInfo::wasmBaseMemoryPointer, GPRInfo::wasmBoundsCheckingSizeRegister, scratch, /* validateAuth */ true, /* mayBeNull */ false);
+            } else
+                jit.loadPtr(CCallHelpers::Address(params[0].gpr(), Instance::offsetOfCachedMemory()), GPRInfo::wasmBaseMemoryPointer);
         });
 
         emitPatchpoint(block, patchpoint, ExpressionType(), instance);
@@ -3409,14 +3413,15 @@ auto AirIRGeneratorBase<Derived, ExpressionType>::emitIndirectCall(ExpressionTyp
             UNUSED_PARAM(scratch);
             jit.storeWasmContextInstance(calleeInstance);
 
-            if constexpr (Derived::supportsPinnedStateRegisters) {
+            if constexpr (Derived::supportsPinnedBoundsCheckingSizeRegister) {
                 // FIXME: We should support more than one memory size register
                 //   see: https://bugs.webkit.org/show_bug.cgi?id=162952
                 ASSERT(GPRInfo::wasmBoundsCheckingSizeRegister != calleeInstance);
                 ASSERT(GPRInfo::wasmBaseMemoryPointer != calleeInstance);
                 jit.loadPairPtr(calleeInstance, CCallHelpers::TrustedImm32(Instance::offsetOfCachedMemory()), GPRInfo::wasmBaseMemoryPointer, GPRInfo::wasmBoundsCheckingSizeRegister);
                 jit.cageConditionallyAndUntag(Gigacage::Primitive, GPRInfo::wasmBaseMemoryPointer, GPRInfo::wasmBoundsCheckingSizeRegister, scratch, /* validateAuth */ true, /* mayBeNull */ false);
-            }
+            } else
+                jit.loadPtr(CCallHelpers::Address(calleeInstance, Instance::offsetOfCachedMemory()), GPRInfo::wasmBaseMemoryPointer);
         });
 
         emitPatchpoint(doContextSwitch, patchpoint, ExpressionType(), calleeInstance);

--- a/Source/JavaScriptCore/wasm/WasmBinding.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBinding.cpp
@@ -55,7 +55,9 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToWasm(unsi
     // This switches the current instance.
     jit.loadPtr(JIT::Address(GPRInfo::wasmContextInstancePointer, Instance::offsetOfTargetInstance(importIndex)), GPRInfo::wasmContextInstancePointer); // Instance*.
 
-#if !CPU(ARM) // ARM has no pinned registers for Wasm Memory, so no need to set them up
+#if CPU(ARM) // ARM has only pins memoryBase, so we need to set up the bounds checking register
+    jit.loadPtr(CCallHelpers::Address(GPRInfo::wasmContextInstancePointer, Wasm::Instance::offsetOfCachedMemory()), GPRInfo::wasmBaseMemoryPointer);
+#else
     // FIXME the following code assumes that all Wasm::Instance have the same pinned registers. https://bugs.webkit.org/show_bug.cgi?id=162952
     // Set up the callee's baseMemoryPointer register as well as the memory size registers.
     {

--- a/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
@@ -325,7 +325,10 @@ std::unique_ptr<InternalFunction> createJSToWasmWrapper(CCallHelpers& jit, Calle
         }
     }
 
-#if !CPU(ARM) // ARM has no pinned registers for Wasm Memory, so no need to set them up
+#if CPU(ARM) // ARM has only pins baseMemory
+    if (!!info.memory)
+        jit.loadPtr(CCallHelpers::Address(GPRInfo::wasmContextInstancePointer, Wasm::Instance::offsetOfCachedMemory()), GPRInfo::wasmBaseMemoryPointer);
+#else
     if (!!info.memory) {
         GPRReg size = wasmCallingConvention().prologueScratchGPRs[0];
         GPRReg scratch = wasmCallingConvention().prologueScratchGPRs[1];

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
@@ -357,7 +357,10 @@ CodePtr<JSEntryPtrTag> WebAssemblyFunction::jsCallEntrypointSlow()
 
     jit.move(CCallHelpers::TrustedImmPtr(&instance()->instance()), GPRInfo::wasmContextInstancePointer);
 
-#if !CPU(ARM) // ARM has no pinned registers for Wasm Memory, so no need to set them up
+#if CPU(ARM) // ARM only pins baseMemory
+    if (!!instance()->instance().module().moduleInformation().memory)
+        jit.loadPtr(CCallHelpers::Address(GPRInfo::wasmContextInstancePointer, Wasm::Instance::offsetOfCachedMemory()), GPRInfo::wasmBaseMemoryPointer);
+#else
     if (!!instance()->instance().module().moduleInformation().memory) {
         auto mode = instance()->memoryMode();
         if (mode == MemoryMode::Signaling || (mode == MemoryMode::BoundsChecking && instance()->instance().memory()->sharingMode() == MemorySharingMode::Shared)) {


### PR DESCRIPTION
#### 5769bc3265c227a4d3a863712e70fa907e0571f4
<pre>
Pin wasmMemoryBasePointer on BBQ/ARM
<a href="https://bugs.webkit.org/show_bug.cgi?id=251845">https://bugs.webkit.org/show_bug.cgi?id=251845</a>

Reviewed by NOBODY (OOPS!).

We have enough registers to pin the wasm base memory value (but not the bounds
checking size) on BBQ for ARM. We don&apos;t have enough registers to do the same on
llint. This also means that we need to be careful about loading
wasmBaseMemoryPointer; t7 can be used as a temporary at virtually any point in
the llint code, so we call reloadMemoryRegistersFromInstance as the last thing
we do before switching to the BBQ code.

This results in a 0.7% (statistically significant) improvement on the wasm parts
of JetStream2 (i.e. wasm-cli.js) on ARM.

* Source/JavaScriptCore/jit/GPRInfo.h:
* Source/JavaScriptCore/llint/WebAssembly.asm:
* Source/JavaScriptCore/wasm/WasmAirIRGenerator32_64.cpp:
(JSC::Wasm::AirIRGenerator32::emitCheckAndPreparePointer):
* Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp:
* Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h:
(JSC::Wasm::ExpressionType&gt;::AirIRGeneratorBase):
(JSC::Wasm::ExpressionType&gt;::restoreWebAssemblyGlobalState):
(JSC::Wasm::ExpressionType&gt;::emitIndirectCall):
* Source/JavaScriptCore/wasm/WasmBinding.cpp:
(JSC::Wasm::wasmToWasm):
* Source/JavaScriptCore/wasm/js/JSToWasm.cpp:
(JSC::Wasm::createJSToWasmWrapper):
* Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp:
(JSC::WebAssemblyFunction::jsCallEntrypointSlow):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5769bc3265c227a4d3a863712e70fa907e0571f4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106539 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15555 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39348 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115724 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115369 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17050 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6783 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98731 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112307 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12955 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95924 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40511 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94830 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27568 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82233 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/96111 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8784 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28920 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/95555 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/6682 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9327 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5644 "Found 1 new test failure: fast/text/glyph-display-lists/glyph-display-list-scaled-unshared.html (failure)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30652 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14943 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48468 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/104298 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10865 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25841 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->