### PR TITLE
Adopt ASCIILiterals in makeString, tryMakeString, operator+ calls inside WTF

### DIFF
--- a/Source/WTF/wtf/Logger.cpp
+++ b/Source/WTF/wtf/Logger.cpp
@@ -38,8 +38,8 @@ Lock loggerObserverLock;
 String Logger::LogSiteIdentifier::toString() const
 {
     if (className)
-        return makeString(className, "::", methodName, '(', hex(objectPtr), ") ");
-    return makeString(methodName, '(', hex(objectPtr), ") ");
+        return makeString(className, "::"_s, methodName, '(', hex(objectPtr), ") "_s);
+    return makeString(methodName, '(', hex(objectPtr), ") "_s);
 }
 
 String LogArgument<const void*>::toString(const void* argument)

--- a/Source/WTF/wtf/Logger.h
+++ b/Source/WTF/wtf/Logger.h
@@ -344,8 +344,8 @@ private:
         UNUSED_PARAM(line);
         UNUSED_PARAM(function);
 #elif ENABLE(JOURNALD_LOG)
-        auto fileString = makeString("CODE_FILE=", file);
-        auto lineString = makeString("CODE_LINE=", line);
+        auto fileString = makeString("CODE_FILE="_s, file);
+        auto lineString = makeString("CODE_LINE="_s, line);
         sd_journal_send_with_location(fileString.utf8().data(), lineString.utf8().data(), function, "WEBKIT_SUBSYSTEM=%s", channel.subsystem, "WEBKIT_CHANNEL=%s", channel.name, "MESSAGE=%s", logMessage.utf8().data(), nullptr);
 #else
         fprintf(stderr, "[%s:%s:-] %s FILE=%s:%d %s\n", channel.subsystem, channel.name, logMessage.utf8().data(), file, line, function);

--- a/Source/WTF/wtf/MediaTime.cpp
+++ b/Source/WTF/wtf/MediaTime.cpp
@@ -550,10 +550,10 @@ void MediaTime::dump(PrintStream& out) const
 
 String MediaTime::toString() const
 {
-    const char* invalid = isInvalid() ? ", invalid" : "";
+    auto invalid = isInvalid() ? ", invalid"_s : ""_s;
     if (hasDoubleValue())
         return makeString('{', toDouble(), invalid, '}');
-    return makeString('{', m_timeValue, '/', m_timeScale, " = ", toDouble(), invalid, '}');
+    return makeString('{', m_timeValue, '/', m_timeScale, " = "_s, toDouble(), invalid, '}');
 }
 
 Ref<JSON::Object> MediaTime::toJSONObject() const

--- a/Source/WTF/wtf/URL.cpp
+++ b/Source/WTF/wtf/URL.cpp
@@ -492,7 +492,7 @@ void URL::setHost(StringView newHost)
     bool slashSlashNeeded = m_userStart == m_schemeEnd + 1U;
     parse(makeString(
         StringView(m_string).left(hostStart()),
-        slashSlashNeeded ? "//" : "",
+        slashSlashNeeded ? "//"_s : ""_s,
         hasSpecialScheme() ? StringView(encodedHostName.data(), encodedHostName.size()) : newHost,
         StringView(m_string).substring(m_hostEnd)
     ));
@@ -545,9 +545,9 @@ void URL::setHostAndPort(StringView hostAndPort)
     bool slashSlashNeeded = m_userStart == m_schemeEnd + 1U;
     parse(makeString(
         StringView(m_string).left(hostStart()),
-        slashSlashNeeded ? "//" : "",
+        slashSlashNeeded ? "//"_s : ""_s,
         hasSpecialScheme() ? StringView(encodedHostName.data(), encodedHostName.size()) : hostName,
-        portString.isEmpty() ? "" : ":",
+        portString.isEmpty() ? ""_s : ":"_s,
         portString,
         StringView(m_string).substring(pathStart())
     ));
