### PR TITLE
[JSC] Sort opcodes to remove padding from metadata table

### DIFF
--- a/Source/JavaScriptCore/bytecode/BytecodeList.rb
+++ b/Source/JavaScriptCore/bytecode/BytecodeList.rb
@@ -85,6 +85,7 @@ begin_section :Bytecode,
     op_prefix: "op_",
     preserve_order: true
 
+# Ops with checkpoint must come first
 op :tail_call_varargs,
     args: {
         dst: VirtualRegister,
@@ -207,6 +208,8 @@ op :iterator_open,
         getNext: nil,
     }
 
+# Opcodes with metadata come next, in decreasing order of metadata alignment requirements
+# Alignment: 8
 op :set_private_brand, args: {
         base: VirtualRegister,
         brand: VirtualRegister,
@@ -241,17 +244,6 @@ op :put_by_id,
         structureChain: WriteBarrierBase[StructureChain],
     }
 
-op :put_by_val,
-    args: {
-        base: VirtualRegister,
-        property: VirtualRegister,
-        value: VirtualRegister,
-        ecmaMode: ECMAMode,
-    },
-    metadata: {
-        arrayProfile: ArrayProfile,
-    }
-
 op :construct,
     args: {
         dst: VirtualRegister,
@@ -263,17 +255,6 @@ op :construct,
         callLinkInfo: BaselineCallLinkInfo,
         arrayProfile: ArrayProfile,
         profile: ValueProfile,
-    }
-
-op :put_by_val_direct,
-    args: {
-        base: VirtualRegister,
-        property: VirtualRegister,
-        value: VirtualRegister,
-        ecmaMode: ECMAMode,
-    },
-    metadata: {
-        arrayProfile: ArrayProfile,
     }
 
 op_group :ValueProfiledBinaryOp,
@@ -500,22 +481,6 @@ op :get_by_val_with_this,
         seenIdentifiers: GetByValHistory,
     }
 
-op :enumerator_next,
-    args: {
-        # out
-        propertyName: VirtualRegister,
-        # in/out
-        mode: VirtualRegister, # Will always be a JS UInt32 representing a JSForInMode.
-        index: VirtualRegister, # Gets reset to zero every time mode changes.
-        # in
-        base: VirtualRegister,
-        enumerator: VirtualRegister,
-    },
-    metadata: {
-        arrayProfile: ArrayProfile,
-        enumeratorMetadata: EnumeratorMetadata,
-    }
-
 op :enumerator_get_by_val,
     args: {
         dst: VirtualRegister,
@@ -527,34 +492,6 @@ op :enumerator_get_by_val,
     },
     metadata: {
         profile: ValueProfile,
-        arrayProfile: ArrayProfile,
-        enumeratorMetadata: EnumeratorMetadata,
-    }
-
-op :enumerator_in_by_val,
-    args: {
-        dst: VirtualRegister,
-        base: VirtualRegister,
-        mode: VirtualRegister,
-        propertyName: VirtualRegister,
-        index: VirtualRegister,
-        enumerator: VirtualRegister,
-    },
-    metadata: {
-        arrayProfile: ArrayProfile,
-        enumeratorMetadata: EnumeratorMetadata,
-    }
-
-op :enumerator_has_own_property,
-    args: {
-        dst: VirtualRegister,
-        base: VirtualRegister,
-        mode: VirtualRegister,
-        propertyName: VirtualRegister,
-        index: VirtualRegister,
-        enumerator: VirtualRegister,
-    },
-    metadata: {
         arrayProfile: ArrayProfile,
         enumeratorMetadata: EnumeratorMetadata,
     }
@@ -578,16 +515,6 @@ op :get_prototype_of,
     },
     metadata: {
         profile: ValueProfile,
-    }
-
-op :jneq_ptr,
-    args: {
-        value: VirtualRegister,
-        specialPointer: VirtualRegister,
-        targetLabel: BoundLabel,
-    },
-    metadata: {
-        hasJumped: bool,
     }
 
 op :get_internal_field,
@@ -776,16 +703,6 @@ op :to_this,
         profile: ValueProfile,
     }
 
-op :in_by_val,
-    args: {
-        dst: VirtualRegister,
-        base: VirtualRegister,
-        property: VirtualRegister,
-    },
-    metadata: {
-        arrayProfile: ArrayProfile,
-    }
-
 op :new_array,
     args: {
         dst: VirtualRegister,
@@ -797,6 +714,96 @@ op :new_array,
         arrayAllocationProfile: ArrayAllocationProfile,
     }
 
