### PR TITLE
CSS color gets adjusted for disabled input elements

### DIFF
--- a/LayoutTests/platform/gtk/fast/forms/basic-inputs-expected.txt
+++ b/LayoutTests/platform/gtk/fast/forms/basic-inputs-expected.txt
@@ -38,7 +38,7 @@ layer at (0,0) size 800x600
         RenderTextControl {INPUT} at (8,1) size 192x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
         RenderText {#text} at (200,4) size 27x17
           text run at (200,4) width 27: "text "
-        RenderTextControl {INPUT} at (227,1) size 191x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+        RenderTextControl {INPUT} at (227,1) size 191x24 [color=#575757] [bgcolor=#FFFFFF] [border: (2px inset #575757)]
         RenderText {#text} at (418,4) size 19x17
           text run at (418,4) width 12: "b "
           text run at (430,4) width 7: "a"
@@ -47,7 +47,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 186x18
         RenderText {#text} at (193,28) size 64x17
           text run at (193,28) width 64: "password "
-        RenderTextControl {INPUT} at (257,25) size 191x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+        RenderTextControl {INPUT} at (257,25) size 191x24 [color=#575757] [bgcolor=#FFFFFF] [border: (2px inset #575757)]
           RenderFlexibleBox {DIV} at (3,3) size 185x18
             RenderBlock {DIV} at (0,0) size 185x18
         RenderText {#text} at (1,49) size 8x17
@@ -58,7 +58,7 @@ layer at (0,0) size 800x600
         RenderBlock {INPUT} at (10,4) size 12x12
         RenderText {#text} at (24,2) size 65x17
           text run at (24,2) width 65: "checkbox "
-        RenderBlock {INPUT} at (91,4) size 12x12
+        RenderBlock {INPUT} at (91,4) size 12x12 [color=#575757]
         RenderText {#text} at (105,2) size 8x17
           text run at (105,2) width 8: "b"
       RenderBlock {DIV} at (10,425) size 450x21 [border: (1px solid #FF0000)]
@@ -67,7 +67,7 @@ layer at (0,0) size 800x600
         RenderBlock {INPUT} at (10,4) size 12x12
         RenderText {#text} at (24,2) size 36x17
           text run at (24,2) width 36: "radio "
-        RenderBlock {INPUT} at (62,4) size 12x12
+        RenderBlock {INPUT} at (62,4) size 12x12 [color=#575757]
         RenderText {#text} at (76,2) size 8x17
           text run at (76,2) width 8: "b"
 layer at (29,328) size 186x18 scrollWidth 214
@@ -75,7 +75,7 @@ layer at (29,328) size 186x18 scrollWidth 214
     RenderText {#text} at (0,0) size 213x17
       text run at (0,0) width 213: "foobarbazfoobarbazfoobarbaz"
 layer at (248,328) size 185x18
-  RenderBlock {DIV} at (3,3) size 185x18 [color=#545454]
+  RenderBlock {DIV} at (3,3) size 185x18
     RenderText {#text} at (0,0) size 22x17
       text run at (0,0) width 22: "foo"
 layer at (22,352) size 186x18
@@ -83,6 +83,6 @@ layer at (22,352) size 186x18
     RenderText {#text} at (0,0) size 18x17
       text run at (0,0) width 18: "\x{2022}\x{2022}\x{2022}"
 layer at (278,352) size 185x18
-  RenderBlock {DIV} at (0,0) size 185x18 [color=#545454]
+  RenderBlock {DIV} at (0,0) size 185x18
     RenderText {#text} at (0,0) size 18x17
       text run at (0,0) width 18: "\x{2022}\x{2022}\x{2022}"

--- a/LayoutTests/platform/gtk/fast/forms/basic-textareas-expected.txt
+++ b/LayoutTests/platform/gtk/fast/forms/basic-textareas-expected.txt
@@ -218,8 +218,8 @@ layer at (0,0) size 785x1851
               RenderText {#text} at (0,0) size 132x17
                 text run at (0,0) width 132: "Lorem ipsum dolor"
         layer at (204,75) size 201x42 clip at (205,76) size 184x40 scrollHeight 76
-          RenderTextControl {TEXTAREA} at (1,16) size 201x42 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-            RenderBlock {DIV} at (3,3) size 180x72 [color=#545454]
+          RenderTextControl {TEXTAREA} at (1,16) size 201x42 [color=#575757] [bgcolor=#FFFFFF] [border: (1px solid #575757)]
+            RenderBlock {DIV} at (3,3) size 180x72
               RenderText {#text} at (0,0) size 171x71
                 text run at (0,0) width 136: "Lorem ipsum  dolor"
                 text run at (136,0) width 4: " "
@@ -891,8 +891,8 @@ layer at (0,0) size 785x1851
               RenderText {#text} at (0,0) size 132x17
                 text run at (0,0) width 132: "Lorem ipsum dolor"
         layer at (204,75) size 201x42 clip at (205,76) size 184x40 scrollHeight 76
-          RenderTextControl {TEXTAREA} at (1,16) size 201x42 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-            RenderBlock {DIV} at (3,3) size 180x72 [color=#545454]
+          RenderTextControl {TEXTAREA} at (1,16) size 201x42 [color=#575757] [bgcolor=#FFFFFF] [border: (1px solid #575757)]
+            RenderBlock {DIV} at (3,3) size 180x72
               RenderText {#text} at (0,0) size 171x71
                 text run at (0,0) width 136: "Lorem ipsum  dolor"
                 text run at (136,0) width 4: " "

--- a/LayoutTests/platform/gtk/fast/forms/basic-textareas-quirks-expected.txt
+++ b/LayoutTests/platform/gtk/fast/forms/basic-textareas-quirks-expected.txt
@@ -241,8 +241,8 @@ layer at (23,85) size 201x42 clip at (24,86) size 184x40 scrollHeight 76
         text run at (0,54) width 169: "abcdefghijklmnopqrstuv"
         text run at (169,54) width 4: " "
 layer at (23,146) size 201x42 clip at (24,147) size 184x40 scrollHeight 76
-  RenderTextControl {TEXTAREA} at (14,1) size 202x42 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-    RenderBlock {DIV} at (3,3) size 180x72 [color=#545454]
+  RenderTextControl {TEXTAREA} at (14,1) size 202x42 [color=#575757] [bgcolor=#FFFFFF] [border: (1px solid #575757)]
+    RenderBlock {DIV} at (3,3) size 180x72
       RenderText {#text} at (0,0) size 173x71
         text run at (0,0) width 132: "Lorem ipsum dolor"
         text run at (132,0) width 4: " "

--- a/LayoutTests/platform/gtk/fast/forms/input-appearance-disabled-expected.txt
+++ b/LayoutTests/platform/gtk/fast/forms/input-appearance-disabled-expected.txt
@@ -6,9 +6,9 @@ layer at (0,0) size 800x600
       RenderText {#text} at (0,0) size 393x17
         text run at (0,0) width 393: "This tests that text can not be inserted into a disabled text field."
       RenderBR {BR} at (393,0) size 0x17
-      RenderTextControl {INPUT} at (0,18) size 191x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+      RenderTextControl {INPUT} at (0,18) size 191x24 [color=#575757] [bgcolor=#FFFFFF] [border: (2px inset #575757)]
       RenderText {#text} at (0,0) size 0x0
 layer at (11,29) size 185x18
-  RenderBlock {DIV} at (3,3) size 185x18 [color=#545454]
+  RenderBlock {DIV} at (3,3) size 185x18
     RenderText {#text} at (0,0) size 88x17
       text run at (0,0) width 88: "Test Passed"

--- a/LayoutTests/platform/gtk/fast/forms/input-disabled-color-expected.txt
+++ b/LayoutTests/platform/gtk/fast/forms/input-disabled-color-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x600
       RenderText {#text} at (0,0) size 509x17
         text run at (0,0) width 509: "This tests that the text color changes appropriately when the text field is disabled."
       RenderBR {BR} at (509,0) size 0x17
-      RenderTextControl {INPUT} at (0,18) size 191x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+      RenderTextControl {INPUT} at (0,18) size 191x24 [color=#575757] [bgcolor=#FFFFFF] [border: (2px inset #575757)]
       RenderText {#text} at (191,21) size 4x17
         text run at (191,21) width 4: " "
       RenderTextControl {INPUT} at (195,18) size 192x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
@@ -16,7 +16,7 @@ layer at (0,0) size 800x600
         text run at (191,45) width 4: " "
       RenderTextControl {INPUT} at (195,42) size 192x24 [color=#FF0000] [bgcolor=#FFFFFF] [border: (2px inset #FF0000)]
       RenderBR {BR} at (387,45) size 0x17
-      RenderTextControl {INPUT} at (0,66) size 191x24 [bgcolor=#0000FF] [border: (2px inset #000000)]
+      RenderTextControl {INPUT} at (0,66) size 191x24 [color=#575757] [bgcolor=#0000FF] [border: (2px inset #575757)]
       RenderText {#text} at (191,69) size 4x17
         text run at (191,69) width 4: " "
       RenderTextControl {INPUT} at (195,66) size 192x24 [bgcolor=#0000FF] [border: (2px inset #000000)]
@@ -26,7 +26,7 @@ layer at (0,0) size 800x600
         text run at (191,93) width 4: " "
       RenderTextControl {INPUT} at (195,90) size 192x24 [color=#FF0000] [bgcolor=#0000FF] [border: (2px inset #FF0000)]
       RenderBR {BR} at (387,93) size 0x17
-      RenderTextControl {INPUT} at (0,114) size 191x24 [bgcolor=#000000] [border: (2px inset #000000)]
+      RenderTextControl {INPUT} at (0,114) size 191x24 [color=#575757] [bgcolor=#000000] [border: (2px inset #575757)]
       RenderText {#text} at (191,117) size 4x17
         text run at (191,117) width 4: " "
       RenderTextControl {INPUT} at (195,114) size 192x24 [bgcolor=#000000] [border: (2px inset #000000)]
@@ -36,7 +36,7 @@ layer at (0,0) size 800x600
         text run at (191,141) width 4: " "
       RenderTextControl {INPUT} at (195,138) size 192x24 [color=#FFFFFF] [bgcolor=#000000] [border: (2px inset #FFFFFF)]
       RenderBR {BR} at (387,141) size 0x17
-      RenderTextControl {INPUT} at (0,162) size 191x24 [bgcolor=#808080] [border: (2px inset #000000)]
+      RenderTextControl {INPUT} at (0,162) size 191x24 [color=#575757] [bgcolor=#808080] [border: (2px inset #575757)]
       RenderText {#text} at (191,165) size 4x17
         text run at (191,165) width 4: " "
       RenderTextControl {INPUT} at (195,162) size 192x24 [bgcolor=#808080] [border: (2px inset #000000)]
@@ -77,7 +77,7 @@ layer at (0,0) size 800x600
       RenderTextControl {INPUT} at (195,330) size 192x24 [color=#ACACAC] [bgcolor=#F2F2F2] [border: (2px inset #ACACAC)]
       RenderBR {BR} at (387,333) size 0x17
 layer at (11,29) size 185x18 scrollWidth 462
-  RenderBlock {DIV} at (3,3) size 185x18 [color=#545454]
+  RenderBlock {DIV} at (3,3) size 185x18
     RenderText {#text} at (0,0) size 462x17
       text run at (0,0) width 462: "The text in this disabled field should displayed as dimmed or grey"
 layer at (206,29) size 186x18 scrollWidth 202
@@ -109,7 +109,7 @@ layer at (206,101) size 186x18 scrollWidth 202
     RenderText {#text} at (0,0) size 201x17
       text run at (0,0) width 201: "This text field is not disabled"
 layer at (11,125) size 185x18 scrollWidth 462
-  RenderBlock {DIV} at (3,3) size 185x18 [color=#545454]
+  RenderBlock {DIV} at (3,3) size 185x18
     RenderText {#text} at (0,0) size 462x17
       text run at (0,0) width 462: "The text in this disabled field should displayed as dimmed or grey"
 layer at (206,125) size 186x18 scrollWidth 202
@@ -117,7 +117,7 @@ layer at (206,125) size 186x18 scrollWidth 202
     RenderText {#text} at (0,0) size 201x17
       text run at (0,0) width 201: "This text field is not disabled"
 layer at (11,149) size 185x18 scrollWidth 462
-  RenderBlock {DIV} at (3,3) size 185x18 [color=#ABABAB]
+  RenderBlock {DIV} at (3,3) size 185x18
     RenderText {#text} at (0,0) size 462x17
       text run at (0,0) width 462: "The text in this disabled field should displayed as dimmed or grey"
 layer at (206,149) size 186x18 scrollWidth 202
@@ -125,7 +125,7 @@ layer at (206,149) size 186x18 scrollWidth 202
     RenderText {#text} at (0,0) size 201x17
       text run at (0,0) width 201: "This text field is not disabled"
 layer at (11,173) size 185x18 scrollWidth 462
-  RenderBlock {DIV} at (3,3) size 185x18 [color=#545454]
+  RenderBlock {DIV} at (3,3) size 185x18
     RenderText {#text} at (0,0) size 462x17
       text run at (0,0) width 462: "The text in this disabled field should displayed as dimmed or grey"
 layer at (206,173) size 186x18 scrollWidth 202
@@ -141,7 +141,7 @@ layer at (206,197) size 186x18 scrollWidth 202
     RenderText {#text} at (0,0) size 201x17
       text run at (0,0) width 201: "This text field is not disabled"
 layer at (11,221) size 185x18 scrollWidth 462
-  RenderBlock {DIV} at (3,3) size 185x18 [color=#2C2C2C]
+  RenderBlock {DIV} at (3,3) size 185x18
     RenderText {#text} at (0,0) size 462x17
       text run at (0,0) width 462: "The text in this disabled field should displayed as dimmed or grey"
 layer at (206,221) size 186x18 scrollWidth 202
@@ -157,7 +157,7 @@ layer at (206,245) size 186x18 scrollWidth 202
     RenderText {#text} at (0,0) size 201x17
       text run at (0,0) width 201: "This text field is not disabled"
 layer at (11,269) size 185x18 scrollWidth 462
-  RenderBlock {DIV} at (3,3) size 185x18 [color=#2C2C2C]
+  RenderBlock {DIV} at (3,3) size 185x18
     RenderText {#text} at (0,0) size 462x17
       text run at (0,0) width 462: "The text in this disabled field should displayed as dimmed or grey"
 layer at (206,269) size 186x18 scrollWidth 202

--- a/LayoutTests/platform/gtk/fast/forms/placeholder-pseudo-style-expected.txt
+++ b/LayoutTests/platform/gtk/fast/forms/placeholder-pseudo-style-expected.txt
@@ -20,7 +20,7 @@ layer at (0,0) size 800x600
           RenderBlock {DIV} at (0,0) size 186x18
       RenderText {#text} at (584,21) size 4x17
         text run at (584,21) width 4: " "
-      RenderTextControl {INPUT} at (588,18) size 191x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+      RenderTextControl {INPUT} at (588,18) size 191x24 [color=#575757] [bgcolor=#FFFFFF] [border: (2px inset #575757)]
       RenderText {#text} at (0,0) size 0x0
       RenderTextControl {INPUT} at (0,42) size 192x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
       RenderText {#text} at (192,45) size 4x17
@@ -50,7 +50,7 @@ layer at (599,29) size 185x18
     RenderText {#text} at (0,0) size 90x17
       text run at (0,0) width 90: "disabled text"
 layer at (599,29) size 185x18
-  RenderBlock {DIV} at (3,3) size 185x18 [color=#545454]
+  RenderBlock {DIV} at (3,3) size 185x18
 layer at (11,53) size 186x18
   RenderBlock {DIV} at (3,3) size 186x18 [color=#A9A9A9]
     RenderText {#text} at (0,0) size 48x17

--- a/LayoutTests/platform/gtk/fast/forms/textarea-placeholder-pseudo-style-expected.txt
+++ b/LayoutTests/platform/gtk/fast/forms/textarea-placeholder-pseudo-style-expected.txt
@@ -19,8 +19,8 @@ layer at (8,26) size 201x42 clip at (9,27) size 199x40
       RenderText {#text} at (0,0) size 25x17
         text run at (0,0) width 25: "text"
 layer at (213,26) size 201x42 clip at (214,27) size 199x40
-  RenderTextControl {TEXTAREA} at (205,18) size 201x42 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-    RenderBlock {DIV} at (3,3) size 195x18 [color=#545454]
+  RenderTextControl {TEXTAREA} at (205,18) size 201x42 [color=#575757] [bgcolor=#FFFFFF] [border: (1px solid #575757)]
+    RenderBlock {DIV} at (3,3) size 195x18
     RenderBlock {DIV} at (3,3) size 195x18 [color=#640000]
       RenderText {#text} at (0,0) size 90x17
         text run at (0,0) width 90: "disabled text"
@@ -31,8 +31,8 @@ layer at (418,26) size 201x42 clip at (419,27) size 199x40
       RenderText {#text} at (0,0) size 48x17
         text run at (0,0) width 48: "default"
 layer at (8,72) size 201x42 clip at (9,73) size 199x40
-  RenderTextControl {TEXTAREA} at (0,64) size 201x42 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-    RenderBlock {DIV} at (3,3) size 195x18 [color=#545454]
+  RenderTextControl {TEXTAREA} at (0,64) size 201x42 [color=#575757] [bgcolor=#FFFFFF] [border: (1px solid #575757)]
+    RenderBlock {DIV} at (3,3) size 195x18
     RenderBlock {DIV} at (3,3) size 195x18 [color=#A9A9A9]
       RenderText {#text} at (0,0) size 113x17
         text run at (0,0) width 113: "default disabled"

--- a/LayoutTests/platform/ios-wk2/fast/forms/basic-textareas-quirks-expected.txt
+++ b/LayoutTests/platform/ios-wk2/fast/forms/basic-textareas-quirks-expected.txt
@@ -842,8 +842,8 @@ layer at (376,1010) size 168x34 clip at (377,1011) size 151x32 scrollHeight 424
         text run at (63,392) width 1: " "
       RenderBR {BR} at (0,406) size 0x14
 layer at (24,130) size 168x34 clip at (25,131) size 151x32 scrollHeight 60
-  RenderTextControl {TEXTAREA} at (14,1) size 169x34 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
-    RenderBlock {DIV} at (6,3) size 141x56 [color=#545454]
+  RenderTextControl {TEXTAREA} at (14,1) size 169x34 [color=#575757] [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
+    RenderBlock {DIV} at (6,3) size 141x56
       RenderText {#text} at (0,0) size 140x56
         text run at (0,0) width 98: "Lorem ipsum dolor"
         text run at (97,0) width 4: " "

--- a/LayoutTests/platform/ios/fast/forms/basic-inputs-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/basic-inputs-expected.txt
@@ -54,7 +54,7 @@ layer at (0,0) size 800x600
         RenderBlock {INPUT} at (10,4) size 17x16 [bgcolor=#FFFFFF03]
         RenderText {#text} at (28,3) size 66x19
           text run at (28,3) width 66: "checkbox "
-        RenderBlock {INPUT} at (95,4) size 17x16 [bgcolor=#FFFFFF03]
+        RenderBlock {INPUT} at (95,4) size 17x16 [color=#575757] [bgcolor=#FFFFFF03]
         RenderText {#text} at (113,3) size 9x19
           text run at (113,3) width 9: "b"
       RenderBlock {DIV} at (10,440) size 450x24 [border: (1px solid #FF0000)]
@@ -63,7 +63,7 @@ layer at (0,0) size 800x600
         RenderBlock {INPUT} at (10,4) size 17x16 [bgcolor=#FFFFFF03]
         RenderText {#text} at (28,3) size 37x19
           text run at (28,3) width 37: "radio "
-        RenderBlock {INPUT} at (66,4) size 17x16 [bgcolor=#FFFFFF03]
+        RenderBlock {INPUT} at (66,4) size 17x16 [color=#575757] [bgcolor=#FFFFFF03]
         RenderText {#text} at (84,3) size 9x19
           text run at (84,3) width 9: "b"
 layer at (33,363) size 141x14 scrollWidth 161
@@ -75,16 +75,16 @@ layer at (26,385) size 142x14 backgroundClip at (26,385) size 141x14 clip at (26
     RenderText {#text} at (0,0) size 21x14
       text run at (0,0) width 21: "\x{F79A}\x{F79A}\x{F79A}"
 layer at (209,360) size 153x21
-  RenderTextControl {INPUT} at (190,2) size 154x22 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
+  RenderTextControl {INPUT} at (190,2) size 154x22 [color=#575757] [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
 layer at (215,363) size 139x14
-  RenderBlock {DIV} at (6,3) size 141x15 [color=#545454]
+  RenderBlock {DIV} at (6,3) size 141x15
     RenderText {#text} at (0,0) size 17x14
       text run at (0,0) width 17: "foo"
 layer at (238,382) size 153x21
-  RenderTextControl {INPUT} at (220,24) size 154x22 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
+  RenderTextControl {INPUT} at (220,24) size 154x22 [color=#575757] [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
     RenderFlexibleBox {DIV} at (6,3) size 141x15
       RenderBlock {DIV} at (0,0) size 140x14
 layer at (245,385) size 140x14
-  RenderBlock {DIV} at (0,0) size 140x14 [color=#545454]
+  RenderBlock {DIV} at (0,0) size 140x14
     RenderText {#text} at (0,0) size 21x14
       text run at (0,0) width 21: "\x{F79A}\x{F79A}\x{F79A}"

--- a/LayoutTests/platform/ios/fast/forms/basic-textareas-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/basic-textareas-expected.txt
@@ -637,8 +637,8 @@ layer at (0,0) size 800x1472
                 text run at (0,14) width 195: "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                 text run at (0,28) width 130: " abcdefghijklmnopqrstuv"
         layer at (171,77) size 168x34 clip at (172,78) size 151x32 scrollHeight 60
-          RenderTextControl {TEXTAREA} at (1,16) size 168x34 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
-            RenderBlock {DIV} at (6,3) size 141x56 [color=#545454]
+          RenderTextControl {TEXTAREA} at (1,16) size 168x34 [color=#575757] [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
+            RenderBlock {DIV} at (6,3) size 141x56
               RenderText {#text} at (0,0) size 140x56
                 text run at (0,0) width 101: "Lorem ipsum  dolor"
                 text run at (100,0) width 4: " "
@@ -1371,8 +1371,8 @@ layer at (0,0) size 800x1472
                 text run at (0,14) width 195: "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                 text run at (0,28) width 130: " abcdefghijklmnopqrstuv"
         layer at (171,77) size 168x34 clip at (172,78) size 151x32 scrollHeight 60
-          RenderTextControl {TEXTAREA} at (1,16) size 168x34 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
-            RenderBlock {DIV} at (6,3) size 141x56 [color=#545454]
+          RenderTextControl {TEXTAREA} at (1,16) size 168x34 [color=#575757] [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
+            RenderBlock {DIV} at (6,3) size 141x56
               RenderText {#text} at (0,0) size 140x56
                 text run at (0,0) width 101: "Lorem ipsum  dolor"
                 text run at (100,0) width 4: " "

--- a/LayoutTests/platform/ios/fast/forms/input-appearance-disabled-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/input-appearance-disabled-expected.txt
@@ -8,8 +8,8 @@ layer at (0,0) size 800x600
       RenderBR {BR} at (403,0) size 1x19
       RenderText {#text} at (0,0) size 0x0
 layer at (8,28) size 153x21
-  RenderTextControl {INPUT} at (0,20) size 153x22 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
+  RenderTextControl {INPUT} at (0,20) size 153x22 [color=#575757] [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
 layer at (15,31) size 139x14
-  RenderBlock {DIV} at (6,3) size 141x15 [color=#545454]
+  RenderBlock {DIV} at (6,3) size 141x15
     RenderText {#text} at (0,0) size 63x14
       text run at (0,0) width 63: "Test Passed"

--- a/LayoutTests/platform/ios/fast/forms/input-disabled-color-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/input-disabled-color-expected.txt
@@ -119,9 +119,9 @@ layer at (171,318) size 141x14 scrollWidth 153
     RenderText {#text} at (0,0) size 151x14
       text run at (0,0) width 151: "This text field is not disabled"
 layer at (8,29) size 153x21
-  RenderTextControl {INPUT} at (0,21) size 153x22 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
+  RenderTextControl {INPUT} at (0,21) size 153x22 [color=#575757] [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
 layer at (15,32) size 139x14 scrollWidth 343
-  RenderBlock {DIV} at (6,3) size 141x15 [color=#545454]
+  RenderBlock {DIV} at (6,3) size 141x15
     RenderText {#text} at (0,0) size 344x14
       text run at (0,0) width 344: "The text in this disabled field should displayed as dimmed or grey"
 layer at (8,51) size 153x21
@@ -131,7 +131,7 @@ layer at (15,54) size 139x14 scrollWidth 343
     RenderText {#text} at (0,0) size 344x14
       text run at (0,0) width 344: "The text in this disabled field should displayed as dimmed or grey"
 layer at (8,73) size 153x21
-  RenderTextControl {INPUT} at (0,65) size 153x22 [bgcolor=#0000FF] [border: (1px solid #3C3C4399)]
+  RenderTextControl {INPUT} at (0,65) size 153x22 [color=#575757] [bgcolor=#0000FF] [border: (1px solid #3C3C4399)]
 layer at (15,76) size 139x14 scrollWidth 343
   RenderBlock {DIV} at (6,3) size 141x15
     RenderText {#text} at (0,0) size 344x14
@@ -143,21 +143,21 @@ layer at (15,98) size 139x14 scrollWidth 343
     RenderText {#text} at (0,0) size 344x14
       text run at (0,0) width 344: "The text in this disabled field should displayed as dimmed or grey"
 layer at (8,117) size 153x21
-  RenderTextControl {INPUT} at (0,109) size 153x22 [bgcolor=#000000] [border: (1px solid #3C3C4399)]
+  RenderTextControl {INPUT} at (0,109) size 153x22 [color=#575757] [bgcolor=#000000] [border: (1px solid #3C3C4399)]
 layer at (15,120) size 139x14 scrollWidth 343
-  RenderBlock {DIV} at (6,3) size 141x15 [color=#545454]
+  RenderBlock {DIV} at (6,3) size 141x15
     RenderText {#text} at (0,0) size 344x14
       text run at (0,0) width 344: "The text in this disabled field should displayed as dimmed or grey"
 layer at (8,139) size 153x21
   RenderTextControl {INPUT} at (0,131) size 153x22 [color=#FFFFFF] [bgcolor=#000000] [border: (1px solid #3C3C4399)]
 layer at (15,142) size 139x14 scrollWidth 343
-  RenderBlock {DIV} at (6,3) size 141x15 [color=#ABABAB]
+  RenderBlock {DIV} at (6,3) size 141x15
     RenderText {#text} at (0,0) size 344x14
       text run at (0,0) width 344: "The text in this disabled field should displayed as dimmed or grey"
 layer at (8,161) size 153x21
-  RenderTextControl {INPUT} at (0,153) size 153x22 [bgcolor=#808080] [border: (1px solid #3C3C4399)]
+  RenderTextControl {INPUT} at (0,153) size 153x22 [color=#575757] [bgcolor=#808080] [border: (1px solid #3C3C4399)]
 layer at (15,164) size 139x14 scrollWidth 343
-  RenderBlock {DIV} at (6,3) size 141x15 [color=#545454]
+  RenderBlock {DIV} at (6,3) size 141x15
     RenderText {#text} at (0,0) size 344x14
       text run at (0,0) width 344: "The text in this disabled field should displayed as dimmed or grey"
 layer at (8,183) size 153x21
@@ -169,7 +169,7 @@ layer at (15,186) size 139x14 scrollWidth 343
 layer at (8,205) size 153x21
   RenderTextControl {INPUT} at (0,197) size 153x22 [color=#808080] [bgcolor=#000000] [border: (1px solid #3C3C4399)]
 layer at (15,208) size 139x14 scrollWidth 343
-  RenderBlock {DIV} at (6,3) size 141x15 [color=#2C2C2C]
+  RenderBlock {DIV} at (6,3) size 141x15
     RenderText {#text} at (0,0) size 344x14
       text run at (0,0) width 344: "The text in this disabled field should displayed as dimmed or grey"
 layer at (8,227) size 153x21
@@ -181,7 +181,7 @@ layer at (15,230) size 139x14 scrollWidth 343
 layer at (8,249) size 153x21
   RenderTextControl {INPUT} at (0,241) size 153x22 [color=#808080] [bgcolor=#FF0000] [border: (1px solid #3C3C4399)]
 layer at (15,252) size 139x14 scrollWidth 343
-  RenderBlock {DIV} at (6,3) size 141x15 [color=#2C2C2C]
+  RenderBlock {DIV} at (6,3) size 141x15
     RenderText {#text} at (0,0) size 344x14
       text run at (0,0) width 344: "The text in this disabled field should displayed as dimmed or grey"
 layer at (8,271) size 153x21

--- a/LayoutTests/platform/ios/fast/forms/number/number-appearance-spinbutton-disabled-readonly-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/number/number-appearance-spinbutton-disabled-readonly-expected.txt
@@ -30,8 +30,8 @@ layer at (19,143) size 241x25
     RenderText {#text} at (0,0) size 13x25
       text run at (0,0) width 13: "0"
 layer at (8,101) size 263x37
-  RenderTextControl {INPUT} at (0,0) size 263x37 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
+  RenderTextControl {INPUT} at (0,0) size 263x37 [color=#575757] [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
 layer at (19,106) size 241x25
-  RenderBlock {DIV} at (11,5) size 241x25 [color=#545454]
+  RenderBlock {DIV} at (11,5) size 241x25
     RenderText {#text} at (0,0) size 13x25
       text run at (0,0) width 13: "0"

--- a/LayoutTests/platform/ios/fast/forms/placeholder-pseudo-style-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/placeholder-pseudo-style-expected.txt
@@ -58,10 +58,10 @@ layer at (173,54) size 141x14
 layer at (173,54) size 141x14
   RenderBlock {DIV} at (6,3) size 143x15
 layer at (485,29) size 153x21
-  RenderTextControl {INPUT} at (476,21) size 154x22 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
+  RenderTextControl {INPUT} at (476,21) size 154x22 [color=#575757] [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
 layer at (491,32) size 139x14
   RenderBlock {DIV} at (6,3) size 141x15 [color=#640000]
     RenderText {#text} at (0,0) size 68x14
       text run at (0,0) width 68: "disabled text"
 layer at (491,32) size 139x14
-  RenderBlock {DIV} at (6,3) size 141x15 [color=#545454]
+  RenderBlock {DIV} at (6,3) size 141x15

--- a/LayoutTests/platform/ios/fast/forms/textarea-placeholder-pseudo-style-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/textarea-placeholder-pseudo-style-expected.txt
@@ -26,14 +26,14 @@ layer at (352,28) size 168x34 clip at (353,29) size 166x32
       RenderText {#text} at (0,0) size 37x14
         text run at (0,0) width 37: "default"
 layer at (180,28) size 168x34 clip at (181,29) size 166x32
-  RenderTextControl {TEXTAREA} at (172,20) size 168x34 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
-    RenderBlock {DIV} at (6,3) size 156x14 [color=#545454]
+  RenderTextControl {TEXTAREA} at (172,20) size 168x34 [color=#575757] [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
+    RenderBlock {DIV} at (6,3) size 156x14
     RenderBlock {DIV} at (6,3) size 156x14 [color=#640000]
       RenderText {#text} at (0,0) size 68x14
         text run at (0,0) width 68: "disabled text"
 layer at (524,28) size 168x34 clip at (525,29) size 166x32
-  RenderTextControl {TEXTAREA} at (516,20) size 168x34 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
-    RenderBlock {DIV} at (6,3) size 156x14 [color=#545454]
+  RenderTextControl {TEXTAREA} at (516,20) size 168x34 [color=#575757] [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
+    RenderBlock {DIV} at (6,3) size 156x14
     RenderBlock {DIV} at (6,3) size 156x14 [color=#A9A9A9]
       RenderText {#text} at (0,0) size 85x14
         text run at (0,0) width 85: "default disabled"

--- a/LayoutTests/platform/mac-bigsur/fast/forms/number/number-appearance-spinbutton-disabled-readonly-expected.txt
+++ b/LayoutTests/platform/mac-bigsur/fast/forms/number/number-appearance-spinbutton-disabled-readonly-expected.txt
@@ -16,7 +16,7 @@ layer at (0,0) size 800x600
             text run at (247,8) width 88: " Normal state"
       RenderBlock {DIV} at (0,81) size 784x29
         RenderInline {LABEL} at (0,0) size 342x18
-          RenderTextControl {INPUT} at (0,0) size 247x29 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+          RenderTextControl {INPUT} at (0,0) size 247x29 [color=#575757] [bgcolor=#FFFFFF] [border: (2px inset #575757)]
             RenderFlexibleBox {DIV} at (3,0) size 241x29
               RenderBlock {DIV} at (0,3) size 222x23
           RenderText {#text} at (246,8) size 96x18
@@ -33,7 +33,7 @@ layer at (11,63) size 223x23
     RenderText {#text} at (0,0) size 13x23
       text run at (0,0) width 13: "0"
 layer at (11,92) size 222x23
-  RenderBlock {DIV} at (0,0) size 222x23 [color=#545454]
+  RenderBlock {DIV} at (0,0) size 222x23
     RenderText {#text} at (0,0) size 13x23
       text run at (0,0) width 13: "0"
 layer at (11,121) size 222x23

--- a/LayoutTests/platform/mac/fast/forms/basic-inputs-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/basic-inputs-expected.txt
@@ -38,7 +38,7 @@ layer at (0,0) size 800x600
         RenderTextControl {INPUT} at (8,1) size 147x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
         RenderText {#text} at (154,1) size 29x18
           text run at (154,1) width 29: "text "
-        RenderTextControl {INPUT} at (182,1) size 147x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+        RenderTextControl {INPUT} at (182,1) size 147x19 [color=#575757] [bgcolor=#FFFFFF] [border: (2px inset #575757)]
         RenderText {#text} at (328,1) size 20x18
           text run at (328,1) width 13: "b "
           text run at (340,1) width 8: "a"
@@ -47,7 +47,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 141x13
         RenderText {#text} at (147,20) size 66x18
           text run at (147,20) width 66: "password "
-        RenderTextControl {INPUT} at (212,20) size 147x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+        RenderTextControl {INPUT} at (212,20) size 147x19 [color=#575757] [bgcolor=#FFFFFF] [border: (2px inset #575757)]
           RenderFlexibleBox {DIV} at (3,3) size 140x13
             RenderBlock {DIV} at (0,0) size 140x13
         RenderText {#text} at (358,20) size 9x18
@@ -58,7 +58,7 @@ layer at (0,0) size 800x600
         RenderBlock {INPUT} at (10,5) size 13x12
         RenderText {#text} at (24,1) size 66x18
           text run at (24,1) width 66: "checkbox "
-        RenderBlock {INPUT} at (91,5) size 13x12
+        RenderBlock {INPUT} at (91,5) size 13x12 [color=#575757]
         RenderText {#text} at (105,1) size 9x18
           text run at (105,1) width 9: "b"
       RenderBlock {DIV} at (10,397) size 450x21 [border: (1px solid #FF0000)]
@@ -67,7 +67,7 @@ layer at (0,0) size 800x600
         RenderBlock {INPUT} at (10,5) size 13x12
         RenderText {#text} at (24,1) size 37x18
           text run at (24,1) width 37: "radio "
-        RenderBlock {INPUT} at (62,5) size 13x12
+        RenderBlock {INPUT} at (62,5) size 13x12 [color=#575757]
         RenderText {#text} at (76,1) size 9x18
           text run at (76,1) width 9: "b"
 layer at (29,328) size 141x13 scrollWidth 160
@@ -75,7 +75,7 @@ layer at (29,328) size 141x13 scrollWidth 160
     RenderText {#text} at (0,0) size 160x13
       text run at (0,0) width 160: "foobarbazfoobarbazfoobarbaz"
 layer at (204,328) size 140x13
-  RenderBlock {DIV} at (3,3) size 140x13 [color=#545454]
+  RenderBlock {DIV} at (3,3) size 140x13
     RenderText {#text} at (0,0) size 17x13
       text run at (0,0) width 17: "foo"
 layer at (22,347) size 141x13
@@ -83,6 +83,6 @@ layer at (22,347) size 141x13
     RenderText {#text} at (0,0) size 21x13
       text run at (0,0) width 21: "\x{F79A}\x{F79A}\x{F79A}"
 layer at (233,347) size 140x13
-  RenderBlock {DIV} at (0,0) size 140x13 [color=#545454]
+  RenderBlock {DIV} at (0,0) size 140x13
     RenderText {#text} at (0,0) size 21x13
       text run at (0,0) width 21: "\x{F79A}\x{F79A}\x{F79A}"

--- a/LayoutTests/platform/mac/fast/forms/basic-textareas-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/basic-textareas-expected.txt
@@ -219,8 +219,8 @@ layer at (0,0) size 785x1426
               RenderText {#text} at (0,0) size 98x13
                 text run at (0,0) width 98: "Lorem ipsum dolor"
         layer at (164,73) size 161x32 clip at (165,74) size 144x30 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (1,15) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-            RenderBlock {DIV} at (3,3) size 140x52 [color=#545454]
+          RenderTextControl {TEXTAREA} at (1,15) size 161x32 [color=#575757] [bgcolor=#FFFFFF] [border: (1px solid #575757)]
+            RenderBlock {DIV} at (3,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 101: "Lorem ipsum  dolor"
                 text run at (100,0) width 4: " "
@@ -858,8 +858,8 @@ layer at (0,0) size 785x1426
               RenderText {#text} at (0,0) size 98x13
                 text run at (0,0) width 98: "Lorem ipsum dolor"
         layer at (164,73) size 161x32 clip at (165,74) size 144x30 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (1,15) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-            RenderBlock {DIV} at (3,3) size 140x52 [color=#545454]
+          RenderTextControl {TEXTAREA} at (1,15) size 161x32 [color=#575757] [bgcolor=#FFFFFF] [border: (1px solid #575757)]
+            RenderBlock {DIV} at (3,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 101: "Lorem ipsum  dolor"
                 text run at (100,0) width 4: " "

--- a/LayoutTests/platform/mac/fast/forms/basic-textareas-quirks-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/basic-textareas-quirks-expected.txt
@@ -241,8 +241,8 @@ layer at (24,75) size 161x32 clip at (25,76) size 144x30 scrollHeight 56
         text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
         text run at (126,39) width 4: " "
 layer at (24,126) size 161x32 clip at (25,127) size 144x30 scrollHeight 56
-  RenderTextControl {TEXTAREA} at (14,1) size 162x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-    RenderBlock {DIV} at (3,3) size 140x52 [color=#545454]
+  RenderTextControl {TEXTAREA} at (14,1) size 162x32 [color=#575757] [bgcolor=#FFFFFF] [border: (1px solid #575757)]
+    RenderBlock {DIV} at (3,3) size 140x52
       RenderText {#text} at (0,0) size 140x52
         text run at (0,0) width 98: "Lorem ipsum dolor"
         text run at (97,0) width 4: " "

--- a/LayoutTests/platform/mac/fast/forms/input-appearance-disabled-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/input-appearance-disabled-expected.txt
@@ -6,9 +6,9 @@ layer at (0,0) size 800x600
       RenderText {#text} at (0,0) size 404x18
         text run at (0,0) width 404: "This tests that text can not be inserted into a disabled text field."
       RenderBR {BR} at (403,0) size 1x18
-      RenderTextControl {INPUT} at (0,18) size 146x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+      RenderTextControl {INPUT} at (0,18) size 146x19 [color=#575757] [bgcolor=#FFFFFF] [border: (2px inset #575757)]
       RenderText {#text} at (0,0) size 0x0
 layer at (11,29) size 140x13
-  RenderBlock {DIV} at (3,3) size 140x13 [color=#545454]
+  RenderBlock {DIV} at (3,3) size 140x13
     RenderText {#text} at (0,0) size 63x13
       text run at (0,0) width 63: "Test Passed"

--- a/LayoutTests/platform/mac/fast/forms/input-disabled-color-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/input-disabled-color-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x600
       RenderText {#text} at (0,0) size 521x18
         text run at (0,0) width 521: "This tests that the text color changes appropriately when the text field is disabled."
       RenderBR {BR} at (520,0) size 1x18
-      RenderTextControl {INPUT} at (0,18) size 146x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+      RenderTextControl {INPUT} at (0,18) size 146x19 [color=#575757] [bgcolor=#FFFFFF] [border: (2px inset #575757)]
       RenderText {#text} at (145,18) size 5x18
         text run at (145,18) width 5: " "
       RenderTextControl {INPUT} at (149,18) size 148x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
@@ -16,7 +16,7 @@ layer at (0,0) size 800x600
         text run at (145,37) width 5: " "
       RenderTextControl {INPUT} at (149,37) size 148x19 [color=#FF0000] [bgcolor=#FFFFFF] [border: (2px inset #FF0000)]
       RenderBR {BR} at (296,37) size 1x18
-      RenderTextControl {INPUT} at (0,56) size 146x19 [bgcolor=#0000FF] [border: (2px inset #000000)]
+      RenderTextControl {INPUT} at (0,56) size 146x19 [color=#575757] [bgcolor=#0000FF] [border: (2px inset #575757)]
       RenderText {#text} at (145,56) size 5x18
         text run at (145,56) width 5: " "
       RenderTextControl {INPUT} at (149,56) size 148x19 [bgcolor=#0000FF] [border: (2px inset #000000)]
@@ -26,7 +26,7 @@ layer at (0,0) size 800x600
         text run at (145,75) width 5: " "
       RenderTextControl {INPUT} at (149,75) size 148x19 [color=#FF0000] [bgcolor=#0000FF] [border: (2px inset #FF0000)]
       RenderBR {BR} at (296,75) size 1x18
-      RenderTextControl {INPUT} at (0,94) size 146x19 [bgcolor=#000000] [border: (2px inset #000000)]
+      RenderTextControl {INPUT} at (0,94) size 146x19 [color=#575757] [bgcolor=#000000] [border: (2px inset #575757)]
       RenderText {#text} at (145,94) size 5x18
         text run at (145,94) width 5: " "
       RenderTextControl {INPUT} at (149,94) size 148x19 [bgcolor=#000000] [border: (2px inset #000000)]
@@ -36,7 +36,7 @@ layer at (0,0) size 800x600
         text run at (145,113) width 5: " "
       RenderTextControl {INPUT} at (149,113) size 148x19 [color=#FFFFFF] [bgcolor=#000000] [border: (2px inset #FFFFFF)]
       RenderBR {BR} at (296,113) size 1x18
-      RenderTextControl {INPUT} at (0,132) size 146x19 [bgcolor=#808080] [border: (2px inset #000000)]
+      RenderTextControl {INPUT} at (0,132) size 146x19 [color=#575757] [bgcolor=#808080] [border: (2px inset #575757)]
       RenderText {#text} at (145,132) size 5x18
         text run at (145,132) width 5: " "
       RenderTextControl {INPUT} at (149,132) size 148x19 [bgcolor=#808080] [border: (2px inset #000000)]
@@ -77,7 +77,7 @@ layer at (0,0) size 800x600
       RenderTextControl {INPUT} at (149,265) size 148x19 [color=#ACACAC] [bgcolor=#F2F2F2] [border: (2px inset #ACACAC)]
       RenderBR {BR} at (296,265) size 1x18
 layer at (11,29) size 140x13 scrollWidth 343
-  RenderBlock {DIV} at (3,3) size 140x13 [color=#545454]
+  RenderBlock {DIV} at (3,3) size 140x13
     RenderText {#text} at (0,0) size 344x13
       text run at (0,0) width 344: "The text in this disabled field should displayed as dimmed or grey"
 layer at (161,29) size 141x13 scrollWidth 152
@@ -109,7 +109,7 @@ layer at (161,86) size 141x13 scrollWidth 152
     RenderText {#text} at (0,0) size 151x13
       text run at (0,0) width 151: "This text field is not disabled"
 layer at (11,105) size 140x13 scrollWidth 343
-  RenderBlock {DIV} at (3,3) size 140x13 [color=#545454]
+  RenderBlock {DIV} at (3,3) size 140x13
     RenderText {#text} at (0,0) size 344x13
       text run at (0,0) width 344: "The text in this disabled field should displayed as dimmed or grey"
 layer at (161,105) size 141x13 scrollWidth 152
@@ -117,7 +117,7 @@ layer at (161,105) size 141x13 scrollWidth 152
     RenderText {#text} at (0,0) size 151x13
       text run at (0,0) width 151: "This text field is not disabled"
 layer at (11,124) size 140x13 scrollWidth 343
-  RenderBlock {DIV} at (3,3) size 140x13 [color=#ABABAB]
+  RenderBlock {DIV} at (3,3) size 140x13
     RenderText {#text} at (0,0) size 344x13
       text run at (0,0) width 344: "The text in this disabled field should displayed as dimmed or grey"
 layer at (161,124) size 141x13 scrollWidth 152
@@ -125,7 +125,7 @@ layer at (161,124) size 141x13 scrollWidth 152
     RenderText {#text} at (0,0) size 151x13
       text run at (0,0) width 151: "This text field is not disabled"
 layer at (11,143) size 140x13 scrollWidth 343
-  RenderBlock {DIV} at (3,3) size 140x13 [color=#545454]
+  RenderBlock {DIV} at (3,3) size 140x13
     RenderText {#text} at (0,0) size 344x13
       text run at (0,0) width 344: "The text in this disabled field should displayed as dimmed or grey"
 layer at (161,143) size 141x13 scrollWidth 152
@@ -141,7 +141,7 @@ layer at (161,162) size 141x13 scrollWidth 152
     RenderText {#text} at (0,0) size 151x13
       text run at (0,0) width 151: "This text field is not disabled"
 layer at (11,181) size 140x13 scrollWidth 343
-  RenderBlock {DIV} at (3,3) size 140x13 [color=#2C2C2C]
+  RenderBlock {DIV} at (3,3) size 140x13
     RenderText {#text} at (0,0) size 344x13
       text run at (0,0) width 344: "The text in this disabled field should displayed as dimmed or grey"
 layer at (161,181) size 141x13 scrollWidth 152
@@ -157,7 +157,7 @@ layer at (161,200) size 141x13 scrollWidth 152
     RenderText {#text} at (0,0) size 151x13
       text run at (0,0) width 151: "This text field is not disabled"
 layer at (11,219) size 140x13 scrollWidth 343
-  RenderBlock {DIV} at (3,3) size 140x13 [color=#2C2C2C]
+  RenderBlock {DIV} at (3,3) size 140x13
     RenderText {#text} at (0,0) size 344x13
       text run at (0,0) width 344: "The text in this disabled field should displayed as dimmed or grey"
 layer at (161,219) size 141x13 scrollWidth 152

--- a/LayoutTests/platform/mac/fast/forms/number/number-appearance-spinbutton-disabled-readonly-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/number/number-appearance-spinbutton-disabled-readonly-expected.txt
@@ -16,7 +16,7 @@ layer at (0,0) size 800x600
             text run at (247,8) width 87: " Normal state"
       RenderBlock {DIV} at (0,81) size 784x29
         RenderInline {LABEL} at (0,0) size 341x18
-          RenderTextControl {INPUT} at (0,0) size 247x29 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+          RenderTextControl {INPUT} at (0,0) size 247x29 [color=#575757] [bgcolor=#FFFFFF] [border: (2px inset #575757)]
             RenderFlexibleBox {DIV} at (3,0) size 241x29
               RenderBlock {DIV} at (0,3) size 222x23
           RenderText {#text} at (246,8) size 95x18
@@ -33,7 +33,7 @@ layer at (11,63) size 223x23
     RenderText {#text} at (0,0) size 13x23
       text run at (0,0) width 13: "0"
 layer at (11,92) size 222x23
-  RenderBlock {DIV} at (0,0) size 222x23 [color=#545454]
+  RenderBlock {DIV} at (0,0) size 222x23
     RenderText {#text} at (0,0) size 13x23
       text run at (0,0) width 13: "0"
 layer at (11,121) size 222x23

--- a/LayoutTests/platform/mac/fast/forms/placeholder-pseudo-style-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/placeholder-pseudo-style-expected.txt
@@ -21,7 +21,7 @@ layer at (0,0) size 800x600
           RenderBlock {DIV} at (0,0) size 141x13
       RenderText {#text} at (448,18) size 5x18
         text run at (448,18) width 5: " "
-      RenderTextControl {INPUT} at (452,18) size 147x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+      RenderTextControl {INPUT} at (452,18) size 147x19 [color=#575757] [bgcolor=#FFFFFF] [border: (2px inset #575757)]
       RenderText {#text} at (598,18) size 5x18
         text run at (598,18) width 5: " "
       RenderTextControl {INPUT} at (602,18) size 148x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
@@ -51,7 +51,7 @@ layer at (464,29) size 140x13
     RenderText {#text} at (0,0) size 68x13
       text run at (0,0) width 68: "disabled text"
 layer at (464,29) size 140x13
-  RenderBlock {DIV} at (3,3) size 140x13 [color=#545454]
+  RenderBlock {DIV} at (3,3) size 140x13
 layer at (614,29) size 141x13 backgroundClip at (614,29) size 140x13 clip at (614,29) size 140x13
   RenderBlock {DIV} at (3,3) size 141x13 [color=#A9A9A9]
     RenderText {#text} at (0,0) size 37x13

--- a/LayoutTests/platform/mac/fast/forms/textarea-placeholder-pseudo-style-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/textarea-placeholder-pseudo-style-expected.txt
@@ -20,8 +20,8 @@ layer at (8,26) size 161x32 clip at (9,27) size 159x30
       RenderText {#text} at (0,0) size 21x13
         text run at (0,0) width 21: "text"
 layer at (173,26) size 161x32 clip at (174,27) size 159x30
-  RenderTextControl {TEXTAREA} at (165,18) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-    RenderBlock {DIV} at (3,3) size 155x13 [color=#545454]
+  RenderTextControl {TEXTAREA} at (165,18) size 161x32 [color=#575757] [bgcolor=#FFFFFF] [border: (1px solid #575757)]
+    RenderBlock {DIV} at (3,3) size 155x13
     RenderBlock {DIV} at (3,3) size 155x13 [color=#640000]
       RenderText {#text} at (0,0) size 68x13
         text run at (0,0) width 68: "disabled text"
@@ -32,8 +32,8 @@ layer at (338,26) size 161x32 clip at (339,27) size 159x30
       RenderText {#text} at (0,0) size 37x13
         text run at (0,0) width 37: "default"
 layer at (503,26) size 161x32 clip at (504,27) size 159x30
-  RenderTextControl {TEXTAREA} at (495,18) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-    RenderBlock {DIV} at (3,3) size 155x13 [color=#545454]
+  RenderTextControl {TEXTAREA} at (495,18) size 161x32 [color=#575757] [bgcolor=#FFFFFF] [border: (1px solid #575757)]
+    RenderBlock {DIV} at (3,3) size 155x13
     RenderBlock {DIV} at (3,3) size 155x13 [color=#A9A9A9]
       RenderText {#text} at (0,0) size 85x13
         text run at (0,0) width 85: "default disabled"

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -794,6 +794,10 @@ input::placeholder {
     line-height: initial !important;
 }
 
+input:disabled, textarea:disabled {
+    color: color-mix(in hsl, CanvasText 66%, Canvas);
+}
+
 input:is([type="hidden"], [type="image"], [type="file"]) {
     appearance: initial;
     padding: initial;

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -54,6 +54,7 @@ CSSParserContext::CSSParserContext(CSSParserMode mode, const URL& baseURL)
 {
     // FIXME: We should turn all of the features on from their WebCore Settings defaults.
     if (mode == UASheetMode) {
+        colorMixEnabled = true;
         focusVisibleEnabled = true;
         propertySettings.cssContainmentEnabled = true;
         propertySettings.cssIndividualTransformPropertiesEnabled = true;

--- a/Source/WebCore/html/HTMLTextFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLTextFormControlElement.cpp
@@ -853,8 +853,6 @@ void HTMLTextFormControlElement::adjustInnerTextStyle(const RenderStyle& parentS
         }
     }
 
-    if (isDisabledFormControl())
-        textBlockStyle.setColor(RenderTheme::singleton().disabledTextColor(textBlockStyle.visitedDependentColorWithColorFilter(CSSPropertyColor), parentStyle.visitedDependentColorWithColorFilter(CSSPropertyBackgroundColor)));
 #if PLATFORM(IOS_FAMILY)
     if (textBlockStyle.textSecurity() != TextSecurity::None && !textBlockStyle.isLeftToRightDirection()) {
         // Preserve the alignment but force the direction to LTR so that the last-typed, unmasked character

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -1966,31 +1966,6 @@ Color RenderTheme::tapHighlightColor()
 
 #endif
 
-// Value chosen by observation. This can be tweaked.
-constexpr double minColorContrastValue = 1.195;
-
-// For transparent or translucent background color, use lightening.
-constexpr float minDisabledColorAlphaValue = 0.5f;
-
-Color RenderTheme::disabledTextColor(const Color& textColor, const Color& backgroundColor) const
-{
-    // The explicit check for black is an optimization for the 99% case (black on white).
-    // This also means that black on black will turn into grey on black when disabled.
-    Color disabledColor;
-    if (equalIgnoringSemanticColor(textColor, Color::black) || backgroundColor.alphaAsFloat() < minDisabledColorAlphaValue || textColor.luminance() < backgroundColor.luminance())
-        disabledColor = textColor.lightened();
-    else
-        disabledColor = textColor.darkened();
-
-    // If there's not very much contrast between the disabled color and the background color,
-    // just leave the text color alone. We don't want to change a good contrast color scheme so that it has really bad contrast.
-    // If the contrast was already poor, then it doesn't do any good to change it to a different poor contrast color scheme.
-    if (contrastRatio(disabledColor, backgroundColor) < minColorContrastValue)
-        return textColor;
-
-    return disabledColor;
-}
-
 // Value chosen to return dark gray for both white on black and black on white.
 constexpr float datePlaceholderColorLightnessAdjustmentFactor = 0.66f;
 

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -182,8 +182,6 @@ public:
 
     Color datePlaceholderTextColor(const Color& textColor, const Color& backgroundColor) const;
 
-    virtual Color disabledTextColor(const Color& textColor, const Color& backgroundColor) const;
-
     WEBCORE_EXPORT Color focusRingColor(OptionSet<StyleColorOptions>) const;
     virtual Color platformFocusRingColor(OptionSet<StyleColorOptions>) const { return Color::black; }
     static void setCustomFocusRingColor(const Color&);


### PR DESCRIPTION
#### d9061430480df20b709c6a4014bf5eee587e8c73
<pre>
CSS color gets adjusted for disabled input elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=54643">https://bugs.webkit.org/show_bug.cgi?id=54643</a>
rdar://99826522

Reviewed by Tim Nguyen.

Currently WebKit overrides any style which is being chosen for
input:disabled by web developers. This fixes this by adjusting
a simpler default and making it possible for developers to adjust
the CSS. The solution proposed by Tim Nguyen is using color-mix().

* LayoutTests/platform/gtk/fast/forms/basic-inputs-expected.txt:
* LayoutTests/platform/gtk/fast/forms/basic-textareas-expected.txt:
* LayoutTests/platform/gtk/fast/forms/basic-textareas-quirks-expected.txt:
* LayoutTests/platform/gtk/fast/forms/input-appearance-disabled-expected.txt:
* LayoutTests/platform/gtk/fast/forms/input-disabled-color-expected.txt:
* LayoutTests/platform/gtk/fast/forms/placeholder-pseudo-style-expected.txt:
* LayoutTests/platform/gtk/fast/forms/textarea-placeholder-pseudo-style-expected.txt:
* LayoutTests/platform/ios-wk2/fast/forms/basic-textareas-quirks-expected.txt:
* LayoutTests/platform/ios/fast/forms/basic-inputs-expected.txt:
* LayoutTests/platform/ios/fast/forms/basic-textareas-expected.txt:
* LayoutTests/platform/ios/fast/forms/input-appearance-disabled-expected.txt:
* LayoutTests/platform/ios/fast/forms/input-disabled-color-expected.txt:
* LayoutTests/platform/ios/fast/forms/number/number-appearance-spinbutton-disabled-readonly-expected.txt:
* LayoutTests/platform/ios/fast/forms/placeholder-pseudo-style-expected.txt:
* LayoutTests/platform/ios/fast/forms/textarea-placeholder-pseudo-style-expected.txt:
* LayoutTests/platform/mac-bigsur/fast/forms/number/number-appearance-spinbutton-disabled-readonly-expected.txt:
* LayoutTests/platform/mac/fast/forms/basic-inputs-expected.txt:
* LayoutTests/platform/mac/fast/forms/basic-textareas-expected.txt:
* LayoutTests/platform/mac/fast/forms/basic-textareas-quirks-expected.txt:
* LayoutTests/platform/mac/fast/forms/input-appearance-disabled-expected.txt:
* LayoutTests/platform/mac/fast/forms/input-disabled-color-expected.txt:
* LayoutTests/platform/mac/fast/forms/number/number-appearance-spinbutton-disabled-readonly-expected.txt:
* LayoutTests/platform/mac/fast/forms/placeholder-pseudo-style-expected.txt:
* LayoutTests/platform/mac/fast/forms/textarea-placeholder-pseudo-style-expected.txt:
* Source/WebCore/css/html.css:
(input:disabled, textarea:disabled):
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::CSSParserContext::CSSParserContext):
* Source/WebCore/html/HTMLTextFormControlElement.cpp:
(WebCore::HTMLTextFormControlElement::adjustInnerTextStyle const):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::disabledTextColor const): Deleted.
* Source/WebCore/rendering/RenderTheme.h:

Co-authored-by: Tim Nguyen &lt;ntim@apple.com&gt;

Canonical link: <a href="https://commits.webkit.org/260180@main">https://commits.webkit.org/260180@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/efd6fe5a8251e7b9d57681383a66774eac807340

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107450 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16511 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40352 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116612 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116033 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111348 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17935 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7752 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99613 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113211 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13538 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96717 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41161 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95443 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28343 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82932 "Found 1 new API test failure: /WebKitGTK/TestAuthentication:/webkit/Authentication/authentication-empty-realm (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9518 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29696 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10174 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6595 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15673 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49277 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7042 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11734 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->