### PR TITLE
[GTK] Make cairoSurfaceToGdkPixbuf and cairoSurfaceToGdkTexture return a GRefPtr

### DIFF
--- a/Source/WebCore/platform/graphics/BitmapImage.h
+++ b/Source/WebCore/platform/graphics/BitmapImage.h
@@ -140,9 +140,9 @@ public:
 #endif
 
 #if PLATFORM(GTK)
-    GdkPixbuf* getGdkPixbuf() override;
+    GRefPtr<GdkPixbuf> gdkPixbuf() override;
 #if USE(GTK4)
-    GdkTexture* gdkTexture() override;
+    GRefPtr<GdkTexture> gdkTexture() override;
 #endif
 #endif
 

--- a/Source/WebCore/platform/graphics/Image.h
+++ b/Source/WebCore/platform/graphics/Image.h
@@ -59,6 +59,7 @@ typedef struct HBITMAP__ *HBITMAP;
 #endif
 
 #if PLATFORM(GTK)
+#include <wtf/glib/GRefPtr.h>
 typedef struct _GdkPixbuf GdkPixbuf;
 #if USE(GTK4)
 typedef struct _GdkTexture GdkTexture;
@@ -186,9 +187,9 @@ public:
 #endif
 
 #if PLATFORM(GTK)
-    virtual GdkPixbuf* getGdkPixbuf() { return nullptr; }
+    virtual GRefPtr<GdkPixbuf> gdkPixbuf() { return nullptr; }
 #if USE(GTK4)
-    virtual GdkTexture* gdkTexture() { return nullptr; }
+    virtual GrefPtr<GdkTexture> gdkTexture() { return nullptr; }
 #endif
 #endif
 

--- a/Source/WebCore/platform/graphics/cairo/ImageBufferUtilitiesCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/ImageBufferUtilitiesCairo.cpp
@@ -82,7 +82,7 @@ static bool encodeImage(cairo_surface_t* surface, const String& mimeType, std::o
     if (type != "jpeg"_s && type != "png"_s && type != "tiff"_s && type != "ico"_s && type != "bmp"_s)
         return false;
 
-    GRefPtr<GdkPixbuf> pixbuf = adoptGRef(cairoSurfaceToGdkPixbuf(surface));
+    auto pixbuf = cairoSurfaceToGdkPixbuf(surface);
     if (!pixbuf)
         return false;
 

--- a/Source/WebCore/platform/graphics/gtk/GdkCairoUtilities.cpp
+++ b/Source/WebCore/platform/graphics/gtk/GdkCairoUtilities.cpp
@@ -140,14 +140,14 @@ const cairo_font_options_t* getDefaultCairoFontOptions()
     return SystemFontOptions::singleton().fontOptions();
 }
 
-GdkPixbuf* cairoSurfaceToGdkPixbuf(cairo_surface_t* surface)
+GRefPtr<GdkPixbuf> cairoSurfaceToGdkPixbuf(cairo_surface_t* surface)
 {
     IntSize size = cairoSurfaceSize(surface);
-    return gdk_pixbuf_get_from_surface(surface, 0, 0, size.width(), size.height());
+    return adoptGRef(gdk_pixbuf_get_from_surface(surface, 0, 0, size.width(), size.height()));
 }
 
 #if USE(GTK4)