+
+# Alignment: 4
+op :put_by_val,
+    args: {
+        base: VirtualRegister,
+        property: VirtualRegister,
+        value: VirtualRegister,
+        ecmaMode: ECMAMode,
+    },
+    metadata: {
+        arrayProfile: ArrayProfile,
+    }
+
+op :put_by_val_direct,
+    args: {
+        base: VirtualRegister,
+        property: VirtualRegister,
+        value: VirtualRegister,
+        ecmaMode: ECMAMode,
+    },
+    metadata: {
+        arrayProfile: ArrayProfile,
+    }
+
+op :in_by_val,
+    args: {
+        dst: VirtualRegister,
+        base: VirtualRegister,
+        property: VirtualRegister,
+    },
+    metadata: {
+        arrayProfile: ArrayProfile,
+    }
+
+op :enumerator_next,
+    args: {
+        # out
+        propertyName: VirtualRegister,
+        # in/out
+        mode: VirtualRegister, # Will always be a JS UInt32 representing a JSForInMode.
+        index: VirtualRegister, # Gets reset to zero every time mode changes.
+        # in
+        base: VirtualRegister,
+        enumerator: VirtualRegister,
+    },
+    metadata: {
+        arrayProfile: ArrayProfile,
+        enumeratorMetadata: EnumeratorMetadata,
+    }
+
+op :enumerator_in_by_val,
+    args: {
+        dst: VirtualRegister,
+        base: VirtualRegister,
+        mode: VirtualRegister,
+        propertyName: VirtualRegister,
+        index: VirtualRegister,
+        enumerator: VirtualRegister,
+    },
+    metadata: {
+        arrayProfile: ArrayProfile,
+        enumeratorMetadata: EnumeratorMetadata,
+    }
+
+op :enumerator_has_own_property,
+    args: {
+        dst: VirtualRegister,
+        base: VirtualRegister,
+        mode: VirtualRegister,
+        propertyName: VirtualRegister,
+        index: VirtualRegister,
+        enumerator: VirtualRegister,
+    },
+    metadata: {
+        arrayProfile: ArrayProfile,
+        enumeratorMetadata: EnumeratorMetadata,
+    }
+
+# Alignment: 1
+op :jneq_ptr,
+    args: {
+        value: VirtualRegister,
+        specialPointer: VirtualRegister,
+        targetLabel: BoundLabel,
+    },
+    metadata: {
+        hasJumped: bool,
+    }
+
+# Opcodes without metadata are last
 op :in_by_id,
     args: {
         dst: VirtualRegister,

--- a/Source/JavaScriptCore/bytecode/UnlinkedMetadataTable.cpp
+++ b/Source/JavaScriptCore/bytecode/UnlinkedMetadataTable.cpp
@@ -32,9 +32,17 @@ namespace JSC {
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(MetadataTable);
 
+#if CPU(ADDRESS64)
+static_assert((UnlinkedMetadataTable::s_maxMetadataAlignment >=
+#define JSC_ALIGNMENT_CHECK(size) size) && (size >=
+FOR_EACH_BYTECODE_METADATA_ALIGNMENT(JSC_ALIGNMENT_CHECK)
+#undef JSC_ALIGNMENT_CHECK
+1));
+#else
 #define JSC_ALIGNMENT_CHECK(size) static_assert(size <= UnlinkedMetadataTable::s_maxMetadataAlignment);
 FOR_EACH_BYTECODE_METADATA_ALIGNMENT(JSC_ALIGNMENT_CHECK)
 #undef JSC_ALIGNMENT_CHECK
+#endif
 
 #if ENABLE(METADATA_STATISTICS)
 size_t MetadataStatistics::unlinkedMetadataCount = 0;
@@ -108,8 +116,15 @@ void UnlinkedMetadataTable::finalize()
             }
             buffer[i] = offset; // We align when we access this.
             unsigned alignment = metadataAlignment(static_cast<OpcodeID>(i));
-            offset = roundUpToMultipleOf(alignment, offset);
             ASSERT(alignment <= s_maxMetadataAlignment);
+
+#if CPU(ADDRESS64)
+            // This is only necessary for the first metadata entry, if the buffer
+            // is 4-byte aligned and the entry has an alignment requirement of 8
+            ASSERT(offset == roundUpToMultipleOf(alignment, offset) || offset == s_offset16TableSize);
+#endif
+            offset = roundUpToMultipleOf(alignment, offset);
+
             offset += numberOfEntries * metadataSize(static_cast<OpcodeID>(i));
 #if ENABLE(METADATA_STATISTICS)
             MetadataStatistics::perOpcodeCount[i] += numberOfEntries;


### PR DESCRIPTION
#### e2606b1940c67a766d810a5ad54c114298f37036
<pre>
[JSC] Sort opcodes to remove padding from metadata table
<a href="https://bugs.webkit.org/show_bug.cgi?id=252055">https://bugs.webkit.org/show_bug.cgi?id=252055</a>
rdar://105276503

Reviewed by Yusuke Suzuki.

Sort the opcodes by metadata alignment requirements. We start with 8-byte aligned,
followed by 4-byte, etc. The memory savings are minimal (too small to measure with
confidence), but they are also free.

* Source/JavaScriptCore/bytecode/BytecodeList.rb:
* Source/JavaScriptCore/bytecode/UnlinkedMetadataTable.cpp:
(JSC::UnlinkedMetadataTable::finalize):

Canonical link: <a href="https://commits.webkit.org/260193@main">https://commits.webkit.org/260193@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b30616d6c939345ac6b361341274d489b4ae3de

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107489 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16551 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40392 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116652 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116073 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17976 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7793 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99653 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113250 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96759 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41198 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95482 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28385 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82969 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/96826 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9557 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29738 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/96248 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/7556 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10214 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/6635 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/30811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15713 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49319 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/105096 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7050 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11774 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26063 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->