### PR TITLE
[web-animations] line-height should not transition from default value to a number

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
@@ -22,6 +22,11 @@ PASS lighting-color supports animating as color of hsl()
 PASS lighting-color supports animating as color of #RGBa
 PASS lighting-color supports animating as color of rgba()
 PASS lighting-color supports animating as color of hsla()
+PASS line-height (type: discrete) has testAccumulation function
+PASS line-height: "10px" onto "normal"
+PASS line-height: "normal" onto "10px"
+PASS line-height: "10" onto "normal"
+PASS line-height: "normal" onto "10"
 PASS list-style-image (type: discrete) has testAccumulation function
 PASS list-style-image: "url("http://localhost/test-2")" onto "url("http://localhost/test-1")"
 PASS list-style-image: "url("http://localhost/test-1")" onto "url("http://localhost/test-2")"

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
@@ -22,6 +22,11 @@ PASS lighting-color supports animating as color of hsl()
 PASS lighting-color supports animating as color of #RGBa
 PASS lighting-color supports animating as color of rgba()
 PASS lighting-color supports animating as color of hsla()
+PASS line-height (type: discrete) has testAddition function
+PASS line-height: "10px" onto "normal"
+PASS line-height: "normal" onto "10px"
+PASS line-height: "10" onto "normal"
+PASS line-height: "normal" onto "10"
 PASS list-style-image (type: discrete) has testAddition function
 PASS list-style-image: "url("http://localhost/test-2")" onto "url("http://localhost/test-1")"
 PASS list-style-image: "url("http://localhost/test-1")" onto "url("http://localhost/test-2")"

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
@@ -26,6 +26,13 @@ PASS lighting-color supports animating as color of hsl()
 PASS lighting-color supports animating as color of #RGBa
 PASS lighting-color supports animating as color of rgba()
 PASS lighting-color supports animating as color of hsla()
+PASS line-height (type: discrete) has testInterpolation function
+PASS line-height uses discrete animation when animating between "normal" and "10px" with linear easing
+PASS line-height uses discrete animation when animating between "normal" and "10px" with effect easing
+PASS line-height uses discrete animation when animating between "normal" and "10px" with keyframe easing
+PASS line-height uses discrete animation when animating between "normal" and "10" with linear easing
+PASS line-height uses discrete animation when animating between "normal" and "10" with effect easing
+PASS line-height uses discrete animation when animating between "normal" and "10" with keyframe easing
 PASS list-style-image (type: discrete) has testInterpolation function
 FAIL list-style-image uses discrete animation when animating between "url("http://localhost/test-1")" and "url("http://localhost/test-2")" with linear easing assert_equals: The value should be url("http://localhost/test-1") at 499ms expected "url(\"http://localhost/test-1\")" but got "url(\"http://localhost/test-2\")"
 FAIL list-style-image uses discrete animation when animating between "url("http://localhost/test-1")" and "url("http://localhost/test-2")" with effect easing assert_equals: The value should be url("http://localhost/test-1") at 940ms expected "url(\"http://localhost/test-1\")" but got "url(\"http://localhost/test-2\")"

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js
@@ -747,8 +747,10 @@ const gCSSProperties2 = {
     types: [ 'color' ]
   },
   'line-height': {
-    // https://drafts.csswg.org/css21/visudet.html#propdef-line-height
+    // https://w3c.github.io/csswg-drafts/css-inline/#line-height-property
     types: [
+        { type: 'discrete', options: [ [ 'normal', '10px' ],
+                                       [ 'normal', '10', 'normal', '100px' ] ] }
     ]
   },
   'list-style-image': {

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-types.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-types.js
@@ -1,19 +1,28 @@
 'use strict';
 
+const expected = values => {
+    // Some properties, such as line-height, report computed values which differ
+    // from the keyframe values. To support this, we allow optional values to specify
+    // explicit "from" and "to" values as additional keyframe values.
+    const [ from, to ] = values;
+    return [ values[2] ?? from, values[3] ?? to ];
+};
+
 const discreteType = {
   testInterpolation: (property, setup, options) => {
     for (const keyframes of options) {
       const [ from, to ] = keyframes;
+      const [ expectedFrom, expectedTo ] = expected(keyframes);
       test(t => {
         const idlName = propertyToIDL(property);
         const target = createTestElement(t, setup);
         const animation = target.animate({ [idlName]: [from, to] },
                                          { duration: 1000, fill: 'both' });
         testAnimationSamples(animation, idlName,
-                             [{ time: 0,    expected: from.toLowerCase() },
-                              { time: 499,  expected: from.toLowerCase() },
-                              { time: 500,  expected: to.toLowerCase() },
-                              { time: 1000, expected: to.toLowerCase() }]);
+                             [{ time: 0,    expected: expectedFrom.toLowerCase() },
+                              { time: 499,  expected: expectedFrom.toLowerCase() },
+                              { time: 500,  expected: expectedTo.toLowerCase() },
+                              { time: 1000, expected: expectedTo.toLowerCase() }]);
       }, `${property} uses discrete animation when animating between`
          + ` "${from}" and "${to}" with linear easing`);
 
@@ -33,9 +42,9 @@ const discreteType = {
           }
         );
         testAnimationSamples(animation, idlName,
-                             [{ time: 0,    expected: from.toLowerCase() },
-                              { time: 940,  expected: from.toLowerCase() },
-                              { time: 960,  expected: to.toLowerCase() }]);
+                             [{ time: 0,    expected: expectedFrom.toLowerCase() },
+                              { time: 940,  expected: expectedFrom.toLowerCase() },
+                              { time: 960,  expected: expectedTo.toLowerCase() }]);
       }, `${property} uses discrete animation when animating between`
          + ` "${from}" and "${to}" with effect easing`);
 
