### PR TITLE
[GLib] Most public types should be final; most class structs should be private

### DIFF
--- a/Source/WTF/wtf/glib/WTFGType.h
+++ b/Source/WTF/wtf/glib/WTFGType.h
@@ -43,16 +43,27 @@ static void destroy##structName(structName* data) \
 #define WEBKIT_DEFINE_ABSTRACT_TYPE(TypeName, type_name, TYPE_PARENT) _WEBKIT_DEFINE_TYPE_EXTENDED(TypeName, type_name, TYPE_PARENT, G_TYPE_FLAG_ABSTRACT, { })
 #define WEBKIT_DEFINE_TYPE_WITH_CODE(TypeName, type_name, TYPE_PARENT, Code) _WEBKIT_DEFINE_TYPE_EXTENDED_BEGIN(TypeName, type_name, TYPE_PARENT, 0) {Code;} _WEBKIT_DEFINE_TYPE_EXTENDED_END()
 
+#define _WEBKIT_DEFINE_FINAL_TYPE_STRUCTS(TypeName, ParentName)  \
+    typedef struct _ ## TypeName ## Private TypeName ## Private; \
+    struct _ ## TypeName { \
+        ParentName parent; \
+        TypeName ## Private *priv; \
+    };
+
 // Only the 2022 API uses final types for now. If the old API ever gains
 // a final type, move the corresponding macro above out of the #if block.
 #if ENABLE(2022_GLIB_API)
-#define WEBKIT_DEFINE_FINAL_TYPE(TypeName, type_name, TYPE_PARENT) _WEBKIT_DEFINE_TYPE_EXTENDED(TypeName, type_name, TYPE_PARENT, G_TYPE_FLAG_FINAL, { })
-#define WEBKIT_DEFINE_FINAL_TYPE_WITH_CODE(TypeName, type_name, TYPE_PARENT, Code) _WEBKIT_DEFINE_TYPE_EXTENDED_BEGIN(TypeName, type_name, TYPE_PARENT, G_TYPE_FLAG_FINAL) { Code; } _WEBKIT_DEFINE_TYPE_EXTENDED_END()
-#define WEBKIT_DEFINE_FINAL_TYPE_IN_2022_API WEBKIT_DEFINE_FINAL_TYPE
-#define WEBKIT_DEFINE_FINAL_TYPE_WITH_CODE_IN_2022_API WEBKIT_DEFINE_FINAL_TYPE_WITH_CODE
+#define WEBKIT_DEFINE_FINAL_TYPE(TypeName, type_name, TYPE_PARENT, ParentName) \
+    _WEBKIT_DEFINE_FINAL_TYPE_STRUCTS(TypeName, ParentName) \
+    _WEBKIT_DEFINE_TYPE_EXTENDED(TypeName, type_name, TYPE_PARENT, G_TYPE_FLAG_FINAL, { })
+#define WEBKIT_DEFINE_FINAL_TYPE_WITH_CODE(TypeName, type_name, TYPE_PARENT, ParentName, Code) \
+    _WEBKIT_DEFINE_FINAL_TYPE_STRUCTS(TypeName, ParentName) \
+    _WEBKIT_DEFINE_TYPE_EXTENDED_BEGIN(TypeName, type_name, TYPE_PARENT, G_TYPE_FLAG_FINAL) { Code; } _WEBKIT_DEFINE_TYPE_EXTENDED_END()
 #else
-#define WEBKIT_DEFINE_FINAL_TYPE_IN_2022_API WEBKIT_DEFINE_TYPE
-#define WEBKIT_DEFINE_FINAL_TYPE_WITH_CODE_IN_2022_API WEBKIT_DEFINE_TYPE_WITH_CODE
+#define WEBKIT_DEFINE_FINAL_TYPE(TypeName, type_name, TYPE_PARENT, ParentName) \
+    WEBKIT_DEFINE_TYPE(TypeName, type_name, TYPE_PARENT)
+#define WEBKIT_DEFINE_FINAL_TYPE_WITH_CODE(TypeName, type_name, TYPE_PARENT, ParentName, Code) \
+    _WEBKIT_DEFINE_TYPE_EXTENDED_BEGIN(TypeName, type_name, TYPE_PARENT, 0) { Code; } _WEBKIT_DEFINE_TYPE_EXTENDED_END()
 #endif
 
 #define _WEBKIT_DEFINE_TYPE_EXTENDED(TypeName, type_name, TYPE_PARENT, flags, Code) _WEBKIT_DEFINE_TYPE_EXTENDED_BEGIN(TypeName, type_name, TYPE_PARENT, flags) {Code;} _WEBKIT_DEFINE_TYPE_EXTENDED_END()

--- a/Source/WebKit/PlatformGTK.cmake
+++ b/Source/WebKit/PlatformGTK.cmake
@@ -203,12 +203,17 @@ set(WebKitWebExtension_HEADER_TEMPLATES
     ${WEBKIT_DIR}/WebProcess/InjectedBundle/API/glib/WebKitScriptWorld.h.in
     ${WEBKIT_DIR}/WebProcess/InjectedBundle/API/glib/WebKitWebEditor.h.in
     ${WEBKIT_DIR}/WebProcess/InjectedBundle/API/glib/WebKitWebExtension.h.in
-    ${WEBKIT_DIR}/WebProcess/InjectedBundle/API/glib/WebKitWebExtensionAutocleanups.h.in
     ${WEBKIT_DIR}/WebProcess/InjectedBundle/API/glib/WebKitWebFormManager.h.in
     ${WEBKIT_DIR}/WebProcess/InjectedBundle/API/glib/WebKitWebHitTestResult.h.in
     ${WEBKIT_DIR}/WebProcess/InjectedBundle/API/glib/WebKitWebPage.h.in
     ${WEBKIT_DIR}/WebProcess/InjectedBundle/API/glib/webkit-web-extension.h.in
 )
+
+if (NOT ENABLE_2022_GLIB_API)
+    list(APPEND WebKitGTK_HEADER_TEMPLATES
+        ${WEBKIT_DIR}/WebProcess/InjectedBundle/API/glib/WebKitWebExtensionAutocleanups.h.in
+    )
+endif ()
 
 set(WebKitGTK_FAKE_API_HEADERS
     ${WebKitGTK_FRAMEWORK_HEADERS_DIR}/webkit

--- a/Source/WebKit/Shared/API/glib/WebKitContextMenu.cpp
+++ b/Source/WebKit/Shared/API/glib/WebKitContextMenu.cpp
@@ -61,7 +61,7 @@ struct _WebKitContextMenuPrivate {
 #endif
 };
 
-WEBKIT_DEFINE_FINAL_TYPE_IN_2022_API(WebKitContextMenu, webkit_context_menu, G_TYPE_OBJECT)
+WEBKIT_DEFINE_FINAL_TYPE(WebKitContextMenu, webkit_context_menu, G_TYPE_OBJECT, GObject)
 
 static void webkitContextMenuDispose(GObject* object)
 {

--- a/Source/WebKit/Shared/API/glib/WebKitContextMenuItem.cpp
+++ b/Source/WebKit/Shared/API/glib/WebKitContextMenuItem.cpp
@@ -60,7 +60,7 @@ struct _WebKitContextMenuItemPrivate {
     GRefPtr<WebKitContextMenu> subMenu;
 };
 
-WEBKIT_DEFINE_FINAL_TYPE_IN_2022_API(WebKitContextMenuItem, webkit_context_menu_item, G_TYPE_INITIALLY_UNOWNED)
+WEBKIT_DEFINE_FINAL_TYPE(WebKitContextMenuItem, webkit_context_menu_item, G_TYPE_INITIALLY_UNOWNED, GInitiallyUnowned)
 
 static void webkit_context_menu_item_class_init(WebKitContextMenuItemClass*)
 {

--- a/Source/WebKit/Shared/API/glib/WebKitHitTestResult.cpp
+++ b/Source/WebKit/Shared/API/glib/WebKitHitTestResult.cpp
@@ -74,7 +74,7 @@ struct _WebKitHitTestResultPrivate {
     CString mediaURI;
 };
 
-WEBKIT_DEFINE_FINAL_TYPE_IN_2022_API(WebKitHitTestResult, webkit_hit_test_result, G_TYPE_OBJECT)
+WEBKIT_DEFINE_FINAL_TYPE(WebKitHitTestResult, webkit_hit_test_result, G_TYPE_OBJECT, GObject)
 
 static void webkitHitTestResultGetProperty(GObject* object, guint propId, GValue* value, GParamSpec* paramSpec)
 {

--- a/Source/WebKit/Shared/API/glib/WebKitURIRequest.cpp
+++ b/Source/WebKit/Shared/API/glib/WebKitURIRequest.cpp
@@ -53,7 +53,7 @@ struct _WebKitURIRequestPrivate {
     GUniquePtr<SoupMessageHeaders> httpHeaders;
 };
 
-WEBKIT_DEFINE_FINAL_TYPE_IN_2022_API(WebKitURIRequest, webkit_uri_request, G_TYPE_OBJECT)
+WEBKIT_DEFINE_FINAL_TYPE(WebKitURIRequest, webkit_uri_request, G_TYPE_OBJECT, GObject)
 
 static void webkitURIRequestGetProperty(GObject* object, guint propId, GValue* value, GParamSpec* paramSpec)
 {

--- a/Source/WebKit/Shared/API/glib/WebKitURIResponse.cpp
+++ b/Source/WebKit/Shared/API/glib/WebKitURIResponse.cpp
@@ -57,7 +57,7 @@ struct _WebKitURIResponsePrivate {
     GUniquePtr<SoupMessageHeaders> httpHeaders;
 };
 
-WEBKIT_DEFINE_FINAL_TYPE_IN_2022_API(WebKitURIResponse, webkit_uri_response, G_TYPE_OBJECT)
+WEBKIT_DEFINE_FINAL_TYPE(WebKitURIResponse, webkit_uri_response, G_TYPE_OBJECT, GObject)
 
 static void webkitURIResponseGetProperty(GObject* object, guint propId, GValue* value, GParamSpec* paramSpec)
 {

--- a/Source/WebKit/Shared/API/glib/WebKitUserMessage.cpp
+++ b/Source/WebKit/Shared/API/glib/WebKitUserMessage.cpp
@@ -56,7 +56,7 @@ struct _WebKitUserMessagePrivate {
     CompletionHandler<void(UserMessage&&)> replyHandler;
 };
 
-WEBKIT_DEFINE_FINAL_TYPE_IN_2022_API(WebKitUserMessage, webkit_user_message, G_TYPE_INITIALLY_UNOWNED)
+WEBKIT_DEFINE_FINAL_TYPE(WebKitUserMessage, webkit_user_message, G_TYPE_INITIALLY_UNOWNED, GInitiallyUnowned)
 
 /**
  * webkit_user_message_error_quark:

--- a/Source/WebKit/UIProcess/API/glib/WebKitAuthenticationRequest.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitAuthenticationRequest.cpp
@@ -77,7 +77,7 @@ struct _WebKitAuthenticationRequestPrivate {
 
 static guint signals[LAST_SIGNAL] = { 0, };
 
-WEBKIT_DEFINE_FINAL_TYPE_IN_2022_API(WebKitAuthenticationRequest, webkit_authentication_request, G_TYPE_OBJECT)
+WEBKIT_DEFINE_FINAL_TYPE(WebKitAuthenticationRequest, webkit_authentication_request, G_TYPE_OBJECT, GObject)
 
 static inline WebKitAuthenticationScheme toWebKitAuthenticationScheme(WebCore::ProtectionSpace::AuthenticationScheme coreScheme)
 {

--- a/Source/WebKit/UIProcess/API/glib/WebKitAuthenticationRequest.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitAuthenticationRequest.h.in
@@ -33,22 +33,12 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_AUTHENTICATION_REQUEST            (webkit_authentication_request_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_AUTHENTICATION_REQUEST(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_AUTHENTICATION_REQUEST, WebKitAuthenticationRequest))
 #define WEBKIT_AUTHENTICATION_REQUEST_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_AUTHENTICATION_REQUEST, WebKitAuthenticationRequestClass))
 #define WEBKIT_IS_AUTHENTICATION_REQUEST(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_AUTHENTICATION_REQUEST))
 #define WEBKIT_IS_AUTHENTICATION_REQUEST_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_AUTHENTICATION_REQUEST))
 #define WEBKIT_AUTHENTICATION_REQUEST_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_AUTHENTICATION_REQUEST, WebKitAuthenticationRequestClass))
-
-typedef struct _WebKitAuthenticationRequest        WebKitAuthenticationRequest;
-typedef struct _WebKitAuthenticationRequestClass   WebKitAuthenticationRequestClass;
-typedef struct _WebKitAuthenticationRequestPrivate WebKitAuthenticationRequestPrivate;
-
-struct _WebKitAuthenticationRequest {
-    GObject parent;
-
-    /*< private >*/
-    WebKitAuthenticationRequestPrivate *priv;
-};
 
 struct _WebKitAuthenticationRequestClass {
     GObjectClass parent_class;
@@ -59,6 +49,9 @@ struct _WebKitAuthenticationRequestClass {
     void (*_webkit_reserved2) (void);
     void (*_webkit_reserved3) (void);
 };
+#endif
+
+WEBKIT_DECLARE_FINAL_TYPE (WebKitAuthenticationRequest, webkit_authentication_request, WEBKIT, AUTHENTICATION_REQUEST, GObject)
 
 /**
  * WebKitAuthenticationScheme:
@@ -90,9 +83,6 @@ typedef enum {
     WEBKIT_AUTHENTICATION_SCHEME_UNKNOWN = 100,
 } WebKitAuthenticationScheme;
 
-
-WEBKIT_API GType
-webkit_authentication_request_get_type                (void);
 
 WEBKIT_API gboolean
 webkit_authentication_request_can_save_credentials    (WebKitAuthenticationRequest *request);

--- a/Source/WebKit/UIProcess/API/glib/WebKitAutocleanups.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitAutocleanups.h.in
@@ -25,6 +25,11 @@
 #ifdef G_DEFINE_AUTOPTR_CLEANUP_FUNC
 #ifndef __GI_SCANNER__
 
+#if !ENABLE(2022_GLIB_API)
+/*
+ * All these now use G_DEFINE[_FINAL]_TYPE, which takes care itself of
+ * defining autocleanups, or are not present anymore in the 2022 API.
+ */
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitAuthenticationRequest, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitAutomationSession, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitBackForwardList, g_object_unref)
@@ -34,28 +39,20 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitContextMenuItem, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitCookieManager, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitDownload, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitEditorState, g_object_unref)
-#if PLATFORM(GTK) || (PLATFORM(WPE) && !ENABLE(2022_GLIB_API))
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitFaviconDatabase, g_object_unref)
-#endif
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitFileChooserRequest, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitFindController, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitFormSubmissionRequest, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitGeolocationPermissionRequest, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitHitTestResult, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitInputMethodContext, g_object_unref)
-#if !ENABLE(2022_GLIB_API)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitInstallMissingMediaPluginsPermissionRequest, g_object_unref)
-#endif
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitNavigationPolicyDecision, g_object_unref)
-#if ENABLE(2022_GLIB_API)
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitNetworkSession, g_object_unref)
-#endif
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitMimeInfo, webkit_mime_info_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitNotification, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitNotificationPermissionRequest, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitPermissionRequest, g_object_unref)
-#if !ENABLE(2022_GLIB_API)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitPlugin, g_object_unref)
-#endif
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitPolicyDecision, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitResponsePolicyDecision, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitSecurityManager, g_object_unref)
@@ -80,11 +77,10 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitColorChooserRequest, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitMediaKeySystemPermissionRequest, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitOptionMenu, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitPointerLockPermissionRequest, g_object_unref)
-#if !ENABLE(2022_GLIB_API)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitPrintCustomWidget, g_object_unref)
-#endif
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitPrintOperation, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitWebInspector, g_object_unref)
+#endif
 #endif
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitApplicationInfo, webkit_application_info_unref)
@@ -93,9 +89,6 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitITPFirstParty, webkit_itp_first_party_unref
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitITPThirdParty, webkit_itp_third_party_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitJavascriptResult, webkit_javascript_result_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitMemoryPressureSettings, webkit_memory_pressure_settings_free)
-#if !ENABLE(2022_GLIB_API)
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitMimeInfo, webkit_mime_info_unref)
-#endif
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitNavigationAction, webkit_navigation_action_free)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitNetworkProxySettings, webkit_network_proxy_settings_free)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitSecurityOrigin, webkit_security_origin_unref)

