### PR TITLE
Use currentDrawingAppearance instead of currentAppearance

### DIFF
--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
@@ -201,16 +201,11 @@ enum class FeatureToAnimate {
     UNUSED_PARAM(scrollerImp);
 
     if (!_scroller)
-        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        return [NSAppearance currentAppearance];
-        ALLOW_DEPRECATED_DECLARATIONS_END
-
+        return [NSAppearance currentDrawingAppearance];
     // The base system does not support dark Aqua, so we might get a null result.
     if (auto *appearance = [NSAppearance appearanceNamed:_scroller->pair().useDarkAppearance() ? NSAppearanceNameDarkAqua : NSAppearanceNameAqua])
         return appearance;
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    return [NSAppearance currentAppearance];
-    ALLOW_DEPRECATED_DECLARATIONS_END
+    return [NSAppearance currentDrawingAppearance];
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/mac/AppKitControlSystemImage.mm
+++ b/Source/WebCore/platform/graphics/mac/AppKitControlSystemImage.mm
@@ -40,9 +40,7 @@ AppKitControlSystemImage::AppKitControlSystemImage(AppKitControlSystemImageType 
     : SystemImage(SystemImageType::AppKitControl)
     , m_controlType(controlType)
 {
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    NSAppearance *appearance = [NSAppearance currentAppearance];
-    ALLOW_DEPRECATED_DECLARATIONS_END
+    NSAppearance *appearance = [NSAppearance currentDrawingAppearance];
     m_tintColor = colorFromCocoaColor(appearance.tintColor);
     m_useDarkAppearance = [appearance.name isEqualToString:NSAppearanceNameDarkAqua];
 }

--- a/Source/WebCore/platform/graphics/mac/ScrollbarTrackCornerSystemImageMac.mm
+++ b/Source/WebCore/platform/graphics/mac/ScrollbarTrackCornerSystemImageMac.mm
@@ -47,9 +47,7 @@ void ScrollbarTrackCornerSystemImageMac::drawControl(GraphicsContext& graphicsCo
 
     auto cornerDrawingOptions = @{ (__bridge NSString *)kCUIWidgetKey: (__bridge NSString *)kCUIWidgetScrollBarTrackCorner,
         (__bridge NSString *)kCUIIsFlippedKey: (__bridge NSNumber *)kCFBooleanTrue };
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    [[NSAppearance currentAppearance] _drawInRect:rect context:localContext.cgContext() options:cornerDrawingOptions];
-    ALLOW_DEPRECATED_DECLARATIONS_END
+    [[NSAppearance currentDrawingAppearance] _drawInRect:rect context:localContext.cgContext() options:cornerDrawingOptions];
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm
@@ -72,9 +72,7 @@ NSView *ControlFactoryMac::drawingView(const FloatRect& rect, const ControlStyle
 
     // Use a fake view.
     [m_drawingView setFrameSize:NSSizeFromCGSize(rect.size())];
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    [m_drawingView setAppearance:[NSAppearance currentAppearance]];
-    ALLOW_DEPRECATED_DECLARATIONS_END
+    [m_drawingView setAppearance:[NSAppearance currentDrawingAppearance]];
 #if USE(NSVIEW_SEMANTICCONTEXT)
     if (style.states.contains(ControlStyle::State::FormSemanticContext))
         [m_drawingView _setSemanticContext:NSViewSemanticContextForm];

--- a/Source/WebCore/platform/graphics/mac/controls/ControlMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlMac.mm
@@ -274,10 +274,7 @@ void ControlMac::drawListButton(GraphicsContext& context, const FloatRect& rect,
         coreUIState = (__bridge NSString *)kCUIStatePressed;
     else
         coreUIState = (__bridge NSString *)kCUIStateActive;
-
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    [[NSAppearance currentAppearance] _drawInRect:NSMakeRect(0, 0, comboBoxSize.width(), comboBoxSize.height()) context:cgContext options:@{
-    ALLOW_DEPRECATED_DECLARATIONS_END
+    [[NSAppearance currentDrawingAppearance] _drawInRect:NSMakeRect(0, 0, comboBoxSize.width(), comboBoxSize.height()) context:cgContext options:@{
         (__bridge NSString *)kCUIWidgetKey : (__bridge NSString *)kCUIWidgetButtonComboBox,
         (__bridge NSString *)kCUISizeKey : (__bridge NSString *)kCUISizeRegular,
         (__bridge NSString *)kCUIStateKey : coreUIState,

--- a/Source/WebCore/platform/graphics/mac/controls/InnerSpinButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/InnerSpinButtonMac.mm
@@ -91,9 +91,7 @@ void InnerSpinButtonMac::draw(GraphicsContext& context, const FloatRoundedRect& 
     }
 
     LocalCurrentGraphicsContext localContext(context);
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    [[NSAppearance currentAppearance] _drawInRect:logicalRect context:localContext.cgContext() options:@{
-    ALLOW_DEPRECATED_DECLARATIONS_END
+    [[NSAppearance currentDrawingAppearance] _drawInRect:logicalRect context:localContext.cgContext() options:@{
         (__bridge NSString *)kCUIWidgetKey: (__bridge NSString *)kCUIWidgetButtonLittleArrows,
         (__bridge NSString *)kCUISizeKey: coreUISize,
         (__bridge NSString *)kCUIStateKey: coreUIState,

--- a/Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.mm
@@ -113,9 +113,7 @@ void ProgressBarMac::draw(GraphicsContext& context, const FloatRoundedRect& bord
         return nullptr;
     };
 
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    [[NSAppearance currentAppearance] _drawInRect:NSMakeRect(0, 0, inflatedRect.width(), inflatedRect.height()) context:cgContext options:@{
-    ALLOW_DEPRECATED_DECLARATIONS_END
+    [[NSAppearance currentDrawingAppearance] _drawInRect:NSMakeRect(0, 0, inflatedRect.width(), inflatedRect.height()) context:cgContext options:@{
         (__bridge NSString *)kCUIWidgetKey: (__bridge NSString *)(isIndeterminate ? kCUIWidgetProgressIndeterminateBar : kCUIWidgetProgressBar),
         (__bridge NSString *)kCUIValueKey: @(isIndeterminate ? 1 : std::min(nextafter(1.0, -1), progressBarPart.position())),
         (__bridge NSString *)kCUISizeKey: (__bridge NSString *)coreUISizeForProgressBarSize(controlSize),

--- a/Source/WebCore/platform/mac/LocalDefaultSystemAppearance.mm
+++ b/Source/WebCore/platform/mac/LocalDefaultSystemAppearance.mm
@@ -37,9 +37,7 @@ namespace WebCore {
 LocalDefaultSystemAppearance::LocalDefaultSystemAppearance(bool useDarkAppearance, const Color& tintColor)
 {
 #if HAVE(OS_DARK_MODE_SUPPORT)
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    m_savedSystemAppearance = [NSAppearance currentAppearance];
-    ALLOW_DEPRECATED_DECLARATIONS_END
+    m_savedSystemAppearance = [NSAppearance currentDrawingAppearance];
     m_usingDarkAppearance = useDarkAppearance;
 
     ALLOW_DEPRECATED_DECLARATIONS_BEGIN

--- a/Source/WebCore/platform/mac/ScrollbarsControllerMac.mm
+++ b/Source/WebCore/platform/mac/ScrollbarsControllerMac.mm
@@ -410,20 +410,15 @@ using WebCore::LogOverlayScrollbars;
 {
     UNUSED_PARAM(scrollerImp);
 
-    if (!_scrollbar) {
-        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        return [NSAppearance currentAppearance];
-        ALLOW_DEPRECATED_DECLARATIONS_END
-    }
+    if (!_scrollbar)
+        return [NSAppearance currentDrawingAppearance];
 
     // Keep this in sync with FrameView::paintScrollCorner.
     // The base system does not support dark Aqua, so we might get a null result.
     bool useDarkAppearance = _scrollbar->scrollableArea().useDarkAppearanceForScrollbars();
     if (auto *appearance = [NSAppearance appearanceNamed:useDarkAppearance ? NSAppearanceNameDarkAqua : NSAppearanceNameAqua])
         return appearance;
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    return [NSAppearance currentAppearance];
-    ALLOW_DEPRECATED_DECLARATIONS_END
+    return [NSAppearance currentDrawingAppearance];
 }
 #endif
 

--- a/Source/WebCore/platform/mac/ThemeMac.mm
+++ b/Source/WebCore/platform/mac/ThemeMac.mm
@@ -484,9 +484,7 @@ NSView *ThemeMac::ensuredView(ScrollView* scrollView, const ControlStates& contr
     // Use a fake view.
     static WebCoreThemeView *themeView = [[WebCoreThemeView alloc] init];
     [themeView setFrameSize:NSSizeFromCGSize(scrollView->totalContentsSize())];
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    [themeView setAppearance:[NSAppearance currentAppearance]];
-    ALLOW_DEPRECATED_DECLARATIONS_END
+    [themeView setAppearance:[NSAppearance currentDrawingAppearance]];
 
 #if USE(NSVIEW_SEMANTICCONTEXT)
     if (_useFormSemanticContext)
@@ -680,9 +678,7 @@ bool ThemeMac::userPrefersContrast() const
 
 bool ThemeMac::supportsLargeFormControls()
 {
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    static bool hasSupport = [[NSAppearance currentAppearance] _usesMetricsAppearance];
-    ALLOW_DEPRECATED_DECLARATIONS_END
+    static bool hasSupport = [[NSAppearance currentDrawingAppearance] _usesMetricsAppearance];
     return hasSupport;
 }
 


### PR DESCRIPTION
#### 833921a024bca719124b3dd7e61d207a31ac65a5
<pre>
Use currentDrawingAppearance instead of currentAppearance
<a href="https://bugs.webkit.org/show_bug.cgi?id=251853">https://bugs.webkit.org/show_bug.cgi?id=251853</a>

Reviewed by Aditya Keerthi.

currentAppearance is deprecated. We should be utilizing
currentDrawingAppearance and find a way to avoid having to manually set
and handle appearances. This PR takes the first step in this by using
currentDrawingAppearance.

Canonical link: <a href="https://commits.webkit.org/260017@main">https://commits.webkit.org/260017@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1952a201948ded38c9abab586abab33dc944b164

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106746 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15743 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39532 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115936 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115523 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110652 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17249 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6977 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98941 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112515 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96076 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40675 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/94983 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27728 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8956 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29083 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9519 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/6097 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15129 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48626 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6919 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11042 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->