### PR TITLE
[GLIB] Unify code for accessing default `cairo_font_options`

### DIFF
--- a/Source/WebCore/platform/Cairo.cmake
+++ b/Source/WebCore/platform/Cairo.cmake
@@ -10,6 +10,7 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/cairo/BackingStoreBackendCairo.h
     platform/graphics/cairo/BackingStoreBackendCairoImpl.h
     platform/graphics/cairo/BackingStoreBackendCairoX11.h
+    platform/graphics/cairo/CairoUniquePtr.h
     platform/graphics/cairo/CairoOperations.h
     platform/graphics/cairo/CairoUtilities.h
     platform/graphics/cairo/GraphicsContextCairo.h

--- a/Source/WebCore/platform/graphics/cairo/CairoUtilities.cpp
+++ b/Source/WebCore/platform/graphics/cairo/CairoUtilities.cpp
@@ -30,7 +30,6 @@
 #if USE(CAIRO)
 
 #include "AffineTransform.h"
-#include "CairoUniquePtr.h"
 #include "Color.h"
 #include "FloatPoint.h"
 #include "FloatRect.h"
@@ -49,13 +48,19 @@
 
 namespace WebCore {
 
-#if USE(CAIRO) && !PLATFORM(GTK)
+static CairoUniquePtr<cairo_font_options_t> s_defaultCairoFontOptions;
+
 const cairo_font_options_t* getDefaultCairoFontOptions()
 {
-    static NeverDestroyed<cairo_font_options_t*> options = cairo_font_options_create();
-    return options;
+    ASSERT(s_defaultCairoFontOptions);
+    return s_defaultCairoFontOptions.get();
 }
-#endif
+
+void setDefaultCairoFontOptions(CairoUniquePtr<cairo_font_options_t>&& options)
+{
+    ASSERT(RunLoop::isMain());
+    s_defaultCairoFontOptions = WTFMove(options);
+}
 
 void copyContextProperties(cairo_t* srcCr, cairo_t* dstCr)
 {

--- a/Source/WebCore/platform/graphics/cairo/CairoUtilities.h
+++ b/Source/WebCore/platform/graphics/cairo/CairoUtilities.h
@@ -28,6 +28,7 @@
 
 #if USE(CAIRO)
 
+#include "CairoUniquePtr.h"
 #include "GraphicsTypes.h"
 #include "IntSize.h"
 #include <cairo.h>
@@ -69,9 +70,8 @@ private:
 };
 #endif
 
-#if USE(CAIRO)
 const cairo_font_options_t* getDefaultCairoFontOptions();
-#endif
+void setDefaultCairoFontOptions(CairoUniquePtr<cairo_font_options_t>&&);
 
 void copyContextProperties(cairo_t* srcCr, cairo_t* dstCr);
 void setSourceRGBAFromColor(cairo_t*, const Color&);

--- a/Source/WebCore/platform/graphics/gtk/GdkCairoUtilities.cpp
+++ b/Source/WebCore/platform/graphics/gtk/GdkCairoUtilities.cpp
@@ -26,7 +26,6 @@
 #include "config.h"
 #include "GdkCairoUtilities.h"
 
-#include "CairoUniquePtr.h"
 #include "CairoUtilities.h"
 #include "IntSize.h"
 #include <cairo.h>
@@ -36,109 +35,6 @@
 #include <wtf/glib/GUniquePtr.h>
 
 namespace WebCore {
-
-class SystemFontOptions {
-public:
-    static SystemFontOptions& singleton()
-    {
-        static LazyNeverDestroyed<SystemFontOptions> fontOptions;
-        static std::once_flag flag;
-        std::call_once(flag, [&] {
-            fontOptions.construct();
-        });
-        return fontOptions;
-    }
-
-    SystemFontOptions()
-        : m_settings(gtk_settings_get_default())
-    {
-        if (m_settings) {
-            auto fontOptionsChangedCallback = +[](GtkSettings*, GParamSpec*, SystemFontOptions* systemFontOptions) {
-                systemFontOptions->updateFontOptions();
-            };
-            g_signal_connect(m_settings, "notify::gtk-xft-antialias", G_CALLBACK(fontOptionsChangedCallback), this);
-            g_signal_connect(m_settings, "notify::gtk-xft-hinting", G_CALLBACK(fontOptionsChangedCallback), this);
-            g_signal_connect(m_settings, "notify::gtk-xft-hintstyle", G_CALLBACK(fontOptionsChangedCallback), this);
-            g_signal_connect(m_settings, "notify::gtk-xft-rgba", G_CALLBACK(fontOptionsChangedCallback), this);
-            updateFontOptions();
-        } else
-            m_fontOptions.reset(cairo_font_options_create());
-    }
-
-    const cairo_font_options_t* fontOptions() const
-    {
-        return m_fontOptions.get();
-    }
-
-private:
-    void updateFontOptions()
-    {
-        m_fontOptions.reset(cairo_font_options_create());
-
-        gint antialias, hinting;
-        GUniqueOutPtr<char> hintStyleString;
-        GUniqueOutPtr<char> rgbaString;
-        g_object_get(m_settings, "gtk-xft-antialias", &antialias, "gtk-xft-hinting", &hinting, "gtk-xft-hintstyle",
-            &hintStyleString.outPtr(), "gtk-xft-rgba", &rgbaString.outPtr(), nullptr);
-
-        cairo_font_options_set_hint_metrics(m_fontOptions.get(), CAIRO_HINT_METRICS_ON);
-
-        cairo_hint_style_t hintStyle = CAIRO_HINT_STYLE_DEFAULT;
-        switch (hinting) {
-        case 0:
-            hintStyle = CAIRO_HINT_STYLE_NONE;
-            break;
-        case 1:
-            if (hintStyleString) {
-                if (!strcmp(hintStyleString.get(), "hintnone"))
-                    hintStyle = CAIRO_HINT_STYLE_NONE;
-                else if (!strcmp(hintStyleString.get(), "hintslight"))
-                    hintStyle = CAIRO_HINT_STYLE_SLIGHT;
-                else if (!strcmp(hintStyleString.get(), "hintmedium"))
-                    hintStyle = CAIRO_HINT_STYLE_MEDIUM;
-                else if (!strcmp(hintStyleString.get(), "hintfull"))
-                    hintStyle = CAIRO_HINT_STYLE_FULL;
-            }
-            break;
-        }
-        cairo_font_options_set_hint_style(m_fontOptions.get(), hintStyle);
-
-        cairo_subpixel_order_t subpixelOrder = CAIRO_SUBPIXEL_ORDER_DEFAULT;
-        if (rgbaString) {
-            if (!strcmp(rgbaString.get(), "rgb"))
-                subpixelOrder = CAIRO_SUBPIXEL_ORDER_RGB;
-            else if (!strcmp(rgbaString.get(), "bgr"))
-                subpixelOrder = CAIRO_SUBPIXEL_ORDER_BGR;
-            else if (!strcmp(rgbaString.get(), "vrgb"))
-                subpixelOrder = CAIRO_SUBPIXEL_ORDER_VRGB;
-            else if (!strcmp(rgbaString.get(), "vbgr"))
-                subpixelOrder = CAIRO_SUBPIXEL_ORDER_VBGR;
-        }
-        cairo_font_options_set_subpixel_order(m_fontOptions.get(), subpixelOrder);
-
-        cairo_antialias_t antialiasMode = CAIRO_ANTIALIAS_DEFAULT;
-        switch (antialias) {
-        case 0:
-            antialiasMode = CAIRO_ANTIALIAS_NONE;
-            break;
-        case 1:
-            if (subpixelOrder != CAIRO_SUBPIXEL_ORDER_DEFAULT)
-                antialiasMode = CAIRO_ANTIALIAS_SUBPIXEL;
-            else
-                antialiasMode = CAIRO_ANTIALIAS_GRAY;
-            break;
-        }
-        cairo_font_options_set_antialias(m_fontOptions.get(), antialiasMode);
-    }
-
-    GtkSettings* m_settings;
-    CairoUniquePtr<cairo_font_options_t> m_fontOptions;
-};
-
-const cairo_font_options_t* getDefaultCairoFontOptions()
-{
-    return SystemFontOptions::singleton().fontOptions();
-}
 
 GRefPtr<GdkPixbuf> cairoSurfaceToGdkPixbuf(cairo_surface_t* surface)
 {

--- a/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
+++ b/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
@@ -69,6 +69,10 @@
 #include <gtk/gtk.h>
 #endif
 
+#if PLATFORM(WPE)
+#include <WebCore/CairoUtilities.h>
+#endif
+
 namespace WebKit {
 
 using namespace WebCore;
@@ -157,6 +161,10 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
 
 #if PLATFORM(GTK)
     GtkSettingsManagerProxy::singleton().applySettings(WTFMove(parameters.gtkSettings));
+#endif
+
+#if PLATFORM(WPE)
+    setDefaultCairoFontOptions(CairoUniquePtr<cairo_font_options_t>(cairo_font_options_create()));
 #endif
 
 }

--- a/Source/WebKit/WebProcess/gtk/GtkSettingsManagerProxy.h
+++ b/Source/WebKit/WebProcess/gtk/GtkSettingsManagerProxy.h
@@ -47,6 +47,8 @@ private:
 
     void settingsDidChange(GtkSettingsState&&);
 
+    void applyFontOptions();
+
     GtkSettings* m_settings;
 };
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/ComplexTextController.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ComplexTextController.cpp
@@ -31,6 +31,10 @@
 #include <wtf/MainThread.h>
 #include <wtf/RunLoop.h>
 
+#if PLATFORM(GTK) || PLATFORM(WPE)
+#include <WebCore/CairoUtilities.h>
+#endif
+
 using namespace WebCore;
 
 namespace TestWebKitAPI {
@@ -41,6 +45,9 @@ public:
     {
         JSC::initialize();
         WTF::initializeMainThread();
+#if PLATFORM(GTK) || PLATFORM(WPE)
+        setDefaultCairoFontOptions(CairoUniquePtr<cairo_font_options_t>(cairo_font_options_create()));
+#endif
     }
 };
 


### PR DESCRIPTION
#### 9ccc5caacd23526def9cf7111283b5233be038e1
<pre>
[GLIB] Unify code for accessing default `cairo_font_options`
<a href="https://bugs.webkit.org/show_bug.cgi?id=252057">https://bugs.webkit.org/show_bug.cgi?id=252057</a>

Reviewed by Carlos Garcia Campos.

Currently, there are two different implementations of
`getDefaultCairoFontOptions()` on WPE and GTK.

WPE version simply returns a static value created by
`cairo_font_options_create()`, whereas GTK one is creating a singleton
class that stores and updates an instance variable to keep it in sync
with `GtkSettings`.

This patch makes `getDefaultCairoFontOptions()` simply return a static
value and adds `setDefaultCairoFontOptions()` function. GTK port use it
to set a new value when `GtkSettingsManagerProxy` applies new settings.

* Source/WebCore/platform/graphics/cairo/CairoUtilities.cpp:
(WebCore::getDefaultCairoFontOptions):
(WebCore::setDefaultCairoFontOptions):
* Source/WebCore/platform/graphics/cairo/CairoUtilities.h:
* Source/WebCore/platform/graphics/gtk/GdkCairoUtilities.cpp:
(WebCore::SystemFontOptions::singleton): Deleted.
(WebCore::SystemFontOptions::SystemFontOptions): Deleted.
(WebCore::SystemFontOptions::fontOptions const): Deleted.
(WebCore::SystemFontOptions::updateFontOptions): Deleted.
(WebCore::getDefaultCairoFontOptions): Deleted.
* Source/WebKit/WebProcess/gtk/GtkSettingsManagerProxy.cpp:
(WebKit::GtkSettingsManagerProxy::applySettings):
(WebKit::GtkSettingsManagerProxy::applyFontOptions):
* Source/WebKit/WebProcess/gtk/GtkSettingsManagerProxy.h:

Canonical link: <a href="https://commits.webkit.org/260301@main">https://commits.webkit.org/260301@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08a0452d7dc884d241b5efdd2669e922a5d5f81a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107684 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16736 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40579 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116831 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116225 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111574 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18158 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8054 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99858 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113437 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13703 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96906 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41387 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95619 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28544 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/83223 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9717 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29893 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10395 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6778 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15871 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49478 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11955 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3866 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->