### PR TITLE
Avoid storing effective language on ElementRareData when it matches the effective document element language

### DIFF
--- a/LayoutTests/fast/css/lang-matching-document-invalidation-expected.txt
+++ b/LayoutTests/fast/css/lang-matching-document-invalidation-expected.txt
@@ -1,0 +1,73 @@
+This tests invalidation of :lang selectors when the document element's lang attribute changes and a descendant element is using the 'explicit language matching document element language' optimization
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS matchedLang(container) is "en"
+PASS matchedLang(child) is "en"
+----
+PASS matchedLang(container) is "de"
+PASS matchedLang(child) is "de"
+----
+PASS matchedLang(container) is "en"
+PASS matchedLang(child) is "en"
+----
+PASS matchedLang(container) is "en"
+PASS matchedLang(child) is "en"
+----
+PASS matchedLang(container) is "de"
+PASS matchedLang(child) is "de"
+----
+PASS matchedLang(container) is "de"
+PASS matchedLang(child) is "de"
+----
+PASS matchedLang(container) is "de"
+PASS matchedLang(child) is "de"
+----
+PASS matchedLang(container) is "en"
+PASS matchedLang(child) is "en"
+----
+PASS matchedLang(container) is "de"
+PASS matchedLang(child) is "de"
+----
+PASS matchedLang(child) is "en"
+----
+PASS matchedLang(child) is "en"
+----
+PASS matchedLang(container) is "en"
+PASS matchedLang(child) is "en"
+----
+PASS matchedLang(container) is "de"
+PASS matchedLang(child) is "de"
+----
+PASS matchedLang(container) is "de"
+PASS matchedLang(child) is "de"
+----
+PASS matchedLang(container) is "en"
+PASS matchedLang(child) is "en"
+----
+PASS matchedLang(container) is ""
+PASS matchedLang(child) is ""
+----
+PASS matchedLang(container) is "en"
+PASS matchedLang(child) is "en"
+----
+PASS matchedLang(container) is "en"
+PASS matchedLang(child) is "en"
+----
+PASS matchedLang(container) is "en"
+----
+PASS matchedLang(container) is ""
+----
+PASS matchedLang(container) is "de"
+PASS matchedLang(child) is "de"
+----
+PASS matchedLang(container) is "zh"
+PASS matchedLang(child) is "zh"
+----
+PASS matchedLang(container) is "de"
+----
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/css/lang-matching-document-invalidation.html
+++ b/LayoutTests/fast/css/lang-matching-document-invalidation.html
@@ -1,0 +1,254 @@
+<!DOCTYPE html>
+<script src="../../resources/js-test.js"></script>
+<body>
+<script>
+var container, child, otherFrame;
+var testNumber = 0;
+
+description("This tests invalidation of :lang selectors when the document element's lang attribute changes and a descendant element is using the 'explicit language matching document element language' optimization");
+
+function matchedLang(element) {
+    for (let lang of ["en", "de", "zh"]) {
+        if (element.matches(`:lang(${lang})`))
+            return lang;
+    }
+    return "";
+}
+
+function shouldMatchLang(elementName, lang) {
+    shouldBe(`matchedLang(${elementName})`, `"${lang}"`);
+}
+
+function test(f) {
+    document.documentElement.lang = "en";
+    f();
+    container = null;
+    child = null;
+    debug("----");
+}
+
+function testWithOtherDocument(f) {
+    test(function() {
+        otherFrame = document.createElement("iframe");
+        otherFrame.srcdoc = "<!DOCTYPE html><html lang=en><body>";
+        document.body.append(otherFrame);
+        f();
+        otherFrame.remove();
+        otherFrame = null;
+    });
+}
+
+function makeContainer() {
+    container = document.createElement("div");
+    return container;
+}
+
+function makeChild() {
+    child = document.createElement("div");
+    return child;
+}
+
+function makeContainerWithChild() {
+    container = document.createElement("div");
+    child = document.createElement("div");
+    container.append(child);
+    return container;
+}
+
+test(function() {
+    document.body.append(makeContainerWithChild());
+    shouldMatchLang("container", "en");
+    shouldMatchLang("child", "en");
+    container.remove();
+});
+
+test(function() {
+    document.body.append(makeContainerWithChild());
+    document.documentElement.lang = "de";
+    shouldMatchLang("container", "de");
+    shouldMatchLang("child", "de");
+    container.remove();
+});
+
+test(function() {
+    document.body.append(makeContainerWithChild());
+    container.lang = "en";
+    shouldMatchLang("container", "en");
+    shouldMatchLang("child", "en");
+    container.remove();
+});
+
+test(function() {
+    document.body.append(makeContainerWithChild());
+    container.lang = "en";
+    document.documentElement.lang = "de";
+    shouldMatchLang("container", "en");
+    shouldMatchLang("child", "en");
+    container.remove();
+});
+
+test(function() {
+    document.body.append(makeContainerWithChild());
+    container.lang = "en";
+    document.documentElement.lang = "de";
+    container.lang = "de";
+    shouldMatchLang("container", "de");
+    shouldMatchLang("child", "de");
+    container.remove();
+});
+
+test(function() {
+    document.body.append(makeContainerWithChild());
+    container.lang = "en";
+    document.documentElement.lang = "de";
+    container.lang = "de";
+    document.documentElement.lang = "zh";
+    shouldMatchLang("container", "de");
+    shouldMatchLang("child", "de");
+    container.remove();
+});
+
+test(function() {
+    document.body.append(makeContainerWithChild());
+    container.lang = "en";
+    document.documentElement.lang = "de";
+    container.removeAttribute("lang");
+    shouldMatchLang("container", "de");
+    shouldMatchLang("child", "de");
+    container.remove();
+});
+
+test(function() {
+    document.body.append(makeContainerWithChild());
+    container.lang = "en";
+    container.remove();
+    shouldMatchLang("container", "en");
+    shouldMatchLang("child", "en");
+});
+
+test(function() {
+    document.body.append(makeContainerWithChild());
+    container.lang = "de";
+    container.remove();
+    shouldMatchLang("container", "de");
+    shouldMatchLang("child", "de");
+});
+
+test(function() {
+    document.body.append(makeContainer());
+    container.lang = "en";
+    container.append(makeChild());
+    shouldMatchLang("child", "en");
+    container.remove();
+});
+
+test(function() {
+    document.body.append(makeContainer());
+    container.lang = "de";
+    makeChild();
+    child.lang = "en";
+    container.append(child);
+    shouldMatchLang("child", "en");
+    container.remove();
+});
+
+testWithOtherDocument(function() {
+    document.body.append(makeContainerWithChild());
+    container.lang = "en";
+    otherFrame.contentDocument.body.append(container);
+    shouldMatchLang("container", "en");
+    shouldMatchLang("child", "en");
+});
+
+testWithOtherDocument(function() {
+    document.body.append(makeContainerWithChild());
+    container.lang = "de";
+    otherFrame.contentDocument.body.append(container);
+    shouldMatchLang("container", "de");
+    shouldMatchLang("child", "de");
+});
+
+testWithOtherDocument(function() {
+    document.body.append(makeContainerWithChild());
+    otherFrame.contentDocument.body.append(container);
+    otherFrame.contentDocument.documentElement.lang = "de";
+    shouldMatchLang("container", "de");
+    shouldMatchLang("child", "de");
+});
+
+testWithOtherDocument(function() {
+    document.body.append(makeContainerWithChild());
+    container.lang = "en";
+    otherFrame.contentDocument.body.append(container);
+    otherFrame.contentDocument.documentElement.lang = "de";
+    shouldMatchLang("container", "en");
+    shouldMatchLang("child", "en");
+});
+
+test(function() {
+    makeContainerWithChild();
+    shouldMatchLang("container", "");
+    shouldMatchLang("child", "");
+});
+
+test(function() {
+    makeContainerWithChild();
+    container.lang = "en";
+    shouldMatchLang("container", "en");
+    shouldMatchLang("child", "en");
+});
+
+testWithOtherDocument(function() {
+    otherFrame.contentDocument.documentElement.lang = "de";
+    makeContainerWithChild();
+    container.lang = "en";
+    otherFrame.contentDocument.adoptNode(container);
+    shouldMatchLang("container", "en");
+    shouldMatchLang("child", "en");
+});
+
+test(function() {
+    makeContainer();
+    container.lang = "de";
+    document.documentElement.append(container);
+    container.removeAttribute("lang");
+    shouldMatchLang("container", "en");
+});
+
+testWithOtherDocument(function() {
+    container = otherFrame.contentDocument.documentElement;
+    container.removeAttribute("lang");
+    container.remove();
+    shouldMatchLang("container", "");
+});
+
+testWithOtherDocument(function() {
+    otherFrame.contentDocument.documentElement.lang = "de";
+    makeContainerWithChild();
+    otherFrame.contentDocument.body.append(container);
+    container.lang = "de";
+    otherFrame.contentDocument.documentElement.remove();
+    let newRoot = document.createElement("html");
+    otherFrame.contentDocument.append(newRoot);
+    newRoot.lang = "zh";
+    shouldMatchLang("container", "de");
+    shouldMatchLang("child", "de");
+});
+
+testWithOtherDocument(function() {
+    otherFrame.contentDocument.documentElement.lang = "de";
+    otherFrame.contentDocument.documentElement.remove();
+    makeContainerWithChild();
+    container.lang = "zh";
+    otherFrame.contentDocument.append(container);
+    shouldMatchLang("container", "zh");
+    shouldMatchLang("child", "zh");
+});
+
+testWithOtherDocument(function() {
+    container = otherFrame.contentDocument.documentElement;
+    container.lang = "de";
+    container.remove();
+    shouldMatchLang("container", "de");
+});
+</script>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -1538,7 +1538,14 @@ void Document::setDocumentElementLanguage(const AtomString& language)
 {
     if (m_documentElementLanguage == language)
         return;
+
+    auto oldEffectiveDocumentElementLangauge = effectiveDocumentElementLanguage();
     m_documentElementLanguage = language;
+
+    if (oldEffectiveDocumentElementLangauge != effectiveDocumentElementLanguage()) {
+        for (auto& element : std::exchange(m_elementsWithLangAttrMatchingDocumentElement, { }))
+            element.updateEffectiveLangStateAndPropagateToDescendants();
+    }
 
     if (m_contentLanguage == language)
         return;
@@ -9445,6 +9452,16 @@ void Document::sendReportToEndpoints(const URL& baseURL, const Vector<String>& e
 bool Document::lazyImageLoadingEnabled() const
 {
     return m_settings->lazyImageLoadingEnabled() && !m_quirks->shouldDisableLazyImageLoadingQuirk();
+}
+
+void Document::addElementWithLangAttrMatchingDocumentElement(Element& element)
+{
+    m_elementsWithLangAttrMatchingDocumentElement.add(element);
+}
+
+void Document::removeElementWithLangAttrMatchingDocumentElement(Element& element)
+{
+    m_elementsWithLangAttrMatchingDocumentElement.remove(element);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -492,6 +492,9 @@ public:
     TextDirection documentElementTextDirection() const { return m_documentElementTextDirection; }
     void setDocumentElementTextDirection(TextDirection textDirection) { m_documentElementTextDirection = textDirection; }
 
+    void addElementWithLangAttrMatchingDocumentElement(Element&);
+    void removeElementWithLangAttrMatchingDocumentElement(Element&);
+
     String xmlEncoding() const { return m_xmlEncoding; }
     String xmlVersion() const { return m_xmlVersion; }
     enum class StandaloneStatus : uint8_t { Unspecified, Standalone, NotStandalone };
@@ -1977,6 +1980,8 @@ private:
 
     AtomString m_contentLanguage;
     AtomString m_documentElementLanguage;
+
+    WeakHashSet<Element, WeakPtrImplWithEventTargetData> m_elementsWithLangAttrMatchingDocumentElement;
 
     RefPtr<TextResourceDecoder> m_decoder;
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -265,6 +265,9 @@ Element::~Element()
         if (auto* map = elementRareData()->attributeStyleMap())
             map->clearElement();
     }
+
+    if (hasLangAttrKnownToMatchDocumentElement())
+        document().removeElementWithLangAttrMatchingDocumentElement(*this);
 }
 
 inline ElementRareData& Element::ensureElementRareData()
@@ -2097,31 +2100,14 @@ void Element::attributeChanged(const QualifiedName& name, const AtomString& oldV
                 Style::Invalidator::invalidateShadowParts(*shadowRoot);
             }
         } else if (name == HTMLNames::langAttr || name.matches(XMLNames::langAttr)) {
+            if (name == HTMLNames::langAttr)
+                setHasLangAttr(!newValue.isNull());
+            else
+                setHasXMLLangAttr(!newValue.isNull());
             if (document().documentElement() == this)
-                document().setDocumentElementLanguage(newValue);
-            else {
-                Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassLang, Style::PseudoClassChangeInvalidation::AnyValue);
-                AtomString newValue = langFromAttribute();
-                auto setEffectiveLang = [&](Element& element) {
-                    if (!newValue.isNull())
-                        element.ensureElementRareData().setEffectiveLang(newValue);
-                    else if (element.hasRareData())
-                        element.elementRareData()->setEffectiveLang(nullAtom());
-                };
-                setEffectiveLang(*this);
-                for (auto it = descendantsOfType<Element>(*this).begin(); it;) {
-                    auto& element = *it;
-                    if (auto* elementData = element.elementData()) {
-                        if (elementData->findLanguageAttribute()) {
-                            it.traverseNextSkippingChildren();
-                            continue;
-                        }
-                    }
-                    Style::PseudoClassChangeInvalidation styleInvalidation(element, CSSSelector::PseudoClassLang, Style::PseudoClassChangeInvalidation::AnyValue);
-                    setEffectiveLang(element);
-                    it.traverseNext();
-                }
-            }
+                document().setDocumentElementLanguage(langFromAttribute());
+            else
+                updateEffectiveLangStateAndPropagateToDescendants();
         }
     }
 
