### PR TITLE
Fixup air pointer args if they are not valid in BBQ

### DIFF
--- a/JSTests/wasm/stress/big-try-simd.js
+++ b/JSTests/wasm/stress/big-try-simd.js
@@ -1,0 +1,55 @@
+//@ requireOptions("--useWebAssemblySIMD=1")
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+const N = 10
+
+let wat = `
+(module
+    (tag $t0 (param `
+
+for (let i = 0; i < N; ++i)
+    wat += `v128 `
+
+wat += `))
+
+    (func $f0 `
+for (let i = 0; i < 50; ++i)
+    wat += `(local v128) `
+for (let i = 0; i < N; ++i)
+    wat += `(local $l${i} v128) `
+
+for (let i = 0; i < N; ++i)
+    wat += `(local.set $l${i} (v128.const i64x2 0 ${i + 5})) `
+
+
+for (let i = 0; i < N; ++i)
+    wat += `(local.get $l${i}) `
+
+wat += `
+        (throw $t0)
+    )
+    (func $f1 (export "test")
+      (try
+        (do
+            (call $f0))
+        (catch $t0
+            (return)
+        )
+      )
+      (unreachable)
+      (return))
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { simd: true, exceptions: true })
+    const { test } = instance.exports
+
+    for (let i = 0; i < 10000; ++i) {
+        assert.throws(() => test(42), TypeError, "an exported wasm function cannot contain a v128 parameter or return value")
+    }
+}
+
+assert.asyncTest(test())

--- a/JSTests/wasm/stress/big-try.js
+++ b/JSTests/wasm/stress/big-try.js
@@ -1,0 +1,61 @@
+//@ requireOptions("--useWebAssemblySIMD=1")
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+const N = 1000
+
+let wat = `
+(module
+    (tag $t0 (param `
+
+for (let i = 0; i < N; ++i)
+    wat += `f64 `
+
+wat += `))
+
+    (func $f0 `
+for (let i = 0; i < 5000; ++i)
+    wat += `(local f64) `
+for (let i = 0; i < N; ++i)
+    wat += `(local $l${i} f64) `
+
+for (let i = 0; i < N; ++i)
+    wat += `(local.set $l${i} (f64.const ${i + 5})) `
+
+
+for (let i = 0; i < N; ++i)
+    wat += `(local.get $l${i}) `
+
+wat += `
+        (throw $t0)
+    )
+    (func $f1 (export "test") (result f64)
+      (try
+        (do
+            (call $f0))
+        (catch $t0
+`
+for (let i = 0; i < N - 2; ++i)
+    wat += `(drop) `
+
+wat += `
+            (f64.add)
+            (return)
+        )
+      )
+      (unreachable)
+      (return))
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { simd: true, exceptions: true })
+    const { test } = instance.exports
+
+    for (let i = 0; i < 10000; ++i) {
+        assert.eq(test(42), 2*5 + 0 + 1)
+    }
+}
+
+assert.asyncTest(test())

--- a/JSTests/wasm/stress/big-tuple-args.js
+++ b/JSTests/wasm/stress/big-tuple-args.js
@@ -1,0 +1,38 @@
+//@ requireOptions("--useWebAssemblySIMD=1")
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+const N = 4095 + 32
+
+let wat = `
+(module
+    (func $f0 (result `
+
+for (let i = 0; i < N; ++i)
+    wat += `f64 `
+
+wat += `) (local $l0 f64) `
+
+for (let i = 0; i < N; ++i)
+  wat += `(local.get $l0) `
+
+wat += `
+    )
+    (func $f1 (export "test")
+      (call $f0)
+      (f64.add)
+      (return))
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { simd: true })
+    const { test } = instance.exports
+
+    for (let i = 0; i < 10000; ++i) {
+        assert.eq(test(42), undefined)
+    }
+}
+
+assert.asyncTest(test())

--- a/JSTests/wasm/stress/big-tuple.js
+++ b/JSTests/wasm/stress/big-tuple.js
@@ -1,0 +1,37 @@
+//@ requireOptions("--useWebAssemblySIMD=1")
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+const N = 4095 + 32
+
+let wat = `
+(module
+    (func $f0 (result `
+
+for (let i = 0; i < N; ++i)
+    wat += `f64 `
+
+wat += `) (local $l0 f64) `
+
+for (let i = 0; i < N; ++i)
+  wat += `(local.get $l0) `
+
+wat += `
+    )
+    (func $f1 (export "test")
+      (call $f0)
+      (return))
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { simd: true })
+    const { test } = instance.exports
+
+    for (let i = 0; i < 10000; ++i) {
+        assert.eq(test(42), undefined)
+    }
+}
+
+assert.asyncTest(test())

