### PR TITLE
Reenable BIGINT32 optimization

### DIFF
--- a/Source/WTF/wtf/PlatformUse.h
+++ b/Source/WTF/wtf/PlatformUse.h
@@ -146,9 +146,7 @@
 #endif
 
 #if USE(JSVALUE64)
-/* FIXME: Enable BIGINT32 optimization again after we ensure Speedometer2 and JetStream2 regressions are fixed. */
-/* https://bugs.webkit.org/show_bug.cgi?id=214777 */
-#define USE_BIGINT32 0
+#define USE_BIGINT32 1
 #endif
 
 /* FIXME: This name should be more specific if it is only for use with CallFrame* */


### PR DESCRIPTION
#### 7351530eb7a4e5c4ce43bac4fdf8d365ce83d81c
<pre>
Reenable BIGINT32 optimization
<a href="https://bugs.webkit.org/show_bug.cgi?id=214777">https://bugs.webkit.org/show_bug.cgi?id=214777</a>

Reviewed by NOBODY (OOPS!).

Since the Speedometer2 and JetStream2 regressions were fixed, we can
reenable BIGINT32 optimization.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7351530eb7a4e5c4ce43bac4fdf8d365ce83d81c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106788 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15802 "Hash 7351530e for PR 9824 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39572 "Hash 7351530e for PR 9824 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115975 "Hash 7351530e for PR 9824 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115549 "Hash 7351530e for PR 9824 does not build (failure)") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17303 "Hash 7351530e for PR 9824 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7016 "Hash 7351530e for PR 9824 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98980 "Hash 7351530e for PR 9824 does not build (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112556 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/76/builds/17303 "Hash 7351530e for PR 9824 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/39572 "Hash 7351530e for PR 9824 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/98980 "Hash 7351530e for PR 9824 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/76/builds/17303 "Hash 7351530e for PR 9824 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/39572 "Hash 7351530e for PR 9824 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/98980 "Hash 7351530e for PR 9824 does not build (failure)") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/96322 "Hash 7351530e for PR 9824 does not build (failure)") | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8992 "Hash 7351530e for PR 9824 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/39572 "Hash 7351530e for PR 9824 does not build (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/95791 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/6927 "Hash 7351530e for PR 9824 does not build (failure)") | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9558 "Hash 7351530e for PR 9824 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/85/builds/7016 "Hash 7351530e for PR 9824 does not build (failure)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30699 "Passed tests") | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15161 "Hash 7351530e for PR 9824 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/39572 "Hash 7351530e for PR 9824 does not build (failure)") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/104544 "Built successfully") | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11082 "Hash 7351530e for PR 9824 does not build (failure)") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25892 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->