### PR TITLE
Prototype selection API for shadow DOM

### DIFF
--- a/LayoutTests/fast/shadow-dom/selection-direction-expected.txt
+++ b/LayoutTests/fast/shadow-dom/selection-direction-expected.txt
@@ -1,0 +1,11 @@
+a
+b
+
+PASS direction returns "none" when there is no selection
+PASS direction returns "forward" when there is a forward-direction selection in the document tree
+PASS direction returns "backward" when there is a backward-direction selection in the document tree
+PASS direction returns "forward" when there is a forward selection in the shadow tree
+PASS direction returns "backward" when there is a backward selection in the shadow tree
+PASS direction returns "forward" when there is a forward selection that crosses shadow boundaries
+PASS direction returns "backward" when there is a forward selection that crosses shadow boundaries
+

--- a/LayoutTests/fast/shadow-dom/selection-direction.html
+++ b/LayoutTests/fast/shadow-dom/selection-direction.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+<body>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<meta name="assert" content="Selection's direction should return none, forwad, or backward">
+<link rel="help" href="https://w3c.github.io/selection-api/#dom-selection-getcomposedrange">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<div id="container"></div>
+<script>
+
+test(() => {
+    getSelection().removeAllRanges();
+    assert_equals(getSelection().direction, 'none');
+}, 'direction returns "none" when there is no selection');
+
+test(() => {
+    container.innerHTML = 'hello, world';
+    getSelection().setBaseAndExtent(container.firstChild, 0, container.firstChild, 5);
+    assert_equals(getSelection().direction, 'forward');
+}, 'direction returns "forward" when there is a forward-direction selection in the document tree');
+
+test(() => {
+    container.innerHTML = 'hello, world';
+    getSelection().setBaseAndExtent(container.firstChild, 4, container.firstChild, 3);
+    assert_equals(getSelection().direction, 'backward');
+}, 'direction returns "backward" when there is a backward-direction selection in the document tree');
+
+test(() => {
+    container.innerHTML = 'a<div id="host"></div>b';
+    const shadowRoot = host.attachShadow({mode: 'closed'});
+    shadowRoot.innerHTML = 'hello, world';
+    getSelection().setBaseAndExtent(shadowRoot.firstChild, 0, shadowRoot.firstChild, 5);
+    assert_equals(getSelection().direction, 'forward');
+}, 'direction returns "forward" when there is a forward selection in the shadow tree');
+
+test(() => {
+    container.innerHTML = 'a<div id="host"></div>b';
+    const shadowRoot = host.attachShadow({mode: 'closed'});
+    shadowRoot.innerHTML = 'hello, world';
+    getSelection().setBaseAndExtent(shadowRoot.firstChild, 5, shadowRoot.firstChild, 3);
+    assert_equals(getSelection().direction, 'backward');
+}, 'direction returns "backward" when there is a backward selection in the shadow tree');
+
+test(() => {
+    container.innerHTML = 'a<div id="host"></div>b';
+    const shadowRoot = host.attachShadow({mode: 'closed'});
+    shadowRoot.innerHTML = 'hello, world';
+    getSelection().setBaseAndExtent(shadowRoot.firstChild, 7, container, 2);
+    assert_equals(getSelection().direction, 'forward');
+}, 'direction returns "forward" when there is a forward selection that crosses shadow boundaries');
+
+test(() => {
+    container.innerHTML = 'a<div id="host"></div>b';
+    const shadowRoot = host.attachShadow({mode: 'closed'});
+    shadowRoot.innerHTML = 'hello, world';
+    getSelection().setBaseAndExtent(shadowRoot.firstChild, 7, container, 1);
+    assert_equals(getSelection().direction, 'backward');
+}, 'direction returns "backward" when there is a forward selection that crosses shadow boundaries');
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/shadow-dom/selection-getComposedRanges-expected.txt
+++ b/LayoutTests/fast/shadow-dom/selection-getComposedRanges-expected.txt
@@ -1,0 +1,14 @@
+a
+b
+
+PASS getComposedRanges returns an empty sequence when there is no selection
+PASS getComposedRanges returns a sequence with a static range when there is a forward-direction selection in the document tree
+PASS getComposedRanges returns a sequence with a static range when there is a backward-direction selection in the document tree
+PASS getComposedRanges returns a sequence with a static range pointing to a shadaw tree when there is a selection in the shadow tree and the shadow tree is specified as an argument
+PASS getComposedRanges returns a sequence with a static range pointing to the shadow host when there is a selection in a shadow tree and the shadow tree is not specified as an argument
+PASS getComposedRanges a sequence with a static range pointing to the shadow host when there is a forward selection that crosses shadow boundaries and the shadow tree is not specified as an argument
+PASS getComposedRanges a sequence with a static range that crosses shadow boundaries when there is a forward selection that crosses shadow boundaries and the shadow tree is specified as an argument
+PASS getComposedRanges returns a sequence with a static range pointing to the outer shadow host when there is a selection in an inner shadow tree and no shadow tree is specified as an argument
+PASS getComposedRanges returns a sequence with a static range pointing to the inner shadow tree when there is a selection in an inner shadow tree and the inner shadow tree is specified as an argument
+PASS getComposedRanges returns a sequence with a static range pointing to the outer shadow tree when there is a selection in an inner shadow tree and the outer shadow tree is specified as an argument
+

