### PR TITLE
Remove getStorageUpdates

### DIFF
--- a/LayoutTests/fast/dom/navigator-detached-no-crash-expected.txt
+++ b/LayoutTests/fast/dom/navigator-detached-no-crash-expected.txt
@@ -10,7 +10,6 @@ navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
 navigator.credentials is OK
-navigator.getStorageUpdates() is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK
 navigator.language is OK
@@ -40,7 +39,6 @@ navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
 navigator.credentials is OK
-navigator.getStorageUpdates() is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK
 navigator.language is OK

--- a/LayoutTests/platform/gtk/fast/dom/navigator-detached-no-crash-expected.txt
+++ b/LayoutTests/platform/gtk/fast/dom/navigator-detached-no-crash-expected.txt
@@ -6,7 +6,6 @@ navigator.appVersion is OK
 navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
-navigator.getStorageUpdates() is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK
 navigator.language is OK
@@ -39,7 +38,6 @@ navigator.appVersion is OK
 navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
-navigator.getStorageUpdates() is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK
 navigator.language is OK

--- a/LayoutTests/platform/mac-wk1/fast/dom/navigator-detached-no-crash-expected.txt
+++ b/LayoutTests/platform/mac-wk1/fast/dom/navigator-detached-no-crash-expected.txt
@@ -5,7 +5,6 @@ navigator.appName is OK
 navigator.appVersion is OK
 navigator.audioSession is OK
 navigator.cookieEnabled is OK
-navigator.getStorageUpdates() is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK
 navigator.language is OK
@@ -36,7 +35,6 @@ navigator.appName is OK
 navigator.appVersion is OK
 navigator.audioSession is OK
 navigator.cookieEnabled is OK
-navigator.getStorageUpdates() is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK
 navigator.language is OK

--- a/LayoutTests/platform/mac-wk2/fast/dom/navigator-detached-no-crash-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/dom/navigator-detached-no-crash-expected.txt
@@ -9,7 +9,6 @@ navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
 navigator.credentials is OK
-navigator.getStorageUpdates() is OK
 navigator.hardwareConcurrency is OK
 navigator.isLoggedIn() is OK
 navigator.javaEnabled() is OK
@@ -50,7 +49,6 @@ navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
 navigator.credentials is OK
-navigator.getStorageUpdates() is OK
 navigator.hardwareConcurrency is OK
 navigator.isLoggedIn() is OK
 navigator.javaEnabled() is OK

--- a/LayoutTests/platform/mac/fast/dom/navigator-detached-no-crash-expected.txt
+++ b/LayoutTests/platform/mac/fast/dom/navigator-detached-no-crash-expected.txt
@@ -8,7 +8,6 @@ navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
 navigator.credentials is OK
-navigator.getStorageUpdates() is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK
 navigator.language is OK
@@ -36,7 +35,6 @@ navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
 navigator.credentials is OK
-navigator.getStorageUpdates() is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK
 navigator.language is OK

--- a/LayoutTests/platform/win/fast/dom/navigator-detached-no-crash-expected.txt
+++ b/LayoutTests/platform/win/fast/dom/navigator-detached-no-crash-expected.txt
@@ -8,7 +8,6 @@ navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
 navigator.credentials is OK
-navigator.getStorageUpdates() is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK
 navigator.language is OK
@@ -31,7 +30,6 @@ navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
 navigator.credentials is OK
-navigator.getStorageUpdates() is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK
 navigator.language is OK

--- a/LayoutTests/platform/wincairo/fast/dom/navigator-detached-no-crash-expected.txt
+++ b/LayoutTests/platform/wincairo/fast/dom/navigator-detached-no-crash-expected.txt
@@ -6,7 +6,6 @@ navigator.appVersion is OK
 navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
-navigator.getStorageUpdates() is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK
 navigator.language is OK
@@ -27,7 +26,6 @@ navigator.appVersion is OK
 navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
-navigator.getStorageUpdates() is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK
 navigator.language is OK

--- a/LayoutTests/platform/wpe/fast/dom/navigator-detached-no-crash-expected.txt
+++ b/LayoutTests/platform/wpe/fast/dom/navigator-detached-no-crash-expected.txt
@@ -6,7 +6,6 @@ navigator.appVersion is OK
 navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
-navigator.getStorageUpdates() is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK
 navigator.language is OK
@@ -40,7 +39,6 @@ navigator.appVersion is OK
 navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
-navigator.getStorageUpdates() is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK
 navigator.language is OK

--- a/Source/WebCore/page/Navigator.cpp
+++ b/Source/WebCore/page/Navigator.cpp
@@ -357,10 +357,6 @@ bool Navigator::standalone() const
 
 #endif
 
-void Navigator::getStorageUpdates()
-{
-}
-
 GPU* Navigator::gpu()
 {
     if (!m_gpuForWebGPU) {

--- a/Source/WebCore/page/Navigator.h
+++ b/Source/WebCore/page/Navigator.h
@@ -57,8 +57,6 @@ public:
     bool standalone() const;
 #endif
 
-    void getStorageUpdates();
-
 #if ENABLE(IOS_TOUCH_EVENTS) && !PLATFORM(MACCATALYST)
     int maxTouchPoints() const { return 5; }
 #else

--- a/Source/WebCore/page/Navigator.idl
+++ b/Source/WebCore/page/Navigator.idl
@@ -26,10 +26,6 @@
     [Conditional=NAVIGATOR_STANDALONE] readonly attribute boolean standalone;
 
     readonly attribute unsigned long long hardwareConcurrency;
-
-    // Non-standard.
-    // FIXME: Remove this. WebKit is the only engine that still has this.
-    undefined getStorageUpdates();
 };
 
 Navigator includes NavigatorBadge;


### PR DESCRIPTION
#### 1408c97255e8a7283832d05e2d7e7b5be6cf31a5
<pre>
Remove getStorageUpdates
<a href="https://bugs.webkit.org/show_bug.cgi?id=251867">https://bugs.webkit.org/show_bug.cgi?id=251867</a>

Reviewed by Sihui Liu.

No one uses it anymore. No other web browser has this anymore. No calls
happen to it anymore. Let us remove this.

Canonical link: <a href="https://commits.webkit.org/260020@main">https://commits.webkit.org/260020@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/306e46e386aea1c69be8c7f9eb582a61b1f0638d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106729 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15721 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39516 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115918 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115510 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110635 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17232 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6959 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98924 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112498 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13086 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96063 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40662 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94970 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27714 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8943 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29069 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9503 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/6088 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15115 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48612 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6920 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11025 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->