### PR TITLE
Refactor lookalike character sanitization to use the new type

### DIFF
--- a/Source/WebCore/page/LookalikeCharactersSanitizationData.h
+++ b/Source/WebCore/page/LookalikeCharactersSanitizationData.h
@@ -46,6 +46,11 @@ struct LookalikeCharactersSanitizationData {
     {
     }
 
+    LookalikeCharactersSanitizationData(const String& lookalikeCharacters)
+        : lookalikeCharacters(lookalikeCharacters)
+    {
+    }
+
     template<class Encoder> void encode(Encoder& encoder) const
     {
         encoder << domain;

--- a/Source/WebKit/Platform/cocoa/NetworkConnectionIntegrityHelpers.h
+++ b/Source/WebKit/Platform/cocoa/NetworkConnectionIntegrityHelpers.h
@@ -51,7 +51,7 @@ class LookalikeCharacters {
 public:
     static LookalikeCharacters& shared();
 
-    const Vector<String>& cachedStrings() const { return m_cachedStrings; }
+    const Vector<WebCore::LookalikeCharactersSanitizationData>& cachedStrings() const { return m_cachedStrings; }
     void updateStrings(CompletionHandler<void()>&&);
 
     class Observer : public RefCounted<Observer>, public CanMakeWeakPtr<Observer> {
@@ -80,10 +80,10 @@ public:
 
 private:
     LookalikeCharacters() = default;
-    void setCachedStrings(Vector<String>&&);
+    void setCachedStrings(Vector<WebCore::LookalikeCharactersSanitizationData>&&);
 
     RetainPtr<WKNetworkConnectionIntegrityNotificationListener> m_notificationListener;
-    Vector<String> m_cachedStrings;
+    Vector<WebCore::LookalikeCharactersSanitizationData> m_cachedStrings;
     WeakHashSet<Observer> m_observers;
 };
 

--- a/Source/WebKit/Shared/WebPageCreationParameters.cpp
+++ b/Source/WebKit/Shared/WebPageCreationParameters.cpp
@@ -650,7 +650,7 @@ std::optional<WebPageCreationParameters> WebPageCreationParameters::decode(IPC::
         return std::nullopt;
 
 #if ENABLE(NETWORK_CONNECTION_INTEGRITY)
-    std::optional<Vector<String>> lookalikeCharacterStrings;
+    std::optional<Vector<WebCore::LookalikeCharactersSanitizationData>> lookalikeCharacterStrings;
     decoder >> lookalikeCharacterStrings;
     if (!lookalikeCharacterStrings)
         return std::nullopt;

--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -300,7 +300,7 @@ struct WebPageCreationParameters {
     std::optional<SubframeProcessFrameTreeInitializationParameters> subframeProcessFrameTreeInitializationParameters;
 
 #if ENABLE(NETWORK_CONNECTION_INTEGRITY)
-    Vector<String> lookalikeCharacterStrings;
+    Vector<WebCore::LookalikeCharactersSanitizationData> lookalikeCharacterStrings;
     Vector<WebCore::LookalikeCharactersSanitizationData> allowedLookalikeCharacterStrings;
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1685,7 +1685,7 @@ private:
 #endif
 
 #if ENABLE(NETWORK_CONNECTION_INTEGRITY)
-    void setLookalikeCharacterStrings(Vector<String>&&);
+    void setLookalikeCharacterStrings(Vector<WebCore::LookalikeCharactersSanitizationData>&&);
     void setAllowedLookalikeCharacterStrings(Vector<WebCore::LookalikeCharactersSanitizationData>&&);
 #endif
 
@@ -2588,6 +2588,7 @@ private:
 
 #if ENABLE(NETWORK_CONNECTION_INTEGRITY)
     HashSet<String> m_lookalikeCharacterStrings;
+    HashMap<WebCore::RegistrableDomain, HashSet<String>> m_domainScopedLookalikeCharacterStrings;
     HashMap<WebCore::RegistrableDomain, String> m_allowedLookalikeCharacterStrings;
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -712,7 +712,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
     GenerateTestReport(String message, String group);
 
 #if ENABLE(NETWORK_CONNECTION_INTEGRITY)
-    SetLookalikeCharacterStrings(Vector<String> strings);
+    SetLookalikeCharacterStrings(Vector<WebCore::LookalikeCharactersSanitizationData> strings);
     SetAllowedLookalikeCharacterStrings(Vector<WebCore::LookalikeCharactersSanitizationData> allowedStrings);
 #endif
 


### PR DESCRIPTION
#### 3574f7790d2190267a301c2e211195f2786f6cff
<pre>
Refactor lookalike character sanitization to use the new type
<a href="https://bugs.webkit.org/show_bug.cgi?id=251902">https://bugs.webkit.org/show_bug.cgi?id=251902</a>
rdar://105160778

Reviewed by Wenson Hsieh.

This patch makes changes to lookalike character sanitization such that it
uses the `LookalikeCharacterSanitizationData` struct instead of WTF::String.

* Source/WebCore/page/LookalikeCharactersSanitizationData.h:
(WebCore::LookalikeCharactersSanitizationData::LookalikeCharactersSanitizationData):
(WebCore::LookalikeCharactersSanitizationData::lookalikeCharacters):
* Source/WebKit/Platform/cocoa/NetworkConnectionIntegrityHelpers.h:
(WebKit::LookalikeCharacters::cachedStrings const):
* Source/WebKit/Shared/WebPageCreationParameters.cpp:
(WebKit::WebPageCreationParameters::decode):
* Source/WebKit/Shared/WebPageCreationParameters.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::setLookalikeCharacterStrings):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

Canonical link: <a href="https://commits.webkit.org/261937@main">https://commits.webkit.org/261937@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f49683ae45953c51e7ccea07c61ec8a0177235bb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107551 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16609 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40454 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116713 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116130 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111447 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18036 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7927 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113310 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13622 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96811 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99719 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95531 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28437 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41285 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9612 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29790 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/83077 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10272 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6686 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15769 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49371 "Passed tests") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8346 "Build is in progress. Recent messages:OS: Monterey (12.6.3), Xcode: 13.4.1; Checked out pull request; Reviewed by Wenson Hsieh") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11833 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->