### PR TITLE
[MSE][GStreamer] Don't extend PTS of non-key frame

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -418,7 +418,9 @@ void AppendPipeline::appsinkNewSample(const Track& track, GRefPtr<GstSample>&& s
     //
     // Because a track presentation time starting at some close to zero, but not exactly zero time can cause unexpected
     // results for applications, we extend the duration of this first sample to the left so that it starts at zero.
-    if (mediaSample->decodeTime() == MediaTime::zeroTime() && mediaSample->presentationTime() > MediaTime::zeroTime() && mediaSample->presentationTime() <= MediaTime(1, 10)) {
+    if (mediaSample->decodeTime() == MediaTime::zeroTime() && mediaSample->presentationTime() > MediaTime::zeroTime()
+        && mediaSample->presentationTime() <= MediaTime(1, 10)
+        && mediaSample->isSync()) {
         GST_DEBUG_OBJECT(pipeline(), "Extending first sample to make it start at PTS=0");
         mediaSample->extendToTheBeginning();
     }


### PR DESCRIPTION
#### fa12275b80a8b12cde02cb86e3750bf41b6c71f3
<pre>
[MSE][GStreamer] Don&apos;t extend PTS of non-key frame
<a href="https://bugs.webkit.org/show_bug.cgi?id=251868">https://bugs.webkit.org/show_bug.cgi?id=251868</a>

The edit list support patch from
<a href="https://bugs.webkit.org/show_bug.cgi?id=231019">https://bugs.webkit.org/show_bug.cgi?id=231019</a> was reverted in
<a href="https://bugs.webkit.org/show_bug.cgi?id=244428.">https://bugs.webkit.org/show_bug.cgi?id=244428.</a> While that patch isn&apos;t
landed again, we&apos;re growing the first buffer of an append near the
begining of the stream to make it start from 0. This workaround uses a
tolerance of 0.1s, and can cause problems on frames short enough to fit
more than one time in the tolerance margin (eg: 3 frames at 30fps would
fit, as well as 6 frames at 60fps).

The process of growing the seconde frame that still fit in the tolerance
is triggering the deletion of the first frame, which is usually a sync
one. This sweeps other frames into the deletion and causes problems.

This patch changes the condition to enable frame growing to only apply
on key frames (sync samples).

Original author: Eugene Mutavchi &lt;Ievgen_Mutavchi@comcast.com&gt;
See: <a href="https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1015">https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1015</a>

Reviewed by Alicia Boya Garcia.

* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp:
(WebCore::AppendPipeline::appsinkNewSample): Don&apos;t extend PTS of non-key frame.

Canonical link: <a href="https://commits.webkit.org/260004@main">https://commits.webkit.org/260004@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b8f84574ffe94356aade45961e0a2637bee4aec

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106601 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15606 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39399 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115785 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115415 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110508 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17107 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6837 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98791 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112369 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13001 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95967 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40560 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94879 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27612 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82281 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8832 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28965 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9378 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5999 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14994 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48512 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6914 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10912 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->