--- a/LayoutTests/fast/shadow-dom/selection-getComposedRanges.html
+++ b/LayoutTests/fast/shadow-dom/selection-getComposedRanges.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html>
+<body>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<meta name="assert" content="Selection's getComposedRanges should return a sequence of static ranges">
+<link rel="help" href="https://w3c.github.io/selection-api/#dom-selection-getcomposedrange">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<div id="container"></div>
+<script>
+
+test(() => {
+    getSelection().removeAllRanges();
+    assert_array_equals(getSelection().getComposedRanges(), []);
+}, 'getComposedRanges returns an empty sequence when there is no selection');
+
+test(() => {
+    container.innerHTML = 'hello, world';
+    getSelection().setBaseAndExtent(container.firstChild, 0, container.firstChild, 5);
+    const ranges = getSelection().getComposedRanges();
+    assert_equals(ranges.length, 1);
+    assert_equals(ranges[0].startContainer, container.firstChild);
+    assert_equals(ranges[0].startOffset, 0);
+    assert_equals(ranges[0].endContainer, container.firstChild);
+    assert_equals(ranges[0].endOffset, 5);
+}, 'getComposedRanges returns a sequence with a static range when there is a forward-direction selection in the document tree');
+
+test(() => {
+    container.innerHTML = 'hello, world';
+    getSelection().setBaseAndExtent(container.firstChild, 4, container.firstChild, 3);
+    const ranges = getSelection().getComposedRanges();
+    assert_equals(ranges.length, 1);
+    assert_equals(ranges[0].startContainer, container.firstChild);
+    assert_equals(ranges[0].startOffset, 3);
+    assert_equals(ranges[0].endContainer, container.firstChild);
+    assert_equals(ranges[0].endOffset, 4);
+}, 'getComposedRanges returns a sequence with a static range when there is a backward-direction selection in the document tree');
+
+test(() => {
+    container.innerHTML = 'a<div id="host"></div>b';
+    const shadowRoot = host.attachShadow({mode: 'closed'});
+    shadowRoot.innerHTML = 'hello, world';
+    getSelection().setBaseAndExtent(shadowRoot.firstChild, 0, shadowRoot.firstChild, 5);
+    const ranges = getSelection().getComposedRanges(shadowRoot);
+    assert_equals(ranges.length, 1);
+    assert_equals(ranges[0].startContainer, shadowRoot.firstChild);
+    assert_equals(ranges[0].startOffset, 0);
+    assert_equals(ranges[0].endContainer, shadowRoot.firstChild);
+    assert_equals(ranges[0].endOffset, 5);
+}, 'getComposedRanges returns a sequence with a static range pointing to a shadaw tree when there is a selection in the shadow tree and the shadow tree is specified as an argument');
+
+test(() => {
+    container.innerHTML = 'a<div id="host"></div>b';
+    const shadowRoot = host.attachShadow({mode: 'closed'});
+    shadowRoot.innerHTML = 'hello, world';
+    getSelection().setBaseAndExtent(shadowRoot.firstChild, 0, shadowRoot.firstChild, 5);
+    const ranges = getSelection().getComposedRanges();
+    assert_equals(ranges.length, 1);
+    assert_equals(ranges[0].startContainer, container);
+    assert_equals(ranges[0].startOffset, 1);
+    assert_equals(ranges[0].endContainer, container);
+    assert_equals(ranges[0].endOffset, 2);
+}, 'getComposedRanges returns a sequence with a static range pointing to the shadow host when there is a selection in a shadow tree and the shadow tree is not specified as an argument');
+
+test(() => {
+    container.innerHTML = 'a<div id="host"></div>b';
+    const shadowRoot = host.attachShadow({mode: 'closed'});
+    shadowRoot.innerHTML = 'hello, world';
+    getSelection().setBaseAndExtent(shadowRoot.firstChild, 7, container, 2);
+    const ranges = getSelection().getComposedRanges();
+    assert_equals(ranges.length, 1);
+    assert_equals(ranges[0].startContainer, container);
+    assert_equals(ranges[0].startOffset, 1);
+    assert_equals(ranges[0].endContainer, container);
+    assert_equals(ranges[0].endOffset, 2);
+}, 'getComposedRanges a sequence with a static range pointing to the shadow host when there is a forward selection that crosses shadow boundaries and the shadow tree is not specified as an argument');
+
+test(() => {
+    container.innerHTML = 'a<div id="host"></div>b';
+    const shadowRoot = host.attachShadow({mode: 'closed'});
+    shadowRoot.innerHTML = 'hello, world';
+    getSelection().setBaseAndExtent(shadowRoot.firstChild, 7, container, 2);
+    const ranges = getSelection().getComposedRanges(shadowRoot);
+    assert_equals(ranges.length, 1);
+    assert_equals(ranges[0].startContainer, shadowRoot.firstChild);
+    assert_equals(ranges[0].startOffset, 7);
+    assert_equals(ranges[0].endContainer, container);
+    assert_equals(ranges[0].endOffset, 2);
+}, 'getComposedRanges a sequence with a static range that crosses shadow boundaries when there is a forward selection that crosses shadow boundaries and the shadow tree is specified as an argument');
+
+test(() => {
+    container.innerHTML = 'a<div id="outerHost"></div>b';
+    const outerShadowRoot = outerHost.attachShadow({mode: 'closed'});
+    outerShadowRoot.innerHTML = '<div id="innerHost">hello</div><div>world</div>';
+    const innerHost = outerShadowRoot.getElementById('innerHost');
+    const innerShadowRoot = innerHost.attachShadow({mode: 'closed'});
+    innerShadowRoot.innerHTML = 'some text';
+    getSelection().setBaseAndExtent(innerShadowRoot.firstChild, 5, innerShadowRoot.firstChild, 9);
+    const ranges = getSelection().getComposedRanges();
+    assert_equals(ranges.length, 1);
+    assert_equals(ranges[0].startContainer, container);
+    assert_equals(ranges[0].startOffset, 1);
+    assert_equals(ranges[0].endContainer, container);
+    assert_equals(ranges[0].endOffset, 2);
+}, 'getComposedRanges returns a sequence with a static range pointing to the outer shadow host when there is a selection in an inner shadow tree and no shadow tree is specified as an argument');
+
+test(() => {
+    container.innerHTML = 'a<div id="outerHost"></div>b';
+    const outerShadowRoot = outerHost.attachShadow({mode: 'closed'});
+    outerShadowRoot.innerHTML = '<div id="innerHost">hello</div><div>world</div>';
+    const innerHost = outerShadowRoot.getElementById('innerHost');
+    const innerShadowRoot = innerHost.attachShadow({mode: 'closed'});
+    innerShadowRoot.innerHTML = 'some text';
+    getSelection().setBaseAndExtent(innerShadowRoot.firstChild, 5, innerShadowRoot.firstChild, 9);
+    const ranges = getSelection().getComposedRanges(innerShadowRoot);
+    assert_equals(ranges.length, 1);
+    assert_equals(ranges[0].startContainer, innerShadowRoot.firstChild);
+    assert_equals(ranges[0].startOffset, 5);
+    assert_equals(ranges[0].endContainer, innerShadowRoot.firstChild);
+    assert_equals(ranges[0].endOffset, 9);
+}, 'getComposedRanges returns a sequence with a static range pointing to the inner shadow tree when there is a selection in an inner shadow tree and the inner shadow tree is specified as an argument');
+
+test(() => {
+    container.innerHTML = 'a<div id="outerHost"></div>b';
+    const outerShadowRoot = outerHost.attachShadow({mode: 'closed'});
+    outerShadowRoot.innerHTML = '<div id="innerHost">hello</div><div>world</div>';
+    const innerHost = outerShadowRoot.getElementById('innerHost');
+    const innerShadowRoot = innerHost.attachShadow({mode: 'closed'});
+    innerShadowRoot.innerHTML = 'some text';
+    getSelection().setBaseAndExtent(innerShadowRoot.firstChild, 5, innerShadowRoot.firstChild, 9);
+    const ranges = getSelection().getComposedRanges(outerShadowRoot);
+    assert_equals(ranges.length, 1);
+    assert_equals(ranges[0].startContainer, outerShadowRoot);
+    assert_equals(ranges[0].startOffset, 0);
+    assert_equals(ranges[0].endContainer, outerShadowRoot);
+    assert_equals(ranges[0].endOffset, 1);
+}, 'getComposedRanges returns a sequence with a static range pointing to the outer shadow tree when there is a selection in an inner shadow tree and the outer shadow tree is specified as an argument');
+
+</script>
+</body>
+</html>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -5167,6 +5167,19 @@ SelectTrailingWhitespaceEnabled:
     WebCore:
       default: false
 
