### PR TITLE
[GStreamer] Remove useless code from capturer

### DIFF
--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp
@@ -202,14 +202,7 @@ void GStreamerCapturer::play()
 void GStreamerCapturer::stop()
 {
     ASSERT(m_pipeline);
-
     GST_INFO_OBJECT(pipeline(), "Tearing down!");
-
-    // Make sure to remove sync handler before tearing down, avoiding
-    // possible deadlocks.
-    GRefPtr<GstBus> bus = adoptGRef(gst_pipeline_get_bus(GST_PIPELINE(pipeline())));
-    gst_bus_set_sync_handler(bus.get(), nullptr, nullptr, nullptr);
-
     gst_element_set_state(pipeline(), GST_STATE_NULL);
 }
 


### PR DESCRIPTION
#### d94a8a70284c9c9661c6265df46e8aac97fc3017
<pre>
[GStreamer] Remove useless code from capturer
<a href="https://bugs.webkit.org/show_bug.cgi?id=252008">https://bugs.webkit.org/show_bug.cgi?id=252008</a>

Reviewed by Xabier Rodriguez-Calvar.

The capturer pipeline has no sync bus handler, so not need to reset it when stopping.

* Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp:
(WebCore::GStreamerCapturer::stop):

Canonical link: <a href="https://commits.webkit.org/260184@main">https://commits.webkit.org/260184@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37be4b57a140171ae2b325f231d32da38be98f56

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106998 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16049 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39795 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116176 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115706 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110899 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17516 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7251 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99179 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112763 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13248 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96270 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40857 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95140 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27912 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82606 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9171 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29264 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9760 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6270 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15335 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48823 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7045 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11298 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->