### PR TITLE
`Clear-Site-Data: "cache"` should only suppress the next navigation snapshot in case of same-origin navigation

### DIFF
--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -1898,9 +1898,12 @@ void NetworkProcessProxy::deleteWebsiteDataInWebProcessesForOrigin(OptionSet<Web
         ViewSnapshotStore::singleton().discardSnapshotImagesForOrigin(origin.topOrigin);
 #endif
         // Since this navigation requested that we clear existing navigation snapshots, we shouldn't
-        // create a snapshot for this navigation either.
-        if (auto page = WebProcessProxy::webPage(webPageProxyID))
-            page->suppressNextAutomaticNavigationSnapshot();
+        // create a snapshot for this navigation either if it is same-origin.
+        if (auto page = WebProcessProxy::webPage(webPageProxyID)) {
+            bool isSameOriginNavigation = SecurityOriginData::fromURL(URL(page->pageLoadState().url())) == origin.topOrigin;
+            if (isSameOriginNavigation)
+                page->suppressNextAutomaticNavigationSnapshot();
+        }
     }
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SnapshotStore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SnapshotStore.mm
@@ -245,4 +245,32 @@ TEST(SnapshotStore, ClearSiteDataHeader)
     EXPECT_FALSE(!!adoptCF([[backForwardList itemAtIndex:-2] _copySnapshotForTesting]));
 }
 
+TEST(SnapshotStore, ClearSiteDataHeaderCrossOrigin)
+{
+    HTTPServer server({
+        { "/index1.html"_s, { "foo"_s } },
+        { "/crossOrigin.html"_s, { "bar"_s } },
+        { "/logout.html"_s, { { { "Content-Type"_s, "text/html"_s }, { "Clear-Site-Data"_s, "\"*\""_s } }, "Logged out."_s } },
+    }, HTTPServer::Protocol::Https);
+
+    auto webView = adoptNS([[SnapshotTestWKWebView alloc] init]);
+    for (_WKFeature *feature in [WKPreferences _features]) {
+        if ([feature.key isEqualToString:@"ClearSiteDataHTTPHeaderEnabled"]) {
+            [[[webView configuration] preferences] _setEnabled:YES forFeature:feature];
+            break;
+        }
+    }
+
+    auto *backForwardList = [webView backForwardList];
+    [webView synchronouslyLoadRequestPageAndForceRepaint:server.request("/index1.html"_s)];
+    [webView synchronouslyLoadRequestPageAndForceRepaint:server.requestWithLocalhost("/crossOrigin.html"_s)];
+    EXPECT_TRUE(!!adoptCF([backForwardList.backItem _copySnapshotForTesting]));
+
+    [webView synchronouslyLoadRequestPageAndForceRepaint:server.request("/logout.html"_s)];
+    // Shouldn't clear the crossOrigin.html snapshot since it was cross-origin.
+    EXPECT_TRUE(!!adoptCF([backForwardList.backItem _copySnapshotForTesting]));
+    // Should have cleared the index1.html snapshot though since it was same-origin.
+    EXPECT_FALSE(!!adoptCF([[backForwardList itemAtIndex:-2] _copySnapshotForTesting]));
+}
+
 #endif // PLATFORM(MAC)


### PR DESCRIPTION
#### ff41eac48894511fe1be7de026034a39a27e2f2b
<pre>
`Clear-Site-Data: &quot;cache&quot;` should only suppress the next navigation snapshot in case of same-origin navigation
<a href="https://bugs.webkit.org/show_bug.cgi?id=251855">https://bugs.webkit.org/show_bug.cgi?id=251855</a>

Reviewed by Sihui Liu.

`Clear-Site-Data: &quot;cache&quot;` should only suppress the next navigation snapshot in
case of same-origin navigation.

So if you navigate from A1 to B, and then to A2 (which serves the
Clear-Site-Data HTTP header). You&apos;d expect the snapshot for A1 to get deleted
but not the one for B. This is because A2 served the header and we should thus
only delete snapshots for origin A.

Previously, we would prevent the creation of the snapshot for B when navigating
to A2. This patch fixes this.

* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::deleteWebsiteDataInWebProcessesForOrigin):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SnapshotStore.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/260034@main">https://commits.webkit.org/260034@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a2be6230d4ec090c9214eba21841b21356b0ae1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106807 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15831 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39591 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115990 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/115564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110710 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/17323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7033 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98995 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112575 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/17323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96112 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/40722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/17323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/27764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/9007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/29119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9574 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/6125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/15176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48663 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6925 "Found 1 new test failure: fast/text/web-font-load-invisible-during-loading.html (failure)") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11100 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3741 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->