### PR TITLE
Navigation within iframe doesn't exit fullscreen for parent iframe element

### DIFF
--- a/LayoutTests/fullscreen/fullscreen-iframe-navigation-expected.html
+++ b/LayoutTests/fullscreen/fullscreen-iframe-navigation-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<meta charset="UTF-8">
+<body>
+<iframe id="iframe" src="./resources/fullscreen-iframe-navigation-target.html"></iframe>
+</body>
+</html>

--- a/LayoutTests/fullscreen/fullscreen-iframe-navigation.html
+++ b/LayoutTests/fullscreen/fullscreen-iframe-navigation.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<meta charset="UTF-8">
+<style>
+    .failed {
+        background-color: red;
+    }
+</style>
+</head>
+<body>
+<iframe id="iframe" srcdoc="<button onclick='document.documentElement.requestFullscreen().then(() => (window.location.href=`./resources/fullscreen-iframe-navigation-target.html`))'>Enter fullscreen and navigate</button>"></iframe>
+<script src="../imported/w3c/web-platform-tests/resources/testdriver.js"></script>
+<script src="../imported/w3c/web-platform-tests/resources/testdriver-vendor.js"></script>
+<script>
+    addEventListener("load", async () => {
+        await test_driver.bless("fullscreen", null, iframe.contentWindow);
+        await new Promise(resolve => {
+            addEventListener("fullscreenchange", resolve, { once: true });
+            iframe.contentDocument.documentElement.requestFullscreen();
+        });
+        if (!document.fullscreenElement)
+            document.body.className = "failed";
+        await Promise.all([
+            new Promise(resolve => {
+                addEventListener("message", (e) => {
+                    if (e.data == "loaded")
+                        resolve();
+                }, { once: true });
+                iframe.contentWindow.location.href = "./resources/fullscreen-iframe-navigation-target.html";
+            }),
+            new Promise(resolve => {
+                addEventListener("fullscreenchange", resolve, { once: true });
+            })
+        ]);
+        if (document.fullscreenElement)
+            document.body.className = "failed";
+        document.documentElement.classList.remove("reftest-wait");
+    });
+</script>
+</body>
+</html>