+SelectionAPIForShadowDOMEnabled:
+  type: bool
+  status: testable
+  humanReadableName: "Selection API for shadow DOM"
+  humanReadableDescription: "Enable selection API for shadow DOM"
+  defaultValue:
+    WebKit:
+      default: false
+    WebKitLegacy:
+      default: false
+    WebCore:
+      default: false
+
 SelectionFlippingEnabled:
   type: bool
   status: embedder

--- a/Source/WebCore/dom/ShadowRoot.idl
+++ b/Source/WebCore/dom/ShadowRoot.idl
@@ -25,6 +25,7 @@
 
 [
     JSGenerateToJSObject,
+    JSGenerateToNativeObject,
     Exposed=Window
 ] interface ShadowRoot : DocumentFragment {
     readonly attribute ShadowRootMode mode;

--- a/Source/WebCore/page/DOMSelection.cpp
+++ b/Source/WebCore/page/DOMSelection.cpp
@@ -36,6 +36,7 @@
 #include "FrameSelection.h"
 #include "Range.h"
 #include "Settings.h"
+#include "StaticRange.h"
 #include "TextIterator.h"
 
 namespace WebCore {
@@ -185,6 +186,17 @@ String DOMSelection::type() const
     return "Range"_s;
 }
 
+String DOMSelection::direction() const
+{
+    auto frame = this->frame();
+    if (!frame)
+        return noneAtom();
+    auto& selection = frame->selection().selection();
+    if (!selection.isDirectional() || selection.isNone())
+        return noneAtom();
+    return selection.isBaseFirst() ? "forward"_s : "backward"_s;
+}
+
 unsigned DOMSelection::rangeCount() const
 {
     RefPtr frame = this->frame();
@@ -270,8 +282,13 @@ ExceptionOr<void> DOMSelection::setBaseAndExtent(Node* baseNode, unsigned baseOf
         if (auto result = Range::checkNodeOffsetPair(*extentNode, extentOffset); result.hasException())
             return result.releaseException();
         auto& document = *frame->document();
-        if (!document.contains(*baseNode) || !document.contains(*extentNode))
-            return { };
+        if (frame->settings().selectionAPIForShadowDOMEnabled()) {
+            if (!document.containsIncludingShadowDOM(baseNode) || !document.containsIncludingShadowDOM(extentNode))
+                return { };
+        } else {
+            if (!document.contains(*baseNode) || !document.contains(*extentNode))
+                return { };
+        }
     } else {
         if (!isValidForPosition(baseNode) || !isValidForPosition(extentNode))
             return { };
@@ -414,6 +431,41 @@ ExceptionOr<void> DOMSelection::removeRange(Range& liveRange)
         return Exception { NotFoundError };
     removeAllRanges();
     return { };
+}
+
+Vector<Ref<StaticRange>> DOMSelection::getComposedRanges(FixedVector<std::reference_wrapper<ShadowRoot>>&& shadowRoots)
+{
+    auto frame = this->frame();
+    if (!frame)
+        return { };
+    auto range = frame->selection().selection().range();
+    if (!range)
+        return { };
+
+    HashSet<Ref<ShadowRoot>> shadowRootSet;
+    shadowRootSet.reserveInitialCapacity(shadowRoots.size());
+    for (auto& root : shadowRoots)
+        shadowRootSet.add(root.get());
+
+    Ref<Node> startNode = range->startContainer();
+    unsigned startOffset = range->startOffset();
+    while (startNode->isInShadowTree() && !shadowRootSet.contains(startNode->containingShadowRoot())) {
+        RefPtr host = startNode->shadowHost();
+        ASSERT(host && host->parentNode());
+        startNode = *host->parentNode();
+        startOffset = host->computeNodeIndex();
+    }
+
+    Ref<Node> endNode = range->endContainer();
+    unsigned endOffset = range->endOffset();
+    while (endNode->isInShadowTree() && !shadowRootSet.contains(endNode->containingShadowRoot())) {
+        RefPtr host = endNode->shadowHost();
+        ASSERT(host && host->parentNode());
+        endNode = *host->parentNode();
+        endOffset = host->computeNodeIndex() + 1;
+    }
+
+    return { StaticRange::create(SimpleRange { BoundaryPoint { WTFMove(startNode), startOffset }, BoundaryPoint { WTFMove(endNode), endOffset } }) };
 }
 
 void DOMSelection::deleteFromDocument()

--- a/Source/WebCore/page/DOMSelection.h
+++ b/Source/WebCore/page/DOMSelection.h
@@ -40,6 +40,7 @@ namespace WebCore {
 class Node;
 class Position;
 class Range;
+class StaticRange;
 class VisibleSelection;
 
 struct SimpleRange;
@@ -53,6 +54,7 @@ public:
     unsigned baseOffset() const;
     unsigned extentOffset() const;
     String type() const;
+    String direction() const;
     ExceptionOr<void> setBaseAndExtent(Node* baseNode, unsigned baseOffset, Node* extentNode, unsigned extentOffset);
     ExceptionOr<void> setPosition(Node*, unsigned offset);
     void modify(const String& alter, const String& direction, const String& granularity);
@@ -74,6 +76,9 @@ public:
     void removeAllRanges();
     void addRange(Range&);
     ExceptionOr<void> removeRange(Range&);
+
+    Vector<Ref<StaticRange>> getComposedRanges(FixedVector<std::reference_wrapper<ShadowRoot>>&&);
+
     void deleteFromDocument();
     bool containsNode(Node&, bool partlyContained) const;
     ExceptionOr<void> selectAllChildren(Node&);

--- a/Source/WebCore/page/DOMSelection.idl
+++ b/Source/WebCore/page/DOMSelection.idl
@@ -42,11 +42,14 @@
     readonly attribute unsigned long rangeCount;
 
     readonly attribute DOMString type;
+    [EnabledBySetting=SelectionAPIForShadowDOMEnabled] readonly attribute DOMString direction;
 
     Range getRangeAt(unsigned long index);
     undefined addRange(Range range);
     [EnabledBySetting=LiveRangeSelectionEnabled] undefined removeRange(Range range);
     undefined removeAllRanges();
+
+    [EnabledBySetting=SelectionAPIForShadowDOMEnabled] sequence<StaticRange> getComposedRanges(ShadowRoot... shadowRoots);
 
     undefined empty();
 


### PR DESCRIPTION
#### e29577b1a051a4c2cbec70904df6e2f7cf8b5102
<pre>
Prototype selection API for shadow DOM
<a href="https://bugs.webkit.org/show_bug.cgi?id=251997">https://bugs.webkit.org/show_bug.cgi?id=251997</a>

Reviewed by Wenson Hsieh.

Prototype Selection.prototype.getComposedRanges and Selection.prototype.direction as spec&apos;ed here:
<a href="https://w3c.github.io/selection-api/#dom-selection-getcomposedrange">https://w3c.github.io/selection-api/#dom-selection-getcomposedrange</a>
<a href="https://w3c.github.io/selection-api/#dom-selection-direction">https://w3c.github.io/selection-api/#dom-selection-direction</a>

One notable difference is that we support returning a sequence of StaticRanges as opposed to
a single range so the method name is accordingly getComposedRange&quot;s&quot;.

* LayoutTests/fast/shadow-dom/selection-direction-expected.txt: Added.
* LayoutTests/fast/shadow-dom/selection-direction.html: Added.
* LayoutTests/fast/shadow-dom/selection-getComposedRanges-expected.txt: Added.
* LayoutTests/fast/shadow-dom/selection-getComposedRanges.html: Added.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/dom/ShadowRoot.idl:
* Source/WebCore/dom/StaticRange.h:
* Source/WebCore/page/DOMSelection.cpp:
(WebCore::DOMSelection::direction const):
(WebCore::DOMSelection::setBaseAndExtent):
(WebCore::DOMSelection::getComposedRanges):
* Source/WebCore/page/DOMSelection.h:
* Source/WebCore/page/DOMSelection.idl:

Canonical link: <a href="https://commits.webkit.org/260121@main">https://commits.webkit.org/260121@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06744e575457863194018dc4ab726cea5798c1c3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107089 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16139 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39879 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116265 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115759 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110991 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17598 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7338 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99266 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112854 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13297 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96344 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40907 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95190 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27980 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82663 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/96543 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9230 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29325 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/95981 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/7202 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9837 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6325 "Passed tests") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/30744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15389 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48898 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/104782 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11379 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25959 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3783 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->