### PR TITLE
[web-animations] web-animations/interfaces/Animatable/animate-no-browsing-context.html is a unique failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animatable/animate-no-browsing-context-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animatable/animate-no-browsing-context-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Element.animate() creates an animation with the correct timeline when called on an element in a document without a browsing context
 PASS The timeline associated with an animation trigger on an element in a document without a browsing context is inactive
-FAIL Replacing the timeline of an animation targetting an element in a document without a browsing context leaves it in the pending state assert_true: The animation should still be pending after replacing the document timeline expected true got false
+PASS Replacing the timeline of an animation targetting an element in a document without a browsing context leaves it in the pending state
 PASS Replacing the timeline of an animation targetting an element in a document without a browsing context and then adopting that element causes it to start updating style
 

--- a/Source/WebCore/animation/AnimationEffect.h
+++ b/Source/WebCore/animation/AnimationEffect.h
@@ -102,6 +102,8 @@ public:
 
     virtual Seconds timeToNextTick(const BasicEffectTiming&) const;
 
+    virtual bool preventsAnimationReadiness() const { return false; }
+
 protected:
     explicit AnimationEffect();
 

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -2449,4 +2449,12 @@ void KeyframeEffect::lastStyleChangeEventStyleDidChange(const RenderStyle* previ
         abilityToBeAcceleratedDidChange();
 }
 
+bool KeyframeEffect::preventsAnimationReadiness() const
+{
+    // https://drafts.csswg.org/web-animations-1/#ready
+    // An animation cannot be ready if it's associated with a document that does not have a browsing
+    // context since this will prevent the first frame of the animmation from being rendered.
+    return document() && !document()->hasBrowsingContext();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -235,6 +235,7 @@ private:
     Seconds timeToNextTick(const BasicEffectTiming&) const final;
     bool ticksContinouslyWhileActive() const final;
     std::optional<double> progressUntilNextStep(double) const final;
+    bool preventsAnimationReadiness() const final;
 
     AtomString m_keyframesName;
     KeyframeList m_blendingKeyframes { emptyAtom() };

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -1347,11 +1347,12 @@ void WebAnimation::tick()
     updateFinishedState(DidSeek::No, SynchronouslyNotify::Yes);
     m_shouldSkipUpdatingFinishedStateWhenResolving = true;
 
-    // Run pending tasks, if any.
-    if (hasPendingPauseTask())
-        runPendingPauseTask();
-    if (hasPendingPlayTask())
-        runPendingPlayTask();
+    if (!m_effect || !m_effect->preventsAnimationReadiness()) {
+        if (hasPendingPauseTask())
+            runPendingPauseTask();
+        if (hasPendingPlayTask())
+            runPendingPlayTask();
+    }
 
     if (!isEffectInvalidationSuspended() && m_effect)
         m_effect->animationDidTick();


### PR DESCRIPTION
#### 87f47a6461e3f8051550797467b2071f43eb6304
<pre>
[web-animations] web-animations/interfaces/Animatable/animate-no-browsing-context.html is a unique failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=186494">https://bugs.webkit.org/show_bug.cgi?id=186494</a>
rdar://problem/41000163

Reviewed by Dean Jackson.

The Web Animations spec defines several factors for an animation to be considered &quot;ready&quot; [0], one being
that the &quot;user agent has completed any setup required to begin the playback of the animation&apos;s associated
effect including rendering the first frame of any keyframe effect&quot;.

While it does not specifically calls out the lack of a browsing context for the associated effect&apos;s target&apos;s
document, there certainly won&apos;t be any frames rendered in that specific case. So we do not run pending tasks,
the condition for the &quot;ready&quot; promise to resolve, if the associated effect is associated with a document
lacking a browsing context.

I filed a spec issue [1] to clarify this in the spec, but I believe the spirit of the spec already goes in
the direction of this test.

[0] <a href="https://drafts.csswg.org/web-animations-1/#ready">https://drafts.csswg.org/web-animations-1/#ready</a>
[1] <a href="https://github.com/w3c/csswg-drafts/issues/8439">https://github.com/w3c/csswg-drafts/issues/8439</a>

* LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animatable/animate-no-browsing-context-expected.txt:
* Source/WebCore/animation/AnimationEffect.h:
(WebCore::AnimationEffect::preventsAnimationReadiness const):
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::preventsAnimationReadiness const):
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::tick):

Canonical link: <a href="https://commits.webkit.org/260101@main">https://commits.webkit.org/260101@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80e03dcfe39ada332e6d996d16080beacce8ad93

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106955 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15991 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39748 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116134 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115674 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110856 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17473 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7188 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99140 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112720 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13224 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96246 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40823 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95116 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27888 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82572 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9134 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29240 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9713 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6242 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15301 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48799 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11243 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3774 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->