### PR TITLE
Web Inspector: Show grid/flex overlays when highlighting elements

### DIFF
--- a/Source/JavaScriptCore/inspector/protocol/DOM.json
+++ b/Source/JavaScriptCore/inspector/protocol/DOM.json
@@ -494,18 +494,22 @@
             "description": "Highlights all DOM nodes that match a given selector. A string containing a CSS selector must be specified.",
             "targetTypes": ["page"],
             "parameters": [
-                { "name": "highlightConfig", "$ref": "HighlightConfig", "description": "A descriptor for the highlight appearance." },
                 { "name": "selectorString", "type": "string", "description": "A CSS selector for finding matching nodes to highlight." },
-                { "name": "frameId", "type": "string", "optional": true, "description": "Identifier of the frame which will be searched using the selector.  If not provided, the main frame will be used." }
+                { "name": "frameId", "type": "string", "optional": true, "description": "Identifier of the frame which will be searched using the selector.  If not provided, the main frame will be used." },
+                { "name": "highlightConfig", "$ref": "HighlightConfig", "description": "A descriptor for the highlight appearance." },
+                { "name": "gridOverlayConfig", "$ref": "GridOverlayConfig", "optional": true, "description": "If provided, used to configure a grid overlay shown during element selection. This overrides DOM.showGridOverlay." },
+                { "name": "flexOverlayConfig", "$ref": "FlexOverlayConfig", "optional": true, "description": "If provided, used to configure a flex overlay shown during element selection. This overrides DOM.showFlexOverlay." }
             ]
         },
         {
             "name": "highlightNode",
             "description": "Highlights DOM node with given id or with the given JavaScript object wrapper. Either nodeId or objectId must be specified.",
             "parameters": [
-                { "name": "highlightConfig", "$ref": "HighlightConfig", "description": "A descriptor for the highlight appearance." },
                 { "name": "nodeId", "$ref": "NodeId", "optional": true, "description": "Identifier of the node to highlight." },
-                { "name": "objectId", "$ref": "Runtime.RemoteObjectId", "optional": true, "description": "JavaScript object id of the node to be highlighted." }
+                { "name": "objectId", "$ref": "Runtime.RemoteObjectId", "optional": true, "description": "JavaScript object id of the node to be highlighted." },
+                { "name": "highlightConfig", "$ref": "HighlightConfig", "description": "A descriptor for the highlight appearance." },
+                { "name": "gridOverlayConfig", "$ref": "GridOverlayConfig", "optional": true, "description": "If provided, used to configure a grid overlay shown during element selection. This overrides DOM.showGridOverlay." },
+                { "name": "flexOverlayConfig", "$ref": "FlexOverlayConfig", "optional": true, "description": "If provided, used to configure a flex overlay shown during element selection. This overrides DOM.showFlexOverlay." }
             ]
         },
         {
@@ -513,7 +517,9 @@
             "description": "Highlights each DOM node in the given list.",
             "parameters": [
                 { "name": "nodeIds", "type": "array", "items": { "$ref": "NodeId" } },
-                { "name": "highlightConfig", "$ref": "HighlightConfig" }
+                { "name": "highlightConfig", "$ref": "HighlightConfig" },
+                { "name": "gridOverlayConfig", "$ref": "GridOverlayConfig", "optional": true, "description": "If provided, used to configure a grid overlay shown during element selection. This overrides DOM.showGridOverlay." },
+                { "name": "flexOverlayConfig", "$ref": "FlexOverlayConfig", "optional": true, "description": "If provided, used to configure a flex overlay shown during element selection. This overrides DOM.showFlexOverlay." }
             ]
         },
         {

--- a/Source/WebCore/inspector/InspectorOverlay.h
+++ b/Source/WebCore/inspector/InspectorOverlay.h
@@ -201,8 +201,8 @@ public:
     bool shouldShowOverlay() const;
 
     void hideHighlight();
-    void highlightNodeList(RefPtr<NodeList>&&, const Highlight::Config&);
-    void highlightNode(Node*, const Highlight::Config&);
+    void highlightNodeList(RefPtr<NodeList>&&, const Highlight::Config&, const std::optional<Grid::Config>& = std::nullopt, const std::optional<Flex::Config>& = std::nullopt);
+    void highlightNode(Node*, const Highlight::Config&, const std::optional<Grid::Config>& = std::nullopt, const std::optional<Flex::Config>& = std::nullopt);
     void highlightQuad(std::unique_ptr<FloatQuad>, const Highlight::Config&);
 
     void setShowPaintRects(bool);
@@ -223,14 +223,10 @@ public:
     // Multiple grid and flex overlays can be active at the same time. These methods
     // will fail if the node is not a grid or if the node has been GC'd.
 
-    void showHighlightGridOverlayForNode(Node&, const InspectorOverlay::Grid::Config&);
-    void hideHighlightGridOverlay();
     Inspector::ErrorStringOr<void> setGridOverlayForNode(Node&, const InspectorOverlay::Grid::Config&);
     Inspector::ErrorStringOr<void> clearGridOverlayForNode(Node&);
     void clearAllGridOverlays();
 
-    void showHighlightFlexOverlayForNode(Node&, const InspectorOverlay::Flex::Config&);
-    void hideHighlightFlexOverlay();
     Inspector::ErrorStringOr<void> setFlexOverlayForNode(Node&, const InspectorOverlay::Flex::Config&);
     Inspector::ErrorStringOr<void> clearFlexOverlayForNode(Node&);
     void clearAllFlexOverlays();
@@ -267,6 +263,8 @@ private:
     RefPtr<Node> m_highlightNode;
     RefPtr<NodeList> m_highlightNodeList;
     Highlight::Config m_nodeHighlightConfig;
+    std::optional<Grid::Config> m_nodeGridOverlayConfig;
+    std::optional<Flex::Config> m_nodeFlexOverlayConfig;
 
     std::unique_ptr<FloatQuad> m_highlightQuad;
     Highlight::Config m_quadHighlightConfig;
@@ -274,10 +272,7 @@ private:
     Deque<TimeRectPair> m_paintRects;
     Timer m_paintRectUpdateTimer;
 
-    std::optional<InspectorOverlay::Grid> m_highlightGridOverlay;
     Vector<InspectorOverlay::Grid> m_activeGridOverlays;
-
-    std::optional<InspectorOverlay::Flex> m_highlightFlexOverlay;
     Vector<InspectorOverlay::Flex> m_activeFlexOverlays;
 
     bool m_indicating { false };

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.h
@@ -144,9 +144,9 @@ public:
     Inspector::Protocol::ErrorStringOr<void> hideHighlight();
     Inspector::Protocol::ErrorStringOr<void> highlightRect(int x, int y, int width, int height, RefPtr<JSON::Object>&& color, RefPtr<JSON::Object>&& outlineColor, std::optional<bool>&& usePageCoordinates);
     Inspector::Protocol::ErrorStringOr<void> highlightQuad(Ref<JSON::Array>&& quad, RefPtr<JSON::Object>&& color, RefPtr<JSON::Object>&& outlineColor, std::optional<bool>&& usePageCoordinates);
-    Inspector::Protocol::ErrorStringOr<void> highlightSelector(Ref<JSON::Object>&& highlightConfig, const String& selectorString, const Inspector::Protocol::Network::FrameId&);
-    Inspector::Protocol::ErrorStringOr<void> highlightNode(Ref<JSON::Object>&& highlightConfig, std::optional<Inspector::Protocol::DOM::NodeId>&&, const Inspector::Protocol::Runtime::RemoteObjectId&);
-    Inspector::Protocol::ErrorStringOr<void> highlightNodeList(Ref<JSON::Array>&& nodeIds, Ref<JSON::Object>&& highlightConfig);
+    Inspector::Protocol::ErrorStringOr<void> highlightSelector(const String& selectorString, const Inspector::Protocol::Network::FrameId&, Ref<JSON::Object>&& highlightConfig, RefPtr<JSON::Object>&& gridOverlayConfig, RefPtr<JSON::Object>&& flexOverlayConfig);
+    Inspector::Protocol::ErrorStringOr<void> highlightNode(std::optional<Inspector::Protocol::DOM::NodeId>&&, const Inspector::Protocol::Runtime::RemoteObjectId&, Ref<JSON::Object>&& highlightConfig, RefPtr<JSON::Object>&& gridOverlayConfig, RefPtr<JSON::Object>&& flexOverlayConfig);
+    Inspector::Protocol::ErrorStringOr<void> highlightNodeList(Ref<JSON::Array>&& nodeIds, Ref<JSON::Object>&& highlightConfig, RefPtr<JSON::Object>&& gridOverlayConfig, RefPtr<JSON::Object>&& flexOverlayConfig);
     Inspector::Protocol::ErrorStringOr<void> highlightFrame(const Inspector::Protocol::Network::FrameId&, RefPtr<JSON::Object>&& color, RefPtr<JSON::Object>&& outlineColor);
     Inspector::Protocol::ErrorStringOr<void> showGridOverlay(Inspector::Protocol::DOM::NodeId, Ref<JSON::Object>&& gridOverlayConfig);
     Inspector::Protocol::ErrorStringOr<void> hideGridOverlay(std::optional<Inspector::Protocol::DOM::NodeId>&&);
@@ -226,8 +226,8 @@ private:
     void highlightMousedOverNode();
     void setSearchingForNode(Inspector::Protocol::ErrorString&, bool enabled, RefPtr<JSON::Object>&& highlightConfig, RefPtr<JSON::Object>&& gridOverlayConfig, RefPtr<JSON::Object>&& flexOverlayConfig, bool showRulers);
     std::unique_ptr<InspectorOverlay::Highlight::Config> highlightConfigFromInspectorObject(Inspector::Protocol::ErrorString&, RefPtr<JSON::Object>&& highlightInspectorObject);
-    std::optional<InspectorOverlay::Grid::Config> gridOverlayConfigFromInspectorObject(Inspector::Protocol::ErrorString&, Ref<JSON::Object>&& gridOverlayInspectorObject);
-    std::optional<InspectorOverlay::Flex::Config> flexOverlayConfigFromInspectorObject(Inspector::Protocol::ErrorString&, Ref<JSON::Object>&& flexOverlayInspectorObject);
+    std::optional<InspectorOverlay::Grid::Config> gridOverlayConfigFromInspectorObject(Inspector::Protocol::ErrorString&, RefPtr<JSON::Object>&& gridOverlayInspectorObject);
+    std::optional<InspectorOverlay::Flex::Config> flexOverlayConfigFromInspectorObject(Inspector::Protocol::ErrorString&, RefPtr<JSON::Object>&& flexOverlayInspectorObject);
 
     // Node-related methods.
     Inspector::Protocol::DOM::NodeId bind(Node&);

--- a/Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js
@@ -87,25 +87,45 @@ WI.DOMManager = class DOMManager extends WI.Object
 
     // Static
 
-    static buildHighlightConfig(mode)
+    static buildHighlightConfigs(mode)
     {
         mode = mode || "all";
 
-        let highlightConfig = {showInfo: mode === "all"};
+        let commandArguments = {
+            highlightConfig: {showInfo: mode === "all"},
+        };
 
         if (mode === "all" || mode === "content")
-            highlightConfig.contentColor = {r: 111, g: 168, b: 220, a: 0.66};
+            commandArguments.highlightConfig.contentColor = {r: 111, g: 168, b: 220, a: 0.66};
 
         if (mode === "all" || mode === "padding")
-            highlightConfig.paddingColor = {r: 147, g: 196, b: 125, a: 0.66};
+            commandArguments.highlightConfig.paddingColor = {r: 147, g: 196, b: 125, a: 0.66};
 
         if (mode === "all" || mode === "border")
-            highlightConfig.borderColor = {r: 255, g: 229, b: 153, a: 0.66};
+            commandArguments.highlightConfig.borderColor = {r: 255, g: 229, b: 153, a: 0.66};
 
         if (mode === "all" || mode === "margin")
-            highlightConfig.marginColor = {r: 246, g: 178, b: 107, a: 0.66};
+            commandArguments.highlightConfig.marginColor = {r: 246, g: 178, b: 107, a: 0.66};
 
-        return highlightConfig;
+        if (WI.settings.showGridOverlayDuringElementSelection.value) {
+            commandArguments.gridOverlayConfig = {
+                gridColor: WI.DOMNode.defaultLayoutOverlayColor.toProtocol(),
+                showLineNames: WI.settings.gridOverlayShowLineNames.value,
+                showLineNumbers: WI.settings.gridOverlayShowLineNumbers.value,
+                showExtendedGridLines: WI.settings.gridOverlayShowExtendedGridLines.value,
+                showTrackSizes: WI.settings.gridOverlayShowTrackSizes.value,
+                showAreaNames: WI.settings.gridOverlayShowAreaNames.value,
+            };
+        }
+
+        if (WI.settings.showFlexOverlayDuringElementSelection.value) {
+            commandArguments.flexOverlayConfig = {
+                flexColor: WI.DOMNode.defaultLayoutOverlayColor.toProtocol(),
+                showOrderNumbers: WI.settings.flexOverlayShowOrderNumbers.value,
+            };
+        }
+
+        return commandArguments;
     }
 
     static wrapClientCallback(callback)
@@ -623,10 +643,13 @@ WI.DOMManager = class DOMManager extends WI.Object
         }
 
         let target = WI.assumingMainTarget();