--- a/JSTests/wasm/stress/simd-big-tuple.js
+++ b/JSTests/wasm/stress/simd-big-tuple.js
@@ -1,0 +1,49 @@
+//@ requireOptions("--useWebAssemblySIMD=1")
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func $f0 (result v128 v128 v128 v128 v128 v128 v128 v128 v128 v128 v128 v128 v128 v128 v128 v128 v128 v128 v128 v128 v128 v128 v128)
+      (local $l0 v128)
+      (local.get $l0)
+      (local.get $l0)
+      (local.get $l0)
+      (local.get $l0)
+      (local.get $l0)
+      (local.get $l0)
+      (local.get $l0)
+      (local.get $l0)
+      (local.get $l0)
+      (local.get $l0)
+      (local.get $l0)
+      (local.get $l0)
+      (local.get $l0)
+      (local.get $l0)
+      (local.get $l0)
+      (local.get $l0)
+      (local.get $l0)
+      (local.get $l0)
+      (local.get $l0)
+      (local.get $l0)
+      (local.get $l0)
+      (local.get $l0)
+      (local.get $l0)
+    )
+    (func $f1 (export "test")
+      (call $f0)
+      (return))
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { simd: true })
+    const { test } = instance.exports
+
+    for (let i = 0; i < 10000; ++i) {
+        assert.eq(test(42), undefined)
+    }
+}
+
+assert.asyncTest(test())

--- a/JSTests/wasm/stress/tag-return.js
+++ b/JSTests/wasm/stress/tag-return.js
@@ -1,0 +1,16 @@
+//@ requireOptions("--useWebAssemblySIMD=1")
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+const N = 15
+
+let wat = `
+(module
+    (tag $t0 (result f32)))`
+
+async function test() {
+    await assert.throwsAsync(instantiate(wat, {}, { exceptions: true }), WebAssembly.CompileError, "WebAssembly.Module doesn't parse at byte 20: 0th Exception type cannot have a non-void return type 0 (evaluating 'new WebAssembly.Module(binaryResult.buffer)')")
+}
+
+assert.asyncTest(test())

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
@@ -1268,6 +1268,8 @@ auto SectionParser::parseException() -> PartialResult
         WASM_PARSER_FAIL_IF(!parseVarUInt32(typeNumber), "can't get ", exceptionNumber, "th Exception's type number");
         WASM_PARSER_FAIL_IF(typeNumber >= m_info->typeCount(), exceptionNumber, "th Exception type number is invalid ", typeNumber);
         TypeIndex typeIndex = TypeInformation::get(m_info->typeSignatures[typeNumber]);
+        auto signature = TypeInformation::getFunctionSignature(typeIndex);
+        WASM_PARSER_FAIL_IF(!signature.returnsVoid(), exceptionNumber, "th Exception type cannot have a non-void return type ", typeNumber);
         m_info->internalExceptionTypeIndices.uncheckedAppend(typeIndex);
     }
 


### PR DESCRIPTION
#### 50c7aaec2f53ab3b960f1b299aad5009df6f1967
<pre>
Fixup air pointer args if they are not valid in BBQ
<a href="https://bugs.webkit.org/show_bug.cgi?id=251890">https://bugs.webkit.org/show_bug.cgi?id=251890</a>
rdar://105079565

Reviewed by Mark Lam and Yusuke Suzuki.

We are not fixing up air args if their offsets don&apos;t fit into the instruction
in a few cases.

Here are some examples:

MoveDouble 28480(%sp), %q16 ; too big
MoveVector 248(%sp), %q16 ; not 16-byte aligned

Let&apos;s fix up these arguments. We also fix a missing validation check
when parsing exception tags exposed by this test.

* Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp:
(JSC::Wasm::AirIRGenerator64::addReturn):
* Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h:
(JSC::Wasm::AirIRGeneratorBase::emitPatchpoint):

oops

Canonical link: <a href="https://commits.webkit.org/260038@main">https://commits.webkit.org/260038@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa4909b69dca9eaeaf2daa4104380ebdf7ad32b7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106672 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15663 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39460 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115859 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115461 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17177 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6900 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98867 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112441 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13039 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96007 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40611 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94917 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27656 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82350 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/96221 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8887 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29007 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/95692 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/6813 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9445 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6055 "Found 2 new test failures: fast/css/large-font-size-crash.html, fast/text/glyph-display-lists/glyph-display-list-scaled-unshared.html (failure)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30679 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15059 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48556 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/104437 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6931 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10967 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25869 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->