### PR TITLE
Port the remaining mediastream related types to the new IPC serialization format

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1909,6 +1909,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/mediastream/RTCDataChannelHandler.h
     platform/mediastream/RTCDataChannelHandlerClient.h
     platform/mediastream/RTCDataChannelIdentifier.h
+    platform/mediastream/RTCDataChannelLocalIdentifier.h
     platform/mediastream/RTCDataChannelRemoteHandlerConnection.h
     platform/mediastream/RTCDataChannelRemoteSourceConnection.h
     platform/mediastream/RTCDataChannelState.h

--- a/Source/WebCore/Modules/mediastream/MediaDevices.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.cpp
@@ -62,10 +62,10 @@ inline MediaDevices::MediaDevices(Document& document)
     , m_eventNames(eventNames())
     , m_groupIdHashSalt(createVersion4UUIDString())
 {
-    static_assert(static_cast<size_t>(MediaDevices::DisplayCaptureSurfaceType::Monitor) == static_cast<size_t>(RealtimeMediaSourceSettings::DisplaySurfaceType::Monitor), "MediaDevices::DisplayCaptureSurfaceType::Monitor is not equal to RealtimeMediaSourceSettings::DisplaySurfaceType::Monitor as expected");
-    static_assert(static_cast<size_t>(MediaDevices::DisplayCaptureSurfaceType::Window) == static_cast<size_t>(RealtimeMediaSourceSettings::DisplaySurfaceType::Window), "MediaDevices::DisplayCaptureSurfaceType::Window is not RealtimeMediaSourceSettings::DisplaySurfaceType::Window as expected");
-    static_assert(static_cast<size_t>(MediaDevices::DisplayCaptureSurfaceType::Application) == static_cast<size_t>(RealtimeMediaSourceSettings::DisplaySurfaceType::Application), "MediaDevices::DisplayCaptureSurfaceType::Application is not RealtimeMediaSourceSettings::DisplaySurfaceType::Application as expected");
-    static_assert(static_cast<size_t>(MediaDevices::DisplayCaptureSurfaceType::Browser) == static_cast<size_t>(RealtimeMediaSourceSettings::DisplaySurfaceType::Browser), "MediaDevices::DisplayCaptureSurfaceType::Browser is not RealtimeMediaSourceSettings::DisplaySurfaceType::Browser as expected");
+    static_assert(static_cast<size_t>(MediaDevices::DisplayCaptureSurfaceType::Monitor) == static_cast<size_t>(DisplaySurfaceType::Monitor), "MediaDevices::DisplayCaptureSurfaceType::Monitor is not equal to DisplaySurfaceType::Monitor as expected");
+    static_assert(static_cast<size_t>(MediaDevices::DisplayCaptureSurfaceType::Window) == static_cast<size_t>(DisplaySurfaceType::Window), "MediaDevices::DisplayCaptureSurfaceType::Window is not DisplaySurfaceType::Window as expected");
+    static_assert(static_cast<size_t>(MediaDevices::DisplayCaptureSurfaceType::Application) == static_cast<size_t>(DisplaySurfaceType::Application), "MediaDevices::DisplayCaptureSurfaceType::Application is not DisplaySurfaceType::Application as expected");
+    static_assert(static_cast<size_t>(MediaDevices::DisplayCaptureSurfaceType::Browser) == static_cast<size_t>(DisplaySurfaceType::Browser), "MediaDevices::DisplayCaptureSurfaceType::Browser is not DisplaySurfaceType::Browser as expected");
 }
 
 MediaDevices::~MediaDevices() = default;

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
@@ -276,7 +276,7 @@ MediaStreamTrack::TrackSettings MediaStreamTrack::getSettings() const
         result.deviceId = settings.deviceId();
     if (settings.supportsGroupId())
         result.groupId = settings.groupId();
-    if (settings.supportsDisplaySurface() && settings.displaySurface() != RealtimeMediaSourceSettings::DisplaySurfaceType::Invalid)
+    if (settings.supportsDisplaySurface() && settings.displaySurface() != DisplaySurfaceType::Invalid)
         result.displaySurface = RealtimeMediaSourceSettings::displaySurface(settings.displaySurface());
 
     // FIXME: shouldn't this include logicalSurface?
@@ -324,7 +324,7 @@ static LongRange capabilityIntRange(const CapabilityValueOrRange& value)
     return range;
 }
 
