### PR TITLE
Adjust more DOM-API-exposed screen metrics in headless browsing mode

### DIFF
--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -1249,16 +1249,6 @@ bool DOMWindow::offscreenBuffering() const
 
 int DOMWindow::outerHeight() const
 {
-#if PLATFORM(IOS_FAMILY)
-    if (!frame())
-        return 0;
-
-    RefPtr view = frame()->isMainFrame() ? frame()->view() : frame()->mainFrame().view();
-    if (!view)
-        return 0;
-
-    return view->frameRect().height();
-#else
     RefPtr frame = this->frame();
     if (!frame)
         return 0;
@@ -1267,22 +1257,22 @@ int DOMWindow::outerHeight() const
     if (!page)
         return 0;
 
+    if (page->isLoadingInHeadlessMode())
+        return innerHeight();
+
+#if PLATFORM(IOS_FAMILY)
+    RefPtr view = frame->isMainFrame() ? frame->view() : frame->mainFrame().view();
+    if (!view)
+        return 0;
+
+    return view->frameRect().height();
+#else
     return static_cast<int>(page->chrome().windowRect().height());
 #endif
 }
 
 int DOMWindow::outerWidth() const
 {
-#if PLATFORM(IOS_FAMILY)
-    if (!frame())
-        return 0;
-
-    RefPtr view = frame()->isMainFrame() ? frame()->view() : frame()->mainFrame().view();
-    if (!view)
-        return 0;
-
-    return view->frameRect().width();
-#else
     RefPtr frame = this->frame();
     if (!frame)
         return 0;
@@ -1291,6 +1281,16 @@ int DOMWindow::outerWidth() const
     if (!page)
         return 0;
 
+    if (page->isLoadingInHeadlessMode())
+        return innerWidth();
+
+#if PLATFORM(IOS_FAMILY)
+    RefPtr view = frame->isMainFrame() ? frame->view() : frame->mainFrame().view();
+    if (!view)
+        return 0;
+
+    return view->frameRect().width();
+#else
     return static_cast<int>(page->chrome().windowRect().width());
 #endif
 }
@@ -1335,16 +1335,6 @@ int DOMWindow::innerWidth() const
     return view->mapFromLayoutToCSSUnits(static_cast<int>(view->unobscuredContentRectIncludingScrollbars().width()));
 }
 
-static bool isLoadingInHeadlessMode(const Page& page)
-{
-    RefPtr document = page.mainFrame().document();
-    if (!document)
-        return false;
-
-    RefPtr loader = document->loader();
-    return loader && loader->isLoadingInHeadlessMode();
-}
-
 int DOMWindow::screenX() const
 {
     RefPtr frame = this->frame();
@@ -1352,7 +1342,7 @@ int DOMWindow::screenX() const
         return 0;
 
     Page* page = frame->page();
-    if (!page || isLoadingInHeadlessMode(*page))
+    if (!page || page->isLoadingInHeadlessMode())
         return 0;
 
     return static_cast<int>(page->chrome().windowRect().x());
@@ -1365,7 +1355,7 @@ int DOMWindow::screenY() const
         return 0;
 
     Page* page = frame->page();
-    if (!page || isLoadingInHeadlessMode(*page))
+    if (!page || page->isLoadingInHeadlessMode())
         return 0;
 
     return static_cast<int>(page->chrome().windowRect().y());

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2780,6 +2780,16 @@ void Page::setCurrentKeyboardScrollingAnimator(KeyboardScrollingAnimator* animat
     m_currentKeyboardScrollingAnimator = animator;
 }
 
+bool Page::isLoadingInHeadlessMode() const
+{
+    RefPtr document = mainFrame().document();
+    if (!document)
+        return false;
+
+    RefPtr loader = document->loader();
+    return loader && loader->isLoadingInHeadlessMode();
+}
+
 #if ENABLE(REMOTE_INSPECTOR)
 
 bool Page::inspectable() const

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -340,6 +340,7 @@ public:
     void setCurrentKeyboardScrollingAnimator(KeyboardScrollingAnimator*);
     KeyboardScrollingAnimator* currentKeyboardScrollingAnimator() const { return m_currentKeyboardScrollingAnimator.get(); }
 
+    bool isLoadingInHeadlessMode() const;
 
 #if ENABLE(REMOTE_INSPECTOR)
     WEBCORE_EXPORT bool inspectable() const;

--- a/Source/WebCore/page/Screen.cpp
+++ b/Source/WebCore/page/Screen.cpp
@@ -32,6 +32,7 @@
 
 #include "DOMWindow.h"
 #include "Document.h"
+#include "DocumentLoader.h"
 #include "FloatRect.h"
 #include "Frame.h"
 #include "FrameView.h"
@@ -53,9 +54,19 @@ Screen::Screen(DOMWindow& window)
 
 Screen::~Screen() = default;
 
+static bool isLoadingInHeadlessMode(const Frame& frame)
+{
+    RefPtr mainDocument = frame.mainFrame().document();
+    if (!mainDocument)
+        return false;
+
+    RefPtr loader = mainDocument->loader();
+    return loader && loader->isLoadingInHeadlessMode();
+}
+
 int Screen::height() const
 {
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame)
         return 0;
     if (frame->settings().webAPIStatisticsEnabled())
@@ -65,7 +76,7 @@ int Screen::height() const
 
 int Screen::width() const
 {
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame)
         return 0;
     if (frame->settings().webAPIStatisticsEnabled())
@@ -75,7 +86,7 @@ int Screen::width() const
 
 unsigned Screen::colorDepth() const
 {
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame)
         return 0;
     if (frame->settings().webAPIStatisticsEnabled())
@@ -85,7 +96,7 @@ unsigned Screen::colorDepth() const
 
 unsigned Screen::pixelDepth() const
 {
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame)
         return 0;
     if (frame->settings().webAPIStatisticsEnabled())
@@ -100,41 +111,61 @@ unsigned Screen::pixelDepth() const
 
 int Screen::availLeft() const
 {
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame)
         return 0;
+
     if (frame->settings().webAPIStatisticsEnabled())
         ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->document(), ScreenAPIsAccessed::AvailLeft);
