### PR TITLE
Initial implementation of margin-trim for legacy inline layout in non-paginated and single column block containers

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6264,6 +6264,9 @@ imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/js
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.html [ Skip ]
 
 webkit.org/b/252183 imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-overflowing-float-margins-tirmmed-at-final-position-block-layout.html [ ImageOnlyFailure ]
+# This test is not being rendered correctly on MiniBrowser but WKTR shows them as passing. Skipping until this is investigated
+webkit.org/b/252638 imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-word-break-all.html [ Skip ]
+webkit.org/b/252638 fast/inline/legacy-margin-trim/block-container-float-inline-word-break-all.html [ Skip ]
 
 #Skipping text-spacing tests until the features get implemented.
 imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-spacing-computed.html [ Skip ]

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-block-end-inline-layout-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-block-end-inline-layout-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<title>margin-trim: block-container-float-block-end-inline-layout</title>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-block-end-inline-layout.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-block-end-inline-layout.html
@@ -1,0 +1,37 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<title>margin-trim: block-container-float-block-end-inline-layout</title>
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<style>
+container {
+    display: flow-root;
+    width: max-content;
+    background-color: green;
+    margin-trim: block;
+    font-size: 0px;
+}
+item {
+    display: inline-block;
+    width: 50px;
+    height: 100px;
+    background-color: green;
+}
+.floating {
+    display: block;
+    float: left;
+    margin-block-end: 50px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item class="floating"></item>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-block-end-up-to-content-inline-layout-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-block-end-up-to-content-inline-layout-expected.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<style>
+container {
+    display: flow-root;
+    width: 100px;
+    border: 20px solid black;
+    padding-top: 55px;
+    font-size: 80px;
+}
+.inline-block-content {
+    display: inline-block;
+    background-color: green;
+}
+.floating {
+    float: right; 
+    background-color: red;
+}
+</style>
+</head>
+<body>
+<container>
+  <div class="inline-block-content" style="width: 80px; height: 30px;"></div>
+  <div class="inline-block-content" style="width: 30px; height: 30px;"></div>
+  <div class="floating" style="width: 30px; height: 30px;"></div>
+  <div class="inline-block-content" style="width: 30px; height: 40px;"></div>
+  <div class="floating" style="width: 30px; height: 30px;"></div>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-block-end-up-to-content-inline-layout-ref.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-block-end-up-to-content-inline-layout-ref.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<style>
+container {
+    display: flow-root;
+    width: 100px;
+    border: 20px solid black;
+    padding-top: 55px;
+    font-size: 80px;
+}
+.inline-block-content {
+    display: inline-block;
+    background-color: green;
+}
+.floating {
+    float: right; 
+    background-color: red;
+}
+</style>
+</head>
+<body>
+<container>
+  <div class="inline-block-content" style="width: 80px; height: 30px;"></div>
+  <div class="inline-block-content" style="width: 30px; height: 30px;"></div>
+  <div class="floating" style="width: 30px; height: 30px;"></div>
+  <div class="inline-block-content" style="width: 30px; height: 40px;"></div>
+  <div class="floating" style="width: 30px; height: 30px;"></div>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-block-end-up-to-content-inline-layout.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-block-end-up-to-content-inline-layout.html
@@ -1,0 +1,38 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-float-block-end-up-to-content-inline-layout</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="BFC that creates IFC should have lowest flowest margin-end trimmed up to content">
+<link rel="match" href="block-container-float-block-end-up-to-content-inline-layout.html">
+<style>
+container {
+    display: flow-root;
+    width: 100px;
+    border: 20px solid black;
+    padding-top: 55px;
+    font-size: 80px;
+    margin-trim: block;
+}
+.inline-block-content {
+    display: inline-block;
+    background-color: green;
+}
+.floating {
+    float: right; 
+    background-color: red;
+}
+</style>
+</head>
+<body>
+<container>
+  <div class="inline-block-content" style="width: 80px; height: 30px;"></div>
+  <div class="inline-block-content" style="width: 30px; height: 30px;"></div>
+  <div class="floating" style="width: 30px; height: 30px;"></div>
+  <div class="inline-block-content" style="width: 30px; height: 40px;"></div>
+  <div class="floating" style="width: 30px; height: 30px; margin-bottom: 100px;"></div>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-block-start-inline-layout-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-block-start-inline-layout-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-block-start-inline-layout.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-block-start-inline-layout.html
@@ -1,0 +1,37 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-float-block-start-inline-layout</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="block-start should be trimmed for float that touches the top of the containing block with inline content present">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<style>
+container {
+    display: block;
+    width: 100px;
+    margin-trim: block-start;
+    font-size: 0px;
+}
+item {
+    display: inline-block;
+    width: 50px;
+    height: 100px;
+    background-color: green;
+}
+.floating {
+    display: block;
+    float: left;
+    margin-block-start: 30px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item></item>
+    <item class="floating"></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-inline-layout-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-inline-layout-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-inline-layout-rtl-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-inline-layout-rtl-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-inline-layout-rtl.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-inline-layout-rtl.html
@@ -1,0 +1,37 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-float-inline-end-inline-layout-rtl</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline-end should be trimmed for float in block container that touches container inline-end edge with inline content present">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<style>
+container {
+    display: block;
+    inline-size: 100px;
+    font-size: 0px;
+    margin-trim: inline-end;
+    direction: rtl;
+}
+item {
+    display: inline-block;
+    inline-size: 50px;
+    block-size: 100px;
+    background-color: green;
+}
+.floating {
+    margin-inline-end: 30px;
+    float: right;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item class="floating"></item>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-inline-layout-vert-lr-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-inline-layout-vert-lr-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-inline-layout-vert-lr-rtl-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-inline-layout-vert-lr-rtl-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-inline-layout-vert-lr-rtl.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-inline-layout-vert-lr-rtl.html
@@ -1,0 +1,38 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-float-inline-end-inline-layout-vert-lr-rtl</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline-end should be trimmed for float in block container that touches container inline-end edge with inline content present">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<style>
+container {
+    display: block;
+    inline-size: 100px;
+    font-size: 0px;
+    margin-trim: inline-end;
+    writing-mode: vertical-lr;
+    direction: rtl;
+}
+item {
+    display: inline-block;
+    inline-size: 50px;
+    block-size: 100px;
+    background-color: green;
+}
+.floating {
+    margin-inline-end: 30px;
+    float: right;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item class="floating"></item>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-inline-layout-vert-lr.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-inline-layout-vert-lr.html
@@ -1,0 +1,37 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-float-inline-end-inline-layout-vert-lr</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline-end should be trimmed for float in block container that touches container inline-end edge with inline content present">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<style>
+container {
+    display: block;
+    inline-size: 100px;
+    font-size: 0px;
+    margin-trim: inline-end;
+    writing-mode: vertical-lr;
+}
+item {
+    display: inline-block;
+    inline-size: 50px;
+    block-size: 100px;
+    background-color: green;
+}
+.floating {
+    margin-inline-end: 30px;
+    float: right;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item class="floating"></item>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-inline-layout.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-inline-layout.html
@@ -1,0 +1,36 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-float-inline-end-inline-layout</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline-end should be trimmed for float in block container that touches container inline-end edge with inline content present">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<style>
+container {
+    display: block;
+    width: 100px;
+    font-size: 0px;
+    margin-trim: inline-end;
+}
+item {
+    display: inline-block;
+    width: 50px;
+    height: 100px;
+    background-color: green;
+}
+.floating {
+    margin-inline-end: 30px;
+    float: right;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item class="floating"></item>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-nested-within-span-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-nested-within-span-expected.html
@@ -1,0 +1,36 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline-end should be trimmed for float in block container that touches container inline-end edge with inline content present">
+<style>
+container {
+    display: block;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 100px;
+    background-color: green;
+}
+.floating {
+    display: block;
+    float: right;
+}
+span {
+  border: 10px solid red;
+  margin-inline: 20px;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>
+      inline content in span
+      <item class="floating"></item>
+    </span>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-nested-within-span-ref.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-nested-within-span-ref.html
@@ -1,0 +1,36 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline-end should be trimmed for float in block container that touches container inline-end edge with inline content present">
+<style>
+container {
+    display: block;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 100px;
+    background-color: green;
+}
+.floating {
+    display: block;
+    float: right;
+}
+span {
+  border: 10px solid red;
+  margin-inline: 20px;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>
+      inline content in span
+      <item class="floating"></item>
+    </span>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-nested-within-span.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-nested-within-span.html
@@ -1,0 +1,40 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-float-inline-end-nested-within-span</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline-end should be trimmed for float in block container that touches container inline-end edge with inline content present">
+<link rel="match" href="block-container-float-inline-end-nested-within-span-ref.html">
+<style>
+container {
+    display: block;
+    margin-trim: inline-end;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 100px;
+    background-color: green;
+}
+.floating {
+    display: block;
+    float: right;
+    margin-inline-end: 30px;
+}
+span {
+  border: 10px solid red;
+  margin-inline: 20px;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>
+      inline content in span
+      <item class="floating"></item>
+    </span>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-with-bidi-content-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-with-bidi-content-expected.html
@@ -1,0 +1,31 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline end margin should be trimmed for float in presence of bidi content">
+<style>
+container {
+    display: block;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+    float: right;
+}
+.bidi-rtl {
+    direction: rtl;
+    unicode-bidi: bidi-override;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>left to right</span> <span class="bidi-rtl">right to left</span>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-with-bidi-content-ref.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-with-bidi-content-ref.html
@@ -1,0 +1,31 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline end margin should be trimmed for float in presence of bidi content">
+<style>
+container {
+    display: block;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+    float: right;
+}
+.bidi-rtl {
+    direction: rtl;
+    unicode-bidi: bidi-override;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>left to right</span> <span class="bidi-rtl">right to left</span>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-with-bidi-content.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-with-bidi-content.html
@@ -1,0 +1,35 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-float-inline-end-with-bidi-content</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline end margin should be trimmed for float in presence of bidi content">
+<link rel="match" href="block-container-float-inline-end-with-bidi-content-ref.html">
+<style>
+container {
+    display: block;
+    margin-trim: inline-end;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+    float: right;
+    margin-inline-end: 50px;
+}
+.bidi-rtl {
+    direction: rtl;
+    unicode-bidi: bidi-override;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>left to right</span> <span class="bidi-rtl">right to left</span>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-inline-layout-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-inline-layout-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-inline-layout.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-inline-layout.html
@@ -1,0 +1,45 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-float-inline-inline-layout</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline should trim inline-start edge for floats that touch the inline-start edge of container and inline-end edge for floats that touch inline-end edge of container">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<style>
+container {
+    display: block;
+    width: 100px;
+    font-size: 0px;
+    margin-trim: inline;
+}
+item {
+    display: inline-block;
+    width: 50px;
+    height: 100px;
+    background-color: green;
+}
+.floating-left {
+    display: block;
+    width: 25px;
+    float: left;
+    margin-inline-start: 20px;
+}
+.floating-right {
+    display: block;
+    width: 25px;
+    float: right;
+    margin-inline-end: 20px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item class="floating-left"></item>
+    <item></item>
+    <item class="floating-right"></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-inline-layout-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-inline-layout-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-inline-layout-rtl-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-inline-layout-rtl-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-inline-layout-rtl.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-inline-layout-rtl.html
@@ -1,0 +1,37 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-float-inline-start-inline-layout-rtl</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline-start should be trimmed for float in block container that touches container inline-start edge with inline content present">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<style>
+container {
+    display: block;
+    width: 100px;
+    font-size: 0px;
+    margin-trim: inline-start;
+    direction: rtl;
+}
+item {
+    display: inline-block;
+    width: 50px;
+    height: 100px;
+    background-color: green;
+}
+.floating {
+    margin-inline-start: 30px;
+    float: left;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item class="floating"></item>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-inline-layout-vert-lr-rtl-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-inline-layout-vert-lr-rtl-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-inline-layout-vert-lr-rtl.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-inline-layout-vert-lr-rtl.html
@@ -1,0 +1,38 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-float-inline-start-inline-layout-vert-lr-rtl</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline-start should be trimmed for float in block container that touches container inline-start edge with inline content present">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<style>
+container {
+    display: block;
+    inline-size: 100px;
+    font-size: 0px;
+    margin-trim: inline-start;
+    writing-mode: vertical-lr;
+    direction: rtl;
+}
+item {
+    display: inline-block;
+    inline-size: 50px;
+    block-size: 100px;
+    background-color: green;
+}
+.floating {
+    margin-inline-start: 30px;
+    float: left;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item class="floating"></item>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-inline-layout-vertl-lr-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-inline-layout-vertl-lr-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-inline-layout-vertl-lr.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-inline-layout-vertl-lr.html
@@ -1,0 +1,37 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-float-inline-start-inline-layout-vert-lr</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline-start should be trimmed for float in block container that touches container inline-start edge with inline content present">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<style>
+container {
+    display: block;
+    inline-size: 100px;
+    font-size: 0px;
+    margin-trim: inline-start;
+    writing-mode: vertical-lr;
+}
+item {
+    display: inline-block;
+    inline-size: 50px;
+    block-size: 100px;
+    background-color: green;
+}
+.floating {
+    margin-inline-start: 30px;
+    float: left;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item class="floating"></item>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-inline-layout.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-inline-layout.html
@@ -1,0 +1,36 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-float-inline-start-inline-layout</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline-start should be trimmed for float in block container that touches container inline-start edge with inline content present">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<style>
+container {
+    display: block;
+    width: 100px;
+    font-size: 0px;
+    margin-trim: inline-start;
+}
+item {
+    display: inline-block;
+    width: 50px;
+    height: 100px;
+    background-color: green;
+}
+.floating {
+    margin-inline-start: 30px;
+    float: left;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item class="floating"></item>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-nested-within-span-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-nested-within-span-expected.html
@@ -1,0 +1,36 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline-start should be trimmed for float in block container that touches container inline-start edge with inline content present">
+<style>
+container {
+    display: block;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 100px;
+    background-color: green;
+}
+.floating {
+    display: block;
+    float: left;
+}
+span {
+  border: 10px solid red;
+  margin-inline: 20px;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>
+      inline content in span
+      <item class="floating"></item>
+    </span>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-nested-within-span-ref.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-nested-within-span-ref.html
@@ -1,0 +1,36 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline-start should be trimmed for float in block container that touches container inline-start edge with inline content present">
+<style>
+container {
+    display: block;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 100px;
+    background-color: green;
+}
+.floating {
+    display: block;
+    float: left;
+}
+span {
+  border: 10px solid red;
+  margin-inline: 20px;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>
+      inline content in span
+      <item class="floating"></item>
+    </span>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-nested-within-span.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-nested-within-span.html
@@ -1,0 +1,40 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-float-inline-start-nested-within-span</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline-start should be trimmed for float in block container that touches container inline-start edge with inline content present">
+<link rel="match" href="block-container-float-inline-start-nested-within-span-ref.html">
+<style>
+container {
+    display: block;
+    margin-trim: inline-start;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 100px;
+    background-color: green;
+}
+.floating {
+    display: block;
+    float: left;
+    margin-inline-start: 30px;
+}
+span {
+  border: 10px solid red;
+  margin-inline: 20px;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>
+      inline content in span
+      <item class="floating"></item>
+    </span>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-with-bidi-content-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-with-bidi-content-expected.html
@@ -1,0 +1,31 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline start margin should be trimmed for float in presence of bidi content">
+<style>
+container {
+    display: block;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+    float: left;
+}
+.bidi-rtl {
+    direction: rtl;
+    unicode-bidi: bidi-override;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>left to right</span> <span class="bidi-rtl">right to left</span>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-with-bidi-content-ref.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-with-bidi-content-ref.html
@@ -1,0 +1,31 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline start margin should be trimmed for float in presence of bidi content">
+<style>
+container {
+    display: block;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+    float: left;
+}
+.bidi-rtl {
+    direction: rtl;
+    unicode-bidi: bidi-override;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>left to right</span> <span class="bidi-rtl">right to left</span>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-with-bidi-content.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-with-bidi-content.html
@@ -1,0 +1,35 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-float-inline-start-with-bidi-content</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline start margin should be trimmed for float in presence of bidi content">
+<link rel="match" href="block-container-float-inline-start-with-bidiy-content-ref.html">
+<style>
+container {
+    display: block;
+    margin-trim: inline-start;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+    float: left;
+    margin-inline-start: 50px;
+}
+.bidi-rtl {
+    direction: rtl;
+    unicode-bidi: bidi-override;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>left to right</span> <span class="bidi-rtl">right to left</span>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-with-intruding-floats-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-with-intruding-floats-expected.html
@@ -1,0 +1,35 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline-start should be trimmed for float in block container that touches container inline-start edge with inline content present">
+<style>
+container {
+    display: block;
+    width: 80px;
+    margin-trim: inline-start;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+}
+.floating {
+    display: block;
+    float: left;
+}
+</style>
+</head>
+<body>
+<container>
+  <item></item>
+  <item class="floating" style="background-color: red;"></item>
+</container>
+<container>
+<item class="floating"></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-with-intruding-floats-ref.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-with-intruding-floats-ref.html
@@ -1,0 +1,35 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline-start should be trimmed for float in block container that touches container inline-start edge with inline content present">
+<style>
+container {
+    display: block;
+    width: 80px;
+    margin-trim: inline-start;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+}
+.floating {
+    display: block;
+    float: left;
+}
+</style>
+</head>
+<body>
+<container>
+  <item></item>
+  <item class="floating" style="background-color: red;"></item>
+</container>
+<container>
+<item class="floating"></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-with-intruding-floats.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-with-intruding-floats.html
@@ -1,0 +1,37 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-float-inline-start-with-intruding-floats</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline-start should be trimmed for float in block container that touches container inline-start edge with inline content present">
+<link rel="match" href="block-container-float-inline-start-with-intruding-floats-ref.html">
+<style>
+container {
+    display: block;
+    width: 80px;
+    margin-trim: inline-start;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+}
+.floating {
+    display: block;
+    float: left;
+}
+</style>
+</head>
+<body>
+<container>
+  <item></item>
+  <item class="floating" style="background-color: red;"></item>
+</container>
+<container>
+<item class="floating" style="margin-inline-start: 25px;"></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-word-break-all-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-word-break-all-expected.html
@@ -1,0 +1,37 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline margins should be trimmed for floats that have margin edges adjacent to respective side">
+<style>
+container {
+    display: block;
+    width: 100px;
+    border: solid blue;
+    word-break: break-all;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+}
+.floating-right {
+    float: right;
+}
+.floating-left {
+  float: left;
+}
+</style>
+</head>
+<body>
+<container>
+<item class="floating-right"></item>
+inline margins should be trimmed for 
+<item class="floating-left"></item>
+floats that have margin edgesadjacent to respective side
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-word-break-all-ref.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-word-break-all-ref.html
@@ -1,0 +1,37 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline margins should be trimmed for floats that have margin edges adjacent to respective side">
+<style>
+container {
+    display: block;
+    width: 100px;
+    border: solid blue;
+    word-break: break-all;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+}
+.floating-right {
+    float: right;
+}
+.floating-left {
+  float: left;
+}
+</style>
+</head>
+<body>
+<container>
+<item class="floating-right"></item>
+inline margins should be trimmed for 
+<item class="floating-left"></item>
+floats that have margin edgesadjacent to respective side
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-word-break-all.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-word-break-all.html
@@ -1,0 +1,42 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-float-inline-word-break-all</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline margins should be trimmed for floats that have margin edges adjacent to respective side">
+<link rel="match" href="block-container-float-inline-word-break-all-ref.html">
+<style>
+container {
+    display: block;
+    width: 100px;
+    border: solid blue;
+    word-break: break-all;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+}
+.floating-right {
+    margin-inline-end: 30px;
+    float: right;
+}
+.floating-left {
+  margin-inline-start: 30px;
+  float: left;
+}
+</style>
+</head>
+<body>
+<container>
+<item class="floating-right"></item>
+inline margins should be trimmed for 
+<item class="floating-left"></item>
+floats that have margin edgesadjacent to respective side
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-min-content-inline-layout-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-min-content-inline-layout-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-min-content-inline-layout.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-min-content-inline-layout.html
@@ -1,0 +1,37 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-float-min-content-inline-layout</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="floats should not contribute trimmed margins for container intrinsic sizing">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<style>
+container {
+    display: block;
+    width: min-content;
+    font-size: 0px;
+    margin-trim: inline;
+    background-color: green;
+}
+item {
+    display: inline-block;
+    width: 100px;
+    height: 100px;
+}
+.floating {
+    display: block;
+    float: left;
+    margin-inline: 30px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item></item>
+    <item class="floating"></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-multiple-formatting-contexts-inline-layout-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-multiple-formatting-contexts-inline-layout-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-multiple-formatting-contexts-inline-layout.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-multiple-formatting-contexts-inline-layout.html
@@ -1,0 +1,38 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-float-multiple-formatting-contexts-inline-layout</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<style>
+container {
+    margin-trim: block;
+    display: flow-root;
+    width: max-content;
+}
+item {
+    display: block;
+    width: 25px;
+    height: 100px;
+    margin-block-end: 50px;
+    float: left;
+}
+.inline-block {
+    display: inline-block;
+    width: 25px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container style="background-color: green;">
+<item style="width: 50px;"></item>
+<container>
+    <item class="inline-block"></item>
+    <item></item>
+</container>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-nested-inside-inline-inline-layout-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-nested-inside-inline-inline-layout-expected.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-block-start-002</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-nested-inside-inline-inline-layout.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-nested-inside-inline-inline-layout.html
@@ -1,0 +1,39 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<title>block-container-float-nested-inside-inline-inline-layout</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Float nested in an inline should determine margin trimming from IFC root">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<style>
+container {
+    display: block;
+    width: 100px;
+    margin-trim: inline;
+    font-size: 0px;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 100px;
+    background-color: green;
+}
+.inline-block {
+    display: inline-block;
+}
+.floating {
+    float: right;
+    margin-inline-end: 20px; 
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+<item class="inline-block"></item>
+<span><item class="floating"></item></span>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-overflowing-margin-has-margin-trimmed-at-final-position-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-overflowing-margin-has-margin-trimmed-at-final-position-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-overflowing-margin-has-margin-trimmed-at-final-position.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-overflowing-margin-has-margin-trimmed-at-final-position.html
@@ -1,0 +1,43 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-float-overflowing-margin-has-margin-trimmed-at-final-position</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="When a float is not able to fit on the current line, it should have its margins trimmed when placed under other floats">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<style>
+container {
+    display: block;
+    width: 110px;
+    margin-trim: inline;
+    font-size: 0px;
+}
+item {
+    display: block;
+    width: 100px;
+    height: 25px;
+    background-color: green;
+}
+.inline-block {
+    display: inline-block;
+    height: 50px;
+}
+.float-left {
+    float: left;
+}
+.overflowing {
+    margin-inline-start: 55px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item class="inline-block"></item>
+    <item class="float-left"></item>
+    <item class="float-left overflowing"></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-overflowing-positioned-at-first-available-vertical-position-with-trimmed-margin-inline-layout-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-overflowing-positioned-at-first-available-vertical-position-with-trimmed-margin-inline-layout-expected.html
@@ -1,0 +1,45 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<title>margin-trim: block-container-float-overflowing-positioned-at-first-available-vertical-position-with-trimmed-margin</title>
+<meta name="assert" content="The final float (blue) should be able to get positioned right under the text with its trimmed margin">
+<link rel="match" href="block-container-float-overflowing-positioned-at-first-available-vertical-position-with-trimmed-margin-inline-layout-ref.html">
+<style>
+container {
+    display: block;
+    width: 200px;
+    margin-trim: inline;
+    line-height: 30px;
+}
+item {
+    display: inline-block;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+}
+.tall {
+    height: 75px;
+}
+.floating-left {
+    display: block;
+    float: left;
+    background-color: blue;
+}
+.floating-right {
+    display: block;
+    float: right;
+    background-color: red;
+}
+</style>
+</head>
+<body>
+<container>
+    blue below the text
+    <item class="tall"></item>
+    <item id="blue"></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-overflowing-positioned-at-first-available-vertical-position-with-trimmed-margin-inline-layout-ref.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-overflowing-positioned-at-first-available-vertical-position-with-trimmed-margin-inline-layout-ref.html
@@ -1,0 +1,45 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<title>margin-trim: block-container-float-overflowing-positioned-at-first-available-vertical-position-with-trimmed-margin</title>
+<meta name="assert" content="The final float (blue) should be able to get positioned right under the text with its trimmed margin">
+<link rel="match" href="block-container-float-overflowing-positioned-at-first-available-vertical-position-with-trimmed-margin-inline-layout-ref.html">
+<style>
+container {
+    display: block;
+    width: 200px;
+    margin-trim: inline;
+    line-height: 30px;
+}
+item {
+    display: inline-block;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+}
+.tall {
+    height: 75px;
+}
+.floating-left {
+    display: block;
+    float: left;
+    background-color: blue;
+}
+.floating-right {
+    display: block;
+    float: right;
+    background-color: red;
+}
+</style>
+</head>
+<body>
+<container>
+    blue below the text
+    <item class="tall"></item>
+    <item id="blue"></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-overflowing-positioned-at-first-available-vertical-position-with-trimmed-margin-inline-layout.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-overflowing-positioned-at-first-available-vertical-position-with-trimmed-margin-inline-layout.html
@@ -1,0 +1,46 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<title>margin-trim: block-container-float-overflowing-positioned-at-first-available-vertical-position-with-trimmed-margin</title>
+<meta name="assert" content="The final float (blue) should be able to get positioned right under the text with its trimmed margin">
+<link rel="match" href="block-container-float-overflowing-positioned-at-first-available-vertical-position-with-trimmed-margin-inline-layout-ref.html">
+<style>
+container {
+    display: block;
+    width: 200px;
+    margin-trim: inline;
+    line-height: 30px;
+}
+item {
+    display: inline-block;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+}
+.tall {
+    height: 75px;
+}
+.floating-left {
+    display: block;
+    float: left;
+    background-color: blue;
+    margin-inline-start: 110px;
+}
+.floating-right {
+    display: block;
+    float: right;
+    background-color: red;
+}
+</style>
+</head>
+<body>
+<container>
+    blue below the text
+    <item class="tall"></item>
+    <item id="blue"></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-trimmed-margin-allows-float-to-fit-inline-layout-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-trimmed-margin-allows-float-to-fit-inline-layout-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-trimmed-margin-allows-float-to-fit-inline-layout.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-trimmed-margin-allows-float-to-fit-inline-layout.html
@@ -1,0 +1,37 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-float-trimmed-margin-allows-float-to-fit-inline-layout</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="float that overflows into another item stays on the same line due to trimmed margin">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<style>
+container {
+    display: block;
+    width: 100px;
+    height: 100px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    width: 25px;
+    height: 100px;
+    background-color: green;
+}
+.inline-block-content {
+    display: inline-block;
+    width: 50px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item style="float: left"></item>
+    <item class="inline-block-content"></item>
+    <item style="float: right; margin-inline-end: 150px;"></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-inline-layout-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-inline-layout-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<title>margin-trim: block-container-float-block-end-inline-layout</title>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-inline-layout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-inline-layout.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<title>margin-trim: block-container-float-block-end-inline-layout</title>
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<style>
+container {
+    display: flow-root;
+    width: max-content;
+    background-color: green;
+    margin-trim: block;
+    font-size: 0px;
+}
+item {
+    display: inline-block;
+    width: 50px;
+    height: 100px;
+    background-color: green;
+}
+.floating {
+    display: block;
+    float: left;
+    margin-block-end: 50px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item class="floating"></item>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-up-to-content-inline-layout-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-up-to-content-inline-layout-expected.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<style>
+container {
+    display: flow-root;
+    width: 100px;
+    border: 20px solid black;
+    padding-top: 55px;
+    font-size: 80px;
+}
+.inline-block-content {
+    display: inline-block;
+    background-color: green;
+}
+.floating {
+    float: right; 
+    background-color: red;
+}
+</style>
+</head>
+<body>
+<container>
+  <div class="inline-block-content" style="width: 80px; height: 30px;"></div>
+  <div class="inline-block-content" style="width: 30px; height: 30px;"></div>
+  <div class="floating" style="width: 30px; height: 30px;"></div>
+  <div class="inline-block-content" style="width: 30px; height: 40px;"></div>
+  <div class="floating" style="width: 30px; height: 30px;"></div>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-up-to-content-inline-layout-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-up-to-content-inline-layout-ref.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<style>
+container {
+    display: flow-root;
+    width: 100px;
+    border: 20px solid black;
+    padding-top: 55px;
+    font-size: 80px;
+}
+.inline-block-content {
+    display: inline-block;
+    background-color: green;
+}
+.floating {
+    float: right; 
+    background-color: red;
+}
+</style>
+</head>
+<body>
+<container>
+  <div class="inline-block-content" style="width: 80px; height: 30px;"></div>
+  <div class="inline-block-content" style="width: 30px; height: 30px;"></div>
+  <div class="floating" style="width: 30px; height: 30px;"></div>
+  <div class="inline-block-content" style="width: 30px; height: 40px;"></div>
+  <div class="floating" style="width: 30px; height: 30px;"></div>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-up-to-content-inline-layout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-up-to-content-inline-layout.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-float-block-end-up-to-content-inline-layout</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="BFC that creates IFC should have lowest flowest margin-end trimmed up to content">
+<link rel="match" href="block-container-float-block-end-up-to-content-inline-layout.html">
+<style>
+container {
+    display: flow-root;
+    width: 100px;
+    border: 20px solid black;
+    padding-top: 55px;
+    font-size: 80px;
+    margin-trim: block;
+}
+.inline-block-content {
+    display: inline-block;
+    background-color: green;
+}
+.floating {
+    float: right; 
+    background-color: red;
+}
+</style>
+</head>
+<body>
+<container>
+  <div class="inline-block-content" style="width: 80px; height: 30px;"></div>
+  <div class="inline-block-content" style="width: 30px; height: 30px;"></div>
+  <div class="floating" style="width: 30px; height: 30px;"></div>
+  <div class="inline-block-content" style="width: 30px; height: 40px;"></div>
+  <div class="floating" style="width: 30px; height: 30px; margin-bottom: 100px;"></div>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-start-inline-layout-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-start-inline-layout-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-start-inline-layout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-start-inline-layout.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-float-block-start-inline-layout</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="block-start should be trimmed for float that touches the top of the containing block with inline content present">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<style>
+container {
+    display: block;
+    width: 100px;
+    margin-trim: block-start;
+    font-size: 0px;
+}
+item {
+    display: inline-block;
+    width: 50px;
+    height: 100px;
+    background-color: green;
+}
+.floating {
+    display: block;
+    float: left;
+    margin-block-start: 30px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item></item>
+    <item class="floating"></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-inline-layout-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-inline-layout-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-inline-layout-rtl-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-inline-layout-rtl-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-inline-layout-rtl.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-inline-layout-rtl.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-float-inline-end-inline-layout-rtl</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline-end should be trimmed for float in block container that touches container inline-end edge with inline content present">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<style>
+container {
+    display: block;
+    inline-size: 100px;
+    font-size: 0px;
+    margin-trim: inline-end;
+    direction: rtl;
+}
+item {
+    display: inline-block;
+    inline-size: 50px;
+    block-size: 100px;
+    background-color: green;
+}
+.floating {
+    margin-inline-end: 30px;
+    float: right;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item class="floating"></item>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-inline-layout-vert-lr-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-inline-layout-vert-lr-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-inline-layout-vert-lr-rtl-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-inline-layout-vert-lr-rtl-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-inline-layout-vert-lr-rtl.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-inline-layout-vert-lr-rtl.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-float-inline-end-inline-layout-vert-lr-rtl</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline-end should be trimmed for float in block container that touches container inline-end edge with inline content present">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<style>
+container {
+    display: block;
+    inline-size: 100px;
+    font-size: 0px;
+    margin-trim: inline-end;
+    writing-mode: vertical-lr;
+    direction: rtl;
+}
+item {
+    display: inline-block;
+    inline-size: 50px;
+    block-size: 100px;
+    background-color: green;
+}
+.floating {
+    margin-inline-end: 30px;
+    float: right;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item class="floating"></item>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-inline-layout-vert-lr.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-inline-layout-vert-lr.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-float-inline-end-inline-layout-vert-lr</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline-end should be trimmed for float in block container that touches container inline-end edge with inline content present">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<style>
+container {
+    display: block;
+    inline-size: 100px;
+    font-size: 0px;
+    margin-trim: inline-end;
+    writing-mode: vertical-lr;
+}
+item {
+    display: inline-block;
+    inline-size: 50px;
+    block-size: 100px;
+    background-color: green;
+}
+.floating {
+    margin-inline-end: 30px;
+    float: right;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item class="floating"></item>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-inline-layout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-inline-layout.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-float-inline-end-inline-layout</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline-end should be trimmed for float in block container that touches container inline-end edge with inline content present">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<style>
+container {
+    display: block;
+    width: 100px;
+    font-size: 0px;
+    margin-trim: inline-end;
+}
+item {
+    display: inline-block;
+    width: 50px;
+    height: 100px;
+    background-color: green;
+}
+.floating {
+    margin-inline-end: 30px;
+    float: right;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item class="floating"></item>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-nested-within-span-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-nested-within-span-expected.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline-end should be trimmed for float in block container that touches container inline-end edge with inline content present">
+<style>
+container {
+    display: block;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 100px;
+    background-color: green;
+}
+.floating {
+    display: block;
+    float: right;
+}
+span {
+  border: 10px solid red;
+  margin-inline: 20px;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>
+      inline content in span
+      <item class="floating"></item>
+    </span>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-nested-within-span-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-nested-within-span-ref.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline-end should be trimmed for float in block container that touches container inline-end edge with inline content present">
+<style>
+container {
+    display: block;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 100px;
+    background-color: green;
+}
+.floating {
+    display: block;
+    float: right;
+}
+span {
+  border: 10px solid red;
+  margin-inline: 20px;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>
+      inline content in span
+      <item class="floating"></item>
+    </span>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-nested-within-span.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-nested-within-span.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-float-inline-end-nested-within-span</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline-end should be trimmed for float in block container that touches container inline-end edge with inline content present">
+<link rel="match" href="block-container-float-inline-end-nested-within-span-ref.html">
+<style>
+container {
+    display: block;
+    margin-trim: inline-end;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 100px;
+    background-color: green;
+}
+.floating {
+    display: block;
+    float: right;
+    margin-inline-end: 30px;
+}
+span {
+  border: 10px solid red;
+  margin-inline: 20px;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>
+      inline content in span
+      <item class="floating"></item>
+    </span>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-with-bidi-content-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-with-bidi-content-expected.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline end margin should be trimmed for float in presence of bidi content">
+<style>
+container {
+    display: block;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+    float: right;
+}
+.bidi-rtl {
+    direction: rtl;
+    unicode-bidi: bidi-override;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>left to right</span> <span class="bidi-rtl">right to left</span>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-with-bidi-content-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-with-bidi-content-ref.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline end margin should be trimmed for float in presence of bidi content">
+<style>
+container {
+    display: block;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+    float: right;
+}
+.bidi-rtl {
+    direction: rtl;
+    unicode-bidi: bidi-override;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>left to right</span> <span class="bidi-rtl">right to left</span>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-with-bidi-content.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-with-bidi-content.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-float-inline-end-with-bidi-content</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline end margin should be trimmed for float in presence of bidi content">
+<link rel="match" href="block-container-float-inline-end-with-bidi-content-ref.html">
+<style>
+container {
+    display: block;
+    margin-trim: inline-end;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+    float: right;
+    margin-inline-end: 50px;
+}
+.bidi-rtl {
+    direction: rtl;
+    unicode-bidi: bidi-override;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>left to right</span> <span class="bidi-rtl">right to left</span>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-inline-layout-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-inline-layout-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-inline-layout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-inline-layout.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-float-inline-inline-layout</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline should trim inline-start edge for floats that touch the inline-start edge of container and inline-end edge for floats that touch inline-end edge of container">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<style>
+container {
+    display: block;
+    width: 100px;
+    font-size: 0px;
+    margin-trim: inline;
+}
+item {
+    display: inline-block;
+    width: 50px;
+    height: 100px;
+    background-color: green;
+}
+.floating-left {
+    display: block;
+    width: 25px;
+    float: left;
+    margin-inline-start: 20px;
+}
+.floating-right {
+    display: block;
+    width: 25px;
+    float: right;
+    margin-inline-end: 20px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item class="floating-left"></item>
+    <item></item>
+    <item class="floating-right"></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-inline-layout-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-inline-layout-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-inline-layout-rtl-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-inline-layout-rtl-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-inline-layout-rtl.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-inline-layout-rtl.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-float-inline-start-inline-layout-rtl</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline-start should be trimmed for float in block container that touches container inline-start edge with inline content present">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<style>
+container {
+    display: block;
+    width: 100px;
+    font-size: 0px;
+    margin-trim: inline-start;
+    direction: rtl;
+}
+item {
+    display: inline-block;
+    width: 50px;
+    height: 100px;
+    background-color: green;
+}
+.floating {
+    margin-inline-start: 30px;
+    float: left;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item class="floating"></item>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-inline-layout-vert-lr-rtl-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-inline-layout-vert-lr-rtl-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-inline-layout-vert-lr-rtl.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-inline-layout-vert-lr-rtl.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-float-inline-start-inline-layout-vert-lr-rtl</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline-start should be trimmed for float in block container that touches container inline-start edge with inline content present">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<style>
+container {
+    display: block;
+    inline-size: 100px;
+    font-size: 0px;
+    margin-trim: inline-start;
+    writing-mode: vertical-lr;
+    direction: rtl;
+}
+item {
+    display: inline-block;
+    inline-size: 50px;
+    block-size: 100px;
+    background-color: green;
+}
+.floating {
+    margin-inline-start: 30px;
+    float: left;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item class="floating"></item>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-inline-layout-vertl-lr-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-inline-layout-vertl-lr-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-inline-layout-vertl-lr.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-inline-layout-vertl-lr.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-float-inline-start-inline-layout-vert-lr</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline-start should be trimmed for float in block container that touches container inline-start edge with inline content present">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<style>
+container {
+    display: block;
+    inline-size: 100px;
+    font-size: 0px;
+    margin-trim: inline-start;
+    writing-mode: vertical-lr;
+}
+item {
+    display: inline-block;
+    inline-size: 50px;
+    block-size: 100px;
+    background-color: green;
+}
+.floating {
+    margin-inline-start: 30px;
+    float: left;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item class="floating"></item>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-inline-layout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-inline-layout.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-float-inline-start-inline-layout</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline-start should be trimmed for float in block container that touches container inline-start edge with inline content present">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<style>
+container {
+    display: block;
+    width: 100px;
+    font-size: 0px;
+    margin-trim: inline-start;
+}
+item {
+    display: inline-block;
+    width: 50px;
+    height: 100px;
+    background-color: green;
+}
+.floating {
+    margin-inline-start: 30px;
+    float: left;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item class="floating"></item>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-nested-within-span-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-nested-within-span-expected.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline-start should be trimmed for float in block container that touches container inline-start edge with inline content present">
+<style>
+container {
+    display: block;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 100px;
+    background-color: green;
+}
+.floating {
+    display: block;
+    float: left;
+}
+span {
+  border: 10px solid red;
+  margin-inline: 20px;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>
+      inline content in span
+      <item class="floating"></item>
+    </span>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-nested-within-span-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-nested-within-span-ref.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline-start should be trimmed for float in block container that touches container inline-start edge with inline content present">
+<style>
+container {
+    display: block;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 100px;
+    background-color: green;
+}
+.floating {
+    display: block;
+    float: left;
+}
+span {
+  border: 10px solid red;
+  margin-inline: 20px;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>
+      inline content in span
+      <item class="floating"></item>
+    </span>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-nested-within-span.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-nested-within-span.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-float-inline-start-nested-within-span</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline-start should be trimmed for float in block container that touches container inline-start edge with inline content present">
+<link rel="match" href="block-container-float-inline-start-nested-within-span-ref.html">
+<style>
+container {
+    display: block;
+    margin-trim: inline-start;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 100px;
+    background-color: green;
+}
+.floating {
+    display: block;
+    float: left;
+    margin-inline-start: 30px;
+}
+span {
+  border: 10px solid red;
+  margin-inline: 20px;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>
+      inline content in span
+      <item class="floating"></item>
+    </span>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-with-bidi-content-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-with-bidi-content-expected.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline start margin should be trimmed for float in presence of bidi content">
+<style>
+container {
+    display: block;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+    float: left;
+}
+.bidi-rtl {
+    direction: rtl;
+    unicode-bidi: bidi-override;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>left to right</span> <span class="bidi-rtl">right to left</span>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-with-bidi-content-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-with-bidi-content-ref.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline start margin should be trimmed for float in presence of bidi content">
+<style>
+container {
+    display: block;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+    float: left;
+}
+.bidi-rtl {
+    direction: rtl;
+    unicode-bidi: bidi-override;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>left to right</span> <span class="bidi-rtl">right to left</span>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-with-bidi-content.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-with-bidi-content.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-float-inline-start-with-bidi-content</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline start margin should be trimmed for float in presence of bidi content">
+<link rel="match" href="block-container-float-inline-start-with-bidiy-content-ref.html">
+<style>
+container {
+    display: block;
+    margin-trim: inline-start;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+    float: left;
+    margin-inline-start: 50px;
+}
+.bidi-rtl {
+    direction: rtl;
+    unicode-bidi: bidi-override;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>left to right</span> <span class="bidi-rtl">right to left</span>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-with-intruding-floats-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-with-intruding-floats-expected.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline-start should be trimmed for float in block container that touches container inline-start edge with inline content present">
+<style>
+container {
+    display: block;
+    width: 80px;
+    margin-trim: inline-start;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+}
+.floating {
+    display: block;
+    float: left;
+}
+</style>
+</head>
+<body>
+<container>
+  <item></item>
+  <item class="floating" style="background-color: red;"></item>
+</container>
+<container>
+<item class="floating"></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-with-intruding-floats-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-with-intruding-floats-ref.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline-start should be trimmed for float in block container that touches container inline-start edge with inline content present">
+<style>
+container {
+    display: block;
+    width: 80px;
+    margin-trim: inline-start;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+}
+.floating {
+    display: block;
+    float: left;
+}
+</style>
+</head>
+<body>
+<container>
+  <item></item>
+  <item class="floating" style="background-color: red;"></item>
+</container>
+<container>
+<item class="floating"></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-with-intruding-floats.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-with-intruding-floats.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-float-inline-start-with-intruding-floats</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline-start should be trimmed for float in block container that touches container inline-start edge with inline content present">
+<link rel="match" href="block-container-float-inline-start-with-intruding-floats-ref.html">
+<style>
+container {
+    display: block;
+    width: 80px;
+    margin-trim: inline-start;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+}
+.floating {
+    display: block;
+    float: left;
+}
+</style>
+</head>
+<body>
+<container>
+  <item></item>
+  <item class="floating" style="background-color: red;"></item>
+</container>
+<container>
+<item class="floating" style="margin-inline-start: 25px;"></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-word-break-all-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-word-break-all-expected.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline margins should be trimmed for floats that have margin edges adjacent to respective side">
+<style>
+container {
+    display: block;
+    width: 100px;
+    border: solid blue;
+    word-break: break-all;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+}
+.floating-right {
+    float: right;
+}
+.floating-left {
+  float: left;
+}
+</style>
+</head>
+<body>
+<container>
+<item class="floating-right"></item>
+inline margins should be trimmed for 
+<item class="floating-left"></item>
+floats that have margin edgesadjacent to respective side
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-word-break-all-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-word-break-all-ref.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline margins should be trimmed for floats that have margin edges adjacent to respective side">
+<style>
+container {
+    display: block;
+    width: 100px;
+    border: solid blue;
+    word-break: break-all;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+}
+.floating-right {
+    float: right;
+}
+.floating-left {
+  float: left;
+}
+</style>
+</head>
+<body>
+<container>
+<item class="floating-right"></item>
+inline margins should be trimmed for 
+<item class="floating-left"></item>
+floats that have margin edgesadjacent to respective side
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-word-break-all.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-word-break-all.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-float-inline-word-break-all</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline margins should be trimmed for floats that have margin edges adjacent to respective side">
+<link rel="match" href="block-container-float-inline-word-break-all-ref.html">
+<style>
+container {
+    display: block;
+    width: 100px;
+    border: solid blue;
+    word-break: break-all;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+}
+.floating-right {
+    margin-inline-end: 30px;
+    float: right;
+}
+.floating-left {
+  margin-inline-start: 30px;
+  float: left;
+}
+</style>
+</head>
+<body>
+<container>
+<item class="floating-right"></item>
+inline margins should be trimmed for 
+<item class="floating-left"></item>
+floats that have margin edgesadjacent to respective side
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-min-content-inline-layout-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-min-content-inline-layout-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-min-content-inline-layout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-min-content-inline-layout.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-float-min-content-inline-layout</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="floats should not contribute trimmed margins for container intrinsic sizing">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<style>
+container {
+    display: block;
+    width: min-content;
+    font-size: 0px;
+    margin-trim: inline;
+    background-color: green;
+}
+item {
+    display: inline-block;
+    width: 100px;
+    height: 100px;
+}
+.floating {
+    display: block;
+    float: left;
+    margin-inline: 30px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item></item>
+    <item class="floating"></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-multiple-formatting-contexts-inline-layout-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-multiple-formatting-contexts-inline-layout-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-multiple-formatting-contexts-inline-layout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-multiple-formatting-contexts-inline-layout.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-float-multiple-formatting-contexts-inline-layout</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<style>
+container {
+    margin-trim: block;
+    display: flow-root;
+    width: max-content;
+}
+item {
+    display: block;
+    width: 25px;
+    height: 100px;
+    margin-block-end: 50px;
+    float: left;
+}
+.inline-block {
+    display: inline-block;
+    width: 25px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container style="background-color: green;">
+<item style="width: 50px;"></item>
+<container>
+    <item class="inline-block"></item>
+    <item></item>
+</container>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-nested-inside-inline-inline-layout-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-nested-inside-inline-inline-layout-expected.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-block-start-002</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-nested-inside-inline-inline-layout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-nested-inside-inline-inline-layout.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>block-container-float-nested-inside-inline-inline-layout</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Float nested in an inline should determine margin trimming from IFC root">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<style>
+container {
+    display: block;
+    width: 100px;
+    margin-trim: inline;
+    font-size: 0px;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 100px;
+    background-color: green;
+}
+.inline-block {
+    display: inline-block;
+}
+.floating {
+    float: right;
+    margin-inline-end: 20px; 
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+<item class="inline-block"></item>
+<span><item class="floating"></item></span>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-overflowing-margin-has-margin-trimmed-at-final-position-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-overflowing-margin-has-margin-trimmed-at-final-position-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-overflowing-margin-has-margin-trimmed-at-final-position.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-overflowing-margin-has-margin-trimmed-at-final-position.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-float-overflowing-margin-has-margin-trimmed-at-final-position</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="When a float is not able to fit on the current line, it should have its margins trimmed when placed under other floats">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<style>
+container {
+    display: block;
+    width: 110px;
+    margin-trim: inline;
+    font-size: 0px;
+}
+item {
+    display: block;
+    width: 100px;
+    height: 25px;
+    background-color: green;
+}
+.inline-block {
+    display: inline-block;
+    height: 50px;
+}
+.float-left {
+    float: left;
+}
+.overflowing {
+    margin-inline-start: 55px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item class="inline-block"></item>
+    <item class="float-left"></item>
+    <item class="float-left overflowing"></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-overflowing-positioned-at-first-available-vertical-position-with-trimmed-margin-inline-layout-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-overflowing-positioned-at-first-available-vertical-position-with-trimmed-margin-inline-layout-expected.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<title>margin-trim: block-container-float-overflowing-positioned-at-first-available-vertical-position-with-trimmed-margin</title>
+<meta name="assert" content="The final float (blue) should be able to get positioned right under the text with its trimmed margin">
+<link rel="match" href="block-container-float-overflowing-positioned-at-first-available-vertical-position-with-trimmed-margin-inline-layout-ref.html">
+<style>
+container {
+    display: block;
+    width: 200px;
+    margin-trim: inline;
+    line-height: 30px;
+}
+item {
+    display: inline-block;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+}
+.tall {
+    height: 75px;
+}
+.floating-left {
+    display: block;
+    float: left;
+    background-color: blue;
+}
+.floating-right {
+    display: block;
+    float: right;
+    background-color: red;
+}
+</style>
+</head>
+<body>
+<container>
+    blue below the text
+    <item class="tall"></item>
+    <item id="blue"></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-overflowing-positioned-at-first-available-vertical-position-with-trimmed-margin-inline-layout-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-overflowing-positioned-at-first-available-vertical-position-with-trimmed-margin-inline-layout-ref.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<title>margin-trim: block-container-float-overflowing-positioned-at-first-available-vertical-position-with-trimmed-margin</title>
+<meta name="assert" content="The final float (blue) should be able to get positioned right under the text with its trimmed margin">
+<link rel="match" href="block-container-float-overflowing-positioned-at-first-available-vertical-position-with-trimmed-margin-inline-layout-ref.html">
+<style>
+container {
+    display: block;
+    width: 200px;
+    margin-trim: inline;
+    line-height: 30px;
+}
+item {
+    display: inline-block;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+}
+.tall {
+    height: 75px;
+}
+.floating-left {
+    display: block;
+    float: left;
+    background-color: blue;
+}
+.floating-right {
+    display: block;
+    float: right;
+    background-color: red;
+}
+</style>
+</head>
+<body>
+<container>
+    blue below the text
+    <item class="tall"></item>
+    <item id="blue"></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-overflowing-positioned-at-first-available-vertical-position-with-trimmed-margin-inline-layout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-overflowing-positioned-at-first-available-vertical-position-with-trimmed-margin-inline-layout.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<title>margin-trim: block-container-float-overflowing-positioned-at-first-available-vertical-position-with-trimmed-margin</title>
+<meta name="assert" content="The final float (blue) should be able to get positioned right under the text with its trimmed margin">
+<link rel="match" href="block-container-float-overflowing-positioned-at-first-available-vertical-position-with-trimmed-margin-inline-layout-ref.html">
+<style>
+container {
+    display: block;
+    width: 200px;
+    margin-trim: inline;
+    line-height: 30px;
+}
+item {
+    display: inline-block;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+}
+.tall {
+    height: 75px;
+}
+.floating-left {
+    display: block;
+    float: left;
+    background-color: blue;
+    margin-inline-start: 110px;
+}
+.floating-right {
+    display: block;
+    float: right;
+    background-color: red;
+}
+</style>
+</head>
+<body>
+<container>
+    blue below the text
+    <item class="tall"></item>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-trimmed-margin-allows-float-to-fit-inline-layout-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-trimmed-margin-allows-float-to-fit-inline-layout-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-trimmed-margin-allows-float-to-fit-inline-layout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-trimmed-margin-allows-float-to-fit-inline-layout.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-float-trimmed-margin-allows-float-to-fit-inline-layout</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="float that overflows into another item stays on the same line due to trimmed margin">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<style>
+container {
+    display: block;
+    width: 100px;
+    height: 100px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    width: 25px;
+    height: 100px;
+    background-color: green;
+}
+.inline-block-content {
+    display: inline-block;
+    width: 50px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item style="float: left"></item>
+    <item class="inline-block-content"></item>
+    <item style="float: right; margin-inline-end: 150px;"></item>
+</container>
+</body>
+</html>

--- a/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
@@ -368,6 +368,9 @@ static OptionSet<AvoidanceReason> canUseForChild(const RenderBlockFlow& flow, co
             if (renderer.isFloating() && !renderer.parent()->style().isHorizontalWritingMode())
                 return false;
 #endif
+            // Floats where the block container specifies margin-tirm need IFC implementation (geometry adjustment)
+            if (!flow.style().marginTrim().isEmpty())
+                return false;
             if (renderer.isOutOfFlowPositioned()) {
                 if (!renderer.parent()->style().isLeftToRightDirection())
                     return false;

--- a/Source/WebCore/rendering/LegacyLineLayout.cpp
+++ b/Source/WebCore/rendering/LegacyLineLayout.cpp
@@ -2348,5 +2348,15 @@ const FrameViewLayoutContext& LegacyLineLayout::layoutContext() const
     return m_flow.view().frameView().layoutContext();
 }
 
+LayoutUnit LegacyLineLayout::contentBoxLogicalHeight() const
+{
+    auto firstLine = m_lineBoxes.firstLineBox();
+    auto lastLine = m_lineBoxes.lastLineBox();
+    if (firstLine && lastLine)
+        return LayoutUnit { lastLine->logicalFrameRect().maxY() - firstLine->logicalFrameRect().y() };
+    if (firstLine)
+        return LayoutUnit { firstLine->logicalFrameRect().maxY() };
+    return 0_lu;
+}
 
 }

--- a/Source/WebCore/rendering/LegacyLineLayout.h
+++ b/Source/WebCore/rendering/LegacyLineLayout.h
@@ -72,6 +72,7 @@ public:
 
     size_t lineCount() const;
     size_t lineCountUntil(const LegacyRootInlineBox*) const;
+    LayoutUnit contentBoxLogicalHeight() const;
 
     static void appendRunsForObject(BidiRunList<BidiRun>*, int start, int end, RenderObject&, InlineBidiResolver&);
     static void updateLogicalWidthForAlignment(RenderBlockFlow&, const TextAlignMode&, const LegacyRootInlineBox*, BidiRun* trailingSpaceRun, float& logicalLeft, float& totalLogicalWidth, float& availableLogicalWidth, int expansionOpportunityCount);

--- a/Source/WebCore/rendering/RenderBlockFlow.h
+++ b/Source/WebCore/rendering/RenderBlockFlow.h
@@ -407,7 +407,7 @@ public:
 
     std::optional<LayoutUnit> lowestInitialLetterLogicalBottom() const;
 
-    LayoutUnit blockFormattingContextInFlowBlockLevelContentHeight() const;
+    LayoutUnit blockFormattingContextInFlowContentHeight() const;
 protected:
     bool shouldResetLogicalHeightBeforeLayout() const override { return true; }
 


### PR DESCRIPTION
#### 6e0475da2ecd191b009ae9f1d1d728e7dfcd8972
<pre>
Initial implementation of margin-trim for legacy inline layout in non-paginated and single column block containers
<a href="https://bugs.webkit.org/show_bug.cgi?id=252062">https://bugs.webkit.org/show_bug.cgi?id=252062</a>
rdar://problem/105283580

Reviewed by NOBODY (OOPS!).

This patch attempts to cover as many scenarios as possible for margin
trim in regards to legacy line layout and serves as a basis for an
initial implementation for the property in this context. There should be a comprehensive
suite of tests that range from simple cases to most complex, but there
will likely need to be some iteration on this patch. For example,
currently imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-word-break-all.html
does not render quite correctly and the underlying cause needs to
be investigated. Paginated and multi-column content support will also
need to be provided in a further patch.

When floats are being placed, we can check to see if we can trim some
of its margins based on its surrounding constraints. In particular, we
can check to see if there are any other items on the left/right
(depending on the position of the float) of the box at that candidate
vertical position. If there is nothing there (i.e. the float would be
placed flush against its containing block), then we can trim the
respective margin. However, if there is an item at that vertical, then
we must wait until the float gets its final position before tirmming
any of its margins. This is because trimming a margin too early could
result it in being placed in a position where it should not be.

&lt;div style=&quot;margin-trim: inline;&quot;&gt;
  &lt;div style=&quot;float: left; width: 50px; height: 50px; background-color: green; margin-inline-start: 30px;&quot;&gt;&lt;/div&gt;
  &lt;div style=&quot;float: right; width: 50px; height: 50px; background-color: red; margin-inline-end: 30px;&quot;&gt;&lt;/div&gt;
&lt;/div&gt;

In this simple example we can easily trim both the margins of the floats
as we attempt to place them. Inside BreakingContext::handleFloat() we
check the logical offset for the line against the logical offset for
content inside the containing block. If these two values are equal,
then the float would be placed against the box and we can trim the
margin early.

In all cases this may not entirely be possible:
&lt;style&gt;
container {
    display: block;
    width: 110px;
    margin-trim: inline;
    font-size: 0px;
}
item {
    display: block;
    width: 100px;
    height: 25px;
    background-color: green;
}
.inline-block {
    display: inline-block;
    height: 50px;
}
.float-left {
    float: left;
}
.overflowing {
    margin-inline-start: 55px;
}
&lt;/style&gt;
&lt;container&gt;
    &lt;item class=&quot;inline-block&quot;&gt;&lt;/item&gt;
    &lt;item class=&quot;float-left&quot;&gt;&lt;/item&gt;
    &lt;item class=&quot;float-left overflowing&quot;&gt;&lt;/item&gt;
&lt;/container&gt;
For the last float we see that there is content on the left side at
this vertical position, so we do not trim the margin here. Instead we
have to wait until this float gets pushed under all the other ones
before trimming.

If we trim too early, the float could get positioned in a spot where it
would not normally fit with its margin. For this we fall back to the
code in RenderBlockFlow::computeLogicalLocationForFloat that will trim
the margin at its final position. This is the same logic that was used
to trim the margins for floats in block containers that did not have
any inline children.

* LayoutTests/TestExpectations:
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-block-end-inline-layout-expected.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-block-end-inline-layout.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-block-end-up-to-content-inline-layout-expected.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-block-end-up-to-content-inline-layout-ref.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-block-end-up-to-content-inline-layout.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-block-start-inline-layout-expected.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-block-start-inline-layout.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-inline-layout-expected.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-inline-layout-rtl-expected.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-inline-layout-rtl.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-inline-layout-vert-lr-expected.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-inline-layout-vert-lr-rtl-expected.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-inline-layout-vert-lr-rtl.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-inline-layout-vert-lr.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-inline-layout.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-nested-within-span-expected.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-nested-within-span-ref.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-nested-within-span.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-with-bidi-content-expected.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-with-bidi-content-ref.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-with-bidi-content.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-inline-layout-expected.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-inline-layout.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-inline-layout-expected.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-inline-layout-rtl-expected.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-inline-layout-rtl.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-inline-layout-vert-lr-rtl-expected.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-inline-layout-vert-lr-rtl.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-inline-layout-vertl-lr-expected.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-inline-layout-vertl-lr.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-inline-layout.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-nested-within-span-expected.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-nested-within-span-ref.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-nested-within-span.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-with-bidi-content-expected.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-with-bidi-content-ref.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-with-bidi-content.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-with-intruding-floats-expected.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-with-intruding-floats-ref.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-with-intruding-floats.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-word-break-all-expected.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-word-break-all-ref.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-word-break-all.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-min-content-inline-layout-expected.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-min-content-inline-layout.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-multiple-formatting-contexts-inline-layout-expected.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-multiple-formatting-contexts-inline-layout.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-nested-inside-inline-inline-layout-expected.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-nested-inside-inline-inline-layout.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-overflowing-margin-has-margin-trimmed-at-final-position-expected.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-overflowing-margin-has-margin-trimmed-at-final-position.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-overflowing-positioned-at-first-available-vertical-position-with-trimmed-margin-inline-layout-expected.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-overflowing-positioned-at-first-available-vertical-position-with-trimmed-margin-inline-layout-ref.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-overflowing-positioned-at-first-available-vertical-position-with-trimmed-margin-inline-layout.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-trimmed-margin-allows-float-to-fit-inline-layout-expected.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-trimmed-margin-allows-float-to-fit-inline-layout.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-inline-layout-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-inline-layout.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-up-to-content-inline-layout-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-up-to-content-inline-layout-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-up-to-content-inline-layout.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-start-inline-layout-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-start-inline-layout.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-inline-layout-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-inline-layout-rtl-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-inline-layout-rtl.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-inline-layout-vert-lr-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-inline-layout-vert-lr-rtl-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-inline-layout-vert-lr-rtl.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-inline-layout-vert-lr.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-inline-layout.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-nested-within-span-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-nested-within-span-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-nested-within-span.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-with-bidi-content-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-with-bidi-content-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-with-bidi-content.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-inline-layout-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-inline-layout.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-inline-layout-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-inline-layout-rtl-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-inline-layout-rtl.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-inline-layout-vert-lr-rtl-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-inline-layout-vert-lr-rtl.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-inline-layout-vertl-lr-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-inline-layout-vertl-lr.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-inline-layout.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-nested-within-span-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-nested-within-span-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-nested-within-span.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-with-bidi-content-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-with-bidi-content-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-with-bidi-content.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-with-intruding-floats-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-with-intruding-floats-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-with-intruding-floats.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-word-break-all-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-word-break-all-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-word-break-all.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-min-content-inline-layout-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-min-content-inline-layout.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-multiple-formatting-contexts-inline-layout-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-multiple-formatting-contexts-inline-layout.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-nested-inside-inline-inline-layout-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-nested-inside-inline-inline-layout.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-overflowing-margin-has-margin-trimmed-at-final-position-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-overflowing-margin-has-margin-trimmed-at-final-position.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-overflowing-positioned-at-first-available-vertical-position-with-trimmed-margin-inline-layout-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-overflowing-positioned-at-first-available-vertical-position-with-trimmed-margin-inline-layout-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-overflowing-positioned-at-first-available-vertical-position-with-trimmed-margin-inline-layout.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-trimmed-margin-allows-float-to-fit-inline-layout-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-trimmed-margin-allows-float-to-fit-inline-layout.html: Added.
* Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp:
(WebCore::LayoutIntegration::canUseForChild):
* Source/WebCore/rendering/LegacyLineLayout.cpp:
(WebCore::LegacyLineLayout::contentBoxLogicalHeight const):
* Source/WebCore/rendering/LegacyLineLayout.h:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::layoutBlock):
(WebCore::RenderBlockFlow::computeInlinePreferredLogicalWidths const):
(WebCore::RenderBlockFlow::blockFormattingContextInFlowContentHeight const):
(WebCore::RenderBlockFlow::blockFormattingContextInFlowBlockLevelContentHeight const): Deleted.
* Source/WebCore/rendering/RenderBlockFlow.h:
* Source/WebCore/rendering/line/BreakingContext.h:
(WebCore::BreakingContext::handleFloat):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e0475da2ecd191b009ae9f1d1d728e7dfcd8972

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108791 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17890 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41624 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/116 "Updated wpe dependencies (failure)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118093 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112673 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19344 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9167 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101018 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114559 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14514 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97733 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42484 "Found 2 new test failures: webgl/2.0.y/conformance/glsl/bugs/character-set.html, webgl/2.0.y/conformance/glsl/misc/fragcolor-fragdata-invariant.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96502 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29371 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84334 "Found 2 new API test failures: /TestWebKit:WebKit.OnDeviceChangeCrash, /TestWebKit:WebKit.PrivateBrowsingPushStateNoHistoryCallback (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10674 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30722 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11435 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7650 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16822 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50313 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13022 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->