### PR TITLE
[WGSL] Initial implementation of operator overload resolution

### DIFF
--- a/Source/WebGPU/WGSL/Overload.cpp
+++ b/Source/WebGPU/WGSL/Overload.cpp
@@ -1,0 +1,538 @@
+/*
+ * Copyright (c) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "Overload.h"
+
+#include "Types.h"
+#include <wtf/DataLog.h>
+
+namespace WGSL {
+
+static constexpr bool shouldDumpOverloadDebugInformation = false;
+static constexpr ASCIILiteral logPrefix = "> overload: "_s;
+
+template<typename... Arguments>
+inline void log(Arguments&&... arguments)
+{
+    if (shouldDumpOverloadDebugInformation)
+        dataLog(logPrefix, std::forward<Arguments>(arguments)...);
+}
+
+template<typename... Arguments>
+inline void logLn(Arguments&&... arguments)
+{
+    if (shouldDumpOverloadDebugInformation)
+        dataLogLn(logPrefix, std::forward<Arguments>(arguments)...);
+}
+
+struct ViableOverload {
+    const OverloadCandidate* candidate;
+    FixedVector<unsigned> ranks;
+    Type* result;
+};
+
+class OverloadResolver {
+public:
+    OverloadResolver(TypeStore&, const Vector<OverloadCandidate>&, const Vector<Type*>&, unsigned numberOfTypeSubstitutions, unsigned numberOfValueSubstitutions);
+
+    Type* resolve();
+
+private:
+    static constexpr unsigned s_noConversion = std::numeric_limits<unsigned>::max();
+
+    FixedVector<std::optional<ViableOverload>> considerCandidates();
+    std::optional<ViableOverload> considerCandidate(const OverloadCandidate&);
+    unsigned calculateRank(const AbstractType&, Type*);
+    unsigned conversionRank(Type*, Type*) const;
+    unsigned conversionRankImpl(Type*, Type*) const;
+
+    bool unify(const AbstractType&, Type*);
+    void assign(TypeVariable, Type*);
+    Type* resolve(TypeVariable) const;
+    Type* materialize(const AbstractType&) const;
+
+    bool unify(const AbstractValue&, unsigned);
+    void assign(NumericVariable, unsigned);
+    std::optional<unsigned> resolve(NumericVariable) const;
+    unsigned materialize(const AbstractValue&) const;
+
+    TypeStore& m_types;
+    const Vector<OverloadCandidate>& m_candidates;
+    const Vector<Type*>& m_arguments;
+    FixedVector<Type*> m_typeSubstitutions;
+    FixedVector<std::optional<unsigned>> m_numericSubstitutions;
+};
+
+OverloadResolver::OverloadResolver(TypeStore& types, const Vector<OverloadCandidate>& candidates, const Vector<Type*>& arguments, unsigned numberOfTypeSubstitutions, unsigned numberOfValueSubstitutions)
+    : m_types(types)
+    , m_candidates(candidates)
+    , m_arguments(arguments)
+    , m_typeSubstitutions(numberOfTypeSubstitutions)
+    , m_numericSubstitutions(numberOfValueSubstitutions)
+{
+}
+
+Type* OverloadResolver::resolve()
+{
+    auto candidates = considerCandidates();
+    std::optional<ViableOverload> selectedCandidate = std::nullopt;
+
+    for (auto& candidate : candidates) {
+        if (!candidate.has_value())
+            continue;
+
+        if (!selectedCandidate.has_value()) {
+            std::exchange(selectedCandidate, candidate);
+            continue;
+        }
+        ASSERT(selectedCandidate->ranks.size() == candidate->ranks.size());
+
+        bool isBetterOrEqual = true;
+        bool hasStrictlyBetter = false;
+        for (unsigned i = 0; i < candidate->ranks.size(); ++i) {
+            if (candidate->ranks[i] > selectedCandidate->ranks[i]) {
+                isBetterOrEqual = false;
+                break;
+            }
+            if (candidate->ranks[i] < selectedCandidate->ranks[i])
+                hasStrictlyBetter = true;
+        }
+        if (isBetterOrEqual && hasStrictlyBetter)
+            std::exchange(selectedCandidate, candidate);
+    }
+
+    if (!selectedCandidate.has_value()) {
+        logLn("no suitable overload found");
+        return nullptr;
+    }
+
+    logLn("selected overload: ", *selectedCandidate->candidate);
+    logLn("materialized result type: ", *selectedCandidate->result);
+
+    return selectedCandidate->result;
+}
+
+Type* OverloadResolver::materialize(const AbstractType& abstractType) const
+{
+    return WTF::switchOn(abstractType,
+        [&](Type* type) -> Type* {
+            return type;
+        },
+        [&](TypeVariable variable) -> Type* {
+            auto* resolvedType = resolve(variable);
+            ASSERT(resolvedType);
+            return resolvedType;
+        },
+        [&](const AbstractVector& vector) -> Type* {
+            auto* element = materialize(vector.element);
+            auto size = materialize(vector.size);
+            return m_types.vectorType(element, size);
+        },
+        [&](const AbstractMatrix& matrix) -> Type* {
+            auto* element = materialize(matrix.element);
+            auto columns = materialize(matrix.columns);
+            auto rows = materialize(matrix.rows);
+            return m_types.matrixType(element, columns, rows);
+        });
+}
+
+unsigned OverloadResolver::materialize(const AbstractValue& abstractValue) const
+{
+    return WTF::switchOn(abstractValue,
+        [&](unsigned value) -> unsigned {
+            return value;
+        },
+        [&](NumericVariable variable) -> unsigned {
+            std::optional<unsigned> resolvedValue = resolve(variable);
+            ASSERT(resolvedValue.has_value());
+            return *resolvedValue;
+        });
+}
+
+FixedVector<std::optional<ViableOverload>> OverloadResolver::considerCandidates()
+{
+    FixedVector<std::optional<ViableOverload>> candidates(m_candidates.size());
+    for (unsigned i = 0; i < m_candidates.size(); ++i)
+        candidates[i] = considerCandidate(m_candidates[i]);
+    return candidates;
+}
+
+std::optional<ViableOverload> OverloadResolver::considerCandidate(const OverloadCandidate& candidate)
+{
+    if (candidate.parameters.size() != m_arguments.size())
+        return std::nullopt;
+
+    m_typeSubstitutions.fill(nullptr);
+    m_numericSubstitutions.fill(std::nullopt);
+
+    logLn("Considering overload: ", candidate);
+
+    ViableOverload viableOverload { &candidate, FixedVector<unsigned>(m_arguments.size()), nullptr };
+    for (unsigned i = 0; i < m_arguments.size(); ++i) {
+        auto& parameter = candidate.parameters[i];
+        auto* argument = m_arguments[i];
+        logLn("matching parameter #", i, " '", parameter, "' with argument '", *argument, "'");
+        if (!unify(parameter, argument)) {
+            logLn("rejected on parameter #", i);
+            return std::nullopt;
+        }
+    }
+    for (unsigned i = 0; i < m_arguments.size(); ++i) {
+        auto& parameter = candidate.parameters[i];
+        auto* argument = m_arguments[i];
+        auto rank = calculateRank(parameter, argument);
+        ASSERT(rank != s_noConversion);
+        viableOverload.ranks[i] = rank;
+    }
+    viableOverload.result = materialize(candidate.result);
+
+    if (shouldDumpOverloadDebugInformation) {
+        log("found a viable candidate '", candidate, "' materialized as '(");
+        bool first = true;
+        for (auto& parameter : candidate.parameters) {
+            if (!first)
+                dataLog(", ");
+            first = false;
+            dataLog(*materialize(parameter));
+        }
+        dataLog(") -> ", *viableOverload.result, "'");
+        dataLogLn();
+    }
+
+
+    return { WTFMove(viableOverload) };
+}
+
+unsigned OverloadResolver::calculateRank(const AbstractType& parameter, Type* argumentType)
+{
+    if (auto* variable = std::get_if<TypeVariable>(&parameter)) {
+        auto* resolvedType = resolve(*variable);
+        ASSERT(resolvedType);
+        return conversionRank(argumentType, resolvedType);
+    }
+
+    if (auto* vectorParameter = std::get_if<AbstractVector>(&parameter)) {
+        auto& vectorArgument = std::get<Types::Vector>(*argumentType);
+        return calculateRank(vectorParameter->element, vectorArgument.element);
+    }
+
+    if (auto* matrixParameter = std::get_if<AbstractMatrix>(&parameter)) {
+        auto& matrixArgument = std::get<Types::Matrix>(*argumentType);
+        return calculateRank(matrixParameter->element, matrixArgument.element);
+    }
+
+    auto* parameterType = std::get<Type*>(parameter);
+    return conversionRank(argumentType, parameterType);
+}
+
+bool OverloadResolver::unify(const AbstractType& parameter, Type* argumentType)
+{
+    logLn("unify parameter type '", parameter, "' with argument '", *argumentType, "'");
+    if (auto* variable = std::get_if<TypeVariable>(&parameter)) {
+        auto* resolvedType = resolve(*variable);
+        if (!resolvedType) {
+            // FIXME: check the constraints on the variable
+            assign(*variable, argumentType);
+            return true;
+        }
+
+        logLn("resolved '", *variable, "' to '", *resolvedType, "'");
+
+        // Consider the following:
+        // + :: (T, T) -> T
+        // 1 + 1u
+        //
+        // We first unify `Var(T)` with `Type(AbstractInt)`, and assign `T` to `AbstractInt`
+        // Next, we unify `Var(T) with `Type(u32)`, we look up `T => AbstractInt`,
+        //   and promote `T` to `u32`.
+        //
+        // A few more examples to illustrate it:
+        //
+        // vec3 :: (T, T, T) -> T
+        // vec3(1, 1.0, 1.0f) -> vec3<f32>
+        // 1) unify(Var(T), Type(AbstractInt); T => AbstractInt (assign)
+        // 2) unify(Var(T), Type(AbstractFloat); T => AbstractFloat (promote T)
+        // 3) unify(Var(T), Type(f32); T => f32 (promote T again)
+        //
+        // vec3 :: (T, T, T) -> T
+        // vec3(1.0, 1, 1.0f) -> vec3<f32>
+        // 1) unify(Var(T), Type(AbstractFloat); T => AbstractFloat (assign)
+        // 2) unify(Var(T), Type(AbstractInt); T => AbstractFloat (convert the argument to AbstractInt)
+        // 3) unify(Var(T), Type(f32); T => f32 (promote T)
+        //
+        // vec3 :: (T, T, T) -> T
+        // vec3(1.0, 1u, 1.0f) -> vec3<f32>
+        // 1) unify(Var(T), Type(AbstractInt); T => AbstractFloat (assign)
+        // 2) unify(Var(T), Type(u32); Failed! Can't unify AbstractFloat and u32
+        auto variablePromotionRank = conversionRank(resolvedType, argumentType);
+        auto argumentConversionRank = conversionRank(argumentType, resolvedType);
+        logLn("variablePromotionRank: ", variablePromotionRank, ", argumentConversionRank: ", argumentConversionRank);
+        if (variablePromotionRank < argumentConversionRank) {
+            assign(*variable, argumentType);
+            return true;
+        }
+
+        return argumentConversionRank != s_noConversion;
+    }
+
+    if (auto* vectorParameter = std::get_if<AbstractVector>(&parameter)) {
+        auto* vectorArgument = std::get_if<Types::Vector>(argumentType);
+        if (!vectorArgument)
+            return false;
+        if (!unify(vectorParameter->element, vectorArgument->element))
+            return false;
+        return unify(vectorParameter->size, vectorArgument->size);
+    }
+
+    if (auto* matrixParameter = std::get_if<AbstractMatrix>(&parameter)) {
+        auto* matrixArgument = std::get_if<Types::Matrix>(argumentType);
+        if (!matrixArgument)
+            return false;
+        if (!unify(matrixParameter->element, matrixArgument->element))
+            return false;
+        if (!unify(matrixParameter->columns, matrixArgument->columns))
+            return false;
+        return unify(matrixParameter->rows, matrixArgument->rows);
+    }
+
+    auto* parameterType = std::get<Type*>(parameter);
+    return conversionRank(argumentType, parameterType) != s_noConversion;
+}
+
+bool OverloadResolver::unify(const AbstractValue& parameter, unsigned argumentValue)
+{
+    if (auto* parameterValue = std::get_if<unsigned>(&parameter))
+        return *parameterValue == argumentValue;
+
+    auto variable = std::get<NumericVariable>(parameter);
+    auto resolvedValue = resolve(variable);
+    if (!resolvedValue.has_value()) {
+        assign(variable, argumentValue);
+        return true;
+    }
+    return *resolvedValue == argumentValue;
+}
+
+void OverloadResolver::assign(TypeVariable variable, Type* type)
+{
+    logLn("assign ", variable, " => ", *type);
+    m_typeSubstitutions[variable.id] = type;
+}
+
+void OverloadResolver::assign(NumericVariable variable, unsigned value)
+{
+    logLn("assign ", variable, " => ", value);
+    m_numericSubstitutions[variable.id] = { value };
+}
+
+Type* OverloadResolver::resolve(TypeVariable variable) const
+{
+    return m_typeSubstitutions[variable.id];
+}
+
+std::optional<unsigned> OverloadResolver::resolve(NumericVariable variable) const
+{
+    return m_numericSubstitutions[variable.id];
+}
+
+unsigned OverloadResolver::conversionRank(Type* from, Type* to) const
+{
+    auto rank = conversionRankImpl(from, to);
+    logLn("conversionRank(from: ", *from, ", to: ", *to, ") = ", rank);
+    return rank;
+}
+
+constexpr unsigned primitivePair(Types::Primitive::Kind first, Types::Primitive::Kind second)
+{
+    return first << sizeof(Types::Primitive::Kind) | second;
+}
+
+// https://www.w3.org/TR/WGSL/#conversion-rank
+unsigned OverloadResolver::conversionRankImpl(Type* from, Type* to) const
+{
+    using namespace WGSL::Types;
+
+    if (from == to)
+        return 0;
+
+    if (std::holds_alternative<Bottom>(*from))
+        return 0;
+
+    // FIXME: refs should also return 0
+
+    if (auto* fromPrimitive = std::get_if<Primitive>(from)) {
+        auto* toPrimitive = std::get_if<Primitive>(to);
+        if (!toPrimitive)
+            return s_noConversion;
+
+        switch (primitivePair(fromPrimitive->kind, toPrimitive->kind)) {
+        case primitivePair(Primitive::AbstractFloat, Primitive::F32):
+            return 1;
+        // FIXME: AbstractFloat to f16 should return 2
+        case primitivePair(Primitive::AbstractInt, Primitive::I32):
+            return 3;
+        case primitivePair(Primitive::AbstractInt, Primitive::U32):
+            return 4;
+        case primitivePair(Primitive::AbstractInt, Primitive::AbstractFloat):
+            return 5;
+        case primitivePair(Primitive::AbstractInt, Primitive::F32):
+            return 6;
+        // FIXME: AbstractInt to f16 should return 7
+        default:
+            return s_noConversion;
+        }
+    }
+
+    if (auto* fromVector = std::get_if<Vector>(from)) {
+        auto* toVector = std::get_if<Vector>(to);
+        if (!toVector)
+            return s_noConversion;
+        if (fromVector->size != toVector->size)
+            return s_noConversion;
+        return conversionRank(fromVector->element, toVector->element);
+    }
+
+    if (auto* fromMatrix = std::get_if<Matrix>(from)) {
+        auto* toMatrix = std::get_if<Matrix>(to);
+        if (!toMatrix)
+            return s_noConversion;
+        if (fromMatrix->columns != toMatrix->columns)
+            return s_noConversion;
+        if (fromMatrix->rows != toMatrix->rows)
+            return s_noConversion;
+        return conversionRank(fromMatrix->element, toMatrix->element);
+    }
+
+    if (auto* fromArray = std::get_if<Array>(from)) {
+        auto* toArray = std::get_if<Array>(to);
+        if (!toArray)
+            return s_noConversion;
+        if (fromArray->size != toArray->size)
+            return s_noConversion;
+        return conversionRank(fromArray->element, toArray->element);
+    }
+
+    // FIXME: add the abstract result conversion rules
+    return s_noConversion;
+}
+
+Type* resolveOverloads(TypeStore& types, const Vector<OverloadCandidate>& candidates, const Vector<Type*>& arguments)
+{
+
+    unsigned numberOfTypeSubstitutions = 0;
+    unsigned numberOfValueSubstitutions = 0;
+    for (const auto& candidate : candidates) {
+        numberOfTypeSubstitutions = std::max(numberOfTypeSubstitutions, static_cast<unsigned>(candidate.typeVariables.size()));
+        numberOfValueSubstitutions = std::max(numberOfValueSubstitutions, static_cast<unsigned>(candidate.numericVariables.size()));
+    }
+    OverloadResolver resolver(types, candidates, arguments, numberOfTypeSubstitutions, numberOfValueSubstitutions);
+    return resolver.resolve();
+}
+
+} // namespace WGSL
+
+namespace WTF {
+
+void printInternal(PrintStream& out, const WGSL::NumericVariable& variable)
+{
+    out.print("val", variable.id);
+}
+
+void printInternal(PrintStream& out, const WGSL::AbstractValue& value)
+{
+    WTF::switchOn(value,
+        [&](unsigned value) {
+            out.print(value);
+        },
+        [&](WGSL::NumericVariable variable) {
+            printInternal(out, variable);
+        });
+}
+
+void printInternal(PrintStream& out, const WGSL::TypeVariable& variable)
+{
+    out.print("type", variable.id);
+}
+
+void printInternal(PrintStream& out, const WGSL::AbstractType& type)
+{
+    WTF::switchOn(type,
+        [&](WGSL::Type* type) {
+            printInternal(out, *type);
+        },
+        [&](WGSL::TypeVariable variable) {
+            printInternal(out, variable);
+        },
+        [&](const WGSL::AbstractVector& vector) {
+            out.print("vector<");
+            printInternal(out, vector.element);
+            out.print(", ");
+            printInternal(out, vector.size);
+            out.print(">");
+        },
+        [&](const WGSL::AbstractMatrix& matrix) {
+            out.print("matrix<");
+            printInternal(out, matrix.element);
+            out.print(", ");
+            printInternal(out, matrix.columns);
+            out.print(", ");
+            printInternal(out, matrix.rows);
+            out.print(">");
+        });
+}
+
+void printInternal(PrintStream& out, const WGSL::OverloadCandidate& candidate)
+{
+    if (candidate.typeVariables.size() || candidate.numericVariables.size()) {
+        bool first = true;
+        out.print("<");
+        for (auto& typeVariable : candidate.typeVariables) {
+            if (!first)
+                out.print(", ");
+            first = false;
+            printInternal(out, typeVariable);
+        }
+        for (auto& numericVariable : candidate.numericVariables) {
+            if (!first)
+                out.print(", ");
+            first = false;
+            printInternal(out, numericVariable);
+        }
+        out.print(">");
+    }
+    out.print("(");
+    bool first = true;
+    for (auto& parameter : candidate.parameters) {
+        if (!first)
+            out.print(", ");
+        first = false;
+        printInternal(out, parameter);
+    }
+    out.print(") -> ");
+    printInternal(out, candidate.result);
+}
+
+} // namespace WTF

--- a/Source/WebGPU/WGSL/Overload.h
+++ b/Source/WebGPU/WGSL/Overload.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "TypeStore.h"
+
+namespace WGSL {
+
+struct NumericVariable {
+    unsigned id;
+};
+
+using AbstractValue = std::variant<NumericVariable, unsigned>;
+
+struct TypeVariable {
+    enum Constraint : uint8_t {
+        None = 0,
+        F16 = 1 << 0,
+        F32 = 1 << 1,
+        AbstractFloat = 1 << 2,
+        Float = F16 | F32 | AbstractFloat,
+
+        I32 = 1 << 3,
+        U32 = 1 << 4,
+        AbstractInt = 1 << 5,
+        Integer = I32 | U32 | AbstractInt,
+
+        Number = Float | Integer,
+    };
+
+    unsigned id;
+    Constraint constraints;
+};
+
+struct AbstractVector;
+struct AbstractMatrix;
+using AbstractType = std::variant<
+    AbstractVector,
+    AbstractMatrix,
+    TypeVariable,
+    Type*
+>;
+
+struct AbstractVector {
+    TypeVariable element;
+    AbstractValue size;
+};
+
+struct AbstractMatrix {
+    TypeVariable element;
+    AbstractValue columns;
+    AbstractValue rows;
+};
+
+struct OverloadCandidate {
+    WTF::Vector<TypeVariable, 1> typeVariables;
+    WTF::Vector<NumericVariable, 2> numericVariables;
+    WTF::Vector<AbstractType, 2> parameters;
+    AbstractType result;
+};
+
+Type* resolveOverloads(TypeStore&, const WTF::Vector<OverloadCandidate>&, const WTF::Vector<Type*>&);
+
+} // namespace WGSL
+
+namespace WTF {
+void printInternal(PrintStream&, const WGSL::NumericVariable&);
+void printInternal(PrintStream&, const WGSL::AbstractValue&);
+void printInternal(PrintStream&, const WGSL::TypeVariable&);
+void printInternal(PrintStream&, const WGSL::AbstractType&);
+void printInternal(PrintStream&, const WGSL::OverloadCandidate&);
+} // namespace WTF

--- a/Source/WebGPU/WGSL/TypeStore.cpp
+++ b/Source/WebGPU/WGSL/TypeStore.cpp
@@ -46,18 +46,18 @@ TypeStore::TypeStore()
     m_u32 = allocateType<Primitive>(Primitive::U32);
     m_f32 = allocateType<Primitive>(Primitive::F32);
 
-    allocateConstructor<Vector>(AST::ParameterizedTypeName::Base::Vec2, static_cast<uint8_t>(2));
-    allocateConstructor<Vector>(AST::ParameterizedTypeName::Base::Vec3, static_cast<uint8_t>(3));
-    allocateConstructor<Vector>(AST::ParameterizedTypeName::Base::Vec4, static_cast<uint8_t>(4));
-    allocateConstructor<Matrix>(AST::ParameterizedTypeName::Base::Mat2x2, static_cast<uint8_t>(2), static_cast<uint8_t>(2));
-    allocateConstructor<Matrix>(AST::ParameterizedTypeName::Base::Mat2x3, static_cast<uint8_t>(2), static_cast<uint8_t>(3));
-    allocateConstructor<Matrix>(AST::ParameterizedTypeName::Base::Mat2x4, static_cast<uint8_t>(2), static_cast<uint8_t>(4));
-    allocateConstructor<Matrix>(AST::ParameterizedTypeName::Base::Mat3x2, static_cast<uint8_t>(3), static_cast<uint8_t>(2));
-    allocateConstructor<Matrix>(AST::ParameterizedTypeName::Base::Mat3x3, static_cast<uint8_t>(3), static_cast<uint8_t>(3));
-    allocateConstructor<Matrix>(AST::ParameterizedTypeName::Base::Mat3x4, static_cast<uint8_t>(3), static_cast<uint8_t>(4));
-    allocateConstructor<Matrix>(AST::ParameterizedTypeName::Base::Mat4x2, static_cast<uint8_t>(4), static_cast<uint8_t>(2));
-    allocateConstructor<Matrix>(AST::ParameterizedTypeName::Base::Mat4x3, static_cast<uint8_t>(4), static_cast<uint8_t>(3));
-    allocateConstructor<Matrix>(AST::ParameterizedTypeName::Base::Mat4x4, static_cast<uint8_t>(4), static_cast<uint8_t>(4));
+    allocateConstructor(&TypeStore::vectorType, AST::ParameterizedTypeName::Base::Vec2, 2);
+    allocateConstructor(&TypeStore::vectorType, AST::ParameterizedTypeName::Base::Vec3, 3);
+    allocateConstructor(&TypeStore::vectorType, AST::ParameterizedTypeName::Base::Vec4, 4);
+    allocateConstructor(&TypeStore::matrixType, AST::ParameterizedTypeName::Base::Mat2x2, 2, 2);
+    allocateConstructor(&TypeStore::matrixType, AST::ParameterizedTypeName::Base::Mat2x3, 2, 3);
+    allocateConstructor(&TypeStore::matrixType, AST::ParameterizedTypeName::Base::Mat2x4, 2, 4);
+    allocateConstructor(&TypeStore::matrixType, AST::ParameterizedTypeName::Base::Mat3x2, 3, 2);
+    allocateConstructor(&TypeStore::matrixType, AST::ParameterizedTypeName::Base::Mat3x3, 3, 3);
+    allocateConstructor(&TypeStore::matrixType, AST::ParameterizedTypeName::Base::Mat3x4, 3, 4);
+    allocateConstructor(&TypeStore::matrixType, AST::ParameterizedTypeName::Base::Mat4x2, 4, 2);
+    allocateConstructor(&TypeStore::matrixType, AST::ParameterizedTypeName::Base::Mat4x3, 4, 3);
+    allocateConstructor(&TypeStore::matrixType, AST::ParameterizedTypeName::Base::Mat4x4, 4, 4);
 }
 
 Type* TypeStore::structType(const AST::Identifier& name)
@@ -78,6 +78,18 @@ Type* TypeStore::arrayType(Type* elementType, std::optional<unsigned> size)
     return allocateType<Array>(elementType, size);
 }
 
+Type* TypeStore::vectorType(Type* elementType, uint8_t size)
+{
+    // FIXME: these should be cached
+    return allocateType<Vector>(elementType, size);
+}
+
+Type* TypeStore::matrixType(Type* elementType, uint8_t columns, uint8_t rows)
+{
+    // FIXME: these should be cached
+    return allocateType<Matrix>(elementType, columns, rows);
+}
+
 template<typename TypeKind, typename... Arguments>
 Type* TypeStore::allocateType(Arguments&&... arguments)
 {
@@ -85,13 +97,13 @@ Type* TypeStore::allocateType(Arguments&&... arguments)
     return m_types.last().get();
 }
 
-template<typename TargetType, typename Base, typename... Arguments>
-void TypeStore::allocateConstructor(Base base, Arguments&&... arguments)
+template<typename TargetConstructor, typename Base, typename... Arguments>
+void TypeStore::allocateConstructor(TargetConstructor constructor, Base base, Arguments&&... arguments)
 {
     m_typeConstrutors[WTF::enumToUnderlyingType(base)] =
-        TypeConstructor { [this, arguments...](Type* elementType) -> Type* {
+        TypeConstructor { [this, constructor, arguments...](Type* elementType) -> Type* {
             // FIXME: this should be cached
-            return allocateType<TargetType>(elementType, arguments...);
+            return (this->*constructor)(elementType, arguments...);
         } };
 }
 

--- a/Source/WebGPU/WGSL/TypeStore.h
+++ b/Source/WebGPU/WGSL/TypeStore.h
@@ -53,15 +53,18 @@ public:
     Type* f32Type() const { return m_f32; }
 
     Type* structType(const AST::Identifier& name);
-    Type* constructType(AST::ParameterizedTypeName::Base, Type*);
     Type* arrayType(Type*, std::optional<unsigned>);
+    Type* vectorType(Type*, uint8_t);
+    Type* matrixType(Type*, uint8_t columns, uint8_t rows);
+
+    Type* constructType(AST::ParameterizedTypeName::Base, Type*);
 
 private:
     template<typename TypeKind, typename... Arguments>
     Type* allocateType(Arguments&&...);
 
-    template<typename TargetType, typename Base, typename... Arguments>
-    void allocateConstructor(Base, Arguments&&...);
+    template<typename TargetConstructor, typename Base, typename... Arguments>
+    void allocateConstructor(TargetConstructor, Base, Arguments&&...);
 
     struct TypeConstructor {
         std::function<Type*(Type*)> construct;

--- a/Source/WebGPU/WGSL/Types.h
+++ b/Source/WebGPU/WGSL/Types.h
@@ -45,7 +45,7 @@ namespace Types {
     f(Bool, "bool") \
 
 struct Primitive {
-    enum Kind {
+    enum Kind : uint8_t {
 #define PRIMITIVE_KIND(kind, name) kind,
     FOR_EACH_PRIMITIVE_TYPE(PRIMITIVE_KIND)
 #undef PRIMITIVE_KIND

--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -122,6 +122,8 @@
 		664C92FD286A66090008D143 /* IOSurface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 664C92FC286A66090008D143 /* IOSurface.framework */; };
 		66DC575528627E0B0014CABD /* ParserPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 66DC575428627E0B0014CABD /* ParserPrivate.h */; };
 		9776BE7629957E12002D6D93 /* WGSLShaderModule.h in Headers */ = {isa = PBXBuildFile; fileRef = 9776BE7529957E12002D6D93 /* WGSLShaderModule.h */; };