@@ -53,9 +62,9 @@ const discreteType = {
           { duration: 1000, fill: 'both' }
         );
         testAnimationSamples(animation, idlName,
-                             [{ time: 0,    expected: from.toLowerCase() },
-                              { time: 940,  expected: from.toLowerCase() },
-                              { time: 960,  expected: to.toLowerCase() }]);
+                             [{ time: 0,    expected: expectedFrom.toLowerCase() },
+                              { time: 940,  expected: expectedFrom.toLowerCase() },
+                              { time: 960,  expected: expectedTo.toLowerCase() }]);
       }, `${property} uses discrete animation when animating between`
          + ` "${from}" and "${to}" with keyframe easing`);
     }
@@ -64,6 +73,7 @@ const discreteType = {
   testAdditionOrAccumulation: (property, setup, options, composite) => {
     for (const keyframes of options) {
       const [ from, to ] = keyframes;
+      const [ expectedFrom, expectedTo ] = expected(keyframes);
       test(t => {
         const idlName = propertyToIDL(property);
         const target = createTestElement(t, setup);
@@ -73,7 +83,7 @@ const discreteType = {
           { duration: 1000, composite }
         );
         testAnimationSamples(animation, idlName,
-                             [{ time: 0, expected: to.toLowerCase() }]);
+                             [{ time: 0, expected: expectedTo.toLowerCase() }]);
       }, `${property}: "${to}" onto "${from}"`);
 
       test(t => {
@@ -85,7 +95,7 @@ const discreteType = {
           { duration: 1000, composite }
         );
         testAnimationSamples(animation, idlName,
-                             [{ time: 0, expected: from.toLowerCase() }]);
+                             [{ time: 0, expected: expectedFrom.toLowerCase() }]);
       }, `${property}: "${from}" onto "${to}"`);
     }
   },

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
@@ -22,6 +22,11 @@ PASS lighting-color supports animating as color of hsl()
 PASS lighting-color supports animating as color of #RGBa
 PASS lighting-color supports animating as color of rgba()
 PASS lighting-color supports animating as color of hsla()
