### PR TITLE
[GPU Process] [FormControls] Make it possible to draw a viewless NSCell

### DIFF
--- a/Source/WebCore/PAL/pal/spi/mac/NSCellSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSCellSPI.h
@@ -36,3 +36,12 @@ WTF_EXTERN_C_BEGIN
 void _NSDrawCarbonThemeListBox(NSRect, BOOL enabled, BOOL flipped, BOOL textured);
 
 WTF_EXTERN_C_END
+
+typedef NS_ENUM(NSInteger, NSPresentationState);
+typedef NS_ENUM(NSInteger, NSViewSemanticContext);
+
+@interface NSCell ()
+@property (setter=_setFallbackBackingScaleFactor:) CGFloat _fallbackBackingScaleFactor;
+@property (setter=_setFallbackBezelPresentationState:) NSPresentationState _fallbackBezelPresentationState;
+@property (setter=_setFallbackSemanticContext:) NSViewSemanticContext _fallbackSemanticContext;
+@end

--- a/Source/WebCore/platform/graphics/mac/controls/ControlMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlMac.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -64,6 +64,7 @@ protected:
     void updateCellStates(const FloatRect&, const ControlStyle&) override;
 
     void drawCell(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&, NSCell *, NSView *, bool drawCell = true);
+    void drawCellOrFocusRing(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&, NSCell *, NSView *, bool drawCell = true);
 
 #if ENABLE(DATALIST_ELEMENT)
     void drawListButton(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&);

--- a/Source/WebCore/platform/graphics/mac/controls/ControlMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlMac.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,6 +37,7 @@
 #import <pal/spi/cocoa/NSButtonCellSPI.h>
 #import <pal/spi/mac/CoreUISPI.h>
 #import <pal/spi/mac/NSAppearanceSPI.h>
+#import <pal/spi/mac/NSCellSPI.h>
 #import <pal/spi/mac/NSGraphicsSPI.h>
 
 namespace WebCore {
@@ -176,7 +177,76 @@ void ControlMac::updateCellStates(const FloatRect&, const ControlStyle& style)
     [WebControlWindow setHasKeyAppearance:style.states.contains(ControlStyle::State::WindowActive)];
 }
 
