### PR TITLE
Stop atomizing all-whitespace strings when parsing HTML

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -590,7 +590,6 @@ Document::Document(Frame* frame, const Settings& settings, const URL& url, Docum
     , m_undoManager(UndoManager::create(*this))
     , m_editor(makeUniqueRef<Editor>(*this))
     , m_selection(makeUniqueRef<FrameSelection>(this))
-    , m_whitespaceCache(makeUniqueRef<WhitespaceCache>())
     , m_reportingScope(ReportingScope::create(*this))
     , m_documentClasses(documentClasses)
     , m_latestFocusTrigger { FocusTrigger::Other }

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -228,7 +228,6 @@ class WakeLockManager;
 class WebAnimation;
 class WebGL2RenderingContext;
 class WebGLRenderingContext;
-class WhitespaceCache;
 class WindowEventLoop;
 class WindowProxy;
 class XPathEvaluator;
@@ -1600,8 +1599,6 @@ public:
 
     HTMLDialogElement* activeModalDialog() const;
 
-    WhitespaceCache& whitespaceCache() { return m_whitespaceCache; }
-
 #if ENABLE(ATTACHMENT_ELEMENT)
     void registerAttachmentIdentifier(const String&, const HTMLImageElement&);
     void didInsertAttachmentElement(HTMLAttachmentElement&);
@@ -2173,7 +2170,6 @@ private:
     Ref<UndoManager> m_undoManager;
     UniqueRef<Editor> m_editor;
     UniqueRef<FrameSelection> m_selection;
-    UniqueRef<WhitespaceCache> m_whitespaceCache;
         
     String m_fragmentDirective;
 

--- a/Source/WebCore/html/parser/HTMLConstructionSite.h
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.h
@@ -101,7 +101,6 @@ class Element;
 class HTMLFormElement;
 class HTMLTemplateElement;
 class JSCustomElementInterface;
-class WhitespaceCache;
 
 class HTMLConstructionSite {
     WTF_MAKE_NONCOPYABLE(HTMLConstructionSite);
@@ -129,7 +128,7 @@ public:
     void insertHTMLBodyElement(AtomHTMLToken&&);
     void insertHTMLFormElement(AtomHTMLToken&&, bool isDemoted = false);
     void insertScriptElement(AtomHTMLToken&&);
-    void insertTextNode(const String&, WhitespaceMode = WhitespaceUnknown);
+    void insertTextNode(const String&);
     void insertForeignElement(AtomHTMLToken&&, const AtomString& namespaceURI);
 
     void insertHTMLHtmlStartTagBeforeHTML(AtomHTMLToken&&);
@@ -239,27 +238,6 @@ private:
     unsigned m_maximumDOMTreeDepth;
 
     bool m_inQuirksMode;
-
-    WhitespaceCache& m_whitespaceCache;
-};
-
-class WhitespaceCache {
-    WTF_MAKE_FAST_ALLOCATED;
-public:
-    WhitespaceCache()
-        : m_atoms(maximumCachedStringLength)
-    {
-    }
-
-    AtomString lookup(const String&, WhitespaceMode);
-
-private:
-    template<WhitespaceMode> uint64_t codeForString(const String&);
-
-    constexpr static uint64_t overflowWhitespaceCode = static_cast<uint64_t>(-1);
-    constexpr static size_t maximumCachedStringLength = 128;
-
-    FixedVector<AtomStringWithCode> m_atoms;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
@@ -2365,7 +2365,7 @@ void HTMLTreeBuilder::insertPhoneNumberLink(const String& string)
 
     processStartTag(WTFMove(aStartToken));
     m_tree.executeQueuedTasks();
-    m_tree.insertTextNode(string, NotAllWhitespace);
+    m_tree.insertTextNode(string);
     processEndTag(WTFMove(aEndToken));
 }
 
@@ -2374,7 +2374,7 @@ void HTMLTreeBuilder::insertPhoneNumberLink(const String& string)
 // 2. Wraps the phone number in a tel: link.
 // 3. Goes back to step 1 if a phone number is found in the rest of the string.
 // 4. Appends the rest of the string as a text node.
-void HTMLTreeBuilder::linkifyPhoneNumbers(const String& string, WhitespaceMode whitespaceMode)
+void HTMLTreeBuilder::linkifyPhoneNumbers(const String& string)
 {
     ASSERT(TelephoneNumberDetector::isSupported());
 
@@ -2397,7 +2397,7 @@ void HTMLTreeBuilder::linkifyPhoneNumbers(const String& string, WhitespaceMode w
 
         ASSERT(scannerPosition + relativeEndPosition < length);
 
-        m_tree.insertTextNode(string.substring(scannerPosition, relativeStartPosition), whitespaceMode);
+        m_tree.insertTextNode(string.substring(scannerPosition, relativeStartPosition));
         insertPhoneNumberLink(string.substring(scannerPosition + relativeStartPosition, relativeEndPosition - relativeStartPosition + 1));
 
         scannerPosition += relativeEndPosition + 1;
@@ -2407,10 +2407,10 @@ void HTMLTreeBuilder::linkifyPhoneNumbers(const String& string, WhitespaceMode w
     if (scannerPosition > 0) {
         if (scannerPosition < length) {
             String after = string.substring(scannerPosition, length - scannerPosition);
-            m_tree.insertTextNode(after, whitespaceMode);
+            m_tree.insertTextNode(after);
         }
     } else
-        m_tree.insertTextNode(string, whitespaceMode);
+        m_tree.insertTextNode(string);
 }
 
 // Looks at the ancestors of the element to determine whether we're inside an element which disallows parsing phone numbers.
@@ -2492,7 +2492,7 @@ ReprocessBuffer:
     case InsertionMode::InHead: {
         String leadingWhitespace = buffer.takeLeadingWhitespace();
         if (!leadingWhitespace.isEmpty())
-            m_tree.insertTextNode(leadingWhitespace, AllWhitespace);
+            m_tree.insertTextNode(leadingWhitespace);
         if (buffer.isEmpty())
             return;
         defaultForInHead();
@@ -2502,7 +2502,7 @@ ReprocessBuffer:
     case InsertionMode::AfterHead: {
         String leadingWhitespace = buffer.takeLeadingWhitespace();
         if (!leadingWhitespace.isEmpty())
-            m_tree.insertTextNode(leadingWhitespace, AllWhitespace);
+            m_tree.insertTextNode(leadingWhitespace);
         if (buffer.isEmpty())
             return;
         defaultForAfterHead();
@@ -2540,7 +2540,7 @@ ReprocessBuffer:
     case InsertionMode::InColumnGroup: {
         String leadingWhitespace = buffer.takeLeadingWhitespace();
         if (!leadingWhitespace.isEmpty())
-            m_tree.insertTextNode(leadingWhitespace, AllWhitespace);
+            m_tree.insertTextNode(leadingWhitespace);
         if (buffer.isEmpty())
             return;
         if (!processColgroupEndTagForInColumnGroup()) {
@@ -2563,7 +2563,7 @@ ReprocessBuffer:
     case InsertionMode::InHeadNoscript: {
         String leadingWhitespace = buffer.takeLeadingWhitespace();
         if (!leadingWhitespace.isEmpty())
-            m_tree.insertTextNode(leadingWhitespace, AllWhitespace);
+            m_tree.insertTextNode(leadingWhitespace);
         if (buffer.isEmpty())
             return;
         defaultForInHeadNoscript();
@@ -2573,7 +2573,7 @@ ReprocessBuffer:
     case InsertionMode::AfterFrameset: {
         String leadingWhitespace = buffer.takeRemainingWhitespace();
         if (!leadingWhitespace.isEmpty())
-            m_tree.insertTextNode(leadingWhitespace, AllWhitespace);
+            m_tree.insertTextNode(leadingWhitespace);
         // FIXME: We should generate a parse error if we skipped over any
         // non-whitespace characters.
         break;
@@ -2586,7 +2586,7 @@ ReprocessBuffer:
         String leadingWhitespace = buffer.takeRemainingWhitespace();
         if (!leadingWhitespace.isEmpty()) {
             m_tree.reconstructTheActiveFormattingElements();
-            m_tree.insertTextNode(leadingWhitespace, AllWhitespace);
+            m_tree.insertTextNode(leadingWhitespace);
         }
         // FIXME: We should generate a parse error if we skipped over any
         // non-whitespace characters.
@@ -2598,15 +2598,14 @@ ReprocessBuffer:
 void HTMLTreeBuilder::processCharacterBufferForInBody(ExternalCharacterTokenBuffer& buffer)
 {
     m_tree.reconstructTheActiveFormattingElements();
-    auto whitespaceMode = buffer.isAll8BitData() ? WhitespaceUnknown : NotAllWhitespace;
     String characters = buffer.takeRemaining();
 #if ENABLE(TELEPHONE_NUMBER_DETECTION) && PLATFORM(IOS_FAMILY)
     if (!isParsingFragment() && m_tree.isTelephoneNumberParsingEnabled() && shouldParseTelephoneNumbersInNode(m_tree.currentNode()) && TelephoneNumberDetector::isSupported())
-        linkifyPhoneNumbers(characters, whitespaceMode);
+        linkifyPhoneNumbers(characters);
     else
-        m_tree.insertTextNode(characters, whitespaceMode);
+        m_tree.insertTextNode(characters);
 #else
-    m_tree.insertTextNode(characters, whitespaceMode);
+    m_tree.insertTextNode(characters);
 #endif
     if (m_framesetOk && !isAllWhitespaceOrReplacementCharacters(characters))
         m_framesetOk = false;
@@ -2746,7 +2745,7 @@ void HTMLTreeBuilder::defaultForInTableText()
         // FIXME: parse error
         HTMLConstructionSite::RedirectToFosterParentGuard redirecter(m_tree);
         m_tree.reconstructTheActiveFormattingElements();
-        m_tree.insertTextNode(characters, NotAllWhitespace);
+        m_tree.insertTextNode(characters);
         m_framesetOk = false;
         m_insertionMode = m_originalInsertionMode;
         return;

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.h
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.h
@@ -111,7 +111,7 @@ private:
 
 #if ENABLE(TELEPHONE_NUMBER_DETECTION) && PLATFORM(IOS_FAMILY)
     void insertPhoneNumberLink(const String&);
-    void linkifyPhoneNumbers(const String&, WhitespaceMode);
+    void linkifyPhoneNumbers(const String&);
 #endif
 
     void processToken(AtomHTMLToken&&);


### PR DESCRIPTION
#### 0481f360769fc8d580a499ba543b661ac884e79a
<pre>
Stop atomizing all-whitespace strings when parsing HTML
<a href="https://bugs.webkit.org/show_bug.cgi?id=251924">https://bugs.webkit.org/show_bug.cgi?id=251924</a>

Reviewed by Ryosuke Niwa.

Stop atomizing all-whitespace strings when parsing HTML. This is very CPU
intensive on Speedometer despite our optimizations.

Not atomizing those whitespace strings simplifies our code quite a bit and
is a confirmed 0.85% progression on Speedometer. It also shows as neutral on
both Membuster and PLUM.

Blink already made this change in:
<a href="https://chromium-review.googlesource.com/c/chromium/src/+/4128925">https://chromium-review.googlesource.com/c/chromium/src/+/4128925</a>

* Source/WebCore/dom/Document.cpp:
* Source/WebCore/dom/Document.h:
(WebCore::Document::whitespaceCache): Deleted.
* Source/WebCore/html/parser/HTMLConstructionSite.cpp:
(WebCore::HTMLConstructionSite::HTMLConstructionSite):
(WebCore::HTMLConstructionSite::insertTextNode):
(WebCore::WhitespaceCache::codeForString): Deleted.
(WebCore::WhitespaceCache::lookup): Deleted.
* Source/WebCore/html/parser/HTMLConstructionSite.h:
(WebCore::WhitespaceCache::WhitespaceCache): Deleted.
* Source/WebCore/html/parser/HTMLTreeBuilder.cpp:
(WebCore::HTMLTreeBuilder::insertPhoneNumberLink):
(WebCore::HTMLTreeBuilder::linkifyPhoneNumbers):
(WebCore::HTMLTreeBuilder::processCharacterBuffer):
(WebCore::HTMLTreeBuilder::processCharacterBufferForInBody):
(WebCore::HTMLTreeBuilder::defaultForInTableText):

Canonical link: <a href="https://commits.webkit.org/260039@main">https://commits.webkit.org/260039@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f8fa7658ac1d1b4d9f04424d59579e4c466a237

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106771 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15784 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39598 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115961 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115540 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110677 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17290 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7043 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98966 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112540 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13111 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/96123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40700 "Found 1 new test failure: fast/mediastream/resize-trim.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94994 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/27775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8980 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/29130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9544 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/6136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15149 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48674 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6927 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11067 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->