### PR TITLE
CachedFont objects gets created for every 'src' attribute in @font-face rules, even if they're never loaded.

### DIFF
--- a/Source/WebCore/css/CSSFontFaceSource.cpp
+++ b/Source/WebCore/css/CSSFontFaceSource.cpp
@@ -80,16 +80,6 @@ CSSFontFaceSource::CSSFontFaceSource(CSSFontFace& owner, CSSFontSelector& fontSe
 {
     // This may synchronously call fontLoaded().
     m_fontRequest->setClient(this);
-
-    if (status() == Status::Pending && !m_fontRequest->isPending()) {
-        setStatus(Status::Loading);
-        if (!shouldIgnoreFontLoadCompletions()) {
-            if (m_fontRequest->errorOccurred())
-                setStatus(Status::Failure);
-            else
-                setStatus(Status::Success);
-        }
-    }
 }
 
 CSSFontFaceSource::CSSFontFaceSource(CSSFontFace& owner, AtomString fontFaceName, SVGFontFaceElement& fontFace)

--- a/Source/WebCore/css/CSSFontFaceSrcValue.cpp
+++ b/Source/WebCore/css/CSSFontFaceSrcValue.cpp
@@ -127,4 +127,9 @@ bool CSSFontFaceSrcResourceValue::equals(const CSSFontFaceSrcResourceValue& othe
     return m_location.specifiedURLString == m_location.specifiedURLString && m_format == other.m_format;
 }
 
+const URL& CSSFontFaceSrcResourceValue::resolvedURL() const
+{
+    return m_location.resolvedURL;
+}
+
 }

--- a/Source/WebCore/css/CSSFontFaceSrcValue.h
+++ b/Source/WebCore/css/CSSFontFaceSrcValue.h
@@ -70,6 +70,8 @@ public:
     bool customTraverseSubresources(const Function<bool(const CachedResource&)>&) const;
     bool equals(const CSSFontFaceSrcResourceValue&) const;
 
+    const URL& resolvedURL() const;
+
 private:
     explicit CSSFontFaceSrcResourceValue(ResolvedURL&&, String&& format, LoadedFromOpaqueSource);
 