-static void drawFocusRing(NSRect cellFrame, NSCell *cell, NSView *view)
+static bool supportsViewlessCells()
+{
+    static std::optional<BOOL> supportsViewlessCells;
+    if (!supportsViewlessCells)
+        supportsViewlessCells = [NSCell instancesRespondToSelector:@selector(_setFallbackBackingScaleFactor:)];
+    return *supportsViewlessCells;
+}
+
+// FIXME: rdar://105194487 - Remove flipping the coordinates.
+static bool shouldFlipContext(const ControlPart& owningPart)
+{
+    // Don't flip the context if we are just drawing an image.
+    return owningPart.type() != StyleAppearance::Checkbox
+        && owningPart.type() != StyleAppearance::SearchFieldResultsButton
+        && owningPart.type() != StyleAppearance::SearchFieldResultsDecoration;
+}
+
+static void applyViewlessCellSettings(float deviceScaleFactor, const ControlStyle& style, NSCell *cell)
+{
+    ASSERT(supportsViewlessCells());
+
+    [cell _setFallbackBackingScaleFactor:deviceScaleFactor];
+
+#if USE(NSVIEW_SEMANTICCONTEXT)
+    if (style.states.contains(ControlStyle::State::FormSemanticContext))
+        [cell _setFallbackSemanticContext:NSViewSemanticContextForm];
+#else
+    UNUSED_PARAM(style);
+#endif
+}
+
+static void drawViewlessCell(const FloatRect& rect, float deviceScaleFactor, const ControlStyle& style, NSCell *cell, bool flipContext)
+{
+    CGContextRef cgContext = [[NSGraphicsContext currentContext] CGContext];
+    CGContextStateSaver stateSaver(cgContext);
+
+    applyViewlessCellSettings(deviceScaleFactor, style, cell);
+
+    auto adjustedRect = rect;
+
+    // FIXME: rdar://105194487 - Remove flipping the coordinates.
+    if (flipContext) {
+        // Move the coordinates origin to topleft of rect.
+        CGContextTranslateCTM(cgContext, adjustedRect.x(), adjustedRect.y());
+        adjustedRect.setLocation(FloatPoint::zero());
+
+        // Flip the coordinates.
+        CGContextTranslateCTM(cgContext, 0, adjustedRect.height());
+        CGContextScaleCTM(cgContext, 1, -1);
+    }
+
+    // FIXME: rdar://105250010 - Needs a nullable version of [NSCell drawWithFrame].
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
+    [cell drawWithFrame:adjustedRect inView:nil];
+#pragma clang diagnostic pop
+}
+
+static void drawCellInView(const FloatRect& rect, NSCell *cell, NSView *view)
+{
+    [cell drawWithFrame:rect inView:view];
+    [cell setControlView:nil];
+}
+
+static void drawCellFocusRingInView(const FloatRect& rect, NSCell *cell, NSView *view)
+{
+    [cell drawFocusRingMaskWithFrame:rect inView:view];
+}
+
+static void drawCellFocusRing(const FloatRect& rect, NSCell *cell, NSView *view)
 {
     CGContextRef cgContext = [[NSGraphicsContext currentContext] CGContext];
 
@@ -194,30 +264,32 @@ static void drawFocusRing(NSRect cellFrame, NSCell *cell, NSView *view)
     // FIXME: This color should be shared with RenderThemeMac. For now just use the same NSColor color.
     // The color is expected to be opaque, since CoreGraphics will apply opacity when drawing (because opacity is normally animated).
     auto color = colorFromCocoaColor([NSColor keyboardFocusIndicatorColor]).opaqueColor();
-    auto style = adoptCF(CGStyleCreateFocusRingWithColor(&focusRingStyle, cachedCGColor(color).get()));
-    CGContextSetStyle(cgContext, style.get());
+    auto cgStyle = adoptCF(CGStyleCreateFocusRingWithColor(&focusRingStyle, cachedCGColor(color).get()));
+    CGContextSetStyle(cgContext, cgStyle.get());
 
-    CGContextBeginTransparencyLayerWithRect(cgContext, NSRectToCGRect(cellFrame), nullptr);
-    [cell drawFocusRingMaskWithFrame:cellFrame inView:view];
+    CGContextBeginTransparencyLayerWithRect(cgContext, rect, nullptr);
+
+    // FIXME: rdar://105249508 - Needs to call viewless version of drawCellFocusRing().
+    drawCellFocusRingInView(rect, cell, view);
     CGContextEndTransparencyLayer(cgContext);
 }
 
-static void drawCellOrFocusRing(GraphicsContext& context, const FloatRect& rect, const ControlStyle& style, NSCell *cell, NSView *view, bool drawCell)
+void ControlMac::drawCellOrFocusRing(GraphicsContext& context, const FloatRect& rect, float deviceScaleFactor, const ControlStyle& style, NSCell *cell, NSView *view, bool drawCell)
 {
     LocalCurrentGraphicsContext localContext(context);
 
     if (drawCell) {
-        if ([cell isKindOfClass:[NSSliderCell class]]) {
-            // For slider cells, draw only the knob.
+        // For slider cells, draw only the knob.
+        if ([cell isKindOfClass:[NSSliderCell class]])
             [(NSSliderCell *)cell drawKnob:rect];
-        } else {
-            [cell drawWithFrame:rect inView:view];
-            [cell setControlView:nil];
-        }
+        else if (supportsViewlessCells())
+            drawViewlessCell(rect, deviceScaleFactor, style, cell, shouldFlipContext(m_owningPart));
+        else
+            drawCellInView(rect, cell, view);
     }
 
     if (style.states.contains(ControlStyle::State::Focused))
-        drawFocusRing(rect, cell, view);
+        drawCellFocusRing(rect, cell, view);
 }
 
 void ControlMac::drawCell(GraphicsContext& context, const FloatRect& rect, float deviceScaleFactor, const ControlStyle& style, NSCell *cell, NSView *view, bool drawCell)
