### PR TITLE
Correct some misspelled "identifier"s

### DIFF
--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -201,7 +201,7 @@ CSSSelectorList CSSSelectorParser::consumeCompoundSelectorList(CSSParserTokenRan
     return CSSSelectorList { WTFMove(selectorList) };
 }
 
-static PossiblyQuotedIdentifier consumePossiblyQuotedIdentifer(CSSParserTokenRange& range)
+static PossiblyQuotedIdentifier consumePossiblyQuotedIdentifier(CSSParserTokenRange& range)
 {
     auto& token = range.consumeIncludingWhitespace();
     if (token.type() != IdentToken && token.type() != StringToken)
@@ -215,13 +215,13 @@ static PossiblyQuotedIdentifier consumePossiblyQuotedIdentifer(CSSParserTokenRan
 static FixedVector<PossiblyQuotedIdentifier> consumeLangArgumentList(CSSParserTokenRange& range)
 {
     Vector<PossiblyQuotedIdentifier> list;
-    auto item = consumePossiblyQuotedIdentifer(range);
+    auto item = consumePossiblyQuotedIdentifier(range);
     if (item.isNull())
         return { };
     list.append(WTFMove(item));
     while (!range.atEnd() && range.peek().type() == CommaToken) {
         range.consumeIncludingWhitespace();
-        item = consumePossiblyQuotedIdentifer(range);
+        item = consumePossiblyQuotedIdentifier(range);
         if (item.isNull())
             return { };
         list.append(WTFMove(item));

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
@@ -423,18 +423,18 @@ void CacheStorageManager::dereference(IPC::Connection::UniqueID connection, WebC
 
 void CacheStorageManager::connectionClosed(IPC::Connection::UniqueID connection)
 {
-    HashSet<WebCore::DOMCacheIdentifier> unusedCacheIdentifers;
+    HashSet<WebCore::DOMCacheIdentifier> unusedCacheIdentifiers;
     for (auto& [identifier, refConnections] : m_cacheRefConnections) {
         refConnections.removeAllMatching([&](auto refConnection) {
             return refConnection == connection;
         });
         if (refConnections.isEmpty()) {
             removeUnusedCache(identifier);
-            unusedCacheIdentifers.add(identifier);
+            unusedCacheIdentifiers.add(identifier);
         }
     }
 
-    for (auto& identifier : unusedCacheIdentifers)
+    for (auto& identifier : unusedCacheIdentifiers)
         m_cacheRefConnections.remove(identifier);
 }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerConfiguration.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerConfiguration.mm
@@ -47,15 +47,14 @@ String WebExtensionControllerConfiguration::createStorageDirectoryPath(std::opti
         if (libraryPath.isEmpty())
             RELEASE_ASSERT_NOT_REACHED();
 
-        String identiferPath = identifier ? identifier->toString() : "Default"_s;
-
+        String identifierPath = identifier ? identifier->toString() : "Default"_s;
         if (processHasContainer()) {
-            defaultStoragePath.get() = FileSystem::pathByAppendingComponents(libraryPath, { "WebKit"_s, "WebExtensions"_s, identiferPath });
+            defaultStoragePath.get() = FileSystem::pathByAppendingComponents(libraryPath, { "WebKit"_s, "WebExtensions"_s, identifierPath });
             return;
         }
 
         String appDirectoryName = [NSBundle mainBundle].bundleIdentifier ?: [NSProcessInfo processInfo].processName;
-        defaultStoragePath.get() = FileSystem::pathByAppendingComponents(libraryPath, { "WebKit"_s, appDirectoryName, "WebExtensions"_s, identiferPath });
+        defaultStoragePath.get() = FileSystem::pathByAppendingComponents(libraryPath, { "WebKit"_s, appDirectoryName, "WebExtensions"_s, identifierPath });
     });
 
     return defaultStoragePath.get();

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -341,7 +341,7 @@ void WebsiteDataStore::resolveDirectoriesIfNecessary()
         m_resolvedConfiguration->setCookieStorageFile(FileSystem::pathByAppendingComponent(resolvedCookieDirectory, FileSystem::pathFileName(m_configuration->cookieStorageFile())));
     }
 
-    // Default paths of WebsiteDataStore created with identifer are not under caches or tmp directory,
+    // Default paths of WebsiteDataStore created with identifier are not under caches or tmp directory,
     // so we need to explicitly exclude them from backup.
     if (m_configuration->identifier()) {
         Vector<String> allCacheDirectories = {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebBroadcastChannelRegistry.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebBroadcastChannelRegistry.cpp
@@ -108,10 +108,10 @@ void WebBroadcastChannelRegistry::postMessageLocally(const WebCore::PartitionedS
         return;
 
     auto channelIdentifiersForName = channelsForOriginIterator->value;
-    for (auto& channelIdentier : channelIdentifiersForName) {
-        if (channelIdentier == sourceInProcess)
+    for (auto& channelIdentifier : channelIdentifiersForName) {
+        if (channelIdentifier == sourceInProcess)
             continue;
-        WebCore::BroadcastChannel::dispatchMessageTo(channelIdentier, message.copyRef(), [callbackAggregator] { });
+        WebCore::BroadcastChannel::dispatchMessageTo(channelIdentifier, message.copyRef(), [callbackAggregator] { });
     }
 }
 


### PR DESCRIPTION
#### afda2079a89c622a506a3902b238bcfb4996bace
<pre>
Correct some misspelled &quot;identifier&quot;s
<a href="https://bugs.webkit.org/show_bug.cgi?id=251996">https://bugs.webkit.org/show_bug.cgi?id=251996</a>
rdar://105228274

Reviewed by Wenson Hsieh.

* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::consumePossiblyQuotedIdentifier):
(WebCore::consumeLangArgumentList):
(WebCore::consumePossiblyQuotedIdentifer): Deleted.
* Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp:
(WebKit::CacheStorageManager::connectionClosed):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerConfiguration.mm:
(WebKit::WebExtensionControllerConfiguration::createStorageDirectoryPath):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::resolveDirectoriesIfNecessary):
* Source/WebKit/WebProcess/WebCoreSupport/WebBroadcastChannelRegistry.cpp:
(WebKit::WebBroadcastChannelRegistry::postMessageLocally):

Canonical link: <a href="https://commits.webkit.org/260086@main">https://commits.webkit.org/260086@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed0582a07466c7419c57f27cee53383cd40da363

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106965 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16001 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39758 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116144 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115680 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110866 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17481 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7197 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99149 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112730 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13228 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96257 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40829 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95120 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27899 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9148 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29251 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9722 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/6249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15309 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48810 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6967 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11253 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->