### PR TITLE
Implement parser for text-spacing and its longhands for auto and none

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6252,8 +6252,3 @@ imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/js
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.html [ Skip ]
 
 webkit.org/b/252183 imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-overflowing-float-margins-tirmmed-at-final-position-block-layout.html [ ImageOnlyFailure ]
-
-#Skipping text-spacing tests until the features get implemented.
-imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-spacing-computed.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-spacing-invalid.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-spacing-valid.html [ Skip ]

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -3580,6 +3580,7 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         CSSPropertyPerspectiveOrigin,
         CSSPropertyOffset,
         CSSPropertyTextEmphasis,
+        CSSPropertyTextSpacing,
         CSSPropertyFontVariant,
         CSSPropertyFontSynthesis,
         CSSPropertyContainIntrinsicSize

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -1184,6 +1184,21 @@
                 "non-canonical-url": "https://www.w3.org/TR/css-text-4/#text-spacing-property"
             }
         },
+        "text-spacing": {
+            "inherited": true,
+            "codegen-properties": {
+                "longhands": [
+                    "text-autospace",
+                    "text-spacing-trim"
+                ],
+                "settings-flag": "cssTextSpacingEnabled"
+            },
+            "status": "experimental",
+            "specification": {
+                "category": "css-text",
+                "non-canonical-url": "https://www.w3.org/TR/css-text-4/#text-spacing-property"
+            }
+        },
         "writing-mode": {
             "inherited": true,
             "values": [

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -385,6 +385,25 @@ static Ref<CSSPrimitiveValue> textAutospaceFromStyle(const RenderStyle& style)
     return CSSPrimitiveValue::create(CSSValueNoAutospace);
 }
 
+static Ref<CSSValue> textSpacingFromStyle(const RenderStyle& style)
+{
+    // FIXME: add support for remaining values once spec is stable and we are parsing them.
+    auto list = CSSValueList::createSpaceSeparated();
+    auto textSpacingTrim = style.textSpacingTrim();
+    auto textAutospace = style.textAutospace();
+    if (textSpacingTrim.isAuto() && textAutospace.isAuto()) {
+        list->append(CSSPrimitiveValue::create(CSSValueAuto));
+        return list;
+    }
+    if (textSpacingTrim.isSpaceAll() && textAutospace.isNoAutospace()) {
+        list->append(CSSPrimitiveValue::create(CSSValueNone));
+        return list;
+    }
+    list->append(textAutospaceFromStyle(style));
+    list->append(textSpacingTrimFromStyle(style));
+    return list;
+}
+
 static Ref<CSSPrimitiveValue> zoomAdjustedPixelValue(double value, const RenderStyle& style)
 {
     return CSSPrimitiveValue::create(adjustFloatForAbsoluteZoom(value, style), CSSUnitType::CSS_PX);
@@ -3575,6 +3594,8 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
     }
     case CSSPropertyTextShadow:
         return valueForShadow(style.textShadow(), propertyID, style);
+    case CSSPropertyTextSpacing:
+        return textSpacingFromStyle(style);
     case CSSPropertyTextSpacingTrim:
         return textSpacingTrimFromStyle(style);
     case CSSPropertyTextAutospace:

--- a/Source/WebCore/css/ShorthandSerializer.cpp
+++ b/Source/WebCore/css/ShorthandSerializer.cpp
@@ -122,6 +122,7 @@ private:
     String serializeGridTemplate() const;
     String serializeOffset() const;
     String serializePageBreak() const;
+    String serializeTextSpacing() const;
 
     StylePropertyShorthand m_shorthand;
     RefPtr<CSSValue> m_longhandValues[maxShorthandLength];
@@ -378,6 +379,8 @@ String ShorthandSerializer::serialize()
     case CSSPropertyWebkitPerspective:
     case CSSPropertyWebkitTextOrientation:
         return serializeLonghandValue(0);
+    case CSSPropertyTextSpacing:
+        return serializeTextSpacing();
     case CSSPropertyTransformOrigin:
         return serializeLonghandsOmittingTrailingInitialValue();
     case CSSPropertyWebkitColumnBreakAfter:
@@ -915,6 +918,22 @@ String ShorthandSerializer::serializeFont() const
         sizeSeparator, serializeLonghandValue(sizeIndex),
         lineHeightSeparator, lineHeight,
         ' ', serializeLonghandValue(familyIndex));
