### PR TITLE
[WebGPU] Implement ShaderModule::convertPipelineLayout

### DIFF
--- a/Source/WebGPU/WebGPU/BindGroupLayout.h
+++ b/Source/WebGPU/WebGPU/BindGroupLayout.h
@@ -29,6 +29,7 @@
 #import <wtf/HashMap.h>
 #import <wtf/Ref.h>
 #import <wtf/RefCounted.h>
+#import <wtf/Vector.h>
 
 struct WGPUBindGroupLayoutImpl {
 };
@@ -47,9 +48,9 @@ class Device;
 class BindGroupLayout : public WGPUBindGroupLayoutImpl, public RefCounted<BindGroupLayout> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<BindGroupLayout> create(HashMap<uint32_t, WGPUShaderStageFlags>&& stageMapTable, id<MTLArgumentEncoder> vertexArgumentEncoder, id<MTLArgumentEncoder> fragmentArgumentEncoder, id<MTLArgumentEncoder> computeArgumentEncoder)
+    static Ref<BindGroupLayout> create(HashMap<uint32_t, WGPUShaderStageFlags>&& stageMapTable, id<MTLArgumentEncoder> vertexArgumentEncoder, id<MTLArgumentEncoder> fragmentArgumentEncoder, id<MTLArgumentEncoder> computeArgumentEncoder, Vector<WGPUBindGroupLayoutEntry>&& entries)
     {
-        return adoptRef(*new BindGroupLayout(WTFMove(stageMapTable), vertexArgumentEncoder, fragmentArgumentEncoder, computeArgumentEncoder));
+        return adoptRef(*new BindGroupLayout(WTFMove(stageMapTable), vertexArgumentEncoder, fragmentArgumentEncoder, computeArgumentEncoder, WTFMove(entries)));
     }
     static Ref<BindGroupLayout> createInvalid(Device&)
     {
@@ -73,9 +74,15 @@ public:
 #if HAVE(METAL_BUFFER_BINDING_REFLECTION)
     static WGPUBindGroupLayoutEntry createEntryFromStructMember(MTLStructMember *, uint32_t&, WGPUShaderStage);
 #endif
+    static bool isPresent(const WGPUBufferBindingLayout&);
+    static bool isPresent(const WGPUSamplerBindingLayout&);
+    static bool isPresent(const WGPUTextureBindingLayout&);
+    static bool isPresent(const WGPUStorageTextureBindingLayout&);
+
+    const Vector<WGPUBindGroupLayoutEntry>& entries() const;
 
 private:
-    BindGroupLayout(HashMap<uint32_t, WGPUShaderStageFlags>&&, id<MTLArgumentEncoder>, id<MTLArgumentEncoder>, id<MTLArgumentEncoder>);
+    BindGroupLayout(HashMap<uint32_t, WGPUShaderStageFlags>&&, id<MTLArgumentEncoder>, id<MTLArgumentEncoder>, id<MTLArgumentEncoder>, Vector<WGPUBindGroupLayoutEntry>&&);
     BindGroupLayout();
 
     const HashMap<uint32_t, WGPUShaderStageFlags> m_shaderStageForBinding;
@@ -83,6 +90,8 @@ private:
     const id<MTLArgumentEncoder> m_vertexArgumentEncoder { nil };
     const id<MTLArgumentEncoder> m_fragmentArgumentEncoder { nil };
     const id<MTLArgumentEncoder> m_computeArgumentEncoder { nil };
+
+    const Vector<WGPUBindGroupLayoutEntry> m_bindGroupLayoutEntries;
 };
 
 } // namespace WebGPU


### PR DESCRIPTION
#### 950195b08903eed3cfac66f3f21162992fd08297
<pre>
[WebGPU] Implement ShaderModule::convertPipelineLayout
<a href="https://bugs.webkit.org/show_bug.cgi?id=251877">https://bugs.webkit.org/show_bug.cgi?id=251877</a>
&lt;radar://105140101&gt;

Reviewed by Myles C. Maxfield.

Implement ShaderModule::convertPipelineLayout which
is a straightforwards mapping

* Source/WebGPU/WebGPU/BindGroupLayout.h:
(WebGPU::BindGroupLayout::create):
* Source/WebGPU/WebGPU/BindGroupLayout.mm:
(WebGPU::BindGroupLayout::isPresent):
(WebGPU::Device::createBindGroupLayout):
(WebGPU::BindGroupLayout::BindGroupLayout):
(WebGPU::BindGroupLayout::entries const):
(WebGPU::isPresent): Deleted.
* Source/WebGPU/WebGPU/ShaderModule.mm:
(WebGPU::wgslBindingType):
(WebGPU::wgslSamplerType):
(WebGPU::wgslSampleType):
(WebGPU::wgslViewDimension):
(WebGPU::populateBindingMember):
(WebGPU::ShaderModule::convertPipelineLayout):

Canonical link: <a href="https://commits.webkit.org/260050@main">https://commits.webkit.org/260050@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4ed37832c000659bf7dc78a4669a66cd71a29d6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106811 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15833 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39663 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115994 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115566 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17326 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7037 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98999 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112579 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13131 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96174 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40716 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95014 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/27824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9010 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/29179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9578 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6130 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15179 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48727 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6938 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11104 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->