### PR TITLE
Reduce compile times by forward-declaring VideoFrame

### DIFF
--- a/Source/WebCore/Modules/speech/SpeechRecognitionCaptureSource.h
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionCaptureSource.h
@@ -47,7 +47,7 @@ public:
     WEBCORE_EXPORT void mute();
 
 #if ENABLE(MEDIA_STREAM)
-    using DataCallback = Function<void(const MediaTime&, const PlatformAudioData&, const AudioStreamDescription&, size_t)>;
+    using DataCallback = Function<void(const WTF::MediaTime&, const PlatformAudioData&, const AudioStreamDescription&, size_t)>;
     using StateUpdateCallback = Function<void(const SpeechRecognitionUpdate&)>;
     SpeechRecognitionCaptureSource(SpeechRecognitionConnectionClientIdentifier, DataCallback&&, StateUpdateCallback&&, Ref<RealtimeMediaSource>&&);
     WEBCORE_EXPORT static std::optional<WebCore::CaptureDevice> findCaptureDevice();

--- a/Source/WebCore/Modules/speech/SpeechRecognitionCaptureSourceImpl.h
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionCaptureSourceImpl.h
@@ -51,7 +51,7 @@ class SpeechRecognitionCaptureSourceImpl
     , public RealtimeMediaSource::AudioSampleObserver {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    using DataCallback = Function<void(const MediaTime&, const PlatformAudioData&, const AudioStreamDescription&, size_t)>;
+    using DataCallback = Function<void(const WTF::MediaTime&, const PlatformAudioData&, const AudioStreamDescription&, size_t)>;
     using StateUpdateCallback = Function<void(const SpeechRecognitionUpdate&)>;
     SpeechRecognitionCaptureSourceImpl(SpeechRecognitionConnectionClientIdentifier, DataCallback&&, StateUpdateCallback&&, Ref<RealtimeMediaSource>&&);
     ~SpeechRecognitionCaptureSourceImpl();
@@ -59,10 +59,10 @@ public:
 
 private:
     // RealtimeMediaSource::AudioSampleObserver
-    void audioSamplesAvailable(const MediaTime&, const PlatformAudioData&, const AudioStreamDescription&, size_t) final;
+    void audioSamplesAvailable(const WTF::MediaTime&, const PlatformAudioData&, const AudioStreamDescription&, size_t) final;
 
 #if PLATFORM(COCOA)
-    void pullSamplesAndCallDataCallback(AudioSampleDataSource*, const MediaTime&, const CAAudioStreamDescription&, size_t sampleCount);
+    void pullSamplesAndCallDataCallback(AudioSampleDataSource*, const WTF::MediaTime&, const CAAudioStreamDescription&, size_t sampleCount);
 #endif
 
     // RealtimeMediaSource::Observer

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameAlgorithms.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameAlgorithms.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "VideoFrame.h"
 #include "WebCodecsVideoFrame.h"
 
 #if ENABLE(WEB_CODECS)

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2184,6 +2184,7 @@ platform/graphics/LayoutRect.cpp
 platform/graphics/LayoutSize.cpp
 platform/graphics/MIMETypeCache.cpp
 platform/graphics/MediaPlayer.cpp
+platform/graphics/MediaPlayerPrivate.cpp
 platform/graphics/Model.cpp
 platform/graphics/NamedImageGeneratedImage.cpp
 platform/graphics/NativeImage.cpp

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -48,6 +48,7 @@
 #include "RenderVideo.h"
 #include "ScriptController.h"
 #include "Settings.h"
+#include "VideoFrameMetadata.h"
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/text/TextStream.h>
 

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -48,6 +48,7 @@
 #include "OESDrawBuffersIndexed.h"
 #include "OESTextureFloatLinear.h"
 #include "RenderBox.h"
+#include "WebCodecsVideoFrame.h"
 #include "WebCoreOpaqueRoot.h"
 #include "WebGLActiveInfo.h"
 #include "WebGLBuffer.h"

--- a/Source/WebCore/html/canvas/WebGLRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContext.cpp
@@ -54,6 +54,7 @@
 #include "OESTextureHalfFloatLinear.h"
 #include "OESVertexArrayObject.h"
 #include "RenderBox.h"
+#include "WebCodecsVideoFrame.h"
 #include "WebGLBuffer.h"
 #include "WebGLColorBufferFloat.h"
 #include "WebGLCompressedTextureASTC.h"

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -81,6 +81,7 @@
 #include "Page.h"
 #include "RenderBox.h"
 #include "Settings.h"
+#include "WebCodecsVideoFrame.h"
 #include "WebCoreOpaqueRoot.h"
 #include "WebGL2RenderingContext.h"
 #include "WebGLActiveInfo.h"

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -55,10 +55,6 @@
 #include <wtf/ListHashSet.h>
 #include <wtf/Lock.h>
 
-#if ENABLE(WEB_CODECS)
-#include "WebCodecsVideoFrame.h"
-#endif
-
 #if ENABLE(WEBXR)
 #include "JSDOMPromiseDeferredForward.h"
 #endif
@@ -103,6 +99,7 @@ class OESVertexArrayObject;
 #if ENABLE(OFFSCREEN_CANVAS)
 class OffscreenCanvas;
 #endif
+class WebCodecsVideoFrame;
 class WebCoreOpaqueRoot;
 class WebGLActiveInfo;
 class WebGLClipCullDistance;

--- a/Source/WebCore/platform/VideoDecoder.cpp
+++ b/Source/WebCore/platform/VideoDecoder.cpp
@@ -84,6 +84,9 @@ void VideoDecoder::createLocalDecoder(const String& codecName, const Config& con
     callback(makeUnexpected("Not supported"_s));
 }
 
+VideoDecoder::VideoDecoder() = default;
+VideoDecoder::~VideoDecoder() = default;
+
 }
 
 #endif // ENABLE(WEB_CODECS)

