### PR TITLE
Use separate search field history for WebsiteDataStore created with identifier

### DIFF
--- a/Source/WebCore/platform/SearchPopupMenu.h
+++ b/Source/WebCore/platform/SearchPopupMenu.h
@@ -32,6 +32,8 @@ class PopupMenu;
 struct RecentSearch {
     String string;
     WallTime time;
+
+    RecentSearch isolatedCopy() const { return { string.isolatedCopy(), time.isolatedCopy() }; }
 };
 
 class SearchPopupMenu : public RefCounted<SearchPopupMenu> {

--- a/Source/WebCore/platform/cocoa/SearchPopupMenuCocoa.h
+++ b/Source/WebCore/platform/cocoa/SearchPopupMenuCocoa.h
@@ -23,17 +23,14 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef SearchPopupMenuCocoa_h
-#define SearchPopupMenuCocoa_h
+#pragma once
 
 #import "SearchPopupMenu.h"
 
 namespace WebCore {
 
-WEBCORE_EXPORT void saveRecentSearches(const String& name, const Vector<RecentSearch>&);
-WEBCORE_EXPORT Vector<RecentSearch> loadRecentSearches(const String& name);
-WEBCORE_EXPORT void removeRecentlyModifiedRecentSearches(WallTime);
+WEBCORE_EXPORT void saveRecentSearchesToFile(const String& name, const Vector<RecentSearch>&, const String& directory);
+WEBCORE_EXPORT Vector<RecentSearch> loadRecentSearchesFromFile(const String& name, const String& directory);
+WEBCORE_EXPORT void removeRecentlyModifiedRecentSearchesFromFile(WallTime, const String& directory);
 
 }
-
-#endif // SearchPopupMenuCocoa_h

--- a/Source/WebCore/platform/cocoa/SearchPopupMenuCocoa.mm
+++ b/Source/WebCore/platform/cocoa/SearchPopupMenuCocoa.mm
@@ -35,23 +35,14 @@ static NSString * const itemsKey = @"items";
 static NSString * const searchesKey = @"searches";
 static NSString * const searchStringKey = @"searchString";
 
-static NSString *searchFieldRecentSearchesStorageDirectory()
+static NSString *searchFieldRecentSearchesPlistPath(NSString *baseDirectory)
 {
-    NSString *appName = [[NSBundle mainBundle] bundleIdentifier];
-    if (!appName)
-        appName = [[NSProcessInfo processInfo] processName];
-    
-    return [[NSHomeDirectory() stringByAppendingPathComponent:@"Library/WebKit"] stringByAppendingPathComponent:appName];
+    return [baseDirectory stringByAppendingPathComponent:@"RecentSearches.plist"];
 }
 
-static NSString *searchFieldRecentSearchesPlistPath()
+static RetainPtr<NSMutableDictionary> readSearchFieldRecentSearchesPlist(NSString *baseDirectory)
 {
-    return [searchFieldRecentSearchesStorageDirectory() stringByAppendingPathComponent:@"RecentSearches.plist"];
-}
-
-static RetainPtr<NSMutableDictionary> readSearchFieldRecentSearchesPlist()
-{
-    return adoptNS([[NSMutableDictionary alloc] initWithContentsOfFile:searchFieldRecentSearchesPlistPath()]);
+    return adoptNS([[NSMutableDictionary alloc] initWithContentsOfFile:searchFieldRecentSearchesPlistPath(baseDirectory)]);
 }
 
 static WallTime toSystemClockTime(NSDate *date)
@@ -90,12 +81,12 @@ static NSDate *typeCheckedDateInRecentSearch(NSDictionary *recentSearch)
     return date;
 }
 
-static RetainPtr<NSDictionary> typeCheckedRecentSearchesRemovingRecentSearchesAddedAfterDate(NSDate *date)
+static RetainPtr<NSDictionary> typeCheckedRecentSearchesRemovingRecentSearchesAddedAfterDate(NSDate *date, const String& directory)
 {
     if ([date isEqualToDate:[NSDate distantPast]])
         return nil;
 
-    RetainPtr<NSMutableDictionary> recentSearchesPlist = readSearchFieldRecentSearchesPlist();
+    RetainPtr<NSMutableDictionary> recentSearchesPlist = readSearchFieldRecentSearchesPlist(directory);
     NSMutableDictionary *itemsDictionary = [recentSearchesPlist objectForKey:itemsKey];
     if (![itemsDictionary isKindOfClass:[NSDictionary class]])
         return nil;
@@ -131,19 +122,12 @@ static RetainPtr<NSDictionary> typeCheckedRecentSearchesRemovingRecentSearchesAd
     return recentSearchesPlist;
 }
 
