### PR TITLE
[git-webkit] Allow Trackers to hide bug titles

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/setup.py
+++ b/Tools/Scripts/libraries/webkitbugspy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='webkitbugspy',
-    version='0.9.4',
+    version='0.9.5',
     description='Library containing a shared API for various bug trackers.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(0, 9, 4)
+version = Version(0, 9, 5)
 
 from .user import User
 from .issue import Issue

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py
@@ -50,6 +50,7 @@ class Tracker(GenericTracker):
                 result = dict(
                     type='bugzilla',
                     url=obj.url,
+                    hide_title=obj.hide_title,
                 )
                 if obj._res[len(Tracker.RE_TEMPLATES):]:
                     result['res'] = [compiled.pattern for compiled in obj._res[len(Tracker.RE_TEMPLATES):]]
@@ -60,8 +61,8 @@ class Tracker(GenericTracker):
                 raise TypeError('Cannot invoke parent class when classmethod')
             return super(Tracker.Encoder, context).default(obj)
 
-    def __init__(self, url, users=None, res=None, login_attempts=3, redact=None, radar_importer=None):
-        super(Tracker, self).__init__(users=users, redact=redact)
+    def __init__(self, url, users=None, res=None, login_attempts=3, redact=None, radar_importer=None, hide_title=None):
+        super(Tracker, self).__init__(users=users, redact=redact, hide_title=hide_title)
 
         self._logins_left = login_attempts + 1 if login_attempts else 1
         match = self.ROOT_RE.match(url)

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py
@@ -66,6 +66,7 @@ class Tracker(GenericTracker):
                 result = dict(
                     type='github',
                     url=obj.url,
+                    hide_title=obj.hide_title,
                 )
                 if obj._res[len(Tracker.RE_TEMPLATES):]:
                     result['res'] = [compiled.pattern for compiled in obj._res[len(Tracker.RE_TEMPLATES):]]
@@ -78,9 +79,9 @@ class Tracker(GenericTracker):
             self, url, users=None, res=None,
             component_color=DEFAULT_COMPONENT_COLOR,
             version_color=DEFAULT_VERSION_COLOR,
-            session=None, redact=None,
+            session=None, redact=None, hide_title=None,
     ):
-        super(Tracker, self).__init__(users=users, redact=redact)
+        super(Tracker, self).__init__(users=users, redact=redact, hide_title=hide_title)
 
         self.session = session or requests.Session()
         self.component_color = component_color

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py
@@ -84,7 +84,11 @@ class Tracker(GenericTracker):
         @decorators.hybridmethod
         def default(context, obj):
             if isinstance(obj, Tracker):
-                return dict(type='radar', projects=obj._projects)
+                return dict(
+                    type='radar',
+                    projects=obj._projects,
+                    hide_title=obj.hide_title,
+                )
             if isinstance(context, type):
                 raise TypeError('Cannot invoke parent class when classmethod')
             return super(Tracker.Encoder, context).default(obj)
@@ -98,8 +102,9 @@ class Tracker(GenericTracker):
         except ImportError:
             return None
 
-    def __init__(self, users=None, authentication=None, project=None, projects=None, redact=None):
-        super(Tracker, self).__init__(users=users, redact=redact)
+    def __init__(self, users=None, authentication=None, project=None, projects=None, redact=None, hide_title=None):
+        hide_title = True if hide_title is None else hide_title
+        super(Tracker, self).__init__(users=users, redact=redact, hide_title=hide_title)
         self._projects = [project] if project else (projects or [])
 
         self.library = self.radarclient()

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py
@@ -41,6 +41,7 @@ class TestBugzilla(unittest.TestCase):
             )), dict(
                 type='bugzilla',
                 url='https://bugs.example.com',
+                hide_title=False,
                 res=['\\Aexample.com/b/(?P<id>\\d+)\\Z']
             ),
         )

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/github_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/github_unittest.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+# Copyright (C) 2021-2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -39,6 +39,7 @@ class TestGitHub(unittest.TestCase):
             )), dict(
                 type='github',
                 url='https://github.example.com/WebKit/WebKit',
+                hide_title=False,
                 res=['\\Aexample.com/b/(?P<id>\\d+)\\Z']
             ),
         )

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py
@@ -31,7 +31,7 @@ class TestRadar(unittest.TestCase):
     def test_encoding(self):
         self.assertEqual(
             radar.Tracker.Encoder().default(radar.Tracker(project='WebKit')),
-            dict(type='radar', projects=['WebKit']),
+            dict(hide_title=True, type='radar', projects=['WebKit']),
         )
 
     def test_decoding(self):

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tracker.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tracker.py
@@ -89,6 +89,7 @@ class Tracker(object):
 
         unpacked = dict(
             redact=data.get('redact'),
+            hide_title=data.get('hide_title'),
         )
         if data.get('type') in ('bugzilla', 'github'):
             unpacked['url'] = data.get('url')
@@ -120,8 +121,9 @@ class Tracker(object):
             return cls._trackers[0]
         return None
 
-    def __init__(self, users=None, redact=None):
+    def __init__(self, users=None, redact=None, hide_title=None):
         self.users = users or User.Mapping()
+        self.hide_title = False if hide_title is None else hide_title
         if redact is None:
             self._redact = {re.compile('.*'): False}
         elif isinstance(redact, dict):

--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.12.0',
+    version='5.12.1',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 12, 0)
+version = Version(5, 12, 1)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/branch.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/branch.py
@@ -116,13 +116,13 @@ class Branch(Command):
                 prompt = '{}nter name of new branch (or issue URL): '.format('{}, e'.format(why) if why else 'E')
             args.issue = Terminal.input(prompt, alert_after=2 * Terminal.RING_INTERVAL)
 
