### PR TITLE
Web Inspector: Add initial support for color-mix CSS values

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Models/Color.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Color.js
@@ -909,6 +909,7 @@ WI.Color.FunctionNames = new Set([
     "hsl",
     "hsla",
     "color",
+    "color-mix",
 ]);
 
 WI.Color.Keywords = {


### PR DESCRIPTION
#### f6173b46292f4fda92346060b35d6a78bf7eb650
<pre>
Web Inspector: Add initial support for color-mix CSS values
<a href="https://bugs.webkit.org/show_bug.cgi?id=252031">https://bugs.webkit.org/show_bug.cgi?id=252031</a>
rdar://105254118

Reviewed by Tim Nguyen.

Correct the display of `color-mix` to not truncate itself when not being edited, and to correctly show nested color
swatches within itself. This is achieved by sending tokens within a function&apos;s parentheses back through _addColorTokens
so that they in turn can be parsed for functions and color keywords. We also now enforce that a function keyword is
followed by a parenthesis to form a function, since some keywords like `rgb` and `hsl` are now also used to denote the
color space in which mixing should occur.

* Source/WebInspectorUI/UserInterface/Models/Color.js:
* Source/WebInspectorUI/UserInterface/Views/SpreadsheetStyleProperty.js:
(WI.SpreadsheetStyleProperty.prototype._addColorTokens):

Canonical link: <a href="https://commits.webkit.org/260332@main">https://commits.webkit.org/260332@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23823af9a284afaf5624b0260ab6d718d60ab963

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107283 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16340 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40296 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116440 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115890 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17767 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7579 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99454 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113048 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13402 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96669 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41035 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95304 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28295 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82806 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9376 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29648 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10017 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6461 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15531 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49229 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7155 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11568 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->