+		9776BE732992A236002D6D93 /* Overload.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9776BE712992A236002D6D93 /* Overload.cpp */; };
+		9776BE742992A236002D6D93 /* Overload.h in Headers */ = {isa = PBXBuildFile; fileRef = 9776BE722992A236002D6D93 /* Overload.h */; };
 		9789C31A297EA105009E9006 /* CallGraph.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9789C318297EA105009E9006 /* CallGraph.cpp */; };
 		978A9125298A4E8400B37E5E /* MangleNames.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 978A9123298A4E8400B37E5E /* MangleNames.cpp */; };
 		978A9126298A4E8400B37E5E /* MangleNames.h in Headers */ = {isa = PBXBuildFile; fileRef = 978A9124298A4E8400B37E5E /* MangleNames.h */; };
@@ -331,6 +333,8 @@
 		664C92FC286A66090008D143 /* IOSurface.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOSurface.framework; path = System/Library/Frameworks/IOSurface.framework; sourceTree = SDKROOT; };
 		66DC575428627E0B0014CABD /* ParserPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ParserPrivate.h; sourceTree = "<group>"; };
 		9776BE7529957E12002D6D93 /* WGSLShaderModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WGSLShaderModule.h; sourceTree = "<group>"; };
+		9776BE712992A236002D6D93 /* Overload.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Overload.cpp; sourceTree = "<group>"; };
+		9776BE722992A236002D6D93 /* Overload.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Overload.h; sourceTree = "<group>"; };
 		9789C318297EA105009E9006 /* CallGraph.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CallGraph.cpp; sourceTree = "<group>"; };
 		9789C319297EA105009E9006 /* CallGraph.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CallGraph.h; sourceTree = "<group>"; };
 		978A9123298A4E8400B37E5E /* MangleNames.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MangleNames.cpp; sourceTree = "<group>"; };
@@ -487,6 +491,8 @@
 				338BB2D327B6B66C00E066AB /* Lexer.h */,
 				978A9123298A4E8400B37E5E /* MangleNames.cpp */,
 				978A9124298A4E8400B37E5E /* MangleNames.h */,
