### PR TITLE
Fix non-unified build (2023.02.09)

### DIFF
--- a/Source/WebCore/bindings/js/DOMGCOutputConstraint.cpp
+++ b/Source/WebCore/bindings/js/DOMGCOutputConstraint.cpp
@@ -30,6 +30,7 @@
 #include <JavaScriptCore/BlockDirectoryInlines.h>
 #include <JavaScriptCore/HeapInlines.h>
 #include <JavaScriptCore/MarkedBlockInlines.h>
+#include <JavaScriptCore/SlotVisitorInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <JavaScriptCore/VM.h>
 

--- a/Source/WebCore/bindings/js/InternalWritableStream.cpp
+++ b/Source/WebCore/bindings/js/InternalWritableStream.cpp
@@ -29,6 +29,7 @@
 #include "Exception.h"
 #include "WebCoreJSClientData.h"
 #include <JavaScriptCore/JSArrayBufferViewInlines.h>
+#include <JavaScriptCore/JSObjectInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/bindings/js/JSIDBSerializationGlobalObject.cpp
+++ b/Source/WebCore/bindings/js/JSIDBSerializationGlobalObject.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "JSIDBSerializationGlobalObject.h"
 
+#include "JSDOMGlobalObjectInlines.h"
 #include "WebCoreJSClientData.h"
 
 namespace WebCore {

--- a/Source/WebCore/bindings/js/JSRemoteDOMWindowBase.h
+++ b/Source/WebCore/bindings/js/JSRemoteDOMWindowBase.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "JSDOMGlobalObject.h"
+#include "JSDOMGlobalObjectInlines.h"
 #include "RemoteDOMWindow.h"
 #include <JavaScriptCore/StructureInlines.h>
 

--- a/Source/WebCore/bindings/js/JSShadowRealmGlobalScopeBase.h
+++ b/Source/WebCore/bindings/js/JSShadowRealmGlobalScopeBase.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "JSDOMGlobalObject.h"
+#include "JSDOMGlobalObjectInlines.h"
 #include "JSDOMWrapper.h"
 
 namespace WebCore {

--- a/Source/WebCore/bindings/js/JSWorkerGlobalScopeCustom.cpp
+++ b/Source/WebCore/bindings/js/JSWorkerGlobalScopeCustom.cpp
@@ -32,6 +32,7 @@
 #include "WorkerGlobalScope.h"
 #include "WorkerLocation.h"
 #include "WorkerNavigator.h"
+#include <JavaScriptCore/Error.h>
 
 namespace WebCore {
 using namespace JSC;

--- a/Source/WebCore/dom/ScriptExecutionContext.cpp
+++ b/Source/WebCore/dom/ScriptExecutionContext.cpp
@@ -316,7 +316,7 @@ URL ScriptExecutionContext::currentSourceURL() const
         return { };
 
     URL sourceURL;
-    StackVisitor::visit(topCallFrame, vm, [&sourceURL](auto& visitor) {
+    JSC::StackVisitor::visit(topCallFrame, vm, [&sourceURL](auto& visitor) {
         if (visitor->isNativeFrame())
             return IterationStatus::Continue;
 

--- a/Source/WebCore/inspector/InspectorFrontendClientLocal.cpp
+++ b/Source/WebCore/inspector/InspectorFrontendClientLocal.cpp
@@ -55,6 +55,7 @@
 #include <JavaScriptCore/FrameTracers.h>
 #include <JavaScriptCore/InspectorBackendDispatchers.h>
 #include <wtf/Deque.h>
+#include <wtf/RunLoop.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/StringToIntegerConversion.h>
 

--- a/Source/WebCore/inspector/PageDebugger.cpp
+++ b/Source/WebCore/inspector/PageDebugger.cpp
@@ -41,6 +41,7 @@
 #include "Timer.h"
 #include <JavaScriptCore/JSLock.h>
 #include <wtf/MainThread.h>
+#include <wtf/RunLoop.h>
 #include <wtf/StdLibExtras.h>
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp
@@ -28,6 +28,8 @@
 
 #if ENABLE(GPU_PROCESS)
 
+#include "RemoteImageBuffer.h"
+
 namespace WebKit {
 using namespace WebCore;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.h
@@ -44,6 +44,7 @@ namespace WebKit {
 
 namespace WebGPU {
 class ObjectHeap;
+struct CanvasConfiguration;
 }
 
 class RemotePresentationContext final : public IPC::StreamMessageReceiver {

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
@@ -37,6 +37,7 @@
 #include "SharedVideoFrame.h"
 #include "StreamClientConnection.h"
 #include "WebCoreArgumentCoders.h"
+#include <WebCore/GCGLSpan.h>
 #include <WebCore/GraphicsContextGL.h>
 #include <WebCore/NotImplemented.h>
 #include <wtf/HashMap.h>

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(GPU_PROCESS)
 
+#include "GPUConnectionToWebProcessMessages.h"
 #include "Logging.h"
 #include "PlatformImageBufferShareableBackend.h"
 #include "RemoteRenderingBackendProxy.h"


### PR DESCRIPTION
#### 6f4997e4346cf3f2f22ef985b8c0e70ed5508cae
<pre>
Fix non-unified build (2023.02.09)
<a href="https://bugs.webkit.org/show_bug.cgi?id=251961">https://bugs.webkit.org/show_bug.cgi?id=251961</a>

Unreviewed speculative fix for PlayStation Release build.

One way or another, this corrects a slew of includes following 259903@main.

* Source/WebCore/bindings/js/DOMGCOutputConstraint.cpp:
* Source/WebCore/bindings/js/InternalWritableStream.cpp:
* Source/WebCore/bindings/js/JSIDBSerializationGlobalObject.cpp:
* Source/WebCore/bindings/js/JSRemoteDOMWindowBase.h:
* Source/WebCore/bindings/js/JSShadowRealmGlobalScopeBase.h:
* Source/WebCore/bindings/js/JSWorkerGlobalScopeCustom.cpp:
* Source/WebCore/dom/ScriptExecutionContext.cpp:
(WebCore::ScriptExecutionContext::currentSourceURL const):
* Source/WebCore/inspector/InspectorFrontendClientLocal.cpp:
* Source/WebCore/inspector/PageDebugger.cpp:
* Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp:

Canonical link: <a href="https://commits.webkit.org/260046@main">https://commits.webkit.org/260046@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4ab68e27250ceec77e20c31df346d4e5885ed27

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106852 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15887 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39643 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116035 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/115595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110755 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17366 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7088 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99038 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112620 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/96154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/40748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/95033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/27805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/9042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/29160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9617 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/6168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/15209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48706 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6937 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11146 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->