-        if string_utils.decode(args.issue).isnumeric() and Tracker.instance() and not redact:
+        if string_utils.decode(args.issue).isnumeric() and Tracker.instance() and not redact and not Tracker.instance().hide_title:
             issue = Tracker.instance().issue(int(args.issue))
             if issue and issue.title and not issue.redacted:
                 args.issue = cls.to_branch_name(issue.title)
         else:
             issue = Tracker.from_string(args.issue)
-            if issue and issue.title and not redact and not issue.redacted:
+            if issue and issue.title and not redact and not issue.redacted and not issue.tracker.hide_title:
                 args.issue = cls.to_branch_name(issue.title)
             elif issue:
                 args.issue = str(issue.id)
@@ -139,7 +139,7 @@ class Branch(Command):
                     sys.stderr.write('Failed to create new issue\n')
                     return 1
                 print("Created '{}'".format(issue))
-                if issue and issue.title and not redact and not issue.redacted:
+                if issue and issue.title and not redact and not issue.redacted and not issue.tracker.hide_title:
                     args.issue = cls.to_branch_name(issue.title)
                 elif issue:
                     args.issue = str(issue.id)
@@ -167,8 +167,9 @@ class Branch(Command):
                 rdar = Tracker.from_string(input)
             issue.cc_radar(block=True, radar=rdar)
 
-        if issue and not isinstance(issue.tracker, radar.Tracker):
+        if issue and not issue.tracker.hide_title:
             args._title = issue.title
+        if issue:
             args._bug_urls = Commit.bug_urls(issue)
 
         args.issue = cls.normalize_branch_name(args.issue)

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/branch_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/branch_unittest.py
@@ -95,9 +95,9 @@ class TestBranch(testing.PathTestCase):
             bmocks.Radar(issues=bmocks.ISSUES), patch('webkitbugspy.Tracker._trackers', [radar.Tracker()]), mocks.local.Svn(), MockTime:
 
             self.assertEqual(0, program.main(args=('branch', '-v'), path=self.path))
-            self.assertEqual(local.Git(self.path).branch, 'eng/Example-feature-1')
-        self.assertEqual(captured.root.log.getvalue(), "Creating the local development branch 'eng/Example-feature-1'...\n")
-        self.assertEqual(captured.stdout.getvalue(), "Enter issue URL or title of new issue: \nCreated the local development branch 'eng/Example-feature-1'\n")
+            self.assertEqual(local.Git(self.path).branch, 'eng/2')
+        self.assertEqual(captured.root.log.getvalue(), "Creating the local development branch 'eng/2'...\n")
+        self.assertEqual(captured.stdout.getvalue(), "Enter issue URL or title of new issue: \nCreated the local development branch 'eng/2'\n")
 
     def test_automatic_radar_cc(self):
         with MockTerminal.input('{}/show_bug.cgi?id=2'.format(self.BUGZILLA), ''), OutputCapture(level=logging.INFO) as captured, mocks.local.Git(self.path), bmocks.Bugzilla(
@@ -284,7 +284,7 @@ Created the local development branch 'eng/Area-New-Issue'
                 args=('branch',),
                 path=self.path,
             ))
-            self.assertEqual(local.Git(self.path).branch, 'eng/Area-New-Issue')
+            self.assertEqual(local.Git(self.path).branch, 'eng/4')
 
             issue = radar.Tracker(project='WebKit').issue(4)
             self.assertEqual(issue.title, '[Area] New Issue')
@@ -310,7 +310,7 @@ What version of 'WebKit SVG' should the bug be associated with?:
     4) WebKit Local Build
 : 
 Created 'rdar://4 [Area] New Issue'
-Created the local development branch 'eng/Area-New-Issue'
+Created the local development branch 'eng/4'
 ''',
         )
         self.assertEqual(captured.stderr.getvalue(), '')


### PR DESCRIPTION
#### 69c4012c1ffe6eb6b54f6613c1daa259429c6556
<pre>
[git-webkit] Allow Trackers to hide bug titles
<a href="https://bugs.webkit.org/show_bug.cgi?id=251894">https://bugs.webkit.org/show_bug.cgi?id=251894</a>
rdar://105153144

Reviewed by Aakash Jain.

* Tools/Scripts/libraries/webkitbugspy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py:
(Tracker.Encoder.default):
(Tracker.__init__): Add hide_title member,.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py:
(Tracker.Encoder.default):
(Tracker.__init__): Add hide_title member.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py:
(Tracker.Encoder.default):
(Tracker.__init__): Add hide_title member, True by default.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py:
(TestBugzilla.test_encoding):
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/github_unittest.py:
(TestGitHub.test_encoding):
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py:
(TestRadar.test_encoding):
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tracker.py:
(Tracker.from_json): Decode
(Tracker.__init__): Add hide_title member, False by default.
* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/branch.py:
(Branch.main): If a Tracker is hiding it&apos;s titles, don&apos;t encode the title in the branch name.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/branch_unittest.py:
(TestBranch.test_prompt_url):

Canonical link: <a href="https://commits.webkit.org/260012@main">https://commits.webkit.org/260012@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77f2e264a52d27f7adf392894f7952e50c5abe69

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/106760 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/15772 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/39546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/115950 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/115532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/110666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/17274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/6991 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/98955 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/112529 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/17274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/39546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/98955 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/5/builds/110252 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/17274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/39546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/98955 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/8969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/39546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/9533 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/6991 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/20/builds/105575 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/15141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/39546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/11056 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3727 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->