### PR TITLE
[WGSL] Implement additive & multiplicative expression parsing

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTForward.h
+++ b/Source/WebGPU/WGSL/AST/ASTForward.h
@@ -104,8 +104,10 @@ class Variable;
 class VariableQualifier;
 
 enum class AccessMode : uint8_t;
+enum class BinaryOperation : uint8_t;
 enum class ParameterRole : uint8_t;
 enum class StorageClass : uint8_t;
 enum class StructureRole : uint8_t;
+enum class UnaryOperation : uint8_t;
 
 } // namespace WGSL::AST

--- a/Source/WebGPU/WGSL/Lexer.cpp
+++ b/Source/WebGPU/WGSL/Lexer.cpp
@@ -41,6 +41,9 @@ Token Lexer<T>::lex()
         return makeToken(TokenType::EndOfFile);
 
     switch (m_current) {
+    case '%':
+        shift();
+        return makeToken(TokenType::Modulo);
     case '(':
         shift();
         return makeToken(TokenType::ParenLeft);
@@ -83,6 +86,9 @@ Token Lexer<T>::lex()
     case '*':
         shift();
         return makeToken(TokenType::Star);
+    case '/':
+        shift();
+        return makeToken(TokenType::Slash);
     case '.': {
         shift();
         unsigned offset = currentOffset();

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -41,6 +41,9 @@ namespace WGSL {
 #define CURRENT_SOURCE_SPAN() \
     SourceSpan(_startOfElementPosition, m_lexer.currentPosition())
 
+#define MAKE_NODE_UNIQUE_REF(type, ...) \
+    makeUniqueRef<AST::type>(CURRENT_SOURCE_SPAN() __VA_OPT__(,) __VA_ARGS__) /* NOLINT */
+
 #define RETURN_NODE(type, ...) \
     do { \
         AST::type astNodeResult(CURRENT_SOURCE_SPAN(), __VA_ARGS__); \
@@ -58,7 +61,7 @@ namespace WGSL {
     return { adoptRef(*new AST::type(CURRENT_SOURCE_SPAN(), __VA_ARGS__)) };
 
 #define RETURN_NODE_UNIQUE_REF(type, ...) \
-    return { makeUniqueRef<AST::type>(CURRENT_SOURCE_SPAN(), __VA_ARGS__) };
+    return { MAKE_NODE_UNIQUE_REF(type, __VA_ARGS__) };
 
 // Passing 0 arguments beyond the type to RETURN_NODE_UNIQUE_REF is invalid because of a stupid limitation of the C preprocessor
 #define RETURN_NODE_UNIQUE_REF_NO_ARGS(type) \
@@ -74,6 +77,12 @@ namespace WGSL {
     if (!name##Expected) \
         return makeUnexpected(name##Expected.error()); \
     auto& name = *name##Expected;
+
+#define PARSE_MOVE(name, element, ...) \
+    auto name##Expected = parse##element(__VA_ARGS__); \
+    if (!name##Expected) \
+        return makeUnexpected(name##Expected.error()); \
+    name = WTFMove(*name##Expected);
 
 // Warning: cannot use the do..while trick because it defines a new identifier named `name`.
 // So do not use after an if/for/while without braces.
@@ -118,6 +127,22 @@ std::optional<Error> parse(ShaderModule& shaderModule)
     if (shaderModule.source().is8Bit())
         return parse<Lexer<LChar>>(shaderModule);
     return parse<Lexer<UChar>>(shaderModule);
+}
+
+template<typename Lexer>
+Expected<AST::Expression::Ref, Error> parseExpression(const String& source)
+{
+    ShaderModule shaderModule(source);
+    Lexer lexer(shaderModule.source());
+    Parser parser(shaderModule, lexer);
+    return parser.parseExpression();
+}
+
+Expected<AST::Expression::Ref, Error> parseExpression(const String& source)
+{
+    if (source.is8Bit())
+        return parseExpression<Lexer<LChar>>(source);
+    return parseExpression<Lexer<UChar>>(source);
 }
 
 template<typename Lexer>
@@ -620,28 +645,69 @@ Expected<UniqueRef<AST::Expression>, Error> Parser<Lexer>::parseShiftExpression(
 }
 
 template<typename Lexer>
+Expected<AST::BinaryOperation, Error> Parser<Lexer>::parseAdditiveOperator()
+{
+    START_PARSE();
+
+    switch (current().m_type) {
+    case TokenType::Minus:
+        consume();
+        return AST::BinaryOperation::Subtract;
+    case TokenType::Plus:
+        consume();
+        return AST::BinaryOperation::Add;
+    default:
+        FAIL("Expected one of + or -"_s);
+    }
+}
+
+template<typename Lexer>
 Expected<UniqueRef<AST::Expression>, Error> Parser<Lexer>::parseAdditiveExpression(AST::Expression::Ref&& lhs)
 {
-    // FIXME: fill in
     START_PARSE();
-    if (current().m_type == TokenType::Plus) {
-        consume();
-        PARSE(rhs, UnaryExpression);
-        RETURN_NODE_UNIQUE_REF(BinaryExpression, WTFMove(lhs), WTFMove(rhs), AST::BinaryOperation::Add);
+    PARSE_MOVE(lhs, MultiplicativeExpression, WTFMove(lhs));
+
+    while (current().m_type == TokenType::Plus || current().m_type == TokenType::Minus) {
+        PARSE(op, AdditiveOperator);
+        PARSE(unary, UnaryExpression);
+        PARSE(rhs, MultiplicativeExpression, WTFMove(unary));
+        lhs = MAKE_NODE_UNIQUE_REF(BinaryExpression, WTFMove(lhs), WTFMove(rhs), op);
     }
-    return parseMultiplicativeExpression(WTFMove(lhs));
+
+    return WTFMove(lhs);
+}
+
+template<typename Lexer>
+Expected<AST::BinaryOperation, Error> Parser<Lexer>::parseMultiplicativeOperator()
+{
+    START_PARSE();
+    switch (current().m_type) {
+    case TokenType::Modulo:
+        consume();
+        return AST::BinaryOperation::Modulo;
+    case TokenType::Slash:
+        consume();
+        return AST::BinaryOperation::Divide;
+    case TokenType::Star:
+        consume();
+        return AST::BinaryOperation::Multiply;
+    default:
+        FAIL("Expected one of %, / or *"_s);
+    }
 }
 
 template<typename Lexer>
 Expected<UniqueRef<AST::Expression>, Error> Parser<Lexer>::parseMultiplicativeExpression(AST::Expression::Ref&& lhs)
 {
-    // FIXME: fill in
     START_PARSE();
-    if (current().m_type == TokenType::Star) {
-        consume();
+    while (current().m_type == TokenType::Modulo
+        || current().m_type == TokenType::Slash
+        || current().m_type == TokenType::Star) {
+        PARSE(op, MultiplicativeOperator)
         PARSE(rhs, UnaryExpression);
-        RETURN_NODE_UNIQUE_REF(BinaryExpression, WTFMove(lhs), WTFMove(rhs), AST::BinaryOperation::Multiply);
+        lhs = MAKE_NODE_UNIQUE_REF(BinaryExpression, WTFMove(lhs), WTFMove(rhs), op);
     }
+
     return WTFMove(lhs);
 }
 

--- a/Source/WebGPU/WGSL/ParserPrivate.h
+++ b/Source/WebGPU/WGSL/ParserPrivate.h
@@ -28,6 +28,7 @@
 #include "ASTAttribute.h"
 #include "ASTExpression.h"
 #include "ASTForward.h"
+#include "ASTStatement.h"
 #include "ASTStructure.h"
 #include "ASTTypeName.h"
 #include "ASTVariable.h"
@@ -75,7 +76,9 @@ public:
     Expected<AST::Expression::Ref, Error> parseRelationalExpression(AST::Expression::Ref&& lhs);
     Expected<AST::Expression::Ref, Error> parseShiftExpression(AST::Expression::Ref&& lhs);
     Expected<AST::Expression::Ref, Error> parseAdditiveExpression(AST::Expression::Ref&& lhs);
+    Expected<AST::BinaryOperation, Error> parseAdditiveOperator();
     Expected<AST::Expression::Ref, Error> parseMultiplicativeExpression(AST::Expression::Ref&& lhs);
+    Expected<AST::BinaryOperation, Error> parseMultiplicativeOperator();
     Expected<AST::Expression::Ref, Error> parseUnaryExpression();
     Expected<AST::Expression::Ref, Error> parseSingularExpression();
     Expected<AST::Expression::Ref, Error> parsePostfixExpression(AST::Expression::Ref&& base, SourcePosition startPosition);
@@ -95,5 +98,7 @@ private:
     Lexer& m_lexer;
     Token m_current;
 };
+
+Expected<AST::Expression::Ref, Error> parseExpression(const String& source);
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/Token.cpp
+++ b/Source/WebGPU/WGSL/Token.cpp
@@ -113,6 +113,8 @@ String toString(TokenType type)
         return "-"_s;
     case TokenType::MinusMinus:
         return "--"_s;
+    case TokenType::Modulo:
+        return "%"_s;
     case TokenType::Plus:
         return "+"_s;
     case TokenType::PlusPlus:
@@ -125,6 +127,8 @@ String toString(TokenType type)
         return ")"_s;
     case TokenType::Semicolon:
         return ";"_s;
+    case TokenType::Slash:
+        return "/"_s;
     case TokenType::Star:
         return "*"_s;
     }

--- a/Source/WebGPU/WGSL/Token.h
+++ b/Source/WebGPU/WGSL/Token.h
@@ -83,12 +83,14 @@ enum class TokenType: uint32_t {
     LT,
     Minus,
     MinusMinus,
+    Modulo,
     Plus,
     PlusPlus,
     Period,
     ParenLeft,
     ParenRight,
     Semicolon,
+    Slash,
     Star,
     // FIXME: add all the other special tokens
 };

--- a/Source/WebGPU/WGSL/WGSL.h
+++ b/Source/WebGPU/WGSL/WGSL.h
@@ -64,7 +64,7 @@ struct SourceMap {
 };
 
 struct Configuration {
-    uint32_t maxBuffersPlusVertexBuffersForVertexStage;
+    uint32_t maxBuffersPlusVertexBuffersForVertexStage = 8;
 };
 
 std::variant<SuccessfulCheck, FailedCheck> staticCheck(const String& wgsl, const std::optional<SourceMap>&, const Configuration&);

--- a/Source/WebGPU/WGSL/WGSLShaderModule.h
+++ b/Source/WebGPU/WGSL/WGSLShaderModule.h
@@ -39,11 +39,14 @@ namespace WGSL {
 class ShaderModule {
     WTF_MAKE_FAST_ALLOCATED;
 public:
+    explicit ShaderModule(const String& source)
+        : ShaderModule(source, { })
+    { }
+    
     ShaderModule(const String& source, const Configuration& configuration)
         : m_source(source)
         , m_configuration(configuration)
-    {
-    }
+    { }
 
     const String& source() const { return m_source; }
     const Configuration& configuration() const { return m_configuration; }

--- a/Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp
@@ -138,10 +138,13 @@ TEST(WGSLLexerTests, SpecialTokens)
     checkSingleToken("<"_s, TokenType::LT);
     checkSingleToken("-"_s, TokenType::Minus);
     checkSingleToken("--"_s, TokenType::MinusMinus);
+    checkSingleToken("%"_s, TokenType::Modulo);
     checkSingleToken("."_s, TokenType::Period);
     checkSingleToken("("_s, TokenType::ParenLeft);
     checkSingleToken(")"_s, TokenType::ParenRight);
     checkSingleToken(";"_s, TokenType::Semicolon);
+    checkSingleToken("/"_s, TokenType::Slash);
+    checkSingleToken("*"_s, TokenType::Star);
 }
 
 TEST(WGSLLexerTests, ComputeShader)

--- a/Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp
@@ -27,6 +27,7 @@
 #include "ASTAttribute.h"
 #include "ASTTypeName.h"
 #include "Parser.h"
+#include "ParserPrivate.h"
 
 #include "AST.h"
 #include "Lexer.h"
@@ -495,6 +496,105 @@ TEST(WGSLParserTests, BinaryExpression)
         EXPECT_EQ(rhs.identifier(), "y"_s);
     }
 }
+
+TEST(WGSLParserTests, BinaryExpression2)
+{
+    EXPECT_EXPRESSION(expression, R"(x - y + 1)"_s);
+    EXPECT_TRUE(is<WGSL::AST::BinaryExpression>(expression));
+    auto& binaryExpression = downcast<WGSL::AST::BinaryExpression>(expression.get());
+
+    {
+        // op: +
+        EXPECT_EQ(binaryExpression.operation(), WGSL::AST::BinaryOperation::Add);
+        // lhs: x - y
+        EXPECT_TRUE(is<WGSL::AST::BinaryExpression>(binaryExpression.leftExpression()));
+        // rhs: 1
+        EXPECT_TRUE(is<WGSL::AST::AbstractIntegerLiteral>(binaryExpression.rightExpression()));
+        checkIntLiteral(binaryExpression.rightExpression(), 1);
+    }
+
+    {
+        EXPECT_TRUE(is<WGSL::AST::BinaryExpression>(binaryExpression.leftExpression()));
+        auto& binaryExpression2 = downcast<WGSL::AST::BinaryExpression>(binaryExpression.leftExpression());
+        // op: -
+        EXPECT_EQ(binaryExpression2.operation(), WGSL::AST::BinaryOperation::Subtract);
+        // lhs: x
+        EXPECT_TRUE(is<WGSL::AST::IdentifierExpression>(binaryExpression2.leftExpression()));
+        auto& lhs = downcast<WGSL::AST::IdentifierExpression>(binaryExpression2.leftExpression());
+        EXPECT_EQ(lhs.identifier(), "x"_s);
+        // rhs: y
+        EXPECT_TRUE(is<WGSL::AST::IdentifierExpression>(binaryExpression2.rightExpression()));
+        auto& rhs = downcast<WGSL::AST::IdentifierExpression>(binaryExpression2.rightExpression());
+        EXPECT_EQ(rhs.identifier(), "y"_s);
+    }
+}
+
+TEST(WGSLParserTests, BinaryExpression3)
+{
+    EXPECT_EXPRESSION(expression, R"(x + y * z)"_s);
+    EXPECT_TRUE(is<WGSL::AST::BinaryExpression>(expression));
+    auto& binaryExpression = downcast<WGSL::AST::BinaryExpression>(expression.get());
+
+    {
+        // op: +
+        EXPECT_EQ(binaryExpression.operation(), WGSL::AST::BinaryOperation::Add);
+        // lhs: x
+        EXPECT_TRUE(is<WGSL::AST::IdentifierExpression>(binaryExpression.leftExpression()));
+        auto& lhs = downcast<WGSL::AST::IdentifierExpression>(binaryExpression.leftExpression());
+        EXPECT_EQ(lhs.identifier(), "x"_s);
+        // rhs: y * z
+        EXPECT_TRUE(is<WGSL::AST::BinaryExpression>(binaryExpression.rightExpression()));
+    }
+
+    {
+        EXPECT_TRUE(is<WGSL::AST::BinaryExpression>(binaryExpression.rightExpression()));
+        auto& binaryExpression2 = downcast<WGSL::AST::BinaryExpression>(binaryExpression.rightExpression());
+        // op: *
+        EXPECT_EQ(binaryExpression2.operation(), WGSL::AST::BinaryOperation::Multiply);
+        // lhs: y
+        EXPECT_TRUE(is<WGSL::AST::IdentifierExpression>(binaryExpression2.leftExpression()));
+        auto& lhs = downcast<WGSL::AST::IdentifierExpression>(binaryExpression2.leftExpression());
+        EXPECT_EQ(lhs.identifier(), "y"_s);
+        // rhs: z
+        EXPECT_TRUE(is<WGSL::AST::IdentifierExpression>(binaryExpression2.rightExpression()));
+        auto& rhs = downcast<WGSL::AST::IdentifierExpression>(binaryExpression2.rightExpression());
+        EXPECT_EQ(rhs.identifier(), "z"_s);
+    }
+}
+
+TEST(WGSLParserTests, BinaryExpression4)
+{
+    EXPECT_EXPRESSION(expression, R"(x / y + z)"_s);
+    EXPECT_TRUE(is<WGSL::AST::BinaryExpression>(expression));
+    auto& binaryExpression = downcast<WGSL::AST::BinaryExpression>(expression.get());
+
+    {
+        // op: +
+        EXPECT_EQ(binaryExpression.operation(), WGSL::AST::BinaryOperation::Add);
+        // lhs: x * y
+        EXPECT_TRUE(is<WGSL::AST::BinaryExpression>(binaryExpression.leftExpression()));
+        // rhs: z
+        EXPECT_TRUE(is<WGSL::AST::IdentifierExpression>(binaryExpression.rightExpression()));
+        auto& rhs = downcast<WGSL::AST::IdentifierExpression>(binaryExpression.rightExpression());
+        EXPECT_EQ(rhs.identifier(), "z"_s);
+    }
+
+    {
+        EXPECT_TRUE(is<WGSL::AST::BinaryExpression>(binaryExpression.leftExpression()));
+        auto& binaryExpression2 = downcast<WGSL::AST::BinaryExpression>(binaryExpression.leftExpression());
+        // op: /
+        EXPECT_EQ(binaryExpression2.operation(), WGSL::AST::BinaryOperation::Divide);
+        // lhs: x
+        EXPECT_TRUE(is<WGSL::AST::IdentifierExpression>(binaryExpression2.leftExpression()));
+        auto& lhs = downcast<WGSL::AST::IdentifierExpression>(binaryExpression2.leftExpression());
+        EXPECT_EQ(lhs.identifier(), "x"_s);
+        // rhs: y
+        EXPECT_TRUE(is<WGSL::AST::IdentifierExpression>(binaryExpression2.rightExpression()));
+        auto& rhs = downcast<WGSL::AST::IdentifierExpression>(binaryExpression2.rightExpression());
+        EXPECT_EQ(rhs.identifier(), "y"_s);
+    }
+}
+
 #pragma mark -
 #pragma mark WebGPU Example Shaders
 

--- a/Tools/TestWebKitAPI/Tests/WGSL/TestWGSLAPI.h
+++ b/Tools/TestWebKitAPI/Tests/WGSL/TestWGSLAPI.h
@@ -33,6 +33,14 @@
         } \
     } while (false)
 
+#define EXPECT_EXPRESSION(name, source) \
+    auto name##Expected = WGSL::parseExpression(source); \
+    if (!name##Expected) { \
+        ::TestWGSLAPI::logCompilationError(name##Expected.error()); \
+        return; \
+    } \
+    auto& name = *name##Expected;
+
 namespace WGSL {
 class CompilationMessage;
 }


### PR DESCRIPTION
#### 42ed4169750a07eb3722672485888398f9048e68
<pre>
[WGSL] Implement additive &amp; multiplicative expression parsing
<a href="https://bugs.webkit.org/show_bug.cgi?id=251573">https://bugs.webkit.org/show_bug.cgi?id=251573</a>
rdar://problem/104951203

Reviewed by Tadeu Zagallo.

Relanding with linking fix by moving parseExpression implement to WebGPU
module. Originally review in <a href="https://github.com/WebKit/WebKit/pull/9506">https://github.com/WebKit/WebKit/pull/9506</a>

Implement parsing of expressions involving +, -, *, / and % with correct
precedence by handling -, / and % operators.

Canonical link: <a href="https://commits.webkit.org/260159@main">https://commits.webkit.org/260159@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5bde21d3cbd6ec1d62ef5d6237c5f6e9b280dac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107280 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16337 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40149 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116437 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115887 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111179 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17764 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7576 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99433 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113045 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13404 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96550 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41017 "Found 1 new test failure: fast/scrolling/gtk/user-scroll-snapping-interaction.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95306 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/28185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82787 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9373 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29529 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10014 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6459 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15528 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49109 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7027 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11565 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->