### PR TITLE
[JSC] Disable automatic sorting of JS opcodes

### DIFF
--- a/Source/JavaScriptCore/generator/DSL.rb
+++ b/Source/JavaScriptCore/generator/DSL.rb
@@ -42,7 +42,12 @@ module DSL
 
     def self.end_section(name)
         assert("current section's name is `#{@current_section.name}`, but end_section was called with `#{name}`") { @current_section.name == name }
-        @current_section.sort!
+        if @current_section.config[:preserve_order]
+            @current_section.validate
+        else
+            @current_section.sort!
+        end
+        @current_section.create_ids!
         @sections << @current_section
         if @current_section.is_wasm?
           assert("Cannot have 2 wasm sections") { @wasm_section.nil? }


### PR DESCRIPTION
#### 7b5086f554ead526bfcc16e38da92711308a8f66
<pre>
[JSC] Disable automatic sorting of JS opcodes
<a href="https://bugs.webkit.org/show_bug.cgi?id=251940">https://bugs.webkit.org/show_bug.cgi?id=251940</a>
rdar://105186257

Reviewed by Yusuke Suzuki.

This patch doesn&apos;t really change anything yet. I simply dumped the order in which we
were sorting the opcodes, disabled the automatic sorting and added some validation,
then changed BytecodeList.rb so the source matches the previous order.

In a subsequent patch I&apos;ll actually use a different order based on the Metadata
alignment requirements so we can get rid of all padding in the MetadataTable.

* Source/JavaScriptCore/bytecode/BytecodeList.rb:
* Source/JavaScriptCore/generator/DSL.rb:
* Source/JavaScriptCore/generator/Section.rb:

Canonical link: <a href="https://commits.webkit.org/260055@main">https://commits.webkit.org/260055@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79d48daf212fbeb8e679bc1fdc35eabdb9435c36

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106805 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15826 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39657 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115988 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115562 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17321 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7031 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98993 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112573 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13127 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96168 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40714 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95010 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27818 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/96335 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9005 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/29173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/95801 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/6940 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9572 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6127 "Passed tests") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/30703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15174 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48721 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/104557 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6941 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11098 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25897 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->