--- a/Source/WebKit/UIProcess/API/glib/WebKitAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitAutomationSession.cpp
@@ -73,7 +73,7 @@ struct _WebKitAutomationSessionPrivate {
 
 static guint signals[LAST_SIGNAL] = { 0, };
 
-WEBKIT_DEFINE_FINAL_TYPE_IN_2022_API(WebKitAutomationSession, webkit_automation_session, G_TYPE_OBJECT)
+WEBKIT_DEFINE_FINAL_TYPE(WebKitAutomationSession, webkit_automation_session, G_TYPE_OBJECT, GObject)
 
 class AutomationSessionClient final : public API::AutomationSessionClient {
     WTF_MAKE_FAST_ALLOCATED;

--- a/Source/WebKit/UIProcess/API/glib/WebKitAutomationSession.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitAutomationSession.h.in
@@ -29,11 +29,25 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_AUTOMATION_SESSION            (webkit_automation_session_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_AUTOMATION_SESSION(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_AUTOMATION_SESSION, WebKitAutomationSession))
 #define WEBKIT_IS_AUTOMATION_SESSION(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_AUTOMATION_SESSION))
 #define WEBKIT_AUTOMATION_SESSION_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_AUTOMATION_SESSION, WebKitAutomationSessionClass))
 #define WEBKIT_IS_AUTOMATION_SESSION_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_AUTOMATION_SESSION))
 #define WEBKIT_AUTOMATION_SESSION_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_AUTOMATION_SESSION, WebKitAutomationSessionClass))
+
+struct _WebKitAutomationSessionClass {
+    GObjectClass parent_class;
+
+    /*< private >*/
+    void (*_webkit_reserved0) (void);
+    void (*_webkit_reserved1) (void);
+    void (*_webkit_reserved2) (void);
+    void (*_webkit_reserved3) (void);
+};
+#endif
+
+WEBKIT_DECLARE_FINAL_TYPE (WebKitAutomationSession, webkit_automation_session, WEBKIT, AUTOMATION_SESSION, GObject)
 
 /**
  * WebKitAutomationBrowsingContextPresentation:
@@ -48,30 +62,6 @@ typedef enum {
     WEBKIT_AUTOMATION_BROWSING_CONTEXT_PRESENTATION_WINDOW,
     WEBKIT_AUTOMATION_BROWSING_CONTEXT_PRESENTATION_TAB
 } WebKitAutomationBrowsingContextPresentation;
-
-typedef struct _WebKitAutomationSession        WebKitAutomationSession;
-typedef struct _WebKitAutomationSessionClass   WebKitAutomationSessionClass;
-typedef struct _WebKitAutomationSessionPrivate WebKitAutomationSessionPrivate;
-
-struct _WebKitAutomationSession {
-    GObject parent;
-
-    /*< private >*/
-    WebKitAutomationSessionPrivate *priv;
-};
-
-struct _WebKitAutomationSessionClass {
-    GObjectClass parent_class;
-
-    /*< private >*/
-    void (*_webkit_reserved0) (void);
-    void (*_webkit_reserved1) (void);
-    void (*_webkit_reserved2) (void);
-    void (*_webkit_reserved3) (void);
-};
-
-WEBKIT_API GType
-webkit_automation_session_get_type             (void);
 
 WEBKIT_API const char *
 webkit_automation_session_get_id               (WebKitAutomationSession *session);

--- a/Source/WebKit/UIProcess/API/glib/WebKitBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitBackForwardList.cpp
@@ -63,7 +63,7 @@ struct _WebKitBackForwardListPrivate {
 
 static guint signals[LAST_SIGNAL] = { 0, };
 
-WEBKIT_DEFINE_FINAL_TYPE_IN_2022_API(WebKitBackForwardList, webkit_back_forward_list, G_TYPE_OBJECT)
+WEBKIT_DEFINE_FINAL_TYPE(WebKitBackForwardList, webkit_back_forward_list, G_TYPE_OBJECT, GObject)
 
 static void webkit_back_forward_list_class_init(WebKitBackForwardListClass* listClass)
 {

--- a/Source/WebKit/UIProcess/API/glib/WebKitBackForwardList.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitBackForwardList.h.in
@@ -24,27 +24,16 @@
 
 #include <glib-object.h>
 #include <@API_INCLUDE_PREFIX@/WebKitBackForwardListItem.h>
-#include <@API_INCLUDE_PREFIX@/WebKitDefines.h>
 
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_BACK_FORWARD_LIST            (webkit_back_forward_list_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_BACK_FORWARD_LIST(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_BACK_FORWARD_LIST, WebKitBackForwardList))
 #define WEBKIT_BACK_FORWARD_LIST_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_BACK_FORWARD_LIST, WebKitBackForwardListClass))
 #define WEBKIT_IS_BACK_FORWARD_LIST(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_BACK_FORWARD_LIST))
 #define WEBKIT_IS_BACK_FORWARD_LIST_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_BACK_FORWARD_LIST))
 #define WEBKIT_BACK_FORWARD_LIST_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_BACK_FORWARD_LIST, WebKitBackForwardListClass))
-
-typedef struct _WebKitBackForwardList        WebKitBackForwardList;
-typedef struct _WebKitBackForwardListClass   WebKitBackForwardListClass;
-typedef struct _WebKitBackForwardListPrivate WebKitBackForwardListPrivate;
-
-struct _WebKitBackForwardList {
-    GObject parent;
-
-    /*< private >*/
-    WebKitBackForwardListPrivate *priv;
-};
 
 struct _WebKitBackForwardListClass {
     GObjectClass parent_class;
@@ -55,9 +44,9 @@ struct _WebKitBackForwardListClass {
     void (*_webkit_reserved2) (void);
     void (*_webkit_reserved3) (void);
 };
+#endif
 
-WEBKIT_API GType
-webkit_back_forward_list_get_type                    (void);
+WEBKIT_DECLARE_FINAL_TYPE (WebKitBackForwardList, webkit_back_forward_list, WEBKIT, BACK_FORWARD_LIST, GObject)
 
 WEBKIT_API WebKitBackForwardListItem *
 webkit_back_forward_list_get_current_item            (WebKitBackForwardList *back_forward_list);

--- a/Source/WebKit/UIProcess/API/glib/WebKitBackForwardListItem.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitBackForwardListItem.cpp
@@ -46,7 +46,7 @@ struct _WebKitBackForwardListItemPrivate {
     CString originalURI;
 };
 
-WEBKIT_DEFINE_FINAL_TYPE_IN_2022_API(WebKitBackForwardListItem, webkit_back_forward_list_item, G_TYPE_INITIALLY_UNOWNED)
+WEBKIT_DEFINE_FINAL_TYPE(WebKitBackForwardListItem, webkit_back_forward_list_item, G_TYPE_INITIALLY_UNOWNED, GInitiallyUnowned)
 
 static void webkit_back_forward_list_item_class_init(WebKitBackForwardListItemClass*)
 {

--- a/Source/WebKit/UIProcess/API/glib/WebKitBackForwardListItem.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitBackForwardListItem.h.in
@@ -28,22 +28,12 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_BACK_FORWARD_LIST_ITEM            (webkit_back_forward_list_item_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_BACK_FORWARD_LIST_ITEM(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_BACK_FORWARD_LIST_ITEM, WebKitBackForwardListItem))
 #define WEBKIT_BACK_FORWARD_LIST_ITEM_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_BACK_FORWARD_LIST_ITEM, WebKitBackForwardListItemClass))
 #define WEBKIT_IS_BACK_FORWARD_LIST_ITEM(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_BACK_FORWARD_LIST_ITEM))
 #define WEBKIT_IS_BACK_FORWARD_LIST_ITEM_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_BACK_FORWARD_LIST_ITEM))
 #define WEBKIT_BACK_FORWARD_LIST_ITEM_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_BACK_FORWARD_LIST_ITEM, WebKitBackForwardListItemClass))
-
-typedef struct _WebKitBackForwardListItem        WebKitBackForwardListItem;
-typedef struct _WebKitBackForwardListItemClass   WebKitBackForwardListItemClass;
-typedef struct _WebKitBackForwardListItemPrivate WebKitBackForwardListItemPrivate;
-
-struct _WebKitBackForwardListItem {
-    GInitiallyUnowned parent;
-
-    /*< private >*/
-    WebKitBackForwardListItemPrivate *priv;
-};
 
 struct _WebKitBackForwardListItemClass {
     GInitiallyUnownedClass parent_class;
@@ -54,9 +44,9 @@ struct _WebKitBackForwardListItemClass {
     void (*_webkit_reserved2) (void);
     void (*_webkit_reserved3) (void);
 };
+#endif
 
-WEBKIT_API GType
-webkit_back_forward_list_item_get_type         (void);
+WEBKIT_DECLARE_FINAL_TYPE (WebKitBackForwardListItem, webkit_back_forward_list_item, WEBKIT, BACK_FORWARD_LIST_ITEM, GInitiallyUnowned)
 
 WEBKIT_API const gchar *
 webkit_back_forward_list_item_get_uri          (WebKitBackForwardListItem* list_item);

--- a/Source/WebKit/UIProcess/API/glib/WebKitContextMenu.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitContextMenu.h.in
@@ -31,24 +31,12 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_CONTEXT_MENU            (webkit_context_menu_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_CONTEXT_MENU(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_CONTEXT_MENU, WebKitContextMenu))
 #define WEBKIT_IS_CONTEXT_MENU(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_CONTEXT_MENU))
 #define WEBKIT_CONTEXT_MENU_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_CONTEXT_MENU, WebKitContextMenuClass))
 #define WEBKIT_IS_CONTEXT_MENU_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_CONTEXT_MENU))
 #define WEBKIT_CONTEXT_MENU_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_CONTEXT_MENU, WebKitContextMenuClass))
-
-typedef struct _WebKitContextMenu        WebKitContextMenu;
-typedef struct _WebKitContextMenuClass   WebKitContextMenuClass;
-typedef struct _WebKitContextMenuPrivate WebKitContextMenuPrivate;
-
-typedef struct _WebKitContextMenuItem WebKitContextMenuItem;
-
-struct _WebKitContextMenu {
-    GObject parent;
-
-    /*< private >*/
-    WebKitContextMenuPrivate *priv;
-};
 
 struct _WebKitContextMenuClass {
     GObjectClass parent_class;
@@ -59,9 +47,11 @@ struct _WebKitContextMenuClass {
     void (*_webkit_reserved2) (void);
     void (*_webkit_reserved3) (void);
 };
+#endif
 
-WEBKIT_API GType
-webkit_context_menu_get_type             (void);
+WEBKIT_DECLARE_FINAL_TYPE (WebKitContextMenu, webkit_context_menu, WEBKIT, CONTEXT_MENU, GObject)
+
+typedef struct _WebKitContextMenuItem WebKitContextMenuItem;
 
 WEBKIT_API WebKitContextMenu *
 webkit_context_menu_new                  (void);

--- a/Source/WebKit/UIProcess/API/glib/WebKitContextMenuItem.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitContextMenuItem.h.in
@@ -34,22 +34,12 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_CONTEXT_MENU_ITEM            (webkit_context_menu_item_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_CONTEXT_MENU_ITEM(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_CONTEXT_MENU_ITEM, WebKitContextMenuItem))
 #define WEBKIT_IS_CONTEXT_MENU_ITEM(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_CONTEXT_MENU_ITEM))
 #define WEBKIT_CONTEXT_MENU_ITEM_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_CONTEXT_MENU_ITEM, WebKitContextMenuItemClass))
 #define WEBKIT_IS_CONTEXT_MENU_ITEM_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_CONTEXT_MENU_ITEM))
 #define WEBKIT_CONTEXT_MENU_ITEM_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_CONTEXT_MENU_ITEM, WebKitContextMenuItemClass))
-
-typedef struct _WebKitContextMenuItem        WebKitContextMenuItem;
-typedef struct _WebKitContextMenuItemClass   WebKitContextMenuItemClass;
-typedef struct _WebKitContextMenuItemPrivate WebKitContextMenuItemPrivate;
-
-struct _WebKitContextMenuItem {
-    GInitiallyUnowned parent;
-
-    /*< private >*/
-    WebKitContextMenuItemPrivate *priv;
-};
 
 struct _WebKitContextMenuItemClass {
     GInitiallyUnownedClass parent_class;
@@ -60,9 +50,9 @@ struct _WebKitContextMenuItemClass {
     void (*_webkit_reserved2) (void);
     void (*_webkit_reserved3) (void);
 };
+#endif
 
-WEBKIT_API GType
-webkit_context_menu_item_get_type                         (void);
+WEBKIT_DECLARE_FINAL_TYPE (WebKitContextMenuItem, webkit_context_menu_item, WEBKIT, CONTEXT_MENU_ITEM, GInitiallyUnowned)
 
 #if PLATFORM(GTK) && !USE(GTK4)
 WEBKIT_DEPRECATED_FOR(webkit_context_menu_item_new_from_gaction) WebKitContextMenuItem *

--- a/Source/WebKit/UIProcess/API/glib/WebKitCookieManager.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitCookieManager.cpp
@@ -95,7 +95,7 @@ struct _WebKitCookieManagerPrivate {
 
 static guint signals[LAST_SIGNAL] = { 0, };
 
-WEBKIT_DEFINE_FINAL_TYPE_IN_2022_API(WebKitCookieManager, webkit_cookie_manager, G_TYPE_OBJECT)
+WEBKIT_DEFINE_FINAL_TYPE(WebKitCookieManager, webkit_cookie_manager, G_TYPE_OBJECT, GObject)
 
 static inline SoupCookiePersistentStorageType toSoupCookiePersistentStorageType(WebKitCookiePersistentStorage kitStorage)
 {

--- a/Source/WebKit/UIProcess/API/glib/WebKitCookieManager.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitCookieManager.h.in
@@ -31,15 +31,25 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_COOKIE_MANAGER            (webkit_cookie_manager_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_COOKIE_MANAGER(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_COOKIE_MANAGER, WebKitCookieManager))
 #define WEBKIT_IS_COOKIE_MANAGER(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_COOKIE_MANAGER))
 #define WEBKIT_COOKIE_MANAGER_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_COOKIE_MANAGER, WebKitCookieManagerClass))
 #define WEBKIT_IS_COOKIE_MANAGER_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_COOKIE_MANAGER))
 #define WEBKIT_COOKIE_MANAGER_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_COOKIE_MANAGER, WebKitCookieManagerClass))
 
-typedef struct _WebKitCookieManager        WebKitCookieManager;
-typedef struct _WebKitCookieManagerClass   WebKitCookieManagerClass;
-typedef struct _WebKitCookieManagerPrivate WebKitCookieManagerPrivate;
+struct _WebKitCookieManagerClass {
+    GObjectClass parent_class;
+
+    /*< private >*/
+    void (*_webkit_reserved0) (void);
+    void (*_webkit_reserved1) (void);
+    void (*_webkit_reserved2) (void);
+    void (*_webkit_reserved3) (void);
+};
+#endif
+
+WEBKIT_DECLARE_FINAL_TYPE (WebKitCookieManager, webkit_cookie_manager, WEBKIT, COOKIE_MANAGER, GObject)
 
 /**
  * WebKitCookiePersistentStorage:
@@ -68,26 +78,6 @@ typedef enum {
     WEBKIT_COOKIE_POLICY_ACCEPT_NEVER,
     WEBKIT_COOKIE_POLICY_ACCEPT_NO_THIRD_PARTY
 } WebKitCookieAcceptPolicy;
-
-struct _WebKitCookieManager {
-    GObject parent;
-
-    /*< private >*/
-    WebKitCookieManagerPrivate *priv;
-};
-
-struct _WebKitCookieManagerClass {
-    GObjectClass parent_class;
-
-    /*< private >*/
-    void (*_webkit_reserved0) (void);
-    void (*_webkit_reserved1) (void);
-    void (*_webkit_reserved2) (void);
-    void (*_webkit_reserved3) (void);
-};
-
-WEBKIT_API GType
-webkit_cookie_manager_get_type                        (void);
 
 WEBKIT_API void
 webkit_cookie_manager_set_persistent_storage          (WebKitCookieManager          *cookie_manager,

--- a/Source/WebKit/UIProcess/API/glib/WebKitDefines.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitDefines.h.in
@@ -50,4 +50,61 @@
  * Marks a symbol as deprecated, indicating a replacement.
  */
 
+#if ENABLE(2022_GLIB_API)
+/*
+ * The G_DECLARE_DERIVABLE_TYPE macro creates an instance struct that
+ * has ParentName as its only member; but in order to keep the same code
+ * for the pre-2022 API it should have also a "priv" member. There is no
+ * reasonable way of bending the GLib macro to do what we want; so this is
+ * a version of the GLib macro adapted accordingly.
+ */
+#define WEBKIT_DECLARE_TYPE(ModuleObjName, module_obj_name, MODULE, OBJ_NAME, ParentName)               \
+    WEBKIT_API GType module_obj_name##_get_type (void);                                                 \
+    G_GNUC_BEGIN_IGNORE_DEPRECATIONS                                                                    \
+    typedef struct _##ModuleObjName ModuleObjName;                                                      \
+    typedef struct _##ModuleObjName##Class ModuleObjName##Class;                                        \
+    typedef struct _##ModuleObjName##Private ModuleObjName##Private;                                    \
+                                                                                                        \
+    _GLIB_DEFINE_AUTOPTR_CHAINUP (ModuleObjName, ParentName)                                            \
+    G_DEFINE_AUTOPTR_CLEANUP_FUNC (ModuleObjName##Class, g_type_class_unref)                            \
+                                                                                                        \
+    G_GNUC_UNUSED static inline ModuleObjName * MODULE##_##OBJ_NAME (gpointer ptr) {                    \
+      return G_TYPE_CHECK_INSTANCE_CAST (ptr, module_obj_name##_get_type (), ModuleObjName); }          \
+    G_GNUC_UNUSED static inline ModuleObjName##Class * MODULE##_##OBJ_NAME##_CLASS (gpointer ptr) {     \
+      return G_TYPE_CHECK_CLASS_CAST (ptr, module_obj_name##_get_type (), ModuleObjName##Class); }      \
+    G_GNUC_UNUSED static inline gboolean MODULE##_IS_##OBJ_NAME (gpointer ptr) {                        \
+      return G_TYPE_CHECK_INSTANCE_TYPE (ptr, module_obj_name##_get_type ()); }                         \
+    G_GNUC_UNUSED static inline gboolean MODULE##_IS_##OBJ_NAME##_CLASS (gpointer ptr) {                \
+      return G_TYPE_CHECK_CLASS_TYPE (ptr, module_obj_name##_get_type ()); }                            \
+    G_GNUC_UNUSED static inline ModuleObjName##Class * MODULE##_##OBJ_NAME##_GET_CLASS (gpointer ptr) { \
+      return G_TYPE_INSTANCE_GET_CLASS (ptr, module_obj_name##_get_type (), ModuleObjName##Class); }    \
+    G_GNUC_END_IGNORE_DEPRECATIONS
+
+#define WEBKIT_DECLARE_DERIVABLE_TYPE(ModuleObjName, module_obj_name, MODULE, OBJ_NAME, ParentName)     \
+    WEBKIT_DECLARE_TYPE(ModuleObjName, module_obj_name, MODULE, OBJ_NAME, ParentName)                   \
+    struct _##ModuleObjName { ParentName parent_instance; ModuleObjName ## Private *priv; };
+
+#define WEBKIT_DECLARE_FINAL_TYPE(ModuleObjName, module_obj_name, MODULE, OBJ_NAME, ParentName) \
+    WEBKIT_API G_DECLARE_FINAL_TYPE(ModuleObjName, module_obj_name, MODULE, OBJ_NAME, ParentName)
+
+#else
+
+#define WEBKIT_DECLARE_TYPE(ModuleObjName, module_obj_name, MODULE, OBJ_NAME, ParentName) \
+    WEBKIT_API GType module_obj_name ## _get_type (void);                  \
+                                                                           \
+    typedef struct _ ## ModuleObjName ModuleObjName;                       \
+    typedef struct _ ## ModuleObjName ## Class ModuleObjName ## Class;     \
+    typedef struct _ ## ModuleObjName ## Private ModuleObjName ## Private; \
+                                                                           \
+    struct _ ## ModuleObjName {                                            \
+        ParentName parent;                                                 \
+        /*< private >*/                                                    \
+        ModuleObjName ## Private *priv;                                    \
+    };
+
+#define WEBKIT_DECLARE_DERIVABLE_TYPE WEBKIT_DECLARE_TYPE
+#define WEBKIT_DECLARE_FINAL_TYPE WEBKIT_DECLARE_TYPE
+
+#endif
+
 #endif /* WebKitDefines_h */

--- a/Source/WebKit/UIProcess/API/glib/WebKitDeviceInfoPermissionRequest.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitDeviceInfoPermissionRequest.cpp
@@ -53,8 +53,8 @@ struct _WebKitDeviceInfoPermissionRequestPrivate {
     bool madeDecision;
 };
 
-WEBKIT_DEFINE_FINAL_TYPE_WITH_CODE_IN_2022_API(
-    WebKitDeviceInfoPermissionRequest, webkit_device_info_permission_request, G_TYPE_OBJECT,
+WEBKIT_DEFINE_FINAL_TYPE_WITH_CODE(
+    WebKitDeviceInfoPermissionRequest, webkit_device_info_permission_request, G_TYPE_OBJECT, GObject,
     G_IMPLEMENT_INTERFACE(WEBKIT_TYPE_PERMISSION_REQUEST, webkit_permission_request_interface_init))
 
 static void webkitDeviceInfoPermissionRequestAllow(WebKitPermissionRequest* request)

--- a/Source/WebKit/UIProcess/API/glib/WebKitDeviceInfoPermissionRequest.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitDeviceInfoPermissionRequest.h.in
@@ -27,22 +27,12 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_DEVICE_INFO_PERMISSION_REQUEST            (webkit_device_info_permission_request_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_DEVICE_INFO_PERMISSION_REQUEST(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_DEVICE_INFO_PERMISSION_REQUEST, WebKitDeviceInfoPermissionRequest))
 #define WEBKIT_DEVICE_INFO_PERMISSION_REQUEST_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_DEVICE_INFO_PERMISSION_REQUEST, WebKitDeviceInfoPermissionRequestClass))
 #define WEBKIT_IS_DEVICE_INFO_PERMISSION_REQUEST(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_DEVICE_INFO_PERMISSION_REQUEST))
 #define WEBKIT_IS_DEVICE_INFO_PERMISSION_REQUEST_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_DEVICE_INFO_PERMISSION_REQUEST))
 #define WEBKIT_DEVICE_INFO_PERMISSION_REQUEST_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_DEVICE_INFO_PERMISSION_REQUEST, WebKitDeviceInfoPermissionRequestClass))
-
-typedef struct _WebKitDeviceInfoPermissionRequest        WebKitDeviceInfoPermissionRequest;
-typedef struct _WebKitDeviceInfoPermissionRequestClass   WebKitDeviceInfoPermissionRequestClass;
-typedef struct _WebKitDeviceInfoPermissionRequestPrivate WebKitDeviceInfoPermissionRequestPrivate;
-
-struct _WebKitDeviceInfoPermissionRequest {
-    GObject parent;
-
-    /*< private >*/
-    WebKitDeviceInfoPermissionRequestPrivate *priv;
-};
 
 struct _WebKitDeviceInfoPermissionRequestClass {
     GObjectClass parent_class;
@@ -53,9 +43,9 @@ struct _WebKitDeviceInfoPermissionRequestClass {
     void (*_webkit_reserved2) (void);
     void (*_webkit_reserved3) (void);
 };
+#endif
 
-WEBKIT_API GType
-webkit_device_info_permission_request_get_type (void);
+WEBKIT_DECLARE_FINAL_TYPE (WebKitDeviceInfoPermissionRequest, webkit_device_info_permission_request, WEBKIT, DEVICE_INFO_PERMISSION_REQUEST, GObject)
 
 G_END_DECLS
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitDownload.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitDownload.cpp
@@ -89,7 +89,7 @@ struct _WebKitDownloadPrivate {
 
 static guint signals[LAST_SIGNAL] = { 0, };
 
-WEBKIT_DEFINE_FINAL_TYPE_IN_2022_API(WebKitDownload, webkit_download, G_TYPE_OBJECT)
+WEBKIT_DEFINE_FINAL_TYPE(WebKitDownload, webkit_download, G_TYPE_OBJECT, GObject)
 
 static void webkitDownloadSetProperty(GObject* object, guint propId, const GValue* value, GParamSpec* paramSpec)
 {

--- a/Source/WebKit/UIProcess/API/glib/WebKitDownload.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitDownload.h.in
@@ -30,24 +30,17 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_DOWNLOAD            (webkit_download_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_DOWNLOAD(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_DOWNLOAD, WebKitDownload))
 #define WEBKIT_IS_DOWNLOAD(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_DOWNLOAD))
 #define WEBKIT_DOWNLOAD_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_DOWNLOAD, WebKitDownloadClass))
 #define WEBKIT_IS_DOWNLOAD_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_DOWNLOAD))
 #define WEBKIT_DOWNLOAD_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_DOWNLOAD, WebKitDownloadClass))
+#endif
 
-typedef struct _WebKitDownload        WebKitDownload;
-typedef struct _WebKitDownloadClass   WebKitDownloadClass;
-typedef struct _WebKitDownloadPrivate WebKitDownloadPrivate;
+WEBKIT_DECLARE_TYPE (WebKitDownload, webkit_download, WEBKIT, DOWNLOAD, GObject)
 
 typedef struct _WebKitWebView WebKitWebView;
-
-struct _WebKitDownload {
-    GObject parent;
-
-    /*< private >*/
-    WebKitDownloadPrivate *priv;
-};
 
 struct _WebKitDownloadClass {
     GObjectClass parent_class;
@@ -62,9 +55,6 @@ struct _WebKitDownloadClass {
     void (*_webkit_reserved2) (void);
     void (*_webkit_reserved3) (void);
 };
-
-WEBKIT_API GType
-webkit_download_get_type                 (void);
 
 WEBKIT_API WebKitURIRequest *
 webkit_download_get_request              (WebKitDownload *download);

--- a/Source/WebKit/UIProcess/API/glib/WebKitEditorState.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitEditorState.cpp
@@ -59,7 +59,7 @@ struct _WebKitEditorStatePrivate {
     unsigned isRedoAvailable : 1;
 };
 
-WEBKIT_DEFINE_FINAL_TYPE_IN_2022_API(WebKitEditorState, webkit_editor_state, G_TYPE_OBJECT)
+WEBKIT_DEFINE_FINAL_TYPE(WebKitEditorState, webkit_editor_state, G_TYPE_OBJECT, GObject)
 
 static void webkitEditorStateGetProperty(GObject* object, guint propId, GValue* value, GParamSpec* paramSpec)
 {

--- a/Source/WebKit/UIProcess/API/glib/WebKitEditorState.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitEditorState.h.in
@@ -28,15 +28,25 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_EDITOR_STATE            (webkit_editor_state_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_EDITOR_STATE(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_EDITOR_STATE, WebKitEditorState))
 #define WEBKIT_IS_EDITOR_STATE(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_EDITOR_STATE))
 #define WEBKIT_EDITOR_STATE_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_EDITOR_STATE, WebKitEditorStateClass))
 #define WEBKIT_IS_EDITOR_STATE_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_EDITOR_STATE))
 #define WEBKIT_EDITOR_STATE_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_EDITOR_STATE, WebKitEditorStateClass))
 
-typedef struct _WebKitEditorState        WebKitEditorState;
-typedef struct _WebKitEditorStateClass   WebKitEditorStateClass;
-typedef struct _WebKitEditorStatePrivate WebKitEditorStatePrivate;
+struct _WebKitEditorStateClass {
+    GObjectClass parent_class;
+
+    /*< private >*/
+    void (*_webkit_reserved0) (void);
+    void (*_webkit_reserved1) (void);
+    void (*_webkit_reserved2) (void);
+    void (*_webkit_reserved3) (void);
+};
+#endif
+
+WEBKIT_DECLARE_FINAL_TYPE (WebKitEditorState, webkit_editor_state, WEBKIT, EDITOR_STATE, GObject)
 
 /**
  * WebKitEditorTypingAttributes:
@@ -58,26 +68,6 @@ typedef enum
     WEBKIT_EDITOR_TYPING_ATTRIBUTE_UNDERLINE      = 1 << 4,
     WEBKIT_EDITOR_TYPING_ATTRIBUTE_STRIKETHROUGH  = 1 << 5
 } WebKitEditorTypingAttributes;
-
-struct _WebKitEditorState {
-    GObject parent;
-
-    /*< private >*/
-    WebKitEditorStatePrivate *priv;
-};
-
-struct _WebKitEditorStateClass {
-    GObjectClass parent_class;
-
-    /*< private >*/
-    void (*_webkit_reserved0) (void);
-    void (*_webkit_reserved1) (void);
-    void (*_webkit_reserved2) (void);
-    void (*_webkit_reserved3) (void);
-};
-
-WEBKIT_API GType
-webkit_editor_state_get_type              (void);
 
 WEBKIT_API guint
 webkit_editor_state_get_typing_attributes (WebKitEditorState *editor_state);

--- a/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp
@@ -69,7 +69,7 @@ struct _WebKitFaviconDatabasePrivate {
     RefPtr<IconDatabase> iconDatabase;
 };
 
-WEBKIT_DEFINE_FINAL_TYPE_IN_2022_API(WebKitFaviconDatabase, webkit_favicon_database, G_TYPE_OBJECT)
+WEBKIT_DEFINE_FINAL_TYPE(WebKitFaviconDatabase, webkit_favicon_database, G_TYPE_OBJECT, GObject)
 
 static void webkit_favicon_database_class_init(WebKitFaviconDatabaseClass* faviconDatabaseClass)
 {

--- a/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.h.in
@@ -36,24 +36,14 @@
 
 G_BEGIN_DECLS
 
+#define WEBKIT_FAVICON_DATABASE_ERROR           (webkit_favicon_database_error_quark())
 #define WEBKIT_TYPE_FAVICON_DATABASE            (webkit_favicon_database_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_FAVICON_DATABASE(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_FAVICON_DATABASE, WebKitFaviconDatabase))
 #define WEBKIT_IS_FAVICON_DATABASE(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_FAVICON_DATABASE))
 #define WEBKIT_FAVICON_DATABASE_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_FAVICON_DATABASE, WebKitFaviconDatabaseClass))
 #define WEBKIT_IS_FAVICON_DATABASE_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_FAVICON_DATABASE))
 #define WEBKIT_FAVICON_DATABASE_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_FAVICON_DATABASE, WebKitFaviconDatabaseClass))
-#define WEBKIT_FAVICON_DATABASE_ERROR           (webkit_favicon_database_error_quark())
-
-typedef struct _WebKitFaviconDatabase        WebKitFaviconDatabase;
-typedef struct _WebKitFaviconDatabaseClass   WebKitFaviconDatabaseClass;
-typedef struct _WebKitFaviconDatabasePrivate WebKitFaviconDatabasePrivate;
-
-struct _WebKitFaviconDatabase {
-    GObject parent;
-
-    /*< private >*/
-    WebKitFaviconDatabasePrivate *priv;
-};
 
 struct _WebKitFaviconDatabaseClass {
     GObjectClass parent_class;
@@ -64,6 +54,9 @@ struct _WebKitFaviconDatabaseClass {
     void (*_webkit_reserved2) (void);
     void (*_webkit_reserved3) (void);
 };
+#endif
+
+WEBKIT_DECLARE_FINAL_TYPE (WebKitFaviconDatabase, webkit_favicon_database, WEBKIT, FAVICON_DATABASE, GObject)
 
 /**
  * WebKitFaviconDatabaseError:
@@ -81,9 +74,6 @@ typedef enum {
 
 WEBKIT_API GQuark
 webkit_favicon_database_error_quark        (void);
-
-WEBKIT_API GType
-webkit_favicon_database_get_type           (void);
 
 #if PLATFORM(GTK)
 WEBKIT_API void

--- a/Source/WebKit/UIProcess/API/glib/WebKitFileChooserRequest.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFileChooserRequest.cpp
@@ -72,7 +72,7 @@ struct _WebKitFileChooserRequestPrivate {
     bool handledRequest;
 };
 
-WEBKIT_DEFINE_FINAL_TYPE_IN_2022_API(WebKitFileChooserRequest, webkit_file_chooser_request, G_TYPE_OBJECT)
+WEBKIT_DEFINE_FINAL_TYPE(WebKitFileChooserRequest, webkit_file_chooser_request, G_TYPE_OBJECT, GObject)
 
 enum {
     PROP_0,

--- a/Source/WebKit/UIProcess/API/glib/WebKitFileChooserRequest.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFileChooserRequest.h.in
@@ -32,22 +32,12 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_FILE_CHOOSER_REQUEST            (webkit_file_chooser_request_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_FILE_CHOOSER_REQUEST(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_FILE_CHOOSER_REQUEST, WebKitFileChooserRequest))
 #define WEBKIT_FILE_CHOOSER_REQUEST_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_FILE_CHOOSER_REQUEST, WebKitFileChooserRequestClass))
 #define WEBKIT_IS_FILE_CHOOSER_REQUEST(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_FILE_CHOOSER_REQUEST))
 #define WEBKIT_IS_FILE_CHOOSER_REQUEST_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_FILE_CHOOSER_REQUEST))
 #define WEBKIT_FILE_CHOOSER_REQUEST_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_FILE_CHOOSER_REQUEST, WebKitFileChooserRequestClass))
-
-typedef struct _WebKitFileChooserRequest        WebKitFileChooserRequest;
-typedef struct _WebKitFileChooserRequestClass   WebKitFileChooserRequestClass;
-typedef struct _WebKitFileChooserRequestPrivate WebKitFileChooserRequestPrivate;
-
-struct _WebKitFileChooserRequest {
-    GObject parent;
-
-    /*< private >*/
-    WebKitFileChooserRequestPrivate *priv;
-};
 
 struct _WebKitFileChooserRequestClass {
     GObjectClass parent_class;
@@ -58,9 +48,9 @@ struct _WebKitFileChooserRequestClass {
     void (*_webkit_reserved2) (void);
     void (*_webkit_reserved3) (void);
 };
+#endif
 
-WEBKIT_API GType
-webkit_file_chooser_request_get_type                  (void);
+WEBKIT_DECLARE_FINAL_TYPE (WebKitFileChooserRequest, webkit_file_chooser_request, WEBKIT, FILE_CHOOSER_REQUEST, GObject)
 
 WEBKIT_API const gchar * const *
 webkit_file_chooser_request_get_mime_types        (WebKitFileChooserRequest *request);

--- a/Source/WebKit/UIProcess/API/glib/WebKitFindController.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFindController.cpp
@@ -80,7 +80,7 @@ struct _WebKitFindControllerPrivate {
 
 static guint signals[LAST_SIGNAL] = { 0, };
 
-WEBKIT_DEFINE_FINAL_TYPE_IN_2022_API(WebKitFindController, webkit_find_controller, G_TYPE_OBJECT)
+WEBKIT_DEFINE_FINAL_TYPE(WebKitFindController, webkit_find_controller, G_TYPE_OBJECT, GObject)
 
 static inline OptionSet<WebKit::FindOptions> toWebFindOptions(uint32_t findOptions)
 {

--- a/Source/WebKit/UIProcess/API/glib/WebKitFindController.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFindController.h.in
@@ -28,15 +28,25 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_FIND_CONTROLLER            (webkit_find_controller_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_FIND_CONTROLLER(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_FIND_CONTROLLER, WebKitFindController))
 #define WEBKIT_FIND_CONTROLLER_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_FIND_CONTROLLER, WebKitFindControllerClass))
 #define WEBKIT_IS_FIND_CONTROLLER(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_FIND_CONTROLLER))
 #define WEBKIT_IS_FIND_CONTROLLER_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_FIND_CONTROLLER))
 #define WEBKIT_FIND_CONTROLLER_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_FIND_CONTROLLER, WebKitFindControllerClass))
 
-typedef struct _WebKitFindController        WebKitFindController;
-typedef struct _WebKitFindControllerPrivate WebKitFindControllerPrivate;
-typedef struct _WebKitFindControllerClass   WebKitFindControllerClass;
+struct _WebKitFindControllerClass {
+    GObjectClass parent_class;
+
+    /*< private >*/
+    void (*_webkit_reserved0) (void);
+    void (*_webkit_reserved1) (void);
+    void (*_webkit_reserved2) (void);
+    void (*_webkit_reserved3) (void);
+};
+#endif
+
+WEBKIT_DECLARE_FINAL_TYPE (WebKitFindController, webkit_find_controller, WEBKIT, FIND_CONTROLLER, GObject)
 
 typedef struct _WebKitWebView WebKitWebView;
 
@@ -64,26 +74,6 @@ typedef enum {
   WEBKIT_FIND_OPTIONS_BACKWARDS =                          1 << 3,
   WEBKIT_FIND_OPTIONS_WRAP_AROUND =                        1 << 4
 } WebKitFindOptions;
-
-struct _WebKitFindController {
-    GObject parent;
-
-  /*< private >*/
-  WebKitFindControllerPrivate *priv;
-};
-
-struct _WebKitFindControllerClass {
-    GObjectClass parent_class;
-
-    /*< private >*/
-    void (*_webkit_reserved0) (void);
-    void (*_webkit_reserved1) (void);
-    void (*_webkit_reserved2) (void);
-    void (*_webkit_reserved3) (void);
-};
-
-WEBKIT_API GType
-webkit_find_controller_get_type            (void);
 
 WEBKIT_API void
 webkit_find_controller_search              (WebKitFindController *find_controller,

--- a/Source/WebKit/UIProcess/API/glib/WebKitFormSubmissionRequest.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFormSubmissionRequest.cpp
@@ -52,7 +52,7 @@ struct _WebKitFormSubmissionRequestPrivate {
     bool handledRequest;
 };
 
-WEBKIT_DEFINE_FINAL_TYPE_IN_2022_API(WebKitFormSubmissionRequest, webkit_form_submission_request, G_TYPE_OBJECT)
+WEBKIT_DEFINE_FINAL_TYPE(WebKitFormSubmissionRequest, webkit_form_submission_request, G_TYPE_OBJECT, GObject)
 
 static void webkitFormSubmissionRequestDispose(GObject* object)
 {

--- a/Source/WebKit/UIProcess/API/glib/WebKitFormSubmissionRequest.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFormSubmissionRequest.h.in
@@ -28,22 +28,12 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_FORM_SUBMISSION_REQUEST            (webkit_form_submission_request_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_FORM_SUBMISSION_REQUEST(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_FORM_SUBMISSION_REQUEST, WebKitFormSubmissionRequest))
 #define WEBKIT_IS_FORM_SUBMISSION_REQUEST(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_FORM_SUBMISSION_REQUEST))
 #define WEBKIT_FORM_SUBMISSION_REQUEST_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_FORM_SUBMISSION_REQUEST, WebKitFormSubmissionRequestClass))
 #define WEBKIT_IS_FORM_SUBMISSION_REQUEST_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_FORM_SUBMISSION_REQUEST))
 #define WEBKIT_FORM_SUBMISSION_REQUEST_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_FORM_SUBMISSION_REQUEST, WebKitFormSubmissionRequestClass))
-
-typedef struct _WebKitFormSubmissionRequest        WebKitFormSubmissionRequest;
-typedef struct _WebKitFormSubmissionRequestClass   WebKitFormSubmissionRequestClass;
-typedef struct _WebKitFormSubmissionRequestPrivate WebKitFormSubmissionRequestPrivate;
-
-struct _WebKitFormSubmissionRequest {
-    GObject parent;
-
-    /*< private >*/
-    WebKitFormSubmissionRequestPrivate *priv;
-};
 
 struct _WebKitFormSubmissionRequestClass {
     GObjectClass parent_class;
@@ -54,9 +44,9 @@ struct _WebKitFormSubmissionRequestClass {
     void (*_webkit_reserved2) (void);
     void (*_webkit_reserved3) (void);
 };
+#endif
 
-WEBKIT_API GType
-webkit_form_submission_request_get_type         (void);
+WEBKIT_DECLARE_FINAL_TYPE (WebKitFormSubmissionRequest, webkit_form_submission_request, WEBKIT, FORM_SUBMISSION_REQUEST, GObject)
 
 #if PLATFORM(GTK) && !USE(GTK4)
 WEBKIT_DEPRECATED_FOR(webkit_form_submission_request_list_text_fields) GHashTable *

--- a/Source/WebKit/UIProcess/API/glib/WebKitGeolocationManager.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitGeolocationManager.cpp
@@ -245,7 +245,7 @@ struct _WebKitGeolocationManagerPrivate {
 
 static guint signals[LAST_SIGNAL] = { 0, };
 
-WEBKIT_DEFINE_FINAL_TYPE_IN_2022_API(WebKitGeolocationManager, webkit_geolocation_manager, G_TYPE_OBJECT)
+WEBKIT_DEFINE_FINAL_TYPE(WebKitGeolocationManager, webkit_geolocation_manager, G_TYPE_OBJECT, GObject)
 
 static void webkitGeolocationManagerStart(WebKitGeolocationManager* manager)
 {

--- a/Source/WebKit/UIProcess/API/glib/WebKitGeolocationManager.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitGeolocationManager.h.in
@@ -28,25 +28,12 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_GEOLOCATION_MANAGER            (webkit_geolocation_manager_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_GEOLOCATION_MANAGER(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_GEOLOCATION_MANAGER, WebKitGeolocationManager))
 #define WEBKIT_IS_GEOLOCATION_MANAGER(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_GEOLOCATION_MANAGER))
 #define WEBKIT_GEOLOCATION_MANAGER_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_GEOLOCATION_MANAGER, WebKitGeolocationManagerClass))
 #define WEBKIT_IS_GEOLOCATION_MANAGER_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_GEOLOCATION_MANAGER))
 #define WEBKIT_GEOLOCATION_MANAGER_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_GEOLOCATION_MANAGER, WebKitGeolocationManagerClass))
-
-#define WEBKIT_TYPE_GEOLOCATION_POSITION           (webkit_geolocation_position_get_type())
-
-typedef struct _WebKitGeolocationManager        WebKitGeolocationManager;
-typedef struct _WebKitGeolocationManagerClass   WebKitGeolocationManagerClass;
-typedef struct _WebKitGeolocationManagerPrivate WebKitGeolocationManagerPrivate;
-typedef struct _WebKitGeolocationPosition       WebKitGeolocationPosition;
-
-struct _WebKitGeolocationManager {
-    GObject parent;
-
-    /*< private >*/
-    WebKitGeolocationManagerPrivate *priv;
-};
 
 struct _WebKitGeolocationManagerClass {
     GObjectClass parent_class;
@@ -57,9 +44,13 @@ struct _WebKitGeolocationManagerClass {
     void (*_webkit_reserved2) (void);
     void (*_webkit_reserved3) (void);
 };
+#endif
 
-WEBKIT_API GType
-webkit_geolocation_manager_get_type                 (void);
+WEBKIT_DECLARE_FINAL_TYPE (WebKitGeolocationManager, webkit_geolocation_manager, WEBKIT, GEOLOCATION_MANAGER, GObject)
+
+#define WEBKIT_TYPE_GEOLOCATION_POSITION           (webkit_geolocation_position_get_type())
+
+typedef struct _WebKitGeolocationPosition WebKitGeolocationPosition;
 
 WEBKIT_API void
 webkit_geolocation_manager_update_position           (WebKitGeolocationManager  *manager,

--- a/Source/WebKit/UIProcess/API/glib/WebKitGeolocationPermissionRequest.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitGeolocationPermissionRequest.cpp
@@ -64,8 +64,8 @@ struct _WebKitGeolocationPermissionRequestPrivate {
     bool madeDecision;
 };
 
-WEBKIT_DEFINE_FINAL_TYPE_WITH_CODE_IN_2022_API(
-    WebKitGeolocationPermissionRequest, webkit_geolocation_permission_request, G_TYPE_OBJECT,
+WEBKIT_DEFINE_FINAL_TYPE_WITH_CODE(
+    WebKitGeolocationPermissionRequest, webkit_geolocation_permission_request, G_TYPE_OBJECT, GObject,
     G_IMPLEMENT_INTERFACE(WEBKIT_TYPE_PERMISSION_REQUEST, webkit_permission_request_interface_init))
 
 static void webkitGeolocationPermissionRequestAllow(WebKitPermissionRequest* request)

--- a/Source/WebKit/UIProcess/API/glib/WebKitGeolocationPermissionRequest.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitGeolocationPermissionRequest.h.in
@@ -28,22 +28,12 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_GEOLOCATION_PERMISSION_REQUEST            (webkit_geolocation_permission_request_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_GEOLOCATION_PERMISSION_REQUEST(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_GEOLOCATION_PERMISSION_REQUEST, WebKitGeolocationPermissionRequest))
 #define WEBKIT_GEOLOCATION_PERMISSION_REQUEST_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_GEOLOCATION_PERMISSION_REQUEST, WebKitGeolocationPermissionRequestClass))
 #define WEBKIT_IS_GEOLOCATION_PERMISSION_REQUEST(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_GEOLOCATION_PERMISSION_REQUEST))
 #define WEBKIT_IS_GEOLOCATION_PERMISSION_REQUEST_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_GEOLOCATION_PERMISSION_REQUEST))
 #define WEBKIT_GEOLOCATION_PERMISSION_REQUEST_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_GEOLOCATION_PERMISSION_REQUEST, WebKitGeolocationPermissionRequestClass))
-
-typedef struct _WebKitGeolocationPermissionRequest        WebKitGeolocationPermissionRequest;
-typedef struct _WebKitGeolocationPermissionRequestClass   WebKitGeolocationPermissionRequestClass;
-typedef struct _WebKitGeolocationPermissionRequestPrivate WebKitGeolocationPermissionRequestPrivate;
-
-struct _WebKitGeolocationPermissionRequest {
-    GObject parent;
-
-    /*< private >*/
-    WebKitGeolocationPermissionRequestPrivate *priv;
-};
 
 struct _WebKitGeolocationPermissionRequestClass {
     GObjectClass parent_class;
@@ -54,9 +44,9 @@ struct _WebKitGeolocationPermissionRequestClass {
     void (*_webkit_reserved2) (void);
     void (*_webkit_reserved3) (void);
 };
+#endif
 
-WEBKIT_API GType
-webkit_geolocation_permission_request_get_type (void);
+WEBKIT_DECLARE_FINAL_TYPE (WebKitGeolocationPermissionRequest, webkit_geolocation_permission_request, WEBKIT, GEOLOCATION_PERMISSION_REQUEST, GObject)
 
 G_END_DECLS
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitHitTestResult.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitHitTestResult.h.in
@@ -28,15 +28,25 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_HIT_TEST_RESULT            (webkit_hit_test_result_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_HIT_TEST_RESULT(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_HIT_TEST_RESULT, WebKitHitTestResult))
 #define WEBKIT_IS_HIT_TEST_RESULT(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_HIT_TEST_RESULT))
 #define WEBKIT_HIT_TEST_RESULT_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_HIT_TEST_RESULT, WebKitHitTestResultClass))
 #define WEBKIT_IS_HIT_TEST_RESULT_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_HIT_TEST_RESULT))
 #define WEBKIT_HIT_TEST_RESULT_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_HIT_TEST_RESULT, WebKitHitTestResultClass))
 
-typedef struct _WebKitHitTestResult        WebKitHitTestResult;
-typedef struct _WebKitHitTestResultClass   WebKitHitTestResultClass;
-typedef struct _WebKitHitTestResultPrivate WebKitHitTestResultPrivate;
+struct _WebKitHitTestResultClass {
+    GObjectClass parent_class;
+
+    /*< private >*/
+    void (*_webkit_reserved0) (void);
+    void (*_webkit_reserved1) (void);
+    void (*_webkit_reserved2) (void);
+    void (*_webkit_reserved3) (void);
+};
+#endif
+
+WEBKIT_DECLARE_FINAL_TYPE (WebKitHitTestResult, webkit_hit_test_result, WEBKIT, HIT_TEST_RESULT, GObject)
 
 /**
  * WebKitHitTestResultContext:
@@ -60,26 +70,6 @@ typedef enum
     WEBKIT_HIT_TEST_RESULT_CONTEXT_SCROLLBAR = 1 << 6,
     WEBKIT_HIT_TEST_RESULT_CONTEXT_SELECTION = 1 << 7
 } WebKitHitTestResultContext;
-
-struct _WebKitHitTestResult {
-    GObject parent;
-
-    /*< private >*/
-    WebKitHitTestResultPrivate *priv;
-};
-
-struct _WebKitHitTestResultClass {
-    GObjectClass parent_class;
-
-    /*< private >*/
-    void (*_webkit_reserved0) (void);
-    void (*_webkit_reserved1) (void);
-    void (*_webkit_reserved2) (void);
-    void (*_webkit_reserved3) (void);
-};
-
-WEBKIT_API GType
-webkit_hit_test_result_get_type             (void);
 
 WEBKIT_API guint
 webkit_hit_test_result_get_context          (WebKitHitTestResult *hit_test_result);

--- a/Source/WebKit/UIProcess/API/glib/WebKitInputMethodContext.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitInputMethodContext.h.in
@@ -34,14 +34,17 @@
 
 G_BEGIN_DECLS
 
+#define WEBKIT_TYPE_INPUT_METHOD_UNDERLINE          (webkit_input_method_underline_get_type())
 #define WEBKIT_TYPE_INPUT_METHOD_CONTEXT            (webkit_input_method_context_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_INPUT_METHOD_CONTEXT(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_INPUT_METHOD_CONTEXT, WebKitInputMethodContext))
 #define WEBKIT_INPUT_METHOD_CONTEXT_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_INPUT_METHOD_CONTEXT, WebKitInputMethodContextClass))
 #define WEBKIT_IS_INPUT_METHOD_CONTEXT(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_INPUT_METHOD_CONTEXT))
 #define WEBKIT_IS_INPUT_METHOD_CONTEXT_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_INPUT_METHOD_CONTEXT))
 #define WEBKIT_INPUT_METHOD_CONTEXT_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_INPUT_METHOD_CONTEXT, WebKitInputMethodContextClass))
+#endif
 
-#define WEBKIT_TYPE_INPUT_METHOD_UNDERLINE          (webkit_input_method_underline_get_type())
+WEBKIT_DECLARE_DERIVABLE_TYPE (WebKitInputMethodContext, webkit_input_method_context, WEBKIT, INPUT_METHOD_CONTEXT, GObject)
 
 /**
  * WebKitInputPurpose:
@@ -91,17 +94,7 @@ typedef enum {
     WEBKIT_INPUT_HINT_INHIBIT_OSK         = 1 << 5
 } WebKitInputHints;
 
-typedef struct _WebKitInputMethodContext        WebKitInputMethodContext;
-typedef struct _WebKitInputMethodContextClass   WebKitInputMethodContextClass;
-typedef struct _WebKitInputMethodContextPrivate WebKitInputMethodContextPrivate;
 typedef struct _WebKitInputMethodUnderline      WebKitInputMethodUnderline;
-
-struct _WebKitInputMethodContext {
-    GObject parent;
-
-    /*< private >*/
-    WebKitInputMethodContextPrivate *priv;
-};
 
 struct _WebKitInputMethodContextClass {
     GObjectClass parent_class;
@@ -169,9 +162,6 @@ struct _WebKitInputMethodContextClass {
     void (*_webkit_reserved15) (void);
 #endif
 };
-
-WEBKIT_API GType
-webkit_input_method_context_get_type           (void);
 
 WEBKIT_API void
 webkit_input_method_context_set_enable_preedit (WebKitInputMethodContext   *context,

--- a/Source/WebKit/UIProcess/API/glib/WebKitMediaKeySystemPermissionRequest.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitMediaKeySystemPermissionRequest.cpp
@@ -52,8 +52,8 @@ struct _WebKitMediaKeySystemPermissionRequestPrivate {
     CString keySystem;
 };
 
-WEBKIT_DEFINE_FINAL_TYPE_WITH_CODE_IN_2022_API(
-    WebKitMediaKeySystemPermissionRequest, webkit_media_key_system_permission_request, G_TYPE_OBJECT,
+WEBKIT_DEFINE_FINAL_TYPE_WITH_CODE(
+    WebKitMediaKeySystemPermissionRequest, webkit_media_key_system_permission_request, G_TYPE_OBJECT, GObject,
     G_IMPLEMENT_INTERFACE(WEBKIT_TYPE_PERMISSION_REQUEST, webkit_permission_request_interface_init))
 
 static void webkitMediaKeySystemPermissionRequestAllow(WebKitPermissionRequest* request)

--- a/Source/WebKit/UIProcess/API/glib/WebKitMediaKeySystemPermissionRequest.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitMediaKeySystemPermissionRequest.h.in
@@ -28,22 +28,12 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_MEDIA_KEY_SYSTEM_PERMISSION_REQUEST            (webkit_media_key_system_permission_request_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_MEDIA_KEY_SYSTEM_PERMISSION_REQUEST(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_MEDIA_KEY_SYSTEM_PERMISSION_REQUEST, WebKitMediaKeySystemPermissionRequest))
 #define WEBKIT_MEDIA_KEY_SYSTEM_PERMISSION_REQUEST_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_MEDIA_KEY_SYSTEM_PERMISSION_REQUEST, WebKitMediaKeySystemPermissionRequestClass))
 #define WEBKIT_IS_MEDIA_KEY_SYSTEM_PERMISSION_REQUEST(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_MEDIA_KEY_SYSTEM_PERMISSION_REQUEST))
 #define WEBKIT_IS_MEDIA_KEY_SYSTEM_PERMISSION_REQUEST_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_MEDIA_KEY_SYSTEM_PERMISSION_REQUEST))
 #define WEBKIT_MEDIA_KEY_SYSTEM_PERMISSION_REQUEST_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_MEDIA_KEY_SYSTEM_PERMISSION_REQUEST, WebKitMediaKeySystemPermissionRequestClass))
-
-typedef struct _WebKitMediaKeySystemPermissionRequest        WebKitMediaKeySystemPermissionRequest;
-typedef struct _WebKitMediaKeySystemPermissionRequestClass   WebKitMediaKeySystemPermissionRequestClass;
-typedef struct _WebKitMediaKeySystemPermissionRequestPrivate WebKitMediaKeySystemPermissionRequestPrivate;
-
-struct _WebKitMediaKeySystemPermissionRequest {
-    GObject parent;
-
-    /*< private >*/
-    WebKitMediaKeySystemPermissionRequestPrivate *priv;
-};
 
 struct _WebKitMediaKeySystemPermissionRequestClass {
     GObjectClass parent_class;
@@ -54,9 +44,9 @@ struct _WebKitMediaKeySystemPermissionRequestClass {
     void (*_webkit_reserved2) (void);
     void (*_webkit_reserved3) (void);
 };
+#endif
 
-WEBKIT_API GType
-webkit_media_key_system_permission_request_get_type (void);
+WEBKIT_DECLARE_FINAL_TYPE (WebKitMediaKeySystemPermissionRequest, webkit_media_key_system_permission_request, WEBKIT, MEDIA_KEY_SYSTEM_PERMISSION_REQUEST, GObject)
 
 WEBKIT_API const gchar *
 webkit_media_key_system_permission_get_name (WebKitMediaKeySystemPermissionRequest *request);

--- a/Source/WebKit/UIProcess/API/glib/WebKitNavigationPolicyDecision.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNavigationPolicyDecision.cpp
@@ -52,7 +52,7 @@ struct _WebKitNavigationPolicyDecisionPrivate {
     WebKitNavigationAction* navigationAction;
 };
 
-WEBKIT_DEFINE_FINAL_TYPE_IN_2022_API(WebKitNavigationPolicyDecision, webkit_navigation_policy_decision, WEBKIT_TYPE_POLICY_DECISION)
+WEBKIT_DEFINE_FINAL_TYPE(WebKitNavigationPolicyDecision, webkit_navigation_policy_decision, WEBKIT_TYPE_POLICY_DECISION, WebKitPolicyDecision)
 
 enum {
     PROP_0,

--- a/Source/WebKit/UIProcess/API/glib/WebKitNavigationPolicyDecision.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNavigationPolicyDecision.h.in
@@ -31,22 +31,12 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_NAVIGATION_POLICY_DECISION            (webkit_navigation_policy_decision_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_NAVIGATION_POLICY_DECISION(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_NAVIGATION_POLICY_DECISION, WebKitNavigationPolicyDecision))
 #define WEBKIT_NAVIGATION_POLICY_DECISION_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_NAVIGATION_POLICY_DECISION, WebKitNavigationPolicyDecisionClass))
 #define WEBKIT_IS_NAVIGATION_POLICY_DECISION(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_NAVIGATION_POLICY_DECISION))
 #define WEBKIT_IS_NAVIGATION_POLICY_DECISION_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_NAVIGATION_POLICY_DECISION))
 #define WEBKIT_NAVIGATION_POLICY_DECISION_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_NAVIGATION_POLICY_DECISION, WebKitNavigationPolicyDecisionClass))
-
-typedef struct _WebKitNavigationPolicyDecision        WebKitNavigationPolicyDecision;
-typedef struct _WebKitNavigationPolicyDecisionClass   WebKitNavigationPolicyDecisionClass;
-typedef struct _WebKitNavigationPolicyDecisionPrivate WebKitNavigationPolicyDecisionPrivate;
-
-struct _WebKitNavigationPolicyDecision {
-    WebKitPolicyDecision parent;
-
-    /*< private >*/
-    WebKitNavigationPolicyDecisionPrivate *priv;
-};
 
 struct _WebKitNavigationPolicyDecisionClass {
     WebKitPolicyDecisionClass parent_class;
@@ -57,9 +47,9 @@ struct _WebKitNavigationPolicyDecisionClass {
     void (*_webkit_reserved2) (void);
     void (*_webkit_reserved3) (void);
 };
+#endif
 
-WEBKIT_API GType
-webkit_navigation_policy_decision_get_type            (void);
+WEBKIT_DECLARE_FINAL_TYPE (WebKitNavigationPolicyDecision, webkit_navigation_policy_decision, WEBKIT, NAVIGATION_POLICY_DECISION, WebKitPolicyDecision)
 
 WEBKIT_API WebKitNavigationAction *
 webkit_navigation_policy_decision_get_navigation_action (WebKitNavigationPolicyDecision *decision);

--- a/Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.cpp
@@ -95,7 +95,7 @@ struct _WebKitNetworkSessionPrivate {
     PAL::HysteresisActivity dnsPrefetchHystereris;
 };
 
-WEBKIT_DEFINE_FINAL_TYPE(WebKitNetworkSession, webkit_network_session, G_TYPE_OBJECT)
+WEBKIT_DEFINE_FINAL_TYPE(WebKitNetworkSession, webkit_network_session, G_TYPE_OBJECT, GObject)
 
 static void webkitNetworkSessionGetProperty(GObject* object, guint propID, GValue* value, GParamSpec* paramSpec)
 {

--- a/Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.h.in
@@ -33,22 +33,12 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_NETWORK_SESSION            (webkit_network_session_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_NETWORK_SESSION(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_NETWORK_SESSION, WebKitNetworkSession))
 #define WEBKIT_IS_NETWORK_SESSION(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_NETWORK_SESSION))
 #define WEBKIT_NETWORK_SESSION_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_NETWORK_SESSION, WebKitNetworkSessionClass))
 #define WEBKIT_IS_NETWORK_SESSION_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_NETWORK_SESSION))
 #define WEBKIT_NETWORK_SESSION_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_NETWORK_SESSION, WebKitNetworkSessionClass))
-
-typedef struct _WebKitNetworkSession        WebKitNetworkSession;
-typedef struct _WebKitNetworkSessionClass   WebKitNetworkSessionClass;
-typedef struct _WebKitNetworkSessionPrivate WebKitNetworkSessionPrivate;
-
-struct _WebKitNetworkSession {
-    GObject parent;
-
-    /*< private >*/
-    WebKitNetworkSessionPrivate *priv;
-};
 
 struct _WebKitNetworkSessionClass {
     GObjectClass parent_class;
@@ -59,9 +49,9 @@ struct _WebKitNetworkSessionClass {
     void (*_webkit_reserved2) (void);
     void (*_webkit_reserved3) (void);
 };
+#endif
 
-WEBKIT_API GType
-webkit_network_session_get_type                                  (void);
+WEBKIT_DECLARE_FINAL_TYPE (WebKitNetworkSession, webkit_network_session, WEBKIT, NETWORK_SESSION, GObject)
 
 WEBKIT_API WebKitNetworkSession *
 webkit_network_session_get_default                               (void);

--- a/Source/WebKit/UIProcess/API/glib/WebKitNotification.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNotification.cpp
@@ -60,7 +60,7 @@ struct _WebKitNotificationPrivate {
 
 static guint signals[LAST_SIGNAL] = { 0, };
 
-WEBKIT_DEFINE_FINAL_TYPE_IN_2022_API(WebKitNotification, webkit_notification, G_TYPE_OBJECT)
+WEBKIT_DEFINE_FINAL_TYPE(WebKitNotification, webkit_notification, G_TYPE_OBJECT, GObject)
 
 static void webkitNotificationGetProperty(GObject* object, guint propId, GValue* value, GParamSpec* paramSpec)
 {

--- a/Source/WebKit/UIProcess/API/glib/WebKitNotification.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNotification.h.in
@@ -28,22 +28,12 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_NOTIFICATION            (webkit_notification_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_NOTIFICATION(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_NOTIFICATION, WebKitNotification))
 #define WEBKIT_IS_NOTIFICATION(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_NOTIFICATION))
 #define WEBKIT_NOTIFICATION_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_NOTIFICATION, WebKitNotificationClass))
 #define WEBKIT_IS_NOTIFICATION_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_NOTIFICATION))
 #define WEBKIT_NOTIFICATION_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_NOTIFICATION, WebKitNotificationClass))
-
-typedef struct _WebKitNotification        WebKitNotification;
-typedef struct _WebKitNotificationClass   WebKitNotificationClass;
-typedef struct _WebKitNotificationPrivate WebKitNotificationPrivate;
-
-struct _WebKitNotification {
-    GObject parent;
-
-    /*< private >*/
-    WebKitNotificationPrivate *priv;
-};
 
 struct _WebKitNotificationClass {
     GObjectClass parent_class;
@@ -56,9 +46,9 @@ struct _WebKitNotificationClass {
     void (*_webkit_reserved4) (void);
     void (*_webkit_reserved5) (void);
 };
+#endif
 
-WEBKIT_API GType
-webkit_notification_get_type                 (void);
+WEBKIT_DECLARE_FINAL_TYPE (WebKitNotification, webkit_notification, WEBKIT, NOTIFICATION, GObject)
 
 WEBKIT_API guint64
 webkit_notification_get_id                   (WebKitNotification *notification);

--- a/Source/WebKit/UIProcess/API/glib/WebKitNotificationPermissionRequest.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNotificationPermissionRequest.cpp
@@ -50,8 +50,8 @@ struct _WebKitNotificationPermissionRequestPrivate {
     bool madeDecision;
 };
 
-WEBKIT_DEFINE_FINAL_TYPE_WITH_CODE_IN_2022_API(
-    WebKitNotificationPermissionRequest, webkit_notification_permission_request, G_TYPE_OBJECT,
+WEBKIT_DEFINE_FINAL_TYPE_WITH_CODE(
+    WebKitNotificationPermissionRequest, webkit_notification_permission_request, G_TYPE_OBJECT, GObject,
     G_IMPLEMENT_INTERFACE(WEBKIT_TYPE_PERMISSION_REQUEST, webkit_permission_request_interface_init))
 
 static void webkitNotificationPermissionRequestAllow(WebKitPermissionRequest* request)

--- a/Source/WebKit/UIProcess/API/glib/WebKitNotificationPermissionRequest.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNotificationPermissionRequest.h.in
@@ -28,29 +28,19 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_NOTIFICATION_PERMISSION_REQUEST            (webkit_notification_permission_request_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_NOTIFICATION_PERMISSION_REQUEST(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_NOTIFICATION_PERMISSION_REQUEST, WebKitNotificationPermissionRequest))
 #define WEBKIT_NOTIFICATION_PERMISSION_REQUEST_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_NOTIFICATION_PERMISSION_REQUEST, WebKitNotificationPermissionRequestClass))
 #define WEBKIT_IS_NOTIFICATION_PERMISSION_REQUEST(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_NOTIFICATION_PERMISSION_REQUEST))
 #define WEBKIT_IS_NOTIFICATION_PERMISSION_REQUEST_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_NOTIFICATION_PERMISSION_REQUEST))
 #define WEBKIT_NOTIFICATION_PERMISSION_REQUEST_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_NOTIFICATION_PERMISSION_REQUEST, WebKitNotificationPermissionRequestClass))
 
-typedef struct _WebKitNotificationPermissionRequest        WebKitNotificationPermissionRequest;
-typedef struct _WebKitNotificationPermissionRequestClass   WebKitNotificationPermissionRequestClass;
-typedef struct _WebKitNotificationPermissionRequestPrivate WebKitNotificationPermissionRequestPrivate;
-
-struct _WebKitNotificationPermissionRequest {
-    GObject parent;
-
-    /*< private >*/
-    WebKitNotificationPermissionRequestPrivate *priv;
-};
-
 struct _WebKitNotificationPermissionRequestClass {
     GObjectClass parent_class;
 };
+#endif
 
-WEBKIT_API GType
-webkit_notification_permission_request_get_type (void);
+WEBKIT_DECLARE_FINAL_TYPE (WebKitNotificationPermissionRequest, webkit_notification_permission_request, WEBKIT, NOTIFICATION_PERMISSION_REQUEST, GObject)
 
 G_END_DECLS
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitOptionMenu.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitOptionMenu.cpp
@@ -58,7 +58,7 @@ enum {
 
 static guint signals[LAST_SIGNAL] = { 0, };
 
-WEBKIT_DEFINE_FINAL_TYPE_IN_2022_API(WebKitOptionMenu, webkit_option_menu, G_TYPE_OBJECT)
+WEBKIT_DEFINE_FINAL_TYPE(WebKitOptionMenu, webkit_option_menu, G_TYPE_OBJECT, GObject)
 
 static void webkit_option_menu_class_init(WebKitOptionMenuClass* optionMenuClass)
 {

--- a/Source/WebKit/UIProcess/API/glib/WebKitOptionMenu.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitOptionMenu.h.in
@@ -32,22 +32,12 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_OPTION_MENU            (webkit_option_menu_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_OPTION_MENU(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_OPTION_MENU, WebKitOptionMenu))
 #define WEBKIT_IS_OPTION_MENU(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_OPTION_MENU))
 #define WEBKIT_OPTION_MENU_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_OPTION_MENU, WebKitOptionMenuClass))
 #define WEBKIT_IS_OPTION_MENU_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_OPTION_MENU))
 #define WEBKIT_OPTION_MENU_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_OPTION_MENU, WebKitOptionMenuClass))
-
-typedef struct _WebKitOptionMenu        WebKitOptionMenu;
-typedef struct _WebKitOptionMenuClass   WebKitOptionMenuClass;
-typedef struct _WebKitOptionMenuPrivate WebKitOptionMenuPrivate;
-
-struct _WebKitOptionMenu {
-    GObject parent;
-
-    /*< private >*/
-    WebKitOptionMenuPrivate *priv;
-};
 
 struct _WebKitOptionMenuClass {
     GObjectClass parent_class;
@@ -58,9 +48,9 @@ struct _WebKitOptionMenuClass {
     void (*_webkit_reserved2) (void);
     void (*_webkit_reserved3) (void);
 };
+#endif
 
-WEBKIT_API GType
-webkit_option_menu_get_type       (void);
+WEBKIT_DECLARE_FINAL_TYPE (WebKitOptionMenu, webkit_option_menu, WEBKIT, OPTION_MENU, GObject)
 
 WEBKIT_API guint
 webkit_option_menu_get_n_items    (WebKitOptionMenu *menu);

--- a/Source/WebKit/UIProcess/API/glib/WebKitPointerLockPermissionRequest.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitPointerLockPermissionRequest.cpp
@@ -48,8 +48,8 @@ struct _WebKitPointerLockPermissionRequestPrivate {
     bool madeDecision;
 };
 
-WEBKIT_DEFINE_FINAL_TYPE_WITH_CODE_IN_2022_API(
-    WebKitPointerLockPermissionRequest, webkit_pointer_lock_permission_request, G_TYPE_OBJECT,
+WEBKIT_DEFINE_FINAL_TYPE_WITH_CODE(
+    WebKitPointerLockPermissionRequest, webkit_pointer_lock_permission_request, G_TYPE_OBJECT, GObject,
     G_IMPLEMENT_INTERFACE(WEBKIT_TYPE_PERMISSION_REQUEST, webkit_permission_request_interface_init))
 
 static void webkitPointerLockPermissionRequestAllow(WebKitPermissionRequest* request)

--- a/Source/WebKit/UIProcess/API/glib/WebKitPolicyDecision.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitPolicyDecision.h.in
@@ -29,22 +29,15 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_POLICY_DECISION            (webkit_policy_decision_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_POLICY_DECISION(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_POLICY_DECISION, WebKitPolicyDecision))
 #define WEBKIT_POLICY_DECISION_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_POLICY_DECISION, WebKitPolicyDecisionClass))
 #define WEBKIT_IS_POLICY_DECISION(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_POLICY_DECISION))
 #define WEBKIT_IS_POLICY_DECISION_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_POLICY_DECISION))
 #define WEBKIT_POLICY_DECISION_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_POLICY_DECISION, WebKitPolicyDecisionClass))
+#endif
 
-typedef struct _WebKitPolicyDecision        WebKitPolicyDecision;
-typedef struct _WebKitPolicyDecisionClass   WebKitPolicyDecisionClass;
-typedef struct _WebKitPolicyDecisionPrivate WebKitPolicyDecisionPrivate;
-
-struct _WebKitPolicyDecision {
-    GObject parent;
-
-    /*< private >*/
-    WebKitPolicyDecisionPrivate *priv;
-};
+WEBKIT_DECLARE_DERIVABLE_TYPE (WebKitPolicyDecision, webkit_policy_decision, WEBKIT, POLICY_DECISION, GObject)
 
 struct _WebKitPolicyDecisionClass {
     GObjectClass parent_class;
@@ -55,9 +48,6 @@ struct _WebKitPolicyDecisionClass {
     void (*_webkit_reserved2) (void);
     void (*_webkit_reserved3) (void);
 };
-
-WEBKIT_API GType
-webkit_policy_decision_get_type (void);
 
 WEBKIT_API void
 webkit_policy_decision_use      (WebKitPolicyDecision *decision);

--- a/Source/WebKit/UIProcess/API/glib/WebKitResponsePolicyDecision.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitResponsePolicyDecision.cpp
@@ -51,7 +51,7 @@ struct _WebKitResponsePolicyDecisionPrivate {
     GRefPtr<WebKitURIResponse> response;
 };
 
-WEBKIT_DEFINE_FINAL_TYPE_IN_2022_API(WebKitResponsePolicyDecision, webkit_response_policy_decision, WEBKIT_TYPE_POLICY_DECISION)
+WEBKIT_DEFINE_FINAL_TYPE(WebKitResponsePolicyDecision, webkit_response_policy_decision, WEBKIT_TYPE_POLICY_DECISION, WebKitPolicyDecision)
 
 enum {
     PROP_0,

--- a/Source/WebKit/UIProcess/API/glib/WebKitResponsePolicyDecision.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitResponsePolicyDecision.h.in
@@ -31,22 +31,12 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_RESPONSE_POLICY_DECISION            (webkit_response_policy_decision_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_RESPONSE_POLICY_DECISION(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_RESPONSE_POLICY_DECISION, WebKitResponsePolicyDecision))
 #define WEBKIT_RESPONSE_POLICY_DECISION_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_RESPONSE_POLICY_DECISION, WebKitResponsePolicyDecisionClass))
 #define WEBKIT_IS_RESPONSE_POLICY_DECISION(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_RESPONSE_POLICY_DECISION))
 #define WEBKIT_IS_RESPONSE_POLICY_DECISION_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_RESPONSE_POLICY_DECISION))
 #define WEBKIT_RESPONSE_POLICY_DECISION_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_RESPONSE_POLICY_DECISION, WebKitResponsePolicyDecisionClass))
-
-typedef struct _WebKitResponsePolicyDecision        WebKitResponsePolicyDecision;
-typedef struct _WebKitResponsePolicyDecisionClass   WebKitResponsePolicyDecisionClass;
-typedef struct _WebKitResponsePolicyDecisionPrivate WebKitResponsePolicyDecisionPrivate;
-
-struct _WebKitResponsePolicyDecision {
-    WebKitPolicyDecision parent;
-
-    /*< private >*/
-    WebKitResponsePolicyDecisionPrivate *priv;
-};
 
 struct _WebKitResponsePolicyDecisionClass {
     WebKitPolicyDecisionClass parent_class;
@@ -57,9 +47,9 @@ struct _WebKitResponsePolicyDecisionClass {
     void (*_webkit_reserved2) (void);
     void (*_webkit_reserved3) (void);
 };
+#endif
 
-WEBKIT_API GType
-webkit_response_policy_decision_get_type                    (void);
+WEBKIT_DECLARE_FINAL_TYPE (WebKitResponsePolicyDecision, webkit_response_policy_decision, WEBKIT, RESPONSE_POLICY_DECISION, WebKitPolicyDecision)
 
 WEBKIT_API WebKitURIRequest *
 webkit_response_policy_decision_get_request                 (WebKitResponsePolicyDecision *decision);

--- a/Source/WebKit/UIProcess/API/glib/WebKitSecurityManager.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSecurityManager.cpp
@@ -54,7 +54,7 @@ struct _WebKitSecurityManagerPrivate {
     WebKitWebContext* webContext;
 };
 
-WEBKIT_DEFINE_FINAL_TYPE_IN_2022_API(WebKitSecurityManager, webkit_security_manager, G_TYPE_OBJECT)
+WEBKIT_DEFINE_FINAL_TYPE(WebKitSecurityManager, webkit_security_manager, G_TYPE_OBJECT, GObject)
 
 static void webkit_security_manager_class_init(WebKitSecurityManagerClass*)
 {

--- a/Source/WebKit/UIProcess/API/glib/WebKitSecurityManager.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSecurityManager.h.in
@@ -28,22 +28,12 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_SECURITY_MANAGER            (webkit_security_manager_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_SECURITY_MANAGER(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_SECURITY_MANAGER, WebKitSecurityManager))
 #define WEBKIT_IS_SECURITY_MANAGER(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_SECURITY_MANAGER))
 #define WEBKIT_SECURITY_MANAGER_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_SECURITY_MANAGER, WebKitSecurityManagerClass))
 #define WEBKIT_IS_SECURITY_MANAGER_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_SECURITY_MANAGER))
 #define WEBKIT_SECURITY_MANAGER_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_SECURITY_MANAGER, WebKitSecurityManagerClass))
-
-typedef struct _WebKitSecurityManager        WebKitSecurityManager;
-typedef struct _WebKitSecurityManagerClass   WebKitSecurityManagerClass;
-typedef struct _WebKitSecurityManagerPrivate WebKitSecurityManagerPrivate;
-
-struct _WebKitSecurityManager {
-    GObject parent;
-
-    /*< private >*/
-    WebKitSecurityManagerPrivate *priv;
-};
 
 struct _WebKitSecurityManagerClass {
     GObjectClass parent_class;
@@ -54,9 +44,9 @@ struct _WebKitSecurityManagerClass {
     void (*_webkit_reserved2) (void);
     void (*_webkit_reserved3) (void);
 };
+#endif
 
-WEBKIT_API GType
-webkit_security_manager_get_type                                (void);
+WEBKIT_DECLARE_FINAL_TYPE (WebKitSecurityManager, webkit_security_manager, WEBKIT, SECURITY_MANAGER, GObject)
 
 WEBKIT_API void
 webkit_security_manager_register_uri_scheme_as_local            (WebKitSecurityManager *security_manager,

--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
@@ -104,7 +104,7 @@ struct _WebKitSettingsPrivate {
  * ```
  */
 
-WEBKIT_DEFINE_FINAL_TYPE_IN_2022_API(WebKitSettings, webkit_settings, G_TYPE_OBJECT)
+WEBKIT_DEFINE_FINAL_TYPE(WebKitSettings, webkit_settings, G_TYPE_OBJECT, GObject)
 
 enum {
     PROP_0,

--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.h.in
@@ -39,11 +39,25 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_SETTINGS            (webkit_settings_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_SETTINGS(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_SETTINGS, WebKitSettings))
 #define WEBKIT_SETTINGS_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_SETTINGS, WebKitSettingsClass))
 #define WEBKIT_IS_SETTINGS(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_SETTINGS))
 #define WEBKIT_IS_SETTINGS_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_SETTINGS))
 #define WEBKIT_SETTINGS_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_SETTINGS, WebKitSettingsClass))
+
+struct _WebKitSettingsClass {
+    GObjectClass parent_class;
+
+    /*< private >*/
+    void (*_webkit_reserved0) (void);
+    void (*_webkit_reserved1) (void);
+    void (*_webkit_reserved2) (void);
+    void (*_webkit_reserved3) (void);
+};
+#endif
+
+WEBKIT_DECLARE_FINAL_TYPE (WebKitSettings, webkit_settings, WEBKIT, SETTINGS, GObject)
 
 #if PLATFORM(GTK)
 #if USE(GTK4)
@@ -76,30 +90,6 @@ typedef enum {
     WEBKIT_HARDWARE_ACCELERATION_POLICY_NEVER
 } WebKitHardwareAccelerationPolicy;
 #endif
-
-typedef struct _WebKitSettings WebKitSettings;
-typedef struct _WebKitSettingsClass WebKitSettingsClass;
-typedef struct _WebKitSettingsPrivate WebKitSettingsPrivate;
-
-struct _WebKitSettings {
-    GObject parent_instance;
-
-    /*< private >*/
-    WebKitSettingsPrivate *priv;
-};
-
-struct _WebKitSettingsClass {
-    GObjectClass parent_class;
-
-    /*< private >*/
-    void (*_webkit_reserved0) (void);
-    void (*_webkit_reserved1) (void);
-    void (*_webkit_reserved2) (void);
-    void (*_webkit_reserved3) (void);
-};
-
-WEBKIT_API GType
-webkit_settings_get_type(void);
 
 WEBKIT_API WebKitSettings *
 webkit_settings_new                                            (void);

--- a/Source/WebKit/UIProcess/API/glib/WebKitURIRequest.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitURIRequest.h.in
@@ -29,22 +29,12 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_URI_REQUEST            (webkit_uri_request_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_URI_REQUEST(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_URI_REQUEST, WebKitURIRequest))
 #define WEBKIT_IS_URI_REQUEST(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_URI_REQUEST))
 #define WEBKIT_URI_REQUEST_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_URI_REQUEST, WebKitURIRequestClass))
 #define WEBKIT_IS_URI_REQUEST_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_URI_REQUEST))
 #define WEBKIT_URI_REQUEST_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_URI_REQUEST, WebKitURIRequestClass))
-
-typedef struct _WebKitURIRequest WebKitURIRequest;
-typedef struct _WebKitURIRequestClass WebKitURIRequestClass;
-typedef struct _WebKitURIRequestPrivate WebKitURIRequestPrivate;
-
-struct _WebKitURIRequest {
-    GObject parent;
-
-    /*< private >*/
-    WebKitURIRequestPrivate *priv;
-};
 
 struct _WebKitURIRequestClass {
     GObjectClass parent_class;
@@ -55,9 +45,9 @@ struct _WebKitURIRequestClass {
     void (*_webkit_reserved2) (void);
     void (*_webkit_reserved3) (void);
 };
+#endif
 
-WEBKIT_API GType
-webkit_uri_request_get_type         (void);
+WEBKIT_DECLARE_FINAL_TYPE (WebKitURIRequest, webkit_uri_request, WEBKIT, URI_REQUEST, GObject)
 
 WEBKIT_API WebKitURIRequest *
 webkit_uri_request_new              (const gchar      *uri);

--- a/Source/WebKit/UIProcess/API/glib/WebKitURIResponse.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitURIResponse.h.in
@@ -29,22 +29,12 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_URI_RESPONSE            (webkit_uri_response_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_URI_RESPONSE(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_URI_RESPONSE, WebKitURIResponse))
 #define WEBKIT_IS_URI_RESPONSE(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_URI_RESPONSE))
 #define WEBKIT_URI_RESPONSE_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_URI_RESPONSE, WebKitURIResponseClass))
 #define WEBKIT_IS_URI_RESPONSE_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_URI_RESPONSE))
 #define WEBKIT_URI_RESPONSE_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_URI_RESPONSE, WebKitURIResponseClass))
-
-typedef struct _WebKitURIResponse WebKitURIResponse;
-typedef struct _WebKitURIResponseClass WebKitURIResponseClass;
-typedef struct _WebKitURIResponsePrivate WebKitURIResponsePrivate;
-
-struct _WebKitURIResponse {
-    GObject parent;
-
-    /*< private >*/
-    WebKitURIResponsePrivate *priv;
-};
 
 struct _WebKitURIResponseClass {
     GObjectClass parent_class;
@@ -55,9 +45,9 @@ struct _WebKitURIResponseClass {
     void (*_webkit_reserved2) (void);
     void (*_webkit_reserved3) (void);
 };
+#endif
 
-WEBKIT_API GType
-webkit_uri_response_get_type               (void);
+WEBKIT_DECLARE_FINAL_TYPE (WebKitURIResponse, webkit_uri_response, WEBKIT, URI_RESPONSE, GObject)
 
 WEBKIT_API const gchar *
 webkit_uri_response_get_uri                (WebKitURIResponse    *response);

--- a/Source/WebKit/UIProcess/API/glib/WebKitURISchemeRequest.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitURISchemeRequest.cpp
@@ -73,7 +73,7 @@ struct _WebKitURISchemeRequestPrivate {
     GUniquePtr<SoupMessageHeaders> headers;
 };
 
-WEBKIT_DEFINE_TYPE(WebKitURISchemeRequest, webkit_uri_scheme_request, G_TYPE_OBJECT)
+WEBKIT_DEFINE_FINAL_TYPE(WebKitURISchemeRequest, webkit_uri_scheme_request, G_TYPE_OBJECT, GObject)
 
 static void webkit_uri_scheme_request_class_init(WebKitURISchemeRequestClass*)
 {

--- a/Source/WebKit/UIProcess/API/glib/WebKitURISchemeRequest.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitURISchemeRequest.h.in
@@ -30,24 +30,12 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_URI_SCHEME_REQUEST            (webkit_uri_scheme_request_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_URI_SCHEME_REQUEST(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_URI_SCHEME_REQUEST, WebKitURISchemeRequest))
 #define WEBKIT_IS_URI_SCHEME_REQUEST(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_URI_SCHEME_REQUEST))
 #define WEBKIT_URI_SCHEME_REQUEST_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_URI_SCHEME_REQUEST, WebKitURISchemeRequestClass))
 #define WEBKIT_IS_URI_SCHEME_REQUEST_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_URI_SCHEME_REQUEST))
 #define WEBKIT_URI_SCHEME_REQUEST_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_URI_SCHEME_REQUEST, WebKitURISchemeRequestClass))
-
-typedef struct _WebKitURISchemeRequest        WebKitURISchemeRequest;
-typedef struct _WebKitURISchemeRequestClass   WebKitURISchemeRequestClass;
-typedef struct _WebKitURISchemeRequestPrivate WebKitURISchemeRequestPrivate;
-
-typedef struct _WebKitWebView WebKitWebView;
-
-struct _WebKitURISchemeRequest {
-    GObject parent;
-
-    /*< private >*/
-    WebKitURISchemeRequestPrivate *priv;
-};
 
 struct _WebKitURISchemeRequestClass {
     GObjectClass parent_class;
@@ -58,9 +46,11 @@ struct _WebKitURISchemeRequestClass {
     void (*_webkit_reserved2) (void);
     void (*_webkit_reserved3) (void);
 };
+#endif
 
-WEBKIT_API GType
-webkit_uri_scheme_request_get_type     (void);
+WEBKIT_DECLARE_FINAL_TYPE (WebKitURISchemeRequest, webkit_uri_scheme_request, WEBKIT, URI_SCHEME_REQUEST, GObject)
+
+typedef struct _WebKitWebView WebKitWebView;
 
 WEBKIT_API const gchar *
 webkit_uri_scheme_request_get_scheme   (WebKitURISchemeRequest *request);

--- a/Source/WebKit/UIProcess/API/glib/WebKitURISchemeResponse.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitURISchemeResponse.cpp
@@ -65,7 +65,7 @@ struct _WebKitURISchemeResponsePrivate {
     GUniquePtr<SoupMessageHeaders> headers;
 };
 
-WEBKIT_DEFINE_TYPE(WebKitURISchemeResponse, webkit_uri_scheme_response, G_TYPE_OBJECT)
+WEBKIT_DEFINE_FINAL_TYPE(WebKitURISchemeResponse, webkit_uri_scheme_response, G_TYPE_OBJECT, GObject)
 
 static void webkitURISchemeResponseSetProperty(GObject* object, guint propId, const GValue* value, GParamSpec* paramSpec)
 {

--- a/Source/WebKit/UIProcess/API/glib/WebKitURISchemeResponse.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitURISchemeResponse.h.in
@@ -29,22 +29,12 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_URI_SCHEME_RESPONSE            (webkit_uri_scheme_response_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_URI_SCHEME_RESPONSE(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_URI_SCHEME_RESPONSE, WebKitURISchemeResponse))
 #define WEBKIT_IS_URI_SCHEME_RESPONSE(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_URI_SCHEME_RESPONSE))
 #define WEBKIT_URI_SCHEME_RESPONSE_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_URI_SCHEME_RESPONSE, WebKitURISchemeResponseClass))
 #define WEBKIT_IS_URI_SCHEME_RESPONSE_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_URI_SCHEME_RESPONSE))
 #define WEBKIT_URI_SCHEME_RESPONSE_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_URI_SCHEME_RESPONSE, WebKitURISchemeResponseClass))
-
-typedef struct _WebKitURISchemeResponse        WebKitURISchemeResponse;
-typedef struct _WebKitURISchemeResponseClass   WebKitURISchemeResponseClass;
-typedef struct _WebKitURISchemeResponsePrivate WebKitURISchemeResponsePrivate;
-
-struct _WebKitURISchemeResponse {
-    GObject parent;
-
-    /*< private >*/
-    WebKitURISchemeResponsePrivate *priv;
-};
 
 struct _WebKitURISchemeResponseClass {
     GObjectClass parent_class;
@@ -55,9 +45,9 @@ struct _WebKitURISchemeResponseClass {
     void (*_webkit_reserved2) (void);
     void (*_webkit_reserved3) (void);
 };
+#endif
 
-WEBKIT_API GType
-webkit_uri_scheme_response_get_type           (void);
+WEBKIT_DECLARE_FINAL_TYPE (WebKitURISchemeResponse, webkit_uri_scheme_response, WEBKIT, URI_SCHEME_RESPONSE, GObject)
 
 WEBKIT_API WebKitURISchemeResponse *
 webkit_uri_scheme_response_new                (GInputStream            *input_stream,

--- a/Source/WebKit/UIProcess/API/glib/WebKitUserContentFilterStore.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitUserContentFilterStore.cpp
@@ -85,7 +85,7 @@ struct _WebKitUserContentFilterStorePrivate {
 #endif
 };
 
-WEBKIT_DEFINE_FINAL_TYPE_IN_2022_API(WebKitUserContentFilterStore, webkit_user_content_filter_store, G_TYPE_OBJECT)
+WEBKIT_DEFINE_FINAL_TYPE(WebKitUserContentFilterStore, webkit_user_content_filter_store, G_TYPE_OBJECT, GObject)
 
 static void webkitUserContentFilterStoreGetProperty(GObject* object, guint propID, GValue* value, GParamSpec* paramSpec)
 {

--- a/Source/WebKit/UIProcess/API/glib/WebKitUserContentFilterStore.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitUserContentFilterStore.h.in
@@ -34,24 +34,12 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_USER_CONTENT_FILTER_STORE            (webkit_user_content_filter_store_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_USER_CONTENT_FILTER_STORE(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_USER_CONTENT_FILTER_STORE, WebKitUserContentFilterStore))
 #define WEBKIT_IS_USER_CONTENT_FILTER_STORE(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_USER_CONTENT_FILTER_STORE))
 #define WEBKIT_USER_CONTENT_FILTER_STORE_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_USER_CONTENT_FILTER_STORE, WebKitUserContentFilterStoreClass))
 #define WEBKIT_IS_USER_CONTENT_FILTER_STORE_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_USER_CONTENT_FILTER_STORE))
 #define WEBKIT_USER_CONTENT_FILTER_STORE_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_USER_CONTENT_FILTER_STORE, WebKitUserContentFilterStoreClass))
-
-typedef struct _WebKitUserContentFilterStore        WebKitUserContentFilterStore;
-typedef struct _WebKitUserContentFilterStoreClass   WebKitUserContentFilterStoreClass;
-typedef struct _WebKitUserContentFilterStorePrivate WebKitUserContentFilterStorePrivate;
-
-typedef struct _WebKitUserContentFilter             WebKitUserContentFilter;
-
-struct _WebKitUserContentFilterStore {
-    GObject parent;
-
-    /*< private >*/
-    WebKitUserContentFilterStorePrivate *priv;
-};
 
 struct _WebKitUserContentFilterStoreClass {
     GObjectClass parent_class;
@@ -62,10 +50,11 @@ struct _WebKitUserContentFilterStoreClass {
     void (*_webkit_reserved2) (void);
     void (*_webkit_reserved3) (void);
 };
+#endif
 
+WEBKIT_DECLARE_FINAL_TYPE (WebKitUserContentFilterStore, webkit_user_content_filter_store, WEBKIT, USER_CONTENT_FILTER_STORE, GObject)
 
-WEBKIT_API GType
-webkit_user_content_filter_store_get_type                 (void);
+typedef struct _WebKitUserContentFilter WebKitUserContentFilter;
 
 WEBKIT_API WebKitUserContentFilterStore *
 webkit_user_content_filter_store_new                      (const gchar                  *storage_path);

--- a/Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.cpp
@@ -68,7 +68,7 @@ struct _WebKitUserContentManagerPrivate {
  * Since: 2.6
  */
 
-WEBKIT_DEFINE_FINAL_TYPE_IN_2022_API(WebKitUserContentManager, webkit_user_content_manager, G_TYPE_OBJECT)
+WEBKIT_DEFINE_FINAL_TYPE(WebKitUserContentManager, webkit_user_content_manager, G_TYPE_OBJECT, GObject)
 
 enum {
     SCRIPT_MESSAGE_RECEIVED,

--- a/Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.h.in
@@ -30,23 +30,12 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_USER_CONTENT_MANAGER            (webkit_user_content_manager_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_USER_CONTENT_MANAGER(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_USER_CONTENT_MANAGER, WebKitUserContentManager))
 #define WEBKIT_IS_USER_CONTENT_MANAGER(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_USER_CONTENT_MANAGER))
 #define WEBKIT_USER_CONTENT_MANAGER_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_USER_CONTENT_MANAGER, WebKitUserContentManagerClass))
 #define WEBKIT_IS_USER_CONTENT_MANAGER_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_USER_CONTENT_MANAGER))
 #define WEBKIT_USER_CONTENT_MANAGER_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_USER_CONTENT_MANAGER, WebKitUserContentManagerClass))
-
-typedef struct _WebKitUserContentManager        WebKitUserContentManager;
-typedef struct _WebKitUserContentManagerClass   WebKitUserContentManagerClass;
-typedef struct _WebKitUserContentManagerPrivate WebKitUserContentManagerPrivate;
-
-
-struct _WebKitUserContentManager {
-    GObject parent;
-
-    /*< private >*/
-    WebKitUserContentManagerPrivate *priv;
-};
 
 struct _WebKitUserContentManagerClass {
     GObjectClass parent_class;
@@ -57,9 +46,9 @@ struct _WebKitUserContentManagerClass {
     void (*_webkit_reserved2) (void);
     void (*_webkit_reserved3) (void);
 };
+#endif
 
-WEBKIT_API GType
-webkit_user_content_manager_get_type                                   (void);
+WEBKIT_DECLARE_FINAL_TYPE (WebKitUserContentManager, webkit_user_content_manager, WEBKIT, USER_CONTENT_MANAGER, GObject)
 
 WEBKIT_API WebKitUserContentManager *
 webkit_user_content_manager_new                                        (void);

--- a/Source/WebKit/UIProcess/API/glib/WebKitUserMediaPermissionRequest.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitUserMediaPermissionRequest.cpp
@@ -56,8 +56,8 @@ struct _WebKitUserMediaPermissionRequestPrivate {
     bool madeDecision;
 };
 
-WEBKIT_DEFINE_FINAL_TYPE_WITH_CODE_IN_2022_API(
-    WebKitUserMediaPermissionRequest, webkit_user_media_permission_request, G_TYPE_OBJECT,
+WEBKIT_DEFINE_FINAL_TYPE_WITH_CODE(
+    WebKitUserMediaPermissionRequest, webkit_user_media_permission_request, G_TYPE_OBJECT, GObject,
     G_IMPLEMENT_INTERFACE(WEBKIT_TYPE_PERMISSION_REQUEST, webkit_permission_request_interface_init))
 
 static void webkitUserMediaPermissionRequestAllow(WebKitPermissionRequest* request)

--- a/Source/WebKit/UIProcess/API/glib/WebKitUserMediaPermissionRequest.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitUserMediaPermissionRequest.h.in
@@ -27,22 +27,12 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_USER_MEDIA_PERMISSION_REQUEST            (webkit_user_media_permission_request_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_USER_MEDIA_PERMISSION_REQUEST(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_USER_MEDIA_PERMISSION_REQUEST, WebKitUserMediaPermissionRequest))
 #define WEBKIT_USER_MEDIA_PERMISSION_REQUEST_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_USER_MEDIA_PERMISSION_REQUEST, WebKitUserMediaPermissionRequestClass))
 #define WEBKIT_IS_USER_MEDIA_PERMISSION_REQUEST(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_USER_MEDIA_PERMISSION_REQUEST))
 #define WEBKIT_IS_USER_MEDIA_PERMISSION_REQUEST_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_USER_MEDIA_PERMISSION_REQUEST))
 #define WEBKIT_USER_MEDIA_PERMISSION_REQUEST_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_USER_MEDIA_PERMISSION_REQUEST, WebKitUserMediaPermissionRequestClass))
-
-typedef struct _WebKitUserMediaPermissionRequest        WebKitUserMediaPermissionRequest;
-typedef struct _WebKitUserMediaPermissionRequestClass   WebKitUserMediaPermissionRequestClass;
-typedef struct _WebKitUserMediaPermissionRequestPrivate WebKitUserMediaPermissionRequestPrivate;
-
-struct _WebKitUserMediaPermissionRequest {
-    GObject parent;
-
-    /*< private >*/
-    WebKitUserMediaPermissionRequestPrivate *priv;
-};
 
 struct _WebKitUserMediaPermissionRequestClass {
     GObjectClass parent_class;
@@ -53,9 +43,9 @@ struct _WebKitUserMediaPermissionRequestClass {
     void (*_webkit_reserved2) (void);
     void (*_webkit_reserved3) (void);
 };
+#endif
 
-WEBKIT_API GType
-webkit_user_media_permission_request_get_type    (void);
+WEBKIT_DECLARE_FINAL_TYPE (WebKitUserMediaPermissionRequest, webkit_user_media_permission_request, WEBKIT, USER_MEDIA_PERMISSION_REQUEST, GObject)
 
 WEBKIT_API gboolean
 webkit_user_media_permission_is_for_audio_device (WebKitUserMediaPermissionRequest *request);

--- a/Source/WebKit/UIProcess/API/glib/WebKitUserMessage.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitUserMessage.h.in
@@ -28,17 +28,27 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_USER_MESSAGE            (webkit_user_message_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_USER_MESSAGE(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_USER_MESSAGE, WebKitUserMessage))
 #define WEBKIT_IS_USER_MESSAGE(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_USER_MESSAGE))
 #define WEBKIT_USER_MESSAGE_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_USER_MESSAGE, WebKitUserMessageClass))
 #define WEBKIT_IS_USER_MESSAGE_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_USER_MESSAGE))
 #define WEBKIT_USER_MESSAGE_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_USER_MESSAGE, WebKitUserMessageClass))
 
-#define WEBKIT_USER_MESSAGE_ERROR webkit_user_message_error_quark ()
+struct _WebKitUserMessageClass {
+    GInitiallyUnownedClass parent_class;
 
-typedef struct _WebKitUserMessage        WebKitUserMessage;
-typedef struct _WebKitUserMessageClass   WebKitUserMessageClass;
-typedef struct _WebKitUserMessagePrivate WebKitUserMessagePrivate;
+    /*< private >*/
+    void (*_webkit_reserved0) (void);
+    void (*_webkit_reserved1) (void);
+    void (*_webkit_reserved2) (void);
+    void (*_webkit_reserved3) (void);
+};
+#endif
+
+WEBKIT_DECLARE_FINAL_TYPE (WebKitUserMessage, webkit_user_message, WEBKIT, USER_MESSAGE, GInitiallyUnowned)
+
+#define WEBKIT_USER_MESSAGE_ERROR webkit_user_message_error_quark ()
 
 /**
  * WebKitUserMessageError:
@@ -51,26 +61,6 @@ typedef struct _WebKitUserMessagePrivate WebKitUserMessagePrivate;
 typedef enum {
     WEBKIT_USER_MESSAGE_UNHANDLED_MESSAGE
 } WebKitUserMessageError;
-
-struct _WebKitUserMessage {
-    GInitiallyUnowned parent;
-
-    /*< private >*/
-    WebKitUserMessagePrivate *priv;
-};
-
-struct _WebKitUserMessageClass {
-    GInitiallyUnownedClass parent_class;
-
-    /*< private >*/
-    void (*_webkit_reserved0) (void);
-    void (*_webkit_reserved1) (void);
-    void (*_webkit_reserved2) (void);
-    void (*_webkit_reserved3) (void);
-};
-
-WEBKIT_API GType
-webkit_user_message_get_type         (void);
 
 WEBKIT_API GQuark
 webkit_user_message_error_quark      (void);

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
@@ -267,6 +267,8 @@ struct _WebKitWebContextPrivate {
 
 static guint signals[LAST_SIGNAL] = { 0, };
 
+WEBKIT_DEFINE_FINAL_TYPE(WebKitWebContext, webkit_web_context, G_TYPE_OBJECT, GObject)
+
 std::unique_ptr<WebKitNotificationProvider> s_serviceWorkerNotificationProvider;
 
 #if ENABLE(REMOTE_INSPECTOR)
@@ -320,8 +322,6 @@ void webkitWebContextWillCloseAutomationSession(WebKitWebContext* webContext)
     webContext->priv->automationSession = nullptr;
 }
 #endif
-
-WEBKIT_DEFINE_FINAL_TYPE_IN_2022_API(WebKitWebContext, webkit_web_context, G_TYPE_OBJECT)
 
 #if PLATFORM(GTK)
 #define INJECTED_BUNDLE_FILENAME "libwebkit" WEBKITGTK_API_INFIX "gtkinjectedbundle.so"

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebContext.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebContext.h.in
@@ -43,11 +43,15 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_WEB_CONTEXT            (webkit_web_context_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_WEB_CONTEXT(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_WEB_CONTEXT, WebKitWebContext))
 #define WEBKIT_WEB_CONTEXT_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_WEB_CONTEXT, WebKitWebContextClass))
 #define WEBKIT_IS_WEB_CONTEXT(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_WEB_CONTEXT))
 #define WEBKIT_IS_WEB_CONTEXT_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_WEB_CONTEXT))
 #define WEBKIT_WEB_CONTEXT_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_WEB_CONTEXT, WebKitWebContextClass))
+#endif
+
+WEBKIT_DECLARE_TYPE (WebKitWebContext, webkit_web_context, WEBKIT, WEB_CONTEXT, GObject)
 
 /**
  * WebKitCacheModel:
@@ -106,17 +110,6 @@ typedef enum {
 typedef void (* WebKitURISchemeRequestCallback) (WebKitURISchemeRequest *request,
                                                  gpointer                user_data);
 
-typedef struct _WebKitWebContext        WebKitWebContext;
-typedef struct _WebKitWebContextClass   WebKitWebContextClass;
-typedef struct _WebKitWebContextPrivate WebKitWebContextPrivate;
-
-struct _WebKitWebContext {
-    GObject parent;
-
-    /*< private >*/
-    WebKitWebContextPrivate *priv;
-};
-
 struct _WebKitWebContextClass {
     GObjectClass parent;
 
@@ -137,9 +130,6 @@ struct _WebKitWebContextClass {
     void (*_webkit_reserved1) (void);
     void (*_webkit_reserved2) (void);
 };
-
-WEBKIT_API GType
-webkit_web_context_get_type                         (void);
 
 WEBKIT_API WebKitWebContext *
 webkit_web_context_get_default                      (void);

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebResource.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebResource.cpp
@@ -76,7 +76,7 @@ struct _WebKitWebResourcePrivate {
     bool isMainResource;
 };
 
-WEBKIT_DEFINE_FINAL_TYPE_IN_2022_API(WebKitWebResource, webkit_web_resource, G_TYPE_OBJECT)
+WEBKIT_DEFINE_FINAL_TYPE(WebKitWebResource, webkit_web_resource, G_TYPE_OBJECT, GObject)
 
 static guint signals[LAST_SIGNAL] = { 0, };
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebResource.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebResource.h.in
@@ -30,22 +30,12 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_WEB_RESOURCE            (webkit_web_resource_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_WEB_RESOURCE(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_WEB_RESOURCE, WebKitWebResource))
 #define WEBKIT_IS_WEB_RESOURCE(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_WEB_RESOURCE))
 #define WEBKIT_WEB_RESOURCE_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_WEB_RESOURCE, WebKitWebResourceClass))
 #define WEBKIT_IS_WEB_RESOURCE_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_WEB_RESOURCE))
 #define WEBKIT_WEB_RESOURCE_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_WEB_RESOURCE, WebKitWebResourceClass))
-
-typedef struct _WebKitWebResource        WebKitWebResource;
-typedef struct _WebKitWebResourceClass   WebKitWebResourceClass;
-typedef struct _WebKitWebResourcePrivate WebKitWebResourcePrivate;
-
-struct _WebKitWebResource {
-    GObject parent;
-
-    /*< private >*/
-    WebKitWebResourcePrivate *priv;
-};
 
 struct _WebKitWebResourceClass {
     GObjectClass parent_class;
@@ -56,9 +46,9 @@ struct _WebKitWebResourceClass {
     void (*_webkit_reserved2) (void);
     void (*_webkit_reserved3) (void);
 };
+#endif
 
-WEBKIT_API GType
-webkit_web_resource_get_type        (void);
+WEBKIT_DECLARE_FINAL_TYPE (WebKitWebResource, webkit_web_resource, WEBKIT, WEB_RESOURCE, GObject)
 
 WEBKIT_API const gchar *
 webkit_web_resource_get_uri         (WebKitWebResource  *resource);

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
@@ -72,17 +72,22 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_WEB_VIEW            (webkit_web_view_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_WEB_VIEW(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_WEB_VIEW, WebKitWebView))
 #define WEBKIT_IS_WEB_VIEW(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_WEB_VIEW))
 #define WEBKIT_WEB_VIEW_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_WEB_VIEW, WebKitWebViewClass))
 #define WEBKIT_IS_WEB_VIEW_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_WEB_VIEW))
 #define WEBKIT_WEB_VIEW_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_WEB_VIEW, WebKitWebViewClass))
+#endif
+
+#if PLATFORM(GTK)
+WEBKIT_DECLARE_DERIVABLE_TYPE (WebKitWebView, webkit_web_view, WEBKIT, WEB_VIEW, WebKitWebViewBase)
+#elif PLATFORM(WPE)
+WEBKIT_DECLARE_DERIVABLE_TYPE (WebKitWebView, webkit_web_view, WEBKIT, WEB_VIEW, GObject)
+#else
+#endif
 
 typedef struct _WebKitPrintOperation WebKitPrintOperation;
-
-typedef struct _WebKitWebView        WebKitWebView;
-typedef struct _WebKitWebViewClass   WebKitWebViewClass;
-typedef struct _WebKitWebViewPrivate WebKitWebViewPrivate;
 
 /**
  * WebKitPolicyDecisionType:
@@ -267,17 +272,6 @@ typedef void (* WebKitFrameDisplayedCallback) (WebKitWebView *web_view,
                                                gpointer       user_data);
 #endif
 
-struct _WebKitWebView {
-#if PLATFORM(GTK)
-    WebKitWebViewBase parent;
-#elif PLATFORM(WPE)
-    GObject parent;
-#endif
-
-    /*< private >*/
-    WebKitWebViewPrivate *priv;
-};
-
 struct _WebKitWebViewClass {
 #if PLATFORM(GTK)
     WebKitWebViewBaseClass parent;
@@ -426,9 +420,6 @@ struct _WebKitWebViewClass {
     void (*_webkit_reserved30) (void);
 #endif
 };
-
-WEBKIT_API GType
-webkit_web_view_get_type                             (void);
 
 #if PLATFORM(GTK)
 WEBKIT_API GtkWidget *

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataAccessPermissionRequest.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataAccessPermissionRequest.cpp
@@ -47,8 +47,8 @@ struct _WebKitWebsiteDataAccessPermissionRequestPrivate {
     CompletionHandler<void(bool)> completionHandler;
 };
 
-WEBKIT_DEFINE_FINAL_TYPE_WITH_CODE_IN_2022_API(
-    WebKitWebsiteDataAccessPermissionRequest, webkit_website_data_access_permission_request, G_TYPE_OBJECT,
+WEBKIT_DEFINE_FINAL_TYPE_WITH_CODE(
+    WebKitWebsiteDataAccessPermissionRequest, webkit_website_data_access_permission_request, G_TYPE_OBJECT, GObject,
     G_IMPLEMENT_INTERFACE(WEBKIT_TYPE_PERMISSION_REQUEST, webkit_permission_request_interface_init))
 
 static void webkitWebsiteDataAccessPermissionRequestAllow(WebKitPermissionRequest* request)

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataAccessPermissionRequest.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataAccessPermissionRequest.h.in
@@ -27,22 +27,12 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_WEBSITE_DATA_ACCESS_PERMISSION_REQUEST            (webkit_website_data_access_permission_request_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_WEBSITE_DATA_ACCESS_PERMISSION_REQUEST(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_WEBSITE_DATA_ACCESS_PERMISSION_REQUEST, WebKitWebsiteDataAccessPermissionRequest))
 #define WEBKIT_IS_WEBSITE_DATA_ACCESS_PERMISSION_REQUEST(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_WEBSITE_DATA_ACCESS_PERMISSION_REQUEST))
 #define WEBKIT_WEBSITE_DATA_ACCESS_PERMISSION_REQUEST_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_WEBSITE_DATA_ACCESS_PERMISSION_REQUEST, WebKitWebsiteDataAccessPermissionRequestClass))
 #define WEBKIT_IS_WEBSITE_DATA_ACCESS_PERMISSION_REQUEST_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_WEBSITE_DATA_ACCESS_PERMISSION_REQUEST))
 #define WEBKIT_WEBSITE_DATA_ACCESS_PERMISSION_REQUEST_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_WEBSITE_DATA_ACCESS_PERMISSION_REQUEST, WebKitWebsiteDataAccessPermissionRequestClass))
-
-typedef struct _WebKitWebsiteDataAccessPermissionRequest        WebKitWebsiteDataAccessPermissionRequest;
-typedef struct _WebKitWebsiteDataAccessPermissionRequestClass   WebKitWebsiteDataAccessPermissionRequestClass;
-typedef struct _WebKitWebsiteDataAccessPermissionRequestPrivate WebKitWebsiteDataAccessPermissionRequestPrivate;
-
-struct _WebKitWebsiteDataAccessPermissionRequest {
-    GObject parent;
-
-    /*< private >*/
-    WebKitWebsiteDataAccessPermissionRequestPrivate *priv;
-};
 
 struct _WebKitWebsiteDataAccessPermissionRequestClass {
     GObjectClass parent_class;
@@ -53,9 +43,9 @@ struct _WebKitWebsiteDataAccessPermissionRequestClass {
     void (*_webkit_reserved2) (void);
     void (*_webkit_reserved3) (void);
 };
+#endif
 
-WEBKIT_API GType
-webkit_website_data_access_permission_request_get_type              (void);
+WEBKIT_DECLARE_FINAL_TYPE (WebKitWebsiteDataAccessPermissionRequest, webkit_website_data_access_permission_request, WEBKIT, WEBSITE_DATA_ACCESS_PERMISSION_REQUEST, GObject)
 
 WEBKIT_API const char *
 webkit_website_data_access_permission_request_get_requesting_domain (WebKitWebsiteDataAccessPermissionRequest *request);

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.cpp
@@ -120,7 +120,7 @@ struct _WebKitWebsiteDataManagerPrivate {
 #endif
 };
 
-WEBKIT_DEFINE_FINAL_TYPE_IN_2022_API(WebKitWebsiteDataManager, webkit_website_data_manager, G_TYPE_OBJECT)
+WEBKIT_DEFINE_FINAL_TYPE(WebKitWebsiteDataManager, webkit_website_data_manager, G_TYPE_OBJECT, GObject)
 
 static void webkitWebsiteDataManagerGetProperty(GObject* object, guint propID, GValue* value, GParamSpec* paramSpec)
 {

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.h.in
@@ -35,11 +35,25 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_WEBSITE_DATA_MANAGER            (webkit_website_data_manager_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_WEBSITE_DATA_MANAGER(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_WEBSITE_DATA_MANAGER, WebKitWebsiteDataManager))
 #define WEBKIT_IS_WEBSITE_DATA_MANAGER(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_WEBSITE_DATA_MANAGER))
 #define WEBKIT_WEBSITE_DATA_MANAGER_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_WEBSITE_DATA_MANAGER, WebKitWebsiteDataManagerClass))
 #define WEBKIT_IS_WEBSITE_DATA_MANAGER_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_WEBSITE_DATA_MANAGER))
 #define WEBKIT_WEBSITE_DATA_MANAGER_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_WEBSITE_DATA_MANAGER, WebKitWebsiteDataManagerClass))
+
+struct _WebKitWebsiteDataManagerClass {
+    GObjectClass parent_class;
+
+    /*< private >*/
+    void (*_webkit_reserved0) (void);
+    void (*_webkit_reserved1) (void);
+    void (*_webkit_reserved2) (void);
+    void (*_webkit_reserved3) (void);
+};
+#endif
+
+WEBKIT_DECLARE_FINAL_TYPE (WebKitWebsiteDataManager, webkit_website_data_manager, WEBKIT, WEBSITE_DATA_MANAGER, GObject)
 
 /**
  * WebKitTLSErrorsPolicy:
@@ -55,30 +69,6 @@ typedef enum {
     WEBKIT_TLS_ERRORS_POLICY_IGNORE,
     WEBKIT_TLS_ERRORS_POLICY_FAIL
 } WebKitTLSErrorsPolicy;
-
-typedef struct _WebKitWebsiteDataManager        WebKitWebsiteDataManager;
-typedef struct _WebKitWebsiteDataManagerClass   WebKitWebsiteDataManagerClass;
-typedef struct _WebKitWebsiteDataManagerPrivate WebKitWebsiteDataManagerPrivate;
-
-struct _WebKitWebsiteDataManager {
-    GObject parent;
-
-    /*< private >*/
-    WebKitWebsiteDataManagerPrivate *priv;
-};
-
-struct _WebKitWebsiteDataManagerClass {
-    GObjectClass parent_class;
-
-    /*< private >*/
-    void (*_webkit_reserved0) (void);
-    void (*_webkit_reserved1) (void);
-    void (*_webkit_reserved2) (void);
-    void (*_webkit_reserved3) (void);
-};
-
-WEBKIT_API GType
-webkit_website_data_manager_get_type                                  (void);
 
 #if !ENABLE(2022_GLIB_API)
 WEBKIT_API WebKitWebsiteDataManager *

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebsitePolicies.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebsitePolicies.cpp
@@ -56,7 +56,7 @@ struct _WebKitWebsitePoliciesPrivate {
     RefPtr<API::WebsitePolicies> websitePolicies;
 };
 
-WEBKIT_DEFINE_TYPE(WebKitWebsitePolicies, webkit_website_policies, G_TYPE_OBJECT)
+WEBKIT_DEFINE_FINAL_TYPE(WebKitWebsitePolicies, webkit_website_policies, G_TYPE_OBJECT, GObject)
 
 API::WebsitePolicies& webkitWebsitePoliciesGetWebsitePolicies(WebKitWebsitePolicies* policies)
 {

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebsitePolicies.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebsitePolicies.h.in
@@ -27,22 +27,12 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_WEBSITE_POLICIES            (webkit_website_policies_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_WEBSITE_POLICIES(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_WEBSITE_POLICIES, WebKitWebsitePolicies))
 #define WEBKIT_IS_WEBSITE_POLICIES(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_WEBSITE_POLICIES))
 #define WEBKIT_WEBSITE_POLICIES_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_WEBSITE_POLICIES, WebKitWebsitePoliciesClass))
 #define WEBKIT_IS_WEBSITE_POLICIES_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_WEBSITE_POLICIES))
 #define WEBKIT_WEBSITE_POLICIES_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_WEBSITE_POLICIES, WebKitWebsitePoliciesClass))
-
-typedef struct _WebKitWebsitePolicies        WebKitWebsitePolicies;
-typedef struct _WebKitWebsitePoliciesClass   WebKitWebsitePoliciesClass;
-typedef struct _WebKitWebsitePoliciesPrivate WebKitWebsitePoliciesPrivate;
-
-struct _WebKitWebsitePolicies {
-    GObject parent;
-
-    /*< private >*/
-    WebKitWebsitePoliciesPrivate *priv;
-};
 
 struct _WebKitWebsitePoliciesClass {
     GObjectClass parent_class;
@@ -53,6 +43,9 @@ struct _WebKitWebsitePoliciesClass {
     void (*_webkit_reserved2) (void);
     void (*_webkit_reserved3) (void);
 };
+#endif
+
+WEBKIT_DECLARE_FINAL_TYPE (WebKitWebsitePolicies, webkit_website_policies, WEBKIT, WEBSITE_POLICIES, GObject)
 
 /**
  * WebKitAutoplayPolicy:
@@ -70,9 +63,6 @@ typedef enum {
     WEBKIT_AUTOPLAY_ALLOW_WITHOUT_SOUND,
     WEBKIT_AUTOPLAY_DENY
 } WebKitAutoplayPolicy;
-
-WEBKIT_API GType
-webkit_website_policies_get_type                              (void);
 
 WEBKIT_API WebKitWebsitePolicies *
 webkit_website_policies_new                                   (void);

--- a/Source/WebKit/UIProcess/API/glib/WebKitWindowProperties.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWindowProperties.cpp
@@ -123,7 +123,7 @@ struct _WebKitWindowPropertiesPrivate {
     bool fullscreen : 1;
 };
 
-WEBKIT_DEFINE_FINAL_TYPE_IN_2022_API(WebKitWindowProperties, webkit_window_properties, G_TYPE_OBJECT)
+WEBKIT_DEFINE_FINAL_TYPE(WebKitWindowProperties, webkit_window_properties, G_TYPE_OBJECT, GObject)
 
 static void webkitWindowPropertiesGetProperty(GObject* object, guint propId, GValue* value, GParamSpec* paramSpec)
 {

--- a/Source/WebKit/UIProcess/API/glib/WebKitWindowProperties.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWindowProperties.h.in
@@ -32,22 +32,12 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_WINDOW_PROPERTIES            (webkit_window_properties_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_WINDOW_PROPERTIES(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_WINDOW_PROPERTIES, WebKitWindowProperties))
 #define WEBKIT_IS_WINDOW_PROPERTIES(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_WINDOW_PROPERTIES))
 #define WEBKIT_WINDOW_PROPERTIES_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_WINDOW_PROPERTIES, WebKitWindowPropertiesClass))
 #define WEBKIT_IS_WINDOW_PROPERTIES_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_WINDOW_PROPERTIES))
 #define WEBKIT_WINDOW_PROPERTIES_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_WINDOW_PROPERTIES, WebKitWindowPropertiesClass))
-
-typedef struct _WebKitWindowProperties WebKitWindowProperties;
-typedef struct _WebKitWindowPropertiesClass WebKitWindowPropertiesClass;
-typedef struct _WebKitWindowPropertiesPrivate WebKitWindowPropertiesPrivate;
-
-struct _WebKitWindowProperties {
-    GObject parent;
-
-    /*< private >*/
-    WebKitWindowPropertiesPrivate *priv;
-};
 
 struct _WebKitWindowPropertiesClass {
     GObjectClass parent_class;
@@ -58,9 +48,9 @@ struct _WebKitWindowPropertiesClass {
     void (*_webkit_reserved2) (void);
     void (*_webkit_reserved3) (void);
 };
+#endif
 
-WEBKIT_API GType
-webkit_window_properties_get_type                (void);
+WEBKIT_DECLARE_FINAL_TYPE (WebKitWindowProperties, webkit_window_properties, WEBKIT, WINDOW_PROPERTIES, GObject)
 
 #if PLATFORM(GTK)
 WEBKIT_API void

--- a/Source/WebKit/UIProcess/API/gtk/WebKitColorChooserRequest.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitColorChooserRequest.cpp
@@ -77,7 +77,7 @@ struct _WebKitColorChooserRequestPrivate {
 
 static guint signals[LAST_SIGNAL] = { 0, };
 
-WEBKIT_DEFINE_FINAL_TYPE_IN_2022_API(WebKitColorChooserRequest, webkit_color_chooser_request, G_TYPE_OBJECT)
+WEBKIT_DEFINE_FINAL_TYPE(WebKitColorChooserRequest, webkit_color_chooser_request, G_TYPE_OBJECT, GObject)
 
 static void webkitColorChooserRequestDispose(GObject* object)
 {

--- a/Source/WebKit/UIProcess/API/gtk/WebKitColorChooserRequest.h.in
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitColorChooserRequest.h.in
@@ -35,29 +35,19 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_COLOR_CHOOSER_REQUEST            (webkit_color_chooser_request_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_COLOR_CHOOSER_REQUEST(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_COLOR_CHOOSER_REQUEST, WebKitColorChooserRequest))
 #define WEBKIT_IS_COLOR_CHOOSER_REQUEST(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_COLOR_CHOOSER_REQUEST))
 #define WEBKIT_COLOR_CHOOSER_REQUEST_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_COLOR_CHOOSER_REQUEST, WebKitColorChooserRequestClass))
 #define WEBKIT_IS_COLOR_CHOOSER_REQUEST_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_COLOR_CHOOSER_REQUEST))
 #define WEBKIT_COLOR_CHOOSER_REQUEST_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_COLOR_CHOOSER_REQUEST, WebKitColorChooserRequestClass))
 
-typedef struct _WebKitColorChooserRequest        WebKitColorChooserRequest;
-typedef struct _WebKitColorChooserRequestClass   WebKitColorChooserRequestClass;
-typedef struct _WebKitColorChooserRequestPrivate WebKitColorChooserRequestPrivate;
-
-struct _WebKitColorChooserRequest {
-    GObject parent;
-
-    /*< private >*/
-    WebKitColorChooserRequestPrivate *priv;
-};
-
 struct _WebKitColorChooserRequestClass {
     GObjectClass parent_class;
 };
+#endif
 
-WEBKIT_API GType
-webkit_color_chooser_request_get_type              (void);
+WEBKIT_DECLARE_FINAL_TYPE (WebKitColorChooserRequest, webkit_color_chooser_request, WEBKIT, COLOR_CHOOSER_REQUEST, GObject)
 
 WEBKIT_API void
 webkit_color_chooser_request_get_rgba              (WebKitColorChooserRequest *request,

--- a/Source/WebKit/UIProcess/API/gtk/WebKitPointerLockPermissionRequest.h.in
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitPointerLockPermissionRequest.h.in
@@ -28,22 +28,12 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_POINTER_LOCK_PERMISSION_REQUEST            (webkit_pointer_lock_permission_request_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_POINTER_LOCK_PERMISSION_REQUEST(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_POINTER_LOCK_PERMISSION_REQUEST, WebKitPointerLockPermissionRequest))
 #define WEBKIT_POINTER_LOCK_PERMISSION_REQUEST_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_POINTER_LOCK_PERMISSION_REQUEST, WebKitPointerLockPermissionRequestClass))
 #define WEBKIT_IS_POINTER_LOCK_PERMISSION_REQUEST(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_POINTER_LOCK_PERMISSION_REQUEST))
 #define WEBKIT_IS_POINTER_LOCK_PERMISSION_REQUEST_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_POINTER_LOCK_PERMISSION_REQUEST))
 #define WEBKIT_POINTER_LOCK_PERMISSION_REQUEST_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_POINTER_LOCK_PERMISSION_REQUEST, WebKitPointerLockPermissionRequestClass))
-
-typedef struct _WebKitPointerLockPermissionRequest        WebKitPointerLockPermissionRequest;
-typedef struct _WebKitPointerLockPermissionRequestClass   WebKitPointerLockPermissionRequestClass;
-typedef struct _WebKitPointerLockPermissionRequestPrivate WebKitPointerLockPermissionRequestPrivate;
-
-struct _WebKitPointerLockPermissionRequest {
-    GObject parent;
-
-    /*< private >*/
-    WebKitPointerLockPermissionRequestPrivate *priv;
-};
 
 struct _WebKitPointerLockPermissionRequestClass {
     GObjectClass parent_class;
@@ -54,9 +44,9 @@ struct _WebKitPointerLockPermissionRequestClass {
     void (*_webkit_reserved2) (void);
     void (*_webkit_reserved3) (void);
 };
+#endif
 
-WEBKIT_API GType
-webkit_pointer_lock_permission_request_get_type (void);
+WEBKIT_DECLARE_FINAL_TYPE (WebKitPointerLockPermissionRequest, webkit_pointer_lock_permission_request, WEBKIT, POINTER_LOCK_PERMISSION_REQUEST, GObject)
 
 G_END_DECLS
 

--- a/Source/WebKit/UIProcess/API/gtk/WebKitPrintOperation.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitPrintOperation.cpp
@@ -89,7 +89,7 @@ struct _WebKitPrintOperationPrivate {
 
 static guint signals[LAST_SIGNAL] = { 0, };
 
-WEBKIT_DEFINE_FINAL_TYPE_IN_2022_API(WebKitPrintOperation, webkit_print_operation, G_TYPE_OBJECT)
+WEBKIT_DEFINE_FINAL_TYPE(WebKitPrintOperation, webkit_print_operation, G_TYPE_OBJECT, GObject)
 
 static void webkitPrintOperationGetProperty(GObject* object, guint propId, GValue* value, GParamSpec* paramSpec)
 {

--- a/Source/WebKit/UIProcess/API/gtk/WebKitPrintOperation.h.in
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitPrintOperation.h.in
@@ -29,15 +29,25 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_PRINT_OPERATION            (webkit_print_operation_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_PRINT_OPERATION(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_PRINT_OPERATION, WebKitPrintOperation))
 #define WEBKIT_IS_PRINT_OPERATION(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_PRINT_OPERATION))
 #define WEBKIT_PRINT_OPERATION_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_PRINT_OPERATION, WebKitPrintOperationClass))
 #define WEBKIT_IS_PRINT_OPERATION_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_PRINT_OPERATION))
 #define WEBKIT_PRINT_OPERATION_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_PRINT_OPERATION, WebKitPrintOperationClass))
 
-typedef struct _WebKitPrintOperation        WebKitPrintOperation;
-typedef struct _WebKitPrintOperationClass   WebKitPrintOperationClass;
-typedef struct _WebKitPrintOperationPrivate WebKitPrintOperationPrivate;
+struct _WebKitPrintOperationClass {
+    GObjectClass parent_class;
+
+    /*< private >*/
+    void (*_webkit_reserved0) (void);
+    void (*_webkit_reserved1) (void);
+    void (*_webkit_reserved2) (void);
+    void (*_webkit_reserved3) (void);
+};
+#endif
+
+WEBKIT_DECLARE_FINAL_TYPE (WebKitPrintOperation, webkit_print_operation, WEBKIT, PRINT_OPERATION, GObject)
 
 /**
  * WebKitPrintOperationResponse:
@@ -51,26 +61,6 @@ typedef enum {
     WEBKIT_PRINT_OPERATION_RESPONSE_PRINT,
     WEBKIT_PRINT_OPERATION_RESPONSE_CANCEL
 } WebKitPrintOperationResponse;
-
-struct _WebKitPrintOperation {
-    GObject parent;
-
-    /*< private >*/
-    WebKitPrintOperationPrivate *priv;
-};
-
-struct _WebKitPrintOperationClass {
-    GObjectClass parent_class;
-
-    /*< private >*/
-    void (*_webkit_reserved0) (void);
-    void (*_webkit_reserved1) (void);
-    void (*_webkit_reserved2) (void);
-    void (*_webkit_reserved3) (void);
-};
-
-WEBKIT_API GType
-webkit_print_operation_get_type           (void);
 
 WEBKIT_API WebKitPrintOperation *
 webkit_print_operation_new                (WebKitWebView        *web_view);

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebInspector.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebInspector.cpp
@@ -90,7 +90,7 @@ struct _WebKitWebInspectorPrivate {
     bool canAttach;
 };
 
-WEBKIT_DEFINE_FINAL_TYPE_IN_2022_API(WebKitWebInspector, webkit_web_inspector, G_TYPE_OBJECT)
+WEBKIT_DEFINE_FINAL_TYPE(WebKitWebInspector, webkit_web_inspector, G_TYPE_OBJECT, GObject)
 
 static guint signals[LAST_SIGNAL] = { 0, };
 

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebInspector.h.in
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebInspector.h.in
@@ -29,22 +29,12 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_WEB_INSPECTOR            (webkit_web_inspector_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_WEB_INSPECTOR(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_WEB_INSPECTOR, WebKitWebInspector))
 #define WEBKIT_IS_WEB_INSPECTOR(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_WEB_INSPECTOR))
 #define WEBKIT_WEB_INSPECTOR_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_WEB_INSPECTOR, WebKitWebInspectorClass))
 #define WEBKIT_IS_WEB_INSPECTOR_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_WEB_INSPECTOR))
 #define WEBKIT_WEB_INSPECTOR_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_WEB_INSPECTOR, WebKitWebInspectorClass))
-
-typedef struct _WebKitWebInspector        WebKitWebInspector;
-typedef struct _WebKitWebInspectorClass   WebKitWebInspectorClass;
-typedef struct _WebKitWebInspectorPrivate WebKitWebInspectorPrivate;
-
-struct _WebKitWebInspector {
-    GObject parent;
-
-    /*< private >*/
-    WebKitWebInspectorPrivate *priv;
-};
 
 struct _WebKitWebInspectorClass {
     GObjectClass parent_class;
@@ -55,9 +45,9 @@ struct _WebKitWebInspectorClass {
     void (*_webkit_reserved2) (void);
     void (*_webkit_reserved3) (void);
 };
+#endif
 
-WEBKIT_API GType
-webkit_web_inspector_get_type            (void);
+WEBKIT_DECLARE_FINAL_TYPE (WebKitWebInspector, webkit_web_inspector, WEBKIT, WEB_INSPECTOR, GObject)
 
 WEBKIT_API WebKitWebViewBase *
 webkit_web_inspector_get_web_view        (WebKitWebInspector *inspector);

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.h.in
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.h.in
@@ -36,25 +36,19 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_WEB_VIEW_BASE              (webkit_web_view_base_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_WEB_VIEW_BASE(object)           (G_TYPE_CHECK_INSTANCE_CAST((object), WEBKIT_TYPE_WEB_VIEW_BASE, WebKitWebViewBase))
 #define WEBKIT_WEB_VIEW_BASE_CLASS(klass)      (G_TYPE_CHECK_CLASS_CAST((klass), WEBKIT_TYPE_WEB_VIEW_BASE, WebKitWebViewBaseClass))
 #define WEBKIT_IS_WEB_VIEW_BASE(object)        (G_TYPE_CHECK_INSTANCE_TYPE((object), WEBKIT_TYPE_WEB_VIEW_BASE))
 #define WEBKIT_IS_WEB_VIEW_BASE_CLASS(klass)   (G_TYPE_CHECK_CLASS_TYPE((klass), WEBKIT_TYPE_WEB_VIEW_BASE))
 #define WEBKIT_WEB_VIEW_BASE_GET_CLASS(object) (G_TYPE_INSTANCE_GET_CLASS((object), WEBKIT_TYPE_WEB_VIEW_BASE, WebKitWebViewBaseClass))
-
-typedef struct _WebKitWebViewBase WebKitWebViewBase;
-typedef struct _WebKitWebViewBaseClass WebKitWebViewBaseClass;
-typedef struct _WebKitWebViewBasePrivate WebKitWebViewBasePrivate;
-
-struct _WebKitWebViewBase {
-#if USE(GTK4)
-    GtkWidget parentInstance;
-#else
-    GtkContainer parentInstance;
 #endif
-    /*< private >*/
-    WebKitWebViewBasePrivate* priv;
-};
+
+#if USE(GTK4)
+WEBKIT_DECLARE_DERIVABLE_TYPE (WebKitWebViewBase, webkit_web_view_base, WEBKIT, WEB_VIEW_BASE, GtkWidget)
+#else
+WEBKIT_DECLARE_DERIVABLE_TYPE (WebKitWebViewBase, webkit_web_view_base, WEBKIT, WEB_VIEW_BASE, GtkContainer)
+#endif
 
 struct _WebKitWebViewBaseClass {
 #if USE(GTK4)
@@ -68,9 +62,6 @@ struct _WebKitWebViewBaseClass {
     void (*_webkit_reserved2) (void);
     void (*_webkit_reserved3) (void);
 };
-
-WEBKIT_API GType
-webkit_web_view_base_get_type (void);
 
 G_END_DECLS
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitFrame.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitFrame.cpp
@@ -58,7 +58,7 @@ struct _WebKitFramePrivate {
     CString uri;
 };
 
-WEBKIT_DEFINE_TYPE(WebKitFrame, webkit_frame, G_TYPE_OBJECT)
+WEBKIT_DEFINE_FINAL_TYPE(WebKitFrame, webkit_frame, G_TYPE_OBJECT, GObject)
 
 static void webkit_frame_class_init(WebKitFrameClass*)
 {

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitFrame.h.in
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitFrame.h.in
@@ -39,6 +39,7 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_FRAME            (webkit_frame_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_FRAME(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_FRAME, WebKitFrame))
 #define WEBKIT_IS_FRAME(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_FRAME))
 #define WEBKIT_FRAME_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_FRAME, WebKitFrameClass))
@@ -49,19 +50,12 @@ typedef struct _WebKitFrame        WebKitFrame;
 typedef struct _WebKitFrameClass   WebKitFrameClass;
 typedef struct _WebKitFramePrivate WebKitFramePrivate;
 
-struct _WebKitFrame {
-    GObject parent;
-
-    /*< private >*/
-    WebKitFramePrivate *priv;
-};
-
 struct _WebKitFrameClass {
     GObjectClass parent_class;
 };
+#endif
 
-WEBKIT_API GType
-webkit_frame_get_type                                    (void);
+WEBKIT_DECLARE_FINAL_TYPE (WebKitFrame, webkit_frame, WEBKIT, FRAME, GObject)
 
 WEBKIT_API guint64
 webkit_frame_get_id                                      (WebKitFrame       *frame);

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitScriptWorld.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitScriptWorld.cpp
@@ -55,7 +55,7 @@ struct _WebKitScriptWorldPrivate {
 
 static guint signals[LAST_SIGNAL] = { 0, };
 
-WEBKIT_DEFINE_TYPE(WebKitScriptWorld, webkit_script_world, G_TYPE_OBJECT)
+WEBKIT_DEFINE_FINAL_TYPE(WebKitScriptWorld, webkit_script_world, G_TYPE_OBJECT, GObject)
 
 static void webkit_script_world_class_init(WebKitScriptWorldClass* klass)
 {

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitScriptWorld.h.in
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitScriptWorld.h.in
@@ -28,6 +28,7 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_SCRIPT_WORLD            (webkit_script_world_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_SCRIPT_WORLD(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_SCRIPT_WORLD, WebKitScriptWorld))
 #define WEBKIT_IS_SCRIPT_WORLD(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_SCRIPT_WORLD))
 #define WEBKIT_SCRIPT_WORLD_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_SCRIPT_WORLD, WebKitScriptWorldClass))
@@ -38,12 +39,6 @@ typedef struct _WebKitScriptWorld        WebKitScriptWorld;
 typedef struct _WebKitScriptWorldClass   WebKitScriptWorldClass;
 typedef struct _WebKitScriptWorldPrivate WebKitScriptWorldPrivate;
 
-struct _WebKitScriptWorld {
-    GObject parent;
-
-    WebKitScriptWorldPrivate *priv;
-};
-
 struct _WebKitScriptWorldClass {
     GObjectClass parent_class;
 
@@ -52,9 +47,9 @@ struct _WebKitScriptWorldClass {
     void (*_webkit_reserved2) (void);
     void (*_webkit_reserved3) (void);
 };
+#endif
 
-WEBKIT_API GType
-webkit_script_world_get_type      (void);
+WEBKIT_DECLARE_FINAL_TYPE (WebKitScriptWorld, webkit_script_world, WEBKIT, SCRIPT_WORLD, GObject )
 
 WEBKIT_API WebKitScriptWorld *
 webkit_script_world_get_default   (void);

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebEditor.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebEditor.cpp
@@ -51,7 +51,7 @@ struct _WebKitWebEditorPrivate {
 
 static guint signals[LAST_SIGNAL] = { 0, };
 
-WEBKIT_DEFINE_TYPE(WebKitWebEditor, webkit_web_editor, G_TYPE_OBJECT)
+WEBKIT_DEFINE_FINAL_TYPE(WebKitWebEditor, webkit_web_editor, G_TYPE_OBJECT, GObject)
 
 static void webkit_web_editor_class_init(WebKitWebEditorClass* klass)
 {

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebEditor.h.in
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebEditor.h.in
@@ -29,6 +29,7 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_WEB_EDITOR               (webkit_web_editor_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_WEB_EDITOR(obj)               (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_WEB_EDITOR, WebKitWebEditor))
 #define WEBKIT_IS_WEB_EDITOR(obj)            (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_WEB_EDITOR))
 #define WEBKIT_WEB_EDITOR_CLASS(klass)       (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_WEB_EDITOR, WebKitWebEditorClass))
@@ -39,21 +40,15 @@ typedef struct _WebKitWebEditor        WebKitWebEditor;
 typedef struct _WebKitWebEditorClass   WebKitWebEditorClass;
 typedef struct _WebKitWebEditorPrivate WebKitWebEditorPrivate;
 
-/* Forward declarations */
-typedef struct _WebKitWebPage          WebKitWebPage;
-
-struct _WebKitWebEditor {
-    GObject parent;
-
-    WebKitWebEditorPrivate *priv;
-};
-
 struct _WebKitWebEditorClass {
     GObjectClass parent_class;
 };
+#endif
 
-WEBKIT_API GType
-webkit_web_editor_get_type (void);
+WEBKIT_DECLARE_FINAL_TYPE (WebKitWebEditor, webkit_web_editor, WEBKIT, WEB_EDITOR, GObject)
+
+/* Forward declarations */
+typedef struct _WebKitWebPage          WebKitWebPage;
 
 WEBKIT_API WebKitWebPage *
 webkit_web_editor_get_page (WebKitWebEditor *editor);

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebExtension.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebExtension.cpp
@@ -130,7 +130,7 @@ struct _WebKitWebExtensionPrivate {
 
 static guint signals[LAST_SIGNAL] = { 0, };
 
-WEBKIT_DEFINE_TYPE(WebKitWebExtension, webkit_web_extension, G_TYPE_OBJECT)
+WEBKIT_DEFINE_FINAL_TYPE(WebKitWebExtension, webkit_web_extension, G_TYPE_OBJECT, GObject)
 
 static void webkit_web_extension_class_init(WebKitWebExtensionClass* klass)
 {

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebExtension.h.in
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebExtension.h.in
@@ -30,6 +30,7 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_WEB_EXTENSION            (webkit_web_extension_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_WEB_EXTENSION(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_WEB_EXTENSION, WebKitWebExtension))
 #define WEBKIT_IS_WEB_EXTENSION(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_WEB_EXTENSION))
 #define WEBKIT_WEB_EXTENSION_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_WEB_EXTENSION, WebKitWebExtensionClass))
@@ -39,6 +40,13 @@ G_BEGIN_DECLS
 typedef struct _WebKitWebExtension        WebKitWebExtension;
 typedef struct _WebKitWebExtensionClass   WebKitWebExtensionClass;
 typedef struct _WebKitWebExtensionPrivate WebKitWebExtensionPrivate;
+
+struct _WebKitWebExtensionClass {
+    GObjectClass parent_class;
+};
+#endif
+
+WEBKIT_DECLARE_FINAL_TYPE (WebKitWebExtension, webkit_web_extension, WEBKIT, WEB_EXTENSION, GObject)
 
 /**
  * WebKitWebExtensionInitializeFunction:
@@ -63,19 +71,6 @@ typedef void (* WebKitWebExtensionInitializeFunction) (WebKitWebExtension *exten
  */
 typedef void (* WebKitWebExtensionInitializeWithUserDataFunction) (WebKitWebExtension *extension,
                                                                    const GVariant     *user_data);
-
-struct _WebKitWebExtension {
-    GObject parent;
-
-    WebKitWebExtensionPrivate *priv;
-};
-
-struct _WebKitWebExtensionClass {
-    GObjectClass parent_class;
-};
-
-WEBKIT_API GType
-webkit_web_extension_get_type                       (void);
 
 WEBKIT_API WebKitWebPage *
 webkit_web_extension_get_page                       (WebKitWebExtension *extension,

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebHitTestResult.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebHitTestResult.cpp
@@ -56,14 +56,6 @@ using namespace WebCore;
  * Since: 2.8
  */
 
-#if !ENABLE(2022_GLIB_API)
-enum {
-    PROP_0,
-
-    PROP_NODE
-};
-#endif
-
 struct _WebKitWebHitTestResultPrivate {
     WeakPtr<Node, WeakPtrImplWithEventTargetData> node;
 
@@ -73,16 +65,16 @@ struct _WebKitWebHitTestResultPrivate {
 };
 
 #if ENABLE(2022_GLIB_API)
-struct _WebKitWebHitTestResultClass {
-    GObjectClass parent;
-};
-
-WEBKIT_DEFINE_FINAL_TYPE(WebKitWebHitTestResult, webkit_web_hit_test_result, G_TYPE_OBJECT)
+WEBKIT_DEFINE_FINAL_TYPE(WebKitWebHitTestResult, webkit_web_hit_test_result, G_TYPE_OBJECT, GObject)
 #else
 WEBKIT_DEFINE_TYPE(WebKitWebHitTestResult, webkit_web_hit_test_result, WEBKIT_TYPE_HIT_TEST_RESULT)
-#endif
 
-#if !ENABLE(2022_GLIB_API)
+enum {
+    PROP_0,
+
+    PROP_NODE
+};
+
 static void webkitWebHitTestResultGetProperty(GObject* object, guint propId, GValue* value, GParamSpec* paramSpec)
 {
     WebKitWebHitTestResult* webHitTestResult = WEBKIT_WEB_HIT_TEST_RESULT(object);

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebHitTestResult.h.in
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebHitTestResult.h.in
@@ -39,6 +39,7 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_WEB_HIT_TEST_RESULT            (webkit_web_hit_test_result_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_WEB_HIT_TEST_RESULT(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_WEB_HIT_TEST_RESULT, WebKitWebHitTestResult))
 #define WEBKIT_IS_WEB_HIT_TEST_RESULT(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_WEB_HIT_TEST_RESULT))
 #define WEBKIT_WEB_HIT_TEST_RESULT_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_WEB_HIT_TEST_RESULT, WebKitWebHitTestResultClass))
@@ -49,17 +50,6 @@ typedef struct _WebKitWebHitTestResult        WebKitWebHitTestResult;
 typedef struct _WebKitWebHitTestResultClass   WebKitWebHitTestResultClass;
 typedef struct _WebKitWebHitTestResultPrivate WebKitWebHitTestResultPrivate;
 
-struct _WebKitWebHitTestResult {
-#if ENABLE(2022_GLIB_API)
-    GObject parent;
-#else
-    WebKitHitTestResult parent;
-#endif
-
-    WebKitWebHitTestResultPrivate *priv;
-};
-
-#if !ENABLE(2022_GLIB_API)
 struct _WebKitWebHitTestResultClass {
     WebKitHitTestResultClass parent_class;
 
@@ -68,10 +58,11 @@ struct _WebKitWebHitTestResultClass {
     void (*_webkit_reserved2) (void);
     void (*_webkit_reserved3) (void);
 };
-#endif // !ENABLE(2022_GLIB_API)
 
-WEBKIT_API GType
-webkit_web_hit_test_result_get_type             (void);
+WEBKIT_DECLARE_TYPE (WebKitWebHitTestResult, webkit_web_hit_test_result, WEBKIT, WEB_HIT_TEST_RESULT, WebKitHitTestResult)
+#else
+WEBKIT_DECLARE_FINAL_TYPE (WebKitWebHitTestResult, webkit_web_hit_test_result, WEBKIT, WEB_HIT_TEST_RESULT, GObject)
+#endif
 
 #if ENABLE(2022_GLIB_API)
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp
@@ -101,7 +101,7 @@ struct _WebKitWebPagePrivate {
 
 static guint signals[LAST_SIGNAL] = { 0, };
 
-WEBKIT_DEFINE_TYPE(WebKitWebPage, webkit_web_page, G_TYPE_OBJECT)
+WEBKIT_DEFINE_FINAL_TYPE(WebKitWebPage, webkit_web_page, G_TYPE_OBJECT, GObject)
 
 static void webFrameDestroyed(WebFrame*);
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.h.in
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.h.in
@@ -40,6 +40,7 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_WEB_PAGE            (webkit_web_page_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_WEB_PAGE(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_WEB_PAGE, WebKitWebPage))
 #define WEBKIT_IS_WEB_PAGE(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_WEB_PAGE))
 #define WEBKIT_WEB_PAGE_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_WEB_PAGE, WebKitWebPageClass))
@@ -49,6 +50,13 @@ G_BEGIN_DECLS
 typedef struct _WebKitWebPage        WebKitWebPage;
 typedef struct _WebKitWebPageClass   WebKitWebPageClass;
 typedef struct _WebKitWebPagePrivate WebKitWebPagePrivate;
+
+struct _WebKitWebPageClass {
+    GObjectClass parent_class;
+};
+#endif
+
+WEBKIT_DECLARE_FINAL_TYPE (WebKitWebPage, webkit_web_page, WEBKIT, WEB_PAGE, GObject)
 
 /* Forward declarations */
 typedef struct _WebKitWebEditor      WebKitWebEditor;
@@ -73,20 +81,6 @@ typedef enum {
     WEBKIT_FORM_SUBMISSION_WILL_COMPLETE,
 } WebKitFormSubmissionStep;
 #endif
-
-struct _WebKitWebPage {
-    GObject parent;
-
-    /*< private >*/
-    WebKitWebPagePrivate *priv;
-};
-
-struct _WebKitWebPageClass {
-    GObjectClass parent_class;
-};
-
-WEBKIT_API GType
-webkit_web_page_get_type                    (void);
 
 #if !ENABLE(2022_GLIB_API)
 WEBKIT_DEPRECATED WebKitDOMDocument *

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/webkit-web-extension.h.in
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/webkit-web-extension.h.in
@@ -55,7 +55,9 @@
 #include <@API_INCLUDE_PREFIX@/WebKitWebPage.h>
 #include <@API_INCLUDE_PREFIX@/WebKitWebProcessEnumTypes.h>
 
+#if !ENABLE(2022_GLIB_API)
 #include <@API_INCLUDE_PREFIX@/WebKitWebExtensionAutocleanups.h>
+#endif
 
 #undef __WEBKIT_WEB_EXTENSION_H_INSIDE__
 


### PR DESCRIPTION
#### 234799572ddb4c3f4de5bce7784441165474d038
<pre>
[GLib] Most public types should be final; most class structs should be private
<a href="https://bugs.webkit.org/show_bug.cgi?id=243663">https://bugs.webkit.org/show_bug.cgi?id=243663</a>

Reviewed by Michael Catanzaro.

Switch over to using the WEBKIT}_DECLARE_{DERIVABLE,FINAL}_TYPE in
headers for the 2022 API, and provide a version of the macros which
expands to the pre-2022 code when the new API is not in use. By always
using macros to generate boilerplate there is less manually-written code
to maintain, which is always a good thing. There are some caveats:

- For the old API the WEBKIT_*_FOO macros have to be kept, because the
  macros that generate boilerplate produce those as static inline
  functions and existing code might be relying on them being macros.
  This results using guards in the code, which is not great, but there
  is not a better option.

- The G_DECLARE_DERIVABLE_TYPE macro produces itself the instance struct,
  with the parent type struct as only member. Using it would need
  modifying the code to avoid using the &quot;priv&quot; member, which would be
  some churn. Moreover, the &quot;priv&quot; member is used by the for the
  old API and making every access to it conditional would be
  cumbersome. A modified version of the macro that keeps the &quot;priv&quot;
  member is used instead.

  While in theory we could save 8 bytes (or 4 in 32-bit) per instance
  using G_ADD_PRIVATE, in practice GLib rounds up the size of instance
  to ensure its beginning is aligned, which in cases would practically
  cancel out the savings. Also, API objects are not so numerous, and
  therefore the potential memory savings are a moot point.

  Tackling the removal of the &quot;priv&quot; instance members might be done
  at some point in the future.

- On the other hand, while G_DECLARE_FINAL_TYPE also creates the class
  struct without any frills, we can use the macro because it is allowed
  to turn later on a final type into a non-final one without breaking
  the ABI. Hence, this GLib macro gets reused with a few additions.

While at it, derivable types (WebKitWebView, WebKitInputMethodContext,
WebKitPolicyDecision) have been changed to use the DERIVABLE version of
the macros. This needs to be done in the same patch because the
subclasses of WebKitPolicyDecision are final and the generated
boilerplace includes definitions for autocleanups, and expects that the
parent type has their autocleanups defined in a certain way. Conversely,
the WebKitAutocleanups.h.in header needed a touch-up to avoid providing
duplicate definitions of the autocleanups generated by the boilerplate
macros.

The instance struct for the types which are now final has been moved
into the implementation files, by piggybacking into the
WEBKIT_DEFINE_FINAL_TYPE[_WITH_CODE] macros to emit its definition.

Finally, the _IN_2022_API suffix gets removed from the
WEBKIT_DEFINE_FINAL_TYPE_WITH_CODE_IN_2022_API and
WEBKIT_DEFINE_FINAL_TYPE_IN_2022_API for the sake of brevity, and a
few more types are marked as final.

* Source/WTF/wtf/glib/WTFGType.h:
* Source/WebKit/PlatformGTK.cmake: Install WebKitWebExtensionAutocleanups.h
  only for the old API.
* Source/WebKit/UIProcess/API/glib/WebKitAuthenticationRequest.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitAuthenticationRequest.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitAutocleanups.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitAutomationSession.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitAutomationSession.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitBackForwardList.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitBackForwardList.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitBackForwardListItem.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitBackForwardListItem.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitContextMenu.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitContextMenuItem.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitCookieManager.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitCookieManager.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitDefines.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitDeviceInfoPermissionRequest.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitDeviceInfoPermissionRequest.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitDownload.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitDownload.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitEditorState.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitEditorState.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitFileChooserRequest.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitFileChooserRequest.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitFindController.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitFindController.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitFormSubmissionRequest.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitFormSubmissionRequest.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitGeolocationManager.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitGeolocationManager.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitGeolocationPermissionRequest.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitGeolocationPermissionRequest.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitHitTestResult.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitInputMethodContext.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitMediaKeySystemPermissionRequest.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitMediaKeySystemPermissionRequest.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitNavigationPolicyDecision.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitNavigationPolicyDecision.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitNotification.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitNotification.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitNotificationPermissionRequest.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitNotificationPermissionRequest.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitOptionMenu.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitOptionMenu.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitPointerLockPermissionRequest.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitPolicyDecision.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitResponsePolicyDecision.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitResponsePolicyDecision.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitSecurityManager.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitSecurityManager.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitSettings.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitURIRequest.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitURIResponse.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitURISchemeRequest.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitURISchemeRequest.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitURISchemeResponse.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitURISchemeResponse.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitUserContentFilterStore.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitUserContentFilterStore.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitUserMediaPermissionRequest.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitUserMediaPermissionRequest.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitUserMessage.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitWebContext.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitWebResource.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitWebResource.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataAccessPermissionRequest.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataAccessPermissionRequest.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitWebsitePolicies.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitWebsitePolicies.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitWindowProperties.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitWindowProperties.h.in:
* Source/WebKit/UIProcess/API/gtk/WebKitColorChooserRequest.cpp:
* Source/WebKit/UIProcess/API/gtk/WebKitColorChooserRequest.h.in:
* Source/WebKit/UIProcess/API/gtk/WebKitPointerLockPermissionRequest.h.in:
* Source/WebKit/UIProcess/API/gtk/WebKitPrintOperation.cpp:
* Source/WebKit/UIProcess/API/gtk/WebKitPrintOperation.h.in:
* Source/WebKit/UIProcess/API/gtk/WebKitWebInspector.cpp:
* Source/WebKit/UIProcess/API/gtk/WebKitWebInspector.h.in:
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.h.in:
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitFrame.cpp:
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitFrame.h.in:
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitScriptWorld.cpp:
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitScriptWorld.h.in:
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebEditor.cpp:
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebEditor.h.in:
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebExtension.cpp:
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebExtension.h.in:
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebHitTestResult.cpp:
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebHitTestResult.h.in:
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp:
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.h.in:
* Source/WebKit/WebProcess/InjectedBundle/API/glib/webkit-web-extension.h.in:

Canonical link: <a href="https://commits.webkit.org/260190@main">https://commits.webkit.org/260190@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/629e8e09b1d63a9e0eb749cec04de3eaf2743734

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107487 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16549 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40390 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116650 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116071 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17974 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7791 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99651 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113248 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13573 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96758 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41196 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95478 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28384 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82967 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/96824 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9555 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29737 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/96246 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/7554 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10212 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/6631 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/30810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15711 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49318 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/105094 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7048 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11772 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26061 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->