### PR TITLE
Make mainFrame() return an AbstractFrame

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -1199,7 +1199,11 @@ Frame* AccessibilityObject::mainFrame() const
     if (!frame)
         return nullptr;
     
-    return &frame->mainFrame();
+    auto* localFrame = dynamicDowncast<LocalFrame>(frame->mainFrame());
+    if (!localFrame)
+        return nullptr;
+
+    return localFrame;
 }
 
 Document* AccessibilityObject::topDocument() const

--- a/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
@@ -211,8 +211,10 @@ ContentRuleListResults ContentExtensionsBackend::processContentRuleListsForLoad(
             && frame->isMainFrame()
             && resourceType == ResourceType::Document)
             mainDocumentURL = url;
-        else if (auto* mainDocument = frame->mainFrame().document())
-            mainDocumentURL = mainDocument->url();
+        else if (auto* localFrame = dynamicDowncast<LocalFrame>(frame->mainFrame())) {
+            if (auto* mainDocument = localFrame->document())
+                mainDocumentURL = mainDocument->url();
+        }
     }
     if (currentDocument)
         frameURL = currentDocument->url();

--- a/Source/WebCore/css/query/MediaQueryFeatures.cpp
+++ b/Source/WebCore/css/query/MediaQueryFeatures.cpp
@@ -248,7 +248,9 @@ const FeatureSchema& color()
     static MainThreadNeverDestroyed<IntegerSchema> schema {
         "color"_s,
         [](auto& context) {
-            return screenDepthPerComponent(context.document.frame()->mainFrame().view());
+            if (auto* localFrame = dynamicDowncast<LocalFrame>(context.document.frame()->mainFrame()))
+                return screenDepthPerComponent(localFrame->view()); 
+            return 8;
         }
     };
     return schema;
@@ -264,8 +266,10 @@ const FeatureSchema& colorGamut()
 
             // FIXME: At some point we should start detecting displays that support more colors.
             MatchingIdentifiers identifiers { CSSValueSRGB };
-            if (screenSupportsExtendedColor(frame.mainFrame().view()))
-                identifiers.append(CSSValueP3);
+            if (auto* localFrame = dynamicDowncast<LocalFrame>(frame.mainFrame())) {
+                if (screenSupportsExtendedColor(localFrame->view()))
+                    identifiers.append(CSSValueP3);
+            }
             return identifiers;
         }
     };
@@ -286,8 +290,11 @@ const FeatureSchema& deviceAspectRatio()
     static MainThreadNeverDestroyed<RatioSchema> schema {
         "device-aspect-ratio"_s,
         [](auto& context) {
-            auto screenSize = context.document.frame()->mainFrame().screenSize();
-            return FloatSize { screenSize.width(), screenSize.height() };
+            if (auto* localFrame = dynamicDowncast<LocalFrame>(context.document.frame()->mainFrame())) {
+                auto screenSize = localFrame->screenSize();
+                return FloatSize { screenSize.width(), screenSize.height() };
+            }
+            return FloatSize { 0.0f, 0.0f };
         }
     };
     return schema;
@@ -298,7 +305,9 @@ const FeatureSchema& deviceHeight()
     static MainThreadNeverDestroyed<LengthSchema> schema {
         "device-height"_s,
         [](auto& context) {
-            return LayoutUnit { context.document.frame()->mainFrame().screenSize().height() };
+            if (auto* localFrame = dynamicDowncast<LocalFrame>(context.document.frame()->mainFrame()))
+                return LayoutUnit { localFrame->screenSize().height() };
+            return LayoutUnit { 0.0f };
         }
     };
     return schema;
@@ -320,7 +329,9 @@ const FeatureSchema& deviceWidth()
     static MainThreadNeverDestroyed<LengthSchema> schema {
         "device-width"_s,
         [](auto& context) {
-            return LayoutUnit { context.document.frame()->mainFrame().screenSize().width() };
+            if (auto* localFrame = dynamicDowncast<LocalFrame>(context.document.frame()->mainFrame()))
+                return LayoutUnit { localFrame->screenSize().width() };
+            return LayoutUnit { 0.0f };
         }
     };
     return schema;
@@ -338,7 +349,9 @@ const FeatureSchema& dynamicRange()
                     return true;
                 if (frame.settings().forcedSupportsHighDynamicRangeValue() == ForcedAccessibilityValue::Off)
                     return false;
-                return screenSupportsHighDynamicRange(frame.mainFrame().view());
+                if (auto* localFrame = dynamicDowncast<LocalFrame>(frame.mainFrame()))
+                    return screenSupportsHighDynamicRange(localFrame->view());
+                return false;
             }();
 
             MatchingIdentifiers identifiers { CSSValueStandard };
