### PR TITLE
Expose dataStoreIdentifier and webPushPartition getters on WKWebsiteDataStore

### DIFF
--- a/Source/WebKit/PlatformMac.cmake
+++ b/Source/WebKit/PlatformMac.cmake
@@ -305,6 +305,7 @@ list(APPEND WebKit_PUBLIC_FRAMEWORK_HEADERS
     UIProcess/API/C/mac/WKInspectorPrivateMac.h
     UIProcess/API/C/mac/WKPagePrivateMac.h
     UIProcess/API/C/mac/WKProtectionSpaceNS.h
+    UIProcess/API/C/mac/WKWebsiteDataStoreRefPrivateMac.h
 
     UIProcess/API/Cocoa/NSAttributedString.h
     UIProcess/API/Cocoa/NSAttributedStringPrivate.h

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -252,6 +252,7 @@ UIProcess/API/C/mac/WKFrameMac.cpp
 UIProcess/API/C/mac/WKNotificationPrivateMac.mm
 UIProcess/API/C/mac/WKPagePrivateMac.mm
 UIProcess/API/C/mac/WKProtectionSpaceNS.mm
+UIProcess/API/C/mac/WKWebsiteDataStoreRefPrivateMac.mm
 
 UIProcess/API/Cocoa/_WKActivatedElementInfo.mm
 UIProcess/API/Cocoa/_WKAppHighlight.mm

--- a/Source/WebKit/UIProcess/API/C/mac/WKWebsiteDataStoreRefPrivateMac.h
+++ b/Source/WebKit/UIProcess/API/C/mac/WKWebsiteDataStoreRefPrivateMac.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,23 +23,23 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "_WKInspectorPrivate.h"
+#pragma once
 
-#import "WKObject.h"
-#import "WebInspectorUIProxy.h"
-#import <wtf/WeakObjCPtr.h>
+#include <WebKit/WKBase.h>
+#include <sys/types.h>
 
-namespace WebKit {
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-template<> struct WrapperTraits<WebInspectorUIProxy> {
-    using WrapperClass = _WKInspector;
-};
+#ifdef __OBJC__
 
+@class WKWebsiteDataStore;
+
+WK_EXPORT WKWebsiteDataStore *WKWebsiteDataStoreGetDataStore(WKWebsiteDataStoreRef);
+
+#endif
+
+#ifdef __cplusplus
 }
-
-@interface _WKInspector () <WKObject> {
-@package
-    API::ObjectStorage<WebKit::WebInspectorUIProxy> _inspector;
-    WeakObjCPtr<id <_WKInspectorDelegate> > _delegate;
-}
-@end
+#endif

--- a/Source/WebKit/UIProcess/API/C/mac/WKWebsiteDataStoreRefPrivateMac.mm
+++ b/Source/WebKit/UIProcess/API/C/mac/WKWebsiteDataStoreRefPrivateMac.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,23 +23,13 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "_WKInspectorPrivate.h"
+#import "config.h"
+#import "WKWebsiteDataStoreRefPrivateMac.h"
 
-#import "WKObject.h"
-#import "WebInspectorUIProxy.h"
-#import <wtf/WeakObjCPtr.h>
+#import "WKAPICast.h"
+#import "WKWebsiteDataStoreInternal.h"
 
-namespace WebKit {
-
-template<> struct WrapperTraits<WebInspectorUIProxy> {
-    using WrapperClass = _WKInspector;
-};
-
+WKWebsiteDataStore *WKWebsiteDataStoreGetDataStore(WKWebsiteDataStoreRef dataStore)
+{
+    return dataStore ? wrapper(WebKit::toImpl(dataStore)) : nil;
 }
-
-@interface _WKInspector () <WKObject> {
-@package
-    API::ObjectStorage<WebKit::WebInspectorUIProxy> _inspector;
-    WeakObjCPtr<id <_WKInspectorDelegate> > _delegate;
-}
-@end

--- a/Source/WebKit/UIProcess/API/Cocoa/APIAttachmentCocoa.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/APIAttachmentCocoa.mm
@@ -27,6 +27,7 @@
 #import "APIAttachment.h"
 
 #import "PageClient.h"
+#import "WebPageProxy.h"
 #import <WebCore/MIMETypeRegistry.h>
 #import <WebCore/SharedBuffer.h>
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -1020,5 +1020,18 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
 #endif
 }
 
+- (NSUUID *)_identifier
+{
+    auto identifier = _websiteDataStore->configuration().identifier();
+    if (!identifier)
+        return nil;
+
+    return *identifier;
+}
+
+- (NSString *)_webPushPartition
+{
+    return _websiteDataStore->configuration().webPushPartitionString();
+}
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h
@@ -123,6 +123,10 @@ typedef NS_OPTIONS(NSUInteger, _WKWebsiteDataStoreFetchOptions) {
 -(void)_scopeURL:(NSURL *)scopeURL hasPushSubscriptionForTesting:(void(^)(BOOL))completionHandler WK_API_AVAILABLE(macos(13.0), ios(16.0));
 -(void)_originDirectoryForTesting:(NSURL *)origin topOrigin:(NSURL *)topOrigin type:(NSString *)dataType completionHandler:(void(^)(NSString *))completionHandler WK_API_AVAILABLE(macos(13.0), ios(16.0));
 -(void)_setBackupExclusionPeriodForTesting:(double)seconds completionHandler:(void(^)(void))completionHandler WK_API_AVAILABLE(macos(13.0), ios(16.0));
+
+@property (nonatomic, readonly) NSUUID *_identifier;
+@property (nonatomic, readonly) NSString *_webPushPartition;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKInspector.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInspector.mm
@@ -37,6 +37,7 @@
 #import "_WKInspectorPrivateForTesting.h"
 #import "_WKRemoteObjectRegistry.h"
 #import <WebCore/FrameIdentifier.h>
+#import <WebCore/WebCoreObjCExtras.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/text/WTFString.h>
 

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
@@ -40,6 +40,7 @@
 #import <WebCore/ColorCocoa.h>
 #import <WebCore/ColorSerialization.h>
 #import <WebCore/ElementContext.h>
+#import <pal/spi/cocoa/QuartzCoreSPI.h>
 #import <wtf/SortedArrayMap.h>
 #import <wtf/text/TextStream.h>
 

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm
@@ -34,6 +34,7 @@
 #import "ObjCObjectGraph.h"
 #import "SandboxUtilities.h"
 #import "SharedBufferReference.h"
+#import "WKAPICast.h"
 #import "WKBrowsingContextControllerInternal.h"
 #import "WKBrowsingContextHandleInternal.h"
 #import "WKTypeRefWrapper.h"

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2147,6 +2147,7 @@
 		E5DEFA6826F8F42600AB68DB /* PhotosUISPI.h in Headers */ = {isa = PBXBuildFile; fileRef = E5DEFA6726F8F42600AB68DB /* PhotosUISPI.h */; };
 		EB36B16827A7B4500050E00D /* PushService.h in Headers */ = {isa = PBXBuildFile; fileRef = EB36B16627A7B4500050E00D /* PushService.h */; };
 		EB36B16927A7B4500050E00D /* PushService.mm in Sources */ = {isa = PBXBuildFile; fileRef = EB36B16727A7B4500050E00D /* PushService.mm */; };
+		EB450E0F2996C7B6009724B1 /* WKWebsiteDataStoreRefPrivateMac.h in Headers */ = {isa = PBXBuildFile; fileRef = EB450E0D2996C7A1009724B1 /* WKWebsiteDataStoreRefPrivateMac.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EB7D252B27B31B77009CB586 /* com.apple.WebKit.webpushd.mac.sb in Resources */ = {isa = PBXBuildFile; fileRef = EB7D252A27B31B3F009CB586 /* com.apple.WebKit.webpushd.mac.sb */; };
 		EBA8D3AB27A5E31300CB7900 /* ApplePushServiceSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = EBA8D3AA27A5E31300CB7900 /* ApplePushServiceSPI.h */; };
 		EBA8D3B227A5E33F00CB7900 /* ApplePushServiceConnection.mm in Sources */ = {isa = PBXBuildFile; fileRef = EBA8D3AC27A5E33E00CB7900 /* ApplePushServiceConnection.mm */; };
@@ -7051,6 +7052,8 @@
 		EB0D312E275AE13300863D8F /* com.apple.webkit.webpushd.ios.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = com.apple.webkit.webpushd.ios.plist; sourceTree = "<group>"; };
 		EB36B16627A7B4500050E00D /* PushService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PushService.h; sourceTree = "<group>"; };
 		EB36B16727A7B4500050E00D /* PushService.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = PushService.mm; sourceTree = "<group>"; };
+		EB450E0D2996C7A1009724B1 /* WKWebsiteDataStoreRefPrivateMac.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKWebsiteDataStoreRefPrivateMac.h; path = mac/WKWebsiteDataStoreRefPrivateMac.h; sourceTree = "<group>"; };
+		EB450E0E2996C7A1009724B1 /* WKWebsiteDataStoreRefPrivateMac.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WKWebsiteDataStoreRefPrivateMac.mm; path = mac/WKWebsiteDataStoreRefPrivateMac.mm; sourceTree = "<group>"; };
 		EB7D252927B316A6009CB586 /* com.apple.WebKit.webpushd.mac.sb.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = com.apple.WebKit.webpushd.mac.sb.in; sourceTree = "<group>"; };
 		EB7D252A27B31B3F009CB586 /* com.apple.WebKit.webpushd.mac.sb */ = {isa = PBXFileReference; lastKnownFileType = file; path = com.apple.WebKit.webpushd.mac.sb; sourceTree = "<group>"; };
 		EBA8D3AA27A5E31300CB7900 /* ApplePushServiceSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ApplePushServiceSPI.h; sourceTree = "<group>"; };
@@ -11186,6 +11189,8 @@
 				BCE17B7B1381F1170012A641 /* WKPagePrivateMac.mm */,
 				5272D4C71E735F0900EB4290 /* WKProtectionSpaceNS.h */,
 				5272D4C81E735F0900EB4290 /* WKProtectionSpaceNS.mm */,
+				EB450E0D2996C7A1009724B1 /* WKWebsiteDataStoreRefPrivateMac.h */,
+				EB450E0E2996C7A1009724B1 /* WKWebsiteDataStoreRefPrivateMac.mm */,
 			);
 			name = mac;
 			sourceTree = "<group>";
@@ -15238,6 +15243,7 @@
 				75A8D2D6187D1C0E00C39C9E /* WKWebsiteDataStoreInternal.h in Headers */,
 				1AE2867A1C7F7BA60069AC4F /* WKWebsiteDataStorePrivate.h in Headers */,
 				1A57109F1ABA0027002FABBE /* WKWebsiteDataStoreRef.h in Headers */,
+				EB450E0F2996C7B6009724B1 /* WKWebsiteDataStoreRefPrivateMac.h in Headers */,
 				5C9E56831DF7F1B300C9EE33 /* WKWebsitePolicies.h in Headers */,
 				1A3CC16718906ACF001E6ED8 /* WKWebView.h in Headers */,
 				1ADF591B1890528E0043C145 /* WKWebViewConfiguration.h in Headers */,


### PR DESCRIPTION
#### f8d4e263f3a9d2e00d6f348a7d176d57bcfd02f5
<pre>
Expose dataStoreIdentifier and webPushPartition getters on WKWebsiteDataStore
<a href="https://bugs.webkit.org/show_bug.cgi?id=252067">https://bugs.webkit.org/show_bug.cgi?id=252067</a>
rdar://problem/105287995

Reviewed by Sihui Liu.

When showing a notification, we need to provide the embedder with a way to know the data store
identifier and push partition that the notification is associated with. This patch facilitates this
by adding those properties to WKWebsiteDataStore. You could do this before, but it would require
accessing the configuration property on WKWebsiteDataStore, which does a large copy operation.

Additionally, this provides a way to go from a the C API WKWebsiteDataStoreRef to Obj-C API
WKWebsiteDataStore. This is because the callback for showing a notification uses the C API.

Contains miscellaneous unified build fixes.

* Source/WebKit/PlatformMac.cmake:
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/API/C/mac/WKWebsiteDataStoreRefPrivateMac.h: Copied from Source/WebKit/UIProcess/API/Cocoa/_WKInspectorInternal.h.
* Source/WebKit/UIProcess/API/C/mac/WKWebsiteDataStoreRefPrivateMac.mm: Copied from Source/WebKit/UIProcess/API/Cocoa/_WKInspectorInternal.h.
(WKWebsiteDataStoreGetDataStore):
* Source/WebKit/UIProcess/API/Cocoa/APIAttachmentCocoa.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(-[WKWebsiteDataStore _identifier]):
(-[WKWebsiteDataStore _webPushPartition]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKInspector.mm:
* Source/WebKit/UIProcess/API/Cocoa/_WKInspectorInternal.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm:
* Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebsiteDatastore.mm:
(TestWebKitAPI::createWebsiteDataStoreAndPrepare):
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/260379@main">https://commits.webkit.org/260379@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31f4b61bc920b891546c7165c3d9f3bd0d744fbf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108099 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17169 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40967 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117224 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116548 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111988 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18524 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8465 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100303 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113867 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97192 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41899 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95877 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28830 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10051 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30178 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10773 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7081 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16199 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49769 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7184 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12354 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->