@@ -2139,6 +2125,23 @@ void Element::attributeChanged(const QualifiedName& name, const AtomString& oldV
 
     if (AXObjectCache* cache = document().existingAXObjectCache())
         cache->deferAttributeChangeIfNeeded(this, name, oldValue, newValue);
+}
+
+void Element::updateEffectiveLangStateAndPropagateToDescendants()
+{
+    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassLang, Style::PseudoClassChangeInvalidation::AnyValue);
+    updateEffectiveLangState();
+
+    for (auto it = descendantsOfType<Element>(*this).begin(); it;) {
+        auto& element = *it;
+        if (element.hasLanguageAttribute()) {
+            it.traverseNextSkippingChildren();
+            continue;
+        }
+        Style::PseudoClassChangeInvalidation styleInvalidation(element, CSSSelector::PseudoClassLang, Style::PseudoClassChangeInvalidation::AnyValue);
+        element.updateEffectiveLangStateFromParent();
+        it.traverseNext();
+    }
 }
 
 ExplicitlySetAttrElementsMap& Element::explicitlySetAttrElementsMap()
@@ -2498,6 +2501,57 @@ void Element::didMoveToNewDocument(Document& oldDocument, Document& newDocument)
             }
         }
     }
+
+    if (hasLangAttrKnownToMatchDocumentElement()) {
+        oldDocument.removeElementWithLangAttrMatchingDocumentElement(*this);
+        setEffectiveLangKnownToMatchDocumentElement(false);
+    }
+
+    updateEffectiveLangState();
+}
+
+void Element::updateEffectiveLangStateFromParent()
+{
+    ASSERT(!hasLanguageAttribute());
+    ASSERT(parentNode() != &document());
+
+    auto* parent = parentOrShadowHostElement();
+
+    if (!parent || parent == document().documentElement()) {
+        setEffectiveLangKnownToMatchDocumentElement(parent);
+        if (hasRareData())
+            elementRareData()->setEffectiveLang(nullAtom());
+        return;
+    }
+
+    setEffectiveLangKnownToMatchDocumentElement(parent->effectiveLangKnownToMatchDocumentElement());
+    if (UNLIKELY(parent->hasRareData()) && !parent->elementRareData()->effectiveLang().isNull())
+        ensureElementRareData().setEffectiveLang(parent->elementRareData()->effectiveLang());
+    else if (hasRareData())
+        elementRareData()->setEffectiveLang(nullAtom());
+}
+
+void Element::updateEffectiveLangState()
+{
+    auto& lang = langFromAttribute();
+    if (!lang) {
+        updateEffectiveLangStateFromParent();
+        return;
+    }
+
+    if (lang == document().effectiveDocumentElementLanguage()) {
+        if (hasRareData())
+            elementRareData()->setEffectiveLang(nullAtom());
+        document().addElementWithLangAttrMatchingDocumentElement(*this);
+        setEffectiveLangKnownToMatchDocumentElement(true);
+        return;
+    }
+
+    if (hasLangAttrKnownToMatchDocumentElement())
+        document().removeElementWithLangAttrMatchingDocumentElement(*this);
+
+    setEffectiveLangKnownToMatchDocumentElement(false);
+    ensureElementRareData().setEffectiveLang(lang);
 }
 
 bool Element::hasAttributes() const
