### PR TITLE
New test: http/tests/site-isolation/basic-iframe.html is a flaky failure and crash

### DIFF
--- a/LayoutTests/http/tests/site-isolation/basic-iframe-expected.html
+++ b/LayoutTests/http/tests/site-isolation/basic-iframe-expected.html
@@ -1,3 +1,0 @@
-<body bgcolor=blue>
-<div style="width:300px;height:150px;background-color:green;">
-</body>

--- a/LayoutTests/http/tests/site-isolation/basic-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/basic-iframe.html
@@ -1,9 +1,0 @@
-<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
-<body bgcolor=blue>
-<iframe src="http://localhost:8000/site-isolation/resources/green-background.html" frameborder=0></iframe>
-<script>
-    // FIXME: This should not be necessary. WebKitTestRunner should wait for all frames from all processes to paint before finishing the test.
-    onload = ()=>{ setTimeout(()=>{ testRunner.notifyDone() }, 1000); }
-    testRunner.waitUntilDone();
-</script>
-</body>


### PR DESCRIPTION
#### 1518c19eac0106e2f2b0a55e542d088610edc765
<pre>
New test: http/tests/site-isolation/basic-iframe.html is a flaky failure and crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=251884">https://bugs.webkit.org/show_bug.cgi?id=251884</a>
rdar://105144957

Unreviewed.

The layout test I added in 259937@main passes most of the time, but is flaky.
More work is needed to make it not flaky.  The code is good progress and is only
used when site isolation is on, so only the test isn&apos;t quite ready yet.
I&apos;ll re-add the test when it is.

* LayoutTests/http/tests/site-isolation/basic-iframe-expected.html: Removed.
* LayoutTests/http/tests/site-isolation/basic-iframe.html: Removed.

Canonical link: <a href="https://commits.webkit.org/259982@main">https://commits.webkit.org/259982@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e107dd1d07858afcf491297f272453e3cd891a7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/106641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/15634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/39430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/115826 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/115442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/17146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/6870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/98834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112411 "Failed to checkout and rebase branch from PR 9781") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/17146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/39430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/98834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/17146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/39430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/98834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/8860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/39430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9416 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/6870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/15031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/39430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/10940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3708 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->