-static void writeEmptyRecentSearchesPlist()
+void saveRecentSearchesToFile(const String& name, const Vector<RecentSearch>& searchItems, const String& directory)
 {
-    auto emptyItemsDictionary = adoptNS([[NSDictionary alloc] init]);
-    auto emptyRecentSearchesDictionary = adoptNS([[NSDictionary alloc] initWithObjectsAndKeys:emptyItemsDictionary.get(), itemsKey, nil]);
-    [emptyRecentSearchesDictionary writeToFile:searchFieldRecentSearchesPlistPath() atomically:YES];
-}
-
-void saveRecentSearches(const String& name, const Vector<RecentSearch>& searchItems)
-{
-    if (name.isEmpty())
+    if (name.isEmpty() || directory.isEmpty())
         return;
 
-    RetainPtr<NSDictionary> recentSearchesPlist = readSearchFieldRecentSearchesPlist();
+    RetainPtr<NSDictionary> recentSearchesPlist = readSearchFieldRecentSearchesPlist(directory);
     RetainPtr<NSMutableDictionary> itemsDictionary = [recentSearchesPlist objectForKey:itemsKey];
 
     // The NSMutableDictionary method we use to read the property list guarantees we get only
@@ -162,18 +146,16 @@ void saveRecentSearches(const String& name, const Vector<RecentSearch>& searchIt
         [itemsDictionary setObject:adoptNS([[NSDictionary alloc] initWithObjectsAndKeys:items.get(), searchesKey, nil]).get() forKey:name];
     }
 
-    [[NSFileManager defaultManager] createDirectoryAtPath:searchFieldRecentSearchesStorageDirectory() withIntermediateDirectories:YES attributes:nil error: nil];
-    [recentSearchesPlist writeToFile:searchFieldRecentSearchesPlistPath() atomically:YES];
+    [recentSearchesPlist writeToFile:searchFieldRecentSearchesPlistPath(directory) atomically:YES];
 }
 
-Vector<RecentSearch> loadRecentSearches(const String& name)
+Vector<RecentSearch> loadRecentSearchesFromFile(const String& name, const String& directory)
 {
     Vector<RecentSearch> searchItems;
-
-    if (name.isEmpty())
+    if (name.isEmpty() || directory.isEmpty())
         return searchItems;
 
-    RetainPtr<NSMutableDictionary> recentSearchesPlist = readSearchFieldRecentSearchesPlist();
+    RetainPtr<NSMutableDictionary> recentSearchesPlist = readSearchFieldRecentSearchesPlist(directory);
     if (!recentSearchesPlist)
         return searchItems;
 
@@ -200,14 +182,21 @@ Vector<RecentSearch> loadRecentSearches(const String& name)
     return searchItems;
 }
 