@@ -2597,13 +2651,37 @@ Node::InsertedIntoAncestorResult Element::insertedIntoAncestor(InsertionType ins
             shadowRoot->hostChildElementDidChange(*this);
     }
 
-    if (auto* parent = parentOrShadowHostElement(); parent && parent != document().documentElement() && UNLIKELY(parent->hasRareData())) {
-        auto& lang = parent->elementRareData()->effectiveLang();
-        if (!lang.isNull() && langFromAttribute().isNull())
-            ensureElementRareData().setEffectiveLang(lang);
-    }
+    if (parentNode() == &parentOfInsertedTree && is<Document>(*parentNode())) {
+        clearEffectiveLangStateOnNewDocumentElement();
+        document().setDocumentElementLanguage(langFromAttribute());
+    } else if (!hasLanguageAttribute())
+        updateEffectiveLangStateFromParent();
 
     return InsertedIntoAncestorResult::Done;
+}
+
+void Element::clearEffectiveLangStateOnNewDocumentElement()
+{
+    ASSERT(parentNode() == &document());
+
+    if (hasLangAttrKnownToMatchDocumentElement()) {
+        document().removeElementWithLangAttrMatchingDocumentElement(*this);
+        setEffectiveLangKnownToMatchDocumentElement(false);
+    }
+
+    if (hasRareData())
+        elementRareData()->setEffectiveLang(nullAtom());
+}
+
+void Element::setEffectiveLangStateOnOldDocumentElement()
+{
+    if (auto& lang = langFromAttribute(); !lang.isNull() || hasRareData())
+        ensureElementRareData().setEffectiveLang(lang);
+}
+
+bool Element::hasEffectiveLangState() const
+{
+    return effectiveLangKnownToMatchDocumentElement() || (UNLIKELY(hasRareData()) && !elementRareData()->effectiveLang().isNull());
 }
 
 void Element::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
