### PR TITLE
Import 'form-associated-element.html' test from Chromium (Blink)

### DIFF
--- a/LayoutTests/fast/forms/form-associated-element-expected.txt
+++ b/LayoutTests/fast/forms/form-associated-element-expected.txt
@@ -1,0 +1,69 @@
+Verify that only elements that are 'form associatable' get a form owner.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS elements.length > 0 is true
+Testing LABEL
+PASS formOwner is "not defined"
+Testing INPUT
+PASS formOwner is "not defined"
+Testing BUTTON
+PASS formOwner is "defined"
+Testing FIELDSET
+PASS formOwner is "defined"
+Testing INPUT
+PASS formOwner is "defined"
+Testing INPUT
+PASS formOwner is "defined"
+Testing LABEL
+PASS formOwner is "not defined"
+Testing INPUT
+PASS formOwner is "not defined"
+Testing OBJECT
+PASS formOwner is "defined"
+Testing SELECT
+PASS formOwner is "defined"
+Testing TEXTAREA
+PASS formOwner is "defined"
+Testing IMG
+PASS formOwner is "defined"
+Testing OPTION
+PASS formOwner is "not defined"
+Testing DIV
+PASS formOwner is "not defined"
+Testing A
+PASS formOwner is "not defined"
+Testing P
+PASS formOwner is "not defined"
+Testing INPUT
+PASS formOwner is "defined"
+Testing OBJECT
+PASS formOwner is "defined"
+Testing SELECT
+PASS formOwner is "defined"
+Testing PRE
+PASS formOwner is "not defined"
+Testing SPAN
+PASS formOwner is "not defined"
+Testing IMG
+PASS formOwner is "not defined"
+
+Tests for association-by-parser:
+PASS form2['input1'] is defined.
+PASS form2['image1'] is defined.
+PASS form2['input-in-document'] is defined.
+PASS form2['image-in-document'] is defined.
+Detach a form, input1 and image1 from the document
+PASS form2['input1'] is defined.
+PASS form2['image1'] is defined.
+PASS form2['input-in-document'] is undefined.
+PASS form2['image-in-document'] is undefined.
+Association-by-parser should not work for non-Document trees
+PASS removed.querySelector('form')['image4'] is undefined.
+PASS removed.querySelector('input').form is null
+PASS removed.querySelector('object').form is null
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/form-associated-element.html
+++ b/LayoutTests/fast/forms/form-associated-element.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script type="text/javascript" src="../../resources/js-test.js"></script>
+<script type="text/javascript">
+var formOwner;
+function hasFormOwner(shouldHaveOwner, haveIt, event)
+{
+    formOwner = haveIt || "not defined";
+    debug("Testing " + event.target.tagName);
+    if (shouldHaveOwner)
+        shouldBeEqualToString("formOwner", "defined");
+    else
+        shouldBeEqualToString("formOwner", "not defined");
+}
+</script>
+</head>
+<body>
+<div style="display: none;">
+<form id=topForm>
+<label form=topForm onerror="" onclick="hasFormOwner(false, typeof canary !== 'undefined' && canary, event);"><input type="button"/></label>
+<!-- Form-associated elements per http://whatwg.org/specs/web-apps/current-work/#form-associated-element -->
+<button onerror="hasFormOwner(true, typeof canary !== 'undefined' && canary, event);"></button>
+<fieldset onerror="hasFormOwner(true, typeof canary !== 'undefined' && canary, event);"></fieldset>
+<input type=radio onerror="hasFormOwner(true, typeof canary !== 'undefined' && canary, event);"/>
+<input type=number onerror="hasFormOwner(true, typeof canary !== 'undefined' && canary, event);"/>
+<label onerror="" onclick="hasFormOwner(false, typeof canary !== 'undefined' && canary, event);"><input type="button"/></label>
+<object onerror="hasFormOwner(true, typeof canary !== 'undefined' && canary, event);"></object>
+<select onerror="hasFormOwner(true, typeof canary !== 'undefined' && canary, event);"></select>
+<textarea onerror="hasFormOwner(true, typeof canary !== 'undefined' && canary, event);"></textarea>
+<img onerror="hasFormOwner(true, typeof canary !== 'undefined' && canary, event);"></img>
+
+<!-- Elements that aren't associated. -->
+<option onerror="hasFormOwner(false, typeof canary !== 'undefined' && canary, event);"></option>
+<div onerror="hasFormOwner(false, typeof canary !== 'undefined' && canary, event);"></div>
+<a onerror="hasFormOwner(false, typeof canary !== 'undefined' && canary, event);"></a>
+<p onerror="hasFormOwner(false, typeof canary !== 'undefined' && canary, event);"></p>
+</form>
+
+<!-- Elements that associated by 'form' reference rather than ancestor. -->
+<input form=topForm type="number" onerror="hasFormOwner(true, typeof canary !== 'undefined' && canary, event);"/>
+<object form=topForm onerror="hasFormOwner(true, typeof canary !== 'undefined' && canary, event);"></object>
+<select form=topForm onerror="hasFormOwner(true, typeof canary !== 'undefined' && canary, event);"></select>
+<pre form=topForm onerror="hasFormOwner(false, typeof canary !== 'undefined' && canary, event);"></pre>
+<span form=topForm onerror="hasFormOwner(false, typeof canary !== 'undefined' && canary, event);"></span>
+<img form=topForm onerror="hasFormOwner(false, typeof canary !== 'undefined' && canary, event);"></img>
+
+<!-- Elements associated to a unclosed <form> by the HTML parser -->
+<div id="willBeRemoved">
+<div><form id="form2"></div>
+<input name="input1">
+<img name="image1">
+</div>
+<input name="input-in-document">
+<select name="select-in-document"></select>
+<img name="image-in-document">
+
+</div>
+<script>
+description("Verify that only elements that are 'form associatable' get a form owner.");
+
+var elements;
+function testFormAssociation()
+{
+   document.forms[0].canary = "defined";
+   elements = document.querySelectorAll("*[onerror]");
+   shouldBeTrue("elements.length > 0");
+   for (var i = 0; i < elements.length; ++i) {
+        // <label/> won't handle 'error', use 'click'.
+        var eventType = (elements[i] instanceof HTMLLabelElement) ? "click" : "error";
+        elements[i].dispatchEvent(new MouseEvent(eventType));
+   }
+}
+testFormAssociation();
+
+debug("");
+debug("Tests for association-by-parser:");
+var form2 = document.querySelector("#form2");
+shouldBeDefined("form2['input1']");
+shouldBeDefined("form2['image1']");
+shouldBeDefined("form2['input-in-document']");
+shouldBeDefined("form2['image-in-document']");
+var removed = document.querySelector("#willBeRemoved");
+removed.parentNode.removeChild(removed);
+debug("Detach a form, input1 and image1 from the document");
+shouldBeDefined("form2['input1']");
+shouldBeDefined("form2['image1']");
+shouldBeUndefined("form2['input-in-document']");
+shouldBeUndefined("form2['image-in-document']");
+
+debug("Association-by-parser should not work for non-Document trees");
+removed.innerHTML = "<table><form><tr><td><input><object></object><img name='image4'></td></tr></form>";
+shouldBeUndefined("removed.querySelector('form')['image4']");
+shouldBeNull("removed.querySelector('input').form");
+shouldBeNull("removed.querySelector('object').form");
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 52f00031f8623ddd369b88b7b34285a3caed7b19
<pre>
Import &apos;form-associated-element.html&apos; test from Chromium (Blink)

Import &apos;form-associated-element.html&apos; test from Chromium (Blink)
<a href="https://bugs.webkit.org/show_bug.cgi?id=250695">https://bugs.webkit.org/show_bug.cgi?id=250695</a>

Reviewed by Alexey Shvayka.

Import - <a href="https://github.com/chromium/chromium/blob/main/third_party/blink/web_tests/fast/forms/form-associated-element.html">https://github.com/chromium/chromium/blob/main/third_party/blink/web_tests/fast/forms/form-associated-element.html</a>

This PR is to bring above linked test case from Chromium repository to WebKit
for future tracking of any possible regressions.

* LayoutTests/fast/forms/form-associated-element.html: Add Test Case
* LayoutTests/fast/forms/form-associated-element-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/260053@main">https://commits.webkit.org/260053@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5b196c7a98e0bae60e6f006479d54ada3024369

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106836 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15869 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39627 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116019 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115581 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17346 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7074 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99023 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112604 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13143 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96142 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40747 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95027 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27794 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9028 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29149 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9603 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6158 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15195 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48694 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6940 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11130 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->