### PR TITLE
Rename of ShaderModule.h -> WGSLShaderModule.h causes a build failure in tests

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WGSL/ASTStringDumperTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/ASTStringDumperTests.cpp
@@ -28,8 +28,8 @@
 
 #include "AST.h"
 #include "Parser.h"
-#include "ShaderModule.h"
 #include "TestWGSLAPI.h"
+#include "WGSLShaderModule.h"
 
 namespace TestWGSLAPI {
 

--- a/Tools/TestWebKitAPI/Tests/WGSL/ConstLiteralTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/ConstLiteralTests.cpp
@@ -27,7 +27,7 @@
 
 #include "AST.h"
 #include "ParserPrivate.h"
-#include "ShaderModule.h"
+#include "WGSLShaderModule.h"
 
 static Expected<UniqueRef<WGSL::AST::Expression>, WGSL::Error> parseLCharPrimaryExpression(const String& input)
 {

--- a/Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp
@@ -30,8 +30,8 @@
 
 #include "AST.h"
 #include "Lexer.h"
-#include "ShaderModule.h"
 #include "TestWGSLAPI.h"
+#include "WGSLShaderModule.h"
 
 #include <wtf/Assertions.h>
 


### PR DESCRIPTION
#### 530549943b71b1c8551f6486ae7026489e7e76d4
<pre>
Rename of ShaderModule.h -&gt; WGSLShaderModule.h causes a build failure in tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=252006">https://bugs.webkit.org/show_bug.cgi?id=252006</a>
&lt;radar://105235392&gt;

Reviewed by Myles C. Maxfield.

The file was renamed but the include statement was not updated.

* Tools/TestWebKitAPI/Tests/WGSL/ASTStringDumperTests.cpp:
* Tools/TestWebKitAPI/Tests/WGSL/ConstLiteralTests.cpp:
* Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp:

Canonical link: <a href="https://commits.webkit.org/260078@main">https://commits.webkit.org/260078@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b713560b3289748f706a42268e2db1f2a5df930

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106994 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/16044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/39791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/116172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/115702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110895 "Failed to checkout and rebase branch from PR 9885") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/17512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/7247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/99175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112759 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/17512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/39791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/99175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/17512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/39791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/99175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/9167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/39791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/9756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/7247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/15331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/39791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/11294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3767 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->