### PR TITLE
Implement focus fixup rule

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/layout-dependent-focus-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/layout-dependent-focus-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Verify that onblur is called on hidden input assert_unreached: Event listener for 'blur' not called Reached unreachable code
+PASS Verify that onblur is called on hidden input
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/focus-display-none-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/focus-display-none-001-expected.txt
@@ -1,5 +1,5 @@
 
 
-FAIL Test ':focus' after 'display:none' on input assert_false: Check input doesn't match ':focus' after getting 'display: none' expected false got true
-FAIL Test ':focus' after 'display:none' on input's parent assert_false: Check input doesn't match ':focus' after parent got 'display: none' expected false got true
+PASS Test ':focus' after 'display:none' on input
+PASS Test ':focus' after 'display:none' on input's parent
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/focus-within-display-none-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/focus-within-display-none-001-expected.txt
@@ -1,5 +1,5 @@
 
 
-FAIL Test ':focus-within' after 'display:none' on input assert_false: Check input doesn't match ':focus-within' after getting 'display: none' expected false got true
-FAIL Test ':focus-within' after 'display:none' on input's parent assert_false: Check input doesn't match ':focus-within' after parent got 'display: none' expected false got true
+PASS Test ':focus-within' after 'display:none' on input
+PASS Test ':focus-within' after 'display:none' on input's parent
 

--- a/LayoutTests/imported/w3c/web-platform-tests/inert/dynamic-inert-on-focused-element-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/inert/dynamic-inert-on-focused-element-expected.txt
@@ -1,22 +1,10 @@
 
-FAIL <input> that gets 'inert' attribute assert_equals: The element stops being focused expected Element node <body><div id="log"></div>
-
-<div class="test-wrapper" dat... but got Element node <input class="becomes-inert check-focus" inert=""></input>
-FAIL <input> whose parent gets 'inert' attribute assert_equals: The element stops being focused expected Element node <body><div id="log"></div>
-
-<div class="test-wrapper" dat... but got Element node <input class="check-focus"></input>
-FAIL <button> that gets 'inert' attribute assert_equals: The element stops being focused expected Element node <body><div id="log"></div>
-
-<div class="test-wrapper" dat... but got Element node <button class="becomes-inert check-focus" inert="">foo</b...
-FAIL <div> that gets 'inert' attribute assert_equals: The element stops being focused expected Element node <body><div id="log"></div>
-
-<div class="test-wrapper" dat... but got Element node <div class="becomes-inert check-focus" tabindex="-1" iner...
-FAIL <div> whose parent gets 'inert' attribute assert_equals: The element stops being focused expected Element node <body><div id="log"></div>
-
-<div class="test-wrapper" dat... but got Element node <div class="check-focus" tabindex="-1">bar</div>
-FAIL <div> whose grandparent gets 'inert' attribute assert_equals: The element stops being focused expected Element node <body><div id="log"></div>
-
-<div class="test-wrapper" dat... but got Element node <span class="check-focus" tabindex="-1">baz</span>
+PASS <input> that gets 'inert' attribute
+PASS <input> whose parent gets 'inert' attribute
+PASS <button> that gets 'inert' attribute
+PASS <div> that gets 'inert' attribute
+PASS <div> whose parent gets 'inert' attribute
+PASS <div> whose grandparent gets 'inert' attribute
 
 
 foo

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus/focus-shadowhost-display-none-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus/focus-shadowhost-display-none-expected.txt
@@ -1,6 +1,4 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT when shadow host itself is focused, it should match display:none, lose focus then becomes display:block again. Test timed out
-NOTRUN when shadow host with delegatesFocus=true has focused element inside the shadow, it should also match display:none, then lose focus and become display:block again.
+PASS when shadow host itself is focused, it should match display:none, lose focus then becomes display:block again.
+PASS when shadow host with delegatesFocus=true has focused element inside the shadow, it should also match display:none, then lose focus and become display:block again.
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1734,6 +1734,13 @@ void Page::updateRendering()
         document.updateResizeObservations(*this);
     });
 
+    runProcessingStep(RenderingUpdateStep::FocusFixup, [&] (Document& document) {
+        if (RefPtr focusedElement = document.focusedElement()) {
+            if (!focusedElement->isFocusable())
+                document.setFocusedElement(nullptr);
+        }
+    });
+
     runProcessingStep(RenderingUpdateStep::IntersectionObservations, [] (Document& document) {
         document.updateIntersectionObservations();
     });
@@ -3956,6 +3963,7 @@ WTF::TextStream& operator<<(WTF::TextStream& ts, RenderingUpdateStep step)
     case RenderingUpdateStep::VideoFrameCallbacks: ts << "VideoFrameCallbacks"; break;
     case RenderingUpdateStep::PrepareCanvasesForDisplay: ts << "PrepareCanvasesForDisplay"; break;
     case RenderingUpdateStep::CaretAnimation: ts << "CaretAnimation"; break;
+    case RenderingUpdateStep::FocusFixup: ts << "FocusFixup"; break;
     }
     return ts;
 }

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -236,6 +236,7 @@ enum class RenderingUpdateStep : uint32_t {
     VideoFrameCallbacks             = 1 << 15,
     PrepareCanvasesForDisplay       = 1 << 16,
     CaretAnimation                  = 1 << 17,
+    FocusFixup                      = 1 << 18,
 };
 
 enum LookalikeCharacterSanitizationTrigger : uint8_t {


### PR DESCRIPTION
#### 71bc5343fd7bfd20cde526af2f9941b8ed980b6f
<pre>
Implement focus fixup rule
<a href="https://bugs.webkit.org/show_bug.cgi?id=237273">https://bugs.webkit.org/show_bug.cgi?id=237273</a>

Reviewed by Tim Nguyen.

Implement step 15 of update the rendering between 14. servicing resize observers and 16. updating intersection observations:
<a href="https://github.com/whatwg/html/pull/8392">https://github.com/whatwg/html/pull/8392</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/layout-dependent-focus-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/focus-display-none-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/focus-within-display-none-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/inert/dynamic-inert-on-focused-element-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus/focus-shadowhost-display-none-expected.txt:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::updateRendering):
(WebCore::operator&lt;&lt;):
* Source/WebCore/page/Page.h:

Canonical link: <a href="https://commits.webkit.org/260067@main">https://commits.webkit.org/260067@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3f1140520c7124d6972490927d2be1bdcf7d067

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106873 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15909 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39672 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116054 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115610 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110776 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17394 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7107 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99057 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112640 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13165 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96177 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40764 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95051 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27827 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9060 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29182 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9636 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6183 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15227 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48730 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11165 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3761 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->