-void removeRecentlyModifiedRecentSearches(WallTime oldestTimeToRemove)
+void removeRecentlyModifiedRecentSearchesFromFile(WallTime oldestTimeToRemove, const String& directory)
 {
+    if (directory.isEmpty())
+        return;
+
+    NSString *plistPath = searchFieldRecentSearchesPlistPath(directory);
     NSDate *date = toNSDateFromSystemClock(oldestTimeToRemove);
-    auto recentSearchesPlist = typeCheckedRecentSearchesRemovingRecentSearchesAddedAfterDate(date);
+    auto recentSearchesPlist = typeCheckedRecentSearchesRemovingRecentSearchesAddedAfterDate(date, directory);
     if (recentSearchesPlist)
-        [recentSearchesPlist writeToFile:searchFieldRecentSearchesPlistPath() atomically:YES];
-    else
-        writeEmptyRecentSearchesPlist();
+        [recentSearchesPlist writeToFile:plistPath atomically:YES];
+    else {
+        auto emptyItemsDictionary = adoptNS([[NSDictionary alloc] init]);
+        auto emptyRecentSearchesDictionary = adoptNS([[NSDictionary alloc] initWithObjectsAndKeys:emptyItemsDictionary.get(), itemsKey, nil]);
+        [emptyRecentSearchesDictionary writeToFile:plistPath atomically:YES];
+    }
 }
 
 }

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -178,14 +178,14 @@ void WebPageProxy::saveRecentSearches(const String& name, const Vector<WebCore::
 {
     MESSAGE_CHECK(!name.isNull());
 
-    WebCore::saveRecentSearches(name, searchItems);
+    m_websiteDataStore->saveRecentSearches(name, searchItems);
 }
 
 void WebPageProxy::loadRecentSearches(const String& name, CompletionHandler<void(Vector<WebCore::RecentSearch>&&)>&& completionHandler)
 {
     MESSAGE_CHECK_COMPLETION(!name.isNull(), completionHandler({ }));
 
-    completionHandler(WebCore::loadRecentSearches(name));
+    m_websiteDataStore->loadRecentSearches(name, WTFMove(completionHandler));
 }
 
 void WebPageProxy::grantAccessToCurrentPasteboardData(const String& pasteboardName)

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -336,6 +336,8 @@ void WebsiteDataStore::resolveDirectoriesIfNecessary()
     if (!m_configuration->modelElementCacheDirectory().isEmpty())
         m_resolvedConfiguration->setModelElementCacheDirectory(resolveAndCreateReadWriteDirectoryForSandboxExtension(m_configuration->modelElementCacheDirectory()));
 #endif
+    if (!m_configuration->searchFieldHistoryDirectory().isEmpty())
+        m_resolvedConfiguration->setSearchFieldHistoryDirectory(resolveAndCreateReadWriteDirectoryForSandboxExtension(m_configuration->searchFieldHistoryDirectory()));
 
     // Resolve file paths.
     if (!m_configuration->cookieStorageFile().isEmpty()) {
@@ -701,11 +703,8 @@ void WebsiteDataStore::removeData(OptionSet<WebsiteDataType> dataTypes, WallTime
         });
     }
 
