### PR TITLE
Cocoa availability macros are not working for non-WebKit sources on buildbots

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -103,6 +103,7 @@
 		7A6EBA3420746C34004F9C44 /* MachSendRight.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7A6EBA3320746C34004F9C44 /* MachSendRight.cpp */; };
 		7AF023B52061E17000A8EFD6 /* ProcessPrivilege.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7AF023B42061E16F00A8EFD6 /* ProcessPrivilege.cpp */; };
 		7AFEC6B11EB22B5900DADE36 /* UUID.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7AFEC6B01EB22B5900DADE36 /* UUID.cpp */; };
+		7B9D3E9F2995371E001C869C /* PlatformMacroOverrides.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B9D3E9E2995371E001C869C /* PlatformMacroOverrides.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		8134013815B092FD001FF0B8 /* Base64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8134013615B092FD001FF0B8 /* Base64.cpp */; };
 		8348BA0E21FBC0D500FD3054 /* ObjectIdentifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8348BA0D21FBC0D400FD3054 /* ObjectIdentifier.cpp */; };
 		93853DD328755A6C00FF4E2B /* EscapedFormsForJSON.h in Headers */ = {isa = PBXBuildFile; fileRef = 93853DD228755A6600FF4E2B /* EscapedFormsForJSON.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1205,6 +1206,7 @@
 		7AFEC6B01EB22B5900DADE36 /* UUID.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UUID.cpp; sourceTree = "<group>"; };
 		7B2739DC2624DAAA0040F182 /* ThreadSafetyAnalysis.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ThreadSafetyAnalysis.h; sourceTree = "<group>"; };
 		7B2739F12632A8940040F182 /* ThreadAssertions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ThreadAssertions.h; sourceTree = "<group>"; };
+		7B9D3E9E2995371E001C869C /* PlatformMacroOverrides.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PlatformMacroOverrides.h; sourceTree = "<group>"; };
 		7C137941222326C700D7A824 /* AUTHORS */ = {isa = PBXFileReference; lastKnownFileType = text; path = AUTHORS; sourceTree = "<group>"; };
 		7C137942222326D500D7A824 /* ieee.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ieee.h; sourceTree = "<group>"; };
 		7C137943222326D500D7A824 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
@@ -2211,6 +2213,7 @@
 				7C98CDC923E7AFC80012F232 /* PlatformEnableWinCairo.h */,
 				7C3A45D023CFA883007DE3A6 /* PlatformHave.h */,
 				7C42307423CEB187006E54D0 /* PlatformLegacy.h */,
+				7B9D3E9E2995371E001C869C /* PlatformMacroOverrides.h */,
 				7C42307323CE2D8B006E54D0 /* PlatformOS.h */,
 				FE1E2C41224187C600F6B729 /* PlatformRegisters.cpp */,
 				E3200AB41E9A536D003B59D2 /* PlatformRegisters.h */,
@@ -3176,6 +3179,7 @@
 				DD3DC96327A4BF8E007E5B61 /* PlatformEnableWinCairo.h in Headers */,
 				DD3DC8B927A4BF8E007E5B61 /* PlatformHave.h in Headers */,
 				DD3DC93827A4BF8E007E5B61 /* PlatformLegacy.h in Headers */,
+				7B9D3E9F2995371E001C869C /* PlatformMacroOverrides.h in Headers */,
 				DD3DC8C527A4BF8E007E5B61 /* PlatformOS.h in Headers */,
 				DD3DC8FD27A4BF8E007E5B61 /* PlatformRegisters.h in Headers */,
 				DD3DC92B27A4BF8E007E5B61 /* PlatformUse.h in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -207,6 +207,7 @@ set(WTF_PUBLIC_HEADERS
     PlatformEnableWinCairo.h
     PlatformHave.h
     PlatformLegacy.h
+    PlatformMacroOverrides.h
     PlatformOS.h
     PlatformRegisters.h
     PlatformUse.h

--- a/Source/WTF/wtf/Platform.h
+++ b/Source/WTF/wtf/Platform.h
@@ -66,6 +66,10 @@
 /* Macros for specifing specific calling conventions. */
 #include <wtf/PlatformCallingConventions.h>
 
+/* Macros for configuring platform headers that subsequent 
+   WTF using code might include.
+  */
+#include <wtf/PlatformMacroOverrides.h>
 
 /* ==== Platform additions: additions to Platform.h from outside the main repository ==== */
 

--- a/Source/WTF/wtf/PlatformMacroOverrides.h
+++ b/Source/WTF/wtf/PlatformMacroOverrides.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#ifndef WTF_PLATFORM_GUARD_AGAINST_INDIRECT_INCLUSION
+#error "Please #include <wtf/Platform.h> instead of this file directly."
+#endif
+
+/* Macros for configuring platform headers that subsequent 
+   WTF using code might include.
+*/ 
+
+#if !USE(APPLE_INTERNAL_SDK) && (PLATFORM(WATCHOS) || PLATFORM(APPLETV) || PLATFORM(IOS_FAMILY))
+// Configure availability macros in SDK headers to not apply, since WebKit uses APIs for building
+// the platform.
+#include <os/availability.h>
+
+// Remove limitations so that WebKit can be compiled with the public SDK against
+// APIs intended for system components only.
+
+#if PLATFORM(WATCHOS)
+#ifdef __WATCHOS_PROHIBITED
+#undef __WATCHOS_PROHIBITED
+#define __WATCHOS_PROHIBITED
+#endif
+#elif PLATFORM(APPLETV)
+#ifdef __TVOS_PROHIBITED
+#undef __TVOS_PROHIBITED
+#define __TVOS_PROHIBITED
+#endif
+#else
+#ifdef __IOS_PROHIBITED
+#undef __IOS_PROHIBITED
+#define __IOS_PROHIBITED
+#endif
+#endif
+
+// Remove API_AVAILABLE, API_UNAVAILABLE, since the public SDK is not compatible with above relaxation
+// of APIs. Note: this causes compile failures, for example turning comprehensive
+// switch statements into non-comprehensive.
+#undef API_UNAVAILABLE
+#define API_UNAVAILABLE(...)
+#undef API_AVAILABLE
+#define API_AVAILABLE(...)
+
+#endif
+
+// FIXME: Possibly move DisallowCType.h contents here.

--- a/Source/bmalloc/PlatformMac.cmake
+++ b/Source/bmalloc/PlatformMac.cmake
@@ -6,5 +6,6 @@ list(APPEND bmalloc_SOURCES
 )
 
 list(APPEND bmalloc_PUBLIC_HEADERS
+    bmalloc/darwin/BAllowProhibitedAPIs.h
     bmalloc/darwin/MemoryStatusSPI.h
 )

--- a/Source/bmalloc/bmalloc.xcodeproj/project.pbxproj
+++ b/Source/bmalloc/bmalloc.xcodeproj/project.pbxproj
@@ -643,6 +643,7 @@
 		6599C5CD1EC3F15900A2F7BB /* AvailableMemory.h in Headers */ = {isa = PBXBuildFile; fileRef = 6599C5CB1EC3F15900A2F7BB /* AvailableMemory.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7939885B2076EEB60074A2E7 /* BulkDecommit.h in Headers */ = {isa = PBXBuildFile; fileRef = 7939885A2076EEB50074A2E7 /* BulkDecommit.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		795AB3C7206E0D340074FE76 /* PhysicalPageMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 795AB3C6206E0D250074FE76 /* PhysicalPageMap.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		7B9D3EA129953B0E001C869C /* BAllowProhibitedAPIs.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B9D3EA029953B0E001C869C /* BAllowProhibitedAPIs.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7C571F0122388B840077A3C7 /* StdLibExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C571F0022388B840077A3C7 /* StdLibExtras.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		AD0934331FCF406D00E85EB5 /* BCompiler.h in Headers */ = {isa = PBXBuildFile; fileRef = AD0934321FCF405000E85EB5 /* BCompiler.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		AD14AD29202529C400890E3B /* ProcessCheck.h in Headers */ = {isa = PBXBuildFile; fileRef = AD14AD27202529A600890E3B /* ProcessCheck.h */; };
@@ -1317,6 +1318,7 @@
 		6599C5CB1EC3F15900A2F7BB /* AvailableMemory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AvailableMemory.h; path = bmalloc/AvailableMemory.h; sourceTree = "<group>"; };
 		7939885A2076EEB50074A2E7 /* BulkDecommit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BulkDecommit.h; path = bmalloc/BulkDecommit.h; sourceTree = "<group>"; };
 		795AB3C6206E0D250074FE76 /* PhysicalPageMap.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = PhysicalPageMap.h; path = bmalloc/PhysicalPageMap.h; sourceTree = "<group>"; };
+		7B9D3EA029953B0E001C869C /* BAllowProhibitedAPIs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BAllowProhibitedAPIs.h; path = bmalloc/darwin/BAllowProhibitedAPIs.h; sourceTree = "<group>"; };
 		7C571F0022388B840077A3C7 /* StdLibExtras.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = StdLibExtras.h; path = bmalloc/StdLibExtras.h; sourceTree = "<group>"; };
 		AD0934321FCF405000E85EB5 /* BCompiler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BCompiler.h; path = bmalloc/BCompiler.h; sourceTree = "<group>"; };
 		AD14AD27202529A600890E3B /* ProcessCheck.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ProcessCheck.h; path = bmalloc/ProcessCheck.h; sourceTree = "<group>"; };
@@ -2117,6 +2119,7 @@
 		4408F2961C9896C40012EC64 /* darwin */ = {
 			isa = PBXGroup;
 			children = (
+				7B9D3EA029953B0E001C869C /* BAllowProhibitedAPIs.h */,
 				52F47248210BA2F500B730BB /* MemoryStatusSPI.h */,
 			);
 			name = darwin;
@@ -2141,6 +2144,7 @@
 				0F7EB84F1F954D4E00F1ABCB /* AllIsoHeapsInlines.h in Headers */,
 				14DD789818F48D4A00950702 /* Allocator.h in Headers */,
 				6599C5CD1EC3F15900A2F7BB /* AvailableMemory.h in Headers */,
+				7B9D3EA129953B0E001C869C /* BAllowProhibitedAPIs.h in Headers */,
 				14DD78C718F48D7500950702 /* BAssert.h in Headers */,
 				AD0934331FCF406D00E85EB5 /* BCompiler.h in Headers */,
 				0F5BF1731F23C5710029D91D /* BExport.h in Headers */,

--- a/Source/bmalloc/bmalloc/AvailableMemory.cpp
+++ b/Source/bmalloc/bmalloc/AvailableMemory.cpp
@@ -27,6 +27,7 @@
 
 #include "Environment.h"
 #if BPLATFORM(IOS_FAMILY)
+#include "BAllowProhibitedAPIs.h"
 #include "MemoryStatusSPI.h"
 #endif
 #include "PerProcess.h"

--- a/Source/bmalloc/bmalloc/darwin/BAllowProhibitedAPIs.h
+++ b/Source/bmalloc/bmalloc/darwin/BAllowProhibitedAPIs.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#pragma once
+
+#include "BPlatform.h"
+
+#if !__has_include(<AvailabilityProhibitedInternal.h>)
+
+#if BPLATFORM(WATCHOS)
+#ifdef __WATCHOS_PROHIBITED
+#undef __WATCHOS_PROHIBITED
+#define __WATCHOS_PROHIBITED
+#endif
+#elif BPLATFORM(APPLETV)
+#ifdef __TVOS_PROHIBITED
+#undef __TVOS_PROHIBITED
+#define __TVOS_PROHIBITED
+#endif
+#elif BPLATFORM(IOS_FAMILY)
+#ifdef __IOS_PROHIBITED
+#undef __IOS_PROHIBITED
+#define __IOS_PROHIBITED
+#endif
+#endif
+
+#endif

--- a/Tools/Scripts/configure-xcode-for-embedded-development
+++ b/Tools/Scripts/configure-xcode-for-embedded-development
@@ -139,30 +139,6 @@ XCSPEC_INFO = [dict(
 ''',
 )]
 
-AVAILABILITY_FILE = pathlib.Path("usr/local/include/AvailabilityProhibitedInternal.h")
-AVAILABILTY_TEXT = """\
-// Handle __IOS_PROHIBITED and friends.
-#undef __OS_AVAILABILITY
-#define __OS_AVAILABILITY(...)
-
-// Take care of {A,S}PI_AVAILABLE{,_BEGIN,_END}
-#undef __API_AVAILABLE_GET_MACRO
-#define __API_AVAILABLE_GET_MACRO(...) __NULL_AVAILABILITY
-
-#undef SWIFT_AVAILABILITY
-#define SWIFT_AVAILABILITY __NULL_AVAILABILITY
-
-// Take care of {A,S}PI_DEPRECATED{,WITH_REPLACEMENT}{,_BEGIN,_END}
-#undef __API_DEPRECATED_MSG_GET_MACRO
-#define __API_DEPRECATED_MSG_GET_MACRO(...) __NULL_AVAILABILITY
-
-// Take care of API_UNAVAILABLE{,_BEGIN,_END}
-#undef __API_UNAVAILABLE_GET_MACRO
-#define __API_UNAVAILABLE_GET_MACRO(...) __NULL_AVAILABILITY
-
-#define __NULL_AVAILABILITY(...)
-"""
-
 SDKS_TO_UPDATE = [
     "iphoneos",
     "iphonesimulator",
@@ -338,20 +314,6 @@ def copy_missing_frameworks(source_sdk, dest_sdk):
             patch_tbd_architecture(dest_framework_path)
 
 
-# Some functions that WebKit needs to call are marked as "unavailable" on the
-# embedded platforms. Create a stub header that will nullify the effect of the
-# annotations on those functions. Note that there's no guarantee that the
-# resulting product can run -- we just want to build.
-
-def create_availability_header(sdk):
-    sdk_path = sdk_directory(sdk)
-    availability_header_path = sdk_path / AVAILABILITY_FILE
-    print(f"Creating/updating {availability_header_path}")
-    os.makedirs(availability_header_path.parent, exist_ok=True)
-    with open(availability_header_path, "w") as f:
-        f.write(AVAILABILTY_TEXT)
-
-
 def main():
     if not os.geteuid() == 0 and not os.access(xcode_developer_dir(), os.R_OK | os.W_OK | os.X_OK, effective_ids=True):
         raise RuntimeError(f"{__file__} must be run as root")
@@ -361,7 +323,6 @@ def main():
     for sdk in SDKS_TO_UPDATE:
         copy_missing_headers("macosx", sdk)
         copy_missing_frameworks("iphoneos", sdk)
-        create_availability_header(sdk)
     return 0
 
 


### PR DESCRIPTION
#### 6c8a32161892afea56cbf1ec103f2fe9efe1ea30
<pre>
Cocoa availability macros are not working for non-WebKit sources on buildbots
<a href="https://bugs.webkit.org/show_bug.cgi?id=251989">https://bugs.webkit.org/show_bug.cgi?id=251989</a>
rdar://105221617

Reviewed by NOBODY (OOPS!).

For public SDK use-cases, such as WebKit iOS, TvOS, WatchOS build bots
and non-Apple contributors:

configure-xcode-for-embedded-development would remove the
availability macros for any code that is compiled with the TvOS,
WatchOS, iOS SDKs.

This causes compile errors in comprehensive switch statements, as
removing the availability may add new enumeration cases that are not
valid for the platform.

Using the invalid enumeration cases is problematic for non-WebKit
codebases such as ANGLE that uses Metal API. Since the upstream likely
does not have the modified SDK, the invalid enumeration cases will cause
errors for the upstream compile.

Solve this by moving the availability macro erasure to affect all
WTF projects, not all projects compiled with WebKit SDK.

The erasure is invoked from Platform.h include chain.
The erasure is not invoked from config.h of the various projects since
since config.h and *Prefix.h files both include platform headers that
already need the modification. If it was applied
only to various config.h files, then the *Prefix.h files would cause
platform includes that already would need the override.

The most beneficial would be to apply the erasure per-compilation unit
basis. This is not done because of the above problem. Also, the
compilation units would need to not be built with unified build as they
are today. Changing them to @no-unify surfaces compilation logic errors
that are currently hidden due to unified build. Example of how the
per-compilation unit erasure would work is shown with the modifications
to bmalloc AvailableMemory.cpp.

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/Platform.h:
* Source/WTF/wtf/PlatformMacroOverrides.h: Added.
* Source/bmalloc/PlatformMac.cmake:
* Source/bmalloc/bmalloc.xcodeproj/project.pbxproj:
* Source/bmalloc/bmalloc/AvailableMemory.cpp:
(bmalloc::memorySizeAccordingToKernel):
* Source/bmalloc/bmalloc/darwin/BAllowProhibitedAPIs.h: Added.
* Tools/Scripts/configure-xcode-for-embedded-development:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c8a32161892afea56cbf1ec103f2fe9efe1ea30

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106933 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15969 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39729 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116113 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115659 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110836 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17453 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7167 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99119 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112698 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13213 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96238 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40816 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95105 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27881 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82565 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/96443 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9116 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29233 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/95893 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/7066 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9694 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6231 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30724 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15283 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48791 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/104667 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11224 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25930 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->