### PR TITLE
Avoid the unnecessary setting of min-width 0 on RenderButton & RenderMenuList

### DIFF
--- a/Source/WebCore/rendering/RenderButton.cpp
+++ b/Source/WebCore/rendering/RenderButton.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2005-2022 Apple Inc.
+ * Copyright (C) 2005-2023 Apple Inc.
  * Copyright (C) 2015 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -74,8 +74,6 @@ void RenderButton::setInnerRenderer(RenderBlock& innerRenderer)
 void RenderButton::updateAnonymousChildStyle(RenderStyle& childStyle) const
 {
     childStyle.setFlexGrow(1.0f);
-    // min-width: 0; is needed for correct shrinking.
-    childStyle.setMinWidth(Length(0, LengthType::Fixed));
     // Use margin:auto instead of align-items:center to get safe centering, i.e.
     // when the content overflows, treat it the same as align-items: flex-start.
     childStyle.setMarginTop(Length());

--- a/Source/WebCore/rendering/RenderMenuList.cpp
+++ b/Source/WebCore/rendering/RenderMenuList.cpp
@@ -2,7 +2,7 @@
  * This file is part of the select element renderer in WebCore.
  *
  * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies).
- * Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011, 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2023 Apple Inc. All rights reserved.
  *               2009 Torch Mobile Inc. All rights reserved. (http://www.torchmobile.com/)
  *
  * This library is free software; you can redistribute it and/or
@@ -115,8 +115,6 @@ void RenderMenuList::adjustInnerStyle()
     auto& innerStyle = m_innerBlock->mutableStyle();
     innerStyle.setFlexGrow(1);
     innerStyle.setFlexShrink(1);
-    // min-width: 0; is needed for correct shrinking.
-    innerStyle.setMinWidth(Length(0, LengthType::Fixed));
     // Use margin:auto instead of align-items:center to get safe centering, i.e.
     // when the content overflows, treat it the same as align-items: flex-start.
     // But we only do that for the cases where html.css would otherwise use center.


### PR DESCRIPTION
<pre>
Avoid the unnecessary setting of min-width 0 on RenderButton & RenderMenuList
<a href="https://bugs.webkit.org/show_bug.cgi?id=252046">https://bugs.webkit.org/show_bug.cgi?id=252046</a>

Reviewed by NOBODY (OOPS!).

This patch is to remove redundant calls to apply min-width for shrinking since bug 111790 is now fixed.

* Source/WebCore/rendering/RenderButton.cpp: (RenderButton::setInnerRenderer): Remove 'min-width' shrink
* Source/WebCore/rendering/RenderMenuList.cpp:
(RenderButton::adjustInnerStyle): Remove 'min-width' shrink
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d7b7857b53fa3bc3805ead4f3d47f3fc1317db7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107308 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16365 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40252 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116464 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115909 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111207 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17790 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7602 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99463 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113073 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13425 "Found 6 new test failures: fast/css/text-transform-select.html, fast/forms/control-clip-overflow.html, fast/forms/menulist-narrow-width.html, fast/forms/menulist-option-wrap.html, fast/forms/option-text-clip.html, fast/replaced/width100percent-menulist.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96631 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41039 "Found 8 new test failures: fast/forms/basic-buttons.html, fast/forms/control-clip-overflow.html, fast/forms/menulist-narrow-width.html, fast/forms/menulist-option-wrap.html, fast/forms/option-text-clip.html, fast/replaced/width100percent-menulist.html, fast/text/international/bidi-menulist.html, imported/blink/fast/css/text-overflow-ellipsis-button.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95327 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28258 "Found 7 new test failures: fast/forms/basic-buttons.html, fast/forms/control-clip-overflow.html, fast/forms/menulist-narrow-width.html, fast/forms/menulist-option-wrap.html, fast/forms/option-text-clip.html, fast/replaced/width100percent-menulist.html, imported/blink/fast/css/text-overflow-ellipsis-button.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82817 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9397 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29610 "Found 7 new test failures: fast/forms/basic-buttons.html, fast/forms/control-clip-overflow.html, fast/forms/menulist-narrow-width.html, fast/forms/menulist-option-wrap.html, fast/forms/option-text-clip.html, fast/replaced/width100percent-menulist.html, imported/blink/fast/css/text-overflow-ellipsis-button.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10040 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6480 "Found 7 new test failures: fast/forms/basic-buttons.html, fast/forms/control-clip-overflow.html, fast/forms/menulist-narrow-width.html, fast/forms/menulist-option-wrap.html, fast/forms/option-text-clip.html, fast/replaced/width100percent-menulist.html, imported/blink/fast/css/text-overflow-ellipsis-button.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15550 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49191 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11593 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->