-GdkTexture* cairoSurfaceToGdkTexture(cairo_surface_t* surface)
+GRefPtr<GdkTexture> cairoSurfaceToGdkTexture(cairo_surface_t* surface)
 {
     ASSERT(cairo_image_surface_get_format(surface) == CAIRO_FORMAT_ARGB32);
     auto width = cairo_image_surface_get_width(surface);
@@ -157,7 +157,7 @@ GdkTexture* cairoSurfaceToGdkTexture(cairo_surface_t* surface)
     GRefPtr<GBytes> bytes = adoptGRef(g_bytes_new_with_free_func(data, height * stride, [](gpointer data) {
         cairo_surface_destroy(static_cast<cairo_surface_t*>(data));
     }, cairo_surface_reference(surface)));
-    return gdk_memory_texture_new(width, height, GDK_MEMORY_DEFAULT, bytes.get(), stride);
+    return adoptGRef(gdk_memory_texture_new(width, height, GDK_MEMORY_DEFAULT, bytes.get(), stride));
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/gtk/GdkCairoUtilities.h
+++ b/Source/WebCore/platform/graphics/gtk/GdkCairoUtilities.h
@@ -25,10 +25,12 @@
 
 #pragma once
 
+#include <wtf/glib/GRefPtr.h>
+
 namespace WebCore {
 
-GdkPixbuf* cairoSurfaceToGdkPixbuf(cairo_surface_t*);
+GRefPtr<GdkPixbuf> cairoSurfaceToGdkPixbuf(cairo_surface_t*);
 #if USE(GTK4)
-GdkTexture* cairoSurfaceToGdkTexture(cairo_surface_t*);
+GRefPtr<GdkTexture> cairoSurfaceToGdkTexture(cairo_surface_t*);
 #endif
 }

--- a/Source/WebCore/platform/graphics/gtk/ImageGtk.cpp
+++ b/Source/WebCore/platform/graphics/gtk/ImageGtk.cpp
@@ -30,7 +30,6 @@
 #include "SharedBuffer.h"
 #include <cairo.h>
 #include <gdk/gdk.h>
-#include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/GUniquePtr.h>
 
 namespace WebCore {
@@ -54,7 +53,7 @@ Ref<Image> Image::loadPlatformResource(const char* name)
     return loadImageFromGResource(name);
 }
 
-GdkPixbuf* BitmapImage::getGdkPixbuf()
+GRefPtr<GdkPixbuf> BitmapImage::gdkPixbuf()
 {
     if (auto nativeImage = nativeImageForCurrentFrame()) {
         auto& surface = nativeImage->platformImage();
@@ -64,7 +63,7 @@ GdkPixbuf* BitmapImage::getGdkPixbuf()
 }
 
 #if USE(GTK4)
-GdkTexture* BitmapImage::gdkTexture()
+GRefPtr<GdkTexture> BitmapImage::gdkTexture()
 {
     if (auto nativeImage = nativeImageForCurrentFrame()) {
         auto& surface = nativeImage->platformImage();

--- a/Source/WebCore/platform/gtk/CursorGtk.cpp
+++ b/Source/WebCore/platform/gtk/CursorGtk.cpp
@@ -56,7 +56,7 @@ static GRefPtr<GdkCursor> createNamedCursor(const char* name)
 static GRefPtr<GdkCursor> createCustomCursor(Image* image, const IntPoint& hotSpot)
 {
 #if USE(GTK4)
-    auto texture = adoptGRef(image->gdkTexture());
+    auto texture = image->gdkTexture();
     if (!texture)
         return nullptr;
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp
@@ -246,7 +246,7 @@ cairo_surface_t* webkit_favicon_database_get_favicon_finish(WebKitFaviconDatabas
 
 #if USE(GTK4)
     auto icon = adoptRef(static_cast<cairo_surface_t*>(g_task_propagate_pointer(G_TASK(result), error)));
-    return icon ? cairoSurfaceToGdkTexture(icon.get()) : nullptr;
+    return icon ? cairoSurfaceToGdkTexture(icon.get()).leakRef() : nullptr;
 #else
     return static_cast<cairo_surface_t*>(g_task_propagate_pointer(G_TASK(result), error));
 #endif

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -4894,7 +4894,7 @@ cairo_surface_t* webkit_web_view_get_snapshot_finish(WebKitWebView* webView, GAs
 
 #if USE(GTK4)
     auto image = adoptRef(static_cast<cairo_surface_t*>(g_task_propagate_pointer(G_TASK(result), error)));
-    return image ? cairoSurfaceToGdkTexture(image.get()) : nullptr;
+    return image ? cairoSurfaceToGdkTexture(image.get()).leakRef() : nullptr;
 #else
     return static_cast<cairo_surface_t*>(g_task_propagate_pointer(G_TASK(result), error));
 #endif

--- a/Source/WebKit/UIProcess/API/gtk/DragSourceGtk3.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/DragSourceGtk3.cpp
@@ -68,7 +68,7 @@ DragSource::DragSource(GtkWidget* webView)
             break;
         }
         case DragTargetType::Image: {
-            GRefPtr<GdkPixbuf> pixbuf = adoptGRef(drag.m_selectionData->image()->getGdkPixbuf());
+            auto pixbuf = drag.m_selectionData->image()->gdkPixbuf();
             gtk_selection_data_set_pixbuf(data, pixbuf.get());
             break;
         }

--- a/Source/WebKit/UIProcess/API/gtk/DragSourceGtk4.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/DragSourceGtk4.cpp
@@ -75,7 +75,7 @@ void DragSource::begin(SelectionData&& selectionData, OptionSet<DragOperation> o
     }
 
     if (m_selectionData->hasImage()) {
-        GRefPtr<GdkPixbuf> pixbuf = adoptGRef(m_selectionData->image()->getGdkPixbuf());
+        auto pixbuf = m_selectionData->image()->gdkPixbuf();
         providers.append(gdk_content_provider_new_typed(GDK_TYPE_PIXBUF, pixbuf.get()));
     }
 
@@ -128,7 +128,7 @@ void DragSource::begin(SelectionData&& selectionData, OptionSet<DragOperation> o
     auto* dragIcon = gtk_drag_icon_get_for_drag(m_drag.get());
     RefPtr<Image> iconImage = image ? image->createImage() : nullptr;
     if (iconImage) {
-        if (GRefPtr<GdkTexture> texture = adoptGRef(iconImage->gdkTexture())) {
+        if (auto texture = iconImage->gdkTexture()) {
             gdk_drag_set_hotspot(m_drag.get(), -imageHotspot.x(), -imageHotspot.y());
             auto* picture = gtk_picture_new_for_paintable(GDK_PAINTABLE(texture.get()));
             gtk_drag_icon_set_child(GTK_DRAG_ICON(dragIcon), picture);

--- a/Source/WebKit/UIProcess/gtk/ClipboardGtk3.cpp
+++ b/Source/WebKit/UIProcess/gtk/ClipboardGtk3.cpp
@@ -199,7 +199,7 @@ void Clipboard::write(WebCore::SelectionData&& selectionData)
                 break;
             case ClipboardTargetType::Image: {
                 if (data.selectionData.hasImage()) {
-                    GRefPtr<GdkPixbuf> pixbuf = adoptGRef(data.selectionData.image()->getGdkPixbuf());
+                    auto pixbuf = data.selectionData.image()->gdkPixbuf();
                     gtk_selection_data_set_pixbuf(selection, pixbuf.get());
                 }
                 break;

--- a/Source/WebKit/UIProcess/gtk/ClipboardGtk4.cpp
+++ b/Source/WebKit/UIProcess/gtk/ClipboardGtk4.cpp
@@ -173,7 +173,7 @@ void Clipboard::write(WebCore::SelectionData&& selectionData)
     }
 
     if (selectionData.hasImage()) {
-        GRefPtr<GdkPixbuf> pixbuf = adoptGRef(selectionData.image()->getGdkPixbuf());
+        auto pixbuf = selectionData.image()->gdkPixbuf();
         providers.append(gdk_content_provider_new_typed(GDK_TYPE_PIXBUF, pixbuf.get()));
     }
 


### PR DESCRIPTION
#### d859e45fa3e8ea91f90fda507769b03f4bcf0e1d
<pre>
[GTK] Make cairoSurfaceToGdkPixbuf and cairoSurfaceToGdkTexture return a GRefPtr
<a href="https://bugs.webkit.org/show_bug.cgi?id=251910">https://bugs.webkit.org/show_bug.cgi?id=251910</a>

Reviewed by Žan Doberšek.

* Source/WebCore/platform/graphics/BitmapImage.h:
* Source/WebCore/platform/graphics/Image.h:
(WebCore::Image::gdkPixbuf):
(WebCore::Image::gdkTexture):
(WebCore::Image::getGdkPixbuf): Deleted.
* Source/WebCore/platform/graphics/cairo/ImageBufferUtilitiesCairo.cpp:
(WebCore::encodeImage):
* Source/WebCore/platform/graphics/gtk/GdkCairoUtilities.cpp:
(WebCore::cairoSurfaceToGdkPixbuf):
(WebCore::cairoSurfaceToGdkTexture):
* Source/WebCore/platform/graphics/gtk/GdkCairoUtilities.h:
* Source/WebCore/platform/graphics/gtk/ImageGtk.cpp:
(WebCore::BitmapImage::gdkPixbuf):
(WebCore::BitmapImage::gdkTexture):
(WebCore::BitmapImage::getGdkPixbuf): Deleted.
* Source/WebCore/platform/gtk/CursorGtk.cpp:
(WebCore::createCustomCursor):
* Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp:
(webkit_favicon_database_get_favicon_finish):
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
* Source/WebKit/UIProcess/API/gtk/DragSourceGtk3.cpp:
(WebKit::DragSource::DragSource):
* Source/WebKit/UIProcess/API/gtk/DragSourceGtk4.cpp:
(WebKit::DragSource::begin):
* Source/WebKit/UIProcess/gtk/ClipboardGtk3.cpp:
(WebKit::Clipboard::write):
* Source/WebKit/UIProcess/gtk/ClipboardGtk4.cpp:
(WebKit::Clipboard::write):

Canonical link: <a href="https://commits.webkit.org/260001@main">https://commits.webkit.org/260001@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4895bedb386324ce7478bb0fd1acf745081ff3c5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106718 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15711 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39506 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115907 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115500 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110624 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17222 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6948 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98914 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112488 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/96052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/40654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/94959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/27703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8933 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/29058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9492 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/6080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15105 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/48601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11014 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3723 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->