### PR TITLE
Use dynamicDowncast instead of downcast in InjectedBundleNodeHandle::htmlIFrameElementContentFrame

### DIFF
--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
@@ -419,24 +419,13 @@ RefPtr<WebFrame> InjectedBundleNodeHandle::documentFrame()
     return WebFrame::fromCoreFrame(*frame);
 }
 
-RefPtr<WebFrame> InjectedBundleNodeHandle::htmlFrameElementContentFrame()
-{
-    if (!is<HTMLFrameElement>(m_node))
-        return nullptr;
-
-    auto* frame = dynamicDowncast<LocalFrame>(downcast<HTMLFrameElement>(*m_node).contentFrame());
-    if (!frame)
-        return nullptr;
-
-    return WebFrame::fromCoreFrame(*frame);
-}
-
 RefPtr<WebFrame> InjectedBundleNodeHandle::htmlIFrameElementContentFrame()
 {
-    if (!is<HTMLIFrameElement>(m_node))
+    auto* iframeElement = dynamicDowncast<HTMLIFrameElement>(m_node.get());
+    if (!iframeElement)
         return nullptr;
 
-    auto* frame = dynamicDowncast<LocalFrame>(downcast<HTMLFrameElement>(*m_node).contentFrame());
+    auto* frame = dynamicDowncast<LocalFrame>(iframeElement->contentFrame());
     if (!frame)
         return nullptr;
 

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.h
@@ -88,7 +88,6 @@ public:
     RefPtr<InjectedBundleNodeHandle> htmlTableCellElementCellAbove();
 
     RefPtr<WebFrame> documentFrame();
-    RefPtr<WebFrame> htmlFrameElementContentFrame();
     RefPtr<WebFrame> htmlIFrameElementContentFrame();
 
 private:

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/DidResignInputElementStrongPasswordAppearance.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/DidResignInputElementStrongPasswordAppearance.mm
@@ -69,6 +69,12 @@ void didResignInputElementStrongPasswordAppearance(WKBundlePageRef, WKBundleNode
     [nodeHandle setHTMLInputElementIsAutoFilled:YES];
     [nodeHandle setHTMLInputElementAutoFillButtonEnabledWithButtonType:_WKAutoFillButtonTypeStrongPassword];
     [[[browserContextController mainFrame] jsContextForWorld:[WKWebProcessPlugInScriptWorld normalWorld]] evaluateScript:@"alert('ready to resign!')"];
+
+    WKDOMElement *iframeElement = [document createElement:@"iframe"];
+    [[document body] appendChild:iframeElement];
+    auto *iframeValue = [jsContext evaluateScript:@"document.querySelector('iframe')"];
+    auto *iframeNodeHandle = [WKWebProcessPlugInNodeHandle nodeHandleWithJSValue:iframeValue inContext:jsContext];
+    [iframeNodeHandle htmlIFrameElementContentFrame];
 }
 
 @end


### PR DESCRIPTION
#### 72357c53b5ff55ace758892da24cc4bd86f96c5c
<pre>
Use dynamicDowncast instead of downcast in InjectedBundleNodeHandle::htmlIFrameElementContentFrame
<a href="https://bugs.webkit.org/show_bug.cgi?id=251882">https://bugs.webkit.org/show_bug.cgi?id=251882</a>
rdar://105143592

Reviewed by Chris Dumez.

There was some unused code.  Removed.
We were downcasting to the wrong type.  Removed and replaced with dynamicDowncast.
I added the first use of htmlIFrameElementContentFrame in automated tests to prevent this in the future.

* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp:
(WebKit::InjectedBundleNodeHandle::htmlIFrameElementContentFrame):
(WebKit::InjectedBundleNodeHandle::htmlFrameElementContentFrame): Deleted.
* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/DidResignInputElementStrongPasswordAppearance.mm:
(-[DidResignInputElementStrongPasswordAppearance webProcessPlugIn:didCreateBrowserContextController:]):

Canonical link: <a href="https://commits.webkit.org/259985@main">https://commits.webkit.org/259985@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50412b149acf742379d6e7f7910cd0e0dec19e7a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106632 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15627 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39422 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115817 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/115435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110539 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17137 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6861 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98825 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112402 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/95981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/40587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/94892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/27626 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8853 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/28980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9407 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/6017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15022 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48526 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6903 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10933 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->