### PR TITLE
Table with fixed layout behaves like auto layout when its width is set by JS instead of css

### DIFF
--- a/LayoutTests/fast/table/fixed-table-layout-width-change-expected.txt
+++ b/LayoutTests/fast/table/fixed-table-layout-width-change-expected.txt
@@ -1,0 +1,2 @@
+Tests that the table width having table-layout fixed changes when width is changed dynamically.
+PASS

--- a/LayoutTests/fast/table/fixed-table-layout-width-change.html
+++ b/LayoutTests/fast/table/fixed-table-layout-width-change.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script type="text/javascript">
+            function runTest() {
+                var outer = document.getElementById('outer');
+                outer.style.width = '100px';
+                window.checkLayout("#outer", document.getElementById("test-output"));
+            };
+        </script>
+        <script src="../../resources/check-layout.js"></script>
+        <style>
+            #outer {
+                display: table;
+                table-layout: fixed;
+            }
+            #inner {
+                display: table-cell;
+                height: 50px;
+                background-color: green;
+                min-width: 200px;
+            }
+        </style>
+    </head>
+    <body onload="runTest()">
+        Tests that the table width having table-layout fixed changes when width is changed dynamically.
+        <div id="outer" data-expected-width="100">
+            <div id="inner"></div>
+        </div>
+        <div id="test-output"></div>
+    </body>
+</html>

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -4,8 +4,8 @@
  *           (C) 1998 Waldo Bastian (bastian@kde.org)
  *           (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2003-2022 Apple Inc. All rights reserved.
- * Copyright (C) 2015 Google Inc. All rights reserved.
+ * Copyright (C) 2003-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2015 Google Inc. All rights reserved.
  * Copyright (C) 2006 Alexey Proskuryakov (ap@nypop.com)
  *
  * This library is free software; you can redistribute it and/or
@@ -130,17 +130,17 @@ void RenderTable::styleDidChange(StyleDifference diff, const RenderStyle* oldSty
     RenderBlock::styleDidChange(diff, oldStyle);
     propagateStyleToAnonymousChildren(PropagateToAllChildren);
 
-    auto oldTableLayout = oldStyle ? oldStyle->tableLayout() : TableLayoutType::Auto;
+    bool oldFixedTableLayout = oldStyle ? oldStyle->isFixedTableLayout() : false;
 
     // In the collapsed border model, there is no cell spacing.
     m_hSpacing = collapseBorders() ? 0 : style().horizontalBorderSpacing();
     m_vSpacing = collapseBorders() ? 0 : style().verticalBorderSpacing();
     m_columnPos[0] = m_hSpacing;
 
-    if (!m_tableLayout || style().tableLayout() != oldTableLayout) {
+    if (!m_tableLayout || style().isFixedTableLayout() != oldFixedTableLayout) {
         // According to the CSS2 spec, you only use fixed table layout if an
         // explicit width is specified on the table.  Auto width implies auto table layout.
-        if (style().tableLayout() == TableLayoutType::Fixed && !style().logicalWidth().isAuto())
+        if (style().isFixedTableLayout())
             m_tableLayout = makeUnique<FixedTableLayout>(this);
         else
             m_tableLayout = makeUnique<AutoTableLayout>(this);

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -2,7 +2,8 @@
  * Copyright (C) 2000 Lars Knoll (knoll@kde.org)
  *           (C) 2000 Antti Koivisto (koivisto@kde.org)
  *           (C) 2000 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2003-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2014 Google Inc. All rights reserved.
  * Copyright (C) 2006 Graham Dennis (graham.dennis@gmail.com)
  *
  * This library is free software; you can redistribute it and/or
@@ -483,6 +484,7 @@ public:
     ListStyleType listStyleType() const { return static_cast<ListStyleType>(m_inheritedFlags.listStyleType); }
     StyleImage* listStyleImage() const;
     ListStylePosition listStylePosition() const { return static_cast<ListStylePosition>(m_inheritedFlags.listStylePosition); }
+    bool isFixedTableLayout() const { return tableLayout() == TableLayoutType::Fixed && !logicalWidth().isAuto(); }
 
     const Length& marginTop() const { return m_surroundData->margin.top(); }
     const Length& marginBottom() const { return m_surroundData->margin.bottom(); }


### PR DESCRIPTION
#### b6c71868cecccf5d205892dc0688a40504eda3b9
<pre>
Table with fixed layout behaves like auto layout when its width is set by JS instead of css

Table with fixed layout behaves like auto layout when its width is set by JS instead of css
<a href="https://bugs.webkit.org/show_bug.cgi?id=130239">https://bugs.webkit.org/show_bug.cgi?id=130239</a>

Reviewed by Alan Baradlay.

This patch is to align WebKit with Blink / Chromium and Gecko / Firefox.

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/17dc4cd863992d6f9932ba40d5cf41a1389dfa97">https://chromium.googlesource.com/chromium/blink/+/17dc4cd863992d6f9932ba40d5cf41a1389dfa97</a>

The new width of table was not being applied when changed dynamically
even though the table-layout is fixed.

On calculating whether we need to set the m_tableLayout as fixed or
auto the change in layout parameters such as width, height etc was
not considered hence the right layout type was not being set. Incase
there are any layout changes we need to see whether m_tableLayout
needs to be changed or not.

* Source/WebCore/rendering/RenderTable.cpp:
(RenderTable::styleDidChange): Update as per commit message
* Source/WebCore/rendering/style/RenderStyle.h: Add bool &apos;isFixedTableLayout&apos; with return value
* LayoutTests/fast/table/fixed-table-layout-width-change.html: Add Test Case
* LayoutTests/fast/table/fixed-table-layout-width-change-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/260143@main">https://commits.webkit.org/260143@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f9c13af71d4797dba9405856c5cbef2c49aef80

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107123 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16173 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39915 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116300 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115787 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111025 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17634 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7373 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99305 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112888 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13322 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96380 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40930 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95221 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28017 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82694 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9261 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29358 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9870 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6351 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15419 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48936 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7017 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11411 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->