### PR TITLE
Update site isolated iframe sizes when they change

### DIFF
--- a/LayoutTests/http/tests/site-isolation/basic-iframe-expected.html
+++ b/LayoutTests/http/tests/site-isolation/basic-iframe-expected.html
@@ -1,0 +1,3 @@
+<body bgcolor=blue>
+<div style="width:300px;height:150px;background-color:green;">
+</body>

--- a/LayoutTests/http/tests/site-isolation/basic-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/basic-iframe.html
@@ -1,0 +1,4 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<body bgcolor=blue>
+<iframe src="http://localhost:8000/site-isolation/resources/green-background.html" frameborder=0></iframe>
+</body>

--- a/Source/WebCore/page/RemoteFrameClient.h
+++ b/Source/WebCore/page/RemoteFrameClient.h
@@ -29,10 +29,13 @@
 
 namespace WebCore {
 
+class IntSize;
+
 class RemoteFrameClient {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     virtual void frameDetached() = 0;
+    virtual void sizeDidChange(IntSize) = 0;
     virtual ~RemoteFrameClient() { }
 };
 

--- a/Source/WebCore/page/RemoteFrameView.cpp
+++ b/Source/WebCore/page/RemoteFrameView.cpp
@@ -27,12 +27,21 @@
 #include "RemoteFrameView.h"
 
 #include "RemoteFrame.h"
+#include "RemoteFrameClient.h"
 
 namespace WebCore {
 
 RemoteFrameView::RemoteFrameView(RemoteFrame& frame)
     : m_frame(frame)
 {
+}
+
+void RemoteFrameView::setFrameRect(const IntRect& newRect)
+{
+    IntRect oldRect = frameRect();
+    if (newRect.size() != oldRect.size())
+        m_frame->client().sizeDidChange(newRect.size());
+    AbstractFrameView::setFrameRect(newRect);
 }
 
 // FIXME: Implement all the stubs below.

--- a/Source/WebCore/page/RemoteFrameView.h
+++ b/Source/WebCore/page/RemoteFrameView.h
@@ -66,6 +66,8 @@ private:
     void updateLayerPositionsAfterScrolling() final;
     void updateCompositingLayersAfterScrolling() final;
 
+    void setFrameRect(const IntRect&) final;
+
     const Ref<RemoteFrame> m_frame;
 };
 

--- a/Source/WebKit/Platform/IPC/MessageSender.h
+++ b/Source/WebKit/Platform/IPC/MessageSender.h
@@ -88,6 +88,12 @@ public:
         return sendWithAsyncReply(WTFMove(message), WTFMove(completionHandler), messageSenderDestinationID(), sendOptions);
     }
 