@@ -2663,11 +2741,11 @@ void Element::removedFromAncestor(RemovalType removalType, ContainerNode& oldPar
     document().fullscreenManager().exitRemovedFullscreenElementIfNeeded(*this);
 #endif
 
-    if (UNLIKELY(hasRareData()) && !elementRareData()->effectiveLang().isNull()) {
-        if (auto* parent = parentOrShadowHostElement(); langFromAttribute().isNull()
-            && !(parent && UNLIKELY(parent->hasRareData()) && !parent->elementRareData()->effectiveLang().isNull()))
-            elementRareData()->setEffectiveLang(nullAtom());
-    }
+    if (!parentNode() && is<Document>(oldParentOfRemovedTree)) {
+        setEffectiveLangStateOnOldDocumentElement();
+        document().setDocumentElementLanguage(nullAtom());
+    } else if (!hasLanguageAttribute())
+        updateEffectiveLangStateFromParent();
 
     Styleable::fromElement(*this).elementWasRemoved();
 
@@ -3989,22 +4067,26 @@ unsigned Element::rareDataChildIndex() const
     return elementRareData()->childIndex();
 }
 
-AtomString Element::effectiveLang() const
+const AtomString& Element::effectiveLang() const
 {
+    if (effectiveLangKnownToMatchDocumentElement())
+        return document().effectiveDocumentElementLanguage();
+
     if (hasRareData()) {
-        auto lang = elementRareData()->effectiveLang();
-        if (!lang.isNull())
+        if (auto& lang = elementRareData()->effectiveLang(); !lang.isNull())
             return lang;
     }
+
     return isConnected() ? document().effectiveDocumentElementLanguage() : nullAtom();
 }
 