-        target.DOMAgent.highlightNodeList(nodeIds, DOMManager.buildHighlightConfig(mode));
+        target.DOMAgent.highlightNodeList.invoke({
+            nodeIds,
+            ...WI.DOMManager.buildHighlightConfigs(mode),
+        });
     }
 
-    highlightSelector(selectorText, frameId, mode)
+    highlightSelector(selectorString, frameId, mode)
     {
         if (this._hideDOMNodeHighlightTimeout) {
             clearTimeout(this._hideDOMNodeHighlightTimeout);
@@ -634,7 +657,11 @@ WI.DOMManager = class DOMManager extends WI.Object
         }
 
         let target = WI.assumingMainTarget();
-        target.DOMAgent.highlightSelector(DOMManager.buildHighlightConfig(mode), selectorText, frameId);
+        target.DOMAgent.highlightSelector.invoke({
+            selectorString,
+            frameId,
+            ...WI.DOMManager.buildHighlightConfigs(mode),
+        });
     }
 
     highlightRect(rect, usePageCoordinates)
@@ -681,30 +708,11 @@ WI.DOMManager = class DOMManager extends WI.Object
             return;
 
         let target = WI.assumingMainTarget();
-
-        let commandArguments = {
+        target.DOMAgent.setInspectModeEnabled.invoke({
             enabled,
-            highlightConfig: DOMManager.buildHighlightConfig(),
+            ...WI.DOMManager.buildHighlightConfigs(),
             showRulers: WI.settings.showRulersDuringElementSelection.value,
-        };
-        if (WI.settings.showGridOverlayDuringElementSelection.value) {
-            commandArguments.gridOverlayConfig = {
-                gridColor: WI.DOMNode.defaultLayoutOverlayColor.toProtocol(),
-                showLineNames: WI.settings.gridOverlayShowLineNames.value,
-                showLineNumbers: WI.settings.gridOverlayShowLineNumbers.value,
-                showExtendedGridLines: WI.settings.gridOverlayShowExtendedGridLines.value,
-                showTrackSizes: WI.settings.gridOverlayShowTrackSizes.value,
-                showAreaNames: WI.settings.gridOverlayShowAreaNames.value,
-            };
-        }
-        if (WI.settings.showFlexOverlayDuringElementSelection.value) {
-            commandArguments.flexOverlayConfig = {
-                flexColor: WI.DOMNode.defaultLayoutOverlayColor.toProtocol(),
-                showOrderNumbers: WI.settings.flexOverlayShowOrderNumbers.value,
-            };
-        }
-
-        target.DOMAgent.setInspectModeEnabled.invoke(commandArguments, (error) => {
+        }, (error) => {
             if (error) {
                 WI.reportInternalError(error);
                 return;

--- a/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
+++ b/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
@@ -633,7 +633,10 @@ WI.DOMNode = class DOMNode extends WI.Object
         }
 
         let target = WI.assumingMainTarget();
-        target.DOMAgent.highlightNode(WI.DOMManager.buildHighlightConfig(mode), this.id);
+        target.DOMAgent.highlightNode.invoke({
+            nodeId: this.id,
+            ...WI.DOMManager.buildHighlightConfigs(mode),
+        });
     }
 
     showLayoutOverlay({color} = {})


### PR DESCRIPTION
#### 7cd36695ab33c2bc51653d1124f4b0ff2a6130ba
<pre>
Web Inspector: Show grid/flex overlays when highlighting elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=251937">https://bugs.webkit.org/show_bug.cgi?id=251937</a>

Reviewed by Patrick Angle.

This makes it so that the experience is the same between element selection and highlighting elements in Web Inspector (e.g. via the Elements Tab). Otherwise, it could be confusing for a developer to see grid/flex/etc. overlays when in element selection but not when highlighting the same element in Web Inspector.

* Source/JavaScriptCore/inspector/protocol/DOM.json:
* Source/WebCore/inspector/agents/InspectorDOMAgent.h:
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::willDestroyFrontendAndBackend):
(WebCore::InspectorDOMAgent::handleTouchEvent):
(WebCore::InspectorDOMAgent::highlightMousedOverNode):
(WebCore::InspectorDOMAgent::setSearchingForNode):
(WebCore::InspectorDOMAgent::gridOverlayConfigFromInspectorObject):
(WebCore::InspectorDOMAgent::flexOverlayConfigFromInspectorObject):
(WebCore::InspectorDOMAgent::highlightSelector):
(WebCore::InspectorDOMAgent::highlightNode):
(WebCore::InspectorDOMAgent::highlightNodeList):
Add optional parameters for `DOM.GridOverlayConfig` and `DOM.FlexOverlayConfig` to `DOM.highlightSelector`, `DOM.highlightNode`, and `DOM.highlightNodeList`.

* Source/WebCore/inspector/InspectorOverlay.h:
* Source/WebCore/inspector/InspectorOverlay.cpp:
(WebCore::isInNodeList): Added.
(WebCore::InspectorOverlay::paint):
(WebCore::InspectorOverlay::getHighlight):
(WebCore::InspectorOverlay::hideHighlight):
(WebCore::InspectorOverlay::highlightNodeList):
(WebCore::InspectorOverlay::highlightNode):
(WebCore::InspectorOverlay::shouldShowOverlay const):
(WebCore::InspectorOverlay::showHighlightGridOverlayForNode): Deleted.
(WebCore::InspectorOverlay::hideHighlightGridOverlay): Deleted.
(WebCore::InspectorOverlay::showHighlightFlexOverlayForNode): Deleted.
(WebCore::InspectorOverlay::hideHighlightFlexOverlay): Deleted.
Move the logic for `*Highlight{Grid,Flex}Overlay` to be part of `highlightNodeList` and `highlightNode`, since they all operate on the same `m_highlightNode` (and `m_highlightNodeList`) anyways.

* Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js:
(WI.DOMManager.buildHighlightConfigs): Renamed from `buildHighlightConfig`.
(WI.DOMManager.prototype.highlightDOMNodeList):
(WI.DOMManager.prototype.highlightSelector):
(WI.DOMManager.prototype.set inspectModeEnabled):
* Source/WebInspectorUI/UserInterface/Models/DOMNode.js:
(WI.DOMNode.prototype.highlight):
Pass all the grid/flex overlay options to all callers of `DOM.highlightSelector`, `DOM.highlightNode`, and `DOM.highlightNodeList`.
Drive-by: Unify all the places where these arguments are generated to avoid repeated code.

Canonical link: <a href="https://commits.webkit.org/260061@main">https://commits.webkit.org/260061@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dedcf634812cd19afeafd9adada692818decde3b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106838 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15872 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39630 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116021 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115583 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110741 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17368 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7076 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99025 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112606 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13154 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96155 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40737 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95038 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27806 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82473 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/96357 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9030 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29161 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/95822 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/6970 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9605 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6159 "Found 1 new test failure: fast/text/bulgarian-system-language-shaping.html (failure)") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/30708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15197 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48707 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/104580 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6946 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11132 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25903 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->