### PR TITLE
[iOS] Print preview should use images instead of PDFs

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -63,6 +63,7 @@
 #import <UIKit/UIPickerView_Private.h>
 #import <UIKit/UIPopoverPresentationController_Private.h>
 #import <UIKit/UIPresentationController_Private.h>
+#import <UIKit/UIPrintPageRenderer_Private.h>
 #import <UIKit/UIResponder_Private.h>
 #import <UIKit/UIScene_Private.h>
 #import <UIKit/UIScrollEvent_Private.h>
@@ -512,6 +513,10 @@ typedef struct CGSVGDocument *CGSVGDocumentRef;
 + (CGSize)defaultSizeForCurrentOrientation;
 - (void)_setUsesCheckedSelection:(BOOL)usesCheckedSelection;
 @property (nonatomic, setter=_setMagnifierEnabled:) BOOL _magnifierEnabled;
+@end
+
+@interface UIPrintPageRenderer ()
+@property (readonly) UIPrintRenderingQuality requestedRenderingQuality;
 @end
 
 @interface UIResponder ()

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1479,6 +1479,7 @@ public:
     void drawToPDF(WebCore::FrameIdentifier, const std::optional<WebCore::FloatRect>&, bool allowTransparentBackground,  CompletionHandler<void(RefPtr<WebCore::SharedBuffer>&&)>&&);
 #if PLATFORM(IOS_FAMILY)
     size_t computePagesForPrintingiOS(WebCore::FrameIdentifier, const PrintInfo&);
+    IPC::Connection::AsyncReplyID drawToImage(WebCore::FrameIdentifier, const PrintInfo&, size_t pageCount, CompletionHandler<void(WebKit::ShareableBitmapHandle&&)>&&);
     IPC::Connection::AsyncReplyID drawToPDFiOS(WebCore::FrameIdentifier, const PrintInfo&, size_t pageCount, CompletionHandler<void(RefPtr<WebCore::SharedBuffer>&&)>&&);
 #endif
 #elif PLATFORM(GTK)

--- a/Source/WebKit/UIProcess/_WKWebViewPrintFormatter.mm
+++ b/Source/WebKit/UIProcess/_WKWebViewPrintFormatter.mm
@@ -28,6 +28,7 @@
 
 #if PLATFORM(IOS_FAMILY)
 
+#import "UIKitSPI.h"
 #import "WKWebViewInternal.h"
 #import "_WKFrameHandle.h"
 #import <wtf/Condition.h>
@@ -47,6 +48,7 @@
     Lock _printLock;
     Condition _printCompletionCondition;
     RetainPtr<CGPDFDocumentRef> _printedDocument;
+    RetainPtr<CGImageRef> _printPreviewImage;
 }
 
 - (BOOL)requiresMainThread
@@ -71,6 +73,20 @@
     return static_cast<WKWebView *>(view);
 }
 
+- (BOOL)_shouldDrawUsingBitmap
+{
+    if (self.snapshotFirstPage)
+        return NO;
+
+    if (![self._webView._printProvider respondsToSelector:@selector(_wk_requestImageForPrintFormatter:)])
+        return NO;
+
+    if (self.printPageRenderer.requestedRenderingQuality == UIPrintRenderingQualityBest)
+        return NO;
+
+    return YES;
+}
+
 - (CGPDFDocumentRef)_printedDocument
 {
     if (self.requiresMainThread)
@@ -92,7 +108,28 @@
     _printCompletionCondition.notifyOne();
 }
 
-- (void)_waitForPrintedDocument
+- (CGImageRef)_printPreviewImage
+{
+    if (self.requiresMainThread)
+        return _printPreviewImage.get();
+
+    Locker locker { _printLock };
+    return _printPreviewImage.get();
+}
+
+- (void)_setPrintPreviewImage:(CGImageRef)printPreviewImage
+{
+    if (self.requiresMainThread) {
+        _printPreviewImage = printPreviewImage;
+        return;
+    }
+
+    Locker locker { _printLock };
+    _printPreviewImage = printPreviewImage;
+    _printCompletionCondition.notifyOne();
+}
+
+- (void)_waitForPrintedDocumentOrImage
 {
     Locker locker { _printLock };
     _printCompletionCondition.wait(_printLock);
@@ -106,9 +143,15 @@
     printPageRenderer.printableRect = paperRect;
 }
 
