### PR TITLE
[iOS] Crashes when WebValidationBubbleViewController is presented twice

### DIFF
--- a/Source/WebCore/platform/ValidationBubble.h
+++ b/Source/WebCore/platform/ValidationBubble.h
@@ -106,6 +106,7 @@ private:
     RetainPtr<WebValidationBubbleTapRecognizer> m_tapRecognizer;
     RetainPtr<WebValidationBubbleDelegate> m_popoverDelegate;
     WeakObjCPtr<UIViewController> m_presentingViewController;
+    bool m_startingToPresentViewController { false };
 #elif PLATFORM(GTK)
     GtkWidget* m_popover { nullptr };
     ShouldNotifyFocusEventsCallback m_shouldNotifyFocusEventsCallback { nullptr };

--- a/Source/WebCore/platform/ios/ValidationBubbleIOS.mm
+++ b/Source/WebCore/platform/ios/ValidationBubbleIOS.mm
@@ -187,15 +187,17 @@ ValidationBubble::~ValidationBubble()
 
 void ValidationBubble::show()
 {
-    if ([m_popoverController parentViewController] || [m_popoverController presentingViewController])
+    if ([m_popoverController parentViewController] || [m_popoverController presentingViewController] || m_startingToPresentViewController)
         return;
 
     // Protect the validation bubble so it stays alive until it is effectively presented. UIKit does not deal nicely with
     // dismissing a popover that is being presented.
     RefPtr<ValidationBubble> protectedThis(this);
+    m_startingToPresentViewController = true;
     [m_presentingViewController presentViewController:m_popoverController.get() animated:NO completion:[protectedThis]() {
         // Hide this popover from VoiceOver and instead announce the message.
         [protectedThis->m_popoverController view].accessibilityElementsHidden = YES;
+        protectedThis->m_startingToPresentViewController = false;
     }];
 
     PAL::softLinkUIKitUIAccessibilityPostNotification(PAL::get_UIKit_UIAccessibilityAnnouncementNotification(), m_message);


### PR DESCRIPTION
#### 01bfc814e82974f331eaf1523356e79211574e2f
<pre>
[iOS] Crashes when WebValidationBubbleViewController is presented twice
<a href="https://bugs.webkit.org/show_bug.cgi?id=251548">https://bugs.webkit.org/show_bug.cgi?id=251548</a>

Reviewed by Wenson Hsieh.

The logic in ValidationBubble::show to guard against presenting the view
controller when it is already presented has a race condition. After starting
to present the view controller, this view controller doesn&apos;t immediately have
a parent view controller or presenting view controller, and yet these are
the conditions used to guard against presenting it twice. This means there is
a short window where a second call to ValidationBubble::show will not
early-out, but will instead try to present the view controller again,
leading to an exception in UIKit.

Fix this issue by adding a bool that tracks when the view controller is in
the process of being presented.

No tests since the conditions that trigger this bug require precise timing of
web content triggering a validation bubble along with scrolling/zooming in
the UIProcess starting and ending exactly during the time that the view
controller is in the process of being presented.

* Source/WebCore/platform/ValidationBubble.h:
* Source/WebCore/platform/ios/ValidationBubbleIOS.mm:
(WebCore::ValidationBubble::show):

Canonical link: <a href="https://commits.webkit.org/260085@main">https://commits.webkit.org/260085@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98a49d0cbd5b14747ff300a57499dc48fb89a0bb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106984 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16041 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39784 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116162 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/115694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110885 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17504 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7237 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99165 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112749 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96265 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/40849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95133 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27907 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/9159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/29259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9747 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/6259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/15323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48818 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6965 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11284 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->