### PR TITLE
Server-Timing data can be read cross-origin

### DIFF
--- a/LayoutTests/http/wpt/resource-timing/crossorigin-servertiming-expected.txt
+++ b/LayoutTests/http/wpt/resource-timing/crossorigin-servertiming-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Make sure cross origin server timing is not exposed on iframes
+

--- a/LayoutTests/http/wpt/resource-timing/crossorigin-servertiming.html
+++ b/LayoutTests/http/wpt/resource-timing/crossorigin-servertiming.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Resource Timing - CORS requests</title>
+<link rel="help" href="https://w3c.github.io/resource-timing/#cross-origin-resources">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+function with_iframe(url) {
+    return new Promise(function(resolve) {
+        var frame = document.createElement('iframe');
+        frame.className = 'test-iframe';
+        frame.src = url;
+        frame.onload = function() { resolve(frame); };
+        document.body.appendChild(frame);
+    });
+}
+
+promise_test(async t => {
+    let observer;
+    const promise = new Promise(resolve => {
+        observer = new PerformanceObserver(resolve);
+    });
+    observer.observe({entryTypes: ['resource']});
+
+    const frame = await with_iframe("http://127.0.0.1:8800/WebKit/resource-timing/resources/server-timing.py");
+
+    const result = await promise;
+    const entries = result.getEntries();
+
+    frame.remove();
+
+    assert_true(entries.length > 0);
+    for (let entry of entries)
+        assert_equals(entry.serverTiming.length, 0);
+}, "Make sure cross origin server timing is not exposed on iframes");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/wpt/resource-timing/resources/server-timing.py
+++ b/LayoutTests/http/wpt/resource-timing/resources/server-timing.py
@@ -1,0 +1,5 @@
+def main(request, response):
+    response.headers.set(b"Server-Timing", "my server timing")
+    response.headers.set(b"Content-Type", "text/html")
+
+    return "ok"

--- a/Source/WebCore/loader/ResourceTiming.cpp
+++ b/Source/WebCore/loader/ResourceTiming.cpp
@@ -65,6 +65,11 @@ ResourceTiming::ResourceTiming(const URL& url, const String& initiatorType, cons
 {
 }
 
+void ResourceTiming::updateExposure(const SecurityOrigin& origin)
+{
+    m_isSameOriginRequest = m_isSameOriginRequest && origin.canRequest(m_url);
+}
+
 Vector<Ref<PerformanceServerTiming>> ResourceTiming::populateServerTiming() const
 {
     // To increase privacy, this additional check was proposed at https://github.com/w3c/resource-timing/issues/342 .

--- a/Source/WebCore/loader/ResourceTiming.h
+++ b/Source/WebCore/loader/ResourceTiming.h
@@ -55,6 +55,7 @@ public:
     ResourceTiming isolatedCopy() const &;
     ResourceTiming isolatedCopy() &&;
 
+    void updateExposure(const SecurityOrigin&);
     void overrideInitiatorType(const String& type) { m_initiatorType = type; }
     bool isLoadedFromServiceWorker() const { return m_isLoadedFromServiceWorker; }
 

--- a/Source/WebCore/loader/ResourceTimingInformation.cpp
+++ b/Source/WebCore/loader/ResourceTimingInformation.cpp
@@ -59,8 +59,11 @@ void ResourceTimingInformation::addResourceTiming(CachedResource& resource, Docu
         return;
 
     Document* initiatorDocument = &document;
-    if (resource.type() == CachedResource::Type::MainResource && document.frame() && document.frame()->loader().shouldReportResourceTimingToParentFrame())
+    if (resource.type() == CachedResource::Type::MainResource && document.frame() && document.frame()->loader().shouldReportResourceTimingToParentFrame()) {
         initiatorDocument = document.parentDocument();
+        if (initiatorDocument)
+            resourceTiming.updateExposure(initiatorDocument->securityOrigin());
+    }
     if (!initiatorDocument)
         return;
 


### PR DESCRIPTION
#### b67af69609f3209a2a2f72f9ca5c3b03d902df04
<pre>
Server-Timing data can be read cross-origin
<a href="https://bugs.webkit.org/show_bug.cgi?id=250837">https://bugs.webkit.org/show_bug.cgi?id=250837</a>
rdar://problem/104427347

Reviewed by Alex Christensen.

For document (iframe, object, embed) loads, the origin of the load is the origin of the URL.
This is same origin by nature.
But the origin we will expose the timing info is the origin of the initiator.
Make sure to recompute the same origin request flag in that case.

* LayoutTests/http/wpt/resource-timing/crossorigin-servertiming-expected.txt: Added.
* LayoutTests/http/wpt/resource-timing/crossorigin-servertiming.html: Added.
* LayoutTests/http/wpt/resource-timing/server-timing.py: Added.
(main):
* Source/WebCore/loader/ResourceTiming.cpp:
(WebCore::ResourceTiming::updateExposure):
* Source/WebCore/loader/ResourceTiming.h:
* Source/WebCore/loader/ResourceTimingInformation.cpp:
(WebCore::ResourceTimingInformation::addResourceTiming):

Canonical link: <a href="https://commits.webkit.org/260006@main">https://commits.webkit.org/260006@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8ffa6b55c3558d9d8b191a5f584e6ef5470c109

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106712 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15704 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39500 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115900 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115493 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110618 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17216 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6941 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98908 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112482 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96047 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40646 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94955 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27696 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8926 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29053 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9486 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/6073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15099 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48596 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6915 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11008 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->