### PR TITLE
[GTK] Test fast/text/font-promises-gc.html fails after r281465

### DIFF
--- a/LayoutTests/fast/text/font-promises-gc-expected.txt
+++ b/LayoutTests/fast/text/font-promises-gc-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: Font status: unloaded
 CONSOLE MESSAGE: Font loaded
 This test should not time out, and should say "SUCCESS".
 Hello

--- a/LayoutTests/fast/text/font-promises-gc.html
+++ b/LayoutTests/fast/text/font-promises-gc.html
@@ -31,7 +31,6 @@ if (window.testRunner) {
 var promises = [];
 
 document.fonts.forEach(function(f) {
-    console.log("Font status: " + f.status);
     promises.push(f.loaded);
     f.loaded.then(function() { console.log("Font loaded"); });
     gc();


### PR DESCRIPTION
#### c33d32d1b7e5fabca916fd22eb82d646ee2eddec
<pre>
[GTK] Test fast/text/font-promises-gc.html fails after r281465
<a href="https://bugs.webkit.org/show_bug.cgi?id=229732">https://bugs.webkit.org/show_bug.cgi?id=229732</a>

Reviewed by Alan Baradlay.

The test was failing for WebKitGTK/WPE because a console error message
was different. Font was &apos;unloaded&apos; for WebKitGTK/WPE but &apos;loaded&apos; for
general baseline. This message is informative and it doesn&apos;t affect the
result of the test, which was passing too for WebKitGTK/WPE.

* LayoutTests/fast/text/font-promises-gc-expected.txt:
* LayoutTests/fast/text/font-promises-gc.html:

Canonical link: <a href="https://commits.webkit.org/261364@main">https://commits.webkit.org/261364@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/992da67a4f629c17e727e1768c37454981331a91

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111414 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20550 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/25 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/3220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120199 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21920 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11646 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/87/builds/3220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117177 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/99430 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104107 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98226 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/88/builds/15 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44929 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13049 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/89/builds/15 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86724 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13555 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9440 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18999 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51996 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7877 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15520 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->