### PR TITLE
[JSC] Shrink ArrayAllocationProfile from 16 to 8 bytes

### DIFF
--- a/Source/JavaScriptCore/bytecode/ArrayAllocationProfile.cpp
+++ b/Source/JavaScriptCore/bytecode/ArrayAllocationProfile.cpp
@@ -53,19 +53,21 @@ void ArrayAllocationProfile::updateProfile()
     // So for now, we update the allocation profile only from the main thread.
     
     ASSERT(!isCompilationThread());
-    JSArray* lastArray = std::exchange(m_lastArray, nullptr);
+    Storage storage = std::exchange(m_storage, Storage(nullptr, m_storage.type()));
+    JSArray* lastArray = storage.pointer();
+    IndexingTypeAndVectorLength current = storage.type();
     if (!lastArray)
         return;
     if (LIKELY(Options::useArrayAllocationProfiling())) {
         // The basic model here is that we will upgrade ourselves to whatever the CoW version of lastArray is except ArrayStorage since we don't have CoW ArrayStorage.
-        IndexingType indexingType = leastUpperBoundOfIndexingTypes(m_currentIndexingType & IndexingTypeMask, lastArray->indexingType());
-        if (isCopyOnWrite(m_currentIndexingType)) {
+        IndexingType indexingType = leastUpperBoundOfIndexingTypes(current.indexingType() & IndexingTypeMask, lastArray->indexingType());
+        if (isCopyOnWrite(current.indexingType())) {
             if (indexingType > ArrayWithContiguous)
                 indexingType = ArrayWithContiguous;
             indexingType |= CopyOnWrite;
         }
-        m_currentIndexingType = indexingType;
-        m_largestSeenVectorLength = std::min(std::max(m_largestSeenVectorLength, lastArray->getVectorLength()), BASE_CONTIGUOUS_VECTOR_LEN_MAX);
+        unsigned largestSeenVectorLength = std::min(std::max(current.vectorLength(), lastArray->getVectorLength()), BASE_CONTIGUOUS_VECTOR_LEN_MAX);
+        m_storage.setType(IndexingTypeAndVectorLength(indexingType, largestSeenVectorLength));
     }
 }
 


### PR DESCRIPTION
#### 15ea71cc4b7df927a893c0439ab5ca30a852edbb
<pre>
[JSC] Shrink ArrayAllocationProfile from 16 to 8 bytes
<a href="https://bugs.webkit.org/show_bug.cgi?id=252056">https://bugs.webkit.org/show_bug.cgi?id=252056</a>
rdar://105277033

Reviewed by Yusuke Suzuki.

Currently, `ArrayAllocationProfile`s use 16 bytes: `IndexingMode` (1 byte), the
largest vector length seen (4 bytes), and a pointer to the last seen `JSArray`.
However, the vector length is limited to `BASE_CONTIGUOUS_VECTOR_LEN_MAX`, which
is `25`, so we can easily fit it in a byte, and combined with `CompactPointerTuple`,
we can fit the whole thing in 8 bytes.

* Source/JavaScriptCore/bytecode/ArrayAllocationProfile.cpp:
(JSC::ArrayAllocationProfile::updateProfile):
* Source/JavaScriptCore/bytecode/ArrayAllocationProfile.h:
(JSC::ArrayAllocationProfile::selectIndexingType):
(JSC::ArrayAllocationProfile::vectorLengthHint):
(JSC::ArrayAllocationProfile::updateLastAllocation):
(JSC::ArrayAllocationProfile::updateLastAllocationFor):
(JSC::ArrayAllocationProfile::IndexingTypeAndVectorLength::IndexingTypeAndVectorLength):
(JSC::ArrayAllocationProfile::IndexingTypeAndVectorLength::indexingType const):
(JSC::ArrayAllocationProfile::IndexingTypeAndVectorLength::vectorLength const):
(JSC::ArrayAllocationProfile::IndexingTypeAndVectorLength::operator bool const):

Canonical link: <a href="https://commits.webkit.org/260192@main">https://commits.webkit.org/260192@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c199e089a510a21d1feb8a752ec83201ee113bb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107486 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16548 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40389 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116649 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116070 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17973 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7790 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99650 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113247 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13575 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96756 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/41202 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95480 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28382 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/96823 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9554 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29735 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/96245 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/7553 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10211 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/6633 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/30809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15710 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49316 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/105093 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7049 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11771 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26062 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->