+- (void)_invalidatePrintRenderingState
+{
+    [self _setPrintPreviewImage:nullptr];
+    [self _setPrintedDocument:nullptr];
+}
+
 - (NSInteger)_recalcPageCount
 {
-    [self _setPrintedDocument:nullptr];
+    [self _invalidatePrintRenderingState];
     NSUInteger pageCount = [self._webView._printProvider _wk_pageCountForPrintFormatter:self];
     return std::min<NSUInteger>(pageCount, NSIntegerMax);
 }
@@ -127,6 +170,50 @@
 }
 
 - (void)drawInRect:(CGRect)rect forPageAtIndex:(NSInteger)pageIndex
+{
+    if ([self _shouldDrawUsingBitmap])
+        [self _drawInRectUsingBitmap:rect forPageAtIndex:pageIndex];
+    else
+        [self _drawInRectUsingPDF:rect forPageAtIndex:pageIndex];
+}
+
+- (void)_drawInRectUsingBitmap:(CGRect)rect forPageAtIndex:(NSInteger)pageIndex
+{
+    RetainPtr printPreviewImage = [self _printPreviewImage];
+    if (!printPreviewImage) {
+        [self._webView._printProvider _wk_requestImageForPrintFormatter:self];
+        printPreviewImage = [self _printPreviewImage];
+        if (!printPreviewImage)
+            return;
+    }
+
+    if (!self.pageCount)
+        return;
+
+    CGContextRef context = UIGraphicsGetCurrentContext();
+    CGContextSaveGState(context);
+
+    CGImageRef documentImage = _printPreviewImage.get();
+
+    CGFloat pageImageWidth = CGImageGetWidth(documentImage);
+    CGFloat pageImageHeight = CGImageGetHeight(documentImage) / self.pageCount;
+
+    if (!pageImageWidth || !pageImageHeight) {
+        CGContextRestoreGState(context);
+        return;
+    }
+
+    RetainPtr pageImage = adoptCF(CGImageCreateWithImageInRect(documentImage, CGRectMake(0, pageIndex * pageImageHeight, pageImageWidth, pageImageHeight)));
+
+    CGContextTranslateCTM(context, CGRectGetMinX(rect), CGRectGetMaxY(rect));
+    CGContextScaleCTM(context, 1, -1);
+    CGContextScaleCTM(context, CGRectGetWidth(rect) / pageImageWidth, CGRectGetHeight(rect) / pageImageHeight);
+    CGContextDrawImage(context, CGRectMake(0, 0, pageImageWidth, pageImageHeight), pageImage.get());
+
+    CGContextRestoreGState(context);
+}
+
+- (void)_drawInRectUsingPDF:(CGRect)rect forPageAtIndex:(NSInteger)pageIndex
 {
     RetainPtr<CGPDFDocumentRef> printedDocument = [self _printedDocument];
     if (!printedDocument) {

--- a/Source/WebKit/UIProcess/_WKWebViewPrintFormatterInternal.h
+++ b/Source/WebKit/UIProcess/_WKWebViewPrintFormatterInternal.h
@@ -33,16 +33,24 @@
 @end
 
 @interface _WKWebViewPrintFormatter ()
+- (BOOL)_shouldDrawUsingBitmap;
 - (void)_setSnapshotPaperRect:(CGRect)paperRect;
 - (void)_setPrintedDocument:(CGPDFDocumentRef)printedDocument;
+- (void)_setPrintPreviewImage:(CGImageRef)printPreviewImage;
+- (void)_invalidatePrintRenderingState;
 
-- (void)_waitForPrintedDocument;
+- (void)_waitForPrintedDocumentOrImage;
 @end
 
 @protocol _WKWebViewPrintProvider <NSObject>
+
+@property (nonatomic, readonly) BOOL _wk_printFormatterRequiresMainThread;
+
 - (NSUInteger)_wk_pageCountForPrintFormatter:(_WKWebViewPrintFormatter *)printFormatter;
 - (void)_wk_requestDocumentForPrintFormatter:(_WKWebViewPrintFormatter *)printFormatter;
-@property (nonatomic, readonly) BOOL _wk_printFormatterRequiresMainThread;
+
+@optional
+- (void)_wk_requestImageForPrintFormatter:(_WKWebViewPrintFormatter *)printFormatter;
 @end
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -75,6 +75,32 @@
 #import <wtf/threads/BinarySemaphore.h>
 #import "AppKitSoftLink.h"
 
+@interface _WKPrintFormattingAttributes : NSObject
+@property (nonatomic, readonly) size_t pageCount;
+@property (nonatomic, readonly) WebCore::FrameIdentifier frameID;
+@property (nonatomic, readonly) WebKit::PrintInfo printInfo;
+@end
+
+@implementation _WKPrintFormattingAttributes
+
+- (instancetype)initWithPageCount:(size_t)pageCount frameID:(WebCore::FrameIdentifier)frameID printInfo:(WebKit::PrintInfo)printInfo
+{
+    if (!(self = [super init]))
+        return nil;
+
+    _pageCount = pageCount;
+    _frameID = frameID;
+    _printInfo = printInfo;
+
+    return self;
+}
+
+@end
+
+typedef NS_ENUM(NSInteger, _WKPrintRenderingCallbackType) {
+    _WKPrintRenderingCallbackTypePreview,
+    _WKPrintRenderingCallbackTypePrint,
+};
 
 @interface WKInspectorIndicationView : UIView
 @end
@@ -156,7 +182,8 @@
 
     Lock _pendingBackgroundPrintFormattersLock;
     RetainPtr<NSMutableSet> _pendingBackgroundPrintFormatters;
-    IPC::Connection::AsyncReplyID _pdfPrintCallbackID;
+    IPC::Connection::AsyncReplyID _printRenderingCallbackID;
+    _WKPrintRenderingCallbackType _printRenderingCallbackType;
 
     Vector<RetainPtr<NSURL>> _temporaryURLsToDeleteWhenDeallocated;
 }
@@ -680,11 +707,11 @@ static void storeAccessibilityRemoteConnectionInformation(id element, pid_t pid,
 
 - (void)_resetPrintingState
 {
-    _pdfPrintCallbackID = { };
+    _printRenderingCallbackID = { };
 
     Locker locker { _pendingBackgroundPrintFormattersLock };
     for (_WKWebViewPrintFormatter *printFormatter in _pendingBackgroundPrintFormatters.get())
-        [printFormatter _setPrintedDocument:nullptr];
+        [printFormatter _invalidatePrintRenderingState];
     [_pendingBackgroundPrintFormatters removeAllObjects];
 }
 
@@ -900,10 +927,11 @@ static void storeAccessibilityRemoteConnectionInformation(id element, pid_t pid,
     return NO;
 }
 
-- (NSUInteger)_wk_pageCountForPrintFormatter:(_WKWebViewPrintFormatter *)printFormatter
+- (RetainPtr<_WKPrintFormattingAttributes>)_attributesForPrintFormatter:(_WKWebViewPrintFormatter *)printFormatter
 {
     bool isPrintingOnBackgroundThread = !isMainRunLoop();
-
+    
+    [self _waitForDrawToImageCallbackForPrintFormatterIfNeeded:printFormatter];
     [self _waitForDrawToPDFCallbackForPrintFormatterIfNeeded:printFormatter];
 
     // The first page can have a smaller content rect than subsequent pages if a top content inset
@@ -912,7 +940,7 @@ static void storeAccessibilityRemoteConnectionInformation(id element, pid_t pid,
     // FIXME: Teach WebCore::PrintContext to accept an initial content offset when paginating.
     CGRect printingRect = CGRectIntersection([printFormatter _pageContentRect:YES], [printFormatter _pageContentRect:NO]);
     if (CGRectIsEmpty(printingRect))
-        return 0;
+        return nil;
 
     WebKit::PrintInfo printInfo;
     printInfo.pageSetupScaleFactor = 1;
@@ -946,6 +974,8 @@ static void storeAccessibilityRemoteConnectionInformation(id element, pid_t pid,
                 return;
             }
 
+            // This has the side effect of calling `WebPage::beginPrinting`. It is important that all calls
+            // of `WebPage::beginPrinting` are matched with a corresponding call to `WebPage::endPrinting`.
             _page->computePagesForPrinting(frameID, printInfo, [&pageCount, &computePagesSemaphore](const Vector<WebCore::IntRect>& pageRects, double /* totalScaleFactorForPrinting */, const WebCore::FloatBoxExtent& /* computedPageMargin */) mutable {
                 ASSERT(pageRects.size() >= 1);
                 pageCount = pageRects.size();
@@ -956,7 +986,7 @@ static void storeAccessibilityRemoteConnectionInformation(id element, pid_t pid,
     } else {
         auto identifier = [self _frameIdentifierForPrintFormatter:printFormatter];
         if (!identifier)
-            return 0;
+            return nil;
 
         frameID = *identifier;
 
@@ -965,22 +995,66 @@ static void storeAccessibilityRemoteConnectionInformation(id element, pid_t pid,
     }
 
     if (!pageCount)
+        return nil;
+
+    auto attributes = adoptNS([[_WKPrintFormattingAttributes alloc] initWithPageCount:pageCount frameID:frameID printInfo:printInfo]);
+    return attributes;
+}
+
+- (NSUInteger)_wk_pageCountForPrintFormatter:(_WKWebViewPrintFormatter *)printFormatter
+{
+    auto attributes = [self _attributesForPrintFormatter:printFormatter];
+    if (!attributes)
         return 0;
 
-    if (isPrintingOnBackgroundThread) {
-        Locker locker { _pendingBackgroundPrintFormattersLock };
+    return [attributes pageCount];
+}
 
-        if (!_pendingBackgroundPrintFormatters)
-            _pendingBackgroundPrintFormatters = adoptNS([[NSMutableSet alloc] init]);
+- (void)_createImage:(_WKPrintFormattingAttributes *)formatterAttributes printFormatter:(_WKWebViewPrintFormatter *)printFormatter
+{
+    bool isPrintingOnBackgroundThread = !isMainRunLoop();
 
-        [_pendingBackgroundPrintFormatters addObject:printFormatter];
-    }
-
-    ensureOnMainRunLoop([frameID, printInfo, pageCount, isPrintingOnBackgroundThread, printFormatter = retainPtr(printFormatter), retainedSelf = retainPtr(self)] {
-        // Begin generating the PDF in expectation of a (eventual) request for the drawn data.
-        auto callbackID = retainedSelf->_page->drawToPDFiOS(frameID, printInfo, pageCount, [isPrintingOnBackgroundThread, printFormatter, retainedSelf](RefPtr<WebCore::SharedBuffer>&& pdfData) mutable {
+    ensureOnMainRunLoop([formatterAttributes = retainPtr(formatterAttributes), isPrintingOnBackgroundThread, printFormatter = retainPtr(printFormatter), retainedSelf = retainPtr(self)] {
+        // Begin generating the image in expectation of a (eventual) request for the drawn data.
+        auto callbackID = retainedSelf->_page->drawToImage([formatterAttributes frameID], [formatterAttributes printInfo], [formatterAttributes pageCount], [isPrintingOnBackgroundThread, printFormatter, retainedSelf](WebKit::ShareableBitmapHandle&& imageHandle) mutable {
             if (!isPrintingOnBackgroundThread)
-                retainedSelf->_pdfPrintCallbackID = { };
+                retainedSelf->_printRenderingCallbackID = { };
+            else {
+                Locker locker { retainedSelf->_pendingBackgroundPrintFormattersLock };
+                [retainedSelf->_pendingBackgroundPrintFormatters removeObject:printFormatter.get()];
+            }
+
+            if (imageHandle.isNull()) {
+                [printFormatter _setPrintPreviewImage:nullptr];
+                return;
+            }
+
+            auto bitmap = WebKit::ShareableBitmap::create(imageHandle, WebKit::SharedMemory::Protection::ReadOnly);
+            if (!bitmap) {
+                [printFormatter _setPrintPreviewImage:nullptr];
+                return;
+            }
+
+            auto image = bitmap->makeCGImageCopy();
+            [printFormatter _setPrintPreviewImage:image.get()];
+        });
+
+        if (!isPrintingOnBackgroundThread) {
+            retainedSelf->_printRenderingCallbackID = callbackID;
+            retainedSelf->_printRenderingCallbackType = _WKPrintRenderingCallbackTypePreview;
+        }
+    });
+}
+
+- (void)_createPDF:(_WKPrintFormattingAttributes *)formatterAttributes printFormatter:(_WKWebViewPrintFormatter *)printFormatter
+{
+    bool isPrintingOnBackgroundThread = !isMainRunLoop();
+
+    ensureOnMainRunLoop([formatterAttributes = retainPtr(formatterAttributes), isPrintingOnBackgroundThread, printFormatter = retainPtr(printFormatter), retainedSelf = retainPtr(self)] {
+        // Begin generating the PDF in expectation of a (eventual) request for the drawn data.
+        auto callbackID = retainedSelf->_page->drawToPDFiOS([formatterAttributes frameID], [formatterAttributes printInfo], [formatterAttributes pageCount], [isPrintingOnBackgroundThread, printFormatter, retainedSelf](RefPtr<WebCore::SharedBuffer>&& pdfData) mutable {
+            if (!isPrintingOnBackgroundThread)
+                retainedSelf->_printRenderingCallbackID = { };
             else {
                 Locker locker { retainedSelf->_pendingBackgroundPrintFormattersLock };
                 [retainedSelf->_pendingBackgroundPrintFormatters removeObject:printFormatter.get()];
@@ -995,18 +1069,24 @@ static void storeAccessibilityRemoteConnectionInformation(id element, pid_t pid,
             }
         });
 
-        if (!isPrintingOnBackgroundThread)
-            retainedSelf->_pdfPrintCallbackID = callbackID;
+        if (!isPrintingOnBackgroundThread) {
+            retainedSelf->_printRenderingCallbackID = callbackID;
+            retainedSelf->_printRenderingCallbackType = _WKPrintRenderingCallbackTypePrint;
+        }
     });
-
-    return pageCount;
 }
 
 - (void)_waitForDrawToPDFCallbackForPrintFormatterIfNeeded:(_WKWebViewPrintFormatter *)printFormatter
 {
     if (isMainRunLoop()) {
-        if (auto callbackID = std::exchange(_pdfPrintCallbackID, { }))
-            _page->process().connection()->waitForAsyncReplyAndDispatchImmediately<Messages::WebPage::DrawToPDFiOS>(callbackID, Seconds::infinity());
+        if (_printRenderingCallbackType != _WKPrintRenderingCallbackTypePrint)
+            return;
+
+        auto callbackID = std::exchange(_printRenderingCallbackID, { });
+        if (!callbackID)
+            return;
+
+        _page->process().connection()->waitForAsyncReplyAndDispatchImmediately<Messages::WebPage::DrawToPDFiOS>(callbackID, Seconds::infinity());
         return;
     }
 
@@ -1016,12 +1096,72 @@ static void storeAccessibilityRemoteConnectionInformation(id element, pid_t pid,
             return;
     }
 
-    [printFormatter _waitForPrintedDocument];
+    [printFormatter _waitForPrintedDocumentOrImage];
 }
 
 - (void)_wk_requestDocumentForPrintFormatter:(_WKWebViewPrintFormatter *)printFormatter
 {
+    bool isPrintingOnBackgroundThread = !isMainRunLoop();
+
+    auto attributes = [self _attributesForPrintFormatter:printFormatter];
+    if (!attributes)
+        return;
+
+    if (isPrintingOnBackgroundThread) {
+        Locker locker { _pendingBackgroundPrintFormattersLock };
+
+        if (!_pendingBackgroundPrintFormatters)
+            _pendingBackgroundPrintFormatters = adoptNS([[NSMutableSet alloc] init]);
+
+        [_pendingBackgroundPrintFormatters addObject:printFormatter];
+    }
+
+    [self _createPDF:attributes.get() printFormatter:printFormatter];
     [self _waitForDrawToPDFCallbackForPrintFormatterIfNeeded:printFormatter];
+}
+
+- (void)_waitForDrawToImageCallbackForPrintFormatterIfNeeded:(_WKWebViewPrintFormatter *)printFormatter
+{
+    if (isMainRunLoop()) {
+        if (_printRenderingCallbackType != _WKPrintRenderingCallbackTypePreview)
+            return;
+
+        auto callbackID = std::exchange(_printRenderingCallbackID, { });
+        if (!callbackID)
+            return;
+
+        _page->process().connection()->waitForAsyncReplyAndDispatchImmediately<Messages::WebPage::DrawRectToImage>(callbackID, Seconds::infinity());
+        return;
+    }
+
+    {
+        Locker locker { _pendingBackgroundPrintFormattersLock };
+        if (![_pendingBackgroundPrintFormatters containsObject:printFormatter])
+            return;
+    }
+
+    [printFormatter _waitForPrintedDocumentOrImage];
+}
+
+- (void)_wk_requestImageForPrintFormatter:(_WKWebViewPrintFormatter *)printFormatter
+{
+    bool isPrintingOnBackgroundThread = !isMainRunLoop();
+
+    auto attributes = [self _attributesForPrintFormatter:printFormatter];
+    if (!attributes)
+        return;
+
+    if (isPrintingOnBackgroundThread) {
+        Locker locker { _pendingBackgroundPrintFormattersLock };
+
+        if (!_pendingBackgroundPrintFormatters)
+            _pendingBackgroundPrintFormatters = adoptNS([[NSMutableSet alloc] init]);
+
+        [_pendingBackgroundPrintFormatters addObject:printFormatter];
+    }
+
+    [self _createImage:attributes.get() printFormatter:printFormatter];
+    [self _waitForDrawToImageCallbackForPrintFormatterIfNeeded:printFormatter];
 }
 
 @end

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -1053,6 +1053,16 @@ IPC::Connection::AsyncReplyID WebPageProxy::drawToPDFiOS(FrameIdentifier frameID
     return sendWithAsyncReply(Messages::WebPage::DrawToPDFiOS(frameID, printInfo, pageCount), WTFMove(completionHandler));
 }
 
+IPC::Connection::AsyncReplyID WebPageProxy::drawToImage(FrameIdentifier frameID, const PrintInfo& printInfo, size_t pageCount, CompletionHandler<void(WebKit::ShareableBitmapHandle&&)>&& completionHandler)
+{
+    if (!hasRunningProcess()) {
+        completionHandler({ });
+        return { };
+    }
+
+    return sendWithAsyncReply(Messages::WebPage::DrawToImage(frameID, printInfo, pageCount), WTFMove(completionHandler));
+}
+
 void WebPageProxy::contentSizeCategoryDidChange(const String& contentSizeCategory)
 {
     send(Messages::WebPage::ContentSizeCategoryDidChange(contentSizeCategory));

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5878,7 +5878,6 @@ void WebPage::drawPagesToPDFImpl(FrameIdentifier frameID, const PrintInfo& print
 
 #if USE(CG)
     if (coreFrame) {
-
 #if PLATFORM(MAC)
         ASSERT(coreFrame->document()->printing() || pdfDocumentForPrintingFrame(coreFrame));
 #else
@@ -5889,6 +5888,7 @@ void WebPage::drawPagesToPDFImpl(FrameIdentifier frameID, const PrintInfo& print
         RetainPtr<CGDataConsumerRef> pdfDataConsumer = adoptCF(CGDataConsumerCreateWithCFData(pdfPageData.get()));
 
         CGRect mediaBox = (m_printContext && m_printContext->pageCount()) ? m_printContext->pageRect(0) : CGRectMake(0, 0, printInfo.availablePaperWidth, printInfo.availablePaperHeight);
+
         RetainPtr<CGContextRef> context = adoptCF(CGPDFContextCreate(pdfDataConsumer.get(), &mediaBox, 0));
 
 #if PLATFORM(MAC)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1086,6 +1086,7 @@ public:
 #if PLATFORM(IOS_FAMILY)
     void computePagesForPrintingiOS(WebCore::FrameIdentifier, const PrintInfo&, CompletionHandler<void(size_t)>&&);
     void drawToPDFiOS(WebCore::FrameIdentifier, const PrintInfo&, size_t, CompletionHandler<void(RefPtr<WebCore::SharedBuffer>&&)>&&);
+    void drawToImage(WebCore::FrameIdentifier, const PrintInfo&, size_t, CompletionHandler<void(WebKit::ShareableBitmapHandle&&)>&&);
 #endif
 
     void drawToPDF(WebCore::FrameIdentifier, const std::optional<WebCore::FloatRect>&, bool allowTransparentBackground,  CompletionHandler<void(RefPtr<WebCore::SharedBuffer>&&)>&&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -449,6 +449,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
 #if PLATFORM(IOS_FAMILY)
     ComputePagesForPrintingiOS(WebCore::FrameIdentifier frameID, struct WebKit::PrintInfo printInfo) -> (size_t pageCount) Synchronous
     DrawToPDFiOS(WebCore::FrameIdentifier frameID, struct WebKit::PrintInfo printInfo, size_t pageCount) -> (RefPtr<WebCore::SharedBuffer> data)
+    DrawToImage(WebCore::FrameIdentifier frameID, struct WebKit::PrintInfo printInfo, size_t pageCount) -> (WebKit::ShareableBitmapHandle data)
 #endif
     DrawToPDF(WebCore::FrameIdentifier frameID, std::optional<WebCore::FloatRect> rect, bool allowTransparentBackground) -> (RefPtr<WebCore::SharedBuffer> data)
 #endif


### PR DESCRIPTION
#### d56a44cbd116ed60bde26f13beaf33969327feb6
<pre>
[iOS] Print preview should use images instead of PDFs
<a href="https://bugs.webkit.org/show_bug.cgi?id=220815">https://bugs.webkit.org/show_bug.cgi?id=220815</a>
rdar://65129050

Reviewed by Aditya Keerthi.

When generating the print preview, the system will now use an image-backed preview
instead of a PDF-backed one for better performance, if a responsive print rendering
quality was requested. The logic added is analogous with how the PDF generation works.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/_WKWebViewPrintFormatter.h:
* Source/WebKit/UIProcess/_WKWebViewPrintFormatter.mm:
(-[_WKWebViewPrintFormatter _shouldUseResponsivePrintRendering]):
(-[_WKWebViewPrintFormatter _printPreviewImage]):
(-[_WKWebViewPrintFormatter _setPrintPreviewImage:]):
(-[_WKWebViewPrintFormatter _waitForPrintedDocumentOrImage]):
(-[_WKWebViewPrintFormatter _invalidatePrintRenderingState]):
(-[_WKWebViewPrintFormatter _recalcPageCount]):
(-[_WKWebViewPrintFormatter drawInRect:forPageAtIndex:]):
(-[_WKWebViewPrintFormatter _drawInRectUsingBitmap:forPageAtIndex:]):
(-[_WKWebViewPrintFormatter _drawInRectUsingPDF:forPageAtIndex:]):
(-[_WKWebViewPrintFormatter _waitForPrintedDocument]): Deleted.
* Source/WebKit/UIProcess/_WKWebViewPrintFormatterInternal.h:
* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[_WKPrintFormattingAttributes initWithPageCount:frameID:printInfo:]):
(-[WKContentView _commonInitializationWithProcessPool:configuration:]):
(-[WKContentView _resetPrintRenderingState]):
(-[WKContentView _resetPrintingState]):
(-[WKContentView _attributesForPrintFormatter:]):
(-[WKContentView _wk_pageCountForPrintFormatter:]):
(-[WKContentView _createImage:isPrintingOnBackgroundThread:printFormatter:]):
(-[WKContentView _createPDF:isPrintingOnBackgroundThread:printFormatter:]):
(-[WKContentView _waitForDrawToPDFCallbackForPrintFormatterIfNeeded:]):
(-[WKContentView _wk_requestDocumentForPrintFormatter:]):
(-[WKContentView _waitForDrawToImageCallbackForPrintFormatterIfNeeded:]):
(-[WKContentView _wk_requestImageForPrintFormatter:]):
(-[WKContentView _wk_supportsRenderingBitmap]):
* Source/WebKit/UIProcess/ios/WKPDFView.mm:
(-[WKPDFView _wk_supportsRenderingBitmap]):
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::drawToImage):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::drawPagesToPDFImpl):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::drawToImage):

Canonical link: <a href="https://commits.webkit.org/260644@main">https://commits.webkit.org/260644@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c3129aed193d3b610e3346d0e4daca56d82812b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108691 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17793 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41551 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117801 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118003 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19244 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9070 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100941 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114458 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14437 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97672 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42423 "Found 1 new test failure: webgl/2.0.y/conformance2/extensions/promoted-extensions-in-shaders.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96410 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29311 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84269 "Found 2 new API test failures: /TestWebKit:WebKit.OnDeviceChangeCrash, /TestWebKit:WebKit.PrivateBrowsingPushStateNoHistoryCallback (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10597 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30662 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11356 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7573 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16746 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50252 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7357 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12945 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->