### PR TITLE
Give some WebCore classes allocation heap identifiers

### DIFF
--- a/Source/WebCore/Modules/fetch/FetchBodyOwner.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyOwner.cpp
@@ -42,6 +42,8 @@
 
 namespace WebCore {
 
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(FetchBodyOwner);
+
 FetchBodyOwner::FetchBodyOwner(ScriptExecutionContext* context, std::optional<FetchBody>&& body, Ref<FetchHeaders>&& headers)
     : ActiveDOMObject(context)
     , m_body(WTFMove(body))

--- a/Source/WebCore/Modules/fetch/FetchBodyOwner.h
+++ b/Source/WebCore/Modules/fetch/FetchBodyOwner.h
@@ -41,7 +41,10 @@
 
 namespace WebCore {
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(FetchBodyOwner);
+
 class FetchBodyOwner : public RefCounted<FetchBodyOwner>, public ActiveDOMObject, public CanMakeWeakPtr<FetchBodyOwner> {
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(FetchBodyOwner);
 public:
     ~FetchBodyOwner();
 

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2146,6 +2146,7 @@ platform/graphics/FontGenericFamilies.cpp
 platform/graphics/FontPlatformData.cpp
 platform/graphics/FontRanges.cpp
 platform/graphics/FontSelectionAlgorithm.cpp
+platform/graphics/FontSelector.cpp
 platform/graphics/FontTaggedSettings.cpp
 platform/graphics/FourCC.cpp
 platform/graphics/GeneratedImage.cpp

--- a/Source/WebCore/bindings/js/WebCoreJSClientData.cpp
+++ b/Source/WebCore/bindings/js/WebCoreJSClientData.cpp
@@ -62,6 +62,8 @@
 namespace WebCore {
 using namespace JSC;
 
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(JSHeapData);
+
 JSHeapData::JSHeapData(Heap& heap)
     : m_runtimeArrayHeapCellType(JSC::IsoHeapCellType::Args<RuntimeArray>())
     , m_observableArrayHeapCellType(JSC::IsoHeapCellType::Args<JSObservableArray>())
@@ -112,6 +114,8 @@ JSHeapData* JSHeapData::ensureHeapData(Heap& heap)
 }
 
 #define CLIENT_ISO_SUBSPACE_INIT(subspace) subspace(m_heapData->subspace)
+
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(JSVMClientData);
 
 JSVMClientData::JSVMClientData(VM& vm)
     : m_builtinFunctions(vm)

--- a/Source/WebCore/bindings/js/WebCoreJSClientData.h
+++ b/Source/WebCore/bindings/js/WebCoreJSClientData.h
@@ -35,9 +35,11 @@ namespace WebCore {
 class ExtendedDOMClientIsoSubspaces;
 class ExtendedDOMIsoSubspaces;
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(JSHeapData);
+
 class JSHeapData {
     WTF_MAKE_NONCOPYABLE(JSHeapData);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(JSHeapData);
     friend class JSVMClientData;
 public:
     JSHeapData(JSC::Heap&);
@@ -98,9 +100,11 @@ private:
     Vector<JSC::IsoSubspace*> m_outputConstraintSpaces;
 };
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(JSVMClientData);
 
 class JSVMClientData : public JSC::VM::ClientData {
-    WTF_MAKE_NONCOPYABLE(JSVMClientData); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(JSVMClientData);
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(JSVMClientData);
     friend class VMWorldIterator;
 
 public:

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -73,6 +73,8 @@
 namespace WebCore {
 namespace LayoutIntegration {
 
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(LayoutIntegration_LineLayout);
+
 LineLayout::LineLayout(RenderBlockFlow& flow)
     : m_boxTree(flow)
     , m_layoutState(flow.view().ensureLayoutState())

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h
@@ -59,8 +59,10 @@ namespace LayoutIntegration {
 
 struct InlineContent;
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(LayoutIntegration_LineLayout);
+
 class LineLayout : public CanMakeCheckedPtr {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(LayoutIntegration_LineLayout);
 public:
     LineLayout(RenderBlockFlow&);
     ~LineLayout();

--- a/Source/WebCore/platform/graphics/FontSelector.h
+++ b/Source/WebCore/platform/graphics/FontSelector.h
@@ -36,7 +36,10 @@ class FontCascadeDescription;
 class FontDescription;
 class FontSelectorClient;
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(FontAccessor);
+
 class FontAccessor : public RefCounted<FontAccessor> {
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(FontAccessor);
 public:
     virtual ~FontAccessor() = default;
 

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItemBuffer.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItemBuffer.cpp
@@ -664,6 +664,9 @@ ItemBuffer& ItemBuffer::operator=(ItemBuffer&& other)
     return *this;
 }
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(DisplayListItemBufferHandle);
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(DisplayListItemBufferHandle);
+
 ItemBufferHandle ItemBuffer::createItemBuffer(size_t capacity)
 {
     if (m_writingClient) {
@@ -674,7 +677,7 @@ ItemBufferHandle ItemBuffer::createItemBuffer(size_t capacity)
     constexpr size_t defaultItemBufferCapacity = 1 << 10;
 
     auto newBufferCapacity = std::max(capacity, defaultItemBufferCapacity);
-    auto* buffer = static_cast<uint8_t*>(fastMalloc(newBufferCapacity));
+    auto* buffer = static_cast<uint8_t*>(DisplayListItemBufferHandleMalloc::malloc(newBufferCapacity));
     m_allocatedBuffers.append(buffer);
     return { ItemBufferIdentifier::generate(), buffer, newBufferCapacity };
 }
@@ -691,7 +694,7 @@ void ItemBuffer::forEachItemBuffer(Function<void(const ItemBufferHandle&)>&& map
 void ItemBuffer::clear()
 {
     for (auto* buffer : std::exchange(m_allocatedBuffers, { }))
-        fastFree(buffer);
+        DisplayListItemBufferHandleMalloc::free(buffer);
 
     m_readOnlyBuffers.clear();
     m_writableBuffer = { };

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateMock.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateMock.cpp
@@ -31,6 +31,7 @@
 #include "MediaStreamTrackPrivate.h"
 #include "SharedBuffer.h"
 #include "Timer.h"
+#include <wtf/MediaTime.h>
 #include <wtf/MonotonicTime.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateMock.h
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateMock.h
@@ -44,7 +44,7 @@ private:
     // MediaRecorderPrivate
     void videoFrameAvailable(VideoFrame&, VideoFrameTimeMetadata) final;
     void fetchData(FetchDataCallback&&) final;
-    void audioSamplesAvailable(const MediaTime&, const PlatformAudioData&, const AudioStreamDescription&, size_t) final;
+    void audioSamplesAvailable(const WTF::MediaTime&, const PlatformAudioData&, const AudioStreamDescription&, size_t) final;
     void stopRecording(CompletionHandler<void()>&&) final;
     void pauseRecording(CompletionHandler<void()>&&) final;
     void resumeRecording(CompletionHandler<void()>&&) final;

--- a/Source/WebCore/platform/mediastream/mac/MediaStreamTrackAudioSourceProviderCocoa.h
+++ b/Source/WebCore/platform/mediastream/mac/MediaStreamTrackAudioSourceProviderCocoa.h
@@ -57,7 +57,7 @@ private:
     void trackEnabledChanged(MediaStreamTrackPrivate&) final;
 
     // RealtimeMediaSource::AudioSampleObserver
-    void audioSamplesAvailable(const MediaTime&, const PlatformAudioData&, const AudioStreamDescription&, size_t) final;
+    void audioSamplesAvailable(const WTF::MediaTime&, const PlatformAudioData&, const AudioStreamDescription&, size_t) final;
 
     WeakPtr<MediaStreamTrackPrivate> m_captureSource;
     Ref<RealtimeMediaSource> m_source;


### PR DESCRIPTION
#### b0b45e9cb88936a25a0743444a679f195c122413
<pre>
Give some WebCore classes allocation heap identifiers
<a href="https://bugs.webkit.org/show_bug.cgi?id=252113">https://bugs.webkit.org/show_bug.cgi?id=252113</a>
rdar://105334665

Reviewed by NOBODY (OOPS!).

Allocate the following classes in DebugHeap zones with their own identifiers (when debug heaps
are enabled at build time): FetchBodyOwner, JSVMClientData, JSHeapData, LayoutIntegration::LineLayout,
FontAccessor, DisplayListItemBufferHandle.

A few other media-related build fixes presumably triggered by unified build issues.

* Source/WebCore/Modules/fetch/FetchBodyOwner.cpp:
* Source/WebCore/Modules/fetch/FetchBodyOwner.h:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/WebCoreJSClientData.cpp:
* Source/WebCore/bindings/js/WebCoreJSClientData.h:
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h:
* Source/WebCore/platform/graphics/FontSelector.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListItemBuffer.cpp:
(WebCore::DisplayList::ItemBuffer::createItemBuffer):
(WebCore::DisplayList::ItemBuffer::clear):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateMock.cpp:
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateMock.h:
* Source/WebCore/platform/mediastream/mac/MediaStreamTrackAudioSourceProviderCocoa.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0b45e9cb88936a25a0743444a679f195c122413

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107345 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16402 "Hash b0b45e9c for PR 9978 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40186 "Hash b0b45e9c for PR 9978 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116502 "Hash b0b45e9c for PR 9978 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115937 "Hash b0b45e9c for PR 9978 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111243 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17826 "Hash b0b45e9c for PR 9978 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7643 "Hash b0b45e9c for PR 9978 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99503 "Hash b0b45e9c for PR 9978 does not build (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113108 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/76/builds/17826 "Hash b0b45e9c for PR 9978 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/40186 "Hash b0b45e9c for PR 9978 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/99503 "Hash b0b45e9c for PR 9978 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/76/builds/17826 "Hash b0b45e9c for PR 9978 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/40186 "Hash b0b45e9c for PR 9978 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/99503 "Hash b0b45e9c for PR 9978 does not build (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/96703 "Built successfully and passed tests") | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9426 "Hash b0b45e9c for PR 9978 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/40186 "Hash b0b45e9c for PR 9978 does not build (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/96129 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/7420 "Built successfully and passed tests") | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10075 "Hash b0b45e9c for PR 9978 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/85/builds/7643 "Hash b0b45e9c for PR 9978 does not build (failure)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30775 "Passed tests") | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15581 "Hash b0b45e9c for PR 9978 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/40186 "Hash b0b45e9c for PR 9978 does not build (failure)") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/104966 "Built successfully") | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11630 "Hash b0b45e9c for PR 9978 does not build (failure)") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26019 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->