### PR TITLE
[WGSL] Move WGSL types into their own namespace

### DIFF
--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -101,7 +101,7 @@ private:
 
     // FIXME: move this into a class that contains the AST
     TypeStore m_types;
-    WTF::Vector<Error> m_errors;
+    Vector<Error> m_errors;
 };
 
 TypeChecker::TypeChecker(ShaderModule& shaderModule)

--- a/Source/WebGPU/WGSL/TypeStore.cpp
+++ b/Source/WebGPU/WGSL/TypeStore.cpp
@@ -27,9 +27,12 @@
 #include "TypeStore.h"
 
 #include "ASTTypeName.h"
+#include "Types.h"
 #include <wtf/EnumTraits.h>
 
 namespace WGSL {
+
+using namespace Types;
 
 TypeStore::TypeStore()
     : m_typeConstrutors(AST::ParameterizedTypeName::NumberOfBaseTypes)

--- a/Source/WebGPU/WGSL/TypeStore.h
+++ b/Source/WebGPU/WGSL/TypeStore.h
@@ -26,11 +26,12 @@
 #pragma once
 
 #include "ASTTypeName.h"
-#include "Types.h"
 #include <wtf/FixedVector.h>
 #include <wtf/Vector.h>
 
 namespace WGSL {
+
+struct Type;
 
 namespace AST {
 class Identifier;
@@ -62,7 +63,11 @@ private:
     template<typename TargetType, typename Base, typename... Arguments>
     void allocateConstructor(Base, Arguments&&...);
 
-    WTF::Vector<std::unique_ptr<Type>> m_types;
+    struct TypeConstructor {
+        std::function<Type*(Type*)> construct;
+    };
+
+    Vector<std::unique_ptr<Type>> m_types;
     FixedVector<TypeConstructor> m_typeConstrutors;
 
     Type* m_bottom;

--- a/Source/WebGPU/WGSL/Types.cpp
+++ b/Source/WebGPU/WGSL/Types.cpp
@@ -30,9 +30,11 @@
 
 namespace WGSL {
 
-void printInternal(PrintStream& out, const Type& type)
+using namespace Types;
+
+void Type::dump(PrintStream& out) const
 {
-    WTF::switchOn(type,
+    WTF::switchOn(*this,
         [&](const Primitive& primitive) {
             switch (primitive.kind) {
 #define PRIMITIVE_CASE(kind, name) \
@@ -73,10 +75,10 @@ void printInternal(PrintStream& out, const Type& type)
         });
 }
 
-String toString(const Type& type)
+String Type::toString() const
 {
     StringPrintStream out;
-    printInternal(out, type);
+    dump(out);
     return out.toString();
 }
 

--- a/Source/WebGPU/WGSL/Types.h
+++ b/Source/WebGPU/WGSL/Types.h
@@ -31,23 +31,9 @@
 
 namespace WGSL {
 
-struct Primitive;
-struct Vector;
-struct Matrix;
-struct Array;
-struct Struct;
-struct Function;
-struct Bottom;
+struct Type;
 
-using Type = std::variant<
-    Primitive,
-    Vector,
-    Matrix,
-    Array,
-    Struct,
-    Function,
-    Bottom
->;
+namespace Types {
 
 #define FOR_EACH_PRIMITIVE_TYPE(f) \
     f(AbstractInt, "<AbstractInt>") \
@@ -95,12 +81,29 @@ struct Function {
 struct Bottom {
 };
 
-struct TypeConstructor {
-    std::function<Type*(Type*)> construct;
-};
+} // namespace Types
 
-void printInternal(PrintStream&, const Type&);
-String toString(const Type&);
+struct Type : public std::variant<
+    Types::Primitive,
+    Types::Vector,
+    Types::Matrix,
+    Types::Array,
+    Types::Struct,
+    Types::Function,
+    Types::Bottom
+> {
+    using std::variant<
+        Types::Primitive,
+        Types::Vector,
+        Types::Matrix,
+        Types::Array,
+        Types::Struct,
+        Types::Function,
+        Types::Bottom
+        >::variant;
+    void dump(PrintStream&) const;
+    String toString() const;
+};
 
 } // namespace WGSL
 
@@ -109,7 +112,7 @@ namespace WTF {
 template<> class StringTypeAdapter<WGSL::Type, void> : public StringTypeAdapter<String, void> {
 public:
     StringTypeAdapter(const WGSL::Type& type)
-        : StringTypeAdapter<String, void> { toString(type) }
+        : StringTypeAdapter<String, void> { type.toString() }
     { }
 };
 


### PR DESCRIPTION
#### c2d05736104ffce70b1a7f01730f1a7db31be50a
<pre>
[WGSL] Move WGSL types into their own namespace
<a href="https://bugs.webkit.org/show_bug.cgi?id=252109">https://bugs.webkit.org/show_bug.cgi?id=252109</a>
rdar://105329210

Reviewed by Myles C. Maxfield.

`WGSL::Vector` was clashing with `WTF::Vector`, so we move all the specific WGSL
types (i.e. `Primitive`, `Vector`, etc) into the `WGSL::Types` namespace while
keeping the main `Type` in the top-level `WGSL` namespace.

* Source/WebGPU/WGSL/TypeCheck.cpp:
* Source/WebGPU/WGSL/TypeStore.cpp:
* Source/WebGPU/WGSL/TypeStore.h:
* Source/WebGPU/WGSL/Types.cpp:
(WGSL::Type::dump const):
(WGSL::Type::toString const):
(WGSL::printInternal): Deleted.
(WGSL::toString): Deleted.
* Source/WebGPU/WGSL/Types.h:

Canonical link: <a href="https://commits.webkit.org/260182@main">https://commits.webkit.org/260182@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d15f84941f0933fb9f431309b1d456a6f381963

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107313 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16370 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40290 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116469 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115913 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17796 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7608 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99469 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113077 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13429 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96663 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41052 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95333 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28289 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82820 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9401 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29642 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10045 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6484 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15554 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49223 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7044 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11599 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->