--- a/LayoutTests/fullscreen/resources/fullscreen-iframe-navigation-target.html
+++ b/LayoutTests/fullscreen/resources/fullscreen-iframe-navigation-target.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Successfully navigated, test passes if the iframe does not take the full content area size.</p>
+<script>
+    addEventListener("DOMContentLoaded", () => {
+        if (parent)
+            parent.postMessage("loaded", "*");
+    }, { once: true });
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2449,3 +2449,6 @@ imported/w3c/web-platform-tests/geolocation-API/permission.https.html [ WontFix 
 
 # Per-process limit is only for WK2
 http/tests/websocket/tests/hybi/multiple-connections-limit.html [ Skip ]
+
+# Displays blank on WK1
+fullscreen/fullscreen-iframe-navigation.html [ Skip ]

--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -51,7 +51,7 @@ namespace WebCore {
 using namespace HTMLNames;
 
 FullscreenManager::FullscreenManager(Document& document)
-    : m_document { document }
+    : m_document(document)
 #if !RELEASE_LOG_DISABLED
     , m_logIdentifier(LoggerHelper::uniqueLogIdentifier())
 #endif
@@ -154,6 +154,9 @@ void FullscreenManager::requestFullscreenForElement(Ref<Element>&& element, RefP
     INFO_LOG(identifier);
 
     m_pendingFullscreenElement = RefPtr { element.ptr() };
+
+    // We cache the top document here, so we still have the correct one when we exit fullscreen after navigation.
+    m_topDocument = document().topDocument();
 
     m_document.eventLoop().queueTask(TaskSource::MediaElement, [this, weakThis = WeakPtr { *this }, element = WTFMove(element), promise = WTFMove(promise), checkType, hasKeyboardAccess, failedPreflights, identifier] () mutable {
         if (!weakThis) {
@@ -261,8 +264,8 @@ void FullscreenManager::cancelFullscreen()
     // is defined as:
     // "To fully exit fullscreen act as if the exitFullscreen() method was invoked on the top-level browsing
     // context's document and subsequently empty that document's fullscreen element stack."
-    Document& topDocument = document().topDocument();
-    if (!topDocument.fullscreenManager().fullscreenElement()) {
+    Ref topDocument = this->topDocument();
+    if (!topDocument->fullscreenManager().fullscreenElement()) {
         // If there is a pending fullscreen element but no top document fullscreen element,
         // there is a pending task in enterFullscreen(). Cause it to cancel and fire an error
         // by clearing the pending fullscreen element.
@@ -279,14 +282,14 @@ void FullscreenManager::cancelFullscreen()
 
     m_pendingExitFullscreen = true;
 
-    m_document.eventLoop().queueTask(TaskSource::MediaElement, [this, &topDocument, identifier = LOGIDENTIFIER] {
-        if (!topDocument.page()) {
+    m_document.eventLoop().queueTask(TaskSource::MediaElement, [this, topDocument = WTFMove(topDocument), identifier = LOGIDENTIFIER] {
+        if (!topDocument->page()) {
             INFO_LOG(identifier, "Top document has no page.");
             return;
         }
 
         // This triggers finishExitFullscreen with ExitMode::Resize, which fully exits the document.
-        if (auto* fullscreenElement = topDocument.fullscreenManager().fullscreenElement())
+        if (auto* fullscreenElement = topDocument->fullscreenManager().fullscreenElement())
             page()->chrome().client().exitFullScreenForElement(fullscreenElement);
         else
             INFO_LOG(identifier, "Top document has no fullscreen element");
@@ -317,22 +320,22 @@ void FullscreenManager::exitFullscreen(RefPtr<DeferredPromise>&& promise)
 {
     INFO_LOG(LOGIDENTIFIER);
 
-    auto* exitingDocument = &document();
+    Ref exitingDocument = document();
     auto mode = ExitMode::NoResize;
-    auto exitDocuments = documentsToUnfullscreen(*exitingDocument);
-    auto& topDocument = this->topDocument();
+    auto exitDocuments = documentsToUnfullscreen(exitingDocument);
+    Ref topDocument = this->topDocument();
 
     bool exitsTopDocument = exitDocuments.containsIf([&](auto& document) {
-        return document.ptr() == &topDocument;
+        return document.ptr() == topDocument.ptr();
     });
-    if (exitsTopDocument && topDocument.fullscreenManager().isSimpleFullscreenDocument()) {
+    if (exitsTopDocument && topDocument->fullscreenManager().isSimpleFullscreenDocument()) {
         mode = ExitMode::Resize;
-        exitingDocument = &topDocument;
+        exitingDocument = topDocument;
     }
 
     auto element = exitingDocument->fullscreenManager().fullscreenElement();
     if (element && !element->isConnected())
-        addDocumentToFullscreenChangeEventQueue(*exitingDocument);
+        addDocumentToFullscreenChangeEventQueue(exitingDocument);
 
     m_pendingExitFullscreen = true;
 

--- a/Source/WebCore/dom/FullscreenManager.h
+++ b/Source/WebCore/dom/FullscreenManager.h
@@ -47,7 +47,6 @@ public:
 
     Document& document() { return m_document; }
     const Document& document() const { return m_document; }
-    Document& topDocument() const { return m_document.topDocument(); }
     Page* page() const { return m_document.page(); }
     Frame* frame() const { return m_document.frame(); }
     Element* documentElement() const { return m_document.documentElement(); }
@@ -108,7 +107,10 @@ private:
     WTFLogChannel& logChannel() const;
 #endif
 
+    Document& topDocument() { return m_topDocument ? *m_topDocument : document().topDocument(); }
+
     Document& m_document;
+    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_topDocument;
 
     RefPtr<Element> fullscreenOrPendingElement() const { return m_fullscreenElement ? m_fullscreenElement : m_pendingFullscreenElement; }
 


### PR DESCRIPTION
#### 9215d7d582cb6d40cb439a45cb2157ab9bcbb575
<pre>
Navigation within iframe doesn&apos;t exit fullscreen for parent iframe element
<a href="https://bugs.webkit.org/show_bug.cgi?id=251896">https://bugs.webkit.org/show_bug.cgi?id=251896</a>
rdar://104393093

Reviewed by Chris Dumez.

This was because the exiting document was already detached from the Frame object, causing it to fail to find the top document.
To fix this, we store the top document when initializing FullscreenManager.

* LayoutTests/fullscreen/fullscreen-iframe-navigation-expected.html: Added.
* LayoutTests/fullscreen/fullscreen-iframe-navigation.html: Added.
* LayoutTests/fullscreen/resources/fullscreen-iframe-navigation-target.html: Added.
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::cancelFullscreen):
(WebCore::documentsToUnfullscreen):
(WebCore::FullscreenManager::exitFullscreen):
(WebCore::FullscreenManager::finishExitFullscreen):
(WebCore::FullscreenManager::didExitFullscreen):
* Source/WebCore/dom/FullscreenManager.h:

Canonical link: <a href="https://commits.webkit.org/260024@main">https://commits.webkit.org/260024@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2eff2c98c3f57e90eb412765d411802845f9d9d1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106701 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15692 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39489 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115888 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115482 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110607 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17204 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6929 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98896 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112470 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13067 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96031 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40632 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94939 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27683 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8914 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29034 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9474 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6068 "Too many flaky failures: css3/masking/mask-svg-no-fragmentId-tiled.html, css3/masking/mask-svg-script-none-to-png.html, fast/css/large-number-round-trip.html, fast/css/last-child-display-change.html, gamepad/gamepad-vibration-document-no-longer-fully-active.html, http/tests/appcache/cyrillic-uri.html, http/tests/cache-storage/cache-persistency.https.html, imported/w3c/web-platform-tests/css/css-pseudo/first-line-and-marker.html, imported/w3c/web-platform-tests/css/css-pseudo/first-line-line-height-001.html, imported/w3c/web-platform-tests/css/selectors/invalidation/media-loading-pseudo-classes-in-has.html, imported/w3c/web-platform-tests/css/selectors/invalidation/media-pseudo-classes-in-has.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15087 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48583 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6924 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10996 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->