+}
+
+String ShorthandSerializer::serializeTextSpacing() const
+{
+    auto autospaceValueID = longhandValueID(longhandIndex(0, CSSPropertyTextAutospace));
+    auto trimValueID = longhandValueID(longhandIndex(1, CSSPropertyTextSpacingTrim));
+    if (autospaceValueID == CSSValueAuto && trimValueID == CSSValueAuto)
+        return nameString(CSSValueAuto);
+    if (autospaceValueID == CSSValueNoAutospace && trimValueID == CSSValueSpaceAll)
+        return nameString(CSSValueNone);
+    // FIXME: add support for CSSValueNormal serialization when we are parsing this value.
+    return makeString(
+        serializeLonghandValue(longhandIndex(0, CSSPropertyTextAutospace)),
+        ' ',
+        serializeLonghandValue(longhandIndex(1, CSSPropertyTextSpacingTrim))
+    );
 }
 
 String ShorthandSerializer::serializeFontSynthesis() const

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -763,6 +763,103 @@ bool CSSPropertyParser::consumeFontVariantShorthand(bool important)
     return true;
 }
 
+bool CSSPropertyParser::consumeTextSpacing(bool important)
+{
+    // text-spacing: auto | none | <text-space-autospace> || <text-spacing-trim>
+    // text-autospace: auto | no-autospace
+    // text-spacing-trim: auto | space-all
+    // FIXME: parse remaining values once spec is stable.
+
+    // Part I : auto | none
+    auto firstValue = consumeIdent<CSSValueNone, CSSValueAuto>(m_range);
+    if (firstValue && m_range.atEnd()) {
+        if (firstValue->valueID() == CSSValueAuto) {
+            addProperty(CSSPropertyTextAutospace, CSSPropertyTextSpacing, firstValue.releaseNonNull(), important);
+            addProperty(CSSPropertyTextSpacingTrim, CSSPropertyTextSpacing, CSSPrimitiveValue::create(CSSValueAuto), important);
+        } else if (firstValue->valueID() == CSSValueNone) {
+            addProperty(CSSPropertyTextAutospace, CSSPropertyTextSpacing, CSSPrimitiveValue::create(CSSValueNoAutospace), important);
+            addProperty(CSSPropertyTextSpacingTrim, CSSPropertyTextSpacing, CSSPrimitiveValue::create(CSSValueSpaceAll), important);
+        }
+        // FIXME: add support for CSSValueNormal as firstValue here.
+        return true;
+    }
+    // part II (longhands): <text-space-autospace> || <text-spacing-trim> (with fist token = auto or none)
+    if (firstValue && !m_range.atEnd()) {
+        // first-value = auto | none
+        auto nextID = m_range.peek().id();
+        if (firstValue->valueID() == CSSValueNone)
+            return false; // none can just appear alone.
+        if (firstValue->valueID() == CSSValueAuto) {
+        // Here, we have to identify to which longhand the firstValue belongs, since it can appear on both.
+            if (CSSPropertyParserHelpers::isValueIDUniqueToTextSpacingTrimLonghand(nextID)) {
+                // auto belongs to the other longhand
+                addProperty(CSSPropertyTextAutospace, CSSPropertyTextSpacing, firstValue.releaseNonNull(), important);
+                auto remainingValues = CSSPropertyParserHelpers::consumeTextSpacingTrim(m_range);
+                ASSERT(remainingValues);
+                addProperty(CSSPropertyTextSpacingTrim, CSSPropertyTextSpacing, WTFMove(remainingValues), important);
+                return true;
+            }
+            if (CSSPropertyParserHelpers::isValueIDUniqueToTextAutospaceLonghand(nextID)) {
+                // auto belongs to the other longhand
+                addProperty(CSSPropertyTextSpacingTrim, CSSPropertyTextSpacing, firstValue.releaseNonNull(), important);
+                auto remainingValues = CSSPropertyParserHelpers::consumeTextAutospace(m_range);
+                ASSERT(remainingValues);
+                addProperty(CSSPropertyTextAutospace, CSSPropertyTextSpacing, WTFMove(remainingValues), important);
+                return true;
+            }
+            return false;
+        }
+        // FIXME: add support for CSSValueNormal as firstValue here.
+    }
+
+    // part II (longhands): <text-space-autospace> || <text-spacing-trim> (with fist token != auto or none)
+    // From here, we know that first value is is not auto | none . Let's split the range in two subranges, one for each longhand consumer.
+    auto firstID = m_range.peek().id();
+    auto it = m_range;
+    bool isFirtValueFromTextSpacingTrimLongHand { false };
+    if (CSSPropertyParserHelpers::isValueIDUniqueToTextSpacingTrimLonghand(firstID)) {
+        isFirtValueFromTextSpacingTrimLongHand = true;
+        while (!it.atEnd() && CSSPropertyParserHelpers::isValueIDUniqueToTextSpacingTrimLonghand(it.peek().id()))
+            it.consumeIncludingWhitespace();
+        auto longhandRange = m_range.makeSubRange(m_range.begin(), it.begin());
+        auto value = CSSPropertyParserHelpers::consumeTextSpacingTrim(longhandRange);
+        if (!value)
+            return false;
+        addProperty(CSSPropertyTextSpacingTrim, CSSPropertyTextSpacing, WTFMove(value), important);
+    } else if (CSSPropertyParserHelpers::isValueIDUniqueToTextAutospaceLonghand(firstID)) {
+        isFirtValueFromTextSpacingTrimLongHand = false;
+        while (!it.atEnd() && CSSPropertyParserHelpers::isValueIDUniqueToTextAutospaceLonghand(it.peek().id()))
+            it.consumeIncludingWhitespace();
+        auto longhandRange = m_range.makeSubRange(m_range.begin(), it.begin());
+        auto value = CSSPropertyParserHelpers::consumeTextAutospace(longhandRange);
+        if (!value)
+            return false;
+        addProperty(CSSPropertyTextAutospace, CSSPropertyTextSpacing, WTFMove(value), important);
+    } else
+        return false;
+
+    // from here, the first value is for sure consumed, we need to parse the second longhand
+    auto secondLonghandRange = m_range.makeSubRange(it.begin(), m_range.end());
+    if (secondLonghandRange.atEnd())
+        return true;
+    if (isFirtValueFromTextSpacingTrimLongHand) {
+        // consume remaining as text-autospace
+        auto remainingValues = CSSPropertyParserHelpers::consumeTextAutospace(secondLonghandRange);
+        if (remainingValues) {
+            addProperty(CSSPropertyTextAutospace, CSSPropertyTextSpacing, WTFMove(remainingValues), important);
+            return true;
+        }
+    } else {
+        // consume remaining as text-spacing-trim
+        auto remainingValues = CSSPropertyParserHelpers::consumeTextSpacingTrim(secondLonghandRange);
+        if (remainingValues) {
+            addProperty(CSSPropertyTextSpacingTrim, CSSPropertyTextSpacing, WTFMove(remainingValues), important);
+            return true;
+        }
+    }
+    return secondLonghandRange.atEnd();
+}
+
 bool CSSPropertyParser::consumeFontSynthesis(bool important)
 {
     // none | [ weight || style || small-caps ]
@@ -2555,6 +2652,8 @@ bool CSSPropertyParser::parseShorthand(CSSPropertyID property, bool important)
         addProperty(CSSPropertyTextDecorationLine, property, line.releaseNonNull(), important);
         return true;
     }