@@ -425,16 +438,19 @@ const FeatureSchema& monochrome()
     static MainThreadNeverDestroyed<IntegerSchema> schema {
         "monochrome"_s,
         [](auto& context) {
+            auto& frame = *context.document.frame();
+            auto* localFrame = dynamicDowncast<LocalFrame>(frame.mainFrame());
             bool isMonochrome = [&] {
-                auto& frame = *context.document.frame();
                 if (frame.settings().forcedDisplayIsMonochromeAccessibilityValue() == ForcedAccessibilityValue::On)
                     return true;
                 if (frame.settings().forcedDisplayIsMonochromeAccessibilityValue() == ForcedAccessibilityValue::Off)
                     return false;
-                return screenIsMonochrome(frame.mainFrame().view());
+                if (localFrame)
+                    return screenIsMonochrome(localFrame->view());
+                return false;
             }();
 
-            return isMonochrome ? screenDepthPerComponent(context.document.frame()->mainFrame().view()) : 0;
+            return isMonochrome && localFrame ? screenDepthPerComponent(localFrame->view()) : 0;
         }
     };
     return schema;

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2176,7 +2176,8 @@ void Document::resolveStyle(ResolveStyleType type)
         // detached (for example, by setting display:none in the :hover style), schedule another mouseMove event
         // to check if any other elements ended up under the mouse pointer due to re-layout.
         if (m_hoveredElement && !m_hoveredElement->renderer() && is<LocalFrame>(frameView.frame()))
-            downcast<LocalFrame>(frameView.frame()).mainFrame().eventHandler().dispatchFakeMouseMoveEventSoon();
+            if (auto* localMainFrame = dynamicDowncast<LocalFrame>(downcast<LocalFrame>(frameView.frame()).mainFrame()))
+                localMainFrame->eventHandler().dispatchFakeMouseMoveEventSoon();
 
         ++m_styleRecalcCount;
         // FIXME: Assert ASSERT(!needsStyleRecalc()) here. Do we still have some cases where it's not true?
@@ -6238,7 +6239,9 @@ Document& Document::topDocument() const
         if (!m_frame)
             return const_cast<Document&>(*this);
         // This should always be non-null.
-        Document* mainFrameDocument = m_frame->mainFrame().document();
+        Document* mainFrameDocument = nullptr;
+        if (auto* localFrame = dynamicDowncast<LocalFrame>(m_frame->mainFrame()))
+            mainFrameDocument = localFrame->document();
         return mainFrameDocument ? *mainFrameDocument : const_cast<Document&>(*this);
     }
 
