### PR TITLE
Port types relating to SVG and ContentRule's to the new IPC serialization format

### DIFF
--- a/Source/WebCore/contentextensions/ContentRuleListResults.h
+++ b/Source/WebCore/contentextensions/ContentRuleListResults.h
@@ -52,20 +52,15 @@ struct ContentRuleListResults {
                 || redirected
                 || !notifications.isEmpty();
         }
-
-        template<class Encoder> void encode(Encoder&) const;
-        template<class Decoder> static std::optional<Result> decode(Decoder&);
     };
     struct Summary {
         bool blockedLoad { false };
         bool madeHTTPS { false };
         bool blockedCookies { false };
         bool hasNotifications { false };
-        Vector<ContentExtensions::ModifyHeadersAction> modifyHeadersActions;
-        Vector<std::pair<ContentExtensions::RedirectAction, URL>> redirectActions;
-
-        template<class Encoder> void encode(Encoder&) const;
-        template<class Decoder> static std::optional<Summary> decode(Decoder&);
+        // Remaining fields currently aren't serialized as they aren't required by _WKContentRuleListAction
+        Vector<ContentExtensions::ModifyHeadersAction> modifyHeadersActions { };
+        Vector<std::pair<ContentExtensions::RedirectAction, URL>> redirectActions { };
     };
     using ContentRuleListIdentifier = String;
 
@@ -81,122 +76,7 @@ struct ContentRuleListResults {
             || !summary.redirectActions.isEmpty()
             || summary.hasNotifications;
     }
-    
-    template<class Encoder> void encode(Encoder& encoder) const
-    {
-        encoder << summary;
-        encoder << results;
-    }
-    template<class Decoder> static std::optional<ContentRuleListResults> decode(Decoder& decoder)
-    {
-        std::optional<Summary> summary;
-        decoder >> summary;
-        if (!summary)
-            return std::nullopt;
-        
-        std::optional<Vector<std::pair<ContentRuleListIdentifier, Result>>> results;
-        decoder >> results;
-        if (!results)
-            return std::nullopt;
-        
-        return {{
-            WTFMove(*summary),
-            WTFMove(*results)
-        }};
-    }
 };
-
-template<class Encoder> void ContentRuleListResults::Result::encode(Encoder& encoder) const
-{
-    encoder << blockedLoad;
-    encoder << madeHTTPS;
-    encoder << blockedCookies;
-    encoder << modifiedHeaders;
-    encoder << redirected;
-    encoder << notifications;
-}
-
-template<class Decoder> auto ContentRuleListResults::Result::decode(Decoder& decoder) -> std::optional<Result>
-{
-    std::optional<bool> blockedLoad;
-    decoder >> blockedLoad;
-    if (!blockedLoad)
-        return std::nullopt;
-    
-    std::optional<bool> madeHTTPS;
-    decoder >> madeHTTPS;
-    if (!madeHTTPS)
-        return std::nullopt;
-    
-    std::optional<bool> blockedCookies;
-    decoder >> blockedCookies;
-    if (!blockedCookies)
-        return std::nullopt;
-    
-    std::optional<bool> modifiedHeaders;
-    decoder >> modifiedHeaders;
-    if (!modifiedHeaders)
-        return std::nullopt;
-    
-    std::optional<bool> redirected;
-    decoder >> redirected;
-    if (!redirected)
-        return std::nullopt;
-    
-    std::optional<Vector<String>> notifications;
-    decoder >> notifications;
-    if (!notifications)
-        return std::nullopt;
-
-    return {{
-        WTFMove(*blockedLoad),
-        WTFMove(*madeHTTPS),
-        WTFMove(*blockedCookies),
-        WTFMove(*modifiedHeaders),
-        WTFMove(*redirected),
-        WTFMove(*notifications)
-    }};
-}
-
-template<class Encoder> void ContentRuleListResults::Summary::encode(Encoder& encoder) const
-{
-    encoder << blockedLoad;
-    encoder << madeHTTPS;
-    encoder << blockedCookies;
-    encoder << hasNotifications;
-}
-
-template<class Decoder> auto ContentRuleListResults::Summary::decode(Decoder& decoder) -> std::optional<Summary>
-{
-    std::optional<bool> blockedLoad;
-    decoder >> blockedLoad;
-    if (!blockedLoad)
-        return std::nullopt;
-    
-    std::optional<bool> madeHTTPS;
-    decoder >> madeHTTPS;
-    if (!madeHTTPS)
-        return std::nullopt;
-    
-    std::optional<bool> blockedCookies;
-    decoder >> blockedCookies;
-    if (!blockedCookies)
-        return std::nullopt;
-    
-    std::optional<bool> hasNotifications;
-    decoder >> hasNotifications;
-    if (!hasNotifications)
-        return std::nullopt;
-    
-    return {{
-        WTFMove(*blockedLoad),
-        WTFMove(*madeHTTPS),
-        WTFMove(*blockedCookies),
-        WTFMove(*hasNotifications),
-        { }, // modifyHeadersActions and redirectActions have no need to be serialized to another process.
-        { }
-    }};
-}
 
 }
 