+    template<typename T, typename C, typename U>
+    AsyncReplyID sendWithAsyncReply(T&& message, C&& completionHandler, ObjectIdentifier<U> destinationID, OptionSet<SendOption> sendOptions = { })
+    {
+        return sendWithAsyncReply(std::forward<T>(message), std::forward<C>(completionHandler), destinationID.toUInt64(), sendOptions);
+    }
+
     template<typename T, typename C>
     AsyncReplyID sendWithAsyncReply(T&& message, C&& completionHandler, uint64_t destinationID, OptionSet<SendOption> sendOptions = { })
     {

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
@@ -238,9 +238,9 @@ public:
     const LayerPropertiesMap& changedLayerProperties() const { return m_changedLayerProperties; }
     LayerPropertiesMap& changedLayerProperties() { return m_changedLayerProperties; }
 
-    void setRemoteContextHostIdentifier(Markable<WebCore::LayerHostingContextIdentifier> identifier) { m_remoteContextHostIdentifier = identifier; }
-    Markable<WebCore::LayerHostingContextIdentifier> remoteContextHostIdentifier() const { return m_remoteContextHostIdentifier; }
-    bool isMainFrameProcessTransaction() const { return !m_remoteContextHostIdentifier; }
+    void setRemoteContextHostedIdentifier(Markable<WebCore::LayerHostingContextIdentifier> identifier) { m_remoteContextHostedIdentifier = identifier; }
+    Markable<WebCore::LayerHostingContextIdentifier> remoteContextHostedIdentifier() const { return m_remoteContextHostedIdentifier; }
+    bool isMainFrameProcessTransaction() const { return !m_remoteContextHostedIdentifier; }
 
     WebCore::IntSize contentsSize() const { return m_contentsSize; }
     void setContentsSize(const WebCore::IntSize& size) { m_contentsSize = size; };
@@ -337,7 +337,7 @@ private:
     HashSet<RefPtr<PlatformCALayerRemote>> m_changedLayers; // Only used in the Web process.
     LayerPropertiesMap m_changedLayerProperties; // Only used in the UI process.
 
-    Markable<WebCore::LayerHostingContextIdentifier> m_remoteContextHostIdentifier;
+    Markable<WebCore::LayerHostingContextIdentifier> m_remoteContextHostedIdentifier;
 
     Vector<LayerCreationProperties> m_createdLayers;
     Vector<WebCore::GraphicsLayer::PlatformLayerID> m_destroyedLayerIDs;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
@@ -581,7 +581,7 @@ void RemoteLayerTreeTransaction::encode(IPC::Encoder& encoder) const
 {
     encoder << m_rootLayerID;
     encoder << m_createdLayers;
-    encoder << m_remoteContextHostIdentifier;
+    encoder << m_remoteContextHostedIdentifier;
 
     encoder << static_cast<uint64_t>(m_changedLayers.size());
 
@@ -654,7 +654,7 @@ bool RemoteLayerTreeTransaction::decode(IPC::Decoder& decoder, RemoteLayerTreeTr
     if (!decoder.decode(result.m_createdLayers))
         return false;
 
-    if (!decoder.decode(result.m_remoteContextHostIdentifier))
+    if (!decoder.decode(result.m_remoteContextHostedIdentifier))
         return false;
 
     uint64_t numChangedLayerProperties;

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -68,7 +68,13 @@ public:
     enum class ShouldStartProcessThrottlerActivity : bool { No, Yes };
     using AsyncReplyID = IPC::Connection::AsyncReplyID;
     template<typename T, typename C> AsyncReplyID sendWithAsyncReply(T&&, C&&, uint64_t destinationID = 0, OptionSet<IPC::SendOption> = { }, ShouldStartProcessThrottlerActivity = ShouldStartProcessThrottlerActivity::Yes);
-    
+
+    template<typename T, typename C, typename U>
+    AsyncReplyID sendWithAsyncReply(T&& message, C&& completionHandler, ObjectIdentifier<U> destinationID, OptionSet<IPC::SendOption> sendOptions = { }, ShouldStartProcessThrottlerActivity shouldStartProcessThrottlerActivity = ShouldStartProcessThrottlerActivity::Yes)
+    {
+        return sendWithAsyncReply(std::forward<T>(message), std::forward<C>(completionHandler), destinationID.toUInt64(), sendOptions, shouldStartProcessThrottlerActivity);
+    }
+
     template<typename T, typename U>
     bool send(T&& message, ObjectIdentifier<U> destinationID, OptionSet<IPC::SendOption> sendOptions = { })
     {

--- a/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
@@ -65,13 +65,6 @@ ProvisionalFrameProxy::ProvisionalFrameProxy(WebFrameProxy& frame, Ref<WebProces
     auto parameters = page.creationParameters(m_process, *drawingArea);
     parameters.isProcessSwap = true; // FIXME: This should be a parameter to creationParameters rather than doctoring up the parameters afterwards.
     parameters.topContentInset = 0;
-    parameters.viewSize = { 300, 150 }; // FIXME: Get the real size from the parent process.
-#if ENABLE(META_VIEWPORT)
-    // FIXME: This is incorrect, but needed to make the root layer the right size in the basic-iframe.html layout test.
-    // Investigate whether iframes think their viewport size is just the size of the iframe.
-    // and maybe update viewportConfigurationViewSize as well if needed.
-    parameters.viewportConfigurationViewLayoutSize = { 300, 150 };
-#endif
     parameters.layerHostingContextIdentifier = m_layerHostingContextIdentifier;
     parameters.mainFrameIdentifier = frame.frameID();
     m_process->send(Messages::WebProcess::CreateWebPage(m_pageID, parameters), 0);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -126,7 +126,9 @@ private:
     RetainPtr<CALayer> m_exposedRectIndicatorLayer;
 
     TransactionID m_pendingLayerTreeTransactionID;
+#if ASSERT_ENABLED
     TransactionID m_lastVisibleTransactionID;
+#endif
     TransactionID m_transactionIDForPendingCACommit;
     TransactionID m_transactionIDForUnhidingContent;
     ActivityStateChangeID m_activityStateChangeID { ActivityStateChangeAsynchronous };

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
@@ -137,9 +137,10 @@ bool RemoteLayerTreeHost::updateLayerTree(const RemoteLayerTreeTransaction& tran
         RemoteLayerTreePropertyApplier::applyHierarchyUpdates(*node, properties, m_nodes);
     }
 
-    if (auto contextHostID = transaction.remoteContextHostIdentifier()) {
-        m_hostedLayers.set(*contextHostID, rootNode->layerID());
-        if (auto* remoteRootNode = nodeForID(m_hostingLayers.get(*contextHostID)))
+    if (auto contextHostedID = transaction.remoteContextHostedIdentifier()) {
+        m_hostedLayers.set(*contextHostedID, rootNode->layerID());
+        rootNode->setRemoteContextHostedIdentifier(*contextHostedID);
+        if (auto* remoteRootNode = nodeForID(m_hostingLayers.get(*contextHostedID)))
             [remoteRootNode->layer() addSublayer:rootNode->layer()];
     }
 
@@ -215,11 +216,10 @@ void RemoteLayerTreeHost::layerWillBeRemoved(WebCore::GraphicsLayer::PlatformLay
     }
 
     if (auto node = m_nodes.take(layerID)) {
-        if (auto hostIdentifier = node->remoteContextHostIdentifier()) {
-            ASSERT(m_hostingLayers.contains(*hostIdentifier));
-            m_hostingLayers.remove(*hostIdentifier);
-            m_hostedLayers.remove(*hostIdentifier);
-        }
+        if (auto hostingIdentifier = node->remoteContextHostingIdentifier())
+            m_hostingLayers.remove(*hostingIdentifier);
+        if (auto hostedIdentifier = node->remoteContextHostedIdentifier())
+            m_hostedLayers.remove(*hostedIdentifier);
     }
 }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
@@ -83,13 +83,16 @@ public:
     void setScrollingNodeID(WebCore::ScrollingNodeID nodeID) { m_scrollingNodeID = nodeID; }
 #endif
 
-    Markable<WebCore::LayerHostingContextIdentifier> remoteContextHostIdentifier() const { return m_remoteContextHostIdentifier; }
+    Markable<WebCore::LayerHostingContextIdentifier> remoteContextHostingIdentifier() const { return m_remoteContextHostingIdentifier; }
+    Markable<WebCore::LayerHostingContextIdentifier> remoteContextHostedIdentifier() const { return m_remoteContextHostedIdentifier; }
+    void setRemoteContextHostedIdentifier(WebCore::LayerHostingContextIdentifier identifier) { m_remoteContextHostedIdentifier = identifier; }
 
 private:
     void initializeLayer();
 
     WebCore::GraphicsLayer::PlatformLayerID m_layerID;
-    Markable<WebCore::LayerHostingContextIdentifier> m_remoteContextHostIdentifier;
+    Markable<WebCore::LayerHostingContextIdentifier> m_remoteContextHostingIdentifier;
+    Markable<WebCore::LayerHostingContextIdentifier> m_remoteContextHostedIdentifier;
 
     RetainPtr<CALayer> m_layer;
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
@@ -40,7 +40,7 @@ static NSString *const WKRemoteLayerTreeNodePropertyKey = @"WKRemoteLayerTreeNod
 
 RemoteLayerTreeNode::RemoteLayerTreeNode(WebCore::GraphicsLayer::PlatformLayerID layerID, Markable<WebCore::LayerHostingContextIdentifier> hostIdentifier, RetainPtr<CALayer> layer)
     : m_layerID(layerID)
-    , m_remoteContextHostIdentifier(hostIdentifier)
+    , m_remoteContextHostingIdentifier(hostIdentifier)
     , m_layer(WTFMove(layer))
 {
     initializeLayer();
@@ -50,7 +50,7 @@ RemoteLayerTreeNode::RemoteLayerTreeNode(WebCore::GraphicsLayer::PlatformLayerID
 #if PLATFORM(IOS_FAMILY)
 RemoteLayerTreeNode::RemoteLayerTreeNode(WebCore::GraphicsLayer::PlatformLayerID layerID, Markable<WebCore::LayerHostingContextIdentifier> hostIdentifier, RetainPtr<UIView> uiView)
     : m_layerID(layerID)
-    , m_remoteContextHostIdentifier(hostIdentifier)
+    , m_remoteContextHostingIdentifier(hostIdentifier)
     , m_layer([uiView.get() layer])
     , m_uiView(WTFMove(uiView))
 {

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -149,6 +149,8 @@ public:
 
     void getFrameInfo(CompletionHandler<void(FrameTreeNodeData&&)>&&);
 
+    void updateRemoteFrameSize(WebCore::IntSize);
+
     WebFrameProxy* parentFrame() { return m_parentFrame.get(); }
 
 private:

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -4830,6 +4830,12 @@ void WebPageProxy::setNetworkRequestsInProgress(bool networkRequestsInProgress)
     m_pageLoadState.setNetworkRequestsInProgress(transaction, networkRequestsInProgress);
 }
 
+void WebPageProxy::updateRemoteFrameSize(WebCore::FrameIdentifier frameID, WebCore::IntSize size)
+{
+    if (RefPtr frame = WebFrameProxy::webFrame(frameID))
+        frame->updateRemoteFrameSize(size);
+}
+
 void WebPageProxy::preconnectTo(const URL& url, const String& userAgent)
 {
     if (!m_websiteDataStore->configuration().allowsServerPreconnect())

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2283,6 +2283,8 @@ private:
     void didFinishProgress();
     void setNetworkRequestsInProgress(bool);
 
+    void updateRemoteFrameSize(WebCore::FrameIdentifier, WebCore::IntSize);
+
     void didDestroyNavigation(uint64_t navigationID);
 
     void decidePolicyForNavigationAction(Ref<WebProcessProxy>&&, WebCore::PageIdentifier, WebFrameProxy&, FrameInfoData&&, uint64_t navigationID, NavigationActionData&&, FrameInfoData&& originatingFrameInfo,

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -136,6 +136,8 @@ messages -> WebPageProxy {
     DidExplicitOpenForFrame(WebCore::FrameIdentifier frameID, URL url, String mimeType)
     DidDestroyNavigation(uint64_t navigationID)
 
+    UpdateRemoteFrameSize(WebCore::FrameIdentifier frameID, WebCore::IntSize size)
+
     MainFramePluginHandlesPageScaleGestureDidChange(bool mainFramePluginHandlesPageScaleGesture)
 
 #if PLATFORM(GTK) || PLATFORM(WPE)

--- a/Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.mm
@@ -192,7 +192,7 @@ void TiledCoreAnimationDrawingAreaProxy::sendUpdateGeometry()
         if (!weakThis)
             return;
         weakThis->didUpdateGeometry();
-    }, m_identifier.toUInt64());
+    }, m_identifier);
 }
 
 void TiledCoreAnimationDrawingAreaProxy::adjustTransientZoom(double scale, FloatPoint origin)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
@@ -54,4 +54,9 @@ void WebRemoteFrameClient::frameDetached()
     m_frame->invalidate();
 }
 
+void WebRemoteFrameClient::sizeDidChange(WebCore::IntSize size)
+{
+    m_frame->updateRemoteFrameSize(size);
+}
+
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h
@@ -40,6 +40,7 @@ public:
 
 private:
     void frameDetached() final;
+    void sizeDidChange(WebCore::IntSize) final;
 
     Ref<WebFrame> m_frame;
     ScopeExit<Function<void()>> m_frameInvalidator;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
@@ -151,7 +151,7 @@ void RemoteLayerTreeContext::buildTransaction(RemoteLayerTreeTransaction& transa
 
     PlatformCALayerRemote& rootLayerRemote = downcast<PlatformCALayerRemote>(rootLayer);
     transaction.setRootLayerID(rootLayerRemote.layerID());
-    transaction.setRemoteContextHostIdentifier(m_webPage.layerHostingContextIdentifier());
+    transaction.setRemoteContextHostedIdentifier(m_webPage.layerHostingContextIdentifier());
 
     m_currentTransaction = &transaction;
     rootLayerRemote.recursiveBuildTransaction(*this, transaction);

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -952,6 +952,13 @@ String WebFrame::mimeTypeForResourceWithURL(const URL& url) const
     return String();
 }
 
+void WebFrame::updateRemoteFrameSize(WebCore::IntSize size)
+{
+    // FIXME: This should probably be a WebFrameProxy message, but WebFrameProxy::commitProvisionalFrame currently removes the parent frame's process as a message receiver.
+    if (m_page)
+        m_page->send(Messages::WebPageProxy::UpdateRemoteFrameSize(m_frameID, size));
+}
+
 void WebFrame::setTextDirection(const String& direction)
 {
     auto* localFrame = dynamicDowncast<LocalFrame>(m_coreFrame.get());

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -177,6 +177,7 @@ public:
     String mimeTypeForResourceWithURL(const URL&) const;
 
     void setTextDirection(const String&);
+    void updateRemoteFrameSize(WebCore::IntSize);
 
     void documentLoaderDetached(uint64_t navigationID);
 


### PR DESCRIPTION
#### 50e575d266dd7fb9c8e4fe597b2ac4ae1712b5f3
<pre>
Update site isolated iframe sizes when they change
<a href="https://bugs.webkit.org/show_bug.cgi?id=252020">https://bugs.webkit.org/show_bug.cgi?id=252020</a>
rdar://105244387

Reviewed by Simon Fraser.

In order to draw iframes the right size, we get the layer size from the parent
process and send it to the iframe process in a DrawingArea::UpdateGeometry message.

In order to send the DrawingArea::DisplayDidRefresh message to the right process
as a result of a RemoteLayerTreeDrawingAreaProxy::CommitLayerTree message,
instead of calling didRefreshDisplay which does several things that don&apos;t relate
to subframe processes, just send the DrawingArea::DisplayDidRefresh which is the
only part we need for drawing to continue.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTree):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h:
(WebKit::RemoteLayerTreeHost::hostingLayersInverse const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
(WebKit::RemoteLayerTreeHost::layerWillBeRemoved):
(WebKit::RemoteLayerTreeHost::createLayer):
* Source/WebKit/UIProcess/SubframePageProxy.cpp:
(WebKit::SubframePageProxy::SubframePageProxy):
(WebKit::SubframePageProxy::~SubframePageProxy):
* Source/WebKit/UIProcess/SubframePageProxy.h:
(WebKit::SubframePageProxy::layerHostingContextIdentifier const):
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::commitProvisionalFrame):
* Source/WebKit/UIProcess/WebFrameProxy.h:
(WebKit::WebFrameProxy::subframePage const):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::addHostedFrame):
(WebKit::WebPageProxy::removeHostedFrame):
(WebKit::WebPageProxy::getHostedFrame):
* Source/WebKit/UIProcess/WebPageProxy.h:

Canonical link: <a href="https://commits.webkit.org/260406@main">https://commits.webkit.org/260406@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3a9fba86fb104e9e5d6c8ec7f12fe6662b0d439

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108240 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17330 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/41107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/117362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112127 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/18719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8609 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100453 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114009 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/18719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/41107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/42017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/18719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/41107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/10178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/41107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/10914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/7194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/16327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/41107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12497 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3914 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->