### PR TITLE
Replace deprecated CCCryptorGCM function where possible

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/CommonCryptoSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/CommonCryptoSPI.h
@@ -121,7 +121,8 @@ extern "C" CCStatus CCDeriveKey(const CCKDFParametersRef params, CCDigestAlgorit
 extern "C" CCStatus CCKDFParametersCreateHkdf(CCKDFParametersRef *params, const void *salt, size_t saltLen, const void *context, size_t contextLen);
 extern "C" void CCKDFParametersDestroy(CCKDFParametersRef params);
 extern "C" CCCryptorStatus CCCryptorGCM(CCOperation op, CCAlgorithm alg, const void* key, size_t keyLength, const void* iv, size_t ivLen, const void* aData, size_t aDataLen, const void* dataIn, size_t dataInLength, void* dataOut, void* tag, size_t* tagLength);
-extern "C" CCCryptorStatus CCCryptorGCMOneshotDecrypt(CCAlgorithm alg, const void *key, size_t keyLength, const void  *iv, size_t ivLen, const void  *aData, size_t aDataLen, const void *dataIn, size_t dataInLength, void        *dataOut, const void  *tagIn, size_t tagLength);
+extern "C" CCCryptorStatus CCCryptorGCMOneshotEncrypt(CCAlgorithm alg, const void *key, size_t keyLength, const void  *iv, size_t ivLen, const void  *aData, size_t aDataLen, const void *dataIn, size_t dataInLength, void *dataOut, const void *tagIn, size_t tagLength);
+extern "C" CCCryptorStatus CCCryptorGCMOneshotDecrypt(CCAlgorithm alg, const void *key, size_t keyLength, const void  *iv, size_t ivLen, const void  *aData, size_t aDataLen, const void *dataIn, size_t dataInLength, void *dataOut, const void *tagIn, size_t tagLength);
 extern "C" CCCryptorStatus CCRSACryptorCreateFromData(CCRSAKeyType keyType, const uint8_t *modulus, size_t modulusLength, const uint8_t *exponent, size_t exponentLength, const uint8_t *p, size_t pLength, const uint8_t *q, size_t qLength, CCRSACryptorRef *ref);
 
 #endif // !USE(APPLE_INTERNAL_SDK)


### PR DESCRIPTION
#### 14bbde95d1571a1ae4f66332e8e092ab117ec62a
<pre>
Replace deprecated CCCryptorGCM function
<a href="https://bugs.webkit.org/show_bug.cgi?id=251851">https://bugs.webkit.org/show_bug.cgi?id=251851</a>
&lt;rdar://problem/30660074&gt;

Reviewed by NOBODY (OOPS!).

We can use CCCryptorGCMOneshotEncrypt and CCCryptorGCMOneshotDecrypt
instead.

*Source\WebCore\PAL\pal\spi\cocoa\CommonCryptoSPI.h:(CCCryptorGCM):
Deleted.
(CCCryptorGCMOneshotEncrypt): Added.

*Source\WebCore\crypto\mac\CryptoAlgorithmAES_GCMMac.cpp:(encryptAES_GCM): Replaced
CCCryptorGCM with CCCryptorGCMOneshotEncrypt.
(decyptAES_GCM): Replaced CCCryptorGCM with CCCryptorGCMOneshotDecrypt.

Note that CCCryptorGCMOneshotDecrypt does not require the use of
constantTimeMemcmp afterwards because that is part of the
CCCryptorGCMOneshotDecrypt function, which means if the comparison
fails, the function returns an OperationError exception.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f45027865a237ebb864ffcfe0615ea1390281127

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106929 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15965 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39726 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116109 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115656 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110832 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17449 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7163 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99115 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112694 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13212 "Found 6 new test failures: crypto/subtle/aes-gcm-import-key-decrypt-additional-data-tag-length-32.html, crypto/subtle/aes-gcm-import-key-decrypt-tagLengths.html, crypto/subtle/aes-gcm-import-key-encrypt-additional-data-tag-length-32.html, crypto/subtle/aes-gcm-import-key-encrypt-tagLengths.html, imported/w3c/web-platform-tests/WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.html, imported/w3c/web-platform-tests/WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.worker.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96227 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40806 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95104 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27871 "Found 6 new test failures: crypto/subtle/aes-gcm-import-key-decrypt-additional-data-tag-length-32.html, crypto/subtle/aes-gcm-import-key-decrypt-tagLengths.html, crypto/subtle/aes-gcm-import-key-encrypt-additional-data-tag-length-32.html, crypto/subtle/aes-gcm-import-key-encrypt-tagLengths.html, imported/w3c/web-platform-tests/WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.html, imported/w3c/web-platform-tests/WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.worker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82555 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9113 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29224 "Found 6 new test failures: crypto/subtle/aes-gcm-import-key-decrypt-additional-data-tag-length-32.html, crypto/subtle/aes-gcm-import-key-decrypt-tagLengths.html, crypto/subtle/aes-gcm-import-key-encrypt-additional-data-tag-length-32.html, crypto/subtle/aes-gcm-import-key-encrypt-tagLengths.html, imported/w3c/web-platform-tests/WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.html, imported/w3c/web-platform-tests/WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.worker.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9690 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6226 "Found 7 new test failures: crypto/subtle/aes-gcm-import-key-decrypt-additional-data-tag-length-32.html, crypto/subtle/aes-gcm-import-key-decrypt-tagLengths.html, crypto/subtle/aes-gcm-import-key-encrypt-additional-data-tag-length-32.html, crypto/subtle/aes-gcm-import-key-encrypt-tagLengths.html, fast/text/glyph-display-lists/glyph-display-list-scaled-unshared.html, imported/w3c/web-platform-tests/WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.html, imported/w3c/web-platform-tests/WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.worker.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15280 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48781 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11220 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->