### PR TITLE
Resync web-platform-tests/shadow-dom

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4739,6 +4739,16 @@ webkit.org/b/214465 imported/w3c/web-platform-tests/css/mediaqueries/prefers-col
 webkit.org/b/214466 imported/w3c/web-platform-tests/css/css-values/ex-unit-004.html [ ImageOnlyFailure ]
 webkit.org/b/214466 imported/w3c/web-platform-tests/css/css-shapes/shape-outside/formatting-context/shape-outside-formatting-context.tentative.html [ ImageOnlyFailure ]
 
+webkit.org/b/251953 imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-06.html [ ImageOnlyFailure ]
+webkit.org/b/251953 imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-18.html [ ImageOnlyFailure ]
+webkit.org/b/251953 imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-24.html [ ImageOnlyFailure ]
+webkit.org/b/251953 imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-30.html [ ImageOnlyFailure ]
+webkit.org/b/251953 imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-33.html [ ImageOnlyFailure ]
+webkit.org/b/251953 imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-34.html [ ImageOnlyFailure ]
+webkit.org/b/251953 imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-38.html [ ImageOnlyFailure ]
+webkit.org/b/251953 imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-39.html [ ImageOnlyFailure ]
+webkit.org/b/251953 imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-41.html [ ImageOnlyFailure ]
+
 # WebKit2 only.
 js/throw-large-string-oom.html [ Skip ]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/innerhtml-before-closing-tag.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/innerhtml-before-closing-tag.tentative.html
@@ -2,8 +2,8 @@
 <title>Declarative Shadow DOM innerHTML</title>
 <link rel='author' href='mailto:masonf@chromium.org'>
 <link rel='help' href='https://github.com/whatwg/dom/issues/831'>
-<script src='../../resources/testharness.js'></script>
-<script src='../../resources/testharnessreport.js'></script>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
 
 <body>
 <script>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-01-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-01-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+div p {width: 50%; border: 1px dotted;}
