### PR TITLE
Extraneous interaction regions for pseudo elements and some composited childrens

### DIFF
--- a/LayoutTests/interaction-region/nested-composited-text-painter-expected.txt
+++ b/LayoutTests/interaction-region/nested-composited-text-painter-expected.txt
@@ -1,0 +1,41 @@
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (drawsContent 1)
+      (backgroundColor #FFFFFF)
+      (event region
+        (rect (0,0) width=800 height=600)
+
+      (interaction regions [
+        (interaction
+            (rect (0,0) width=100 height=100)
+)
+        (borderRadius 10.00)])
+      )
+      (children 1
+        (GraphicsLayer
+          (bounds 100.00 100.00)
+          (opacity 0.80)
+          (event region
+            (rect (0,0) width=100 height=100)
+          )
+          (children 1
+            (GraphicsLayer
+              (position 35.00 40.00)
+              (bounds 30.00 20.00)
+              (drawsContent 1)
+              (event region
+                (rect (0,0) width=30 height=20)
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/interaction-region/nested-composited-text-painter.html
+++ b/LayoutTests/interaction-region/nested-composited-text-painter.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<style>
+    body { margin: 0; }
+    a {
+        position: relative;
+        display: block;
+        width: 100px;
+        height: 100px;
+        border-radius: 10px;
+    }
+    .content {
+        position: absolute;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        cursor: pointer;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: rgba(0, 0, 255, 0.5);
+        opacity: 0.8;
+    }
+    span {
+        will-change: transform;
+    }
+</style>
+<body>
+<div id="test">
+    <a href="#">
+        <div class="content">
+            <span>span</span>
+        </div>
+    </a>
+</div>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.onload = function () {
+    if (window.internals)
+       results.textContent = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+    document.getElementById("test").remove();
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/interaction-region/pseudo-element-expected.txt
+++ b/LayoutTests/interaction-region/pseudo-element-expected.txt
@@ -1,0 +1,22 @@
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (drawsContent 1)
+      (backgroundColor #FFFFFF)
+      (event region
+        (rect (0,0) width=800 height=600)
+
+      (interaction regions [
+        (interaction
+            (rect (0,0) width=100 height=100)
+)
+        (borderRadius 10.00)])
+      )
+    )
+  )
+)
+

--- a/LayoutTests/interaction-region/pseudo-element.html
+++ b/LayoutTests/interaction-region/pseudo-element.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<style>
+    body { margin: 0; }
+    a {
+        position: relative;
+        display: block;
+        width: 100px;
+        height: 100px;
+        border-radius: 10px;
+    }
+    .content {
+        position: absolute;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        cursor: pointer;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: rgba(0, 0, 255, 0.5);
+        opacity: 0.8;
+    }
+    .content::after {
+        position: absolute;
+        content: " ";
+        right: 10px;
+        bottom: 10px;
+        width: 30px;
+        height: 10px;
+        background: red;
+    }
+</style>
+<body>
+<div id="test">
+    <a href="#">
+        <div class="content">
+        </div>
+    </a>
+</div>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.onload = function () {
+    if (window.internals)
+       results.textContent = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+    document.getElementById("test").remove();
+};
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -125,38 +125,44 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
     if (checkedRegionArea.hasOverflowed())
         return std::nullopt;
 
-    auto element = dynamicDowncast<Element>(regionRenderer.node());
-    if (!element) 
-        element = regionRenderer.node()->parentElement();
-    if (!element)
+    auto originalElement = dynamicDowncast<Element>(regionRenderer.node());
+    if (originalElement && originalElement->isPseudoElement())
         return std::nullopt;
 
-    if (auto* linkElement = element->enclosingLinkEventParentOrSelf())
-        element = linkElement;
-    if (auto* buttonElement = ancestorsOfType<HTMLButtonElement>(*element).first())
-        element = buttonElement;
-
-    if (!shouldAllowElement(*element))
+    auto matchedElement = originalElement;
+    if (!matchedElement)
+        matchedElement = regionRenderer.node()->parentElement();
+    if (!matchedElement)
         return std::nullopt;
 
-    if (!element->renderer())
+    if (auto* linkElement = matchedElement->enclosingLinkEventParentOrSelf())
+        matchedElement = linkElement;
+    if (auto* buttonElement = ancestorsOfType<HTMLButtonElement>(*matchedElement).first())
+        matchedElement = buttonElement;
+
+    if (!shouldAllowElement(*matchedElement))
         return std::nullopt;
-    auto& renderer = *element->renderer();
+
+    if (!matchedElement->renderer())
+        return std::nullopt;
+    auto& renderer = *matchedElement->renderer();
 
     if (renderer.style().effectivePointerEvents() == PointerEvents::None)
         return std::nullopt;
 
+    bool isOriginalMatch = matchedElement == originalElement;
+
     // FIXME: Consider also allowing elements that only receive touch events.
     bool hasListener = renderer.style().eventListenerRegionTypes().contains(EventListenerRegionType::MouseClick);
-    bool hasPointer = cursorTypeForElement(*element) == CursorType::Pointer || shouldAllowNonPointerCursorForElement(*element);
+    bool hasPointer = cursorTypeForElement(*matchedElement) == CursorType::Pointer || shouldAllowNonPointerCursorForElement(*matchedElement);
     if (!hasListener || !hasPointer) {
         bool isOverlay = checkedRegionArea.value() <= frameViewArea && (renderer.style().specifiedZIndex() > 0 || renderer.isFixedPositioned());
-        if (isOverlay) {
+        if (isOverlay && isOriginalMatch) {
             Region boundsRegion;
             boundsRegion.unite(bounds);
 
             return { {
-                element->identifier(),
+                matchedElement->identifier(),
                 boundsRegion,
                 0,
                 InteractionRegion::Type::Occlusion
@@ -171,6 +177,10 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
 
     bool isInlineNonBlock = renderer.isInline() && !renderer.isReplacedOrInlineBlock();
 
+    // The parent will get its own InteractionRegion.
+    if (!isOriginalMatch && !isInlineNonBlock)
+        return std::nullopt;
+
     if (isInlineNonBlock)
         bounds.inflate(regionRenderer.document().settings().interactionRegionInlinePadding());
 
@@ -178,7 +188,7 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
     if (auto* renderBox = dynamicDowncast<RenderBox>(renderer)) {
         borderRadius = renderBox->borderRadii().minimumRadius();
 
-        auto* input = dynamicDowncast<HTMLInputElement>(element);
+        auto* input = dynamicDowncast<HTMLInputElement>(matchedElement);
         if (input && input->containerElement()) {
             auto borderBoxRect = renderBox->borderBoxRect();
             auto contentBoxRect = renderBox->contentBoxRect();
@@ -191,7 +201,7 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
     boundsRegion.unite(bounds);
 
     return { {
-        element->identifier(),
+        matchedElement->identifier(),
         boundsRegion,
         borderRadius,
         InteractionRegion::Type::Interaction


### PR DESCRIPTION
#### ab29cfa512af8fac599ae1f0e7bb19b99980cc52
<pre>
Extraneous interaction regions for pseudo elements and some composited childrens
<a href="https://bugs.webkit.org/show_bug.cgi?id=251995">https://bugs.webkit.org/show_bug.cgi?id=251995</a>
&lt;rdar://104140617&gt;

Reviewed by Tim Horton.

Tweak the interaction regions generation heuristics to avoid extra
regions for:
- pseudo-elements
- children of block elements getting their own InteractionRegion

* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::interactionRegionForRenderedRegion):
Keep track of the original RegionRenderer node separately of the one we
end up matching in order to tweak the heuristics.

* LayoutTests/interaction-region/nested-composited-text-painter-expected.txt: Added.
* LayoutTests/interaction-region/nested-composited-text-painter.html: Added.
* LayoutTests/interaction-region/pseudo-element-expected.txt: Added.
* LayoutTests/interaction-region/pseudo-element.html: Added.
Add tests for these cases.

Canonical link: <a href="https://commits.webkit.org/260567@main">https://commits.webkit.org/260567@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a2a5e94e7999f39cd680cbdb299ce47b6ce12dc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108640 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17741 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41494 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117750 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/117951 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112523 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19192 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9018 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100872 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114407 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14389 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97622 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42358 "Found 2 new test failures: webgl/2.0.0/conformance2/textures/image_bitmap_from_video/tex-2d-r8ui-red_integer-unsigned_byte.html, webgl/2.0.0/conformance2/textures/image_data/tex-2d-r8-red-unsigned_byte.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96365 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29260 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84088 "Found 3 new API test failures: /TestWebKit:WebKit.OnDeviceChangeCrash, /TestWebKit:WebKit.PrivateBrowsingPushStateNoHistoryCallback, /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/cut-copy-paste/editable (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10549 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30610 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11307 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7524 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16698 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50206 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7307 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12895 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->