### PR TITLE
_presentedViewControllerWhileRotating could be nil

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKActionSheet.mm
+++ b/Source/WebKit/UIProcess/ios/WKActionSheet.mm
@@ -220,7 +220,7 @@
         return;
 
     CGRect presentationRect = [self _presentationRectForStyle:_currentPresentationStyle];
-    BOOL wasPresentedViewControllerModal = [_presentedViewControllerWhileRotating isModalInPresentation];
+    BOOL wasPresentedViewControllerModal = [presentedViewController isModalInPresentation];
 
     if (!CGRectIsEmpty(presentationRect) || wasPresentedViewControllerModal) {
         // Re-present the popover only if we are still pointing to content onscreen, or if we can't dismiss it without losing information.


### PR DESCRIPTION
#### 3c274836cc656abf8a3986bfdfdf6191aca20958
<pre>
_presentedViewControllerWhileRotating could be nil
<a href="https://bugs.webkit.org/show_bug.cgi?id=251916">https://bugs.webkit.org/show_bug.cgi?id=251916</a>

Reviewed by NOBODY (OOPS!).

In the event _presentedViewControllerWhileRotating is nil, we fall back
on using self. However, when we call isModalInPopover, we end up calling
that method of the _presentedViewControllerWhileRotating object, when we
really should be calling it from the presentedViewController, or else we
could be invoking a method from a nil object.

Also because isModalInPopover has been renamed to isModalInPresentation,
we can kill two birds with one stone with this PR since the exact same
line is affected.

*Source/WebKit/UIProcess/ios/WKActionSheet.mm:(updateSheetPosition):
call [presentedViewController isModalInPresentation] instead of
[_presentedViewControllerWhileRotating isModalInPopover]
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4965fec10723999fcdd4f0d99f1b6a354ef15474

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/685 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/704 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/732 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/883 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/603 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/753 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/789 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/838 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/692 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/657 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/652 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/856 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/732 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/647 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/669 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/616 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/668 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/648 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/642 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/601 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/653 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/658 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->