### PR TITLE
Attribute change results in assertion failure checking for parent node for a parent less element.

### DIFF
--- a/LayoutTests/fast/html/parent-less-source-crash-type-change-expected.txt
+++ b/LayoutTests/fast/html/parent-less-source-crash-type-change-expected.txt
@@ -1,0 +1,3 @@
+PASS if no crash
+
+

--- a/LayoutTests/fast/html/parent-less-source-crash-type-change.html
+++ b/LayoutTests/fast/html/parent-less-source-crash-type-change.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<script>
+var run_count = 0;
+function main() {
+  if (window.testRunner)
+         testRunner.dumpAsText();
+  x34.addEventListener("DOMNodeRemoved",f3);
+}
+function f1() {
+  run_count++;
+  if (run_count > 2) return;
+  var x34 = document.getElementById("x34");
+  try { x47.append(x34); } catch { }
+  x34.type = "image/png";
+  v59 = document.createRange();
+  v59.setEndAfter(x37);
+  v59.extractContents();
+}
+function f3() {
+  x25.addEventListener("DOMSubtreeModified",f1);
+  x12.setAttribute("vector-effect","non-scaling-size");
+  x4.prepend(x34);
+}
+</script>
+<body onload="main()"><p>PASS if no crash</p>
+<source id="x34">
+<font id="x25">
+<picture id="x4">
+<dl id="x37">
+<svg id="x47">
+<path id="x12">
+<animate attributeName="clip-path" end="100ms" onend="f1()">

--- a/Source/WebCore/html/HTMLSourceElement.cpp
+++ b/Source/WebCore/html/HTMLSourceElement.cpp
@@ -158,7 +158,7 @@ void HTMLSourceElement::parseAttribute(const QualifiedName& name, const AtomStri
         if (name == mediaAttr)
             m_cachedParsedMediaAttribute = std::nullopt;
         RefPtr parent = parentNode();
-        if (m_shouldCallSourcesChanged)
+        if (m_shouldCallSourcesChanged && parent)
             downcast<HTMLPictureElement>(*parent).sourcesChanged();
     }
 #if ENABLE(MODEL_ELEMENT)


### PR DESCRIPTION
#### 0ba2b3fa758f25392de776de7f044a466ca397c2
<pre>
Attribute change results in assertion failure checking for parent node for a parent less element.
<a href="https://bugs.webkit.org/show_bug.cgi?id=251888">https://bugs.webkit.org/show_bug.cgi?id=251888</a>
rdar://104819364

Reviewed by Ryosuke Niwa.

This change sets &apos;m_shouldCallSourcesChanged&apos; to false after the parentNode is disassociated from the Node in question. This will avoid the call that leads to the crash.

* LayoutTests/fast/html/parent-less-source-crash-type-change-expected.txt: Added.
* LayoutTests/fast/html/parent-less-source-crash-type-change.html: Added.
* Source/WebCore/dom/ContainerNodeAlgorithms.cpp:
(WebCore::removeDetachedChildrenInContainer):
* Source/WebCore/html/HTMLSourceElement.cpp:
(WebCore::HTMLSourceElement::setShouldCallSourcesChanged):
* Source/WebCore/html/HTMLSourceElement.h:

Canonical link: <a href="https://commits.webkit.org/260072@main">https://commits.webkit.org/260072@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4dcc8396bd4bca6496ddb0e65776af8a17081ca3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106846 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15881 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39636 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116029 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115589 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110749 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17356 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7082 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99032 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112614 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13145 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96149 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40744 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95029 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27800 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82482 "Found 1 new API test failure: /TestWTF:WTF_ParkingLot.UnparkOneOneFast (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9036 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29155 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9611 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6163 "Found 1 new test failure: fast/text/glyph-display-lists/glyph-display-list-scaled-unshared.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15203 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48701 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6953 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11140 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->