### PR TITLE
Reduce size of code emitted for stack loads/stores from Air on ARM

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.cpp
@@ -143,19 +143,39 @@ void GenerateAndAllocateRegisters::insertBlocksForFlushAfterTerminalPatchpoints(
     blockInsertionSet.execute();
 }
 
-static ALWAYS_INLINE CCallHelpers::Address callFrameAddr(Air::Opcode opcode, CCallHelpers& jit, intptr_t offsetFromFP)
-{
+static ALWAYS_INLINE Air::Arg callFrameAddr(Air::Opcode opcode, CCallHelpers& jit, intptr_t offsetFromFP, intptr_t frameSize, Width width)
+{    
     if (isX86()) {
         ASSERT(Arg::addr(Air::Tmp(GPRInfo::callFrameRegister), offsetFromFP).isValidForm(Move, Width64));
     }
 
     auto addr = Arg::addr(Air::Tmp(GPRInfo::callFrameRegister), offsetFromFP);
-    if (addr.isValidForm(opcode, registerWidth()))
-        return CCallHelpers::Address(GPRInfo::callFrameRegister, offsetFromFP);
+    if (addr.isValidForm(opcode, width))
+        return addr;
+
+    if (isARM64() || isARM_THUMB2()) {
+        // Try finding a valid offset from the stack pointer register instead.
+        // (this trick is also done in Air::lowerStackArgs:126)
+        auto offsetFromSP = offsetFromFP + frameSize;
+        addr = Arg::addr(Air::Tmp(MacroAssembler::stackPointerRegister), offsetFromSP);
+        if (addr.isValidForm(opcode, width))
+            return addr;
+    }
+    
     GPRReg reg = extendedOffsetAddrRegister();
     jit.move(CCallHelpers::TrustedImmPtr(offsetFromFP), reg);
+    if (isARM64() || isARM_THUMB2()) {
+        // Try finding a valid indexing of extendedOffsetAddrRegister
+        // into the frame pointer register.
+        // (Have to materialze the offset into extendedOffsetAddrRegister.)
+        auto index = Arg::index(Air::Tmp(GPRInfo::callFrameRegister), Air::Tmp(reg), 1, 0);
+        if (index.isValidForm(opcode, width))
+            return index;
+    }
+    
+    // Resort to computing the absolute address in extendedOffsetAddrRegister.
     jit.addPtr(GPRInfo::callFrameRegister, reg);
-    return CCallHelpers::Address(reg);
+    return Arg::addr(Air::Tmp(reg));
 }
 
 ALWAYS_INLINE void GenerateAndAllocateRegisters::release(Tmp tmp, Reg reg)
@@ -175,14 +195,22 @@ ALWAYS_INLINE void GenerateAndAllocateRegisters::flush(Tmp tmp, Reg reg)
     ASSERT(tmp);
     intptr_t offset = m_map[tmp].spillSlot->offsetFromFP();
     JIT_COMMENT(*m_jit, "Flush(", tmp, ", ", reg, ", offset=", offset, ")");
-    if (tmp.isGP())
-        m_jit->storeRegWord(reg.gpr(), callFrameAddr(Air::Move, *m_jit, offset));
-    else if (B3::conservativeRegisterBytes(B3::FP) == sizeof(double) || !m_code.usesSIMD()) {
+    if (tmp.isGP()) {
+        auto dest = callFrameAddr(Air::Move, *m_jit, offset, m_code.frameSize(), registerWidth());
+        if (dest.isAddr())
+            m_jit->storeRegWord(reg.gpr(), dest.asAddress());
+        else
+            m_jit->storeRegWord(reg.gpr(), dest.asBaseIndex());
+    } else if (B3::conservativeRegisterBytes(B3::FP) == sizeof(double) || !m_code.usesSIMD()) {
         ASSERT(m_map[tmp].spillSlot->byteSize() == bytesForWidth(Width64));
-        m_jit->storeDouble(reg.fpr(), callFrameAddr(Air::Move, *m_jit, offset));
+        auto dest = callFrameAddr(Air::MoveDouble, *m_jit, offset, m_code.frameSize(), Width64);
+        ASSERT(dest.isAddr());
+        m_jit->storeDouble(reg.fpr(), dest.asAddress());
     } else {
         ASSERT(m_map[tmp].spillSlot->byteSize() == bytesForWidth(Width128));
-        m_jit->storeVector(reg.fpr(), callFrameAddr(Air::MoveDouble, *m_jit, offset));
+        auto dest = callFrameAddr(Air::MoveDouble, *m_jit, offset, m_code.frameSize(), Width128);
+        ASSERT(dest.isAddr());
+        m_jit->storeVector(reg.fpr(), dest.asAddress());
     }
 }
 
@@ -211,14 +239,22 @@ ALWAYS_INLINE void GenerateAndAllocateRegisters::alloc(Tmp tmp, Reg reg, Arg::Ro
     if (Arg::isAnyUse(role)) {
         JIT_COMMENT(*m_jit, "Alloc(", tmp, ", ", reg, ", role=", role, ")");
         intptr_t offset = m_map[tmp].spillSlot->offsetFromFP();
-        if (tmp.bank() == GP)
-            m_jit->loadRegWord(callFrameAddr(Air::Move, *m_jit, offset), reg.gpr());
-        else if (B3::conservativeRegisterBytes(B3::FP) == sizeof(double) || !m_code.usesSIMD()) {
+        if (tmp.bank() == GP) {
+            auto src = callFrameAddr(Air::Move, *m_jit, offset, m_code.frameSize(), registerWidth());
+            if (src.isAddr())
+                m_jit->loadRegWord(src.asAddress(), reg.gpr());
+            else
+                m_jit->loadRegWord(src.asBaseIndex(), reg.gpr());
+        } else if (B3::conservativeRegisterBytes(B3::FP) == sizeof(double) || !m_code.usesSIMD()) {
             ASSERT(m_map[tmp].spillSlot->byteSize() == bytesForWidth(Width64));
-            m_jit->loadDouble(callFrameAddr(Air::MoveDouble, *m_jit, offset), reg.fpr());
+            auto src = callFrameAddr(Air::MoveDouble, *m_jit, offset, m_code.frameSize(), Width64);
+            ASSERT(src.isAddr());
+            m_jit->loadDouble(src.asAddress(), reg.fpr());
         } else {
             ASSERT(m_map[tmp].spillSlot->byteSize() == bytesForWidth(Width128));
-            m_jit->loadVector(callFrameAddr(Air::MoveDouble, *m_jit, offset), reg.fpr());
+            auto src = callFrameAddr(Air::MoveDouble, *m_jit, offset, m_code.frameSize(), Width128);
+            ASSERT(src.isAddr());
+            m_jit->loadVector(src.asAddress(), reg.fpr());
         }
     }
 }

--- a/Source/JavaScriptCore/b3/air/AirArg.h
+++ b/Source/JavaScriptCore/b3/air/AirArg.h
@@ -1304,7 +1304,7 @@ public:
     template<typename Int, typename = Value::IsLegalOffset<Int>>
     static bool isValidAddrForm(Air::Opcode opcode, Int offset, std::optional<Width> width = std::nullopt)
     {
-#if !CPU(ARM_THUM2)
+#if !CPU(ARM_THUMB2)
         UNUSED_PARAM(opcode);
 #endif
         if (isX86())
@@ -1360,6 +1360,22 @@ public:
         return false;
     }
 
+    static bool isValidIndexOp(Air::Opcode opcode)
+    {
+        if (isX86())
+            return true;
+        if (isARM64() || isARM_THUMB2()) {
+            switch (opcode) {
+            case Move:
+            case Move32:
+                return true;
+            default:
+                return false;
+            }
+        }
+        return false;
+    }
+
     template<typename Int, typename = Value::IsLegalOffset<Int>>
     static bool isValidIncrementIndexForm(Int offset)
     {
@@ -1396,7 +1412,7 @@ public:
         case CallArg:
             return isValidAddrForm(opcode, offset(), width);
         case Index:
-            return isValidIndexForm(scale(), offset(), width);
+            return isValidIndexOp(opcode) && isValidIndexForm(scale(), offset(), width);
         case PreIndex:
         case PostIndex:
             return isValidIncrementIndexForm(offset());


### PR DESCRIPTION
#### 2c63ba4e32b8068c4b026a8ea628ea96c0d85a39
<pre>
Reduce size of code emitted for stack loads/stores from Air on ARM

Need the bug URL (OOPS!).

Reviewed by NOBODY (OOPS!).

This changes callFrameAddr (AirAllocateRegistersAndStackAndGenerateCode.cpp)
and its users to (which ever succeeds first)

 1. generate an address offset from GPRInfo::callFrameRegister
    (unchanged)
 2. generate an address offset from MacroAssembler::stackPointerRegister
 3. load the offset into extendedOffsetAddrRegister and generate
    a BaseIndex [GPRInfo::callFrameRegister, extendedOffsetAddrRegister]
 4. resort to computing the absolute address in extendedOffsetAddrRegister
    (this was the previous fallback after 1.)

For 3. to work reliably we need to change Air::Arg::isValidForm
to reject BaseIndex addressing when it is not supported on ARM.

The result of these changes is a significant reduction in code size
due to avoiding the fallback behavior in many cases (4).

Code generated for the JetStream2 WASM benchmarks is ~30% smaller on ARMv7
and ~40% smaller on ARM64.

* Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.cpp:
(JSC::B3::Air::callFrameAddr):
(JSC::B3::Air::GenerateAndAllocateRegisters::flush):
(JSC::B3::Air::GenerateAndAllocateRegisters::alloc):
* Source/JavaScriptCore/b3/air/AirArg.h:
(JSC::B3::Air::Arg::isValidAddrForm):
(JSC::B3::Air::Arg::isValidForm const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22f6fb094b6b5c772ae2f9d016bb8554dc108107

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108310 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/17402 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40977 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/117427 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116555 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18789 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8681 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/100528 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/114079 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97200 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41908 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96023 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28838 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/83581 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/97331 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10061 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30186 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/96695 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/8354 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10980 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7087 "Passed tests") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30899 "Reverted pull request changes (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16390 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49777 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/105715 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12566 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26174 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->