-    if (dataTypes.contains(WebsiteDataType::SearchFieldRecentSearches) && isPersistent()) {
-        m_queue->dispatch([modifiedSince, callbackAggregator] {
-            platformRemoveRecentSearches(modifiedSince);
-        });
-    }
+    if (dataTypes.contains(WebsiteDataType::SearchFieldRecentSearches) && isPersistent())
+        removeRecentSearches(modifiedSince, [callbackAggregator] { });
 
 #if ENABLE(TRACKING_PREVENTION)
     if (dataTypes.contains(WebsiteDataType::ResourceLoadStatistics)) {
@@ -1992,6 +1991,21 @@ bool WebsiteDataStore::networkProcessHasEntitlementForTesting(const String&)
 {
     return false;
 }
+
+void WebsiteDataStore::saveRecentSearches(const String& name, const Vector<WebCore::RecentSearch>&)
+{
+}
+
+void WebsiteDataStore::loadRecentSearches(const String& name, CompletionHandler<void(Vector<WebCore::RecentSearch>&&)>&& completionHandler)
+{
+    completionHandler({ });
+}
+
+void WebsiteDataStore::removeRecentSearches(WallTime, CompletionHandler<void()>&& completionHandler)
+{
+    completionHandler();
+}
+
 #endif // !PLATFORM(COCOA)
 
 #if !USE(GLIB) && !PLATFORM(COCOA)

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -80,6 +80,7 @@ class ResourceRequest;
 class SecurityOrigin;
 class LocalWebLockRegistry;
 class PrivateClickMeasurement;
+struct RecentSearch;
 
 struct MockWebAuthenticationConfiguration;
 struct NotificationData;
@@ -276,6 +277,7 @@ public:
     const String& resolvedResourceLoadStatisticsDirectory() const { return m_resolvedConfiguration->resourceLoadStatisticsDirectory(); }
     const String& resolvedHSTSStorageDirectory() const { return m_resolvedConfiguration->hstsStorageDirectory(); }
     const String& resolvedGeneralStorageDirectory() const { return m_resolvedConfiguration->generalStorageDirectory(); }
+    const String& resolvedSearchFieldHistoryDirectory() const { return m_resolvedConfiguration->searchFieldHistoryDirectory(); }
 #if ENABLE(ARKIT_INLINE_PREVIEW)
     const String& resolvedModelElementCacheDirectory() const { return m_resolvedConfiguration->modelElementCacheDirectory(); }
 #endif
@@ -354,6 +356,7 @@ public:
     static void removeDataStoreWithIdentifier(const UUID& identifier, CompletionHandler<void(const String&)>&&);
     static String defaultWebsiteDataStoreDirectory(const UUID& identifier);
     static String defaultCookieStorageFile(const String& baseDataDirectory = nullString());
+    static String defaultSearchFieldHistoryDirectory(const String& baseDataDirectory = nullString());
 #endif
     static String defaultServiceWorkerRegistrationDirectory(const String& baseDataDirectory = nullString());
     static String defaultLocalStorageDirectory(const String& baseDataDirectory = nullString());
@@ -434,6 +437,9 @@ public:
     void download(const DownloadProxy&, const String& suggestedFilename);
     void resumeDownload(const DownloadProxy&, const API::Data&, const String& path, CallDownloadDidStart);
 
+    void saveRecentSearches(const String& name, const Vector<WebCore::RecentSearch>&);
+    void loadRecentSearches(const String& name, CompletionHandler<void(Vector<WebCore::RecentSearch>&&)>&&);
+
 private:
     enum class ForceReinitialization : bool { No, Yes };
 #if ENABLE(APP_BOUND_DOMAINS)
@@ -446,9 +452,8 @@ private:
 
     void platformInitialize();
     void platformDestroy();
-    static void platformRemoveRecentSearches(WallTime);
-
     void platformSetNetworkParameters(WebsiteDataStoreParameters&);
+    void removeRecentSearches(WallTime, CompletionHandler<void()>&&);
 
     WebsiteDataStore();
 

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp
@@ -110,6 +110,7 @@ void WebsiteDataStoreConfiguration::initializePaths()
     setGeneralStorageDirectory(WebsiteDataStore::defaultGeneralStorageDirectory(m_baseDataDirectory));
 #if PLATFORM(COCOA)
     setCookieStorageFile(WebsiteDataStore::defaultCookieStorageFile(m_baseDataDirectory));
+    setSearchFieldHistoryDirectory(WebsiteDataStore::defaultSearchFieldHistoryDirectory(m_baseDataDirectory));
 #endif
 }
 
@@ -141,6 +142,7 @@ Ref<WebsiteDataStoreConfiguration> WebsiteDataStoreConfiguration::copy() const
     copy->m_deviceIdHashSaltsStorageDirectory = this->m_deviceIdHashSaltsStorageDirectory;
     copy->m_resourceLoadStatisticsDirectory = this->m_resourceLoadStatisticsDirectory;
     copy->m_javaScriptConfigurationDirectory = this->m_javaScriptConfigurationDirectory;
+    copy->m_searchFieldHistoryDirectory = this->m_searchFieldHistoryDirectory;
     copy->m_cookieStorageFile = this->m_cookieStorageFile;
     copy->m_sourceApplicationBundleIdentifier = this->m_sourceApplicationBundleIdentifier;
     copy->m_sourceApplicationSecondaryIdentifier = this->m_sourceApplicationSecondaryIdentifier;

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
@@ -80,6 +80,9 @@ public:
     const String& javaScriptConfigurationDirectory() const { return m_javaScriptConfigurationDirectory; }
     void setJavaScriptConfigurationDirectory(String&& directory) { m_javaScriptConfigurationDirectory = WTFMove(directory); }
 
+    const String& searchFieldHistoryDirectory() const { return m_searchFieldHistoryDirectory; }
+    void setSearchFieldHistoryDirectory(String&& directory) { m_searchFieldHistoryDirectory = WTFMove(directory); }
+
     // indexedDBDatabaseDirectory is sort of deprecated. Data is migrated from here to
     // generalStoragePath unless useCustomStoragePaths is true.
     const String& indexedDBDatabaseDirectory() const { return m_indexedDBDatabaseDirectory; }
@@ -266,6 +269,7 @@ private:
     String m_deviceIdHashSaltsStorageDirectory;
     String m_resourceLoadStatisticsDirectory;
     String m_javaScriptConfigurationDirectory;
