### PR TITLE
[JSC] Add functionality to dump Metadata statistics

### DIFF
--- a/Source/JavaScriptCore/bytecode/UnlinkedMetadataTable.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedMetadataTable.h
@@ -37,10 +37,27 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(MetadataTable);
 
 class MetadataTable;
 
+#if ENABLE(METADATA_STATISTICS)
+struct MetadataStatistics {
+    static size_t unlinkedMetadataCount;
+    static size_t size32MetadataCount;
+    static size_t totalMemory;
+    static size_t perOpcodeCount[NUMBER_OF_BYTECODE_WITH_METADATA];
+    static size_t numberOfCopiesFromLinking;
+    static size_t linkingCopyMemory;
+
+    static void reportMetadataStatistics();
+};
+#endif
+
+
 class UnlinkedMetadataTable : public RefCounted<UnlinkedMetadataTable> {
     friend class LLIntOffsetsExtractor;
     friend class MetadataTable;
     friend class CachedMetadataTable;
+#if ENABLE(METADATA_STATISTICS)
+    friend struct MetadataStatistics;
+#endif
 public:
     static constexpr unsigned s_maxMetadataAlignment = 8;
 

--- a/Source/JavaScriptCore/bytecode/UnlinkedMetadataTableInlines.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedMetadataTableInlines.h
@@ -124,6 +124,10 @@ ALWAYS_INLINE RefPtr<MetadataTable> UnlinkedMetadataTable::link()
         m_isLinked = true;
         m_rawBuffer = buffer = reinterpret_cast<uint8_t*>(MetadataTableMalloc::realloc(m_rawBuffer, sizeof(LinkingData) + totalSize));
     } else {
+#if ENABLE(METADATA_STATISTICS)
+        MetadataStatistics::numberOfCopiesFromLinking++;
+        MetadataStatistics::linkingCopyMemory += sizeof(LinkingData) + totalSize;
+#endif
         buffer = reinterpret_cast<uint8_t*>(MetadataTableMalloc::malloc(sizeof(LinkingData) + totalSize));
         memcpy(buffer, m_rawBuffer, sizeof(LinkingData) + offsetTableSize);
     }


### PR DESCRIPTION
#### 7f321ba0c15adf730ed232d547a2ea389688cc0d
<pre>
[JSC] Add functionality to dump Metadata statistics
<a href="https://bugs.webkit.org/show_bug.cgi?id=251984">https://bugs.webkit.org/show_bug.cgi?id=251984</a>
rdar://105215210

Reviewed by Yusuke Suzuki.

While looking at ways to shrink the size of the metadata table, it was helpful
to dump some statistics of how much memory we&apos;re using and what opcodes contribute
to it the most.

* Source/JavaScriptCore/bytecode/UnlinkedMetadataTable.cpp:
(JSC::MetadataStatistics::reportMetadataStatistics):
(JSC::UnlinkedMetadataTable::finalize):
* Source/JavaScriptCore/bytecode/UnlinkedMetadataTable.h:
* Source/JavaScriptCore/bytecode/UnlinkedMetadataTableInlines.h:
(JSC::UnlinkedMetadataTable::link):

Canonical link: <a href="https://commits.webkit.org/260105@main">https://commits.webkit.org/260105@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/791021e32d96a641dc63b5e5ed8f242b5f6641a7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107090 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16140 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39880 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116266 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115760 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17599 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7339 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99267 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112855 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96347 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/40908 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95194 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27983 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/96544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9231 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29328 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/38/builds/95982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/7203 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9838 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/6326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/38/builds/95982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15390 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48901 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/104783 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6986 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11380 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25961 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->