--- a/Source/WebCore/loader/cache/CachedResource.cpp
+++ b/Source/WebCore/loader/cache/CachedResource.cpp
@@ -105,6 +105,7 @@ CachedResource::CachedResource(CachedResourceRequest&& request, Type type, PAL::
     , m_hasUnknownEncoding(request.isLinkPreload())
     , m_switchingClientsToRevalidatedResource(false)
     , m_ignoreForRequestCount(request.ignoreForRequestCount())
+    , m_forceAsync(false)
 {
     ASSERT(m_sessionID.isValid());
 
@@ -543,7 +544,7 @@ bool CachedResource::addClientToSet(CachedResourceClient& client)
     if (allowsCaching() && !hasClients() && inCache())
         MemoryCache::singleton().addToLiveResourcesSize(*this);
 
-    if ((m_type == Type::RawResource || m_type == Type::MainResource) && !m_response.isNull() && !m_proxyResource) {
+    if (((m_type == Type::RawResource || m_type == Type::MainResource) && !m_response.isNull() && !m_proxyResource) || m_forceAsync) {
         // Certain resources (especially XHRs and main resources) do crazy things if an asynchronous load returns
         // synchronously (e.g., scripts may not have set all the state they need to handle the load).
         // Therefore, rather than immediately sending callbacks on a cache hit like other CachedResources,

--- a/Source/WebCore/loader/cache/CachedResource.h
+++ b/Source/WebCore/loader/cache/CachedResource.h
@@ -198,6 +198,8 @@ public:
             || type() == Type::RawResource;
     }
 
+    void setAsyncLoad() { m_forceAsync = true; }
+
     void setIgnoreForRequestCount(bool ignoreForRequestCount) { m_ignoreForRequestCount = ignoreForRequestCount; }
 
     unsigned accessCount() const { return m_accessCount; }
@@ -395,6 +397,7 @@ private:
     bool m_hasUnknownEncoding : 1;
     bool m_switchingClientsToRevalidatedResource : 1;
     bool m_ignoreForRequestCount : 1;
+    bool m_forceAsync : 1;
 
 #if ASSERT_ENABLED
     bool m_deleted { false };


### PR DESCRIPTION
#### 9d57236813e347938ce0bc95365692e42f0e0174
<pre>
CachedFont objects gets created for every &apos;src&apos; attribute in @font-face rules, even if they&apos;re never loaded.
<a href="https://bugs.webkit.org/show_bug.cgi?id=251892">https://bugs.webkit.org/show_bug.cgi?id=251892</a>
&lt;rdar://104940966&gt;

Reviewed by NOBODY (OOPS!).

The combination of CachedFont, CachedFontLoadRequest and CSSFontFaceSource add up to a significant chunk of memory, which is largely unneeded until we actually load the fonts.

Some sites create a huge number of these (multiple srcs for each @font-face rule, lots of rules for various weight/bold/italic etc combinations of the same family).

This instead just stores the CSSFontFaceSrcResourceValue (effectively just the src URL) on CSSFontFace, until we actually have a reason to request the font, and then it gets replaced with the CSSFontFaceSource.

* Source/WebCore/css/CSSFontFace.cpp:
(WebCore::CSSFontFace::appendSources):
(WebCore::CSSFontFace::computeFailureState const):
(WebCore::CSSFontFace::adoptPendingSource):
(WebCore::CSSFontFace::opportunisticallyStartFontDataURLLoading):
(WebCore::CSSFontFace::ensurePendingSourceFlushed):
(WebCore::CSSFontFace::pump):
(WebCore::CSSFontFace::font):
(WebCore::CSSFontFace::hasSVGFontFaceSource const): Deleted.
* Source/WebCore/css/CSSFontFace.h:
* Source/WebCore/css/CSSFontFaceSrcValue.cpp:
(WebCore::CSSFontFaceSrcResourceValue::resolvedURL const):
* Source/WebCore/css/CSSFontFaceSrcValue.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d57236813e347938ce0bc95365692e42f0e0174

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108597 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17698 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41451 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117707 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/117906 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112480 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19149 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8975 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100829 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114364 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14352 "Found 60 new test failures: css3/font-feature-settings-calc.html, css3/font-feature-settings-font-face-rendering.html, css3/font-synthesis-small-caps.html, css3/images/cross-fade-blending.html, editing/deleting/forward-delete-crash.html, editing/pasteboard/copy-element-with-conflicting-background-color-from-rule.html, editing/spelling/spelling-marker-includes-hyphen.html, fast/canvas/draw-text-repeatedly-into-disconnected-canvas.html, fast/canvas/fill-gradient-text-with-web-font.html, fast/canvas/fill-text-with-font-features.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97584 "Found 3 new API test failures: TestWebKitAPI.TextManipulation.StartTextManipulationExcludesTextRenderedAsIcons, TestWebKitAPI.LockdownMode.AllowedFont, TestWebKitAPI.WebKit.TextSize (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42322 "Found 417 new test failures: animations/font-variations/font-variation-settings-order.html, animations/font-variations/font-variation-settings.html, css3/font-feature-settings-calc.html, css3/font-variant-font-face-override.html, fast/canvas/fill-text-with-font-features.html, fast/css/color-leakage.html, fast/css/custom-font-xheight.html, fast/css/font-face-data-uri.html, fast/css/font-face-download-error.html, fast/css/font-face-multiple-faces.html ... (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96328 "Found 29 new API test failures: TestWebKitAPI.DocumentEditingContext.SpatialRequest_RectInsideInput, TestWebKitAPI.DocumentEditingContext.Simple, TestWebKitAPI.EditorStateTests.MarkedTextRange_VerticalCaretSelection, TestWebKitAPI.DocumentEditingContext.SpatialAndCurrentSelectionRequest_RectAfterCaretSelection, TestWebKitAPI.DocumentEditingContext.RectsRequestInContentEditableWithDivBreaks, TestWebKitAPI.EditorStateTests.MarkedTextRange_VerticalRangeSelection, TestWebKitAPI.DocumentEditingContext.RequestLastWord, TestWebKitAPI.DocumentEditingContext.SpatialAndCurrentSelectionRequest_RectAfterRangeSelection, TestWebKitAPI.DocumentEditingContext.SpatialAndCurrentSelectionRequest_RectAroundRangeSelection, TestWebKitAPI.DocumentEditingContext.RequestLastTwoLines ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29222 "Found 60 new test failures: animations/font-variations/font-variation-settings-order.html, animations/font-variations/font-variation-settings.html, css3/font-feature-settings-calc.html, css3/font-feature-settings-rendering.html, css3/font-synthesis-small-caps.html, editing/deleting/forward-delete-crash.html, editing/text-placeholder/insert-into-content-editable-non-zero-width-and-height.html, editing/text-placeholder/insert-into-content-editable-zero-width.html, editing/text-placeholder/insert-into-content-editable.html, fast/canvas/draw-text-repeatedly-into-disconnected-canvas.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84039 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10506 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30572 "Found 60 new test failures: animations/font-variations/font-variation-settings-order.html, animations/font-variations/font-variation-settings.html, compositing/clipping/border-radius-async-overflow-non-stacking.html, css3/font-feature-settings-calc.html, css3/font-feature-settings-font-face-rendering.html, css3/font-synthesis-small-caps.html, fast/canvas/draw-text-repeatedly-into-disconnected-canvas.html, fast/canvas/fill-gradient-text-with-web-font.html, fast/canvas/fill-text-with-font-features.html, fast/canvas/font-selector-crash.html ... (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11264 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7486 "Found 60 new test failures: animations/font-variations/font-variation-settings-order.html, animations/font-variations/font-variation-settings.html, css3/font-feature-settings-calc.html, css3/font-feature-settings-font-face-rendering.html, css3/font-feature-settings-rendering.html, css3/font-synthesis-small-caps.html, fast/canvas/fill-gradient-text-with-web-font.html, fast/canvas/fill-text-with-font-features.html, fast/canvas/font-selector-crash.html, fast/css/cascade/background-clip-and-webkit-background-clip-cascade-order.html ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16655 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50168 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12852 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->