+				9776BE712992A236002D6D93 /* Overload.cpp */,
+				9776BE722992A236002D6D93 /* Overload.h */,
 				339B7B1A27D800090072BF9A /* Parser.cpp */,
 				339B7B1727D7FFA40072BF9A /* Parser.h */,
 				66DC575428627E0B0014CABD /* ParserPrivate.h */,
@@ -713,6 +719,7 @@
 				978A9126298A4E8400B37E5E /* MangleNames.h in Headers */,
 				979240B6297018290050EA2C /* MetalCodeGenerator.h in Headers */,
 				979240B7297018290050EA2C /* MetalFunctionWriter.h in Headers */,
+				9776BE742992A236002D6D93 /* Overload.h in Headers */,
 				339B7B1827D7FFA40072BF9A /* Parser.h in Headers */,
 				66DC575528627E0B0014CABD /* ParserPrivate.h in Headers */,
 				979240C029753B2A0050EA2C /* PhaseTimer.h in Headers */,
@@ -885,6 +892,7 @@
 				978A9125298A4E8400B37E5E /* MangleNames.cpp in Sources */,
 				979240B8297018290050EA2C /* MetalCodeGenerator.cpp in Sources */,
 				979240B9297018290050EA2C /* MetalFunctionWriter.cpp in Sources */,
