### PR TITLE
Web Inspector: Regression(258675@main) "Selected element" console entry fills entire row

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.css
@@ -61,7 +61,6 @@
 
 .console-message-body {
     white-space: pre-wrap;
-    display: flex;
 }
 
 .console-message-body > span {
@@ -314,7 +313,6 @@
 .console-message .timestamp {
     color: var(--text-color-tertiary);
     padding-inline-end: 5px;
-    display: block;
 }
 
 .console-session:not(.timestamps-visible) .console-message .timestamp {

--- a/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.js
@@ -93,7 +93,7 @@ WI.ConsoleMessageView = class ConsoleMessageView extends WI.Object
         // FIXME: The location link should include stack trace information.
         this._appendLocationLink();
 
-        this._messageBodyElement = this._element.appendChild(document.createElement("div"));
+        this._messageBodyElement = this._element.appendChild(document.createElement("span"));
         this._messageBodyElement.classList.add("console-top-level-message", "console-message-body");
         this._appendMessageTextAndArguments(this._messageBodyElement);
         this._appendSavedResultIndex();
@@ -185,7 +185,7 @@ WI.ConsoleMessageView = class ConsoleMessageView extends WI.Object
         }
 
         if (!this._timestampElement) {
-            this._timestampElement = document.createElement("div");
+            this._timestampElement = document.createElement("span");
             this._timestampElement.classList.add("timestamp");
             this._messageBodyElement.insertBefore(this._timestampElement, this._messageBodyElement.firstChild);
         }
@@ -567,7 +567,7 @@ WI.ConsoleMessageView = class ConsoleMessageView extends WI.Object
         for (let i = 0; i < parameters.length; ++i)
             parameters[i] = this._createRemoteObjectIfNeeded(parameters[i]);
 
-        let builderElement = element.appendChild(document.createElement("div"));
+        let builderElement = element.appendChild(document.createElement("span"));
         let shouldFormatWithStringSubstitution = parameters[0].type === "string" && this._message.type !== WI.ConsoleMessage.MessageType.Result;
 
         // Single object (e.g. console result or logging a non-string object).


### PR DESCRIPTION
#### 80669e5b296b01c3b7c2b737632263c0f3fb16be
<pre>
Web Inspector: Regression(258675@main) &quot;Selected element&quot; console entry fills entire row
<a href="https://bugs.webkit.org/show_bug.cgi?id=252081">https://bugs.webkit.org/show_bug.cgi?id=252081</a>
rdar://105298123

Reviewed by Devin Rousso.

Fix up some console-related styling after 258675@main. The key change is to not set display: flex; on the console
message body and to return to using `span` for a few elements, undoing that change from the regression point and instead
making sure the timestamp itself is a span.

* Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.css:
(.console-message-body):
(.console-message .timestamp):
* Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.js:
(WI.ConsoleMessageView.prototype.render):
(WI.ConsoleMessageView.prototype.renderTimestamp):

Canonical link: <a href="https://commits.webkit.org/260139@main">https://commits.webkit.org/260139@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8955ac6bde83b02aa9ff05a626ec8159fd2a15e4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107236 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16279 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40007 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116394 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/115858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/17732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/7553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99397 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113001 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/17732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96448 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/40995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/17732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/28084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/9344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/29425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/9972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/7553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/15499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49004 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7010 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11509 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->