-AtomString Element::langFromAttribute() const
+const AtomString& Element::langFromAttribute() const
 {
-    if (auto* data = elementData()) {
-        if (auto* attribute = data->findLanguageAttribute())
-            return attribute->value();
-    }
+    // Spec: xml:lang takes precedence over html:lang -- http://www.w3.org/TR/xhtml1/#C_7
+    if (hasXMLLangAttr())
+        return getAttribute(XMLNames::langAttr);
+    if (hasLangAttr())
+        return getAttribute(HTMLNames::langAttr);
     return nullAtom();
 }
 

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -439,9 +439,11 @@ public:
     void setStyleIsAffectedByPreviousSibling() { setStyleFlag(NodeStyleFlag::StyleIsAffectedByPreviousSibling); }
     void setChildIndex(unsigned);
 
-    AtomString effectiveLang() const;
-    AtomString langFromAttribute() const;
+    const AtomString& effectiveLang() const;
+    const AtomString& langFromAttribute() const;
     Locale& locale() const;
+
+    void updateEffectiveLangStateAndPropagateToDescendants();
 
     virtual bool accessKeyAction(bool /*sendToAnyEvent*/) { return false; }
 
@@ -842,6 +844,24 @@ private:
 #if ASSERT_ENABLED
     WEBCORE_EXPORT bool fastAttributeLookupAllowed(const QualifiedName&) const;
 #endif