+    case CSSPropertyTextSpacing:
+        return consumeTextSpacing(important);
     case CSSPropertyWebkitTextDecoration:
         // FIXME-NEWPARSER: We need to unprefix -line/-style/-color ASAP and get rid
         // of -webkit-text-decoration completely.

--- a/Source/WebCore/css/parser/CSSPropertyParser.h
+++ b/Source/WebCore/css/parser/CSSPropertyParser.h
@@ -118,6 +118,7 @@ private:
 
     bool consumeFont(bool important);
     bool consumeTextDecorationSkip(bool important);
+    bool consumeTextSpacing(bool important);
     bool consumeFontVariantShorthand(bool important);
     bool consumeFontSynthesis(bool important);
 

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
@@ -39,6 +39,7 @@
 #include "Length.h"
 #include "StyleColor.h"
 #include "SystemFontDatabase.h"
+#include <unordered_set>
 #include <variant>
 #include <wtf/OptionSet.h>
 #include <wtf/Vector.h>
@@ -434,6 +435,18 @@ RefPtr<CSSValueList> consumeCommaSeparatedListWithoutSingleValueOptimization(CSS
     } while (consumeCommaIncludingWhitespace(range));
 
     return result;
+}
+
+inline bool isValueIDUniqueToTextSpacingTrimLonghand(CSSValueID id)
+{
+    // FIXME: add remaining values when specification is stable and we are parsing them.
+    return id == CSSValueSpaceAll;
+}
+
+inline bool isValueIDUniqueToTextAutospaceLonghand(CSSValueID id)
+{
+    // FIXME: add remaining values when specification is stable and we are parsing them.
+    return id == CSSValueNoAutospace;
 }
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/platform/text/TextSpacing.h
+++ b/Source/WebCore/platform/text/TextSpacing.h
@@ -45,18 +45,6 @@ bool operator==(const TextSpacingTrim& other) const
 TrimType m_trim { TrimType::SpaceAll };
 };
 
-inline WTF::TextStream& operator<<(WTF::TextStream& ts, const TextSpacingTrim& value)
-{
-    // FIXME: add remaining values;
-    switch (value.m_trim) {
-    case TextSpacingTrim::TrimType::Auto:
-        return ts << "auto";
-    case TextSpacingTrim::TrimType::SpaceAll:
-        return ts << "space-all";
-    }
-    return ts;
-}
-
 struct TextAutospace {
 enum class TextAutospaceType: uint8_t {
     Auto = 0,
@@ -71,6 +59,18 @@ bool operator==(const TextAutospace& other) const
 }
 TextAutospaceType m_autoSpace { TextAutospaceType::NoAutospace };
 };