+				9776BE732992A236002D6D93 /* Overload.cpp in Sources */,
 				339B7B1B27D800090072BF9A /* Parser.cpp in Sources */,
 				979240C4297558F10050EA2C /* ResolveTypeReferences.cpp in Sources */,
 				338BB2D027B6B61B00E066AB /* Token.cpp in Sources */,


### PR DESCRIPTION
#### 387c1b1f6bd7c9ae77a9e1ce3c72d85697a14497
<pre>
[WGSL] Initial implementation of operator overload resolution
<a href="https://bugs.webkit.org/show_bug.cgi?id=251863">https://bugs.webkit.org/show_bug.cgi?id=251863</a>
rdar://105133289

Reviewed by Myles C. Maxfield.

First pass at adding support for overloaded operators and functions. For now,
only `+` is implemented with 2 operators, and declaring the operations is very
cumbersome, but the patch is fairly large as it is, so more convenient declarations
will follow in a separate patch.

* Source/WebGPU/WGSL/Overload.cpp: Added.
(WGSL::log):
(WGSL::logLn):
(WGSL::OverloadResolver::OverloadResolver):
(WGSL::OverloadResolver::resolve):
(WGSL::OverloadResolver::materialize const):
(WGSL::OverloadResolver::considerCandidates):
(WGSL::OverloadResolver::considerCandidate):
(WGSL::OverloadResolver::calculateCost):
(WGSL::OverloadResolver::unify):
(WGSL::OverloadResolver::assign):
(WGSL::OverloadResolver::resolve const):
(WGSL::OverloadResolver::conversionCost const):
(WGSL::primitive_pair):
(WGSL::OverloadResolver::conversionCostImpl const):
(WGSL::resolveOverloads):
(WTF::printInternal):
* Source/WebGPU/WGSL/Overload.h: Copied from Source/WebGPU/WGSL/Types.h.
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::TypeChecker):
(WGSL::TypeChecker::visit):
(WGSL::TypeChecker::chooseOverload):
* Source/WebGPU/WGSL/TypeStore.cpp:
(WGSL::TypeStore::TypeStore):
(WGSL::TypeStore::vectorType):
(WGSL::TypeStore::matrixType):
(WGSL::TypeStore::allocateConstructor):
* Source/WebGPU/WGSL/TypeStore.h:
* Source/WebGPU/WGSL/Types.h:
* Source/WebGPU/WGSL/WGSL.h:
* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/260254@main">https://commits.webkit.org/260254@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06571ff0d480be21672fa7c63ffbc05c41d07ff0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107701 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16754 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40596 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116848 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116238 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18175 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8072 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99876 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113455 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13721 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96917 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41401 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/95634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28558 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9733 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29906 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10412 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6794 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15886 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49492 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7088 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11973 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->