+
+    bool hasEffectiveLangState() const;
+    void updateEffectiveLangState();
+    void updateEffectiveLangStateFromParent();
+    void setEffectiveLangStateOnOldDocumentElement();
+    void clearEffectiveLangStateOnNewDocumentElement();
+
+    bool hasLangAttr() const { return hasEventTargetFlag(EventTargetFlag::HasLangAttr); }
+    void setHasLangAttr(bool has) { setEventTargetFlag(EventTargetFlag::HasLangAttr, has); }
+
+    bool hasXMLLangAttr() const { return hasEventTargetFlag(EventTargetFlag::HasXMLLangAttr); }
+    void setHasXMLLangAttr(bool has) { setEventTargetFlag(EventTargetFlag::HasXMLLangAttr, has); }
+
+    bool effectiveLangKnownToMatchDocumentElement() const { return hasEventTargetFlag(EventTargetFlag::EffectiveLangKnownToMatchDocumentElement); }
+    void setEffectiveLangKnownToMatchDocumentElement(bool matches) { setEventTargetFlag(EventTargetFlag::EffectiveLangKnownToMatchDocumentElement, matches); }
+
+    bool hasLanguageAttribute() const { return hasLangAttr() || hasXMLLangAttr(); }
+    bool hasLangAttrKnownToMatchDocumentElement() const { return hasLanguageAttribute() && effectiveLangKnownToMatchDocumentElement(); }
 
     QualifiedName m_tagName;
     RefPtr<ElementData> m_elementData;

--- a/Source/WebCore/dom/ElementData.cpp
+++ b/Source/WebCore/dom/ElementData.cpp
@@ -190,24 +190,4 @@ Attribute* UniqueElementData::findAttributeByName(const QualifiedName& name)
     return nullptr;
 }
 
-const Attribute* ElementData::findLanguageAttribute() const
-{
-    ASSERT(XMLNames::langAttr->localName() == HTMLNames::langAttr->localName());
-
-    const Attribute* attributes = attributeBase();
-    // Spec: xml:lang takes precedence over html:lang -- http://www.w3.org/TR/xhtml1/#C_7
-    const Attribute* languageAttribute = nullptr;
-    for (unsigned i = 0, count = length(); i < count; ++i) {
-        const QualifiedName& name = attributes[i].name();
-        if (name.localName() != HTMLNames::langAttr->localName())
-            continue;
-        if (name.namespaceURI() == XMLNames::langAttr->namespaceURI())
-            return &attributes[i];
-        if (name.namespaceURI() == HTMLNames::langAttr->namespaceURI())
-            languageAttribute = &attributes[i];
-    }
-    return languageAttribute;
 }
-
-}
-

--- a/Source/WebCore/dom/ElementData.h
+++ b/Source/WebCore/dom/ElementData.h
@@ -104,7 +104,6 @@ public:
     const Attribute* findAttributeByName(const QualifiedName&) const;
     unsigned findAttributeIndexByName(const QualifiedName&) const;
     unsigned findAttributeIndexByName(const AtomString& name, bool shouldIgnoreAttributeCase) const;
-    const Attribute* findLanguageAttribute() const;
 
     bool hasID() const { return !m_idForStyleResolution.isNull(); }
     bool hasClass() const { return !m_classNames.isEmpty(); }

