### PR TITLE
Fix bug with empty header values in Headers objects with "request-no-cors" guard

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-headers.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-headers.any-expected.txt
@@ -48,6 +48,7 @@ PASS Adding invalid no-cors request header "proxy: KO"
 PASS Adding invalid no-cors request header "proxya: KO"
 PASS Adding invalid no-cors request header "sec: KO"
 PASS Adding invalid no-cors request header "secb: KO"
+PASS Adding invalid no-cors request header "Empty-Value: "
 PASS Check that request constructor is filtering headers provided as init parameter
 PASS Check that no-cors request constructor is filtering headers provided as init parameter
 PASS Check that no-cors request constructor is filtering headers provided as part of request parameter

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-headers.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-headers.any.js
@@ -58,6 +58,7 @@ var invalidRequestNoCorsHeaders = [
   ["proxya", "KO"],
   ["sec", "KO"],
   ["secb", "KO"],
+  ["Empty-Value", ""],
 ];
 
 validRequestHeaders.forEach(function(header) {

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-headers.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-headers.any.serviceworker-expected.txt
@@ -48,6 +48,7 @@ PASS Adding invalid no-cors request header "proxy: KO"
 PASS Adding invalid no-cors request header "proxya: KO"
 PASS Adding invalid no-cors request header "sec: KO"
 PASS Adding invalid no-cors request header "secb: KO"
+PASS Adding invalid no-cors request header "Empty-Value: "
 PASS Check that request constructor is filtering headers provided as init parameter
 PASS Check that no-cors request constructor is filtering headers provided as init parameter
 PASS Check that no-cors request constructor is filtering headers provided as part of request parameter

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-headers.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-headers.any.sharedworker-expected.txt
@@ -48,6 +48,7 @@ PASS Adding invalid no-cors request header "proxy: KO"
 PASS Adding invalid no-cors request header "proxya: KO"
 PASS Adding invalid no-cors request header "sec: KO"
 PASS Adding invalid no-cors request header "secb: KO"
+PASS Adding invalid no-cors request header "Empty-Value: "
 PASS Check that request constructor is filtering headers provided as init parameter
 PASS Check that no-cors request constructor is filtering headers provided as init parameter
 PASS Check that no-cors request constructor is filtering headers provided as part of request parameter

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-headers.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-headers.any.worker-expected.txt
@@ -48,6 +48,7 @@ PASS Adding invalid no-cors request header "proxy: KO"
 PASS Adding invalid no-cors request header "proxya: KO"
 PASS Adding invalid no-cors request header "sec: KO"
 PASS Adding invalid no-cors request header "secb: KO"
+PASS Adding invalid no-cors request header "Empty-Value: "
 PASS Check that request constructor is filtering headers provided as init parameter
 PASS Check that no-cors request constructor is filtering headers provided as init parameter
 PASS Check that no-cors request constructor is filtering headers provided as part of request parameter

--- a/Source/WebCore/Modules/fetch/FetchHeaders.cpp
+++ b/Source/WebCore/Modules/fetch/FetchHeaders.cpp
@@ -50,7 +50,7 @@ static ExceptionOr<bool> canWriteHeader(const String& name, const String& value,
         return Exception { TypeError, "Headers object's guard is 'immutable'"_s };
     if (guard == FetchHeaders::Guard::Request && isForbiddenHeader(name, value))
         return false;
-    if (guard == FetchHeaders::Guard::RequestNoCors && !combinedValue.isEmpty() && !isSimpleHeader(name, combinedValue))
+    if (guard == FetchHeaders::Guard::RequestNoCors && !isSimpleHeader(name, combinedValue))
         return false;
     if (guard == FetchHeaders::Guard::Response && isForbiddenResponseHeaderName(name))
         return false;


### PR DESCRIPTION
#### 2fbadf6b9f239a07d7480fc0ae39fe96b74ac093
<pre>
Fix bug with empty header values in Headers objects with &quot;request-no-cors&quot; guard
<a href="https://bugs.webkit.org/show_bug.cgi?id=251936">https://bugs.webkit.org/show_bug.cgi?id=251936</a>

Reviewed by Youenn Fablet.

The `canWriteHeader` function in `FetchHeaders.cpp` checks whether a
header name and value are valid for the guard of a Headers object.
However, for the &quot;request-no-cors&quot; guard, this check only applies if the
combined value of that header name is not the empty string.

This check is not in the fetch specification, and seems to be there
because such validation is skipped for the &quot;request-no-cors&quot; guard when
deleting a header, and in the spec this validation happens as if the
combined value was the empty string. However, WebKit&apos;s implementation
does not currently use this method when removing headers, and as shown
here, this extra condition allows setting headers when they should not
be allowed.

* LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-headers.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-headers.any.js:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-headers.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-headers.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-headers.any.worker-expected.txt:
* Source/WebCore/Modules/fetch/FetchHeaders.cpp:
(WebCore::canWriteHeader):

Canonical link: <a href="https://commits.webkit.org/260066@main">https://commits.webkit.org/260066@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ea3dedc5900d94de31d3b3f0f10eca14142d00c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106891 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15927 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39690 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116072 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115624 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110794 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17412 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7125 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99077 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112658 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13174 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96200 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40773 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95064 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27845 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9077 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29200 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9654 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6194 "Found 1 new test failure: fast/text-autosizing/ios/autosize-width.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15244 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48754 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6948 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11183 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->