### PR TITLE
Augment the content rule list allowlist mechanism introduced in 259930@main

### DIFF
--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -158,8 +158,8 @@ enum class ColorSchemePreference : uint8_t {
     Dark
 };
 
-enum class DisabledContentExtensionsMode : bool { None, All };
-using DisabledContentExtensions = std::variant<DisabledContentExtensionsMode, HashSet<String>>;
+enum class ContentExtensionDefaultEnablement : bool { Disabled, Enabled };
+using ContentExtensionEnablement = std::pair<ContentExtensionDefaultEnablement, HashSet<String>>;
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(DocumentLoader);
 class DocumentLoader
@@ -318,8 +318,8 @@ public:
     void stopLoadingSubresources();
     WEBCORE_EXPORT void stopLoadingAfterXFrameOptionsOrContentSecurityPolicyDenied(ResourceLoaderIdentifier, const ResourceResponse&);
 
-    const DisabledContentExtensions& disabledContentExtensions() const { return m_disabledContentExtensions; }
-    void setDisabledContentExtensions(DisabledContentExtensions&& disabledExtensions) { m_disabledContentExtensions = WTFMove(disabledExtensions); }
+    const ContentExtensionEnablement& contentExtensionEnablement() const { return m_contentExtensionEnablement; }
+    void setContentExtensionEnablement(ContentExtensionEnablement&& enablement) { m_contentExtensionEnablement = WTFMove(enablement); }
 
     bool allowsActiveContentRuleListActionsForURL(const String& contentRuleListIdentifier, const URL&) const;
     WEBCORE_EXPORT void setActiveContentRuleListActionPatterns(const HashMap<String, Vector<String>>&);
@@ -680,7 +680,7 @@ private:
     String m_customUserAgentAsSiteSpecificQuirks;
     String m_customNavigatorPlatform;
     MemoryCompactRobinHoodHashMap<String, Vector<UserContentURLPattern>> m_activeContentRuleListActionPatterns;
-    DisabledContentExtensions m_disabledContentExtensions { DisabledContentExtensionsMode::None };
+    ContentExtensionEnablement m_contentExtensionEnablement { ContentExtensionDefaultEnablement::Enabled, { } };
 
     ScriptExecutionContextIdentifier m_resultingClientId;
 

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1814,7 +1814,7 @@ void FrameLoader::reload(OptionSet<ReloadOption> options)
     loader->setIsRequestFromClientOrUserInput(m_documentLoader->isRequestFromClientOrUserInput());
     applyShouldOpenExternalURLsPolicyToNewDocumentLoader(m_frame, loader, InitiatedByMainFrame::Unknown, m_documentLoader->shouldOpenExternalURLsPolicyToPropagate());
 
-    loader->setDisabledContentExtensions({ options.contains(ReloadOption::DisableContentBlockers) ? DisabledContentExtensionsMode::All : DisabledContentExtensionsMode::None });
+    loader->setContentExtensionEnablement({ options.contains(ReloadOption::DisableContentBlockers) ? ContentExtensionDefaultEnablement::Disabled : ContentExtensionDefaultEnablement::Enabled, { } });
     
     ResourceRequest& request = loader->request();
 