+</style>
+</head>
+<body>
+
+<p>`dir=ltr` on the &lt;slot&gt;, paragraph in the light tree</p>
+<div id="host"><p>paragraph</p></div>
+<p id="result">The computed `direction` value for the paragraph is: ltr.</p>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-01.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-01.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<link rel="match" href="dir-shadow-01-ref.html">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+div p {width: 50%; border: 1px dotted;}
+</style>
+</head>
+<body>
+
+<p>`dir=ltr` on the &lt;slot&gt;, paragraph in the light tree</p>
+<div id="host"><p>paragraph</p></div>
+<p id="result">The computed `direction` value for the paragraph is: </p>
+
+<script type="text/javascript">
+  let root = host.attachShadow({mode:"open"});
+  root.innerHTML = `
+    <slot dir="ltr"></slot>
+  `;
+  result.innerHTML += getComputedStyle(host.firstChild).direction + '.';
+</script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-02-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-02-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+div p {width: 50%; border: 1px dotted;}
+</style>
+</head>
+<body>
+
+<p>`dir=ltr` on the &lt;slot&gt;, paragraph in the light tree</p>
+<div id="host"><p>اختبر </p></div>
+<p id="result">The computed `direction` value for the paragraph is: ltr.</p>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-02.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-02.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<link rel="match" href="dir-shadow-02-ref.html">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+div p {width: 50%; border: 1px dotted;}
+</style>
+</head>
+<body>
+
+<p>`dir=ltr` on the &lt;slot&gt;, paragraph in the light tree</p>
+<div id="host"><p>اختبر</p></div>
+<p id="result">The computed `direction` value for the paragraph is: </p>
+
+<script type="text/javascript">
+  let root = host.attachShadow({mode:"open"});
+  root.innerHTML = `
+    <slot dir="ltr"></slot>
+  `;
+  result.innerHTML += getComputedStyle(host.firstChild).direction + '.';
+</script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-03-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-03-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+div p {width: 50%; border: 1px dotted;}
+</style>
+</head>
+<body>
+
+<p>`dir=rtl` on the &lt;slot&gt;, paragraph in the light tree</p>
+<div id="host"><p dir="rtl">paragraph</p></div>
+<p id="result">The computed `direction` value for the paragraph is: rtl.</p>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-03.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-03.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<link rel="match" href="dir-shadow-03-ref.html">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+div p {width: 50%; border: 1px dotted;}
+</style>
+</head>
+<body>
+
+<p>`dir=rtl` on the &lt;slot&gt;, paragraph in the light tree</p>
+<div id="host"><p>paragraph</p></div>
+<p id="result">The computed `direction` value for the paragraph is: </p>
+
+<script type="text/javascript">
+  let root = host.attachShadow({mode:"open"});
+  root.innerHTML = `
+    <slot dir="rtl"></slot>
+  `;
+  result.innerHTML += getComputedStyle(host.firstChild).direction + '.';
+</script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-04-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-04-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+div p {width: 50%; border: 1px dotted;}
+</style>
+</head>
+<body>
+
+<p>`dir=rtl` on the &lt;slot&gt;, paragraph in the light tree</p>
+<div id="host"><p dir="rtl">اختبر </p></div>
+<p id="result">The computed `direction` value for the paragraph is: rtl.</p>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-04.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-04.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<link rel="match" href="dir-shadow-04-ref.html">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+div p {width: 50%; border: 1px dotted;}
+</style>
+</head>
+<body>
+
+<p>`dir=rtl` on the &lt;slot&gt;, paragraph in the light tree</p>
+<div id="host"><p>اختبر</p></div>
+<p id="result">The computed `direction` value for the paragraph is: </p>
+
+<script type="text/javascript">
+  let root = host.attachShadow({mode:"open"});
+  root.innerHTML = `
+    <slot dir="rtl"></slot>
+  `;
+  result.innerHTML += getComputedStyle(host.firstChild).direction + '.';
+</script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-05-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-05-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+div p {width: 50%; border: 1px dotted;}
+</style>
+</head>
+<body>
+
+<p>`dir=auto` on the &lt;slot&gt;, paragraph in the light tree</p>
+<div id="host"><p>paragraph</p></div>
+<p id="result">The computed `direction` value for the paragraph is: ltr.</p>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-05.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-05.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<link rel="match" href="dir-shadow-05-ref.html">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+div p {width: 50%; border: 1px dotted;}
+</style>
+</head>
+<body>
+
+<p>`dir=auto` on the &lt;slot&gt;, paragraph in the light tree</p>
+<div id="host"><p>paragraph</p></div>
+<p id="result">The computed `direction` value for the paragraph is: </p>
+
+<script type="text/javascript">
+  let root = host.attachShadow({mode:"open"});
+  root.innerHTML = `
+    <slot dir="auto"></slot>
+  `;
+  result.innerHTML += getComputedStyle(host.firstChild).direction + '.';
+</script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-06-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-06-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+div p {width: 50%; border: 1px dotted;}
+</style>
+</head>
+<body>
+
+<p>`dir=auto` on the &lt;slot&gt;, paragraph in the light tree</p>
+<div id="host"><p dir="rtl">اختبر</p></div>
+<p id="result">The computed `direction` value for the paragraph is: rtl.</p>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-06.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-06.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<link rel="match" href="dir-shadow-06-ref.html">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+div p {width: 50%; border: 1px dotted;}
+</style>
+</head>
+<body>
+
+<p>`dir=auto` on the &lt;slot&gt;, paragraph in the light tree</p>
+<div id="host"><p>اختبر</p></div>
+<p id="result">The computed `direction` value for the paragraph is: </p>
+
+<script type="text/javascript">
+  let root = host.attachShadow({mode:"open"});
+  root.innerHTML = `
+    <slot dir="auto"></slot>
+  `;
+  result.innerHTML += getComputedStyle(host.firstChild).direction + '.';
+</script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-07-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-07-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+div p {width: 50%; border: 1px dotted;}
+</style>
+</head>
+<body>
+
+<p>`dir=ltr` on the shadow host, paragraph in the light tree</p>
+<div id="host" dir="ltr"><p>paragraph</p></div>
+<p id="result">The computed `direction` value for the paragraph is: ltr.</p>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-07.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-07.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<link rel="match" href="dir-shadow-07-ref.html">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+div p {width: 50%; border: 1px dotted;}
+</style>
+</head>
+<body>
+
+<p>`dir=ltr` on the shadow host, paragraph in the light tree</p>
+<div id="host" dir="ltr"><p>paragraph</p></div>
+<p id="result">The computed `direction` value for the paragraph is: </p>
+
+<script type="text/javascript">
+  let root = host.attachShadow({mode:"open"});
+  root.innerHTML = `
+    <slot></slot>
+  `;
+  result.innerHTML += getComputedStyle(host.firstChild).direction + '.';
+</script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-08-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-08-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+div p {width: 50%; border: 1px dotted;}
+</style>
+</head>
+<body>
+
+<p>`dir=ltr` on the shadow host, paragraph in the light tree</p>
+<div id="host" dir="ltr"><p>اختبر</p></div>
+<p id="result">The computed `direction` value for the paragraph is: ltr.</p>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-08.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-08.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<link rel="match" href="dir-shadow-08-ref.html">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+div p {width: 50%; border: 1px dotted;}
+</style>
+</head>
+<body>
+
+<p>`dir=ltr` on the shadow host, paragraph in the light tree</p>
+<div id="host" dir="ltr"><p>اختبر</p></div>
+<p id="result">The computed `direction` value for the paragraph is: </p>
+
+<script type="text/javascript">
+  let root = host.attachShadow({mode:"open"});
+  root.innerHTML = `
+    <slot></slot>
+  `;
+  result.innerHTML += getComputedStyle(host.firstChild).direction + '.';
+</script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-09-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-09-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+div p {width: 50%; border: 1px dotted;}
+</style>
+</head>
+<body>
+
+<p>`dir=rtl` on the shadow host, paragraph in the light tree</p>
+<div id="host" dir="rtl"><p>paragraph</p></div>
+<p id="result">The computed `direction` value for the paragraph is: rtl.</p>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-09.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-09.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<link rel="match" href="dir-shadow-09-ref.html">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+div p {width: 50%; border: 1px dotted;}
+</style>
+</head>
+<body>
+
+<p>`dir=rtl` on the shadow host, paragraph in the light tree</p>
+<div id="host" dir="rtl"><p>paragraph</p></div>
+<p id="result">The computed `direction` value for the paragraph is: </p>
+
+<script type="text/javascript">
+  let root = host.attachShadow({mode:"open"});
+  root.innerHTML = `
+    <slot></slot>
+  `;
+  result.innerHTML += getComputedStyle(host.firstChild).direction + '.';
+</script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-10-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-10-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+div p {width: 50%; border: 1px dotted;}
+</style>
+</head>
+<body>
+
+<p>`dir=rtl` on the shadow host, paragraph in the light tree</p>
+<div id="host" dir="rtl"><p>اختبر</p></div>
+<p id="result">The computed `direction` value for the paragraph is: rtl.</p>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-10.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-10.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<link rel="match" href="dir-shadow-10-ref.html">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+div p {width: 50%; border: 1px dotted;}
+</style>
+</head>
+<body>
+
+<p>`dir=rtl` on the shadow host, paragraph in the light tree</p>
+<div id="host" dir="rtl"><p>اختبر</p></div>
+<p id="result">The computed `direction` value for the paragraph is: </p>
+
+<script type="text/javascript">
+  let root = host.attachShadow({mode:"open"});
+  root.innerHTML = `
+    <slot></slot>
+  `;
+  result.innerHTML += getComputedStyle(host.firstChild).direction + '.';
+</script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-11-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-11-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+div p {width: 50%; border: 1px dotted;}
+</style>
+</head>
+<body>
+
+<p>`dir=auto` on the shadow host, paragraph in the light tree</p>
+<div id="host" dir="auto"><p>paragraph</p></div>
+<p id="result">The computed `direction` value for the paragraph is: ltr.</p>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-11.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-11.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<link rel="match" href="dir-shadow-11-ref.html">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+div p {width: 50%; border: 1px dotted;}
+</style>
+</head>
+<body>
+
+<p>`dir=auto` on the shadow host, paragraph in the light tree</p>
+<div id="host" dir="auto"><p>paragraph</p></div>
+<p id="result">The computed `direction` value for the paragraph is: </p>
+
+<script type="text/javascript">
+  let root = host.attachShadow({mode:"open"});
+  root.innerHTML = `
+    <slot></slot>
+  `;
+  result.innerHTML += getComputedStyle(host.firstChild).direction + '.';
+</script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-12-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-12-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+div p {width: 50%; border: 1px dotted;}
+</style>
+</head>
+<body>
+
+<p>`dir=auto` on the shadow host, paragraph in the light tree</p>
+<div id="host" dir="rtl"><p>اختبر</p></div>
+<p id="result">The computed `direction` value for the paragraph is: rtl.</p>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-12.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-12.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<link rel="match" href="dir-shadow-12-ref.html">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+div p {width: 50%; border: 1px dotted;}
+</style>
+</head>
+<body>
+
+<p>`dir=auto` on the shadow host, paragraph in the light tree</p>
+<div id="host" dir="rtl"><p>اختبر</p></div>
+<p id="result">The computed `direction` value for the paragraph is: </p>
+
+<script type="text/javascript">
+  let root = host.attachShadow({mode:"open"});
+  root.innerHTML = `<slot></slot>`;
+  result.innerHTML += getComputedStyle(host.firstChild).direction + '.';
+</script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-13-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-13-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+div p {width: 50%; border: 1px dotted;}
+</style>
+</head>
+<body>
+
+<p>`dir=ltr` on the shadow host, paragraph in the shadow tree</p>
+<div id="host" dir="ltr"><p>paragraph</p></div>
+<p id="result">The computed `direction` value for the paragraph is: ltr.</p>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-13.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-13.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<link rel="match" href="dir-shadow-13-ref.html">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+</style>
+</head>
+<body>
+
+<p>`dir=ltr` on the shadow host, paragraph in the shadow tree</p>
+<div id="host" dir="ltr"></div>
+<p id="result">The computed `direction` value for the paragraph is: </p>
+
+<script type="text/javascript">
+  let root = host.attachShadow({mode:"open"});
+  root.innerHTML = `<style>p {width: 50%; border: 1px dotted;}</style><p>paragraph</p>`;
+  result.innerHTML += getComputedStyle(root.querySelector('p')).direction + '.';
+</script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-14-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-14-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+div p {width: 50%; border: 1px dotted;}
+</style>
+</head>
+<body>
+
+<p>`dir=ltr` on the shadow host, paragraph in the shadow tree</p>
+<div id="host" dir="ltr"><p>اختبر</p></div>
+<p id="result">The computed `direction` value for the paragraph is: ltr.</p>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-14.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-14.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<link rel="match" href="dir-shadow-14-ref.html">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+</style>
+</head>
+<body>
+
+<p>`dir=ltr` on the shadow host, paragraph in the shadow tree</p>
+<div id="host" dir="ltr"></div>
+<p id="result">The computed `direction` value for the paragraph is: </p>
+
+<script type="text/javascript">
+  let root = host.attachShadow({mode:"open"});
+  root.innerHTML = `<style>p {width: 50%; border: 1px dotted;}</style><p>اختبر</p>`;
+  result.innerHTML += getComputedStyle(root.querySelector('p')).direction + '.';
+</script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-15-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-15-expected.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+div p {width: 50%; border: 1px dotted;}
+</style>
+</head>
+<body>
+
+<p>`dir=rtl` on the shadow host, paragraph in the shadow tree</p>
+<div id="host" dir="rtl"><p>paragraph</p></div>
+<p id="result">The computed `direction` value for the paragraph is: rtl.</p>
+
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-15.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-15.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<link rel="match" href="dir-shadow-15-ref.html">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+</style>
+</head>
+<body>
+
+<p>`dir=rtl` on the shadow host, paragraph in the shadow tree</p>
+<div id="host" dir="rtl"></div>
+<p id="result">The computed `direction` value for the paragraph is: </p>
+
+<script type="text/javascript">
+  let root = host.attachShadow({mode:"open"});
+  root.innerHTML = `<style>p {width: 50%; border: 1px dotted;}</style><p>paragraph</p>`;
+  result.innerHTML += getComputedStyle(root.querySelector('p')).direction + '.';
+</script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-16-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-16-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+div p {width: 50%; border: 1px dotted;}
+</style>
+</head>
+<body>
+
+<p>`dir=rtl` on the shadow host, paragraph in the shadow tree</p>
+<div id="host" dir="rtl"><p>اختبر</p></div>
+<p id="result">The computed `direction` value for the paragraph is: rtl.</p>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-16.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-16.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<link rel="match" href="dir-shadow-16-ref.html">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+</style>
+</head>
+<body>
+
+<p>`dir=rtl` on the shadow host, paragraph in the shadow tree</p>
+<div id="host" dir="rtl"></div>
+<p id="result">The computed `direction` value for the paragraph is: </p>
+
+<script type="text/javascript">
+  let root = host.attachShadow({mode:"open"});
+  root.innerHTML = `<style>p {width: 50%; border: 1px dotted;}</style><p>اختبر</p>`;
+  result.innerHTML += getComputedStyle(root.querySelector('p')).direction + '.';
+</script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-17-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-17-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+div p {width: 50%; border: 1px dotted;}
+</style>
+</head>
+<body>
+
+<p>`dir=auto` on the shadow host, paragraph in the shadow tree</p>
+<div id="host" dir="auto"><p>paragraph</p></div>
+<p id="result">The computed `direction` value for the paragraph is: ltr.</p>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-17.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-17.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<link rel="match" href="dir-shadow-17-ref.html">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+</style>
+</head>
+<body>
+
+<p>`dir=auto` on the shadow host, paragraph in the shadow tree</p>
+<div id="host" dir="auto"></div>
+<p id="result">The computed `direction` value for the paragraph is: </p>
+
+<script type="text/javascript">
+  let root = host.attachShadow({mode:"open"});
+  root.innerHTML = `<style>p {width: 50%; border: 1px dotted;}</style><p>paragraph</p>`;
+  result.innerHTML += getComputedStyle(root.querySelector('p')).direction + '.';
+</script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-18-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-18-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+div p {width: 50%; border: 1px dotted;}
+</style>
+</head>
+<body>
+
+<p>`dir=auto` on the shadow host, paragraph in the shadow tree</p>
+<div id="host" dir="rtl"><p dir="">اختبر</p></div>
+<p id="result">The computed `direction` value for the paragraph is: rtl.</p>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-18.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-18.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<link rel="match" href="dir-shadow-18-ref.html">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+</style>
+</head>
+<body>
+
+<p>`dir=auto` on the shadow host, paragraph in the shadow tree</p>
+<div id="host" dir="auto"></div>
+<p id="result">The computed `direction` value for the paragraph is: </p>
+
+<script type="text/javascript">
+  let root = host.attachShadow({mode:"open"});
+  root.innerHTML = `<style>p {width: 50%; border: 1px dotted;}</style><p>اختبر</p>`;
+  result.innerHTML += getComputedStyle(root.querySelector('p')).direction + '.';
+</script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-19-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-19-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+
+</style>
+</head>
+<body>
+
+<p>`dir=ltr` on the div (shadow host), text in the shadow tree</p>
+<div id="host" dir="ltr">text</div>
+<p id="result">The computed `direction` value for the host’s text is: ltr.</p>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-19.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-19.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<link rel="match" href="dir-shadow-19-ref.html">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+</style>
+</head>
+<body>
+
+<p>`dir=ltr` on the div (shadow host), text in the shadow tree</p>
+<div id="host" dir="ltr"></div>
+<p id="result">The computed `direction` value for the host’s text is: </p>
+
+<script type="text/javascript">
+  let root = host.attachShadow({mode:"open"});
+  root.innerHTML = `text`;
+  result.innerHTML += getComputedStyle(host).direction + '.';
+</script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-20-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-20-expected.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+</style>
+</head>
+<body>
+
+<p>`dir=ltr` on the div (shadow host), text in the shadow tree</p>
+<div id="host" dir="ltr">اختبر</div>
+<p id="result">The computed `direction` value for the host’s text is: ltr.</p>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-20.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-20.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<link rel="match" href="dir-shadow-20-ref.html">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+</style>
+</head>
+<body>
+
+<p>`dir=ltr` on the div (shadow host), text in the shadow tree</p>
+<div id="host" dir="ltr"></div>
+<p id="result">The computed `direction` value for the host’s text is: </p>
+
+<script type="text/javascript">
+  let root = host.attachShadow({mode:"open"});
+  root.innerHTML = `اختبر`;
+  result.innerHTML += getComputedStyle(host).direction + '.';
+</script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-21-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-21-expected.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+</style>
+</head>
+<body>
+
+<p>`dir=rtl` on the div (shadow host), text in the shadow tree</p>
+<div id="host" dir="rtl">text</div>
+<p id="result">The computed `direction` value for the host’s text is: rtl.</p>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-21.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-21.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<link rel="match" href="dir-shadow-21-ref.html">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+</style>
+</head>
+<body>
+
+<p>`dir=rtl` on the div (shadow host), text in the shadow tree</p>
+<div id="host" dir="rtl"></div>
+<p id="result">The computed `direction` value for the host’s text is: </p>
+
+<script type="text/javascript">
+  let root = host.attachShadow({mode:"open"});
+  root.innerHTML = `text`;
+  result.innerHTML += getComputedStyle(host).direction + '.';
+</script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-22-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-22-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+</style>
+</head>
+<body>
+
+<p>`dir=rtl` on the div (shadow host), text in the shadow tree</p>
+<div id="host" dir="rtl">اختبر</div>
+<p id="result">The computed `direction` value for the host’s text is: rtl.</p>
+
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-22.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-22.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<link rel="match" href="dir-shadow-22-ref.html">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+</style>
+</head>
+<body>
+
+<p>`dir=rtl` on the div (shadow host), text in the shadow tree</p>
+<div id="host" dir="rtl"></div>
+<p id="result">The computed `direction` value for the host’s text is: </p>
+
+<script type="text/javascript">
+  let root = host.attachShadow({mode:"open"});
+  root.innerHTML = `اختبر`;
+  result.innerHTML += getComputedStyle(host).direction + '.';
+</script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-23-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-23-expected.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+</style>
+</head>
+<body>
+
+<p>`dir=auto` on the div (shadow host), text in the shadow tree</p>
+<div id="host" dir="auto">text</div>
+<p id="result">The computed `direction` value for the host’s text is: ltr.</p>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-23.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-23.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<link rel="match" href="dir-shadow-23-ref.html">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+</style>
+</head>
+<body>
+
+<p>`dir=auto` on the div (shadow host), text in the shadow tree</p>
+<div id="host" dir="auto"></div>
+<p id="result">The computed `direction` value for the host’s text is: </p>
+
+<script type="text/javascript">
+  let root = host.attachShadow({mode:"open"});
+  root.innerHTML = `text`;
+  result.innerHTML += getComputedStyle(host).direction + '.';
+</script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-24-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-24-expected.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+</style>
+</head>
+<body>
+
+<p>`dir=auto` on the div (shadow host), text in the shadow tree</p>
+<div id="host" dir="rtl">اختبر</div>
+<p id="result">The computed `direction` value for the host’s text is: rtl.</p>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-24.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-24.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<link rel="match" href="dir-shadow-24-ref.html">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+</style>
+</head>
+<body>
+
+<p>`dir=auto` on the div (shadow host), text in the shadow tree</p>
+<div id="host" dir="auto"></div>
+<p id="result">The computed `direction` value for the host’s text is: </p>
+
+<script type="text/javascript">
+  let root = host.attachShadow({mode:"open"});
+  root.innerHTML = `اختبر`;
+  result.innerHTML += getComputedStyle(host).direction + '.';
+</script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-25-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-25-expected.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+div p {width: 50%; border: 1px dotted;}
+</style>
+</head>
+<body>
+
+<p>`dir=ltr` on a paragraph in the shadow tree, text in the light tree</p>
+<div id="host">
+<p dir="ltr">paragraph</p>
+</div>
+<p id="result">The computed `direction` value for the paragraph is: ltr.</p>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-25.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-25.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<link rel="match" href="dir-shadow-25-ref.html">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+</style>
+</head>
+<body>
+
+<p>`dir=ltr` on a paragraph in the shadow tree, text in the light tree</p>
+<div id="host">
+paragraph
+</div>
+<p id="result">The computed `direction` value for the paragraph is: </p>
+
+<script type="text/javascript">
+  let root = host.attachShadow({mode:"open"});
+  root.innerHTML = `<style>p {width: 50%; border: 1px dotted;}</style><p dir="ltr"><slot></slot></p>`;
+  result.innerHTML += getComputedStyle(root.querySelector('p')).direction + '.';
+</script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-26-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-26-expected.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+div p {width: 50%; border: 1px dotted;}
+</style>
+</head>
+<body>
+
+<p>`dir=ltr` on a paragraph in the shadow tree, text in the light tree</p>
+<div id="host">
+<p dir="ltr">اختبر</p>
+</div>
+<p id="result">The computed `direction` value for the paragraph is: ltr.</p>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-26.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-26.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<link rel="match" href="dir-shadow-26-ref.html">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+</style>
+</head>
+<body>
+
+<p>`dir=ltr` on a paragraph in the shadow tree, text in the light tree</p>
+<div id="host">
+اختبر
+</div>
+<p id="result">The computed `direction` value for the paragraph is: </p>
+
+<script type="text/javascript">
+  let root = host.attachShadow({mode:"open"});
+  root.innerHTML = `<style>p {width: 50%; border: 1px dotted;}</style><p dir="ltr"><slot></slot></p>`;
+  result.innerHTML += getComputedStyle(root.querySelector('p')).direction + '.';
+</script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-27-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-27-expected.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+div p {width: 50%; border: 1px dotted;}
+</style>
+</head>
+<body>
+
+<p>`dir=rtl` on a paragraph in the shadow tree, text in the light tree</p>
+<div id="host">
+<p dir="rtl">paragraph</p>
+</div>
+<p id="result">The computed `direction` value for the paragraph is: rtl.</p>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-27.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-27.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<link rel="match" href="dir-shadow-27-ref.html">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+</style>
+</head>
+<body>
+
+<p>`dir=rtl` on a paragraph in the shadow tree, text in the light tree</p>
+<div id="host">
+paragraph
+</div>
+<p id="result">The computed `direction` value for the paragraph is: </p>
+
+<script type="text/javascript">
+  let root = host.attachShadow({mode:"open"});
+  root.innerHTML = `<style>p {width: 50%; border: 1px dotted;}</style><p dir="rtl"><slot></slot></p>`;
+  result.innerHTML += getComputedStyle(root.querySelector('p')).direction + '.';
+</script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-28-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-28-expected.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+div p {width: 50%; border: 1px dotted;}
+</style>
+</head>
+<body>
+
+<p>`dir=rtl` on a paragraph in the shadow tree, text in the light tree</p>
+<div id="host">
+<p dir="rtl">اختبر</p>
+</div>
+<p id="result">The computed `direction` value for the paragraph is: rtl.</p>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-28.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-28.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<link rel="match" href="dir-shadow-28-ref.html">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+</style>
+</head>
+<body>
+
+<p>`dir=rtl` on a paragraph in the shadow tree, text in the light tree</p>
+<div id="host">
+اختبر
+</div>
+<p id="result">The computed `direction` value for the paragraph is: </p>
+
+<script type="text/javascript">
+  let root = host.attachShadow({mode:"open"});
+  root.innerHTML = `<style>p {width: 50%; border: 1px dotted;}</style><p dir="rtl"><slot></slot></p>`;
+  result.innerHTML += getComputedStyle(root.querySelector('p')).direction + '.';
+</script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-29-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-29-expected.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+div p {width: 50%; border: 1px dotted;}
+</style>
+</head>
+<body>
+
+<p>`dir=auto` on a paragraph in the shadow tree, text in the light tree</p>
+<div id="host">
+<p dir="ltr">para</p>
+</div>
+<p id="result">The computed `direction` value for the paragraph is: ltr.</p>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-29.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-29.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<link rel="match" href="dir-shadow-29-ref.html">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+</style>
+</head>
+<body>
+
+<p>`dir=auto` on a paragraph in the shadow tree, text in the light tree</p>
+<div id="host">
+para
+</div>
+<p id="result">The computed `direction` value for the paragraph is: </p>
+
+<script type="text/javascript">
+  let root = host.attachShadow({mode:"open"});
+  root.innerHTML = `<style>p {width: 50%; border: 1px dotted;}</style><p dir="auto"><slot></slot></p>`;
+  result.innerHTML += getComputedStyle(root.querySelector('p')).direction + '.';
+</script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-30-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-30-expected.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+div p {width: 50%; border: 1px dotted;}
+</style>
+</head>
+<body>
+
+<p>`dir=auto` on a paragraph in the shadow tree, text in the light tree</p>
+<div id="host">
+<p dir="rtl">اختبر</p>
+</div>
+<p id="result">The computed `direction` value for the paragraph is: rtl.</p>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-30.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-30.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<link rel="match" href="dir-shadow-30-ref.html">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em;}
+</style>
+</head>
+<body>
+
+<p>`dir=auto` on a paragraph in the shadow tree, text in the light tree</p>
+<div id="host">
+اختبر
+</div>
+<p id="result">The computed `direction` value for the paragraph is: </p>
+
+<script type="text/javascript">
+  let root = host.attachShadow({mode:"open"});
+  root.innerHTML = `<style>p {width: 50%; border: 1px dotted;}</style><p dir="auto"><slot></slot></p>`;
+  result.innerHTML += getComputedStyle(root.querySelector('p')).direction + '.';
+</script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-31-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-31-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em; padding: 0.25em;}
+span {border: 1px solid silver;}
+</style>
+</head>
+<body>
+
+<p>`dir=rtl` on the slot, span in the light tree</p>
+<div id="host" dir="ltr"><span dir="rtl">RTL</span></div>
+<p id="result">The computed `direction` value for the span is: rtl.</p>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-31.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-31.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<link rel="match" href="dir-shadow-31-ref.html">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em; padding: 0.25em;}
+span {border: 1px solid silver;}
+
+</style>
+</head>
+<body>
+
+<p>`dir=rtl` on the slot, span in the light tree</p>
+<div id="host" dir="ltr"><span>RTL</span></div>
+<p id="result">The computed `direction` value for the span is: </p>
+
+<script type="text/javascript">
+  let root = host.attachShadow({mode:"open"});
+  root.innerHTML = `<slot dir="rtl"></slot>`;
+  result.innerHTML += getComputedStyle(host.querySelector('span')).direction + '.';
+</script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-32-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-32-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em; padding: 0.25em;}
+span {border: 1px solid silver;}
+</style>
+</head>
+<body>
+
+<p>`dir=rtl` on the shadow host, span in the shadow tree</p>
+<div id="host" dir="rtl"><span>RTL</span></div>
+<p id="result">The computed `direction` value for the shadow span is: rtl.</p>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-32.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-32.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<link rel="match" href="dir-shadow-32-ref.html">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em; padding: 0.25em;}
+</style>
+</head>
+<body>
+
+<p>`dir=rtl` on the shadow host, span in the shadow tree</p>
+<div id="host" dir="rtl"></div>
+<p id="result">The computed `direction` value for the shadow span is: </p>
+
+<script type="text/javascript">
+  let root = host.attachShadow({mode:"open"});
+  root.innerHTML = `<style>span {border: 1px solid silver;}</style><span>RTL</span>`;
+  result.innerHTML += getComputedStyle(root.querySelector('span')).direction + '.';
+</script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-33-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-33-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em; padding: 0.25em;}
+span {border: 1px solid silver;}
+</style>
+</head>
+<body>
+
+<p>`dir=auto` on the span (shadow host), text in the shadow tree</p>
+<span id="host" dir="rtl">اختبر</span>
+<p id="result">The computed `direction` value for the shadow host is: rtl.</p>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-33.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-33.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<link rel="match" href="dir-shadow-33-ref.html">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em; padding: 0.25em;}
+span {border: 1px solid silver;}
+
+</style>
+</head>
+<body>
+
+<p>`dir=auto` on the span (shadow host), text in the shadow tree</p>
+<span id="host" dir="auto"></span>
+<p id="result">The computed `direction` value for the shadow host is: </p>
+
+<script type="text/javascript">
+  let root = host.attachShadow({mode:"open"});
+  root.innerHTML = `اختبر`;
+  result.innerHTML += getComputedStyle(host).direction + '.';
+</script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-34-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-34-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em; padding: 0.25em;}
+</style>
+</head>
+<body>
+
+<p>`dir=auto` on a span in the shadow tree, text in the light tree</p>
+<div id="host"><span dir="rtl">اختبر</span></div>
+<p id="result">The computed `direction` value for the shadow span is: rtl.</p>
+
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-34.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-34.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<link rel="match" href="dir-shadow-34-ref.html">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em; padding: 0.25em;}
+span {border: 1px solid silver;}
+
+</style>
+</head>
+<body>
+
+<p>`dir=auto` on a span in the shadow tree, text in the light tree</p>
+<div id="host">اختبر</div>
+<p id="result">The computed `direction` value for the shadow span is: </p>
+
+<script type="text/javascript">
+  let root = host.attachShadow({mode:"open"});
+  root.innerHTML = `<span dir="auto"><slot></slot></span>`;
+  result.innerHTML += getComputedStyle(root.querySelector("span")).direction + '.';
+</script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-35-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-35-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<style type="text/css">
+body {width: 600px;}
+div#host {border: 1px solid gray; margin: 1em; padding: 0.25em;}
+span {border: 1px solid silver;}
+</style>
+</head>
+<body>
+
+<p>`dir=ltr` on a div in the shadow tree, text in the light tree</p>
+<div id="host" dir="rtl"><div dir="ltr"><span>اختبر</span></div></div>
+<p id="result">The computed `direction` value for the span is: ltr.</p>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-35.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-35.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<link rel="match" href="dir-shadow-35-ref.html">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em; padding: 0.25em;}
+span {border: 1px solid silver;}
+
+</style>
+</head>
+<body>
+
+<p>`dir=ltr` on a div in the shadow tree, text in the light tree</p>
+<div id="host" dir="rtl"><span>اختبر</span></div>
+<p id="result">The computed `direction` value for the span is: </p>
+
+<script type="text/javascript">
+  let root = host.attachShadow({mode:"open"});
+  root.innerHTML = `<div dir="ltr"><slot></slot></div>`;
+  result.innerHTML += getComputedStyle(root.querySelector("div").firstChild).direction + '.';
+</script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-36-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-36-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em; padding: 0.25em;}
+span {border: 1px solid silver;}
+</style>
+</head>
+<body>
+
+<p>`dir=auto` and text in a slot in the shadow tree, text in the light tree</p>
+<div id="host">English</div>
+<p id="result">The computed `direction` value for the light tree text is: rtl (on the slot) and ltr (on the English).</p>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-36.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-36.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<link rel="match" href="dir-shadow-36-ref.html">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em; padding: 0.25em;}
+span {border: 1px solid silver;}
+
+</style>
+</head>
+<body>
+
+<p>`dir=auto` and text in a slot in the shadow tree, text in the light tree</p>
+<div id="host">English</div>
+<p id="result">The computed `direction` value for the light tree text is: </p>
+
+<script type="text/javascript">
+  let root = host.attachShadow({mode:"open"});
+  root.innerHTML = `<slot dir=auto>اختبر</slot>`;
+  result.innerHTML += getComputedStyle(root.firstChild).direction + " (on the " +  root.firstChild.localName + ') and ' + getComputedStyle(host).direction + ' (on the ' + host.textContent + ').';
+</script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-37-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-37-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em; padding: 0.25em;}
+span {border: 1px solid silver;}
+</style>
+</head>
+<body>
+
+<p>`dir=auto` and text in a div in the shadow tree, text in the light tree</p>
+<div id="host" dir="rtl">اختبر123 456</div>
+<p id="result">The computed `direction` value for the light tree text is: rtl (on the div) and ltr (on the 123 456).</p>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-37.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-37.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<link rel="match" href="dir-shadow-37-ref.html">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em; padding: 0.25em;}
+span {border: 1px solid silver;}
+
+</style>
+</head>
+<body>
+
+<p>`dir=auto` and text in a div in the shadow tree, text in the light tree</p>
+<div id="host">123 456</div>
+<p id="result">The computed `direction` value for the light tree text is: </p>
+
+<script type="text/javascript">
+  let root = host.attachShadow({mode:"open"});
+  root.innerHTML = `<div dir="auto">اختبر<slot></slot></div>`;
+  result.innerHTML += getComputedStyle(root.firstChild).direction + " (on the " +  root.firstChild.localName + ') and ' + getComputedStyle(host).direction + ' (on the ' + host.textContent + ').';
+</script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-38-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-38-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em; padding: 0.25em;}
+span {border: 1px solid silver;}
+</style>
+</head>
+<body>
+
+<p>`dir=auto` and text in a slot in the shadow tree, text in the light tree</p>
+<div id="host">English</div>
+<p id="result">The computed `direction` value for the light tree text is: ltr (on the slot) and ltr (on the English).</p>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-38.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-38.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<link rel="match" href="dir-shadow-38-ref.html">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em; padding: 0.25em;}
+span {border: 1px solid silver;}
+
+</style>
+</head>
+<body>
+
+<p>`dir=auto` and text in a slot in the shadow tree, text in the light tree</p>
+<div id="host">English</div>
+<p id="result">The computed `direction` value for the light tree text is: </p>
+
+<script type="text/javascript">
+  let root = host.attachShadow({mode:"open"});
+  root.innerHTML = `<slot dir=auto>اختبر</slot>`;
+  result.innerHTML += getComputedStyle(root.firstChild).direction + " (on the " +  root.firstChild.localName + ') and ' + getComputedStyle(host).direction + ' (on the ' + host.textContent + ').';
+</script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-39-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-39-expected.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em; padding: 0.25em;}
+span {border: 1px solid silver;}
+
+</style>
+</head>
+<body>
+
+<p>text in the light tree, slotted node</p>
+<div id="host">slotted text</div>
+<p id="result">The computed `direction` value for the defaultContent when there is a slotted node: ltr (on the div).</p>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-39.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-39.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<link rel="match" href="dir-shadow-39-ref.html">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em; padding: 0.25em;}
+span {border: 1px solid silver;}
+
+</style>
+</head>
+<body>
+
+<p>text in the light tree, slotted node</p>
+<div id="host">slotted text</div>
+<p id="result">The computed `direction` value for the defaultContent when there is a slotted node: </p>
+
+<script type="text/javascript">
+  let root = host.attachShadow({mode:"open"});
+  root.innerHTML = `<slot dir=auto><div>&#1571;&#1582;&#1576;&#1575;&#1585;</div></slot>`;
+  result.innerHTML += getComputedStyle(root.firstChild.firstChild).direction + " (on the " +  root.firstChild.firstChild.localName + ').';
+</script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-40-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-40-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em; padding: 0.25em;}
+span {border: 1px solid silver;}
+</style>
+</head>
+<body>
+
+<p>text in the light tree, no slotted node</p>
+<div id="host" dir="rtl">&#1571;&#1582;&#1576;&#1575;&#1585;</div>
+<p id="result">The computed `direction` value for the defaultContent when there is not a slotted node: rtl (on the div).</p>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-40.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-40.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<link rel="match" href="dir-shadow-40-ref.html">
+<style type="text/css">
+body {width: 600px;}
+div {border: 1px solid gray; margin: 1em; padding: 0.25em;}
+span {border: 1px solid silver;}
+
+</style>
+</head>
+<body>
+
+<p>text in the light tree, no slotted node</p>
+<div id="host"></div>
+<p id="result">The computed `direction` value for the defaultContent when there is not a slotted node: </p>
+
+<script type="text/javascript">
+  let root = host.attachShadow({mode:"open"});
+  root.innerHTML = `<slot dir=auto><div>&#1571;&#1582;&#1576;&#1575;&#1585;</div></slot>`;
+  result.innerHTML += getComputedStyle(root.firstChild.firstChild).direction + " (on the " +  root.firstChild.firstChild.localName + ').';
+</script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-41-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-41-expected.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<style type="text/css">
+body {width: 600px;}
+#host {border: 1px solid gray; margin: 1em; padding: 0.25em;}
+span {border: 1px solid silver;}
+
+</style>
+</head>
+<body>
+
+<p>`dir=ltr` on a div in the shadow tree, `dir=rtl` on the shadow host, no slotted text in the light or dark trees</p>
+<div id="host" dir="rtl"><div dir="ltr"><span dir="rtl"></span></div></div>
+<p id="result">The computed `direction` value is: rtl (on the slot).</p>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-41.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-41.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>[dir] and shadow slots</title>
+<link rel="author" title="Eric Meyer" href="mailto:emeyer@igalia.com">
+<link rel="help" href="">
+<link rel="match" href="dir-shadow-41-ref.html">
+<style type="text/css">
+body {width: 600px;}
+#host {border: 1px solid gray; margin: 1em; padding: 0.25em;}
+span {border: 1px solid silver;}
+
+</style>
+</head>
+<body>
+
+<p>`dir=ltr` on a div in the shadow tree, `dir=rtl` on the shadow host, no slotted text in the light or dark trees</p>
+<div id="host" dir="rtl"><span slot="x1"></span></div>
+<p id="result">The computed `direction` value is: </p>
+
+<script type="text/javascript">
+  let root = host.attachShadow({mode:"open"});
+  root.innerHTML = `<div dir="ltr"><slot dir="auto" name="x1"></slot></div>`;
+  result.innerHTML += getComputedStyle(root.querySelector("div[dir=ltr]").firstChild).direction + " (on the " +  root.querySelector("div[dir=ltr]").firstChild.localName + ').';
+</script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-slot-nested-2levels-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-slot-nested-2levels-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Focus controller should treat each slot as a focus scope. assert_equals: Focus should move forward from nested1/inner-before to nested1/button expected Element node <button id="button"><slot></slot></button> but got Element node <input id="innermost-before"></input>
+PASS Focus controller should treat each slot as a focus scope.
 
 
 button

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-slot-nested-2levels.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-slot-nested-2levels.html
@@ -19,7 +19,7 @@
   <div id='nested1'>
     <template data-mode='open'>
       <input id='inner-before'>