@@ -227,7 +299,7 @@ void ControlMac::drawCell(GraphicsContext& context, const FloatRect& rect, float
     bool useImageBuffer = userCTM.xScale() != 1.0 || userCTM.yScale() != 1.0;
 
     if (!useImageBuffer) {
-        drawCellOrFocusRing(context, rect, style, cell, view, drawCell);
+        drawCellOrFocusRing(context, rect, deviceScaleFactor, style, cell, view, drawCell);
         return;
     }
 
@@ -241,7 +313,7 @@ void ControlMac::drawCell(GraphicsContext& context, const FloatRect& rect, float
     if (!imageBuffer)
         return;
 
-    drawCellOrFocusRing(imageBuffer->context(), cellDrawingRect, style, cell, view, drawCell);
+    drawCellOrFocusRing(imageBuffer->context(), cellDrawingRect, deviceScaleFactor, style, cell, view, drawCell);
     context.drawConsumingImageBuffer(WTFMove(imageBuffer), rect.location() - focusRingPadding);
 }
 

--- a/Source/WebCore/platform/graphics/mac/controls/WebControlView.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/WebControlView.mm
@@ -60,6 +60,7 @@ static BOOL _hasKeyAppearance;
     return _hasKeyAppearance;
 }
 
+// FIXME: rdar://105250168 - Remove this code once viewless NSCell drawing is complete.
 - (BOOL)_needsToResetDragMargins
 {
     return false;


### PR DESCRIPTION
#### b8b3d9929d7dafe50bb11efb9bb066c4d81d0bab
<pre>
[GPU Process] [FormControls] Make it possible to draw a viewless NSCell
<a href="https://bugs.webkit.org/show_bug.cgi?id=252003">https://bugs.webkit.org/show_bug.cgi?id=252003</a>
rdar://105233927

Reviewed by Aditya Keerthi.

AppKit crashes if [NSCell drawWithFrame] is called out of the main thread with a
non-nil NSView. And this is why a hack was added to WebControlWindow to silence
this crash in 257981@main. To fix the crash and to remove the hack, a nil NSView
will be passed to [NSCell drawWithFrame] instead of passing the fake one.

To provide the [NSCell drawWithFrame] with the settings that it used to get from
the fake NSView, new AppKit SPIs will be used to explicitly set them from the
drawing. An NSCell can be drawn without an NSView only if these SPIs are available.

* Source/WebCore/PAL/pal/spi/mac/NSCellSPI.h:
* Source/WebCore/platform/graphics/mac/controls/ControlMac.h:
* Source/WebCore/platform/graphics/mac/controls/ControlMac.mm:
(WebCore::supportsViewlessCells):
(WebCore::shouldFlipContext):
(WebCore::applyViewlessCellSettings):
(WebCore::drawViewlessCell):
(WebCore::drawCellInView):
(WebCore::drawCellFocusRingInView):
(WebCore::drawCellFocusRing):
(WebCore::ControlMac::drawCellOrFocusRing):
(WebCore::ControlMac::drawCell):
(WebCore::drawFocusRing): Deleted.
(WebCore::drawCellOrFocusRing): Deleted.
* Source/WebCore/platform/graphics/mac/controls/WebControlView.mm:

Canonical link: <a href="https://commits.webkit.org/260210@main">https://commits.webkit.org/260210@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9bacde32b4b9715ab7a1d61657461c7c11d6b103

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107049 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16102 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39841 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116225 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115735 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110950 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17559 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7298 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99226 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112814 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13276 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96309 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40883 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95168 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27948 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82634 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9205 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29299 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9802 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6303 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15364 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48863 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7059 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11344 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->