--- a/Source/WebCore/dom/EventTarget.h
+++ b/Source/WebCore/dom/EventTarget.h
@@ -166,6 +166,9 @@ protected:
         // Element bits
         HasDuplicateAttribute = 1 << 2,
         DisplayContentsChanged = 1 << 3,
+        HasLangAttr = 1 << 4,
+        HasXMLLangAttr = 1 << 5,
+        EffectiveLangKnownToMatchDocumentElement = 1 << 6,
     };
 
     EventTargetData& ensureEventTargetData()


### PR DESCRIPTION
#### f31c6cd343763c953418192bbcea0982c167f7f7
<pre>
Avoid storing effective language on ElementRareData when it matches the effective document element language
<a href="https://bugs.webkit.org/show_bug.cgi?id=251657">https://bugs.webkit.org/show_bug.cgi?id=251657</a>
&lt;rdar://problem/104987630&gt;

Reviewed by Ryosuke Niwa.

When an element&apos;s lang attribute is set, we set the effective language on
the ElementRareData of all elements in the subtree. We have an existing
optimization that avoids this if we&apos;re setting it on the document
element. There are some pages, like Wikipedia, that set an explicit
lang on some other element in the body of the page, but which matches
the document element&apos;s lang.

We can avoid the memory overhead of allocating ElementRareData to store
the effective language in this case by using a flag on the element. On
large Wikipedia pages this can save several MB.

If the document element language changes later, we must update the
effective lang state on subtrees that are using this flag. A WeakHashSet
is added to Document to track elements that have an explicit lang
attribute that matches the effective document element language.

Three flags on EventTarget are introduced:

- HasLangAttr and HasXMLLangAttr: records that the element has the
  corresponding lang attribute. This allows us to avoid searching
  for an attribute when updating the effective lang state.

- EffectiveLangKnownToMatchDocument: records that the element has an
  effective lang that matches the effective document element language,
  whether it&apos;s due to an explicit lang attribute or inherited from an
  ancestor. This flag is used in place of
  ElementRareData::m_effectiveLang.

The EffectiveLangKnownToMatchDocument flag is used in place of the &quot;null
effective language means we&apos;ve inherited the effective document
language&quot; state so that disconnected subtrees can also make use of this
optimization. Otherwise, for a case like this:

  let e = document.createElement(&quot;div&quot;);
  e.lang = &quot;en&quot;;  // matching document
  e.append(document.createElement(&quot;div&quot;));

the child element would not know whether to return nullptr or &quot;en&quot; from
Element::effectiveLang() without looking up the tree to see if there is
an ancestor with a langauge attribute.

The EffectiveLangKnownToMatchDocument flag is not
EffectiveLangMatchesDocument, since we don&apos;t set it if the document
element language changes and an existing element starts matching it.
Rather than track all elements with lang attributes to handle such
cases, we leave the effective lang stored on the ElementRareData.

* LayoutTests/fast/css/lang-matching-document-invalidation-expected.txt: Added.
* LayoutTests/fast/css/lang-matching-document-invalidation.html: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setDocumentElementLanguage):
(WebCore::Document::addElementWithLangAttrMatchingDocument):
(WebCore::Document::removeElementWithLangAttrMatchingDocument):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::~Element):
(WebCore::Element::attributeChanged):
(WebCore::Element::setEffectiveLangInSubtree):
(WebCore::Element::didMoveToNewDocument):
(WebCore::Element::setEffectiveLangFromParent):
(WebCore::Element::setEffectiveLang):
(WebCore::Element::insertedIntoAncestor):
(WebCore::Element::hasEffectiveLangState const):
(WebCore::Element::removedFromAncestor):
(WebCore::Element::effectiveLang const):
(WebCore::Element::langFromAttribute const):
(WebCore::Element::langAttrMatchesDocument const):
(WebCore::Element::setLangAttrMatchesDocument):
(WebCore::Element::effectiveLangMatchesDocument const):
(WebCore::Element::setEffectiveLangMatchesDocument):
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/EventTarget.h:

Canonical link: <a href="https://commits.webkit.org/260047@main">https://commits.webkit.org/260047@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6872768c4ffef560add8ce941904a27a793a1933

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106818 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15842 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39604 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116002 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115571 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110721 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17333 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7053 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99006 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112586 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13134 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96126 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40721 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95017 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27778 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9016 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29133 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9585 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6140 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15185 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48677 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11112 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3748 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->