@@ -8280,7 +8283,7 @@ static std::optional<IntersectionObservationState> computeIntersectionState(Fram
     } else {
         ASSERT(is<LocalFrame>(frameView.frame()) && downcast<LocalFrame>(frameView.frame()).isMainFrame());
         // FIXME: Handle the case of an implicit-root observer that has a target in a different frame tree.
-        if (&targetRenderer->frame().mainFrame() != &frameView.frame())
+        if (dynamicDowncast<LocalFrame>(targetRenderer->frame().mainFrame()) != &frameView.frame())
             return std::nullopt;
         rootRenderer = frameView.renderView();
         localRootBounds = frameView.layoutViewportRect();

--- a/Source/WebCore/dom/DocumentMarkerController.cpp
+++ b/Source/WebCore/dom/DocumentMarkerController.cpp
@@ -143,7 +143,11 @@ static void updateMainFrameLayoutIfNeeded(Document& document)
     if (!frame)
         return;
 
-    FrameView* mainFrameView = frame->mainFrame().view();
+    auto* localFrame = dynamicDowncast<LocalFrame>(frame->mainFrame());
+    if (!localFrame)
+        return;
+
+    FrameView* mainFrameView = localFrame->view();
     if (!mainFrameView)
         return;
 

--- a/Source/WebCore/dom/EventDispatcher.cpp
+++ b/Source/WebCore/dom/EventDispatcher.cpp
@@ -121,7 +121,11 @@ static bool shouldSuppressEventDispatchInDOM(Node& node, Event& event)
     if (!frame)
         return false;
 
-    if (!frame->mainFrame().loader().shouldSuppressTextInputFromEditing())
+    auto* localFrame = dynamicDowncast<LocalFrame>(frame->mainFrame());
+    if (!localFrame)
+        return false;
+
+    if (!localFrame->loader().shouldSuppressTextInputFromEditing())
         return false;
 
     if (is<TextEvent>(event)) {

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -532,7 +532,11 @@ bool Editor::canCopy() const
 
 bool Editor::canPaste() const
 {
-    if (m_document.frame()->mainFrame().loader().shouldSuppressTextInputFromEditing())
+    auto* localFrame = dynamicDowncast<LocalFrame>(m_document.frame()->mainFrame());
+    if (!localFrame)
+        return false;
+
+    if (localFrame->loader().shouldSuppressTextInputFromEditing())
         return false;
 
     return canEdit();
@@ -796,7 +800,11 @@ bool Editor::tryDHTMLCut()
 
 bool Editor::shouldInsertText(const String& text, const std::optional<SimpleRange>& range, EditorInsertAction action) const
 {
-    if (m_document.frame()->mainFrame().loader().shouldSuppressTextInputFromEditing() && action == EditorInsertAction::Typed)
+    auto* localFrame = dynamicDowncast<LocalFrame>(m_document.frame()->mainFrame());
+    if (!localFrame)
+        return false;
+
+    if (localFrame->loader().shouldSuppressTextInputFromEditing() && action == EditorInsertAction::Typed)
         return false;
 
     return client() && client()->shouldInsertText(text, range, action);

--- a/Source/WebCore/editing/EditorCommand.cpp
+++ b/Source/WebCore/editing/EditorCommand.cpp
@@ -1628,7 +1628,10 @@ static bool allowExecutionWhenDisabledCopyCut(Frame&, EditorCommandSource source
 
 static bool allowExecutionWhenDisabledPaste(Frame& frame, EditorCommandSource)
 {
-    if (frame.mainFrame().loader().shouldSuppressTextInputFromEditing())
+    auto* localFrame = dynamicDowncast<LocalFrame>(frame.mainFrame());
+    if (!localFrame)
+        return false;
+    if (localFrame->loader().shouldSuppressTextInputFromEditing())
         return false;
     return true;
 }

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -409,7 +409,12 @@ std::optional<URL> HTMLAnchorElement::attributionDestinationURLForPCM() const
 std::optional<RegistrableDomain> HTMLAnchorElement::mainDocumentRegistrableDomainForPCM() const
 {
     if (auto frame = document().frame()) {
-        if (auto mainDocument = frame->mainFrame().document()) {
+
+        auto* localFrame = dynamicDowncast<LocalFrame>(frame->mainFrame());
+        if (!localFrame)
+            return std::nullopt;
+
+        if (auto mainDocument = localFrame->document()) {
             if (auto mainDocumentRegistrableDomain = RegistrableDomain { mainDocument->url() }; !mainDocumentRegistrableDomain.isEmpty())
                 return mainDocumentRegistrableDomain;
         }
@@ -525,7 +530,11 @@ std::optional<PrivateClickMeasurement> HTMLAnchorElement::parsePrivateClickMeasu
     }
 
     RegistrableDomain mainDocumentRegistrableDomain;
-    if (auto mainDocument = frame->mainFrame().document())
+    auto* localFrame = dynamicDowncast<LocalFrame>(frame->mainFrame());
+    if (!localFrame)
+        return std::nullopt;
+
+    if (auto mainDocument = localFrame->document())
         mainDocumentRegistrableDomain = RegistrableDomain { mainDocument->url() };
     else {
         document().addConsoleMessage(MessageSource::Other, MessageLevel::Warning, "Could not find a main document to use as source site for Private Click Measurement."_s);

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -992,7 +992,11 @@ static bool isElementMainContentForPurposesOfAutoplay(const HTMLMediaElement& el
     if (!document.frame() || !document.frame()->isMainFrame())
         return false;
 
-    auto& mainFrame = document.frame()->mainFrame();
+    auto* localFrame = dynamicDowncast<LocalFrame>(document.frame()->mainFrame());
+    if (!localFrame)
+        return false;
+
+    auto& mainFrame = *localFrame;
     if (!mainFrame.view() || !mainFrame.view()->renderView())
         return false;
 
@@ -1028,7 +1032,11 @@ static bool isElementRectMostlyInMainFrame(const HTMLMediaElement& element)
     if (!documentFrame)
         return false;
 
-    auto mainFrameView = documentFrame->mainFrame().view();
+    auto* localFrame = dynamicDowncast<LocalFrame>(documentFrame->mainFrame());
+    if (!localFrame)
+        return false;
+
+    auto mainFrameView = localFrame->view();
     if (!mainFrameView)
         return false;
 
@@ -1054,10 +1062,14 @@ static bool isElementLargeRelativeToMainFrame(const HTMLMediaElement& element)
     if (!documentFrame)
         return false;
 
-    if (!documentFrame->mainFrame().view())
+    auto* localFrame = dynamicDowncast<LocalFrame>(documentFrame->mainFrame());
+    if (!localFrame)
         return false;
 
-    auto& mainFrameView = *documentFrame->mainFrame().view();
+    if (!localFrame->view())
+        return false;
+
+    auto& mainFrameView = *localFrame->view();
     auto maxVisibleClientWidth = std::min(renderer->clientWidth().toInt(), mainFrameView.visibleWidth());
     auto maxVisibleClientHeight = std::min(renderer->clientHeight().toInt(), mainFrameView.visibleHeight());
 

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
@@ -1048,7 +1048,10 @@ void InspectorPageAgent::didPaint(RenderObject& renderer, const LayoutRect& rect
     auto* localFrame = dynamicDowncast<LocalFrame>(view->frame());
     if (localFrame && !localFrame->isMainFrame()) {
         IntRect rootViewRect = view->contentsToRootView(snappedIntRect(absoluteRect));
-        rootRect = localFrame->mainFrame().view()->rootViewToContents(rootViewRect);
+        auto* localMainFrame = dynamicDowncast<LocalFrame>(localFrame->mainFrame());
+        if (!localMainFrame)
+            return;
+        rootRect = localMainFrame->view()->rootViewToContents(rootViewRect);
     }
 
     if (m_client->overridesShowPaintRects()) {

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -1068,7 +1068,11 @@ bool DocumentLoader::disallowWebArchive() const
         return false;
 
     // On purpose of maintaining existing tests.
-    if (frame()->mainFrame().loader().alwaysAllowLocalWebarchive())
+    auto* localFrame = dynamicDowncast<LocalFrame>(frame()->mainFrame());
+    if (!localFrame)
+        return false;
+
+    if (localFrame->loader().alwaysAllowLocalWebarchive())
         return false;
     return true;
 }

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -1051,9 +1051,10 @@ ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::requ
         bool sameOriginRequest = false;
         auto requestedOrigin = SecurityOrigin::create(url);
         if (type == CachedResource::Type::MainResource) {
+            auto* localMainFrame = dynamicDowncast<LocalFrame>(frame.mainFrame());
             if (frame.isMainFrame())
                 sameOriginRequest = true;
-            else if (auto* topDocument = frame.mainFrame().document())
+            else if (auto* topDocument = localMainFrame ? localMainFrame->document() : nullptr)
                 sameOriginRequest = topDocument->securityOrigin().isSameSchemeHostPort(requestedOrigin.get());
         } else if (document()) {
             sameOriginRequest = document()->topOrigin().isSameSchemeHostPort(requestedOrigin.get())

--- a/Source/WebCore/page/AutoscrollController.cpp
+++ b/Source/WebCore/page/AutoscrollController.cpp
@@ -114,8 +114,8 @@ void AutoscrollController::stopAutoscrollTimer(bool rendererIsBeingDestroyed)
 
 #if ENABLE(PAN_SCROLLING)
     // If we're not in the top frame we notify it that we are not doing a panScroll any more.
-    if (frame && !frame->isMainFrame())
-        frame->mainFrame().eventHandler().didPanScrollStop();
+    if (auto* localFrame = (frame && !frame->isMainFrame()) ? dynamicDowncast<LocalFrame>(frame->mainFrame()) : nullptr)
+        localFrame->eventHandler().didPanScrollStop();
 #endif
 }
 

--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -1261,7 +1261,11 @@ int DOMWindow::outerHeight() const
         return innerHeight();
 
 #if PLATFORM(IOS_FAMILY)
-    RefPtr view = frame->isMainFrame() ? frame->view() : frame->mainFrame().view();
+    auto* localFrame = dynamicDowncast<LocalFrame>(frame->mainFrame());
+    if (!localFrame)
+        return 0;
+
+    RefPtr view = frame->isMainFrame() ? frame->view() : localFrame->view();
     if (!view)
         return 0;
 
@@ -1285,7 +1289,11 @@ int DOMWindow::outerWidth() const
         return innerWidth();
 
 #if PLATFORM(IOS_FAMILY)
-    RefPtr view = frame->isMainFrame() ? frame->view() : frame->mainFrame().view();
+    auto* localFrame = dynamicDowncast<LocalFrame>(frame->mainFrame());
+    if (!localFrame)
+        return 0;
+
+    RefPtr view = frame->isMainFrame() ? frame->view() : localFrame->view();
     if (!view)
         return 0;
 
@@ -1988,7 +1996,11 @@ bool DOMWindow::isSameSecurityOriginAsMainFrame() const
     if (frame->isMainFrame())
         return true;
 
-    Document* mainFrameDocument = frame->mainFrame().document();
+    auto* localFrame = dynamicDowncast<LocalFrame>(frame->mainFrame());
+    if (!localFrame)
+        return false;
+
+    Document* mainFrameDocument = localFrame->document();
 
     if (mainFrameDocument && document()->securityOrigin().isSameOriginDomain(mainFrameDocument->securityOrigin()))
         return true;
@@ -2648,7 +2660,12 @@ ExceptionOr<RefPtr<WindowProxy>> DOMWindow::open(DOMWindow& activeWindow, DOMWin
 #if ENABLE(CONTENT_EXTENSIONS)
     auto* page = firstFrame->page();
     RefPtr firstFrameDocument = firstFrame->document();
-    RefPtr mainFrameDocument = firstFrame->mainFrame().document();
+
+    auto* localFrame = dynamicDowncast<LocalFrame>(firstFrame->mainFrame());
+    if (!localFrame)
+        return RefPtr<WindowProxy> { nullptr };
+
+    RefPtr mainFrameDocument = localFrame->document();
     RefPtr mainFrameDocumentLoader = mainFrameDocument ? mainFrameDocument->loader() : nullptr;
     if (firstFrameDocument && page && mainFrameDocumentLoader) {
         auto results = page->userContentProvider().processContentRuleListsForLoad(*page, firstFrameDocument->completeURL(urlString), ContentExtensions::ResourceType::Popup, *mainFrameDocumentLoader);

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -139,7 +139,7 @@ public:
 
     WEBCORE_EXPORT void willDetachPage();
 
-    Frame& mainFrame() const;
+    AbstractFrame& mainFrame() const;
     bool isMainFrame() const { return this == static_cast<void*>(&m_mainFrame); }
 
     Document* document() const;
@@ -375,7 +375,7 @@ inline Document* Frame::document() const
     return m_doc.get();
 }
 
-inline Frame& Frame::mainFrame() const
+inline AbstractFrame& Frame::mainFrame() const
 {
     return m_mainFrame;
 }

--- a/Source/WebCore/page/FrameTree.cpp
+++ b/Source/WebCore/page/FrameTree.cpp
@@ -249,8 +249,13 @@ static bool isFrameFamiliarWith(AbstractFrame& abstractFrameA, AbstractFrame& ab
     if (!frameA || !frameB)
         return false;
 
-    auto* frameAOpener = frameA->mainFrame().loader().opener();
-    auto* frameBOpener = frameB->mainFrame().loader().opener();
+    auto* mainFrameA = dynamicDowncast<LocalFrame>(frameA->mainFrame());
+    auto* mainFrameB = dynamicDowncast<LocalFrame>(frameB->mainFrame());
+    if (!mainFrameA || !mainFrameB)
+        return false;
+
+    auto* frameAOpener = mainFrameA->loader().opener();
+    auto* frameBOpener = mainFrameB->loader().opener();
     return (frameAOpener && frameAOpener->page() == frameB->page()) || (frameBOpener && frameBOpener->page() == frameA->page()) || (frameAOpener && frameBOpener && frameAOpener->page() == frameBOpener->page());
 }
 
@@ -277,7 +282,7 @@ AbstractFrame* FrameTree::find(const AtomString& name, AbstractFrame& activeFram
 
     // Then the rest of the tree.
     auto* localFrame = dynamicDowncast<LocalFrame>(m_thisFrame);
-    for (AbstractFrame* frame = localFrame ? &localFrame->mainFrame() : nullptr; frame; frame = frame->tree().traverseNext()) {
+    for (AbstractFrame* frame = localFrame ? dynamicDowncast<LocalFrame>(localFrame->mainFrame()) : nullptr; frame; frame = frame->tree().traverseNext()) {
         if (frame->tree().uniqueName() == name)
             return frame;
     }
@@ -451,7 +456,7 @@ AbstractFrame* FrameTree::traverseNext(CanWrap canWrap, DidWrap* didWrap) const
         auto* localFrame = dynamicDowncast<LocalFrame>(m_thisFrame);
         if (!localFrame)
             return nullptr;
-        return &localFrame->mainFrame();
+        return dynamicDowncast<LocalFrame>(localFrame->mainFrame());
     }
 
     return nullptr;

--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -5719,8 +5719,11 @@ AXObjectCache* FrameView::axObjectCache() const
     // FIXME: We should generally always be using the main-frame cache rather than
     // using it as a fallback as we do here.
     if (!cache && !m_frame->isMainFrame()) {
-        if (auto* mainFrameDocument = m_frame->mainFrame().document())
-            cache = mainFrameDocument->existingAXObjectCache();
+        auto localMainFrame = dynamicDowncast<LocalFrame>(m_frame->mainFrame());
+        if (localMainFrame) {
+            if (auto* mainFrameDocument = localMainFrame->document())
+                cache = mainFrameDocument->existingAXObjectCache();
+        }
     }
     return cache;
 }

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -109,7 +109,11 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
     if (bounds.isEmpty())
         return std::nullopt;
 
-    auto& mainFrameView = *regionRenderer.document().frame()->mainFrame().view();
+    auto* localFrame = dynamicDowncast<LocalFrame>(regionRenderer.document().frame()->mainFrame());
+    if (!localFrame)
+        return std::nullopt;
+
+    auto& mainFrameView = *localFrame->view();
 
     FloatSize frameViewSize = mainFrameView.size();
     // Adding some wiggle room, we use this to avoid extreme cases.

--- a/Source/WebCore/page/IntersectionObserver.cpp
+++ b/Source/WebCore/page/IntersectionObserver.cpp
@@ -130,8 +130,10 @@ IntersectionObserver::IntersectionObserver(Document& document, Ref<IntersectionO
     } else if (root) {
         auto& observerData = downcast<Element>(*root).ensureIntersectionObserverData();
         observerData.observers.append(*this);
-    } else if (auto* frame = document.frame())
-        m_implicitRootDocument = frame->mainFrame().document();
+    } else if (auto* frame = document.frame()) {
+        if (auto* localFrame = dynamicDowncast<LocalFrame>(frame->mainFrame()))
+            m_implicitRootDocument = localFrame->document();
+    }
 
     std::sort(m_thresholds.begin(), m_thresholds.end());
     

--- a/Source/WebCore/page/Screen.cpp
+++ b/Source/WebCore/page/Screen.cpp
@@ -56,7 +56,11 @@ Screen::~Screen() = default;
 
 static bool isLoadingInHeadlessMode(const Frame& frame)
 {
-    RefPtr mainDocument = frame.mainFrame().document();
+    auto* localFrame = dynamicDowncast<LocalFrame>(frame.mainFrame());
+    if (!localFrame)
+        return false;
+
+    RefPtr mainDocument = localFrame->document();
     if (!mainDocument)
         return false;
 

--- a/Source/WebCore/page/UserContentProvider.cpp
+++ b/Source/WebCore/page/UserContentProvider.cpp
@@ -98,7 +98,10 @@ static DocumentLoader* mainDocumentLoader(DocumentLoader& loader)
     if (auto frame = loader.frame()) {
         if (frame->isMainFrame())
             return &loader;
-        return frame->mainFrame().loader().documentLoader();
+
+        auto* localFrame = dynamicDowncast<LocalFrame>(frame->mainFrame());
+        if (localFrame)
+            return localFrame->loader().documentLoader();
     }
     return nullptr;
 }

--- a/Source/WebCore/page/scrolling/ScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinator.cpp
@@ -335,8 +335,10 @@ void ScrollingCoordinator::updateSynchronousScrollingReasons(FrameView& frameVie
         newSynchronousScrollingReasons.add(SynchronousScrollingReason::HasNonLayerViewportConstrainedObjects);
 
     auto* localFrame = dynamicDowncast<LocalFrame>(frameView.frame());
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(localFrame->mainFrame()); 
     if (localFrame
-        && localFrame->mainFrame().document()
+        && localMainFrame
+        && localMainFrame->document()
         && localFrame->document()->isImageDocument())
         newSynchronousScrollingReasons.add(SynchronousScrollingReason::IsImageDocument);
 

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1983,7 +1983,12 @@ ExceptionOr<void> Internals::scrollBySimulatingWheelEvent(Element& element, doub
     ScrollableArea* scrollableArea;
 
     if (&element == document->scrollingElementForAPI()) {
-        FrameView* frameView = box.frame().mainFrame().view();
+
+        auto* localFrame = dynamicDowncast<LocalFrame>(box.frame().mainFrame());
+        if (!localFrame)
+            return Exception { InvalidAccessError };
+
+        FrameView* frameView = localFrame->view();
         if (!frameView || !frameView->isScrollable())
             return Exception { InvalidAccessError };
 

--- a/Source/WebCore/testing/Internals.mm
+++ b/Source/WebCore/testing/Internals.mm
@@ -130,7 +130,12 @@ ExceptionOr<RefPtr<Range>> Internals::rangeForDictionaryLookupAtLocation(int x, 
     document->updateLayoutIgnorePendingStylesheets();
 
     constexpr OptionSet<HitTestRequest::Type> hitType { HitTestRequest::Type::ReadOnly, HitTestRequest::Type::Active, HitTestRequest::Type::DisallowUserAgentShadowContent, HitTestRequest::Type::AllowChildFrameContent };
-    auto result = document->frame()->mainFrame().eventHandler().hitTestResultAtPoint(IntPoint(x, y), hitType);
+    
+    auto* localFrame = dynamicDowncast<LocalFrame>(document->frame()->mainFrame());
+    if (!localFrame)
+        return nullptr; 
+
+    auto result = localFrame->eventHandler().hitTestResultAtPoint(IntPoint(x, y), hitType);
     auto range = DictionaryLookup::rangeAtHitTestResult(result);
     if (!range)
         return nullptr;

--- a/Source/WebKit/WebProcess/Network/WebSocketChannel.cpp
+++ b/Source/WebKit/WebProcess/Network/WebSocketChannel.cpp
@@ -132,7 +132,10 @@ WebSocketChannel::ConnectStatus WebSocketChannel::connect(const URL& url, const 
     OptionSet<NetworkConnectionIntegrity> networkConnectionIntegrityPolicy;
     bool allowPrivacyProxy { true };
     if (auto* frame = m_document ? m_document->frame() : nullptr) {
-        if (auto* mainFrameDocumentLoader = frame->mainFrame().document() ? frame->mainFrame().document()->loader() : nullptr) {
+        auto* mainFrame = dynamicDowncast<LocalFrame>(frame->mainFrame());
+        if (!mainFrame)
+            return ConnectStatus::KO; 
+        if (auto* mainFrameDocumentLoader = mainFrame->document() ? mainFrame->document()->loader() : nullptr) {
             allowPrivacyProxy = mainFrameDocumentLoader->allowPrivacyProxy();
             networkConnectionIntegrityPolicy = mainFrameDocumentLoader->networkConnectionIntegrityPolicy();
         }

--- a/Source/WebKit/WebProcess/WebCoreSupport/ShareableBitmapUtilities.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/ShareableBitmapUtilities.cpp
@@ -44,7 +44,11 @@ using namespace WebCore;
 RefPtr<ShareableBitmap> createShareableBitmap(RenderImage& renderImage, CreateShareableBitmapFromImageOptions&& options)
 {
     Ref frame = renderImage.frame();
-    auto colorSpaceForBitmap = screenColorSpace(frame->mainFrame().view());
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(frame->mainFrame());
+    if (!localMainFrame)
+        return { };
+
+    auto colorSpaceForBitmap = screenColorSpace(localMainFrame->view());
     if (!renderImage.isMedia() && !renderImage.opacity() && options.useSnapshotForTransparentImages == UseSnapshotForTransparentImages::Yes) {
         auto snapshotRect = renderImage.absoluteBoundingBoxRect();
         if (snapshotRect.isEmpty())

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebResourceLoadObserver.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebResourceLoadObserver.cpp
@@ -276,7 +276,10 @@ void WebResourceLoadObserver::logSubresourceLoading(const Frame* frame, const Re
     bool isRedirect = is3xxRedirect(redirectResponse);
     const URL& redirectedFromURL = redirectResponse.url();
     const URL& targetURL = newRequest.url();
-    const URL& topFrameURL = frame ? frame->mainFrame().document()->url() : URL();
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(frame->mainFrame());
+    if (!localMainFrame)
+        return;
+    const URL& topFrameURL = frame ? localMainFrame->document()->url() : URL();
     
     auto targetHost = targetURL.host();
     auto topFrameHost = topFrameURL.host();

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
@@ -68,7 +68,11 @@ using DragImage = CGImageRef;
 
 static RefPtr<ShareableBitmap> convertDragImageToBitmap(DragImage image, const IntSize& size, Frame& frame)
 {
-    auto bitmap = ShareableBitmap::create(size, { screenColorSpace(frame.mainFrame().view()) });
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(frame.mainFrame());
+    if (!localMainFrame)
+        return nullptr;
+
+    auto bitmap = ShareableBitmap::create(size, { screenColorSpace(localMainFrame->view()) });
     if (!bitmap)
         return nullptr;
 

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -1031,7 +1031,10 @@ std::optional<NavigatingToAppBoundDomain> WebFrame::isTopFrameNavigatingToAppBou
     auto* localFrame = dynamicDowncast<LocalFrame>(m_coreFrame.get());
     if (!localFrame)
         return std::nullopt;
-    return fromCoreFrame(localFrame->mainFrame())->isNavigatingToAppBoundDomain();
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(localFrame->mainFrame());
+    if (!localMainFrame)
+        return std::nullopt;
+    return fromCoreFrame(*localMainFrame)->isNavigatingToAppBoundDomain();
 }
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -1501,8 +1501,11 @@ static std::pair<std::optional<SimpleRange>, SelectionWasFlipped> rangeForPointI
     VisibleSelection existingSelection = frame.selection().selection();
     VisiblePosition selectionStart = existingSelection.visibleStart();
     VisiblePosition selectionEnd = existingSelection.visibleEnd();
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(frame.mainFrame());
+    if (!localMainFrame)
+        return { std::nullopt, SelectionWasFlipped::No };
 
-    auto pointInDocument = frame.view()->rootViewToContents(pointInRootViewCoordinates.constrainedWithin(frame.mainFrame().view()->unobscuredContentRect()));
+    auto pointInDocument = frame.view()->rootViewToContents(pointInRootViewCoordinates.constrainedWithin(localMainFrame->view()->unobscuredContentRect()));
 
     if (!selectionFlippingEnabled) {
         auto node = selectionStart.deepEquivalent().containerNode();

--- a/Source/WebKitLegacy/mac/WebView/WebImmediateActionController.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebImmediateActionController.mm
@@ -165,9 +165,13 @@
     if (!coreFrame)
         return;
 
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(coreFrame->mainFrame());
+    if (!localMainFrame)
+        return;
+
     constexpr OptionSet<HitTestRequest::Type> hitType { HitTestRequest::Type::ReadOnly, HitTestRequest::Type::Active, HitTestRequest::Type::DisallowUserAgentShadowContent, HitTestRequest::Type::AllowChildFrameContent };
     _hitTestResult = coreFrame->eventHandler().hitTestResultAtPoint(WebCore::IntPoint(viewPoint), hitType);
-    coreFrame->mainFrame().eventHandler().setImmediateActionStage(WebCore::ImmediateActionStage::PerformedHitTest);
+    localMainFrame->eventHandler().setImmediateActionStage(WebCore::ImmediateActionStage::PerformedHitTest);
 
     if (auto* element = _hitTestResult.targetElement())
         _contentPreventsDefault = element->dispatchMouseForceWillBegin();


### PR DESCRIPTION
#### 52ec37994c2d2ff334b0e6ee531ac662872e231e
<pre>
Make mainFrame() return an AbstractFrame
<a href="https://bugs.webkit.org/show_bug.cgi?id=252186">https://bugs.webkit.org/show_bug.cgi?id=252186</a>
rdar://105412703

Reviewed by Alex Christensen.

In preparation for website isolation, lets make Frame::mainFrame()
return an AbstractFrame. Going forward, the callers of this method will
need to decide if they are dealing with a LocalFrame or not, and take
action accordingly.

* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::mainFrame const):
* Source/WebCore/contentextensions/ContentExtensionsBackend.cpp:
(WebCore::ContentExtensions::ContentExtensionsBackend::processContentRuleListsForLoad):
* Source/WebCore/css/query/MediaQueryFeatures.cpp:
(WebCore::MQ::Features::color):
(WebCore::MQ::Features::colorGamut):
(WebCore::MQ::Features::deviceAspectRatio):
(WebCore::MQ::Features::deviceHeight):
(WebCore::MQ::Features::deviceWidth):
(WebCore::MQ::Features::dynamicRange):
(WebCore::MQ::Features::monochrome):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::resolveStyle):
(WebCore::Document::topDocument const):
(WebCore::computeIntersectionState):
* Source/WebCore/dom/DocumentMarkerController.cpp:
(WebCore::updateMainFrameLayoutIfNeeded):
* Source/WebCore/dom/EventDispatcher.cpp:
(WebCore::shouldSuppressEventDispatchInDOM):
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::canPaste const):
(WebCore::Editor::shouldInsertText const):
* Source/WebCore/editing/EditorCommand.cpp:
(WebCore::allowExecutionWhenDisabledPaste):
* Source/WebCore/html/HTMLAnchorElement.cpp:
(WebCore::HTMLAnchorElement::mainDocumentRegistrableDomainForPCM const):
(WebCore::HTMLAnchorElement::parsePrivateClickMeasurement const):
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::isElementMainContentForPurposesOfAutoplay):
(WebCore::isElementRectMostlyInMainFrame):
(WebCore::isElementLargeRelativeToMainFrame):
* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
(WebCore::InspectorPageAgent::didPaint):
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::disallowWebArchive const):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::userAgent const):
(WebCore::FrameLoader::navigatorPlatform const):
(WebCore::FrameLoader::updateRequestAndAddExtraFields):
(WebCore::FrameLoader::loadResourceSynchronously):
(WebCore::FrameLoader::continueLoadAfterNavigationPolicy):
(WebCore::FrameLoader::loadDifferentDocumentItem):
(WebCore::FrameLoader::loadProgressingStatusChanged):
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::FrameLoader::HistoryController::updateForCommit):
(WebCore::FrameLoader::HistoryController::updateForSameDocumentNavigation):
(WebCore::FrameLoader::HistoryController::updateBackForwardListClippedAtTarget):
(WebCore::FrameLoader::HistoryController::pushState):
* Source/WebCore/loader/NavigationDisabler.h:
(WebCore::NavigationDisabler::NavigationDisabler):
(WebCore::NavigationDisabler::~NavigationDisabler):
(WebCore::NavigationDisabler::isNavigationAllowed):
* Source/WebCore/loader/cache/CachedResource.cpp:
(WebCore::CachedResource::load):
* Source/WebCore/loader/cache/CachedResource.h:
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::requestResource):
* Source/WebCore/page/AutoscrollController.cpp:
(WebCore::AutoscrollController::stopAutoscrollTimer):
* Source/WebCore/page/DOMWindow.cpp:
(WebCore::DOMWindow::outerHeight const):
(WebCore::DOMWindow::outerWidth const):
(WebCore::DOMWindow::isSameSecurityOriginAsMainFrame const):
(WebCore::DOMWindow::open):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::hitTestResultAtPoint const):
(WebCore::EventHandler::selectCursor):
(WebCore::EventHandler::handleMousePressEvent):
(WebCore::EventHandler::internalKeyEvent):
* Source/WebCore/page/Frame.h:
(WebCore::Frame::mainFrame const):
* Source/WebCore/page/FrameTree.cpp:
(WebCore::isFrameFamiliarWith):
(WebCore::FrameTree::find const):
(WebCore::FrameTree::traverseNext const):
* Source/WebCore/page/FrameView.cpp:
(WebCore::FrameView::axObjectCache const):
* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::interactionRegionForRenderedRegion):
* Source/WebCore/page/IntersectionObserver.cpp:
(WebCore::IntersectionObserver::IntersectionObserver):
* Source/WebCore/page/Screen.cpp:
(WebCore::isLoadingInHeadlessMode):
* Source/WebCore/page/UserContentProvider.cpp:
(WebCore::mainDocumentLoader):
* Source/WebCore/page/scrolling/ScrollingCoordinator.cpp:
(WebCore::ScrollingCoordinator::updateSynchronousScrollingReasons):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::scrollBySimulatingWheelEvent):
* Source/WebCore/testing/Internals.mm:
(WebCore::Internals::rangeForDictionaryLookupAtLocation):
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
(WebKit::WebAutomationSessionProxy::computeElementLayout):
(WebKit::WebAutomationSessionProxy::takeScreenshot):
(WebKit::WebAutomationSessionProxy::snapshotRectForScreenshot):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::loadResource):
(WebKit::addParametersShared):
* Source/WebKit/WebProcess/Network/WebSocketChannel.cpp:
(WebKit::WebSocketChannel::connect):
* Source/WebKit/WebProcess/WebCoreSupport/ShareableBitmapUtilities.cpp:
(WebKit::createShareableBitmap):
* Source/WebKit/WebProcess/WebCoreSupport/WebResourceLoadObserver.cpp:
(WebKit::WebResourceLoadObserver::logSubresourceLoading):
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm:
(WebKit::convertDragImageToBitmap):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::isTopFrameNavigatingToAppBoundDomain const):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::rangeForPointInRootViewCoordinates):
* Source/WebKitLegacy/mac/WebView/WebImmediateActionController.mm:
(-[WebImmediateActionController performHitTestAtPoint:]):
* Source/WebKitLegacy/win/WebCoreSupport/AcceleratedCompositingContext.cpp:
(AcceleratedCompositingContext::flushPendingLayerChanges):
* Source/WebKitLegacy/win/WebCoreSupport/WebDragClient.cpp:
(WebDragClient::dragSourceActionMaskForPoint):

Canonical link: <a href="https://commits.webkit.org/260414@main">https://commits.webkit.org/260414@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/504b16f4b44db9fed0741429cc8ae76416701f32

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108215 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17300 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41082 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117338 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116646 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112102 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18678 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8584 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100423 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113983 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97285 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/42000 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28927 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10154 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30272 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/38/builds/96775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10886 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7177 "Passed tests") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/38/builds/96775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16303 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49867 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7203 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12468 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->