### PR TITLE
[iOS] Idle timer should be enabled/disabled on the main thread

### DIFF
--- a/Source/WebCore/PAL/pal/system/ios/SleepDisablerIOS.mm
+++ b/Source/WebCore/PAL/pal/system/ios/SleepDisablerIOS.mm
@@ -55,12 +55,14 @@ private:
 
     void updateState()
     {
-        if (!m_screenSleepDisablerCount.value())
-            [PAL::getUIApplicationClass() sharedApplication].idleTimerDisabled = NO;
-        else if (m_screenSleepDisablerCount.value() == 1)
-            [PAL::getUIApplicationClass() sharedApplication].idleTimerDisabled = YES;
-    }
+        if (m_screenSleepDisablerCount.value() > 1)
+            return;
 
+        bool idleTimerDisabled = !!m_screenSleepDisablerCount.value();
+        ensureOnMainRunLoop([idleTimerDisabled] {
+            [PAL::getUIApplicationClass() sharedApplication].idleTimerDisabled = idleTimerDisabled;
+        });
+    }
     ScreenSleepDisablerCounter m_screenSleepDisablerCount;
 };
 


### PR DESCRIPTION
#### 1c8de44efc1a1e49d895a2499f4f4ab0d6e7f526
<pre>
[iOS] Idle timer should be enabled/disabled on the main thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=252015">https://bugs.webkit.org/show_bug.cgi?id=252015</a>
rdar://104266428

Reviewed by Chris Dumez.

Use `ensureOnMainRunLoop` so we always change `UIApplication.sharedApplication.idleTimerDisabled`
on the main thread. This is necessary in WebKit where WebKit&apos;s &quot;main thread&quot; is not the
UI thread.

* Source/WebCore/PAL/pal/system/ios/SleepDisablerIOS.mm:
(PAL::ScreenSleepDisabler::updateState):

Canonical link: <a href="https://commits.webkit.org/260098@main">https://commits.webkit.org/260098@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e365f8924d6dac24aee2ee72f09c32e70ce09b89

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107009 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16062 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39804 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116187 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/115714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110910 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17525 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7260 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99188 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112774 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96281 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/40861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95148 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27923 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9180 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/29275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9769 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/6277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/15343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48835 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6974 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11308 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->