### PR TITLE
[ macOS ] webanimations/accelerated-animation-slot-invalidation.html is a flaky image failure

### DIFF
--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2073,7 +2073,6 @@ webkit.org/b/223944 [ BigSur Debug ] imported/w3c/web-platform-tests/xhr/event-u
 
 # webkit.org/b/224066 Updating test expectations for 10 tests
 [ BigSur ] webanimations/accelerated-animation-easing-and-direction-update.html [ Pass ImageOnlyFailure ]
-[ BigSur ] webanimations/accelerated-animation-slot-invalidation.html [ Pass ImageOnlyFailure ]
 [ BigSur ] webanimations/accelerated-animation-with-easing.html [ Pass ImageOnlyFailure ]
 [ BigSur ] webanimations/accelerated-overlapping-transform-animations.html [ Pass ImageOnlyFailure ]
 [ BigSur ] webanimations/accelerated-transform-related-animation-property-order.html [ Pass ImageOnlyFailure ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2623,8 +2623,6 @@ imported/blink/fast/multicol/vertical-lr/float-content-break.html [ ImageOnlyFai
 
 editing/execCommand/insert-ordered-list-and-delete.html [ Pass Failure ]
 
-webkit.org/b/239791 webanimations/accelerated-animation-slot-invalidation.html [ Pass ImageOnlyFailure ]
-
 webkit.org/b/244932 webanimations/accelerated-overlapping-transform-animations.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/239990 css3/calc/transitions-dependent.html [ Pass Failure ]

--- a/LayoutTests/webanimations/accelerated-animation-slot-invalidation.html
+++ b/LayoutTests/webanimations/accelerated-animation-slot-invalidation.html
@@ -55,7 +55,7 @@ window.onload = async function() {
     firstElement.slot = "first";
     firstElement.id = "first";
 
-    await new Promise(resolve => requestAnimationFrame(resolve));
+    await new Promise(requestAnimationFrame);
 
     // Create another named slot and assign another element to it.
     let secondSlot = shadowRoot.appendChild(document.createElement("slot"));
@@ -71,14 +71,15 @@ window.onload = async function() {
 
     await animation.ready;
 
-    await new Promise(resolve => requestAnimationFrame(resolve));
-    await new Promise(resolve => requestAnimationFrame(resolve));
+    await new Promise(requestAnimationFrame);
+    await new Promise(requestAnimationFrame);
+    await new Promise(requestAnimationFrame);
 
     firstElement.remove();
 
     // Wait until animation has progressed some before snapshotting the test result.
     while (animation.currentTime < 100)
-        await new Promise(resolve => requestAnimationFrame(resolve));
+        await new Promise(requestAnimationFrame);
 
     if (window.testRunner)
         testRunner.notifyDone();


### PR DESCRIPTION
#### d45076489b6d0d05337fec3d9dfd19b42cc9a8e3
<pre>
[ macOS ] webanimations/accelerated-animation-slot-invalidation.html is a flaky image failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=239791">https://bugs.webkit.org/show_bug.cgi?id=239791</a>
rdar://problem/92360412

Reviewed by Antti Koivisto.

We need to wait an extra frame after the accelerated animation is committed for stable results.

* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
* LayoutTests/webanimations/accelerated-animation-slot-invalidation.html:

Canonical link: <a href="https://commits.webkit.org/260109@main">https://commits.webkit.org/260109@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/146d7e7c92dc80260205dc76d786bf4c94a8e43e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107093 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16143 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39883 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116269 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115763 "Hash 146d7e7c for PR 9911 does not build (failure)") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17602 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7342 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99270 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112858 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13302 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96350 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40906 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95196 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27986 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9234 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29330 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9841 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/6329 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15393 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48904 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11383 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3775 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->