### PR TITLE
Make more JavaScriptCore allocations use heap identifiers

### DIFF
--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -2574,6 +2574,7 @@
 		0F0B83AA14BCF5B900885B4F /* ExpressionRangeInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ExpressionRangeInfo.h; sourceTree = "<group>"; };
 		0F0B83AE14BCF71400885B4F /* CallLinkInfo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CallLinkInfo.cpp; sourceTree = "<group>"; };
 		0F0B83AF14BCF71400885B4F /* CallLinkInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CallLinkInfo.h; sourceTree = "<group>"; };
+		0F0C03A92995FB710064230A /* HasOwnPropertyCache.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = HasOwnPropertyCache.cpp; sourceTree = "<group>"; };
 		0F0CAEF91EC4DA6200970D12 /* JSHeapFinalizerPrivate.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSHeapFinalizerPrivate.cpp; sourceTree = "<group>"; };
 		0F0CAEFA1EC4DA6200970D12 /* JSHeapFinalizerPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSHeapFinalizerPrivate.h; sourceTree = "<group>"; };
 		0F0CAEFD1EC4DA8500970D12 /* HeapFinalizerCallback.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = HeapFinalizerCallback.cpp; sourceTree = "<group>"; };
@@ -2814,6 +2815,7 @@
 		0F37308E1C0CD68500052BFA /* DisallowMacroScratchRegisterUsage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DisallowMacroScratchRegisterUsage.h; sourceTree = "<group>"; };
 		0F3730901C0CD70C00052BFA /* AllowMacroScratchRegisterUsage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AllowMacroScratchRegisterUsage.h; sourceTree = "<group>"; };
 		0F3730921C0D67EE00052BFA /* AirUseCounts.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AirUseCounts.h; path = b3/air/AirUseCounts.h; sourceTree = "<group>"; };
+		0F376F3E2994BD55004CA2F9 /* JITCodeMap.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JITCodeMap.cpp; sourceTree = "<group>"; };
 		0F38B00F17CF077F00B144D3 /* LLIntEntrypoint.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LLIntEntrypoint.cpp; path = llint/LLIntEntrypoint.cpp; sourceTree = "<group>"; };
 		0F38B01017CF077F00B144D3 /* LLIntEntrypoint.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = LLIntEntrypoint.h; path = llint/LLIntEntrypoint.h; sourceTree = "<group>"; };
 		0F38D2A01D44196600680499 /* AuxiliaryBarrier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AuxiliaryBarrier.h; sourceTree = "<group>"; };
@@ -6681,6 +6683,7 @@
 				86CC85A20EE79B7400288682 /* JITCall.cpp */,
 				0F8F94431667635200D61971 /* JITCode.cpp */,
 				86CCEFDD0F413F8900FD7F9E /* JITCode.h */,
+				0F376F3E2994BD55004CA2F9 /* JITCodeMap.cpp */,
 				FE476FF3207E85D40093CA2D /* JITCodeMap.h */,
 				86D446E825B2124800ECAE75 /* JITCompilation.cpp */,
 				86D446E725B2124800ECAE75 /* JITCompilation.h */,
@@ -7900,6 +7903,7 @@
 				79A0907D1D768465008B889B /* HashMapImpl.cpp */,
 				79A0907E1D768465008B889B /* HashMapImpl.h */,
 				FEF5B4222628A0EE0016E776 /* HashMapImplInlines.h */,
+				0F0C03A92995FB710064230A /* HasOwnPropertyCache.cpp */,
 				79DFCBDA1D88C59600527D03 /* HasOwnPropertyCache.h */,
 				933A349D038AE80F008635CE /* Identifier.cpp */,
 				933A349A038AE7C6008635CE /* Identifier.h */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -665,6 +665,7 @@ jit/JITBitOrGenerator.cpp
 jit/JITBitXorGenerator.cpp
 jit/JITCall.cpp
 jit/JITCode.cpp