-static Vector<String> capabilityStringVector(const Vector<RealtimeMediaSourceSettings::VideoFacingMode>& modes)
+static Vector<String> capabilityStringVector(const Vector<VideoFacingMode>& modes)
 {
     return modes.map([](auto& mode) {
         return RealtimeMediaSourceSettings::facingMode(mode);
@@ -369,7 +369,7 @@ MediaStreamTrack::TrackCapabilities MediaStreamTrack::getCapabilities() const
         result.groupId = capabilities.groupId();
 
     auto settings = m_private->settings();
-    if (settings.supportsDisplaySurface() && settings.displaySurface() != RealtimeMediaSourceSettings::DisplaySurfaceType::Invalid)
+    if (settings.supportsDisplaySurface() && settings.displaySurface() != DisplaySurfaceType::Invalid)
         result.displaySurface = RealtimeMediaSourceSettings::displaySurface(settings.displaySurface());
 
     return result;

--- a/Source/WebCore/platform/mediastream/CaptureDevice.h
+++ b/Source/WebCore/platform/mediastream/CaptureDevice.h
@@ -32,7 +32,7 @@ namespace WebCore {
 
 class CaptureDevice {
 public:
-    enum class DeviceType { Unknown, Microphone, Speaker, Camera, Screen, Window, SystemAudio };
+    enum class DeviceType : uint8_t { Unknown, Microphone, Speaker, Camera, Screen, Window, SystemAudio };
 
     CaptureDevice(const String& persistentId, DeviceType type, const String& label, const String& groupId = emptyString(), bool isEnabled = false, bool isDefault = false, bool isMock = false, bool isEphemeral = false)
         : m_persistentId(persistentId)
@@ -82,72 +82,6 @@ public:
     explicit operator bool() const { return m_type != DeviceType::Unknown; }
 
     CaptureDevice isolatedCopy() &&;
-
-#if ENABLE(MEDIA_STREAM)
-    template<class Encoder>
-    void encode(Encoder& encoder) const
-    {
-        encoder << m_persistentId;
-        encoder << m_label;
-        encoder << m_groupId;
-        encoder << m_enabled;
-        encoder << m_default;
-        encoder << m_type;
-        encoder << m_isMockDevice;
-        encoder << m_isEphemeral;
-    }
-
-    template <class Decoder>
-    static std::optional<CaptureDevice> decode(Decoder& decoder)
-    {
-        std::optional<String> persistentId;
-        decoder >> persistentId;
-        if (!persistentId)
-            return std::nullopt;
-
-        std::optional<String> label;
-        decoder >> label;
-        if (!label)
-            return std::nullopt;
-
-        std::optional<String> groupId;
-        decoder >> groupId;
-        if (!groupId)
-            return std::nullopt;
-
-        std::optional<bool> enabled;
-        decoder >> enabled;
-        if (!enabled)
-            return std::nullopt;
-
-        std::optional<bool> isDefault;
-        decoder >> isDefault;
-        if (!isDefault)
-            return std::nullopt;
-
-        std::optional<CaptureDevice::DeviceType> type;
-        decoder >> type;
-        if (!type)
-            return std::nullopt;
-
-        std::optional<bool> isMockDevice;
-        decoder >> isMockDevice;
-        if (!isMockDevice)
-            return std::nullopt;
-
-        std::optional<bool> isEphemeral;
-        decoder >> isEphemeral;
-        if (!isEphemeral)
-            return std::nullopt;
-
-        std::optional<CaptureDevice> device = {{ WTFMove(*persistentId), WTFMove(*type), WTFMove(*label), WTFMove(*groupId) }};
-        device->setEnabled(*enabled);
-        device->setIsDefault(*isDefault);
-        device->setIsMockDevice(*isMockDevice);
-        device->setIsEphemeral(*isEphemeral);
-        return device;
-    }
-#endif
 
 protected:
     String m_persistentId;

--- a/Source/WebCore/platform/mediastream/RTCDataChannelHandler.h
+++ b/Source/WebCore/platform/mediastream/RTCDataChannelHandler.h
@@ -44,9 +44,6 @@ struct RTCDataChannelInit {
 
     RTCDataChannelInit isolatedCopy() const &;
     RTCDataChannelInit isolatedCopy() &&;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<RTCDataChannelInit> decode(Decoder&);
 };
 
 inline RTCDataChannelInit RTCDataChannelInit::isolatedCopy() const &
@@ -61,50 +58,6 @@ inline RTCDataChannelInit RTCDataChannelInit::isolatedCopy() &&
     auto copy = WTFMove(*this);
     copy.protocol = WTFMove(copy.protocol).isolatedCopy();
     return copy;
-}
-
-template<class Encoder> void RTCDataChannelInit::encode(Encoder& encoder) const
-{
-    encoder << ordered << maxPacketLifeTime << maxRetransmits << protocol << negotiated << id << priority;
-}
-
-template<class Decoder> std::optional<RTCDataChannelInit> RTCDataChannelInit::decode(Decoder& decoder)
-{
-    std::optional<std::optional<bool>> ordered;
-    decoder >> ordered;
-    if (!ordered)
-        return { };
-
-    std::optional<std::optional<unsigned short>> maxPacketLifeTime;
-    decoder >> maxPacketLifeTime;
-    if (!maxPacketLifeTime)
-        return { };
-
-    std::optional<std::optional<unsigned short>> maxRetransmits;
-    decoder >> maxRetransmits;
-    if (!maxRetransmits)
-        return { };
-
-    String protocol;
-    if (!decoder.decode(protocol))
-        return { };
-
-    std::optional<std::optional<bool>> negotiated;
-    decoder >> negotiated;
-    if (!negotiated)
-        return { };
-
-    std::optional<std::optional<unsigned short>> id;
-    decoder >> id;
-    if (!id)
-        return { };
-
-    std::optional<RTCPriorityType> priority;
-    decoder >> priority;
-    if (!priority)
-        return { };
-
-    return RTCDataChannelInit { *ordered, *maxPacketLifeTime, *maxRetransmits, WTFMove(protocol), *negotiated, *id, *priority };
 }
 
 class RTCDataChannelHandlerClient;

--- a/Source/WebCore/platform/mediastream/RTCDataChannelIdentifier.h
+++ b/Source/WebCore/platform/mediastream/RTCDataChannelIdentifier.h
@@ -25,39 +25,13 @@
 #pragma once
 
 #include "ProcessIdentifier.h"
-#include <wtf/ObjectIdentifier.h>
+#include "RTCDataChannelLocalIdentifier.h"
 
 namespace WebCore {
 
-enum RTCDataChannelLocalIdentifierType { };
-using RTCDataChannelLocalIdentifier = ObjectIdentifier<RTCDataChannelLocalIdentifierType>;
 struct RTCDataChannelIdentifier {
     ProcessIdentifier processIdentifier;
     RTCDataChannelLocalIdentifier channelIdentifier;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<RTCDataChannelIdentifier> decode(Decoder&);
 };
-
-template<class Encoder>
-inline void RTCDataChannelIdentifier::encode(Encoder& encoder) const
-{
-    encoder << processIdentifier << channelIdentifier;
-}
-
-template<class Decoder>
-inline std::optional<RTCDataChannelIdentifier> RTCDataChannelIdentifier::decode(Decoder& decoder)
-{
-    std::optional<ProcessIdentifier> processIdentifier;
-    decoder >> processIdentifier;
-    if (!processIdentifier)
-        return std::nullopt;
-
-    std::optional<RTCDataChannelLocalIdentifier> channelIdentifier;
-    decoder >> channelIdentifier;
-    if (!channelIdentifier)
-        return std::nullopt;
-    return RTCDataChannelIdentifier { *processIdentifier, *channelIdentifier };
-}
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/RTCDataChannelLocalIdentifier.h
+++ b/Source/WebCore/platform/mediastream/RTCDataChannelLocalIdentifier.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/ObjectIdentifier.h>
+
+namespace WebCore {
+
+enum RTCDataChannelLocalIdentifierType { };
+using RTCDataChannelLocalIdentifier = ObjectIdentifier<RTCDataChannelLocalIdentifierType>;
+
+} // namespace WebCore

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
@@ -1069,7 +1069,7 @@ void RealtimeMediaSource::setAspectRatio(double ratio)
     notifySettingsDidChangeObservers({ RealtimeMediaSourceSettings::Flag::AspectRatio });
 }
 
-void RealtimeMediaSource::setFacingMode(RealtimeMediaSourceSettings::VideoFacingMode mode)
+void RealtimeMediaSource::setFacingMode(VideoFacingMode mode)
 {
     if (m_facingMode == mode)
         return;

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -178,8 +178,8 @@ public:
     double aspectRatio() const { return m_aspectRatio; }
     void setAspectRatio(double);
 
-    RealtimeMediaSourceSettings::VideoFacingMode facingMode() const { return m_facingMode; }
-    void setFacingMode(RealtimeMediaSourceSettings::VideoFacingMode);
+    VideoFacingMode facingMode() const { return m_facingMode; }
+    void setFacingMode(VideoFacingMode);
 
     double volume() const { return m_volume; }
     void setVolume(double);
@@ -329,7 +329,7 @@ private:
     double m_sampleRate { 0 };
     double m_sampleSize { 0 };
     double m_fitnessScore { 0 };
-    RealtimeMediaSourceSettings::VideoFacingMode m_facingMode { RealtimeMediaSourceSettings::User};
+    VideoFacingMode m_facingMode { VideoFacingMode::User };
 
     bool m_muted { false };
     bool m_pendingSettingsDidChangeNotification { false };

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCapabilities.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCapabilities.h
@@ -147,6 +147,27 @@ public:
         : m_supportedConstraints(supportedConstraints)
     {
     }
+    
+    enum class EchoCancellation : bool {
+        ReadOnly = 0,
+        ReadWrite = 1,
+    };
+    
+    RealtimeMediaSourceCapabilities(CapabilityValueOrRange&& width, CapabilityValueOrRange&& height, CapabilityValueOrRange&& aspectRatio, CapabilityValueOrRange&& frameRate, Vector<VideoFacingMode>&& facingMode, CapabilityValueOrRange&& volume, CapabilityValueOrRange&& sampleRate, CapabilityValueOrRange&& sampleSize, EchoCancellation&& echoCancellation, AtomString&& deviceId, AtomString&& groupId, RealtimeMediaSourceSupportedConstraints&& supportedConstraints)
+        : m_width(WTFMove(width))
+        , m_height(WTFMove(height))
+        , m_aspectRatio(WTFMove(aspectRatio))
+        , m_frameRate(WTFMove(frameRate))
+        , m_facingMode(WTFMove(facingMode))
+        , m_volume(WTFMove(volume))
+        , m_sampleRate(WTFMove(sampleRate))
+        , m_sampleSize(WTFMove(sampleSize))
+        , m_echoCancellation(WTFMove(echoCancellation))
+        , m_deviceId(WTFMove(deviceId))
+        , m_groupId(WTFMove(groupId))
+        , m_supportedConstraints(WTFMove(supportedConstraints))
+    {
+    }
 
     ~RealtimeMediaSourceCapabilities() = default;
 
@@ -169,8 +190,8 @@ public:
     void setFrameRate(const CapabilityValueOrRange& frameRate) { m_frameRate = frameRate; }
 
     bool supportsFacingMode() const { return m_supportedConstraints.supportsFacingMode(); }
-    const Vector<RealtimeMediaSourceSettings::VideoFacingMode>& facingMode() const { return m_facingMode; }
-    void addFacingMode(RealtimeMediaSourceSettings::VideoFacingMode mode) { m_facingMode.append(mode); }
+    const Vector<VideoFacingMode>& facingMode() const { return m_facingMode; }
+    void addFacingMode(VideoFacingMode mode) { m_facingMode.append(mode); }
 
     bool supportsAspectRatio() const { return m_supportedConstraints.supportsAspectRatio(); }
     const CapabilityValueOrRange& aspectRatio() const { return m_aspectRatio; }
@@ -188,10 +209,6 @@ public:
     const CapabilityValueOrRange& sampleSize() const { return m_sampleSize; }
     void setSampleSize(const CapabilityValueOrRange& sampleSize) { m_sampleSize = sampleSize; }
 
-    enum class EchoCancellation : bool {
-        ReadOnly = 0,
-        ReadWrite = 1,
-    };
     bool supportsEchoCancellation() const { return m_supportedConstraints.supportsEchoCancellation(); }
     EchoCancellation echoCancellation() const { return m_echoCancellation; }
     void setEchoCancellation(EchoCancellation echoCancellation) { m_echoCancellation = echoCancellation; }
@@ -207,15 +224,12 @@ public:
     const RealtimeMediaSourceSupportedConstraints& supportedConstraints() const { return m_supportedConstraints; }
     void setSupportedConstraints(const RealtimeMediaSourceSupportedConstraints& constraints) { m_supportedConstraints = constraints; }
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static WARN_UNUSED_RETURN bool decode(Decoder&, RealtimeMediaSourceCapabilities&);
-
 private:
     CapabilityValueOrRange m_width;
     CapabilityValueOrRange m_height;
     CapabilityValueOrRange m_aspectRatio;
     CapabilityValueOrRange m_frameRate;
-    Vector<RealtimeMediaSourceSettings::VideoFacingMode> m_facingMode;
+    Vector<VideoFacingMode> m_facingMode;
     CapabilityValueOrRange m_volume;
     CapabilityValueOrRange m_sampleRate;
     CapabilityValueOrRange m_sampleSize;
@@ -225,40 +239,6 @@ private:
 
     RealtimeMediaSourceSupportedConstraints m_supportedConstraints;
 };
-
-template<class Encoder>
-void RealtimeMediaSourceCapabilities::encode(Encoder& encoder) const
-{
-    encoder << m_width
-        << m_height
-        << m_aspectRatio
-        << m_frameRate
-        << m_facingMode
-        << m_volume
-        << m_sampleRate
-        << m_sampleSize
-        << m_deviceId
-        << m_groupId
-        << m_supportedConstraints
-        << m_echoCancellation;
-}
-
-template<class Decoder>
-bool RealtimeMediaSourceCapabilities::decode(Decoder& decoder, RealtimeMediaSourceCapabilities& capabilities)
-{
-    return decoder.decode(capabilities.m_width)
-        && decoder.decode(capabilities.m_height)
-        && decoder.decode(capabilities.m_aspectRatio)
-        && decoder.decode(capabilities.m_frameRate)
-        && decoder.decode(capabilities.m_facingMode)
-        && decoder.decode(capabilities.m_volume)
-        && decoder.decode(capabilities.m_sampleRate)
-        && decoder.decode(capabilities.m_sampleSize)
-        && decoder.decode(capabilities.m_deviceId)
-        && decoder.decode(capabilities.m_groupId)
-        && decoder.decode(capabilities.m_supportedConstraints)
-        && decoder.decode(capabilities.m_echoCancellation);
-}
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.cpp
@@ -38,7 +38,7 @@
 
 namespace WebCore {
 
-String RealtimeMediaSourceSettings::facingMode(RealtimeMediaSourceSettings::VideoFacingMode mode)
+String RealtimeMediaSourceSettings::facingMode(VideoFacingMode mode)
 {
     static const NeverDestroyed<String> values[] = {
         MAKE_STATIC_STRING_IMPL("unknown"),
@@ -47,27 +47,27 @@ String RealtimeMediaSourceSettings::facingMode(RealtimeMediaSourceSettings::Vide
         MAKE_STATIC_STRING_IMPL("left"),
         MAKE_STATIC_STRING_IMPL("right"),
     };
-    static_assert(static_cast<size_t>(RealtimeMediaSourceSettings::VideoFacingMode::Unknown) == 0, "RealtimeMediaSourceSettings::VideoFacingMode::Unknown is not 0 as expected");
-    static_assert(static_cast<size_t>(RealtimeMediaSourceSettings::VideoFacingMode::User) == 1, "RealtimeMediaSourceSettings::VideoFacingMode::User is not 1 as expected");
-    static_assert(static_cast<size_t>(RealtimeMediaSourceSettings::VideoFacingMode::Environment) == 2, "RealtimeMediaSourceSettings::VideoFacingMode::Environment is not 2 as expected");
-    static_assert(static_cast<size_t>(RealtimeMediaSourceSettings::VideoFacingMode::Left) == 3, "RealtimeMediaSourceSettings::VideoFacingMode::Left is not 3 as expected");
-    static_assert(static_cast<size_t>(RealtimeMediaSourceSettings::VideoFacingMode::Right) == 4, "RealtimeMediaSourceSettings::VideoFacingMode::Right is not 4 as expected");
+    static_assert(static_cast<size_t>(VideoFacingMode::Unknown) == 0, "VideoFacingMode::Unknown is not 0 as expected");
+    static_assert(static_cast<size_t>(VideoFacingMode::User) == 1, "VideoFacingMode::User is not 1 as expected");
+    static_assert(static_cast<size_t>(VideoFacingMode::Environment) == 2, "VideoFacingMode::Environment is not 2 as expected");
+    static_assert(static_cast<size_t>(VideoFacingMode::Left) == 3, "VideoFacingMode::Left is not 3 as expected");
+    static_assert(static_cast<size_t>(VideoFacingMode::Right) == 4, "VideoFacingMode::Right is not 4 as expected");
     ASSERT(static_cast<size_t>(mode) < std::size(values));
     return values[static_cast<size_t>(mode)];
 }
 
-RealtimeMediaSourceSettings::VideoFacingMode RealtimeMediaSourceSettings::videoFacingModeEnum(const String& mode)
+VideoFacingMode RealtimeMediaSourceSettings::videoFacingModeEnum(const String& mode)
 {
     if (mode == "user"_s)
-        return RealtimeMediaSourceSettings::VideoFacingMode::User;
+        return VideoFacingMode::User;
     if (mode == "environment"_s)
-        return RealtimeMediaSourceSettings::VideoFacingMode::Environment;
+        return VideoFacingMode::Environment;
     if (mode == "left"_s)
-        return RealtimeMediaSourceSettings::VideoFacingMode::Left;
+        return VideoFacingMode::Left;
     if (mode == "right"_s)
-        return RealtimeMediaSourceSettings::VideoFacingMode::Right;
+        return VideoFacingMode::Right;
 
-    return RealtimeMediaSourceSettings::Unknown;
+    return VideoFacingMode::Unknown;
 }
 
 String RealtimeMediaSourceSettings::convertFlagsToString(const OptionSet<RealtimeMediaSourceSettings::Flag> flags)
@@ -165,7 +165,7 @@ OptionSet<RealtimeMediaSourceSettings::Flag> RealtimeMediaSourceSettings::differ
     return difference;
 }
 
-String convertEnumerationToString(RealtimeMediaSourceSettings::VideoFacingMode enumerationValue)
+String convertEnumerationToString(VideoFacingMode enumerationValue)
 {
     static const NeverDestroyed<String> values[] = {
         MAKE_STATIC_STRING_IMPL("Unknown"),
@@ -174,16 +174,16 @@ String convertEnumerationToString(RealtimeMediaSourceSettings::VideoFacingMode e
         MAKE_STATIC_STRING_IMPL("Left"),
         MAKE_STATIC_STRING_IMPL("Right"),
     };
-    static_assert(static_cast<size_t>(RealtimeMediaSourceSettings::VideoFacingMode::Unknown) == 0, "RealtimeMediaSourceSettings::VideoFacingMode::Unknown is not 0 as expected");
-    static_assert(static_cast<size_t>(RealtimeMediaSourceSettings::VideoFacingMode::User) == 1, "RealtimeMediaSourceSettings::VideoFacingMode::User is not 1 as expected");
-    static_assert(static_cast<size_t>(RealtimeMediaSourceSettings::VideoFacingMode::Environment) == 2, "RealtimeMediaSourceSettings::VideoFacingMode::Environment is not 2 as expected");
-    static_assert(static_cast<size_t>(RealtimeMediaSourceSettings::VideoFacingMode::Left) == 3, "RealtimeMediaSourceSettings::VideoFacingMode::Left is not 3 as expected");
-    static_assert(static_cast<size_t>(RealtimeMediaSourceSettings::VideoFacingMode::Right) == 4, "RealtimeMediaSourceSettings::VideoFacingMode::Right is not 4 as expected");
+    static_assert(static_cast<size_t>(VideoFacingMode::Unknown) == 0, "VideoFacingMode::Unknown is not 0 as expected");
+    static_assert(static_cast<size_t>(VideoFacingMode::User) == 1, "VideoFacingMode::User is not 1 as expected");
+    static_assert(static_cast<size_t>(VideoFacingMode::Environment) == 2, "VideoFacingMode::Environment is not 2 as expected");
+    static_assert(static_cast<size_t>(VideoFacingMode::Left) == 3, "VideoFacingMode::Left is not 3 as expected");
+    static_assert(static_cast<size_t>(VideoFacingMode::Right) == 4, "VideoFacingMode::Right is not 4 as expected");
     ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
 
-String RealtimeMediaSourceSettings::displaySurface(RealtimeMediaSourceSettings::DisplaySurfaceType surface)
+String RealtimeMediaSourceSettings::displaySurface(DisplaySurfaceType surface)
 {
     static const NeverDestroyed<String> values[] = {
         MAKE_STATIC_STRING_IMPL("monitor"),
@@ -193,11 +193,11 @@ String RealtimeMediaSourceSettings::displaySurface(RealtimeMediaSourceSettings::
         MAKE_STATIC_STRING_IMPL("invalid"),
     };
 
-    static_assert(static_cast<size_t>(RealtimeMediaSourceSettings::DisplaySurfaceType::Monitor) == 0, "RealtimeMediaSourceSettings::DisplaySurface::Monitor is not 0 as expected");
-    static_assert(static_cast<size_t>(RealtimeMediaSourceSettings::DisplaySurfaceType::Window) == 1, "RealtimeMediaSourceSettings::DisplaySurface::Window is not 1 as expected");
-    static_assert(static_cast<size_t>(RealtimeMediaSourceSettings::DisplaySurfaceType::Application) == 2, "RealtimeMediaSourceSettings::DisplaySurface::Application is not 0 as expected");
-    static_assert(static_cast<size_t>(RealtimeMediaSourceSettings::DisplaySurfaceType::Browser) == 3, "RealtimeMediaSourceSettings::DisplaySurface::Browser is not 1 as expected");
-    static_assert(static_cast<size_t>(RealtimeMediaSourceSettings::DisplaySurfaceType::Invalid) == 4, "RealtimeMediaSourceSettings::DisplaySurface::Invalid is not 0 as expected");
+    static_assert(static_cast<size_t>(DisplaySurfaceType::Monitor) == 0, "RealtimeMediaSourceSettings::DisplaySurface::Monitor is not 0 as expected");
+    static_assert(static_cast<size_t>(DisplaySurfaceType::Window) == 1, "RealtimeMediaSourceSettings::DisplaySurface::Window is not 1 as expected");
+    static_assert(static_cast<size_t>(DisplaySurfaceType::Application) == 2, "RealtimeMediaSourceSettings::DisplaySurface::Application is not 0 as expected");
+    static_assert(static_cast<size_t>(DisplaySurfaceType::Browser) == 3, "RealtimeMediaSourceSettings::DisplaySurface::Browser is not 1 as expected");
+    static_assert(static_cast<size_t>(DisplaySurfaceType::Invalid) == 4, "RealtimeMediaSourceSettings::DisplaySurface::Invalid is not 0 as expected");
     ASSERT(static_cast<size_t>(surface) < std::size(values));
     return values[static_cast<size_t>(surface)];
 }

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.h
@@ -35,21 +35,28 @@
 
 namespace WebCore {
 
+enum class VideoFacingMode : uint8_t {
+    Unknown,
+    User,
+    Environment,
+    Left,
+    Right
+};
+
+enum class DisplaySurfaceType : uint8_t {
+    Monitor,
+    Window,
+    Application,
+    Browser,
+    Invalid,
+};
+
 class RealtimeMediaSourceSettings {
 public:
-    enum VideoFacingMode { Unknown, User, Environment, Left, Right };
-    enum class DisplaySurfaceType {
-        Monitor,
-        Window,
-        Application,
-        Browser,
-        Invalid,
-    };
-
-    static String facingMode(RealtimeMediaSourceSettings::VideoFacingMode);
-    static RealtimeMediaSourceSettings::VideoFacingMode videoFacingModeEnum(const String&);
-    static String displaySurface(RealtimeMediaSourceSettings::DisplaySurfaceType);
-
+    static String facingMode(VideoFacingMode);
+    static VideoFacingMode videoFacingModeEnum(const String&);
+    static String displaySurface(DisplaySurfaceType);
+    
     enum Flag {
         Width = 1 << 0,
         Height = 1 << 1,
@@ -72,6 +79,24 @@ public:
     WEBCORE_EXPORT OptionSet<RealtimeMediaSourceSettings::Flag> difference(const RealtimeMediaSourceSettings&) const;
 
     explicit RealtimeMediaSourceSettings() = default;
+    RealtimeMediaSourceSettings(uint32_t width, uint32_t height, float aspectRatio, float frameRate, VideoFacingMode facingMode, double volume, uint32_t sampleRate, uint32_t sampleSize, bool echoCancellation, AtomString&& deviceId, AtomString&& groupId, AtomString&& label, DisplaySurfaceType displaySurface, bool logicalSurface, RealtimeMediaSourceSupportedConstraints&& supportedConstraints)
+        : m_width(width)
+        , m_height(height)
+        , m_aspectRatio(aspectRatio)
+        , m_frameRate(frameRate)
+        , m_facingMode(facingMode)
+        , m_volume(volume)
+        , m_sampleRate(sampleRate)
+        , m_sampleSize(sampleSize)
+        , m_echoCancellation(echoCancellation)
+        , m_deviceId(WTFMove(deviceId))
+        , m_groupId(WTFMove(groupId))
+        , m_label(WTFMove(label))
+        , m_displaySurface(displaySurface)
+        , m_logicalSurface(logicalSurface)
+        , m_supportedConstraints(WTFMove(supportedConstraints))
+    {
+    }
 
     bool supportsWidth() const { return m_supportedConstraints.supportsWidth(); }
     uint32_t width() const { return m_width; }
@@ -131,9 +156,6 @@ public:
     const AtomString& label() const { return m_label; }
     void setLabel(const AtomString& label) { m_label = label; }
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static WARN_UNUSED_RETURN bool decode(Decoder&, RealtimeMediaSourceSettings&);
-
     static String convertFlagsToString(const OptionSet<RealtimeMediaSourceSettings::Flag>);
 
 private:
@@ -141,7 +163,7 @@ private:
     uint32_t m_height { 0 };
     float m_aspectRatio { 0 };
     float m_frameRate { 0 };
-    VideoFacingMode m_facingMode { Unknown };
+    VideoFacingMode m_facingMode { VideoFacingMode::Unknown };
     double m_volume { 0 };
     uint32_t m_sampleRate { 0 };
     uint32_t m_sampleSize { 0 };
@@ -157,80 +179,18 @@ private:
     RealtimeMediaSourceSupportedConstraints m_supportedConstraints;
 };
 
-template<class Encoder>
-void RealtimeMediaSourceSettings::encode(Encoder& encoder) const
-{
-    encoder << m_width
-        << m_height
-        << m_aspectRatio
-        << m_frameRate
-        << m_volume
-        << m_sampleRate
-        << m_sampleSize
-        << m_echoCancellation
-        << m_deviceId
-        << m_groupId
-        << m_displaySurface
-        << m_logicalSurface
-        << m_label
-        << m_supportedConstraints;
-    encoder << m_facingMode;
-}
-
-template<class Decoder>
-bool RealtimeMediaSourceSettings::decode(Decoder& decoder, RealtimeMediaSourceSettings& settings)
-{
-    return decoder.decode(settings.m_width)
-        && decoder.decode(settings.m_height)
-        && decoder.decode(settings.m_aspectRatio)
-        && decoder.decode(settings.m_frameRate)
-        && decoder.decode(settings.m_volume)
-        && decoder.decode(settings.m_sampleRate)
-        && decoder.decode(settings.m_sampleSize)
-        && decoder.decode(settings.m_echoCancellation)
-        && decoder.decode(settings.m_deviceId)
-        && decoder.decode(settings.m_groupId)
-        && decoder.decode(settings.m_displaySurface)
-        && decoder.decode(settings.m_logicalSurface)
-        && decoder.decode(settings.m_label)
-        && decoder.decode(settings.m_supportedConstraints)
-        && decoder.decode(settings.m_facingMode);
-}
-
-String convertEnumerationToString(RealtimeMediaSourceSettings::VideoFacingMode);
+String convertEnumerationToString(VideoFacingMode);
 
 } // namespace WebCore
 
 namespace WTF {
 
-template <> struct EnumTraits<WebCore::RealtimeMediaSourceSettings::VideoFacingMode> {
-    using values = EnumValues<
-        WebCore::RealtimeMediaSourceSettings::VideoFacingMode,
-        WebCore::RealtimeMediaSourceSettings::VideoFacingMode::Unknown,
-        WebCore::RealtimeMediaSourceSettings::VideoFacingMode::User,
-        WebCore::RealtimeMediaSourceSettings::VideoFacingMode::Environment,
-        WebCore::RealtimeMediaSourceSettings::VideoFacingMode::Left,
-        WebCore::RealtimeMediaSourceSettings::VideoFacingMode::Right
-    >;
-};
-
-template <> struct EnumTraits<WebCore::RealtimeMediaSourceSettings::DisplaySurfaceType> {
-    using values = EnumValues<
-        WebCore::RealtimeMediaSourceSettings::DisplaySurfaceType,
-        WebCore::RealtimeMediaSourceSettings::DisplaySurfaceType::Monitor,
-        WebCore::RealtimeMediaSourceSettings::DisplaySurfaceType::Window,
-        WebCore::RealtimeMediaSourceSettings::DisplaySurfaceType::Application,
-        WebCore::RealtimeMediaSourceSettings::DisplaySurfaceType::Browser,
-        WebCore::RealtimeMediaSourceSettings::DisplaySurfaceType::Invalid
-    >;
-};
-
 template<typename Type>
 struct LogArgument;
 
 template <>
-struct LogArgument<WebCore::RealtimeMediaSourceSettings::VideoFacingMode> {
-    static String toString(const WebCore::RealtimeMediaSourceSettings::VideoFacingMode mode)
+struct LogArgument<WebCore::VideoFacingMode> {
+    static String toString(const WebCore::VideoFacingMode mode)
     {
         return convertEnumerationToString(mode);
     }

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceSupportedConstraints.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceSupportedConstraints.h
@@ -58,6 +58,23 @@ public:
     RealtimeMediaSourceSupportedConstraints()
     {
     }
+    
+    RealtimeMediaSourceSupportedConstraints(bool supportsWidth, bool supportsHeight, bool supportsAspectRatio, bool supportsFrameRate, bool supportsFacingMode, bool supportsVolume, bool supportsSampleRate, bool supportsSampleSize, bool supportsEchoCancellation, bool supportsDeviceId, bool supportsGroupId, bool supportsDisplaySurface, bool supportsLogicalSurface)
+        : m_supportsWidth(supportsWidth)
+        , m_supportsHeight(supportsHeight)
+        , m_supportsAspectRatio(supportsAspectRatio)
+        , m_supportsFrameRate(supportsFrameRate)
+        , m_supportsFacingMode(supportsFacingMode)
+        , m_supportsVolume(supportsVolume)
+        , m_supportsSampleRate(supportsSampleRate)
+        , m_supportsSampleSize(supportsSampleSize)
+        , m_supportsEchoCancellation(supportsEchoCancellation)
+        , m_supportsDeviceId(supportsDeviceId)
+        , m_supportsGroupId(supportsGroupId)
+        , m_supportsDisplaySurface(supportsDisplaySurface)
+        , m_supportsLogicalSurface(supportsLogicalSurface)
+    {
+    }
 
     bool supportsWidth() const { return m_supportsWidth; }
     void setSupportsWidth(bool value) { m_supportsWidth = value; }
@@ -100,9 +117,6 @@ public:
 
     bool supportsConstraint(MediaConstraintType) const;
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static WARN_UNUSED_RETURN bool decode(Decoder&, RealtimeMediaSourceSupportedConstraints&);
-
 private:
     bool m_supportsWidth { false };
     bool m_supportsHeight { false };
@@ -118,42 +132,6 @@ private:
     bool m_supportsDisplaySurface { false };
     bool m_supportsLogicalSurface { false };
 };
-
-template<class Encoder>
-void RealtimeMediaSourceSupportedConstraints::encode(Encoder& encoder) const
-{
-    encoder << m_supportsWidth
-        << m_supportsHeight
-        << m_supportsAspectRatio
-        << m_supportsFrameRate
-        << m_supportsFacingMode
-        << m_supportsVolume
-        << m_supportsSampleRate
-        << m_supportsSampleSize
-        << m_supportsEchoCancellation
-        << m_supportsDeviceId
-        << m_supportsGroupId
-        << m_supportsDisplaySurface
-        << m_supportsLogicalSurface;
-}
-
-template<class Decoder>
-bool RealtimeMediaSourceSupportedConstraints::decode(Decoder& decoder, RealtimeMediaSourceSupportedConstraints& constraints)
-{
-    return decoder.decode(constraints.m_supportsWidth)
-        && decoder.decode(constraints.m_supportsHeight)
-        && decoder.decode(constraints.m_supportsAspectRatio)
-        && decoder.decode(constraints.m_supportsFrameRate)
-        && decoder.decode(constraints.m_supportsFacingMode)
-        && decoder.decode(constraints.m_supportsVolume)
-        && decoder.decode(constraints.m_supportsSampleRate)
-        && decoder.decode(constraints.m_supportsSampleSize)
-        && decoder.decode(constraints.m_supportsEchoCancellation)
-        && decoder.decode(constraints.m_supportsDeviceId)
-        && decoder.decode(constraints.m_supportsGroupId)
-        && decoder.decode(constraints.m_supportsDisplaySurface)
-        && decoder.decode(constraints.m_supportsLogicalSurface);
-}
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/mediastream/VideoPreset.h
+++ b/Source/WebCore/platform/mediastream/VideoPreset.h
@@ -37,64 +37,14 @@ namespace WebCore {
 struct FrameRateRange {
     double minimum;
     double maximum;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<FrameRateRange> decode(Decoder&);
 };
 
-template<class Encoder>
-void FrameRateRange::encode(Encoder& encoder) const
-{
-    encoder << minimum;
-    encoder << maximum;
-}
-
-template <class Decoder>
-std::optional<FrameRateRange> FrameRateRange::decode(Decoder& decoder)
-{
-    std::optional<double> minimum;
-    decoder >> minimum;
-    if (!minimum)
-        return std::nullopt;
-
-    std::optional<double> maximum;
-    decoder >> maximum;
-    if (!maximum)
-        return std::nullopt;
-
-    return FrameRateRange { *minimum, *maximum };
-}
 
 struct VideoPresetData {
     IntSize size;
     Vector<FrameRateRange> frameRateRanges;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<VideoPresetData> decode(Decoder&);
 };
 
-template<class Encoder>
-void VideoPresetData::encode(Encoder& encoder) const
-{
-    encoder << size;
-    encoder << frameRateRanges;
-}
-
-template <class Decoder>
-std::optional<VideoPresetData> VideoPresetData::decode(Decoder& decoder)
-{
-    std::optional<IntSize> size;
-    decoder >> size;
-    if (!size)
-        return std::nullopt;
-
-    std::optional<Vector<FrameRateRange>> frameRateRanges;
-    decoder >> frameRateRanges;
-    if (!frameRateRanges)
-        return std::nullopt;
-
-    return VideoPresetData { *size, *frameRateRanges };
-}
 
 class VideoPreset : public RefCounted<VideoPreset> {
 public:

--- a/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h
+++ b/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h
@@ -78,7 +78,7 @@ public:
         virtual void stop() = 0;
         virtual DisplayFrameType generateFrame() = 0;
         virtual CaptureDevice::DeviceType deviceType() const = 0;
-        virtual RealtimeMediaSourceSettings::DisplaySurfaceType surfaceType() const = 0;
+        virtual DisplaySurfaceType surfaceType() const = 0;
         virtual void commitConfiguration(const RealtimeMediaSourceSettings&) = 0;
         virtual IntSize intrinsicSize() const = 0;
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp
@@ -232,7 +232,7 @@ const RealtimeMediaSourceCapabilities& GStreamerVideoCaptureSource::capabilities
     capabilities.setDeviceId(hashedId());
     updateCapabilities(capabilities);
 
-    capabilities.addFacingMode(RealtimeMediaSourceSettings::Unknown);
+    capabilities.addFacingMode(VideoFacingMode::Unknown);
 
     m_capabilities = WTFMove(capabilities);
 

--- a/Source/WebCore/platform/mediastream/ios/ReplayKitCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/ios/ReplayKitCaptureSource.h
@@ -57,7 +57,7 @@ private:
     void stop() final;
     DisplayCaptureSourceCocoa::DisplayFrameType generateFrame() final;
     CaptureDevice::DeviceType deviceType() const final { return CaptureDevice::DeviceType::Screen; }
-    RealtimeMediaSourceSettings::DisplaySurfaceType surfaceType() const final { return RealtimeMediaSourceSettings::DisplaySurfaceType::Monitor; }
+    DisplaySurfaceType surfaceType() const final { return DisplaySurfaceType::Monitor; }
     virtual void commitConfiguration(const RealtimeMediaSourceSettings&) { }
     virtual IntSize intrinsicSize() const { return m_intrinsicSize; }
 

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
@@ -241,11 +241,11 @@ const RealtimeMediaSourceSettings& AVVideoCaptureSource::settings()
 
     RealtimeMediaSourceSettings settings;
     if ([device() position] == AVCaptureDevicePositionFront)
-        settings.setFacingMode(RealtimeMediaSourceSettings::User);
+        settings.setFacingMode(VideoFacingMode::User);
     else if ([device() position] == AVCaptureDevicePositionBack)
-        settings.setFacingMode(RealtimeMediaSourceSettings::Environment);
+        settings.setFacingMode(VideoFacingMode::Environment);
     else
-        settings.setFacingMode(RealtimeMediaSourceSettings::Unknown);
+        settings.setFacingMode(VideoFacingMode::Unknown);
 
     settings.setLabel(name());
     settings.setFrameRate(frameRate());
@@ -283,9 +283,9 @@ const RealtimeMediaSourceCapabilities& AVVideoCaptureSource::capabilities()
 
     AVCaptureDevice *videoDevice = device();
     if ([videoDevice position] == AVCaptureDevicePositionFront)
-        capabilities.addFacingMode(RealtimeMediaSourceSettings::User);
+        capabilities.addFacingMode(VideoFacingMode::User);
     if ([videoDevice position] == AVCaptureDevicePositionBack)
-        capabilities.addFacingMode(RealtimeMediaSourceSettings::Environment);
+        capabilities.addFacingMode(VideoFacingMode::Environment);
 
     updateCapabilities(capabilities);
 

--- a/Source/WebCore/platform/mediastream/mac/CGDisplayStreamScreenCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/CGDisplayStreamScreenCaptureSource.h
@@ -53,7 +53,7 @@ private:
 
     // DisplayCaptureSourceCocoa::Capturer
     CaptureDevice::DeviceType deviceType() const final { return CaptureDevice::DeviceType::Screen; }
-    RealtimeMediaSourceSettings::DisplaySurfaceType surfaceType() const final { return RealtimeMediaSourceSettings::DisplaySurfaceType::Monitor; }
+    DisplaySurfaceType surfaceType() const final { return DisplaySurfaceType::Monitor; }
     IntSize intrinsicSize() const final;
 #if !RELEASE_LOG_DISABLED
     const char* logClassName() const final { return "CGDisplayStreamScreenCaptureSource"; }

--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.h
@@ -77,7 +77,7 @@ private:
     void stop() final;
     DisplayCaptureSourceCocoa::DisplayFrameType generateFrame() final;
     CaptureDevice::DeviceType deviceType() const final;
-    RealtimeMediaSourceSettings::DisplaySurfaceType surfaceType() const final;
+    DisplaySurfaceType surfaceType() const final;
     void commitConfiguration(const RealtimeMediaSourceSettings&) final;
     IntSize intrinsicSize() const final;
 

--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm
@@ -580,9 +580,9 @@ CaptureDevice::DeviceType ScreenCaptureKitCaptureSource::deviceType() const
     return m_captureDevice.type();
 }
 
-RealtimeMediaSourceSettings::DisplaySurfaceType ScreenCaptureKitCaptureSource::surfaceType() const
+DisplaySurfaceType ScreenCaptureKitCaptureSource::surfaceType() const
 {
-    return m_captureDevice.type() == CaptureDevice::DeviceType::Screen ? RealtimeMediaSourceSettings::DisplaySurfaceType::Monitor : RealtimeMediaSourceSettings::DisplaySurfaceType::Window;
+    return m_captureDevice.type() == CaptureDevice::DeviceType::Screen ? DisplaySurfaceType::Monitor : DisplaySurfaceType::Window;
 }
 
 std::optional<CaptureDevice> ScreenCaptureKitCaptureSource::screenCaptureDeviceWithPersistentID(const String& displayIDString)

--- a/Source/WebCore/platform/mock/MockMediaDevice.h
+++ b/Source/WebCore/platform/mock/MockMediaDevice.h
@@ -101,7 +101,7 @@ struct MockCameraProperties {
         if (!defaultFrameRate)
             return std::nullopt;
 
-        std::optional<RealtimeMediaSourceSettings::VideoFacingMode> facingMode;
+        std::optional<VideoFacingMode> facingMode;
         decoder >> facingMode;
         if (!facingMode)
             return std::nullopt;
@@ -120,7 +120,7 @@ struct MockCameraProperties {
     }
 
     double defaultFrameRate { 30 };
-    RealtimeMediaSourceSettings::VideoFacingMode facingMode { RealtimeMediaSourceSettings::VideoFacingMode::User };
+    VideoFacingMode facingMode { VideoFacingMode::User };
     Vector<VideoPresetData> presets { { { 640, 480 }, { { 30, 30}, { 15, 15 } } } };
     Color fillColor { Color::black };
 };

--- a/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
@@ -67,7 +67,7 @@ static inline Vector<MockMediaDevice> defaultDevices()
         MockMediaDevice { "239c24b2-2b15-11e3-8224-0800200c9a66"_s, "Mock video device 1"_s, false,
             MockCameraProperties {
                 30,
-                RealtimeMediaSourceSettings::VideoFacingMode::User, {
+                VideoFacingMode::User, {
                     { { 2560, 1440 }, { { 10, 10 }, { 7.5, 7.5 }, { 5, 5 } } },
                     { { 1280, 720 }, { { 30, 30}, { 27.5, 27.5}, { 25, 25}, { 22.5, 22.5}, { 20, 20}, { 17.5, 17.5}, { 15, 15}, { 12.5, 12.5}, { 10, 10}, { 7.5, 7.5}, { 5, 5} } },
                     { { 640, 480 },  { { 30, 30}, { 27.5, 27.5}, { 25, 25}, { 22.5, 22.5}, { 20, 20}, { 17.5, 17.5}, { 15, 15}, { 12.5, 12.5}, { 10, 10}, { 7.5, 7.5}, { 5, 5} } },
@@ -79,7 +79,7 @@ static inline Vector<MockMediaDevice> defaultDevices()
         MockMediaDevice { "239c24b3-2b15-11e3-8224-0800200c9a66"_s, "Mock video device 2"_s, false,
             MockCameraProperties {
                 15,
-                RealtimeMediaSourceSettings::VideoFacingMode::Environment, {
+                VideoFacingMode::Environment, {
                     { { 3840, 2160 }, { { 2, 30 } } },
                     { { 1920, 1080 }, { { 2, 30 } } },
                     { { 1280, 720 },  { { 3, 120 } } },
@@ -124,7 +124,7 @@ private:
     bool start() final;
     void stop() final  { m_source->stop(); }
     DisplayCaptureSourceCocoa::DisplayFrameType generateFrame() final;
-    RealtimeMediaSourceSettings::DisplaySurfaceType surfaceType() const final { return RealtimeMediaSourceSettings::DisplaySurfaceType::Monitor; }
+    DisplaySurfaceType surfaceType() const final { return DisplaySurfaceType::Monitor; }
     void commitConfiguration(const RealtimeMediaSourceSettings&) final;
     CaptureDevice::DeviceType deviceType() const final { return CaptureDevice::DeviceType::Screen; }
     IntSize intrinsicSize() const final;

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
@@ -172,7 +172,7 @@ const RealtimeMediaSourceSettings& MockRealtimeVideoSource::settings()
         settings.setFacingMode(facingMode());
         settings.setDeviceId(hashedId());
     } else {
-        settings.setDisplaySurface(mockScreen() ? RealtimeMediaSourceSettings::DisplaySurfaceType::Monitor : RealtimeMediaSourceSettings::DisplaySurfaceType::Window);
+        settings.setDisplaySurface(mockScreen() ? DisplaySurfaceType::Monitor : DisplaySurfaceType::Window);
         settings.setLogicalSurface(false);
     }
     settings.setDeviceId(hashedId());
@@ -396,19 +396,19 @@ void MockRealtimeVideoSource::drawText(GraphicsContext& context)
 
         const char* camera;
         switch (facingMode()) {
-        case RealtimeMediaSourceSettings::User:
+        case VideoFacingMode::User:
             camera = "User facing";
             break;
-        case RealtimeMediaSourceSettings::Environment:
+        case VideoFacingMode::Environment:
             camera = "Environment facing";
             break;
-        case RealtimeMediaSourceSettings::Left:
+        case VideoFacingMode::Left:
             camera = "Left facing";
             break;
-        case RealtimeMediaSourceSettings::Right:
+        case VideoFacingMode::Right:
             camera = "Right facing";
             break;
-        case RealtimeMediaSourceSettings::Unknown:
+        case VideoFacingMode::Unknown:
             camera = "Unknown";
             break;
         }

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -249,6 +249,7 @@ def serialized_identifiers():
         'WebCore::RealtimeMediaSourceIdentifier',
         'WebCore::RenderingResourceIdentifier',
         'WebCore::ResourceLoaderIdentifier',
+        'WebCore::RTCDataChannelLocalIdentifier',
         'WebCore::SWServerConnectionIdentifier',
         'WebCore::ServiceWorkerIdentifier',
         'WebCore::ServiceWorkerJobIdentifier',

--- a/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
@@ -103,6 +103,7 @@
 #include <WebCore/PortIdentifier.h>
 #include <WebCore/ProcessIdentifier.h>
 #include <WebCore/PushSubscriptionIdentifier.h>
+#include <WebCore/RTCDataChannelLocalIdentifier.h>
 #include <WebCore/RealtimeMediaSourceIdentifier.h>
 #include <WebCore/RenderingResourceIdentifier.h>
 #include <WebCore/ResourceLoaderIdentifier.h>
@@ -422,6 +423,7 @@ Vector<ASCIILiteral> serializedIdentifiers()
     static_assert(sizeof(uint64_t) == sizeof(WebCore::RealtimeMediaSourceIdentifier));
     static_assert(sizeof(uint64_t) == sizeof(WebCore::RenderingResourceIdentifier));
     static_assert(sizeof(uint64_t) == sizeof(WebCore::ResourceLoaderIdentifier));
+    static_assert(sizeof(uint64_t) == sizeof(WebCore::RTCDataChannelLocalIdentifier));
     static_assert(sizeof(uint64_t) == sizeof(WebCore::SWServerConnectionIdentifier));
     static_assert(sizeof(uint64_t) == sizeof(WebCore::ServiceWorkerIdentifier));
     static_assert(sizeof(uint64_t) == sizeof(WebCore::ServiceWorkerJobIdentifier));
@@ -516,6 +518,7 @@ Vector<ASCIILiteral> serializedIdentifiers()
         "WebCore::RealtimeMediaSourceIdentifier"_s,
         "WebCore::RenderingResourceIdentifier"_s,
         "WebCore::ResourceLoaderIdentifier"_s,
+        "WebCore::RTCDataChannelLocalIdentifier"_s,
         "WebCore::SWServerConnectionIdentifier"_s,
         "WebCore::ServiceWorkerIdentifier"_s,
         "WebCore::ServiceWorkerJobIdentifier"_s,

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3463,25 +3463,6 @@ enum class WebCore::CDMRequirement : uint8_t {
 };
 #endif
 
-#if ENABLE(MEDIA_STREAM)
-enum class WebCore::MediaConstraintType : uint8_t {
-    Unknown,
-    Width,
-    Height,
-    AspectRatio,
-    FrameRate,
-    FacingMode,
-    Volume,
-    SampleRate,
-    SampleSize,
-    EchoCancellation,
-    DeviceId,
-    GroupId,
-    DisplaySurface,
-    LogicalSurface,
-};
-#endif
-
 #if ENABLE(WEB_RTC)
 enum class WebCore::RTCDataChannelState : uint8_t {
     Connecting,
@@ -3930,3 +3911,182 @@ class WebCore::SecurityOriginData {
     String host;
     std::optional<uint16_t> port;
 };
+
+#if ENABLE(MEDIA_STREAM)
+
+[Nested] enum class WebCore::MediaConstraint::DataType : uint8_t {
+    None,
+    Integer,
+    Double,
+    Boolean,
+    String
+};
+
+enum class WebCore::MediaConstraintType : uint8_t {
+    Unknown,
+    Width,
+    Height,
+    AspectRatio,
+    FrameRate,
+    FacingMode,
+    Volume,
+    SampleRate,
+    SampleSize,
+    EchoCancellation,
+    DeviceId,
+    GroupId,
+    DisplaySurface,
+    LogicalSurface,
+};
+
+header: <WebCore/MediaConstraints.h>
+[CustomHeader] class WebCore::MediaConstraint {
+    String name();
+    WebCore::MediaConstraintType constraintType();
+    WebCore::MediaConstraint::DataType dataType();
+};
+
+[CustomHeader] class WebCore::IntConstraint : WebCore::MediaConstraint {
+    std::optional<int> m_min;
+    std::optional<int> m_max;
+    std::optional<int> m_exact;
+    std::optional<int> m_ideal;
+};
+
+[CustomHeader] class WebCore::DoubleConstraint : WebCore::MediaConstraint {
+    std::optional<double> m_min;
+    std::optional<double> m_max;
+    std::optional<double> m_exact;
+    std::optional<double> m_ideal;
+};
+
+[CustomHeader] class WebCore::BooleanConstraint : WebCore::MediaConstraint {
+    std::optional<bool> m_exact;
+    std::optional<bool> m_ideal;
+};
+
+[CustomHeader] class WebCore::StringConstraint : WebCore::MediaConstraint {
+    Vector<String> m_exact;
+    Vector<String> m_ideal;
+};
+
+header: <WebCore/VideoPreset.h>
+[CustomHeader] struct WebCore::FrameRateRange {
+    double minimum;
+    double maximum;
+};
+
+[CustomHeader] struct WebCore::VideoPresetData {
+    WebCore::IntSize size;
+    Vector<WebCore::FrameRateRange> frameRateRanges;
+};
+
+class WebCore::RealtimeMediaSourceSupportedConstraints {
+    bool supportsWidth();
+    bool supportsHeight();
+    bool supportsAspectRatio();
+    bool supportsFrameRate();
+    bool supportsFacingMode();
+    bool supportsVolume();
+    bool supportsSampleRate();
+    bool supportsSampleSize();
+    bool supportsEchoCancellation();
+    bool supportsDeviceId();
+    bool supportsGroupId();
+    bool supportsDisplaySurface();
+    bool supportsLogicalSurface();
+};
+
+enum class WebCore::VideoFacingMode : uint8_t {
+    Unknown,
+    User,
+    Environment,
+    Left,
+    Right
+};
+
+enum class WebCore::DisplaySurfaceType : uint8_t {
+    Monitor,
+    Window,
+    Application,
+    Browser,
+    Invalid,
+};
+
+class WebCore::RealtimeMediaSourceSettings {
+    uint32_t width();
+    uint32_t height();
+    float aspectRatio();
+    float frameRate();
+    WebCore::VideoFacingMode facingMode();
+    double volume();
+    uint32_t sampleRate();
+    uint32_t sampleSize();
+    bool echoCancellation();
+    AtomString deviceId();
+    AtomString groupId();
+    AtomString label();
+    WebCore::DisplaySurfaceType displaySurface();
+    bool logicalSurface();
+    WebCore::RealtimeMediaSourceSupportedConstraints supportedConstraints();
+};
+
+[Nested] enum class WebCore::CaptureDevice::DeviceType : uint8_t {
+    Unknown,
+    Microphone,
+    Speaker,
+    Camera,
+    Screen,
+    Window,
+    SystemAudio
+};
+
+class WebCore::CaptureDevice {
+    String persistentId();
+    WebCore::CaptureDevice::DeviceType type();
+    String label();
+    String groupId();
+    bool enabled();
+    bool isDefault();
+    bool isMockDevice();
+    bool isEphemeral();
+};
+
+[Nested] enum class WebCore::RealtimeMediaSourceCapabilities::EchoCancellation : bool
+
+class WebCore::RealtimeMediaSourceCapabilities {
+    WebCore::CapabilityValueOrRange width();
+    WebCore::CapabilityValueOrRange height();
+    WebCore::CapabilityValueOrRange aspectRatio();
+    WebCore::CapabilityValueOrRange frameRate();
+    Vector<WebCore::VideoFacingMode> facingMode();
+    WebCore::CapabilityValueOrRange volume();
+    WebCore::CapabilityValueOrRange sampleRate();
+    WebCore::CapabilityValueOrRange sampleSize();
+    WebCore::RealtimeMediaSourceCapabilities::EchoCancellation echoCancellation();
+    AtomString deviceId();
+    AtomString groupId();
+    WebCore::RealtimeMediaSourceSupportedConstraints supportedConstraints();
+};
+
+#endif
+
+#if ENABLE(WEB_RTC)
+
+header: <WebCore/RTCDataChannelHandler.h>
+[CustomHeader] struct WebCore::RTCDataChannelInit {
+    std::optional<bool> ordered;
+    std::optional<unsigned short> maxPacketLifeTime;
+    std::optional<unsigned short> maxRetransmits;
+    String protocol;
+    std::optional<bool> negotiated;
+    std::optional<unsigned short> id;
+    WebCore::RTCPriorityType priority;
+};
+
+struct WebCore::RTCDataChannelIdentifier {
+    WebCore::ProcessIdentifier processIdentifier;
+    WebCore::RTCDataChannelLocalIdentifier channelIdentifier;
+};
+
+#endif // ENABLE(WEB_RTC)


### PR DESCRIPTION
#### c46ed9ed7b256953e3af9ad614a42d90dc08d8ea
<pre>
Port the remaining mediastream related types to the new IPC serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=251860">https://bugs.webkit.org/show_bug.cgi?id=251860</a>
rdar://105132585

Reviewed by Youenn Fablet.

This change ports the remaining MediaStream related types. This includes:
    - MediaConstraint::DataType
    - MediaConstraintType
    - MediaConstraint
    - IntConstraint
    - DoubleConstraint
    - BooleanConstraint
    - StringConstraint
    - FrameRateRange
    - VideoPresetData
    - RealtimeMediaSourceSupportedConstraints
    - VideoFacingMode
    - DisplaySurfaceType
    - RealtimeMediaSourceSettings
    - CaptureDevice::DeviceType
    - CaptureDevice
    - RealtimeMediaSourceCapabilities::EchoCancellation
    - RTCDataChannelInit
    - RTCDataChannelIdentifier

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/mediastream/CaptureDevice.h:
(WebCore::CaptureDevice::encode const): Deleted.
(WebCore::CaptureDevice::decode): Deleted.
* Source/WebCore/platform/mediastream/MediaConstraints.h:
(WebCore::NumericConstraint::NumericConstraint):
(WebCore::StringConstraint::StringConstraint):
(WebCore::MediaConstraint::encode const): Deleted.
(WebCore::MediaConstraint::decode): Deleted.
(WebCore::NumericConstraint::encode const): Deleted.
(WebCore::NumericConstraint::decode): Deleted.
(WebCore::StringConstraint::encode const): Deleted.
(WebCore::StringConstraint::decode): Deleted.
* Source/WebCore/platform/mediastream/RTCDataChannelHandler.h:
(WebCore::RTCDataChannelInit::encode const): Deleted.
(WebCore::RTCDataChannelInit::decode): Deleted.
* Source/WebCore/platform/mediastream/RTCDataChannelIdentifier.h:
(): Deleted.
(WebCore::RTCDataChannelIdentifier::encode const): Deleted.
(WebCore::RTCDataChannelIdentifier::decode): Deleted.
* Source/WebCore/platform/mediastream/RTCDataChannelLocalIdentifier.h: Copied from Source/WebCore/platform/mediastream/RTCDataChannelIdentifier.h.
* Source/WebCore/platform/mediastream/RealtimeMediaSource.h:
* Source/WebCore/platform/mediastream/RealtimeMediaSourceCapabilities.h:
(WebCore::RealtimeMediaSourceCapabilities::RealtimeMediaSourceCapabilities):
(WebCore::RealtimeMediaSourceCapabilities::facingMode const):
(WebCore::RealtimeMediaSourceCapabilities::addFacingMode):
(WebCore::RealtimeMediaSourceCapabilities::encode const): Deleted.
(WebCore::RealtimeMediaSourceCapabilities::decode): Deleted.
* Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.cpp:
(WebCore::RealtimeMediaSourceSettings::videoFacingModeEnum):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.h:
(WebCore::RealtimeMediaSourceSettings::RealtimeMediaSourceSettings):
(WTF::LogArgument&lt;WebCore::VideoFacingMode&gt;::toString):
(WebCore::RealtimeMediaSourceSettings::encode const): Deleted.
(WebCore::RealtimeMediaSourceSettings::decode): Deleted.
(WTF::LogArgument&lt;WebCore::RealtimeMediaSourceSettings::VideoFacingMode&gt;::toString): Deleted.
* Source/WebCore/platform/mediastream/RealtimeMediaSourceSupportedConstraints.h:
(WebCore::RealtimeMediaSourceSupportedConstraints::RealtimeMediaSourceSupportedConstraints):
(WebCore::RealtimeMediaSourceSupportedConstraints::encode const): Deleted.
(WebCore::RealtimeMediaSourceSupportedConstraints::decode): Deleted.
* Source/WebCore/platform/mediastream/VideoPreset.h:
(WebCore::FrameRateRange::encode const): Deleted.
(WebCore::FrameRateRange::decode): Deleted.
(WebCore::VideoPresetData::encode const): Deleted.
(WebCore::VideoPresetData::decode): Deleted.
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::AVVideoCaptureSource::settings):
(WebCore::AVVideoCaptureSource::capabilities):
* Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp:
(WebCore::MockRealtimeVideoSource::drawText):
* Source/WebKit/Scripts/webkit/messages.py:
(serialized_identifiers):
* Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp:
(IPC::serializedIdentifiers):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/260561@main">https://commits.webkit.org/260561@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56617e86640e636c518e22270a990fc05f139074

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108651 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17752 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41505 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117761 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/117962 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112534 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19203 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9029 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100884 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114418 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14398 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97632 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42374 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/112181 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96373 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29270 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84106 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10560 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30620 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11318 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7534 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16709 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50216 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7302 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12906 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->