### PR TITLE
Integrate PGM for large heap allocations

### DIFF
--- a/Source/bmalloc/bmalloc.xcodeproj/project.pbxproj
+++ b/Source/bmalloc/bmalloc.xcodeproj/project.pbxproj
@@ -635,7 +635,7 @@
 		2CE2AE3327596DEB00D02BBC /* pas_segregated_deallocation_logging_mode.h in Headers */ = {isa = PBXBuildFile; fileRef = 2CE2AE2C27596DEB00D02BBC /* pas_segregated_deallocation_logging_mode.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2CE2AE5D2769928300D02BBC /* pas_compact_tagged_void_ptr.h in Headers */ = {isa = PBXBuildFile; fileRef = 2CE2AE512769928200D02BBC /* pas_compact_tagged_void_ptr.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2CE2AE632769928300D02BBC /* pas_probabilistic_guard_malloc_allocator.c in Sources */ = {isa = PBXBuildFile; fileRef = 2CE2AE572769928300D02BBC /* pas_probabilistic_guard_malloc_allocator.c */; };
-		2CE2AE642769928300D02BBC /* pas_probabilistic_guard_malloc_allocator.h in Headers */ = {isa = PBXBuildFile; fileRef = 2CE2AE582769928300D02BBC /* pas_probabilistic_guard_malloc_allocator.h */; };
+		2CE2AE642769928300D02BBC /* pas_probabilistic_guard_malloc_allocator.h in Headers */ = {isa = PBXBuildFile; fileRef = 2CE2AE582769928300D02BBC /* pas_probabilistic_guard_malloc_allocator.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		4426E2801C838EE0008EB042 /* Logging.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4426E27E1C838EE0008EB042 /* Logging.cpp */; };
 		4426E2811C838EE0008EB042 /* Logging.h in Headers */ = {isa = PBXBuildFile; fileRef = 4426E27F1C838EE0008EB042 /* Logging.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		52F47249210BA30200B730BB /* MemoryStatusSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 52F47248210BA2F500B730BB /* MemoryStatusSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };

--- a/Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj
+++ b/Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj
@@ -2952,7 +2952,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx;
+				SDKROOT = macosx.internal;
 				SKIP_INSTALL = YES;
 			};
 			name = Debug;
@@ -2968,7 +2968,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx;
+				SDKROOT = macosx.internal;
 				SKIP_INSTALL = YES;
 			};
 			name = Release;
@@ -2990,7 +2990,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx;
+				SDKROOT = macosx.internal;
 				SKIP_INSTALL = YES;
 			};
 			name = Debug;
@@ -3008,7 +3008,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx;
+				SDKROOT = macosx.internal;
 				SKIP_INSTALL = YES;
 			};
 			name = Release;
@@ -3030,7 +3030,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx;
+				SDKROOT = macosx.internal;
 				SKIP_INSTALL = YES;
 			};
 			name = Debug;
@@ -3048,7 +3048,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx;
+				SDKROOT = macosx.internal;
 				SKIP_INSTALL = YES;
 			};
 			name = Release;
@@ -3070,7 +3070,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx;
+				SDKROOT = macosx.internal;
 				SKIP_INSTALL = YES;
 			};
 			name = Debug;
@@ -3088,7 +3088,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx;
+				SDKROOT = macosx.internal;
 				SKIP_INSTALL = YES;
 			};
 			name = Release;
@@ -3274,7 +3274,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx;
+				SDKROOT = macosx.internal;
 				SKIP_INSTALL = YES;
 			};
 			name = Debug;
@@ -3292,7 +3292,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx;
+				SDKROOT = macosx.internal;
 				SKIP_INSTALL = YES;
 			};
 			name = Release;

--- a/Source/bmalloc/libpas/src/libpas/bmalloc_heap_config.h
+++ b/Source/bmalloc/libpas/src/libpas/bmalloc_heap_config.h
@@ -75,7 +75,7 @@ PAS_API void bmalloc_heap_config_activate(void);
     .use_marge_bitfit = true, \
     .marge_bitfit_min_align_shift = PAS_MIN_MARGE_ALIGN_SHIFT, \
     .marge_bitfit_page_size = PAS_MARGE_PAGE_DEFAULT_SIZE, \
-    .pgm_enabled = false)
+    .pgm_enabled = true)
 
 PAS_API extern const pas_heap_config bmalloc_heap_config;
 

--- a/Source/bmalloc/libpas/src/libpas/iso_heap_config.h
+++ b/Source/bmalloc/libpas/src/libpas/iso_heap_config.h
@@ -74,7 +74,7 @@ PAS_BEGIN_EXTERN_C;
     .use_marge_bitfit = true, \
     .marge_bitfit_min_align_shift = PAS_MIN_MARGE_ALIGN_SHIFT, \
     .marge_bitfit_page_size = PAS_MARGE_PAGE_DEFAULT_SIZE, \
-    .pgm_enabled = false)
+    .pgm_enabled = true)
 
 PAS_API extern const pas_heap_config iso_heap_config;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap.c
@@ -38,6 +38,7 @@
 #include "pas_log.h"
 #include "pas_monotonic_time.h"
 #include "pas_primitive_heap_ref.h"
+#include "pas_probabilistic_guard_malloc_allocator.h"
 #include "pas_segregated_size_directory.h"
 
 pas_heap* pas_heap_create(pas_heap_ref* heap_ref,
@@ -68,6 +69,10 @@ pas_heap* pas_heap_create(pas_heap_ref* heap_ref,
     heap->heap_ref = heap_ref;
     heap->heap_ref_kind = heap_ref_kind;
     heap->config_kind = config->kind;
+
+    // PGM being enabled in the config does not guarantee it will be called during runtime.
+    if (config->pgm_enabled)
+        pas_probabilistic_guard_malloc_initialize_pgm();
     
     pas_all_heaps_add_heap(heap);
     

--- a/Source/bmalloc/libpas/src/libpas/pas_heap_config_utils.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap_config_utils.h
@@ -344,7 +344,7 @@ typedef struct {
             pas_heap_config_utils_for_each_shared_page_directory_remote, \
         .dump_shared_page_directory_arg = pas_shared_page_directory_by_size_dump_directory_arg, \
         PAS_HEAP_CONFIG_SPECIALIZATIONS(name ## _heap_config), \
-        .pgm_enabled = false \
+        .pgm_enabled = true \
     })
 
 #define PAS_BASIC_HEAP_CONFIG_SEGREGATED_HEAP_DECLARATIONS(name, upcase_name) \

--- a/Source/bmalloc/libpas/src/libpas/pas_large_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_heap.c
@@ -213,8 +213,14 @@ bool pas_large_heap_try_deallocate(uintptr_t begin,
     
     map_entry = pas_large_map_take(begin);
     
-    if (pas_large_map_entry_is_empty(map_entry))
+    if (pas_large_map_entry_is_empty(map_entry)) {
+        if (heap_config->pgm_enabled && pas_probabilistic_guard_malloc_check_exists(begin)) {
+            pas_probabilistic_guard_malloc_deallocate((void *) begin);
+            return true;
+        }
+
         return false;
+    }
     
     PAS_ASSERT(pas_heap_config_kind_get_config(
                    pas_heap_for_large_heap(map_entry.heap)->config_kind)

--- a/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h
@@ -30,6 +30,7 @@
 #include "pas_utils.h"
 #include "pas_large_heap.h"
 #include <stdbool.h>
+#include <stdint.h>
 
 PAS_BEGIN_EXTERN_C;
 
@@ -44,6 +45,7 @@ struct pas_pgm_storage {
     uintptr_t start_of_data_pages;
     uintptr_t upper_guard_page;
     uintptr_t lower_guard_page;
+    pas_large_heap* large_heap;
 };
 
 // max amount of free memory that can be wasted (1MB)
@@ -53,13 +55,15 @@ struct pas_pgm_storage {
 // including guard pages and wasted memory
 #define PAS_PGM_MAX_VIRTUAL_MEMORY (1024 * 1024 * 1024)
 
-// Probability that we should call PGM in percentage (0-100)
-#define PAS_PGM_PROBABILITY (1)
+// We want a fast way to determine if we can call PGM or not.
+// It would be really wasteful to recompute this answer each time we try to allocate,
+// so just update this variable each time we allocate or deallocate.
+extern PAS_API bool pas_probabilistic_guard_malloc_can_use;
 
-/* We want a fast way to determine if we can call PGM or not.
- * It would be really wasteful to recompute this answer each time we try to allocate,
- * so just update this variable each time we allocate or deallocate. */
-extern PAS_API bool pas_pgm_can_use;
+extern PAS_API bool pas_probabilistic_guard_malloc_is_initialized;
+
+extern PAS_API uint16_t pas_probabilistic_guard_malloc_random;
+extern PAS_API uint16_t pas_probabilistic_guard_malloc_counter;
 
 pas_allocation_result pas_probabilistic_guard_malloc_allocate(pas_large_heap* large_heap, size_t size, const pas_heap_config* heap_config, pas_physical_memory_transaction* transaction);
 void pas_probabilistic_guard_malloc_deallocate(void* memory);
@@ -68,6 +72,21 @@ size_t pas_probabilistic_guard_malloc_get_free_virtual_memory(void);
 size_t pas_probabilistic_guard_malloc_get_free_wasted_memory(void);
 
 bool pas_probabilistic_guard_malloc_check_exists(uintptr_t mem);
+
+// Determine whether PGM can be called at runtime.
+// PGM will be called between every 4,000 to 5,000 times an allocation is tried.
+static PAS_ALWAYS_INLINE bool pas_probabilistic_guard_malloc_should_call_pgm(void)
+{
+    if (++pas_probabilistic_guard_malloc_counter == pas_probabilistic_guard_malloc_random) {
+        pas_probabilistic_guard_malloc_counter = 0;
+        return true;
+    }
+
+    return false;
+}
+
+extern PAS_API void pas_probabilistic_guard_malloc_initialize_pgm(void);
+pas_large_map_entry pas_probabilistic_guard_malloc_return_as_large_map_entry(uintptr_t mem);
 
 PAS_END_EXTERN_C;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h
@@ -331,13 +331,15 @@ pas_try_reallocate(void* old_ptr,
         pas_heap_lock_lock();
         
         entry = pas_large_map_find(begin);
-        
+
         if (pas_large_map_entry_is_empty(entry)) {
-            pas_reallocation_did_fail(
-                "Source object not allocated",
-                NULL, heap, old_ptr, 0, new_size);
+            // Check for PGM case
+            if (config.pgm_enabled && pas_probabilistic_guard_malloc_check_exists(begin))
+                entry = pas_probabilistic_guard_malloc_return_as_large_map_entry(begin);
+            else
+                pas_reallocation_did_fail("Source object not allocated", NULL, heap, old_ptr, 0, new_size);
         }
-        
+
         PAS_ASSERT(entry.begin == begin);
         PAS_ASSERT(entry.end > begin);
         PAS_ASSERT(entry.heap);


### PR DESCRIPTION
#### 122ada5eddb1ba52911f2983e3fa6c04dc311ba3
<pre>
Integrate PGM for large heap allocations
<a href="https://bugs.webkit.org/show_bug.cgi?id=249371">https://bugs.webkit.org/show_bug.cgi?id=249371</a>

Reviewed by NOBODY (OOPS!).

Enable PGM for large heap allocations.

* Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj:
* Source/bmalloc/libpas/src/libpas/bmalloc_heap_config.h:
* Source/bmalloc/libpas/src/libpas/iso_heap_config.h:
* Source/bmalloc/libpas/src/libpas/pas_heap.c:
(pas_heap_create):
* Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c:
(pas_probabilistic_guard_malloc_allocate):
(pas_probabilistic_guard_malloc_return_as_large_map_entry):
(pas_probabilistic_guard_malloc_should_call_pgm):
(pas_probabilistic_guard_malloc_initialize_pgm):
* Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h:
* Source/bmalloc/libpas/src/libpas/pas_try_allocate_common.h:
(pas_try_allocate_common_impl_slow):
* Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h:
(pas_try_reallocate):
* Source/bmalloc/libpas/src/test/PGMTests.cpp:
(std::testPGMRealloc):
(addPGMTests):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3bf5fea6f5c039d915bb4faf595d0e4a09fe1ee7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108035 "10 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17095 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40912 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117165 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116497 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18469 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8407 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100233 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113801 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97156 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41852 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95842 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28794 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/97270 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9998 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30142 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/38/builds/96640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/8088 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10716 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7040 "Passed tests") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/38/builds/96640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16148 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49732 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/105653 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12293 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26162 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->