--- a/Source/WebCore/svg/SVGPreserveAspectRatioValue.h
+++ b/Source/WebCore/svg/SVGPreserveAspectRatioValue.h
@@ -71,12 +71,10 @@ public:
 
     String valueAsString() const;
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<SVGPreserveAspectRatioValue> decode(Decoder&);
-
 private:
-    SVGPreserveAspectRatioType m_align { SVG_PRESERVEASPECTRATIO_XMIDYMID };
-    SVGMeetOrSliceType m_meetOrSlice { SVG_MEETORSLICE_MEET };
+    friend struct IPC::ArgumentCoder<SVGPreserveAspectRatioValue, void>;
+    SVGPreserveAspectRatioType m_align { SVGPreserveAspectRatioValue::SVG_PRESERVEASPECTRATIO_XMIDYMID };
+    SVGMeetOrSliceType m_meetOrSlice { SVGPreserveAspectRatioValue::SVG_MEETORSLICE_MEET };
 
     template<typename CharacterType> bool parseInternal(StringParsingBuffer<CharacterType>&, bool validate);
 };
@@ -87,29 +85,6 @@ template<> struct SVGPropertyTraits<SVGPreserveAspectRatioValue> {
     static std::optional<SVGPreserveAspectRatioValue> parse(const QualifiedName&, const String&) { ASSERT_NOT_REACHED(); return initialValue(); }
     static String toString(const SVGPreserveAspectRatioValue& type) { return type.valueAsString(); }
 };
-
-template<class Encoder>
-void SVGPreserveAspectRatioValue::encode(Encoder& encoder) const
-{
-    encoder << m_align;
-    encoder << m_meetOrSlice;
-}
-
-template<class Decoder>
-std::optional<SVGPreserveAspectRatioValue> SVGPreserveAspectRatioValue::decode(Decoder& decoder)
-{
-    std::optional<SVGPreserveAspectRatioType> align;
-    decoder >> align;
-    if (!align)
-        return std::nullopt;
-
-    std::optional<SVGMeetOrSliceType> meetOrSlice;
-    decoder >> meetOrSlice;
-    if (!meetOrSlice)
-        return std::nullopt;
-
-    return SVGPreserveAspectRatioValue(*align, *meetOrSlice);
-}
 
 } // namespace WebCore
 

--- a/Source/WebCore/svg/graphics/filters/SVGFilterExpressionReference.h
+++ b/Source/WebCore/svg/graphics/filters/SVGFilterExpressionReference.h
@@ -34,40 +34,9 @@ struct SVGFilterExpressionNode {
     unsigned index;
     std::optional<FilterEffectGeometry> geometry;
     unsigned level;
-    
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<SVGFilterExpressionNode> decode(Decoder&);
 };
 
 using SVGFilterExpressionReference = Vector<SVGFilterExpressionNode>;
 
