### PR TITLE
[git-webkit] Consider bug classification

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/setup.py
+++ b/Tools/Scripts/libraries/webkitbugspy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='webkitbugspy',
-    version='0.9.5',
+    version='0.9.6',
     description='Library containing a shared API for various bug trackers.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(0, 9, 5)
+version = Version(0, 9, 6)
 
 from .user import User
 from .issue import Issue

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py
@@ -165,6 +165,7 @@ class Tracker(GenericTracker):
     def populate(self, issue, member=None):
         issue._link = '{}/show_bug.cgi?id={}'.format(self.url, issue.id)
         issue._labels = []
+        issue._classification = ''  # Bugzilla doesn't have a concept of "classification"
 
         if member in ('title', 'timestamp', 'creator', 'opened', 'assignee', 'watchers', 'project', 'component', 'version', 'keywords'):
             response = requests.get('{}/rest/bug/{}{}'.format(self.url, issue.id, self._login_arguments(required=False)))

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py
@@ -235,6 +235,7 @@ with 'repo' and 'workflow' access and appropriate 'Expiration' for your {host} u
         issue._link = '{}/issues/{}'.format(self.url, issue.id)
         issue._project = self.name
         issue._keywords = []  # We don't yet have a defined idiom for "keywords" in GitHub Issues
+        issue._classification = ''  # We don't yet have a defined idiom for "classification" in GitHub issues
 
         if member in ('title', 'timestamp', 'creator', 'opened', 'assignee', 'description', 'project', 'component', 'version', 'labels', 'milestone'):
             response = self.request(path='issues/{}'.format(issue.id))

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py
@@ -73,6 +73,7 @@ class Issue(object):
         self._version = None
         self._milestone = None
         self._keywords = None
+        self._classification = None
 
         self.tracker.populate(self, None)
 
@@ -196,10 +197,16 @@ class Issue(object):
         return self._keywords
 
     @property
+    def classification(self):
+        if self._classification is None:
+            self.tracker.populate(self, 'classification')
+        return self._classification
+
+    @property
     def redacted(self):
-        match_string = 'title:{};project:{};component:{};version:{}'.format(
-            self.title or '', self.project or '', self.component or '', self.version or '',
-        )
+        match_string = ''
+        for member in ('title', 'project', 'component', 'version', 'classification'):
+            match_string += ';{}:{}'.format(member, getattr(self, member, ''))
         for key, value in self.tracker._redact.items():
             if key.search(match_string):
                 return self.tracker.Redaction(

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/radar.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/radar.py
@@ -128,6 +128,7 @@ class RadarModel(object):
         self._issue = issue
         self.title = issue['title']
         self.id = issue['id']
+        self.classification = issue.get('classification', 'Other Bug')
         self.createdAt = datetime.utcfromtimestamp(issue['timestamp'] - timedelta(hours=7).seconds)
         self.assignee = self.Person(Radar.transform_user(issue['assignee']))
         self.description = self.CollectionProperty(self, self.DescriptionEntry(issue['description']))

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py
@@ -210,6 +210,9 @@ class Tracker(GenericTracker):
         if member == 'keywords':
             issue._keywords = [kw.name for kw in (radar.keywords() or [])]
 
+        if member == 'classification':
+            issue._classification = radar.classification
+
         if member == 'watchers':
             issue._watchers = []
             for member in radar.cc_memberships.items():

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py
@@ -516,3 +516,8 @@ What component in 'WebKit' should the bug be associated with?:
         with mocks.Bugzilla(self.URL.split('://')[1], issues=mocks.ISSUES):
             tracker = bugzilla.Tracker(self.URL)
             self.assertEqual(tracker.issue(1).keywords, ['Keyword A'])
+
+    def test_classification(self):
+        with mocks.Bugzilla(self.URL.split('://')[1], issues=mocks.ISSUES):
+            tracker = bugzilla.Tracker(self.URL)
+            self.assertEqual(tracker.issue(1).classification, '')

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/github_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/github_unittest.py
@@ -415,3 +415,8 @@ Documentation URL: https://docs.github.com/rest/reference/pulls#create-a-pull-re
         with mocks.GitHub(self.URL.split('://')[1], issues=mocks.ISSUES):
             tracker = github.Tracker(self.URL)
             self.assertEqual(tracker.issue(1).milestone, 'October')
+
+    def test_classification(self):
+        with mocks.GitHub(self.URL.split('://')[1], issues=mocks.ISSUES):
+            tracker = github.Tracker(self.URL)
+            self.assertEqual(tracker.issue(1).classification, '')

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py
@@ -382,3 +382,8 @@ What version of 'WebKit Text' should the bug be associated with?:
         with mocks.Radar(issues=mocks.ISSUES):
             tracker = radar.Tracker()
             self.assertEqual(tracker.issue(1).keywords, ['Keyword A'])
+
+    def test_classification(self):
+        with mocks.Radar(issues=mocks.ISSUES):
+            tracker = radar.Tracker()
+            self.assertEqual(tracker.issue(1).classification, 'Other Bug')

--- a/metadata/trackers.json
+++ b/metadata/trackers.json
@@ -20,7 +20,8 @@
         "type" : "radar",
         "projects" : ["JavaScriptCore", "WebKit"],
         "redact" : {
-            ".*": true
+            "classification:Security": true,
+            "tentpole:.*Security.*": true
         }
     }
 ]


### PR DESCRIPTION
#### 1e4df5db1f28c4e8ef91e920366bba1a50dfad9c
<pre>
[git-webkit] Consider bug classification
<a href="https://bugs.webkit.org/show_bug.cgi?id=251933">https://bugs.webkit.org/show_bug.cgi?id=251933</a>
rdar://105180880

Reviewed by Dewei Zhu.

* Tools/Scripts/libraries/webkitbugspy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py:
(Tracker.populate): Set classification to empty.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py:
(Tracker.populate): Set classification to empty.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py:
(Issue.__init__): Add classification member.
(Issue.classification): Populate and return classification member.
(Issue.redacted): Include classification in redaction check.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/radar.py:
(RadarModel.__init__): Add classification member.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py:
(Tracker.populate): Populate classification from radar.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py:
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/github_unittest.py:
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py:
* metadata/trackers.json:

Canonical link: <a href="https://commits.webkit.org/260029@main">https://commits.webkit.org/260029@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ae2a67fec2e846918e112ee003e611c31253824

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/106812 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/15834 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/39597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/115995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/115567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/110715 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/17327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/7038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/99000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/112580 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/17327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/39597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/99000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/5/builds/110303 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/17327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/39597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/99000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/9011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/39597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/9579 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/7038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/15180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/39597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/11105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3738 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->