+jit/JITCodeMap.cpp
 jit/JITCompilation.cpp
 jit/JITCompilationKey.cpp
 jit/JITCompilationMode.cpp
@@ -834,6 +835,7 @@ runtime/GetPutInfo.cpp
 runtime/GetterSetter.cpp
 runtime/GlobalExecutable.cpp
 runtime/HashMapImpl.cpp
+runtime/HasOwnPropertyCache.cpp
 runtime/Identifier.cpp
 runtime/ImportMap.cpp
 runtime/IndexingType.cpp

--- a/Source/JavaScriptCore/bytecode/GetByStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/GetByStatus.cpp
@@ -40,6 +40,8 @@
 
 namespace JSC {
 
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(GetByStatus);
+
 bool GetByStatus::appendVariant(const GetByVariant& variant)
 {
     return appendICStatusVariant(m_variants, variant);

--- a/Source/JavaScriptCore/bytecode/GetByStatus.h
+++ b/Source/JavaScriptCore/bytecode/GetByStatus.h
@@ -44,8 +44,10 @@ class JSModuleNamespaceObject;
 class ModuleNamespaceAccessCase;
 class StructureStubInfo;
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(GetByStatus);
+
 class GetByStatus final {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(GetByStatus);
 public:
     enum State : uint8_t {
         // It's uncached so we have no information.

--- a/Source/JavaScriptCore/bytecode/PutByStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/PutByStatus.cpp
@@ -39,6 +39,8 @@
 
 namespace JSC {
 
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(PutByStatus);
+
 bool PutByStatus::appendVariant(const PutByVariant& variant)
 {
     return appendICStatusVariant(m_variants, variant);

--- a/Source/JavaScriptCore/bytecode/PutByStatus.h
+++ b/Source/JavaScriptCore/bytecode/PutByStatus.h
@@ -43,8 +43,10 @@ class StructureStubInfo;
 
 typedef HashMap<CodeOrigin, StructureStubInfo*, CodeOriginApproximateHash> StubInfoMap;
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(PutByStatus);
+
 class PutByStatus final {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(PutByStatus);
 public:
     enum State {
         // It's uncached so we have no information.

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.cpp
@@ -39,6 +39,8 @@
 
 namespace JSC {
 
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(UnlinkedCodeBlock_RareData);
+
 const ClassInfo UnlinkedCodeBlock::s_info = { "UnlinkedCodeBlock"_s, nullptr, nullptr, nullptr, CREATE_METHOD_TABLE(UnlinkedCodeBlock) };
 
 UnlinkedCodeBlock::UnlinkedCodeBlock(VM& vm, Structure* structure, CodeType codeType, const ExecutableInfo& info, OptionSet<CodeGenerationMode> codeGenerationMode)

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h
@@ -76,6 +76,8 @@ class CachedCodeBlock;
 typedef unsigned UnlinkedArrayAllocationProfile;
 typedef unsigned UnlinkedObjectAllocationProfile;
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(UnlinkedCodeBlock_RareData);
+
 struct UnlinkedStringJumpTable {
     struct OffsetLocation {
         int32_t m_branchOffset;
@@ -455,7 +457,7 @@ private:
 
 public:
     struct RareData {
-        WTF_MAKE_STRUCT_FAST_ALLOCATED;
+        WTF_MAKE_STRUCT_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(UnlinkedCodeBlock_RareData);
 
         size_t sizeInBytes(const AbstractLocker&) const;
 

--- a/Source/JavaScriptCore/bytecode/UnlinkedMetadataTable.cpp
+++ b/Source/JavaScriptCore/bytecode/UnlinkedMetadataTable.cpp
@@ -31,6 +31,7 @@
 namespace JSC {
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(MetadataTable);
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(UnlinkedMetadataTable);
 
 #if CPU(ADDRESS64)
 static_assert((UnlinkedMetadataTable::s_maxMetadataAlignment >=

--- a/Source/JavaScriptCore/bytecode/UnlinkedMetadataTable.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedMetadataTable.h
@@ -34,6 +34,7 @@ namespace JSC {
 class VM;
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(MetadataTable);
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(UnlinkedMetadataTable);
 
 class MetadataTable;
 
@@ -52,6 +53,7 @@ struct MetadataStatistics {
 
 
 class UnlinkedMetadataTable : public RefCounted<UnlinkedMetadataTable> {
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(UnlinkedMetadataTable);
     friend class LLIntOffsetsExtractor;
     friend class MetadataTable;
     friend class CachedMetadataTable;

--- a/Source/JavaScriptCore/heap/GigacageAlignedMemoryAllocator.cpp
+++ b/Source/JavaScriptCore/heap/GigacageAlignedMemoryAllocator.cpp
@@ -31,7 +31,7 @@ namespace JSC {
 GigacageAlignedMemoryAllocator::GigacageAlignedMemoryAllocator(Gigacage::Kind kind)
     : m_kind(kind)
 #if ENABLE(MALLOC_HEAP_BREAKDOWN)
-    , m_heap(makeString("WebKit GigacageAlignedMemoryAllocator ", Gigacage::name(m_kind)).utf8().data())
+    , m_heap(makeString("GigacageAlignedMemoryAllocator ", Gigacage::name(m_kind)).utf8().data())
 #endif
 {
 }

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -269,7 +269,7 @@ private:
     , name ISO_SUBSPACE_INIT(*this, heapCellType, type)
 
 #define INIT_SERVER_STRUCTURE_ISO_SUBSPACE(name, heapCellType, type) \
-    , name("Isolated" #name "Space", *this, heapCellType, WTF::roundUpToMultipleOf<type::atomSize>(sizeof(type)), type::numberOfLowerTierCells, makeUnique<StructureAlignedMemoryAllocator>("Structure"))
+    , name("IsoSubspace" #name, *this, heapCellType, WTF::roundUpToMultipleOf<type::atomSize>(sizeof(type)), type::numberOfLowerTierCells, makeUnique<StructureAlignedMemoryAllocator>("Structure"))
 
 Heap::Heap(VM& vm, HeapType heapType)
     : m_heapType(heapType)

--- a/Source/JavaScriptCore/heap/IsoAlignedMemoryAllocator.cpp
+++ b/Source/JavaScriptCore/heap/IsoAlignedMemoryAllocator.cpp
@@ -31,6 +31,9 @@ namespace JSC {
 
 IsoAlignedMemoryAllocator::IsoAlignedMemoryAllocator(CString name)
     : Base(name)
+#if ENABLE(MALLOC_HEAP_BREAKDOWN)
+    , m_heap(makeString("IsoAlignedAllocator ", name.data()).utf8().data())
+#endif
 {
 }
 
@@ -46,12 +49,20 @@ void IsoAlignedMemoryAllocator::dump(PrintStream& out) const
 
 void* IsoAlignedMemoryAllocator::tryAllocateMemory(size_t size)
 {
+#if ENABLE(MALLOC_HEAP_BREAKDOWN)
+    return m_heap.malloc(size);
+#else
     return FastMalloc::tryMalloc(size);
+#endif
 }
 
 void IsoAlignedMemoryAllocator::freeMemory(void* pointer)
 {
+#if ENABLE(MALLOC_HEAP_BREAKDOWN)
+    return m_heap.free(pointer);
+#else
     FastMalloc::free(pointer);
+#endif
 }
 
 void* IsoAlignedMemoryAllocator::tryReallocateMemory(void*, size_t)
@@ -62,12 +73,20 @@ void* IsoAlignedMemoryAllocator::tryReallocateMemory(void*, size_t)
 
 void* IsoAlignedMemoryAllocator::tryMallocBlock()
 {
+#if ENABLE(MALLOC_HEAP_BREAKDOWN)
+    return m_heap.memalign(MarkedBlock::blockSize, MarkedBlock::blockSize, true);
+#else
     return tryFastAlignedMalloc(MarkedBlock::blockSize, MarkedBlock::blockSize);
+#endif
 }
 
 void IsoAlignedMemoryAllocator::freeBlock(void* block)
 {
+#if ENABLE(MALLOC_HEAP_BREAKDOWN)
+    m_heap.free(block);
+#else
     fastAlignedFree(block);
+#endif
 }
 
 void IsoAlignedMemoryAllocator::commitBlock(void* block)

--- a/Source/JavaScriptCore/heap/IsoSubspace.h
+++ b/Source/JavaScriptCore/heap/IsoSubspace.h
@@ -98,7 +98,7 @@ ALWAYS_INLINE Allocator IsoSubspace::allocatorFor(size_t size, AllocatorForMode)
 
 } // namespace GCClient
 
-#define ISO_SUBSPACE_INIT(heap, heapCellType, type) ("Isolated " #type " Space", (heap), (heapCellType), sizeof(type), type::numberOfLowerTierCells)
+#define ISO_SUBSPACE_INIT(heap, heapCellType, type) ("IsoSpace " #type, (heap), (heapCellType), sizeof(type), type::numberOfLowerTierCells)
 
 template<typename T>
 struct isAllocatedFromIsoSubspace {

--- a/Source/JavaScriptCore/heap/IsoSubspacePerVM.h
+++ b/Source/JavaScriptCore/heap/IsoSubspacePerVM.h
@@ -84,7 +84,7 @@ private:
     Function<SubspaceParameters(Heap&)> m_subspaceParameters;
 };
 
-#define ISO_SUBSPACE_PARAMETERS(heapCellType, type) ::JSC::IsoSubspacePerVM::SubspaceParameters("Isolated " #type " Space", (heapCellType), sizeof(type))
+#define ISO_SUBSPACE_PARAMETERS(heapCellType, type) ::JSC::IsoSubspacePerVM::SubspaceParameters("IsoSpace " #type, (heapCellType), sizeof(type))
 
 } // namespace JSC
 

--- a/Source/JavaScriptCore/jit/JITCodeMap.cpp
+++ b/Source/JavaScriptCore/jit/JITCodeMap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,42 +23,15 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
-#pragma once
+#include "config.h"
 
-#include "IsoMemoryAllocatorBase.h"
-#include <wtf/BitVector.h>
-#include <wtf/HashMap.h>
-#include <wtf/Vector.h>
-
-#if ENABLE(MALLOC_HEAP_BREAKDOWN)
-#include <wtf/DebugHeap.h>
-#endif
+#if ENABLE(JIT)
+#include "JITCodeMap.h"
 
 namespace JSC {
 
-class IsoAlignedMemoryAllocator final : public IsoMemoryAllocatorBase {
-public:
-    using Base = IsoMemoryAllocatorBase;
-
-    IsoAlignedMemoryAllocator(CString);
-    ~IsoAlignedMemoryAllocator() final;
-
-    void dump(PrintStream&) const final;
-
-    void* tryAllocateMemory(size_t) final;
-    void freeMemory(void*) final;
-    void* tryReallocateMemory(void*, size_t) final;
-
-protected:
-    void* tryMallocBlock() final;
-    void freeBlock(void* block) final;
-    void commitBlock(void* block) final;
-    void decommitBlock(void* block) final;
-
-#if ENABLE(MALLOC_HEAP_BREAKDOWN)
-    WTF::DebugHeap m_heap;
-#endif
-};
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(JITCodeMap);
 
 } // namespace JSC
 
+#endif // ENABLE(JIT)

--- a/Source/JavaScriptCore/jit/JITCodeMap.h
+++ b/Source/JavaScriptCore/jit/JITCodeMap.h
@@ -33,6 +33,8 @@
 
 namespace JSC {
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(JITCodeMap);
+
 class JITCodeMap {
 public:
     static_assert(std::is_trivially_destructible_v<BytecodeIndex>);
@@ -43,7 +45,7 @@ public:
         : m_size(indexes.size())
     {
         ASSERT(indexes.size() == codeLocations.size());
-        m_pointer = MallocPtr<uint8_t>::malloc(sizeof(CodeLocationLabel<JSEntryPtrTag>) * m_size + sizeof(BytecodeIndex) * m_size);
+        m_pointer = MallocPtr<uint8_t, JITCodeMapMalloc>::malloc(sizeof(CodeLocationLabel<JSEntryPtrTag>) * m_size + sizeof(BytecodeIndex) * m_size);
         std::copy(codeLocations.begin(), codeLocations.end(), this->codeLocations());
         std::copy(indexes.begin(), indexes.end(), this->indexes());
     }
@@ -69,7 +71,7 @@ private:
         return bitwise_cast<BytecodeIndex*>(m_pointer.get() + sizeof(CodeLocationLabel<JSEntryPtrTag>) * m_size);
     }
 
-    MallocPtr<uint8_t> m_pointer;
+    MallocPtr<uint8_t, JITCodeMapMalloc> m_pointer;
     unsigned m_size { 0 };
 };
 

--- a/Source/JavaScriptCore/runtime/HasOwnPropertyCache.cpp
+++ b/Source/JavaScriptCore/runtime/HasOwnPropertyCache.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,42 +23,11 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
-#pragma once
-
-#include "IsoMemoryAllocatorBase.h"
-#include <wtf/BitVector.h>
-#include <wtf/HashMap.h>
-#include <wtf/Vector.h>
-
-#if ENABLE(MALLOC_HEAP_BREAKDOWN)
-#include <wtf/DebugHeap.h>
-#endif
+#include "config.h"
+#include "HasOwnPropertyCache.h"
 
 namespace JSC {
 
-class IsoAlignedMemoryAllocator final : public IsoMemoryAllocatorBase {
-public:
-    using Base = IsoMemoryAllocatorBase;
-
-    IsoAlignedMemoryAllocator(CString);
-    ~IsoAlignedMemoryAllocator() final;
-
-    void dump(PrintStream&) const final;
-
-    void* tryAllocateMemory(size_t) final;
-    void freeMemory(void*) final;
-    void* tryReallocateMemory(void*, size_t) final;
-
-protected:
-    void* tryMallocBlock() final;
-    void freeBlock(void* block) final;
-    void commitBlock(void* block) final;
-    void decommitBlock(void* block) final;
-
-#if ENABLE(MALLOC_HEAP_BREAKDOWN)
-    WTF::DebugHeap m_heap;
-#endif
-};
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HasOwnPropertyCache);
 
 } // namespace JSC
-

--- a/Source/JavaScriptCore/runtime/HasOwnPropertyCache.h
+++ b/Source/JavaScriptCore/runtime/HasOwnPropertyCache.h
@@ -31,6 +31,8 @@
 
 namespace JSC {
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HasOwnPropertyCache);
+
 class HasOwnPropertyCache {
     static const uint32_t size = 2 * 1024;
     static_assert(hasOneBitSet(size), "size should be a power of two.");
@@ -52,13 +54,13 @@ public:
     void operator delete(void* cache)
     {
         static_cast<HasOwnPropertyCache*>(cache)->clear();
-        fastFree(cache);
+        HasOwnPropertyCacheMalloc::free(cache);
     }
 
     static HasOwnPropertyCache* create()
     {
         size_t allocationSize = sizeof(Entry) * size;
-        HasOwnPropertyCache* result = static_cast<HasOwnPropertyCache*>(fastMalloc(allocationSize));
+        HasOwnPropertyCache* result = static_cast<HasOwnPropertyCache*>(HasOwnPropertyCacheMalloc::malloc(allocationSize));
         result->clearBuffer();
         return result;
     }

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -289,6 +289,7 @@ enum VMIdentifierType { };
 using VMIdentifier = ObjectIdentifier<VMIdentifierType>;
 
 class VM : public ThreadSafeRefCounted<VM>, public DoublyLinkedListNode<VM> {
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(VM);
 public:
     // WebCore has a one-to-one mapping of threads to VMs;
     // create() should only be called once


### PR DESCRIPTION
#### 4075b8460d2c901a010f317dfde6a1d20e3f32b4
<pre>
Make more JavaScriptCore allocations use heap identifiers
<a href="https://bugs.webkit.org/show_bug.cgi?id=252104">https://bugs.webkit.org/show_bug.cgi?id=252104</a>
rdar://105315215

Reviewed by Yusuke Suzuki.

When BENABLE_MALLOC_HEAP_BREAKDOWN and ENABLE_MALLOC_HEAP_BREAKDOWN are defined, we use multiple debug heaps
with identifiers to make it easier to determine what is using memory when using system memory tools.

Break down more of the &quot;WebKit Using System Malloc&quot; heap by assigning heap identifiers to more allocations
in JavaScriptCore. These were motivated by tracking the largest uncategorized live allocations, via
TRACK_MALLOC_CALLSTACK.

WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER() is added for GetByStatus, PutByStatus, UnlinkedCodeBlock_RareData,
UnlinkedMetadataTable, JITCodeMap, HasOwnPropertyCache and VM.

IsoAlignedMemoryAllocator gets its own DebugHeap just like GigacageAlignedMemoryAllocator.

* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/bytecode/GetByStatus.cpp:
* Source/JavaScriptCore/bytecode/GetByStatus.h:
* Source/JavaScriptCore/bytecode/PutByStatus.cpp:
* Source/JavaScriptCore/bytecode/PutByStatus.h:
* Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.cpp:
* Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h:
* Source/JavaScriptCore/bytecode/UnlinkedMetadataTable.cpp:
* Source/JavaScriptCore/bytecode/UnlinkedMetadataTable.h:
* Source/JavaScriptCore/heap/GigacageAlignedMemoryAllocator.cpp:
(JSC::GigacageAlignedMemoryAllocator::GigacageAlignedMemoryAllocator): Shorten the name to make output more readable.
* Source/JavaScriptCore/heap/Heap.cpp:
* Source/JavaScriptCore/heap/IsoAlignedMemoryAllocator.cpp:
(JSC::IsoAlignedMemoryAllocator::IsoAlignedMemoryAllocator):
(JSC::IsoAlignedMemoryAllocator::tryAllocateMemory):
(JSC::IsoAlignedMemoryAllocator::freeMemory):
(JSC::IsoAlignedMemoryAllocator::tryMallocBlock):
(JSC::IsoAlignedMemoryAllocator::freeBlock):
* Source/JavaScriptCore/heap/IsoAlignedMemoryAllocator.h:
* Source/JavaScriptCore/heap/IsoSubspace.h: Shorten the name to make output more readable.
* Source/JavaScriptCore/heap/IsoSubspacePerVM.h: Ditto.
* Source/JavaScriptCore/jit/JITCodeMap.cpp: Copied from Source/JavaScriptCore/heap/IsoAlignedMemoryAllocator.h.
* Source/JavaScriptCore/jit/JITCodeMap.h:
(JSC::JITCodeMap::JITCodeMap):
* Source/JavaScriptCore/runtime/HasOwnPropertyCache.cpp: Copied from Source/JavaScriptCore/heap/IsoAlignedMemoryAllocator.h.
* Source/JavaScriptCore/runtime/HasOwnPropertyCache.h:
(JSC::HasOwnPropertyCache::operator delete):
(JSC::HasOwnPropertyCache::create):
* Source/JavaScriptCore/runtime/VM.h:

Canonical link: <a href="https://commits.webkit.org/260257@main">https://commits.webkit.org/260257@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60c2e69b8c909a0428e552f592940c7a237c817d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107300 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16357 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40277 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116456 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115902 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17782 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7594 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99453 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113065 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13424 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96651 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41034 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95325 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28277 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82805 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/96674 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9389 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29630 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/96105 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/7382 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10032 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6473 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30766 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15543 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49211 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/104936 "Built successfully") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7090 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11585 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26004 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->