-template<class Encoder>
-void SVGFilterExpressionNode::encode(Encoder& encoder) const
-{
-    encoder << index;
-    encoder << geometry;
-    encoder << level;
-}
-
-template<class Decoder>
-std::optional<SVGFilterExpressionNode> SVGFilterExpressionNode::decode(Decoder& decoder)
-{
-    std::optional<unsigned> index;
-    decoder >> index;
-    if (!index)
-        return std::nullopt;
-
-    std::optional<std::optional<FilterEffectGeometry>> geometry;
-    decoder >> geometry;
-    if (!geometry)
-        return std::nullopt;
-
-    std::optional<unsigned> level;
-    decoder >> level;
-    if (!level)
-        return std::nullopt;
-
-    return SVGFilterExpressionNode { *index, *geometry, *level };
-}
 
 } // namespace WebCore

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4154,3 +4154,40 @@ struct WebCore::RTCDataChannelIdentifier {
 };
 
 #endif // ENABLE(WEB_RTC)
+
+header: <WebCore/SVGFilterExpressionReference.h>
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::SVGFilterExpressionNode {
+    unsigned index;
+    std::optional<WebCore::FilterEffectGeometry> geometry;
+    unsigned level;
+};
+
+[AdditionalEncoder=StreamConnectionEncoder] class WebCore::SVGPreserveAspectRatioValue {
+    WebCore::SVGPreserveAspectRatioValue::SVGPreserveAspectRatioType m_align;
+    WebCore::SVGPreserveAspectRatioValue::SVGMeetOrSliceType m_meetOrSlice;
+};
+
+#if ENABLE(CONTENT_EXTENSIONS)
+
+[Nested] struct WebCore::ContentRuleListResults::Result {
+    bool blockedLoad;
+    bool madeHTTPS;
+    bool blockedCookies;
+    bool modifiedHeaders;
+    bool redirected;
+    Vector<String> notifications;
+};
+
+[Nested] struct WebCore::ContentRuleListResults::Summary {
+    bool blockedLoad;
+    bool madeHTTPS;
+    bool blockedCookies;
+    bool hasNotifications;
+};
+
+struct WebCore::ContentRuleListResults {
+    WebCore::ContentRuleListResults::Summary summary;
+    Vector<std::pair<String, WebCore::ContentRuleListResults::Result>> results;
+};
+
+#endif


### PR DESCRIPTION
#### 1bf71c6c8b3007c849bcfbf1ebcb03581d9271a3
<pre>
Port types relating to SVG and ContentRule&apos;s to the new IPC serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=251864">https://bugs.webkit.org/show_bug.cgi?id=251864</a>
rdar://105133824

Reviewed by Alex Christensen.

Continues port of IPC types to the new serialization format. This change
includes:
    - SVGFilterExpressionNode
    - SVGPreserveAspectRatioValue
    - ContentRuleListResults::Result
    - ContentRuleListResults::Summary
    - ContentRuleListResults

* Source/WebCore/contentextensions/ContentRuleListResults.h:
(WebCore::ContentRuleListResults::Result::shouldNotifyApplication const):
(WebCore::ContentRuleListResults::shouldNotifyApplication const):
(WebCore::ContentRuleListResults::encode const): Deleted.
(WebCore::ContentRuleListResults::decode): Deleted.
(WebCore::ContentRuleListResults::Result::encode const): Deleted.
(WebCore::ContentRuleListResults::Result::decode): Deleted.
(WebCore::ContentRuleListResults::Summary::encode const): Deleted.
(WebCore::ContentRuleListResults::Summary::decode): Deleted.
* Source/WebCore/svg/SVGPreserveAspectRatioValue.h:
(WebCore::SVGPreserveAspectRatioValue::encode const): Deleted.
(WebCore::SVGPreserveAspectRatioValue::decode): Deleted.
* Source/WebCore/svg/graphics/filters/SVGFilterExpressionReference.h:
(WebCore::SVGFilterExpressionNode::encode const): Deleted.
(WebCore::SVGFilterExpressionNode::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/260604@main">https://commits.webkit.org/260604@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e22023032e6e17ba61ae1aa0f1be27ab04609330

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108848 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17951 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41684 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/385 "Updated wpe dependencies (failure)") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/118133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112730 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19409 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9230 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101085 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114618 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97767 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/42641 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29410 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/84387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10726 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30757 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11481 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/7689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16870 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50358 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7325 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13068 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->