@@ -611,9 +611,9 @@ void URL::setUser(StringView newUser)
         bool needSeparator = end == m_hostEnd || (end == m_passwordEnd && m_string[end] != '@');
         parse(makeString(
             StringView(m_string).left(m_userStart),
-            slashSlashNeeded ? "//" : "",
+            slashSlashNeeded ? "//"_s : ""_s,
             percentEncodeCharacters(newUser, URLParser::isInUserInfoEncodeSet),
-            needSeparator ? "@" : "",
+            needSeparator ? "@"_s : ""_s,
             StringView(m_string).substring(end)
         ));
     } else {
@@ -633,7 +633,7 @@ void URL::setPassword(StringView newPassword)
         bool needLeadingSlashes = m_userEnd == m_schemeEnd + 1U;
         parse(makeString(
             StringView(m_string).left(m_userEnd),
-            needLeadingSlashes ? "//:" : ":",
+            needLeadingSlashes ? "//:"_s : ":"_s,
             percentEncodeCharacters(newPassword, URLParser::isInUserInfoEncodeSet),
             '@',
             StringView(m_string).substring(credentialsEnd())
@@ -687,7 +687,7 @@ void URL::setQuery(StringView newQuery)
 
     parse(makeString(
         StringView(m_string).left(m_pathEnd),
-        (!newQuery.startsWith('?') && !newQuery.isNull()) ? "?" : "",
+        (!newQuery.startsWith('?') && !newQuery.isNull()) ? "?"_s : ""_s,
         newQuery,
         StringView(m_string).substring(m_queryEnd)
     ));
@@ -1092,7 +1092,7 @@ String URL::stringCenterEllipsizedToLength(unsigned length) const
     if (m_string.length() <= length)
         return m_string;
 
-    return makeString(StringView(m_string).left(length / 2 - 1), "...", StringView(m_string).right(length / 2 - 2));
+    return makeString(StringView(m_string).left(length / 2 - 1), "..."_s, StringView(m_string).right(length / 2 - 2));
 }
 
 URL URL::fakeURLWithRelativePart(StringView relativePart)
@@ -1104,7 +1104,7 @@ URL URL::fileURLWithFileSystemPath(StringView path)
 {
     return URL(makeString(
         "file://"_s,
-        path.startsWith('/') ? "" : "/",
+        path.startsWith('/') ? ""_s : "/"_s,
         escapePathWithoutCopying(path)
     ));
 }

--- a/Source/WTF/wtf/URLParser.cpp
+++ b/Source/WTF/wtf/URLParser.cpp
@@ -2510,7 +2510,7 @@ void URLParser::addNonSpecialDotSlash()
 {
     auto oldPathStart = m_url.m_hostEnd + m_url.m_portLength;
     auto& oldString = m_url.m_string;
-    m_url.m_string = makeString(StringView(oldString).left(oldPathStart + 1), "./", StringView(oldString).substring(oldPathStart + 1));
+    m_url.m_string = makeString(StringView(oldString).left(oldPathStart + 1), "./"_s, StringView(oldString).substring(oldPathStart + 1));
     m_url.m_pathAfterLastSlash += 2;
     m_url.m_pathEnd += 2;
     m_url.m_queryEnd += 2;


### PR DESCRIPTION
#### 98c664538460ba8b172b12892675c7a00a728de9
<pre>
Adopt ASCIILiterals in makeString, tryMakeString, operator+ calls inside WTF
<a href="https://bugs.webkit.org/show_bug.cgi?id=251981">https://bugs.webkit.org/show_bug.cgi?id=251981</a>

Reviewed by Darin Adler.

Convert different cases of makeString(), tryMakeString() and StringAppend-producing
operator+ calls from using native C string literals to using more-desired ASCIILiterals.

* Source/WTF/wtf/Logger.cpp:
(WTF::Logger::LogSiteIdentifier::toString const):
* Source/WTF/wtf/Logger.h:
(WTF::Logger::logVerbose):
* Source/WTF/wtf/MediaTime.cpp:
(WTF::MediaTime::toString const):
* Source/WTF/wtf/URL.cpp:
(WTF::URL::setHost):
(WTF::URL::setHostAndPort):
(WTF::URL::setUser):
(WTF::URL::setPassword):
(WTF::URL::setQuery):
(WTF::URL::stringCenterEllipsizedToLength const):
(WTF::URL::fileURLWithFileSystemPath):
* Source/WTF/wtf/URLParser.cpp:
(WTF::URLParser::addNonSpecialDotSlash):

Canonical link: <a href="https://commits.webkit.org/260153@main">https://commits.webkit.org/260153@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a3480308180f6e7087bdd953b147406c64717de

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107312 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16369 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40127 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116468 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115912 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17795 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7607 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99468 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113076 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13428 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96529 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/41044 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95332 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/28164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/96685 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9400 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29508 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/38/builds/96114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/7394 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10044 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6483 "Passed tests") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/38/builds/96114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15553 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49088 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/104949 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7023 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11598 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26008 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->