+
+inline WTF::TextStream& operator<<(WTF::TextStream& ts, const TextSpacingTrim& value)
+{
+    // FIXME: add remaining values;
+    switch (value.m_trim) {
+    case TextSpacingTrim::TrimType::Auto:
+        return ts << "auto";
+    case TextSpacingTrim::TrimType::SpaceAll:
+        return ts << "space-all";
+    }
+    return ts;
+}
 
 inline WTF::TextStream& operator<<(WTF::TextStream& ts, const TextAutospace& value)
 {

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -437,10 +437,9 @@ public:
     TextSpacingTrim textSpacingTrim() const;
     TextAutospace textAutospace() const;
 
-
     float zoom() const { return m_nonInheritedData->rareData->zoom; }
     float effectiveZoom() const { return m_rareInheritedData->effectiveZoom; }
-    
+
     TextZoom textZoom() const { return static_cast<TextZoom>(m_rareInheritedData->textZoom); }
 
     TextDirection direction() const { return static_cast<TextDirection>(m_inheritedFlags.direction); }


### PR DESCRIPTION
#### 45e26321c1e46e84ea2610ec9568783d365ffbe3
<pre>
Implement parser for text-spacing and its longhands for auto and none
<a href="https://bugs.webkit.org/show_bug.cgi?id=252068">https://bugs.webkit.org/show_bug.cgi?id=252068</a>
rdar://105094870
Reviewed by NOBODY (OOPS!).

Reference: <a href="https://github.com/w3c/csswg-drafts/issues/4246#issuecomment-1404738513">https://github.com/w3c/csswg-drafts/issues/4246#issuecomment-1404738513</a>

Implement a parser with longhands support for:
text-spacing: auto | none | &lt;text-autospace&gt; || &lt;text-spacing-trim&gt;

text-autospace: auto | no-autospace
text-spacing-trim: auto | space-all

We can then iterate from here adding support for &apos;normal&apos; in the
shorthand and for the remaining values in the longhands.

For the text-spacing shorthand, apart from appearing as a single token,
&apos;auto&apos; can also appear as belonging to one of the longhands in any order.
In case we parse an &apos;auto&apos; value and the token range is not exhauted,
there is a certain ambiguity if it belongs to the first or second
longhand, since they can come in any order.
Becuse all the other values of the longhands are unique, we can peek
into the next token to solve this ambiguity.

For the common case, where &apos;auto&apos; doesn&apos;t appear as the first token,
we try to re-use the parsing functions for the longhands. For that, we
need to divide the range into 2 subranges, one for each longhand.
We use again our knowledge of unique values for a longhand to identify
such subranges.

* LayoutTests/TestExpectations:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::textSpacingFromStyle):
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle):
* Source/WebCore/css/ShorthandSerializer.cpp:
(WebCore::ShorthandSerializer::serialize):
(WebCore::ShorthandSerializer::serializeTextSpacing const):
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::CSSPropertyParser::consumeTextSpacing):
(WebCore::CSSPropertyParser::parseShorthand):
* Source/WebCore/css/parser/CSSPropertyParser.h:
* Source/WebCore/css/parser/CSSPropertyParserHelpers.h:
(WebCore::CSSPropertyParserHelpers::isValueIDUniqueToTextSpacingTrimLonghand):
(WebCore::CSSPropertyParserHelpers::isValueIDUniqueToTextAutospaceLonghand):
* Source/WebCore/platform/text/TextSpacing.h:
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/style/RenderStyle.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45e26321c1e46e84ea2610ec9568783d365ffbe3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107992 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17054 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40876 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117127 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116465 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111881 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18433 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8369 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100187 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113756 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13910 "Too many flaky failures: editing/deleting/smart-delete-002.html, editing/deleting/smart-delete-004.html, editing/deleting/smart-delete-paragraph-002.html, editing/deleting/smart-editing-disabled-win.html, editing/pasteboard/smart-paste-002.html, editing/pasteboard/smart-paste-004.html, editing/pasteboard/smart-paste-006.html, editing/pasteboard/smart-paste-008.html, editing/pasteboard/smart-paste-paragraph-003.html, editing/selection/doubleclick-whitespace-crash.html, editing/selection/ios/selection-handle-clamping-in-iframe.html, imported/w3c/web-platform-tests/html/semantics/popovers/popover-animated-hide-cleanup.tentative.html, platform/ipad/fast/viewport/empty-meta.html, platform/ipad/fast/viewport/meta-viewport-ignored.html, platform/ipad/fast/viewport/width-is-device-width.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97128 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41826 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95821 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28766 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/83493 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9965 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30114 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10676 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7012 "Found 1 new test failure: fast/images/avif-image-decoding.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16116 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49704 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12252 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->