-      <button id='button'><slot></slot></button>
+      <div id='inner-div' tabindex='0'><slot></slot></div>
       <input id='inner-after'>
     </template>
     <div id='dummy2'></div>
@@ -46,7 +46,7 @@ promise_test(async () => {
     'i0',
     'outer/outer-before',
     'nested1/inner-before',
-    'nested1/button',
+    'nested1/inner-div',
     'nested2/innermost-before',
     'innermost1',
     'innermost2',

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-slots-in-slot-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-slots-in-slot-expected.txt
@@ -1,8 +1,18 @@
 Tests for moving focus by pressing tab key across nodes in slot scope.
+
+outside
+single nested slot
+single nested slot
+single nested slot
+double nested slot
+double nested slot
+single nested slot
+double nested slot
+Triple nested slot
+Triple nested slot
+double nested slot
+single nested slot
 outside
 
-single nested slot  single nested slot  single nested slot  double nested slot  double nested slot  single nested slot double nested slot  Triple nested slot  Triple nested slot  double nested slot  single nested slot
-outside
-
-FAIL Focus should cover assigned nodes of slot, especially for nested slots in slot scope. assert_equals: Focus should move forward from b1 to 1A expected Element node <button id="1A">single nested slot</button> but got Element node <body><p>Tests for moving focus by pressing tab key acros...
+PASS Focus should cover assigned nodes of slot, especially for nested slots in slot scope.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-slots-in-slot.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-slots-in-slot.html
@@ -8,38 +8,38 @@
 <script src="resources/focus-utils.js"></script>
 <p>Tests for moving focus by pressing tab key across nodes in slot scope.<br>
 
-<button id="b1">outside</button>
+<div id="b1" tabindex="0">outside</div>
 <div id='host'>
   <template data-mode='open'>
     <slot></slot>
   </template>
   <slot>
-    <button id="1A">single nested slot</button>
-    <button id="1B">single nested slot</button>
+    <div id="1A" tabindex="0">single nested slot</div>
+    <div id="1B" tabindex="0">single nested slot</div>
   </slot>
   <slot>
-    <button id="1C">single nested slot</button>
+    <div id="1C" tabindex="0">single nested slot</div>
   </slot>
   <slot>
     <slot>
-      <button id="2A">double nested slot</button>
-      <button id="2B">double nested slot</button>
+      <div id="2A" tabindex="0">double nested slot</div>
+      <div id="2B" tabindex="0">double nested slot</div>
     </slot>
   </slot>
   <slot>
-    <button id="3A">single nested slot</button>
+    <div id="3A" tabindex="0">single nested slot</div>
     <slot>
-      <button id="3B">double nested slot</button>
+      <div id="3B" tabindex="0">double nested slot</div>
       <slot>
-        <button id="3C">Triple nested slot</button>
-        <button id="3D">Triple nested slot</button>
+        <div id="3C" tabindex="0">Triple nested slot</div>
+        <div id="3D" tabindex="0">Triple nested slot</div>
       </slot>
-      <button id="3E">double nested slot</button>
+      <div id="3E" tabindex="0">double nested slot</div>
     </slot>
-    <button id="3F">single nested slot</button>
+    <div id="3F" tabindex="0">single nested slot</div>
   </slot>
 </div>
-<button id="b2">outside</button>
+<div id="b2" tabindex="0">outside</div>
 
 <script>
 'use strict';

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-web-component-input-type-radio-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-web-component-input-type-radio-expected.txt
@@ -1,7 +1,0 @@
-OUT
-A B
-C D
-OUT
-
-FAIL Focus for web component input type elements should be bound by <form> inside shadow DOM assert_equals: expected "A" but got "end"
-

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-web-component-radio-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-web-component-radio-expected.txt
@@ -1,0 +1,7 @@
+OUT
+A B
+C D
+OUT
+
+PASS Focus for web component input type elements should be bound by <form> inside shadow DOM
+

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-web-component-radio.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-web-component-radio.html
@@ -8,7 +8,7 @@
 <script src="resources/focus-utils.js"></script>
 
 <template id="custom-radio">
-  <input type="radio">
+  <span aria-role="radio" tabindex="0">&#x1F518;</span>
   <slot></slot>
 </template>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-nested-slots-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-nested-slots-expected.txt
@@ -1,7 +1,8 @@
-one  two  three  four  five
+one
+two
+three
+four
+five
 
-FAIL Verifies that focus order goes in flat tree order with buttons inside nested slots which have a mixture of assigned and unassigned states. assert_equals: expected Element node <button id="button2">two</button> but got Element node <body><button id="button1">one</button>
-<span>
-
-  <slot...
+PASS Verifies that focus order goes in flat tree order with buttons inside nested slots which have a mixture of assigned and unassigned states.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-nested-slots.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-nested-slots.html
@@ -10,42 +10,42 @@
 <script src="resources/shadow-dom.js"></script>
 <script src="resources/focus-utils.js"></script>
 
-<button id=button1>one</button>
+<div id=div1 tabindex=0>one</div>
 <span>
   <template shadowroot=open>
     <slot name=myslot></slot>
   </template>
   <slot slot=myslot>
-    <button id=button2>two</button>
-    <button id=button3>three</button>
-    <button id=button4>four</button>
+    <div id=div2 tabindex=0>two</div>
+    <div id=div3 tabindex=0>three</div>
+    <div id=div4 tabindex=0>four</div>
   </slot>
 </span>
-<button id=button5>five</button>
+<div id=div5 tabindex=0>five</div>
 
 <script>
 
 promise_test(async () => {
   convertDeclarativeTemplatesToShadowRootsWithin(document);
-  button1.focus();
-  assert_equals(document.activeElement, button1);
+  div1.focus();
+  assert_equals(document.activeElement, div1);
 
   await navigateFocusForward();
-  assert_equals(document.activeElement, button2);
+  assert_equals(document.activeElement, div2);
   await navigateFocusForward();
-  assert_equals(document.activeElement, button3);
+  assert_equals(document.activeElement, div3);
   await navigateFocusForward();
-  assert_equals(document.activeElement, button4);
+  assert_equals(document.activeElement, div4);
   await navigateFocusForward();
-  assert_equals(document.activeElement, button5);
+  assert_equals(document.activeElement, div5);
   await navigateFocusBackward();
-  assert_equals(document.activeElement, button4);
+  assert_equals(document.activeElement, div4);
   await navigateFocusBackward();
-  assert_equals(document.activeElement, button3);
+  assert_equals(document.activeElement, div3);
   await navigateFocusBackward();
-  assert_equals(document.activeElement, button2);
+  assert_equals(document.activeElement, div2);
   await navigateFocusBackward();
-  assert_equals(document.activeElement, button1);
+  assert_equals(document.activeElement, div1);
 }, `Verifies that focus order goes in flat tree order with buttons inside nested slots which have a mixture of assigned and unassigned states.`);
 
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/w3c-import.log
@@ -26,7 +26,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-slot-with-tabindex.html
 /LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-slots-in-slot.html
 /LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-slots.html
-/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-web-component-input-type-radio.html
+/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-web-component-radio.html
 /LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-with-delegatesFocus.html
 /LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation.html
 /LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-nested-slots.html

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus/delegatesFocus-tabindex-change-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus/delegatesFocus-tabindex-change-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Setting tabindex on the shadow host of a focused element with delegatesFocus should not change focus.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus/delegatesFocus-tabindex-change.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus/delegatesFocus-tabindex-change.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<link rel=author href="mailto:jarhar@chromium.org">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+<script>
+test(() => {
+  const host = document.createElement('div');
+  document.body.appendChild(host);
+
+  const shadowRoot = host.attachShadow({mode: 'open', delegatesFocus: true});
+
+  const shadowInput = document.createElement('input');
+  shadowRoot.appendChild(shadowInput);
+
+  host.focus();
+  assert_equals(document.activeElement, host, 'The shadow host should be focused.');
+
+  host.setAttribute('tabindex', '0');
+  assert_equals(document.activeElement, host, 'The shadow host should remain focused after changing tabindex.');
+}, 'Setting tabindex on the shadow host of a focused element with delegatesFocus should not change focus.');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus/w3c-import.log
@@ -20,6 +20,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus/click-focus-delegatesFocus-click.html
 /LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus/click-focus-delegatesFocus-tabindex-varies.html
 /LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus/click-focus-delegatesFocus-tabindex-zero.html
+/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus/delegatesFocus-tabindex-change.html
 /LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus/focus-autofocus.html
 /LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus/focus-click-on-shadow-host.html
 /LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus/focus-method-delegatesFocus-nested-browsing-context.html

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-web-component-radio-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-web-component-radio-expected.txt
@@ -1,0 +1,7 @@
+OUT
+A B
+C D
+OUT
+
+FAIL Focus for web component input type elements should be bound by <form> inside shadow DOM assert_equals: expected "A" but got "start"
+

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-web-component-radio-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-web-component-radio-expected.txt
@@ -1,0 +1,7 @@
+OUT
+A B
+C D
+OUT
+
+FAIL Focus for web component input type elements should be bound by <form> inside shadow DOM assert_equals: expected "A" but got "start"
+


### PR DESCRIPTION
#### 7440a0952d96a869a7d67ba01875821687528601
<pre>
Resync web-platform-tests/shadow-dom
<a href="https://bugs.webkit.org/show_bug.cgi?id=251956">https://bugs.webkit.org/show_bug.cgi?id=251956</a>

Reviewed by Tim Nguyen.

Updated web platform tests for shadow DOM as of d7059c01476d1e8a530fca34efdfa7355329a87c.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/innerhtml-before-closing-tag.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-01-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-01.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-02-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-02.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-03-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-03.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-04-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-04.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-05-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-05.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-06-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-06.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-07-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-07.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-08-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-08.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-09-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-09.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-10-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-10.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-11-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-11.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-12-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-12.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-13-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-13.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-14-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-14.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-15-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-15.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-16-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-16.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-17-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-17.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-18-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-18.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-19-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-19.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-20-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-20.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-21-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-21.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-22-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-22.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-23-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-23.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-24-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-24.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-25-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-25.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-26-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-26.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-27-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-27.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-28-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-28.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-29-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-29.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-30-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-30.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-31-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-31.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-32-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-32.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-33-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-33.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-34-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-34.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-35-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-35.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-36-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-36.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-37-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-37.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-38-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-38.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-39-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-39.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-40-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-40.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-41-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/directionality/dir-shadow-41.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-slot-nested-2levels-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-slot-nested-2levels.html:
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-slots-in-slot-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-slots-in-slot.html:
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-web-component-input-type-radio-expected.txt: Removed.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-web-component-radio-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-web-component-radio.html: Renamed from LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-web-component-input-type-radio.html.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-nested-slots-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-nested-slots.html:
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus/delegatesFocus-tabindex-change-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus/delegatesFocus-tabindex-change.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus/w3c-import.log:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-web-component-radio-expected.txt: Added.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/shadow-dom/focus-navigation/focus-navigation-web-component-radio-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/260122@main">https://commits.webkit.org/260122@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7693fe2d028b0c81bccc59fa1b68832d032292f1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106962 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15998 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39755 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116141 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115678 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17478 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7194 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99146 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112727 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13229 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96249 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40827 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95121 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27891 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82576 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9139 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29243 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9719 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6247 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15307 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48802 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11250 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3784 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->