### PR TITLE
Tweak HTML parser yielding

### DIFF
--- a/LayoutTests/fast/forms/focus-option-control-on-page.html
+++ b/LayoutTests/fast/forms/focus-option-control-on-page.html
@@ -3,7 +3,7 @@
 <head>
 <script src="../../resources/js-test-pre.js"></script>
 </head>
-<body>
+<body onload="onLoad()">
 <p id="description"></p>
 <input type="button" onfocus="log('focused first button')" value="1">
 <input type="text" onfocus="log('focused text field')" value="2">
@@ -62,14 +62,17 @@ function log(val) {
     result += val;
 }
 
-/////////////////////////////////
-if (window.testRunner && window.eventSender && testRunner.addChromeInputField) {
-    window.jsTestIsAsync = true;
-    testRunner.addChromeInputField(startTest);
-} else
-    finishJSTest();
+function onLoad() {
+    if (window.testRunner && window.eventSender && testRunner.addChromeInputField) {
+        testRunner.addChromeInputField(startTest);
+    } else
+        finishJSTest();
 
-var successfullyParsed = true;
+    var successfullyParsed = true;
+}
+
+window.jsTestIsAsync = true;
+
 </script>
 <script src="../../resources/js-test-post.js"></script>
 </body>

--- a/Source/WebCore/html/parser/HTMLParserScheduler.cpp
+++ b/Source/WebCore/html/parser/HTMLParserScheduler.cpp
@@ -101,6 +101,16 @@ void HTMLParserScheduler::continueNextChunkTimerFired()
     m_parser.resumeParsingAfterYield();
 }
 
+static bool parsingProgressedSinceLastYield(PumpSession& session)
+{
+    // Only yield if there has been progress since last yield.
+    if (session.processedTokens > session.processedTokensOnLastYieldBeforeScript) {
+        session.processedTokensOnLastYieldBeforeScript = session.processedTokens;
+        return true;
+    }
+    return false;
+}
+
 bool HTMLParserScheduler::shouldYieldBeforeExecutingScript(const ScriptElement* scriptElement, PumpSession& session)
 {
     // If we've never painted before and a layout is pending, yield prior to running
@@ -120,6 +130,10 @@ bool HTMLParserScheduler::shouldYieldBeforeExecutingScript(const ScriptElement* 
 
     if (UNLIKELY(m_documentHasActiveParserYieldTokens))
         return true;
+
+    // Yield if we have never painted and there is meaningful content
+    if (document->view() && !document->view()->hasEverPainted() && document->view()->isVisuallyNonEmpty())
+        return parsingProgressedSinceLastYield(session);
 
     auto elapsedTime = MonotonicTime::now() - session.startTime;
 

--- a/Source/WebCore/html/parser/HTMLParserScheduler.h
+++ b/Source/WebCore/html/parser/HTMLParserScheduler.h
@@ -55,6 +55,7 @@ public:
 
     unsigned processedTokens { 0 };
     unsigned processedTokensOnLastCheck { 0 };
+    unsigned processedTokensOnLastYieldBeforeScript { 0 };
     MonotonicTime startTime { MonotonicTime::now() };
     bool didSeeScript { false };
 };


### PR DESCRIPTION
#### f17bb5ab82ff403ea4fbe2d88c6119b19b4aaab8
<pre>
Tweak HTML parser yielding
<a href="https://bugs.webkit.org/show_bug.cgi?id=228780">https://bugs.webkit.org/show_bug.cgi?id=228780</a>
rdar://81517847

Reviewed by Antti Koivisto.

Tweak html parser yielding to attempt to improve page load performance with respect to certain page load metrics.
This patch makes the parser yield if the page has not painted before and meaningful content has been loaded. Also
make sure that the parser only yields before executing scripts if there has been parsing progress since the last
yield. Measurements show that this is a 1-2% improvement in page load times. This change also revealed a race
condition in a test, where a call to notifyDone() in an inline script was racing with a call to waitForDone() in
a script with SRC attribute. This race was resolved by starting the test in the onload handler.

* LayoutTests/fast/forms/focus-option-control-on-page.html:
* Source/WebCore/html/parser/HTMLParserScheduler.cpp:
(WebCore::HTMLParserScheduler::shouldYieldBeforeExecutingScript):
* Source/WebCore/html/parser/HTMLParserScheduler.h:

Canonical link: <a href="https://commits.webkit.org/261705@main">https://commits.webkit.org/261705@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c0f9331331c5b38d5cdc6236a8e99efe6a90e0a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-16-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wincairo ](https://ews-build.webkit.org/#/builders/WinCairo-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-16-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-9-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8163 "Failed to push commit to Webkit repository") | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-9-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->