+
+    if (isLoadingInHeadlessMode(*frame))
+        return 0;
+
     return static_cast<int>(screenAvailableRect(frame->view()).x());
 }
 
 int Screen::availTop() const
 {
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame)
         return 0;
+
     if (frame->settings().webAPIStatisticsEnabled())
         ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->document(), ScreenAPIsAccessed::AvailTop);
+
+    if (isLoadingInHeadlessMode(*frame))
+        return 0;
+
     return static_cast<int>(screenAvailableRect(frame->view()).y());
 }
 
 int Screen::availHeight() const
 {
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame)
         return 0;
+
     if (frame->settings().webAPIStatisticsEnabled())
         ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->document(), ScreenAPIsAccessed::AvailHeight);
+
+    if (isLoadingInHeadlessMode(*frame))
+        return static_cast<int>(frame->screenSize().height());
+
     return static_cast<int>(screenAvailableRect(frame->view()).height());
 }
 
 int Screen::availWidth() const
 {
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame)
         return 0;
+
     if (frame->settings().webAPIStatisticsEnabled())
         ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->document(), ScreenAPIsAccessed::AvailWidth);
+
+    if (isLoadingInHeadlessMode(*frame))
+        return static_cast<int>(frame->screenSize().width());
+
     return static_cast<int>(screenAvailableRect(frame->view()).width());
 }
 


### PR DESCRIPTION
#### eca2f1b98440149e370561150edd521ee5c71cf7
<pre>
Adjust more DOM-API-exposed screen metrics in headless browsing mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=251962">https://bugs.webkit.org/show_bug.cgi?id=251962</a>
rdar://105198575

Reviewed by Tim Horton.

Align a number of screen-related web APIs in headless browsing mode, such that we fall back to a
screen rect that&apos;s positioned at the origin `(0, 0)`, with dimensions `(innerWidth, innerHeight)`.

* Source/WebCore/page/DOMWindow.cpp:
(WebCore::DOMWindow::outerHeight const):
(WebCore::DOMWindow::outerWidth const):
(WebCore::DOMWindow::screenX const):
(WebCore::DOMWindow::screenY const):
(WebCore::isLoadingInHeadlessMode): Deleted.
* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::screenSize const):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::isLoadingInHeadlessMode const):
* Source/WebCore/page/Page.h:
* Source/WebCore/page/Screen.cpp:
(WebCore::isLoadingInHeadlessMode):
(WebCore::Screen::height const):
(WebCore::Screen::width const):
(WebCore::Screen::colorDepth const):
(WebCore::Screen::pixelDepth const):
(WebCore::Screen::availLeft const):
(WebCore::Screen::availTop const):
(WebCore::Screen::availHeight const):
(WebCore::Screen::availWidth const):

Canonical link: <a href="https://commits.webkit.org/260091@main">https://commits.webkit.org/260091@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f9bbc60ed2474c7c53941599c4d174dae3211071

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106865 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15901 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39659 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116046 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115604 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110768 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17380 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7099 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99081 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112632 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13157 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96169 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40782 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95042 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27819 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9052 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29174 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9628 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6178 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15219 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48722 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6971 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11157 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->