### PR TITLE
ProxyObject's "get" IC should throw an error in case of non-callable non-nullish trap

### DIFF
--- a/JSTests/stress/proxy-get-missing-handler-inline-cache.js
+++ b/JSTests/stress/proxy-get-missing-handler-inline-cache.js
@@ -1,0 +1,59 @@
+function shouldThrow(fn, expectedError) {
+    let errorThrown = false;
+    try {
+        fn();
+    } catch (error) {
+        errorThrown = true;
+        if (error.toString() !== expectedError)
+            throw new Error(`Bad error: ${error}`);
+    }
+    if (!errorThrown)
+        throw new Error("Didn't throw!");
+}
+
+const callableGetTrapError = "TypeError: 'get' property of a Proxy's handler object should be callable";
+
+shouldThrow(() => {
+    var handler = {get: null};
+    var proxy = new Proxy({foo: 1}, handler);
+
+    for (var i = 0; i < 1e7; ++i) {
+        var foo = proxy.foo;
+        if (i === 1e7 / 2)
+            handler.get = 1;
+    }
+}, callableGetTrapError);
+
+shouldThrow(() => {
+    var handler = {get: undefined};
+    var proxy = new Proxy({foo: 1}, handler);
+
+    for (var i = 0; i < 1e7; ++i) {
+        var bar = proxy.bar;
+        if (i === 1e7 / 2)
+            handler.get = "foo";
+    }
+}, callableGetTrapError);
+
+shouldThrow(() => {
+    var handler = {get: null};
+    var proxy = new Proxy({foo: 1}, handler);
+
+    for (var i = 0; i < 1e7; ++i) {
+        var foo = proxy.foo;
+        if (i === 1e7 / 2)
+            handler.get = {};
+    }
+}, callableGetTrapError);
+
+shouldThrow(() => {
+    var handler = {get: undefined};
+    var proxy = new Proxy(() => {}, handler);
+
+    for (var i = 0; i < 1e7; ++i) {
+        var bar = proxy.bar;
+        if (i === 1e7 / 2)
+            handler.get = [];
+    }
+}, callableGetTrapError);
+

--- a/Source/JavaScriptCore/builtins/ProxyHelpers.js
+++ b/Source/JavaScriptCore/builtins/ProxyHelpers.js
@@ -32,8 +32,11 @@ function performProxyObjectGet(target, receiver, handler, propertyName)
         @throwTypeError("Proxy has already been revoked. No more operations are allowed to be performed on it");
 
     var trap = handler.get;
-    if (!@isCallable(trap))
+    if (@isUndefinedOrNull(trap))
         return @getByValWithThis(target, receiver, propertyName);
+
+    if (!@isCallable(trap))
+        @throwTypeError("'get' property of a Proxy's handler object should be callable");
 
     var trapResult = trap.@call(handler, target, propertyName, receiver);
 


### PR DESCRIPTION
#### 0676bad565abafd4b685f61d647ee5cfdf2975a4
<pre>
ProxyObject&apos;s &quot;get&quot; IC should throw an error in case of non-callable non-nullish trap
<a href="https://bugs.webkit.org/show_bug.cgi?id=251945">https://bugs.webkit.org/show_bug.cgi?id=251945</a>

Reviewed by Yusuke Suzuki.

This change fixes IC helper for ProxyObject&apos;s &quot;get&quot; trap to implement GetMethod per spec [1],
throwing a TypeError for non-callable non-nullish traps instead of forwarding [[Get]] to receiver.

[1]: <a href="https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-get-p-receiver">https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-get-p-receiver</a> (steps 5-6)

* JSTests/stress/proxy-get-missing-handler-inline-cache.js: Added.
* Source/JavaScriptCore/builtins/ProxyHelpers.js:
(linkTimeConstant.performProxyObjectGet):

Canonical link: <a href="https://commits.webkit.org/260077@main">https://commits.webkit.org/260077@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c550af093299cf53e85c3950892dc6fdf071f5ce

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106921 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15957 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39718 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116101 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115648 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17441 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7155 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99107 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112686 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13199 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96223 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40800 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95091 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27867 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/96428 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9105 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29220 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/95883 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/7049 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9682 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/6219 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/30720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15272 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48777 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/104656 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6955 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11212 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25926 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->