--- a/Source/WebKit/Shared/WebsitePoliciesData.h
+++ b/Source/WebKit/Shared/WebsitePoliciesData.h
@@ -53,7 +53,7 @@ namespace WebKit {
 struct WebsitePoliciesData {
     static void applyToDocumentLoader(WebsitePoliciesData&&, WebCore::DocumentLoader&);
 
-    WebCore::DisabledContentExtensions disabledContentExtensions;
+    WebCore::ContentExtensionEnablement contentExtensionEnablement;
     HashMap<WTF::String, Vector<WTF::String>> activeContentRuleListActionPatterns;
     OptionSet<WebsiteAutoplayQuirk> allowedAutoplayQuirks;
     WebsiteAutoplayPolicy autoplayPolicy { WebsiteAutoplayPolicy::Default };

--- a/Source/WebKit/UIProcess/API/APIWebsitePolicies.cpp
+++ b/Source/WebKit/UIProcess/API/APIWebsitePolicies.cpp
@@ -38,7 +38,7 @@ WebsitePolicies::WebsitePolicies() = default;
 Ref<WebsitePolicies> WebsitePolicies::copy() const
 {
     auto policies = WebsitePolicies::create();
-    policies->m_disabledContentExtensions = m_disabledContentExtensions;
+    policies->m_contentExtensionEnablement = m_contentExtensionEnablement;
     policies->m_activeContentRuleListActionPatterns = m_activeContentRuleListActionPatterns;
     policies->setAllowedAutoplayQuirks(m_allowedAutoplayQuirks);
     policies->setAutoplayPolicy(m_autoplayPolicy);
@@ -84,30 +84,6 @@ void WebsitePolicies::setUserContentController(RefPtr<WebKit::WebUserContentCont
     m_userContentController = WTFMove(controller);
 }
 
-bool WebsitePolicies::contentBlockersEnabled() const
-{
-    return std::holds_alternative<WebCore::DisabledContentExtensionsMode>(m_disabledContentExtensions)
-        && std::get<WebCore::DisabledContentExtensionsMode>(m_disabledContentExtensions) == WebCore::DisabledContentExtensionsMode::None;
-}
-
-void WebsitePolicies::setContentBlockersEnabled(bool enabled)
-{
-    m_disabledContentExtensions = { enabled ? WebCore::DisabledContentExtensionsMode::None : WebCore::DisabledContentExtensionsMode::All };
-}
-
-void WebsitePolicies::setDisabledContentRuleListIdentifiers(HashSet<WTF::String>&& identifiers)
-{
-    m_disabledContentExtensions = { WTFMove(identifiers) };
-}
-
-HashSet<WTF::String> WebsitePolicies::disabledContentRuleListIdentifiers() const
-{
-    if (!std::holds_alternative<HashSet<WTF::String>>(m_disabledContentExtensions))
-        return { };
-
-    return std::get<HashSet<WTF::String>>(m_disabledContentExtensions);
-}
-
 WebKit::WebsitePoliciesData WebsitePolicies::data()
 {
     Vector<WebCore::CustomHeaderFields> customHeaderFields;
@@ -115,7 +91,7 @@ WebKit::WebsitePoliciesData WebsitePolicies::data()
     customHeaderFields.appendVector(this->customHeaderFields());
 
     return {
-        m_disabledContentExtensions,
+        m_contentExtensionEnablement,
         activeContentRuleListActionPatterns(),
         allowedAutoplayQuirks(),
         autoplayPolicy(),

--- a/Source/WebKit/UIProcess/API/APIWebsitePolicies.h
+++ b/Source/WebKit/UIProcess/API/APIWebsitePolicies.h
@@ -61,11 +61,8 @@ public:
 
     WebKit::WebsitePoliciesData data();
 
-    bool contentBlockersEnabled() const;
-    void setContentBlockersEnabled(bool);
-
-    void setDisabledContentRuleListIdentifiers(HashSet<WTF::String>&&);
-    HashSet<WTF::String> disabledContentRuleListIdentifiers() const;
+    const WebCore::ContentExtensionEnablement& contentExtensionEnablement() const { return m_contentExtensionEnablement; }
+    void setContentExtensionEnablement(WebCore::ContentExtensionEnablement&& enablement) { m_contentExtensionEnablement = WTFMove(enablement); }
 
     void setActiveContentRuleListActionPatterns(HashMap<WTF::String, Vector<WTF::String>>&& patterns) { m_activeContentRuleListActionPatterns = WTFMove(patterns); }
     const HashMap<WTF::String, Vector<WTF::String>>& activeContentRuleListActionPatterns() const { return m_activeContentRuleListActionPatterns; }
@@ -153,7 +150,7 @@ public:
 
 private:
     // FIXME: replace most or all of these members with a WebsitePoliciesData.
-    WebCore::DisabledContentExtensions m_disabledContentExtensions { WebCore::DisabledContentExtensionsMode::None };
+    WebCore::ContentExtensionEnablement m_contentExtensionEnablement { WebCore::ContentExtensionDefaultEnablement::Enabled, { } };
     HashMap<WTF::String, Vector<WTF::String>> m_activeContentRuleListActionPatterns;
     OptionSet<WebKit::WebsiteAutoplayQuirk> m_allowedAutoplayQuirks;
     WebKit::WebsiteAutoplayPolicy m_autoplayPolicy { WebKit::WebsiteAutoplayPolicy::Default };

--- a/Source/WebKit/UIProcess/API/C/WKWebsitePolicies.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKWebsitePolicies.cpp
@@ -33,6 +33,7 @@
 #include "WKDictionary.h"
 #include "WKRetainPtr.h"
 #include "WebsiteDataStore.h"
+#include <WebCore/DocumentLoader.h>
 
 using namespace WebKit;
 
@@ -48,12 +49,13 @@ WKWebsitePoliciesRef WKWebsitePoliciesCreate()
 
 void WKWebsitePoliciesSetContentBlockersEnabled(WKWebsitePoliciesRef websitePolicies, bool enabled)
 {
-    toImpl(websitePolicies)->setContentBlockersEnabled(enabled);
+    auto defaultEnablement = enabled ? WebCore::ContentExtensionDefaultEnablement::Enabled : WebCore::ContentExtensionDefaultEnablement::Disabled;
+    toImpl(websitePolicies)->setContentExtensionEnablement({ defaultEnablement, { } });
 }
 
 bool WKWebsitePoliciesGetContentBlockersEnabled(WKWebsitePoliciesRef websitePolicies)
 {
-    return toImpl(websitePolicies)->contentBlockersEnabled();
+    return toImpl(websitePolicies)->contentExtensionEnablement().first == WebCore::ContentExtensionDefaultEnablement::Enabled;
 }
 
 WK_EXPORT WKDictionaryRef WKWebsitePoliciesCopyCustomHeaderFields(WKWebsitePoliciesRef)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
@@ -194,32 +194,26 @@ private:
 
 - (void)_setContentBlockersEnabled:(BOOL)contentBlockersEnabled
 {
-    _websitePolicies->setContentBlockersEnabled(contentBlockersEnabled);
+    auto defaultEnablement = contentBlockersEnabled ? WebCore::ContentExtensionDefaultEnablement::Enabled : WebCore::ContentExtensionDefaultEnablement::Disabled;
+    _websitePolicies->setContentExtensionEnablement({ defaultEnablement, { } });
 }
 
 - (BOOL)_contentBlockersEnabled
 {
-    return _websitePolicies->contentBlockersEnabled();
+    // Note that this only reports default state, and ignores exceptions. This should be turned into a no-op and
+    // eventually removed, once no more internal clients rely on it.
+    return _websitePolicies->contentExtensionEnablement().first == WebCore::ContentExtensionDefaultEnablement::Enabled;
 }
 
-- (void)_setDisabledContentRuleListIdentifiers:(NSSet<NSString *> *)identifiers
+- (void)_setContentRuleListsEnabled:(BOOL)enabled exceptions:(NSSet<NSString *> *)identifiers
 {
-    _websitePolicies->setDisabledContentRuleListIdentifiers([&] {
-        HashSet<String> result;
-        result.reserveInitialCapacity(identifiers.count);
-        for (NSString *identifier in identifiers)
-            result.add(identifier);
-        return result;
-    }());
-}
+    HashSet<String> exceptions;
+    exceptions.reserveInitialCapacity(identifiers.count);
+    for (NSString *identifier in identifiers)
+        exceptions.add(identifier);
 
-- (NSSet<NSString *> *)_disabledContentRuleListIdentifiers
-{
-    auto identifiers = _websitePolicies->disabledContentRuleListIdentifiers();
-    auto result = adoptNS([[NSMutableSet alloc] initWithCapacity:identifiers.size()]);
-    for (auto& identifier : identifiers)
-        [result addObject:identifier];
-    return result.get();
+    auto defaultEnablement = enabled ? WebCore::ContentExtensionDefaultEnablement::Enabled : WebCore::ContentExtensionDefaultEnablement::Disabled;
+    _websitePolicies->setContentExtensionEnablement({ defaultEnablement, WTFMove(exceptions) });
 }
 
 - (void)_setActiveContentRuleListActionPatterns:(NSDictionary<NSString *, NSSet<NSString *> *> *)patterns

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h
@@ -93,7 +93,6 @@ typedef NS_OPTIONS(NSUInteger, _WKWebsiteNetworkConnectionIntegrityPolicy) {
 @interface WKWebpagePreferences (WKPrivate)
 
 @property (nonatomic, setter=_setContentBlockersEnabled:) BOOL _contentBlockersEnabled;
-@property (nonatomic, copy, setter=_setDisabledContentRuleListIdentifiers:) NSSet<NSString *> *_disabledContentRuleListIdentifiers WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 @property (nonatomic, copy, setter=_setActiveContentRuleListActionPatterns:) NSDictionary<NSString *, NSSet<NSString *> *> *_activeContentRuleListActionPatterns WK_API_AVAILABLE(macos(13.0), ios(16.0));
 @property (nonatomic, setter=_setAllowedAutoplayQuirks:) _WKWebsiteAutoplayQuirk _allowedAutoplayQuirks;
 @property (nonatomic, setter=_setAutoplayPolicy:) _WKWebsiteAutoplayPolicy _autoplayPolicy;
@@ -119,5 +118,7 @@ typedef NS_OPTIONS(NSUInteger, _WKWebsiteNetworkConnectionIntegrityPolicy) {
 
 @property (nonatomic, setter=_setNetworkConnectionIntegrityEnabled:) BOOL _networkConnectionIntegrityEnabled WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 @property (nonatomic, setter=_setNetworkConnectionIntegrityPolicy:) _WKWebsiteNetworkConnectionIntegrityPolicy _networkConnectionIntegrityPolicy WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
+- (void)_setContentRuleListsEnabled:(BOOL)enabled exceptions:(NSSet<NSString *> *)exceptions WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 @end

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -3578,7 +3578,7 @@ void WebPageProxy::receivedNavigationPolicyDecision(PolicyAction policyAction, A
     if (navigation && !navigation->userContentExtensionsEnabled()) {
         if (!navigation->websitePolicies())
             navigation->setWebsitePolicies(API::WebsitePolicies::create());
-        navigation->websitePolicies()->setContentBlockersEnabled(false);
+        navigation->websitePolicies()->setContentExtensionEnablement({ ContentExtensionDefaultEnablement::Disabled, { } });
     }
 
 #if ENABLE(DEVICE_ORIENTATION)

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
@@ -64,6 +64,7 @@
 - (void)synchronouslyLoadHTMLString:(NSString *)html baseURL:(NSURL *)url;
 - (void)synchronouslyLoadHTMLString:(NSString *)html preferences:(WKWebpagePreferences *)preferences;
 - (void)synchronouslyLoadRequest:(NSURLRequest *)request;
+- (void)synchronouslyLoadRequest:(NSURLRequest *)request preferences:(WKWebpagePreferences *)preferences;
 - (void)synchronouslyLoadRequestIgnoringSSLErrors:(NSURLRequest *)request;
 - (void)synchronouslyLoadTestPageNamed:(NSString *)pageName;
 - (BOOL)_synchronouslyExecuteEditCommand:(NSString *)command argument:(NSString *)argument;

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
@@ -87,6 +87,12 @@ static NSString *overrideBundleIdentifier(id, SEL)
     [self _test_waitForDidFinishNavigation];
 }
 
+- (void)synchronouslyLoadRequest:(NSURLRequest *)request preferences:(WKWebpagePreferences *)preferences
+{
+    [self loadRequest:request];
+    [self _test_waitForDidFinishNavigationWithPreferences:preferences];
+}
+
 - (void)synchronouslyLoadRequestIgnoringSSLErrors:(NSURLRequest *)request
 {
     [self loadRequest:request];


### PR DESCRIPTION
#### f9309fb655519c8b3aa0c2ea92813f5c97c44ee7
<pre>
Augment the content rule list allowlist mechanism introduced in 259930@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=251922">https://bugs.webkit.org/show_bug.cgi?id=251922</a>
rdar://104453682

Reviewed by Alex Christensen.

The previous change in <a href="https://commits.webkit.org/259930@main">https://commits.webkit.org/259930@main</a> added a way to configure content rule
list enablement in the following three ways, as a per-navigation switch:

1. Unconditionally enable all content rule lists.
2. Unconditionally disable all content rule lists.
3. Enable a specific subset of content rule lists (by identifier).

Unfortunately, this turned out to be insufficient to fulfill the internal client&apos;s use case, which
requires a fourth enablement configuration that&apos;s not (easily) expressible through existing means:

4. Disable a specific subset of content rule lists (by identifier).

To make it possible to configure all 4 of the above on a per-navigation basis, we replace both the
existing `-_contentBlockersEnabled` flag and the newer `-_disabledContentRuleListIdentifiers`
property with a single SPI:

```
- (void)_setContentRuleListsEnabled:(BOOL)enabled exceptions:(NSSet&lt;NSString *&gt; *)exceptions;
```

* Source/WebCore/loader/DocumentLoader.h:
(WebCore::DocumentLoader::contentExtensionEnablement const):
(WebCore::DocumentLoader::setContentExtensionEnablement):
(WebCore::DocumentLoader::disabledContentExtensions const): Deleted.
(WebCore::DocumentLoader::setDisabledContentExtensions): Deleted.

Rename `DisabledContentExtensions` to `ContentExtensionEnablement`, and change it from a variant to
a pair (now that *both* the enum type and `HashSet` are required in order to express all potential
configurations).

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::reload):
* Source/WebCore/page/UserContentProvider.cpp:
(WebCore::ruleListFilter):
(WebCore::UserContentProvider::processContentRuleListsForLoad):
(WebCore::contentRuleListsEnabled): Deleted.
* Source/WebKit/Shared/WebsitePoliciesData.cpp:
(WebKit::WebsitePoliciesData::encode const):
(WebKit::WebsitePoliciesData::decode):

More renaming: `WebCore::DisabledContentExtensions` -&gt; `WebCore::ContentExtensionEnablement`.

(WebKit::WebsitePoliciesData::applyToDocumentLoader):
* Source/WebKit/Shared/WebsitePoliciesData.h:
* Source/WebKit/UIProcess/API/APIWebsitePolicies.cpp:
(API::WebsitePolicies::copy const):
(API::WebsitePolicies::data):
(API::WebsitePolicies::contentBlockersEnabled const): Deleted.
(API::WebsitePolicies::setContentBlockersEnabled): Deleted.
(API::WebsitePolicies::setDisabledContentRuleListIdentifiers): Deleted.
(API::WebsitePolicies::disabledContentRuleListIdentifiers const): Deleted.
* Source/WebKit/UIProcess/API/APIWebsitePolicies.h:
* Source/WebKit/UIProcess/API/C/WKWebsitePolicies.cpp:
(WKWebsitePoliciesSetContentBlockersEnabled):
(WKWebsitePoliciesGetContentBlockersEnabled):
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm:
(-[WKWebpagePreferences _setContentBlockersEnabled:]):
(-[WKWebpagePreferences _contentBlockersEnabled]):

Reimplement these in terms of the new SPI, by treating these as default-enablement (or default-
disablement) with no rule list exceptions.

(-[WKWebpagePreferences _setContentRuleListsEnabled:exceptions:]):
(-[WKWebpagePreferences _setDisabledContentRuleListIdentifiers:]): Deleted.
(-[WKWebpagePreferences _disabledContentRuleListIdentifiers]): Deleted.

Replace the property added in 259930@main with a set-only method instead.

* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::receivedNavigationPolicyDecision):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm:

Adjust an existing API test to check for both default-enablement (with an exception rule list ID to
disable), as well as default-disablement (with an exception rule list ID to enable).

* Tools/TestWebKitAPI/cocoa/TestWKWebView.h:
* Tools/TestWebKitAPI/cocoa/TestWKWebView.mm:
(-[WKWebView synchronouslyLoadRequest:preferences:]):

Add a new API test helper method on `TestWKWebView`.

Canonical link: <a href="https://commits.webkit.org/260084@main">https://commits.webkit.org/260084@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c78683483e66860ea8288615e0a19888a70dc341

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106954 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15990 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39747 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116133 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115673 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110855 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17472 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7187 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99139 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112719 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13223 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96250 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40821 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95115 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27892 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9133 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29244 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9712 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6243 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15300 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48803 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6964 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11242 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->