### PR TITLE
[GTK][WPE] Poor scrolling performance after a history navigation with PSON enabled

### DIFF
--- a/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp
+++ b/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp
@@ -292,9 +292,9 @@ void ThreadedCompositor::updateSceneWithoutRendering()
     m_scene->updateSceneState();
 }
 
-RefPtr<WebCore::DisplayRefreshMonitor> ThreadedCompositor::displayRefreshMonitor(PlatformDisplayID)
+WebCore::DisplayRefreshMonitor& ThreadedCompositor::displayRefreshMonitor() const
 {
-    return m_displayRefreshMonitor.copyRef();
+    return m_displayRefreshMonitor.get();
 }
 
 void ThreadedCompositor::frameComplete()

--- a/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.h
+++ b/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.h
@@ -70,7 +70,7 @@ public:
 
     void forceRepaint();
 
-    RefPtr<WebCore::DisplayRefreshMonitor> displayRefreshMonitor(WebCore::PlatformDisplayID);
+    WebCore::DisplayRefreshMonitor& displayRefreshMonitor() const;
 
     void frameComplete();
     void targetRefreshRateDidChange(unsigned);

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
@@ -633,7 +633,7 @@ void DrawingAreaCoordinatedGraphics::enterAcceleratedCompositingMode(GraphicsLay
 
     auto changeWindowScreen = [&] {
         // In order to ensure that we get a unique DisplayRefreshMonitor per-DrawingArea (necessary because ThreadedDisplayRefreshMonitor
-        // is driven by the ThreadedCompositor of the drawing area), give each page a unique DisplayID derived from WebPage's unique ID.
+        // is driven by the ThreadedCompositor of the drawing area), give each page a unique DisplayID derived from DrawingArea's unique ID.
         m_webPage.windowScreenDidChange(m_layerTreeHost->displayID(), std::nullopt);
     };
 


### PR DESCRIPTION
#### 1f5e2e27dc7c2cde5131a5bcf0b6c58a28183a0e
<pre>
[GTK][WPE] Poor scrolling performance after a history navigation with PSON enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=252044">https://bugs.webkit.org/show_bug.cgi?id=252044</a>

Reviewed by Žan Doberšek.

With PSON, when there&apos;s a history navigation the WebPage replaces the
drawing area with a new one. In case of coordinated graphics, the new
drawing area ends up using the wrong display refresh monitor because
DrawingArea::createDisplayRefreshMonitor() is not called. We call
WebPage::windowScreenDidChange() after creating the LayerTreeHost to
ensure DrawingArea::createDisplayRefreshMonitor() is called, but in this
case the page is the same, and the displayID hasn&apos;t really changed. So,
we need to ensure that the displayID we create is not based on WebPage
unique identifier, but on DrawingArea&apos;s because the
ThreadedDisplayRefreshMonitor needs to be created for every DrawingArea,
not WebPage.

* Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp:
(WebKit::ThreadedCompositor::displayRefreshMonitor const): Return a reference, caller can decide whether to create a Ref or not.
(WebKit::ThreadedCompositor::displayRefreshMonitor): Deleted.
* Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp:
(WebKit::DrawingAreaCoordinatedGraphics::enterAcceleratedCompositingMode): Update comment.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::LayerTreeHost): Use DrawingArea unique id to generate the display ID.
(WebKit::LayerTreeHost::createDisplayRefreshMonitor): Assert if the given display ID doesn&apos;t match the LayerTreeHost one.

Canonical link: <a href="https://commits.webkit.org/260195@main">https://commits.webkit.org/260195@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8898a7654228332ad5de7286a05035c5c236077f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107317 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16373 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40295 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116473 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115917 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17800 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7612 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99473 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113080 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13431 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96668 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41050 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95335 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28294 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82818 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9404 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29647 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10049 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6487 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15557 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49228 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11603 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3820 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->