+    String m_searchFieldHistoryDirectory;
     String m_cookieStorageFile;
     String m_sourceApplicationBundleIdentifier;
     String m_sourceApplicationSecondaryIdentifier;

--- a/Source/WebKit/UIProcess/WebsiteData/playstation/WebsiteDataStorePlayStation.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/playstation/WebsiteDataStorePlayStation.cpp
@@ -41,11 +41,6 @@ void WebsiteDataStore::platformDestroy()
     notImplemented();
 }
 
-void WebsiteDataStore::platformRemoveRecentSearches(WallTime)
-{
-    notImplemented();
-}
-
 String WebsiteDataStore::defaultApplicationCacheDirectory(const String& baseCacheDirectory)
 {
     return cacheDirectoryFileSystemRepresentation("applications"_s, baseCacheDirectory);

--- a/Source/WebKit/UIProcess/WebsiteData/win/WebsiteDataStoreWin.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/win/WebsiteDataStoreWin.cpp
@@ -41,11 +41,6 @@ void WebsiteDataStore::platformDestroy()
     notImplemented();
 }
 
-void WebsiteDataStore::platformRemoveRecentSearches(WallTime)
-{
-    notImplemented();
-}
-
 String WebsiteDataStore::defaultApplicationCacheDirectory(const String& baseCacheDirectory)
 {
     return cacheDirectoryFileSystemRepresentation("ApplicationCache"_s, baseCacheDirectory);

--- a/Source/WebKit/UIProcess/glib/WebsiteDataStoreGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/WebsiteDataStoreGLib.cpp
@@ -137,11 +137,6 @@ String WebsiteDataStore::websiteDataDirectoryFileSystemRepresentation(const Stri
     return FileSystem::pathByAppendingComponent(baseDataDirectory.isNull() ? defaultBaseDataDirectory() : baseDataDirectory, directoryName);
 }
 
-void WebsiteDataStore::platformRemoveRecentSearches(WallTime)
-{
-    notImplemented();
-}
-
 UnifiedOriginStorageLevel WebsiteDataStore::defaultUnifiedOriginStorageLevel()
 {
 #if ENABLE(2022_GLIB_API)

--- a/Source/WebKitLegacy/mac/WebCoreSupport/SearchPopupMenuMac.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/SearchPopupMenuMac.h
@@ -41,6 +41,7 @@ public:
 
 private:
     RefPtr<PopupMenuMac> m_popup;
+    String m_directory;
 };
 
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/SearchPopupMenuMac.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/SearchPopupMenuMac.mm
@@ -21,11 +21,23 @@
 #import "SearchPopupMenuMac.h"
 
 #import "PopupMenuMac.h"
+#import <wtf/FileSystem.h>
 #import <wtf/text/AtomString.h>
+
+static String defaultSearchFieldRecentSearchesStorageDirectory()
+{
+    NSString *appName = [[NSBundle mainBundle] bundleIdentifier];
+    if (!appName)
+        appName = [[NSProcessInfo processInfo] processName];
+
+    return [[NSHomeDirectory() stringByAppendingPathComponent:@"Library/WebKit"] stringByAppendingPathComponent:appName];
+}
 
 SearchPopupMenuMac::SearchPopupMenuMac(WebCore::PopupMenuClient* client)
     : m_popup(adoptRef(new PopupMenuMac(client)))
+    , m_directory(defaultSearchFieldRecentSearchesStorageDirectory())
 {
+    FileSystem::makeAllDirectories(m_directory);
 }
 
 SearchPopupMenuMac::~SearchPopupMenuMac()
@@ -44,10 +56,10 @@ bool SearchPopupMenuMac::enabled()
 
 void SearchPopupMenuMac::saveRecentSearches(const AtomString& name, const Vector<WebCore::RecentSearch>& searchItems)
 {
-    WebCore::saveRecentSearches(name, searchItems);
+    WebCore::saveRecentSearchesToFile(name, searchItems, m_directory);
 }
 
 void SearchPopupMenuMac::loadRecentSearches(const AtomString& name, Vector<WebCore::RecentSearch>& searchItems)
 {
-    searchItems = WebCore::loadRecentSearches(name);
+    searchItems = WebCore::loadRecentSearchesFromFile(name, m_directory);
 }


### PR DESCRIPTION
#### 6b4139142821cbbcfb7151ed36c27699f2756eba
<pre>
Use separate search field history for WebsiteDataStore created with identifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=252079">https://bugs.webkit.org/show_bug.cgi?id=252079</a>
rdar://105296242

Reviewed by Chris Dumez.

Use separate search field history so it is not shared between sessions and can be cleared by WebsiteDataStore.

* Source/WebCore/platform/SearchPopupMenu.h:
(WebCore::RecentSearch::isolatedCopy const):
* Source/WebCore/platform/cocoa/SearchPopupMenuCocoa.h:
* Source/WebCore/platform/cocoa/SearchPopupMenuCocoa.mm:
(WebCore::searchFieldRecentSearchesPlistPath):
(WebCore::readSearchFieldRecentSearchesPlist):
(WebCore::typeCheckedRecentSearchesRemovingRecentSearchesAddedAfterDate):
(WebCore::saveRecentSearchesToFile):
(WebCore::loadRecentSearchesFromFile):
(WebCore::removeRecentlyModifiedRecentSearchesFromFile):
(WebCore::searchFieldRecentSearchesStorageDirectory): Deleted.
(WebCore::writeEmptyRecentSearchesPlist): Deleted.
(WebCore::saveRecentSearches): Deleted.
(WebCore::loadRecentSearches): Deleted.
(WebCore::removeRecentlyModifiedRecentSearches): Deleted.
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::saveRecentSearches):
(WebKit::WebPageProxy::loadRecentSearches):
* Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm:
(WebKit::WebsiteDataStore::defaultSearchFieldHistoryDirectory):
(WebKit::WebsiteDataStore::saveRecentSearches):
(WebKit::WebsiteDataStore::loadRecentSearches):
(WebKit::WebsiteDataStore::removeRecentSearches):
(WebKit::WebsiteDataStore::platformRemoveRecentSearches): Deleted.
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::resolveDirectoriesIfNecessary):
(WebKit::WebsiteDataStore::removeData):
(WebKit::WebsiteDataStore::saveRecentSearches):
(WebKit::WebsiteDataStore::loadRecentSearches):
(WebKit::WebsiteDataStore::removeRecentSearches):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
(WebKit::WebsiteDataStore::resolvedSearchFieldHistoryDirectory const):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp:
(WebKit::WebsiteDataStoreConfiguration::initializePaths):
(WebKit::WebsiteDataStoreConfiguration::copy const):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h:
(WebKit::WebsiteDataStoreConfiguration::searchFieldHistoryDirectory const):
(WebKit::WebsiteDataStoreConfiguration::setSearchFieldHistoryDirectory):
* Source/WebKit/UIProcess/WebsiteData/playstation/WebsiteDataStorePlayStation.cpp:
(WebKit::WebsiteDataStore::platformRemoveRecentSearches): Deleted.
* Source/WebKit/UIProcess/WebsiteData/win/WebsiteDataStoreWin.cpp:
(WebKit::WebsiteDataStore::platformRemoveRecentSearches): Deleted.
* Source/WebKit/UIProcess/glib/WebsiteDataStoreGLib.cpp:
(WebKit::WebsiteDataStore::platformRemoveRecentSearches): Deleted.
* Source/WebKitLegacy/mac/WebCoreSupport/SearchPopupMenuMac.h:
* Source/WebKitLegacy/mac/WebCoreSupport/SearchPopupMenuMac.mm:
(defaultSearchFieldRecentSearchesStorageDirectory):
(SearchPopupMenuMac::SearchPopupMenuMac):
(SearchPopupMenuMac::saveRecentSearches):
(SearchPopupMenuMac::loadRecentSearches):

Canonical link: <a href="https://commits.webkit.org/260452@main">https://commits.webkit.org/260452@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef7ec59bee26b8c351f1e77d6b40a84cb8f9c3f2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108189 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17272 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41056 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117313 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116628 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112076 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18660 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8558 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100397 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113957 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14077 "Found 5 new test failures: editing/deleting/smart-delete-003.html, editing/pasteboard/smart-paste-005.html, editing/pasteboard/smart-paste-paragraph-004.html, editing/selection/doubleclick-whitespace-img-crash.html, editing/selection/ios/selection-handles-in-iframe.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97266 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41981 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95987 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28906 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/83659 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10135 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30253 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10860 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7155 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16284 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49845 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7231 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12442 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->