--- a/Source/WebCore/platform/VideoDecoder.h
+++ b/Source/WebCore/platform/VideoDecoder.h
@@ -27,7 +27,6 @@
 
 #if ENABLE(WEB_CODECS)
 
-#include "VideoFrame.h"
 #include <wtf/CompletionHandler.h>
 #include <wtf/Expected.h>
 #include <wtf/Span.h>
@@ -38,7 +37,8 @@ class VideoFrame;
 
 class VideoDecoder {
 public:
-    virtual ~VideoDecoder() = default;
+    WEBCORE_EXPORT VideoDecoder();
+    WEBCORE_EXPORT virtual ~VideoDecoder();
 
     struct Config {
         Span<const uint8_t> description;

--- a/Source/WebCore/platform/graphics/GraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContext.cpp
@@ -41,6 +41,7 @@
 #include "RoundedRect.h"
 #include "SystemImage.h"
 #include "TextBoxIterator.h"
+#include "VideoFrame.h"
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -44,6 +44,8 @@
 #include "PlatformTextTrack.h"
 #include "PlatformTimeRanges.h"
 #include "SecurityOrigin.h"
+#include "VideoFrame.h"
+#include "VideoFrameMetadata.h"
 #include <JavaScriptCore/ArrayBuffer.h>
 #include <wtf/Lock.h>
 #include <wtf/NeverDestroyed.h>

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -38,8 +38,6 @@
 #include "PlatformTextTrack.h"
 #include "SecurityOriginData.h"
 #include "Timer.h"
-#include "VideoFrame.h"
-#include "VideoFrameMetadata.h"
 #include "VideoPlaybackQualityMetrics.h"
 #include <JavaScriptCore/Forward.h>
 #include <wtf/CompletionHandler.h>
@@ -87,10 +85,12 @@ class PlatformMediaResourceLoader;
 class PlatformTimeRanges;
 class SharedBuffer;
 class TextTrackRepresentation;
+class VideoFrame;
 class VideoTrackPrivate;
 
 struct GraphicsDeviceAdapter;
 struct SecurityOriginData;
+struct VideoFrameMetadata;
 
 struct MediaEngineSupportParameters {
     ContentType type;

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,26 +24,28 @@
  */
 
 #include "config.h"
-#include "RemoteVideoFrameObjectHeap.h"
+#include "MediaPlayerPrivate.h"
 
-#if ENABLE(GPU_PROCESS) && ENABLE(VIDEO) && PLATFORM(COCOA)
+#if ENABLE(VIDEO)
 
-#include <WebCore/PixelBufferConformerCV.h>
-#include <WebCore/CoreVideoSoftLink.h>
+#include "VideoFrameMetadata.h"
 
-namespace WebKit {
+namespace WebCore {
 
-RefPtr<WebCore::VideoFrame> RemoteVideoFrameObjectHeap::get(RemoteVideoFrameReadReference&& read)
+MediaPlayerPrivateInterface::MediaPlayerPrivateInterface() = default;
+MediaPlayerPrivateInterface::~MediaPlayerPrivateInterface() = default;
+
+RefPtr<VideoFrame> MediaPlayerPrivateInterface::videoFrameForCurrentTime()
 {
-    return m_heap.retire(WTFMove(read), 0_s);
+    return nullptr;
 }
 
-void RemoteVideoFrameObjectHeap::createPixelConformerIfNeeded()
+std::optional<VideoFrameMetadata> MediaPlayerPrivateInterface::videoFrameMetadata()
 {
-    if (!m_pixelBufferConformer)
-        m_pixelBufferConformer = makeUnique<WebCore::PixelBufferConformerCV>((__bridge CFDictionaryRef)@{ (__bridge NSString *)kCVPixelBufferPixelFormatTypeKey: @(kCVPixelFormatType_32BGRA) });
+    return { };
 }
 
 }
 
 #endif
+

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
@@ -32,7 +32,6 @@
 #include "NativeImage.h"
 #include "PlatformTimeRanges.h"
 #include "ProcessIdentity.h"
-#include "VideoFrame.h"
 #include <optional>
 #include <wtf/CompletionHandler.h>
 
@@ -42,11 +41,13 @@
 
 namespace WebCore {
 
+class VideoFrame;
+
 class MediaPlayerPrivateInterface {
     WTF_MAKE_NONCOPYABLE(MediaPlayerPrivateInterface); WTF_MAKE_FAST_ALLOCATED;
 public:
-    MediaPlayerPrivateInterface() = default;
-    virtual ~MediaPlayerPrivateInterface() = default;
+    WEBCORE_EXPORT MediaPlayerPrivateInterface();
+    WEBCORE_EXPORT virtual ~MediaPlayerPrivateInterface();
 
     virtual void load(const String&) { }
     virtual void load(const URL& url, const ContentType&, const String&) { load(url.string()); }
@@ -186,7 +187,7 @@ public:
     virtual void willBeAskedToPaintGL() { }
 #endif
 
-    virtual RefPtr<VideoFrame> videoFrameForCurrentTime() { return nullptr; }
+    virtual RefPtr<VideoFrame> videoFrameForCurrentTime();
     virtual RefPtr<NativeImage> nativeImageForCurrentTime() { return nullptr; }
     virtual DestinationColorSpace colorSpace() = 0;
     virtual bool shouldGetNativeImageForCanvasDrawing() const { return true; }
@@ -328,7 +329,7 @@ public:
     virtual bool playAtHostTime(const MonotonicTime&) { return false; }
     virtual bool pauseAtHostTime(const MonotonicTime&) { return false; }
 
-    virtual std::optional<VideoFrameMetadata> videoFrameMetadata() { return { }; }
+    virtual std::optional<VideoFrameMetadata> videoFrameMetadata();
     virtual void startVideoFrameMetadataGathering() { }
     virtual void stopVideoFrameMetadataGathering() { }
 

--- a/Source/WebCore/platform/graphics/avfoundation/SampleBufferDisplayLayer.h
+++ b/Source/WebCore/platform/graphics/avfoundation/SampleBufferDisplayLayer.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "PlatformLayer.h"
-#include "VideoFrame.h"
 #include <wtf/CompletionHandler.h>
 #include <wtf/WeakPtr.h>
 
@@ -37,6 +36,8 @@ class MediaTime;
 namespace WebCore {
 class IntSize;
 class VideoFrame;
+
+enum class VideoFrameRotation : uint16_t;
 
 class SampleBufferDisplayLayer {
 public:
@@ -61,7 +62,7 @@ public:
     virtual void updateDisplayMode(bool hideDisplayLayer, bool hideRootLayer) = 0;
 
     virtual void updateAffineTransform(CGAffineTransform) = 0;
-    virtual void updateBoundsAndPosition(CGRect, VideoFrame::Rotation) = 0;
+    virtual void updateBoundsAndPosition(CGRect, VideoFrameRotation) = 0;
 
     virtual void flush() = 0;
     virtual void flushAndRemoveImage() = 0;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.h
@@ -32,12 +32,17 @@
 #include <wtf/Deque.h>
 #include <wtf/Forward.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/MediaTime.h>
 #include <wtf/WorkQueue.h>
 
 OBJC_CLASS AVSampleBufferDisplayLayer;
 OBJC_CLASS WebAVSampleBufferStatusChangeListener;
 
+typedef struct __CVBuffer* CVPixelBufferRef;
+
 namespace WebCore {
+
+enum class VideoFrameRotation : uint16_t;
 
 class WEBCORE_EXPORT LocalSampleBufferDisplayLayer final : public SampleBufferDisplayLayer, public CanMakeWeakPtr<LocalSampleBufferDisplayLayer, WeakPtrFactoryInitialization::Eager> {
     WTF_MAKE_FAST_ALLOCATED;
@@ -59,7 +64,7 @@ public:
     PlatformLayer* displayLayer();
 
     enum class ShouldUpdateRootLayer { No, Yes };
-    void updateRootLayerBoundsAndPosition(CGRect, VideoFrame::Rotation, ShouldUpdateRootLayer);
+    void updateRootLayerBoundsAndPosition(CGRect, VideoFrameRotation, ShouldUpdateRootLayer);
     void updateRootLayerAffineTransform(CGAffineTransform);
 
     // SampleBufferDisplayLayer.
@@ -73,7 +78,7 @@ public:
     void updateDisplayMode(bool hideDisplayLayer, bool hideRootLayer) final;
 
     void updateAffineTransform(CGAffineTransform)  final;
-    void updateBoundsAndPosition(CGRect, VideoFrame::Rotation) final;
+    void updateBoundsAndPosition(CGRect, VideoFrameRotation) final;
 
     void flush() final;
     void flushAndRemoveImage() final;
@@ -90,7 +95,7 @@ private:
     void removeOldVideoFramesFromPendingQueue();
     void addVideoFrameToPendingQueue(Ref<VideoFrame>&&);
     void requestNotificationWhenReadyForVideoData();
-    void setRootLayerBoundsAndPositions(CGRect, VideoFrame::Rotation);
+    void setRootLayerBoundsAndPositions(CGRect, VideoFrameRotation);
 
 #if !RELEASE_LOG_DISABLED
     void onIrregularFrameRateNotification(MonotonicTime frameTime, MonotonicTime lastFrameTime);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
@@ -32,6 +32,8 @@
 #import "IntSize.h"
 #import "Logging.h"
 #import "MediaUtilities.h"
+#import "VideoFrame.h"
+#import "VideoFrameMetadata.h"
 
 #import <AVFoundation/AVSampleBufferDisplayLayer.h>
 #import <QuartzCore/CALayer.h>

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -28,6 +28,7 @@
 #if ENABLE(VIDEO) && USE(AVFOUNDATION)
 
 #include "MediaPlayerPrivateAVFoundation.h"
+#include "VideoFrameMetadata.h"
 #include <CoreMedia/CMTime.h>
 #include <wtf/Function.h>
 #include <wtf/Observer.h>

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -29,6 +29,7 @@
 
 #include "MediaPlayerPrivate.h"
 #include "SourceBufferPrivateClient.h"
+#include "VideoFrameMetadata.h"
 #include <CoreMedia/CMTime.h>
 #include <wtf/Deque.h>
 #include <wtf/Function.h>

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
@@ -30,7 +30,6 @@
 #include "MediaPlayerPrivate.h"
 #include "MediaStreamPrivate.h"
 #include "SampleBufferDisplayLayer.h"
-#include "VideoFrame.h"
 #include <wtf/Deque.h>
 #include <wtf/Forward.h>
 #include <wtf/Lock.h>
@@ -48,6 +47,8 @@ class MediaSourcePrivateClient;
 class PixelBufferConformerCV;
 class VideoLayerManagerObjC;
 class VideoTrackPrivateMediaStream;
+
+enum class VideoFrameRotation : uint16_t;
 
 class MediaPlayerPrivateMediaStreamAVFObjC final
     : public MediaPlayerPrivateInterface
@@ -264,7 +265,7 @@ private:
     // Written on main thread, read on sample thread.
     bool m_canEnqueueDisplayLayer { false };
     // Used on sample thread.
-    VideoFrame::Rotation m_videoRotation { VideoFrame::Rotation::None };
+    VideoFrameRotation m_videoRotation { };
     bool m_videoMirrored { false };
 
     Ref<const Logger> m_logger;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
@@ -36,6 +36,7 @@
 #import "MediaSessionManagerCocoa.h"
 #import "MediaStreamPrivate.h"
 #import "PixelBufferConformerCV.h"
+#import "VideoFrame.h"
 #import "VideoLayerManagerObjC.h"
 #import "VideoTrackPrivateMediaStream.h"
 #import <CoreGraphics/CGAffineTransform.h>
@@ -135,6 +136,7 @@ void MediaPlayerPrivateMediaStreamAVFObjC::setNativeImageCreator(NativeImageCrea
 
 MediaPlayerPrivateMediaStreamAVFObjC::MediaPlayerPrivateMediaStreamAVFObjC(MediaPlayer* player)
     : m_player(player)
+    , m_videoRotation { VideoFrameRotation::None }
     , m_logger(player->mediaPlayerLogger())
     , m_logIdentifier(player->mediaPlayerLogIdentifier())
     , m_videoLayerManager(makeUnique<VideoLayerManagerObjC>(m_logger, m_logIdentifier))

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -31,6 +31,7 @@
 #include "PlatformLayer.h"
 #include "SourceBufferParserWebM.h"
 #include "TimeRanges.h"
+#include "VideoFrameMetadata.h"
 #include "WebMResourceClient.h"
 #include <wtf/HashFunctions.h>
 #include <wtf/HashMap.h>

--- a/Source/WebCore/platform/graphics/cv/ImageTransferSessionVT.h
+++ b/Source/WebCore/platform/graphics/cv/ImageTransferSessionVT.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "IntSize.h"
-#include "VideoFrame.h"
 #include <wtf/RetainPtr.h>
 
 typedef struct CGImage *CGImageRef;
@@ -36,7 +35,13 @@ typedef struct __CVPixelBufferPool *CVPixelBufferPoolRef;
 typedef struct __IOSurface *IOSurfaceRef;
 typedef struct opaqueCMSampleBuffer *CMSampleBufferRef;
 
+namespace WTF {
+class MediaTime;
+}
+
 namespace WebCore {
+
+enum class VideoFrameRotation : uint16_t;
 
 class ImageTransferSessionVT {
 public:
@@ -46,11 +51,14 @@ public:
     }
 
     RefPtr<VideoFrame> convertVideoFrame(VideoFrame&, const IntSize&);
-    RefPtr<VideoFrame> createVideoFrame(CGImageRef, const MediaTime&, const IntSize&, VideoFrame::Rotation = VideoFrame::Rotation::None, bool mirrored = false);
-    RefPtr<VideoFrame> createVideoFrame(CMSampleBufferRef, const MediaTime&, const IntSize&, VideoFrame::Rotation = VideoFrame::Rotation::None, bool mirrored = false);
+    RefPtr<VideoFrame> createVideoFrame(CGImageRef, const WTF::MediaTime&, const IntSize&);
+    RefPtr<VideoFrame> createVideoFrame(CMSampleBufferRef, const WTF::MediaTime&, const IntSize&);
+    RefPtr<VideoFrame> createVideoFrame(CGImageRef, const WTF::MediaTime&, const IntSize&, VideoFrameRotation, bool mirrored = false);
+    RefPtr<VideoFrame> createVideoFrame(CMSampleBufferRef, const WTF::MediaTime&, const IntSize&, VideoFrameRotation, bool mirrored = false);
 
 #if !PLATFORM(MACCATALYST)
-    WEBCORE_EXPORT RefPtr<VideoFrame> createVideoFrame(IOSurfaceRef, const MediaTime&, const IntSize&, VideoFrame::Rotation = VideoFrame::Rotation::None, bool mirrored = false);
+    WEBCORE_EXPORT RefPtr<VideoFrame> createVideoFrame(IOSurfaceRef, const WTF::MediaTime&, const IntSize&);
+    WEBCORE_EXPORT RefPtr<VideoFrame> createVideoFrame(IOSurfaceRef, const WTF::MediaTime&, const IntSize&, VideoFrameRotation, bool mirrored = false);
 #endif
 
     uint32_t pixelFormat() const { return m_pixelFormat; }
@@ -60,12 +68,12 @@ private:
     WEBCORE_EXPORT ImageTransferSessionVT(uint32_t pixelFormat, bool shouldUseIOSurface);
 
 #if !PLATFORM(MACCATALYST)
-    RetainPtr<CMSampleBufferRef> createCMSampleBuffer(IOSurfaceRef, const MediaTime&, const IntSize&);
+    RetainPtr<CMSampleBufferRef> createCMSampleBuffer(IOSurfaceRef, const WTF::MediaTime&, const IntSize&);
 #endif
 
-    RetainPtr<CMSampleBufferRef> convertCMSampleBuffer(CMSampleBufferRef, const IntSize&, const MediaTime* = nullptr);
-    RetainPtr<CMSampleBufferRef> createCMSampleBuffer(CVPixelBufferRef, const MediaTime&, const IntSize&);
-    RetainPtr<CMSampleBufferRef> createCMSampleBuffer(CGImageRef, const MediaTime&, const IntSize&);
+    RetainPtr<CMSampleBufferRef> convertCMSampleBuffer(CMSampleBufferRef, const IntSize&, const WTF::MediaTime* = nullptr);
+    RetainPtr<CMSampleBufferRef> createCMSampleBuffer(CVPixelBufferRef, const WTF::MediaTime&, const IntSize&);
+    RetainPtr<CMSampleBufferRef> createCMSampleBuffer(CGImageRef, const WTF::MediaTime&, const IntSize&);
 
     RetainPtr<CVPixelBufferRef> convertPixelBuffer(CVPixelBufferRef, const IntSize&);
     RetainPtr<CVPixelBufferRef> createPixelBuffer(CMSampleBufferRef, const IntSize&);

--- a/Source/WebCore/platform/graphics/cv/ImageTransferSessionVT.mm
+++ b/Source/WebCore/platform/graphics/cv/ImageTransferSessionVT.mm
@@ -267,7 +267,21 @@ RefPtr<VideoFrame> ImageTransferSessionVT::convertVideoFrame(VideoFrame& videoFr
     return VideoFrameCV::create(videoFrame.presentationTime(), videoFrame.isMirrored(), videoFrame.rotation(), WTFMove(resizedBuffer));
 }
 
+RefPtr<VideoFrame> ImageTransferSessionVT::createVideoFrame(CGImageRef image, const WTF::MediaTime& time, const IntSize& size)
+{
+    return createVideoFrame(image, time, size, VideoFrame::Rotation::None);
+}
+RefPtr<VideoFrame> ImageTransferSessionVT::createVideoFrame(CMSampleBufferRef image, const WTF::MediaTime& time, const IntSize& size)
+{
+    return createVideoFrame(image, time, size, VideoFrame::Rotation::None);
+}
+
 #if !PLATFORM(MACCATALYST)
+RefPtr<VideoFrame> ImageTransferSessionVT::createVideoFrame(IOSurfaceRef surface, const MediaTime& sampleTime, const IntSize& size)
+{
+    return createVideoFrame(surface, sampleTime, size, VideoFrame::Rotation::None);
+}
+
 RefPtr<VideoFrame> ImageTransferSessionVT::createVideoFrame(IOSurfaceRef surface, const MediaTime& sampleTime, const IntSize& size, VideoFrame::Rotation rotation, bool mirrored)
 {
     auto sampleBuffer = createCMSampleBuffer(surface, sampleTime, size);

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateAVFImpl.h
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateAVFImpl.h
@@ -51,7 +51,7 @@ private:
     // MediaRecorderPrivate
     void videoFrameAvailable(VideoFrame&, VideoFrameTimeMetadata) final;
     void fetchData(FetchDataCallback&&) final;
-    void audioSamplesAvailable(const MediaTime&, const PlatformAudioData&, const AudioStreamDescription&, size_t) final;
+    void audioSamplesAvailable(const WTF::MediaTime&, const PlatformAudioData&, const AudioStreamDescription&, size_t) final;
     void startRecording(StartRecordingCallback&&) final;
     const String& mimeType() const final;
 

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
@@ -43,6 +43,7 @@
 #include "RealtimeMediaSourceCenter.h"
 #include <wtf/CompletionHandler.h>
 #include <wtf/MainThread.h>
+#include <wtf/MediaTime.h>
 #include <wtf/UUID.h>
 #include <wtf/text/StringHash.h>
 

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -42,7 +42,6 @@
 #include "PlatformLayer.h"
 #include "RealtimeMediaSourceCapabilities.h"
 #include "RealtimeMediaSourceFactory.h"
-#include "VideoFrame.h"
 #include "VideoFrameTimeMetadata.h"
 #include <wtf/CompletionHandler.h>
 #include <wtf/Lock.h>
@@ -72,6 +71,7 @@ class MediaStreamPrivate;
 class OrientationNotifier;
 class PlatformAudioData;
 class RealtimeMediaSourceSettings;
+class VideoFrame;
 
 struct CaptureSourceOrError;
 
@@ -108,7 +108,7 @@ public:
         virtual ~AudioSampleObserver() = default;
 
         // May be called on a background thread.
-        virtual void audioSamplesAvailable(const MediaTime&, const PlatformAudioData&, const AudioStreamDescription&, size_t /*numberOfFrames*/) = 0;
+        virtual void audioSamplesAvailable(const WTF::MediaTime&, const PlatformAudioData&, const AudioStreamDescription&, size_t /*numberOfFrames*/) = 0;
     };
     class VideoFrameObserver {
     public:
@@ -270,7 +270,7 @@ protected:
     void initializeEchoCancellation(bool echoCancellation) { m_echoCancellation = echoCancellation; }
 
     void videoFrameAvailable(VideoFrame&, VideoFrameTimeMetadata);
-    void audioSamplesAvailable(const MediaTime&, const PlatformAudioData&, const AudioStreamDescription&, size_t);
+    void audioSamplesAvailable(const WTF::MediaTime&, const PlatformAudioData&, const AudioStreamDescription&, size_t);
 
     void forEachObserver(const Function<void(Observer&)>&);
     void forEachVideoFrameObserver(const Function<void(VideoFrameObserver&)>&);

--- a/Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.cpp
@@ -31,7 +31,9 @@
 #include "Logging.h"
 #include "RealtimeMediaSourceCenter.h"
 #include "RealtimeMediaSourceSettings.h"
+#include <VideoFrame.h>
 #include <wtf/JSONValues.h>
+#include <wtf/MediaTime.h>
 
 namespace WebCore {
 
@@ -42,6 +44,11 @@ RealtimeVideoCaptureSource::RealtimeVideoCaptureSource(const CaptureDevice& devi
 
 RealtimeVideoCaptureSource::~RealtimeVideoCaptureSource()
 {
+}
+
+VideoFrame::Rotation RealtimeVideoCaptureSource::videoFrameRotation() const
+{
+    return VideoFrame::Rotation::None;
 }
 
 const Vector<Ref<VideoPreset>>& RealtimeVideoCaptureSource::presets()

--- a/Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.h
@@ -37,6 +37,8 @@ namespace WebCore {
 
 class ImageTransferSessionVT;
 
+enum class VideoFrameRotation : uint16_t;
+
 class WEBCORE_EXPORT RealtimeVideoCaptureSource : public RealtimeMediaSource {
 public:
     virtual ~RealtimeVideoCaptureSource();
@@ -45,7 +47,7 @@ public:
 
     bool supportsSizeAndFrameRate(std::optional<int> width, std::optional<int> height, std::optional<double>) override;
     virtual void generatePresets() = 0;
-    virtual VideoFrame::Rotation videoFrameRotation() const { return VideoFrame::Rotation::None; }
+    virtual VideoFrameRotation videoFrameRotation() const;
 
     double observedFrameRate() const { return m_observedFrameRate; }
     Vector<VideoPresetData> presetsData();

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h
@@ -52,6 +52,8 @@ namespace WebCore {
 class AVVideoPreset;
 class ImageTransferSessionVT;
 
+enum class VideoFrameRotation : uint16_t;
+
 class AVVideoCaptureSource : public RealtimeVideoCaptureSource, private OrientationNotifier::Observer {
 public:
     static CaptureSourceOrError create(const CaptureDevice&, MediaDeviceHashSalts&&, const MediaConstraints*, PageIdentifier);
@@ -92,7 +94,7 @@ private:
     CaptureDevice::DeviceType deviceType() const final { return CaptureDevice::DeviceType::Camera; }
     bool interrupted() const final;
 
-    VideoFrame::Rotation videoFrameRotation() const final { return m_videoFrameRotation; }
+    VideoFrameRotation videoFrameRotation() const final { return m_videoFrameRotation; }
     void setFrameRateWithPreset(double, RefPtr<VideoPreset>) final;
     bool prefersPreset(VideoPreset&) final;
     void generatePresets() final;
@@ -125,7 +127,7 @@ private:
 
     int m_sensorOrientation { 0 };
     int m_deviceOrientation { 0 };
-    VideoFrame::Rotation m_videoFrameRotation { VideoFrame::Rotation::None };
+    VideoFrameRotation m_videoFrameRotation { };
 
     std::optional<RealtimeMediaSourceSettings> m_currentSettings;
     std::optional<RealtimeMediaSourceCapabilities> m_capabilities;

--- a/Source/WebCore/platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.h
+++ b/Source/WebCore/platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.h
@@ -30,7 +30,6 @@
 #if USE(LIBWEBRTC)
 
 #include "RealtimeIncomingVideoSource.h"
-#include "VideoFrame.h"
 
 using CVPixelBufferPoolRef = struct __CVPixelBufferPool*;
 using CVPixelBufferRef = struct __CVBuffer*;
@@ -41,6 +40,8 @@ enum class BufferType;
 
 namespace WebCore {
 
+enum class VideoFrameRotation : uint16_t;
+
 class RealtimeIncomingVideoSourceCocoa final : public RealtimeIncomingVideoSource {
 public:
     static Ref<RealtimeIncomingVideoSourceCocoa> create(rtc::scoped_refptr<webrtc::VideoTrackInterface>&&, String&&);
@@ -49,8 +50,8 @@ private:
     RealtimeIncomingVideoSourceCocoa(rtc::scoped_refptr<webrtc::VideoTrackInterface>&&, String&&);
     RetainPtr<CVPixelBufferRef> pixelBufferFromVideoFrame(const webrtc::VideoFrame&);
     CVPixelBufferPoolRef pixelBufferPool(size_t width, size_t height, webrtc::BufferType);
-    RefPtr<VideoFrame> toVideoFrame(const webrtc::VideoFrame&, VideoFrame::Rotation);
-    Ref<VideoFrame> createVideoSampleFromCVPixelBuffer(CVPixelBufferRef, VideoFrame::Rotation, int64_t);
+    RefPtr<VideoFrame> toVideoFrame(const webrtc::VideoFrame&, VideoFrameRotation);
+    Ref<VideoFrame> createVideoSampleFromCVPixelBuffer(CVPixelBufferRef, VideoFrameRotation, int64_t);
 
     // rtc::VideoSinkInterface
     void OnFrame(const webrtc::VideoFrame&) final;

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
@@ -43,6 +43,7 @@
 #include "PlatformLayer.h"
 #include "RealtimeMediaSourceSettings.h"
 #include "RealtimeVideoSource.h"
+#include "VideoFrame.h"
 #include <math.h>
 #include <wtf/UUID.h>
 #include <wtf/text/StringConcatenateNumbers.h>
@@ -76,6 +77,7 @@ static HashSet<MockRealtimeVideoSource*>& allMockRealtimeVideoSource()
 MockRealtimeVideoSource::MockRealtimeVideoSource(String&& deviceID, AtomString&& name, MediaDeviceHashSalts&& hashSalts, PageIdentifier pageIdentifier)
     : RealtimeVideoCaptureSource(CaptureDevice { WTFMove(deviceID), CaptureDevice::DeviceType::Camera, WTFMove(name) }, WTFMove(hashSalts), pageIdentifier)
     , m_emitFrameTimer(RunLoop::current(), this, &MockRealtimeVideoSource::generateFrame)
+    , m_deviceOrientation { VideoFrame::Rotation::None }
 {
     allMockRealtimeVideoSource().add(this);
 

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.h
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.h
@@ -46,6 +46,8 @@ namespace WebCore {
 class FloatRect;
 class GraphicsContext;
 
+enum class VideoFrameRotation : uint16_t;
+
 class MockRealtimeVideoSource : public RealtimeVideoCaptureSource, private OrientationNotifier::Observer {
 public:
     static CaptureSourceOrError create(String&& deviceID, AtomString&& name, MediaDeviceHashSalts&&, const MediaConstraints*, PageIdentifier);
@@ -62,7 +64,7 @@ protected:
 
     Seconds elapsedTime();
     void settingsDidChange(OptionSet<RealtimeMediaSourceSettings::Flag>) override;
-    VideoFrame::Rotation videoFrameRotation() const final { return m_deviceOrientation; }
+    VideoFrameRotation videoFrameRotation() const final { return m_deviceOrientation; }
     void generatePresets() override;
 
     IntSize captureSize() const;
@@ -122,7 +124,7 @@ private:
     Color m_fillColor { Color::black };
     MockMediaDevice m_device;
     RefPtr<VideoPreset> m_preset;
-    VideoFrame::Rotation m_deviceOrientation { VideoFrame::Rotation::None };
+    VideoFrameRotation m_deviceOrientation { };
 };
 
 } // namespace WebCore

--- a/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.h
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.h
@@ -30,15 +30,15 @@
 #include "RemoteVideoFrameProxy.h"
 #include "ThreadSafeObjectHeap.h"
 #include "WorkQueueMessageReceiver.h"
-#include <WebCore/DestinationColorSpace.h>
-#include <WebCore/VideoFrame.h>
 
 #if PLATFORM(COCOA)
 #include "SharedVideoFrame.h"
 #endif
 
 namespace WebCore {
+class DestinationColorSpace;
 class PixelBufferConformerCV;
+class VideoFrame;
 }
 
 namespace WebKit {
@@ -51,7 +51,7 @@ public:
 
     void close();
     RemoteVideoFrameProxy::Properties add(Ref<WebCore::VideoFrame>&&);
-    RefPtr<WebCore::VideoFrame> get(RemoteVideoFrameReadReference&& read) { return m_heap.retire(WTFMove(read), 0_s); }
+    RefPtr<WebCore::VideoFrame> get(RemoteVideoFrameReadReference&&);
 
     void stopListeningForIPC(Ref<RemoteVideoFrameObjectHeap>&&) { close(); }
 

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.h
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.h
@@ -40,6 +40,7 @@
 namespace WebCore {
 class ImageTransferSessionVT;
 class LocalSampleBufferDisplayLayer;
+enum class VideoFrameRotation : uint16_t;
 };
 
 namespace WebKit {
@@ -71,7 +72,7 @@ private:
 #endif
     void updateDisplayMode(bool hideDisplayLayer, bool hideRootLayer);
     void updateAffineTransform(CGAffineTransform);
-    void updateBoundsAndPosition(CGRect, WebCore::VideoFrame::Rotation);
+    void updateBoundsAndPosition(CGRect, WebCore::VideoFrameRotation);
     void flush();
     void flushAndRemoveImage();
     void play();

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3305,6 +3305,7 @@ header: <WebCore/AudioIOCallback.h>
 };
 
 #if ENABLE(VIDEO)
+header: <WebCore/VideoFrame.h>
 enum class WebCore::VideoFrameRotation : uint16_t {
     None,
     UpsideDown,

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -41,7 +41,6 @@
 #include "VideoTrackPrivateRemote.h"
 #include <WebCore/MediaPlayerPrivate.h>
 #include <WebCore/SecurityOriginData.h>
-#include <WebCore/VideoFrame.h>
 #include <WebCore/VideoFrameMetadata.h>
 #include <wtf/LoggerHelper.h>
 #include <wtf/MediaTime.h>
@@ -60,6 +59,7 @@ struct GenericCueData;
 class ISOWebVTTCue;
 class SerializedPlatformDataCueValue;
 class VideoLayerManager;
+class VideoFrame;
 
 #if PLATFORM(COCOA)
 class PixelBufferConformerCV;

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
@@ -57,6 +57,10 @@ class VideoFrame;
 struct WebKitEncodedFrameInfo;
 }
 
+namespace WebCore {
+enum class VideoFrameRotation : uint16_t;
+}
+
 namespace WebKit {
 
 class RemoteVideoFrameObjectHeapProxy;
@@ -180,7 +184,7 @@ private:
 
     Decoder* createDecoderInternal(VideoCodecType, Function<void(Decoder&)>&&);
     Encoder* createEncoderInternal(VideoCodecType, const std::map<std::string, std::string>&, bool isRealtime, bool useAnnexB, Function<void(Encoder&)>&&);
-    template<typename Frame> int32_t encodeFrameInternal(Encoder&, const Frame&, bool shouldEncodeAsKeyFrame, WebCore::VideoFrame::Rotation, MediaTime, uint32_t);
+    template<typename Frame> int32_t encodeFrameInternal(Encoder&, const Frame&, bool shouldEncodeAsKeyFrame, WebCore::VideoFrameRotation, MediaTime, uint32_t);
 
 private:
     HashMap<VideoDecoderIdentifier, std::unique_ptr<Decoder>> m_decoders WTF_GUARDED_BY_CAPABILITY(workQueue());

--- a/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.h
@@ -34,6 +34,10 @@
 #include <WebCore/SampleBufferDisplayLayer.h>
 #include <wtf/WeakPtr.h>
 
+namespace WebCore {
+enum class VideoFrameRotation : uint16_t;
+}
+
 namespace WebKit {
 
 class SampleBufferDisplayLayerManager;
@@ -63,7 +67,7 @@ private:
     bool didFail() const final;
     void updateDisplayMode(bool hideDisplayLayer, bool hideRootLayer) final;
     void updateAffineTransform(CGAffineTransform) final;
-    void updateBoundsAndPosition(CGRect, WebCore::VideoFrame::Rotation) final;
+    void updateBoundsAndPosition(CGRect, WebCore::VideoFrameRotation) final;
     void flush() final;
     void flushAndRemoveImage() final;
     void play() final;

--- a/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.h
@@ -30,8 +30,9 @@
 #include "IPCSemaphore.h"
 #include "RemoteVideoFrameIdentifier.h"
 #include "SharedMemory.h"
+#include <WebCore/IntSize.h>
 #include <WebCore/ProcessIdentity.h>
-#include <WebCore/VideoFrame.h>
+#include <wtf/MediaTime.h>
 #include <wtf/RefPtr.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/UniqueRef.h>
@@ -41,6 +42,8 @@ typedef struct __CVPixelBufferPool* CVPixelBufferPoolRef;
 
 namespace WebCore {
 class SharedVideoFrameInfo;
+class VideoFrame;
+enum class VideoFrameRotation : uint16_t;
 }
 
 namespace webrtc {
@@ -55,7 +58,7 @@ class RemoteVideoFrameObjectHeap;
 struct SharedVideoFrame {
     MediaTime time;
     bool mirrored { false };
-    WebCore::VideoFrame::Rotation rotation { WebCore::VideoFrame::Rotation::None };
+    WebCore::VideoFrameRotation rotation { };
     using Buffer = std::variant<std::nullptr_t, RemoteVideoFrameReadReference, MachSendRight, WebCore::IntSize>;
     Buffer buffer;
 

--- a/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.h
+++ b/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.h
@@ -45,6 +45,7 @@
 
 namespace WebCore {
 class ImageTransferSessionVT;
+enum class VideoFrameRotation : uint16_t;
 }
 
 namespace WebKit {
@@ -73,7 +74,7 @@ private:
     void audioSamplesAvailable(WebCore::RealtimeMediaSourceIdentifier, MediaTime, uint64_t numberOfFrames);
     void videoFrameAvailable(WebCore::RealtimeMediaSourceIdentifier, RemoteVideoFrameProxy::Properties&&, WebCore::VideoFrameTimeMetadata);
     // FIXME: Will be removed once RemoteVideoFrameProxy providers are the only ones sending data.
-    void videoFrameAvailableCV(WebCore::RealtimeMediaSourceIdentifier, RetainPtr<CVPixelBufferRef>&&, WebCore::VideoFrame::Rotation, bool mirrored, MediaTime, WebCore::VideoFrameTimeMetadata);
+    void videoFrameAvailableCV(WebCore::RealtimeMediaSourceIdentifier, RetainPtr<CVPixelBufferRef>&&, WebCore::VideoFrameRotation, bool mirrored, MediaTime, WebCore::VideoFrameTimeMetadata);
 
     void setConnection(IPC::Connection*);
 

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeAudioSource.h
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeAudioSource.h
@@ -36,7 +36,7 @@ public:
     static Ref<WebCore::RealtimeMediaSource> create(const WebCore::CaptureDevice&, const WebCore::MediaConstraints*, WebCore::MediaDeviceHashSalts&&, UserMediaCaptureManager&, bool shouldCaptureInGPUProcess, WebCore::PageIdentifier);
     ~RemoteRealtimeAudioSource();
 
-    void remoteAudioSamplesAvailable(const MediaTime&, const WebCore::PlatformAudioData&, const WebCore::AudioStreamDescription&, size_t);
+    void remoteAudioSamplesAvailable(const WTF::MediaTime&, const WebCore::PlatformAudioData&, const WebCore::AudioStreamDescription&, size_t);
 
 private:
     RemoteRealtimeAudioSource(WebCore::RealtimeMediaSourceIdentifier, const WebCore::CaptureDevice&, const WebCore::MediaConstraints*, WebCore::MediaDeviceHashSalts&&, UserMediaCaptureManager&, bool shouldCaptureInGPUProcess, WebCore::PageIdentifier);

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeVideoSource.h
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeVideoSource.h
@@ -31,9 +31,9 @@
 #include "RemoteRealtimeMediaSourceProxy.h"
 #include <WebCore/CaptureDevice.h>
 #include <WebCore/RealtimeMediaSourceIdentifier.h>
-#include <WebCore/VideoFrame.h>
 
 namespace WebCore {
+class VideoFrame;
 struct MediaConstraints;
 }
 


### PR DESCRIPTION
#### 6ba621fca3e768dedfaf203cbf576888a072368e
<pre>
Reduce compile times by forward-declaring VideoFrame
<a href="https://bugs.webkit.org/show_bug.cgi?id=251923">https://bugs.webkit.org/show_bug.cgi?id=251923</a>
&lt;rdar://problem/105278817&gt;

Reviewed by Cameron McCormack.

Move the declaration of VideoFrame::Rotation out of VideoFrame so that it can be forward-declared.

Move all initializers that reference VideoFrame::Rotation values out-of-line.

Not including VideoFrame.h everywhere exposes other header problems, such as WTF::MediaTime
not being included. Make sure WTF::MediaTime is forward-declared in these instances, or
included where necessary.

Canonical link: <a href="https://commits.webkit.org/260132@main">https://commits.webkit.org/260132@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e6b74332148b009c1ae4e2cdc487452b2f42fbd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107145 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16194 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39935 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116321 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115801 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111047 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17654 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7394 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99327 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112910 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13341 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96392 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40947 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95241 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28028 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9281 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29369 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9890 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6367 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15439 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48948 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7006 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11432 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->