### PR TITLE
Remove outdated UnspecifiedBoolType technique

### DIFF
--- a/Source/JavaScriptCore/runtime/ArrayBuffer.h
+++ b/Source/JavaScriptCore/runtime/ArrayBuffer.h
@@ -195,7 +195,7 @@ public:
         return std::nullopt;
     }
     
-    bool isShared() const { return m_shared; }
+    bool isShared() const { return !!m_shared; }
     bool isResizableOrGrowableShared() const { return m_hasMaxByteLength; }
     bool isGrowableShared() const { return isResizableOrGrowableShared() && isShared(); }
     bool isResizableNonShared() const { return isResizableOrGrowableShared() && !isShared(); }

--- a/Source/JavaScriptCore/runtime/ScriptExecutable.h
+++ b/Source/JavaScriptCore/runtime/ScriptExecutable.h
@@ -101,11 +101,11 @@ public:
 
     bool hasJITCodeForCall() const
     {
-        return m_jitCodeForCall;
+        return !!m_jitCodeForCall;
     }
     bool hasJITCodeForConstruct() const
     {
-        return m_jitCodeForConstruct;
+        return !!m_jitCodeForConstruct;
     }
 
     // This function has an interesting GC story. Callers of this function are asking us to create a CodeBlock

--- a/Source/JavaScriptCore/wasm/WasmInstance.h
+++ b/Source/JavaScriptCore/wasm/WasmInstance.h
@@ -106,7 +106,7 @@ public:
     }
     void updateCachedMemory()
     {
-        if (m_memory != nullptr) {
+        if (!!m_memory) {
             // Note: In MemoryMode::BoundsChecking, mappedCapacity() == size().
             // We assert this in the constructor of MemoryHandle.
 #if CPU(ARM)

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/desktop_capture/linux/wayland/xdg_desktop_portal_utils.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/desktop_capture/linux/wayland/xdg_desktop_portal_utils.cc
@@ -186,7 +186,7 @@ void TearDownSession(absl::string_view session_handle,
     g_object_unref(cancellable);
   }
 
-  if (proxy) {
+  if (!!proxy) {
     g_object_unref(proxy);
   }
 }

--- a/Source/WTF/wtf/CheckedPtr.h
+++ b/Source/WTF/wtf/CheckedPtr.h
@@ -105,10 +105,6 @@ public:
 
     bool isHashTableDeletedValue() const { return PtrTraits::isHashTableDeletedValue(m_ptr); }
 
-    // This conversion operator allows implicit conversion to bool but not to other integer types.
-    using UnspecifiedBoolType = void (CheckedPtr::*)() const;
-    operator UnspecifiedBoolType() const { return m_ptr ? &CheckedPtr::unspecifiedBoolTypeInstance : nullptr; }
-
     ALWAYS_INLINE bool operator!() const { return !PtrTraits::unwrap(m_ptr); }
 
     ALWAYS_INLINE const T* get() const { return PtrTraits::unwrap(m_ptr); }
@@ -178,8 +174,6 @@ public:
 
 private:
     template<typename OtherType, typename OtherPtrTraits> friend class CheckedPtr;
-
-    void unspecifiedBoolTypeInstance() const { }
 
     ALWAYS_INLINE void refIfNotNull()
     {

--- a/Source/WTF/wtf/Packed.h
+++ b/Source/WTF/wtf/Packed.h
@@ -192,9 +192,6 @@ public:
 
     bool operator!() const { return !get(); }
 
-    // This conversion operator allows implicit conversion to bool but not to other integer types.
-    typedef T* (PackedAlignedPtr::*UnspecifiedBoolType);
-    operator UnspecifiedBoolType() const { return get() ? &PackedAlignedPtr::m_storage : nullptr; }
     explicit operator bool() const { return get(); }
 
     PackedAlignedPtr& operator=(T* value)

--- a/Source/WTF/wtf/RefPtr.h
+++ b/Source/WTF/wtf/RefPtr.h
@@ -85,10 +85,6 @@ public:
 
     bool operator!() const { return !m_ptr; }
 
-    // This conversion operator allows implicit conversion to bool but not to other integer types.
-    using UnspecifiedBoolType = void (RefPtr::*)() const;
-    operator UnspecifiedBoolType() const { return m_ptr ? &RefPtr::unspecifiedBoolTypeInstance : nullptr; }
-
     explicit operator bool() const { return !!m_ptr; }
     
     RefPtr& operator=(const RefPtr&);
@@ -105,8 +101,6 @@ public:
     RefPtr copyRef() const & WARN_UNUSED_RETURN { return RefPtr(m_ptr); }
 
 private:
-    void unspecifiedBoolTypeInstance() const { }
-
     friend RefPtr adoptRef<T, PtrTraits, RefDerefTraits>(T*);
     template<typename X, typename Y, typename Z> friend class RefPtr;
 

--- a/Source/WTF/wtf/RetainPtr.h
+++ b/Source/WTF/wtf/RetainPtr.h
@@ -115,11 +115,6 @@ public:
 
     constexpr bool operator!() const { return !m_ptr; }
 
-    // This conversion operator allows implicit conversion to bool but not to other integer types.
-    // FIXME: Eventually we should remove this; it's an outdated technique and less needed since we have explicit operator bool.
-    typedef CFTypeRef RetainPtr::*UnspecifiedBoolType;
-    operator UnspecifiedBoolType() const { return m_ptr ? &RetainPtr::m_ptr : nullptr; }
-
     RetainPtr& operator=(const RetainPtr&);
     template<typename U> RetainPtr& operator=(const RetainPtr<U>&);
     RetainPtr& operator=(PtrType);

--- a/Source/WTF/wtf/SignedPtr.h
+++ b/Source/WTF/wtf/SignedPtr.h
@@ -86,9 +86,6 @@ public:
 
     bool operator!() const { return !m_value; }
     
-    // This conversion operator allows implicit conversion to bool but not to other integer types.
-    typedef T* (SignedPtr::*UnspecifiedBoolType);
-    operator UnspecifiedBoolType() const { return get() ? &SignedPtr::m_value : nullptr; }
     explicit operator bool() const { return get(); }
 
     SignedPtr& operator=(T* value)

--- a/Source/WTF/wtf/glib/GRefPtr.h
+++ b/Source/WTF/wtf/glib/GRefPtr.h
@@ -113,10 +113,6 @@ public:
 
     bool operator!() const { return !m_ptr; }
 
-    // This conversion operator allows implicit conversion to bool but not to other integer types.
-    typedef T* GRefPtr::*UnspecifiedBoolType;
-    operator UnspecifiedBoolType() const { return m_ptr ? &GRefPtr::m_ptr : 0; }
-
     GRefPtr& operator=(const GRefPtr&);
     GRefPtr& operator=(GRefPtr&&);
     GRefPtr& operator=(T*);

--- a/Source/WTF/wtf/glib/GUniquePtr.h
+++ b/Source/WTF/wtf/glib/GUniquePtr.h
@@ -107,10 +107,6 @@ public:
 
     bool operator!() const { return !m_ptr; }
 
-    // This conversion operator allows implicit conversion to bool but not to other integer types.
-    typedef T* GUniqueOutPtr::*UnspecifiedBoolType;
-    operator UnspecifiedBoolType() const { return m_ptr ? &GUniqueOutPtr::m_ptr : 0; }
-
 private:
     void reset()
     {

--- a/Source/WTF/wtf/glib/GWeakPtr.h
+++ b/Source/WTF/wtf/glib/GWeakPtr.h
@@ -83,10 +83,6 @@ public:
 
     bool operator!() const { return !m_ptr; }
 
-    // This conversion operator allows implicit conversion to bool but not to other integer types.
-    typedef T* GWeakPtr::*UnspecifiedBoolType;
-    operator UnspecifiedBoolType() const { return m_ptr ? &GWeakPtr::m_ptr : 0; }
-
 private:
     void addWeakPtr()
     {

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -229,13 +229,6 @@ public:
 
     WTF_EXPORT_PRIVATE bool isSafeToSendToAnotherThread() const;
 
-    // Prevent Strings from being implicitly convertable to bool as it will be ambiguous on any platform that
-    // allows implicit conversion to another pointer type (e.g., Mac allows implicit conversion to NSString *).
-    typedef struct ImplicitConversionFromWTFStringToBoolDisallowedA* (String::*UnspecifiedBoolTypeA);
-    typedef struct ImplicitConversionFromWTFStringToBoolDisallowedB* (String::*UnspecifiedBoolTypeB);
-    operator UnspecifiedBoolTypeA() const;
-    operator UnspecifiedBoolTypeB() const;
-
 #if USE(CF)
     WTF_EXPORT_PRIVATE String(CFStringRef);
     WTF_EXPORT_PRIVATE RetainPtr<CFStringRef> createCFString() const;

--- a/Source/WTF/wtf/win/GDIObject.h
+++ b/Source/WTF/wtf/win/GDIObject.h
@@ -53,10 +53,6 @@ public:
 
     bool operator!() const { return !m_object; }
 
-    // This conversion operator allows implicit conversion to bool but not to other integer types.
-    typedef const void* UnspecifiedBoolType;
-    operator UnspecifiedBoolType() const { return m_object ? reinterpret_cast<UnspecifiedBoolType>(&m_object) : 0; }
-
     GDIObject<T>& operator=(std::nullptr_t) { clear(); return *this; }
 
     GDIObject(GDIObject&&);

--- a/Source/WebCore/PAL/pal/system/glib/SleepDisablerGLib.cpp
+++ b/Source/WebCore/PAL/pal/system/glib/SleepDisablerGLib.cpp
@@ -61,7 +61,7 @@ SleepDisablerGLib::SleepDisablerGLib(const String& reason, Type type)
             return;
 
         auto* self = static_cast<SleepDisablerGLib*>(userData);
-        if (proxy) {
+        if (!!proxy) {
             GUniquePtr<char> nameOwner(g_dbus_proxy_get_name_owner(proxy.get()));
             if (nameOwner) {
                 self->m_screenSaverProxy = WTFMove(proxy);

--- a/Source/WebCore/loader/cache/CachedResourceHandle.h
+++ b/Source/WebCore/loader/cache/CachedResourceHandle.h
@@ -38,10 +38,6 @@ public:
     CachedResource* get() const { return m_resource; }
     
     bool operator!() const { return !m_resource; }
-    
-    // This conversion operator allows implicit conversion to bool but not to other integer types.
-    typedef CachedResource* CachedResourceHandleBase::*UnspecifiedBoolType;
-    operator UnspecifiedBoolType() const { return m_resource ? &CachedResourceHandleBase::m_resource : 0; }
 
 protected:
     CachedResourceHandleBase();

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
@@ -373,7 +373,7 @@ static CDMProxy* getCDMProxyFromGstContext(WebKitMediaCommonEncryptionDecrypt* s
         const GValue* value = gst_structure_get_value(gst_context_get_structure(context.get()), "cdm-proxy");
         if (value) {
             proxy = reinterpret_cast<CDMProxy*>(g_value_get_pointer(value));
-            if (proxy) {
+            if (!!proxy) {
                 GST_DEBUG_OBJECT(self, "received a new CDM proxy instance %p, refcount %u", proxy, proxy->refCount());
                 return proxy;
             }
@@ -401,7 +401,7 @@ static gboolean installCDMProxyIfNotAvailable(WebKitMediaCommonEncryptionDecrypt
         gboolean result = FALSE;
 
         CDMProxy* proxy = getCDMProxyFromGstContext(self);
-        if (proxy) {
+        if (!!proxy) {
             attachCDMProxy(self, proxy);
             result = TRUE;
         } else {

--- a/Source/WebCore/platform/win/COMPtr.h
+++ b/Source/WebCore/platform/win/COMPtr.h
@@ -74,10 +74,6 @@ public:
     T** operator&() { ASSERT(!m_ptr); return &m_ptr; }
 
     bool operator!() const { return !m_ptr; }
-    
-    // This conversion operator allows implicit conversion to bool but not to other integer types.
-    typedef T* (COMPtr::*UnspecifiedBoolType)() const;
-    operator UnspecifiedBoolType() const { return m_ptr ? &COMPtr::get : 0; }
 
     COMPtr& operator=(const COMPtr&);
     COMPtr& operator=(COMPtr&&);

--- a/Source/WebKit/UIProcess/API/cpp/WKRetainPtr.h
+++ b/Source/WebKit/UIProcess/API/cpp/WKRetainPtr.h
@@ -106,10 +106,6 @@ public:
     PtrType operator->() const { return m_ptr; }
     bool operator!() const { return !m_ptr; }
 
-    // This conversion operator allows implicit conversion to bool but not to other integer types.
-    typedef PtrType WKRetainPtr::*UnspecifiedBoolType;
-    operator UnspecifiedBoolType() const { return m_ptr ? &WKRetainPtr::m_ptr : 0; }
-
     WKRetainPtr& operator=(const WKRetainPtr&);
     template<typename U> WKRetainPtr& operator=(const WKRetainPtr<U>&);
     WKRetainPtr& operator=(PtrType);

--- a/Source/bmalloc/bmalloc/Packed.h
+++ b/Source/bmalloc/bmalloc/Packed.h
@@ -169,9 +169,6 @@ public:
     T& operator*() const { return *get(); }
     bool operator!() const { return !get(); }
 
-    // This conversion operator allows implicit conversion to bool but not to other integer types.
-    typedef T* (PackedAlignedPtr::*UnspecifiedBoolType);
-    operator UnspecifiedBoolType() const { return get() ? &PackedAlignedPtr::m_storage : nullptr; }
     explicit operator bool() const { return get(); }
 
     PackedAlignedPtr& operator=(T* value)


### PR DESCRIPTION
Especially now that we have explicit operators now.<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c04e3d1a54783437f1e5d2118f7486f25e58b8df

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106942 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15978 "Hash c04e3d1a for PR 9871 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39736 "Hash c04e3d1a for PR 9871 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116121 "Hash c04e3d1a for PR 9871 does not build (failure)") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/115662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110843 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17461 "Hash c04e3d1a for PR 9871 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7176 "Hash c04e3d1a for PR 9871 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99127 "Hash c04e3d1a for PR 9871 does not build (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112707 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/76/builds/17461 "Hash c04e3d1a for PR 9871 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/39736 "Hash c04e3d1a for PR 9871 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/99127 "Hash c04e3d1a for PR 9871 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/76/builds/17461 "Hash c04e3d1a for PR 9871 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/39736 "Hash c04e3d1a for PR 9871 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/99127 "Hash c04e3d1a for PR 9871 does not build (failure)") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/96446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/9122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/39736 "Hash c04e3d1a for PR 9871 does not build (failure)") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/38/builds/95895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/83/builds/7072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9701 "Hash c04e3d1a for PR 9871 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/85/builds/7176 "Hash c04e3d1a for PR 9871 does not build (failure)") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/38/builds/95895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/15289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/39736 "Hash c04e3d1a for PR 9871 does not build (failure)") | [  ~~🛠 jsc-mips~~](https://ews-build.webkit.org/#/builders/37/builds/104672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11231 "Hash c04e3d1a for PR 9871 does not build (failure)") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/37/builds/104672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | | | | 
<!--EWS-Status-Bubble-End-->