+PASS line-height (type: discrete) has testAccumulation function
+PASS line-height: "10px" onto "normal"
+PASS line-height: "normal" onto "10px"
+PASS line-height: "10" onto "normal"
+PASS line-height: "normal" onto "10"
 PASS list-style-image (type: discrete) has testAccumulation function
 PASS list-style-image: "url("http://localhost/test-2")" onto "url("http://localhost/test-1")"
 PASS list-style-image: "url("http://localhost/test-1")" onto "url("http://localhost/test-2")"

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
@@ -22,6 +22,11 @@ PASS lighting-color supports animating as color of hsl()
 PASS lighting-color supports animating as color of #RGBa
 PASS lighting-color supports animating as color of rgba()
 PASS lighting-color supports animating as color of hsla()
+PASS line-height (type: discrete) has testAddition function
+PASS line-height: "10px" onto "normal"
+PASS line-height: "normal" onto "10px"
+PASS line-height: "10" onto "normal"
+PASS line-height: "normal" onto "10"
 PASS list-style-image (type: discrete) has testAddition function
 PASS list-style-image: "url("http://localhost/test-2")" onto "url("http://localhost/test-1")"
 PASS list-style-image: "url("http://localhost/test-1")" onto "url("http://localhost/test-2")"

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
@@ -26,6 +26,13 @@ PASS lighting-color supports animating as color of hsl()
 PASS lighting-color supports animating as color of #RGBa
 PASS lighting-color supports animating as color of rgba()
 PASS lighting-color supports animating as color of hsla()
+PASS line-height (type: discrete) has testInterpolation function
+PASS line-height uses discrete animation when animating between "normal" and "10px" with linear easing
+PASS line-height uses discrete animation when animating between "normal" and "10px" with effect easing
+PASS line-height uses discrete animation when animating between "normal" and "10px" with keyframe easing
+PASS line-height uses discrete animation when animating between "normal" and "10" with linear easing
+PASS line-height uses discrete animation when animating between "normal" and "10" with effect easing
+PASS line-height uses discrete animation when animating between "normal" and "10" with keyframe easing
 PASS list-style-image (type: discrete) has testInterpolation function
 FAIL list-style-image uses discrete animation when animating between "url("http://localhost/test-1")" and "url("http://localhost/test-2")" with linear easing assert_equals: The value should be url("http://localhost/test-1") at 499ms expected "url(\"http://localhost/test-1\")" but got "url(\"http://localhost/test-2\")"
 FAIL list-style-image uses discrete animation when animating between "url("http://localhost/test-1")" and "url("http://localhost/test-2")" with effect easing assert_equals: The value should be url("http://localhost/test-1") at 940ms expected "url(\"http://localhost/test-1\")" but got "url(\"http://localhost/test-2\")"


### PR DESCRIPTION
#### 221eb1d58b670526e0c7dc3249167a9eef1175dc
<pre>
[web-animations] line-height should not transition from default value to a number
<a href="https://bugs.webkit.org/show_bug.cgi?id=251911">https://bugs.webkit.org/show_bug.cgi?id=251911</a>
rdar://104346766

Reviewed by Antti Koivisto.

By default, properties represented by a Length in RenderStyle use discrete interpolation when
their LengthType differs. In the case of line-height, BuilderConverter::convertLineHeight() yields:

    - LengthType::Percent for the &quot;normal&quot; CSS value (with -100 as the float value),
    - LengthType::Percent for &lt;number&gt; CSS values,
    - LengthType::Fixed for &lt;length-percentage&gt; values.

This means that animating between &quot;normal&quot; and &lt;number&gt; would use an interpolation because we would
see two LengthType::Percent values.

To deal with this, we now have a dedicated animation wrapper for &quot;line-height&quot; which detects &quot;normal&quot;
values and returns false if either the from or to value can be mapped back to &quot;normal&quot;.

* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-types.js:
(const.discreteType.testInterpolation):
(const.discreteType.testAdditionOrAccumulation):
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):

Canonical link: <a href="https://commits.webkit.org/260028@main">https://commits.webkit.org/260028@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25ea9e2f35d82222be0915c7045669b1482e326e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106761 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15773 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39585 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115951 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115533 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110667 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17275 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6992 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98956 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112530 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13101 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/96111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40687 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94985 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/27763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8970 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/29118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9534 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/6107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15142 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48661 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11057 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3736 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->