### PR TITLE
[JSC] Fix wasm tests on MIPS

### DIFF
--- a/JSTests/wasm/stress/throw-from-wasm-catch-in-baseline-JIT.js
+++ b/JSTests/wasm/stress/throw-from-wasm-catch-in-baseline-JIT.js
@@ -1,3 +1,4 @@
+//@ skip if $architecture != "arm64" && $architecture != "x86_64" && $architecture != "arm"
 //@ runNoisyTestDefault("--traceBaselineJITExecution=1", "--jitPolicyScale=0")
 
 let x = readFile('throw-from-wasm-catch-in-baseline-JIT-payload.bin', 'binary');

--- a/JSTests/wasm/stress/timer-exception.js
+++ b/JSTests/wasm/stress/timer-exception.js
@@ -1,3 +1,4 @@
+//@ skip if $architecture != "arm64" && $architecture != "x86_64" && $architecture != "arm"
 //@ runDefault("--watchdog=100", "--watchdog-exception-ok")
 (async function () {
   let bytes = readFile('./resources/large.wasm', 'binary');


### PR DESCRIPTION
#### 6767f1e0f7fc2e9536ea44755c07761a931154ee
<pre>
[JSC] Fix wasm tests on MIPS
<a href="https://bugs.webkit.org/show_bug.cgi?id=251917">https://bugs.webkit.org/show_bug.cgi?id=251917</a>

Unreviewed test gardening. Prevent MIPS failure by checking if wasm is available.

* JSTests/wasm/stress/throw-from-wasm-catch-in-baseline-JIT.js:
(vm.isWasmSupported):
(foo): Deleted.
* JSTests/wasm/stress/timer-exception.js:
(async let): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/536f9d10fefa98de4f0fe54b42f072ffe23b5729

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106795 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15819 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39628 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115981 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115555 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17312 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7022 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98986 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112563 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13122 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96144 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40707 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95005 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27796 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82439 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/96328 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8998 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29151 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/95796 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/6933 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9564 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6120 "Found 2 new test failures: fast/events/blur-remove-parent-crash.html, fast/text-autosizing/ios/autosize-width.html (failure)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30702 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15167 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48696 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/104550 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11089 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25895 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->