### PR TITLE
[JSC] Vector operations should work with CSE

### DIFF
--- a/Source/JavaScriptCore/b3/B3SIMDValue.h
+++ b/Source/JavaScriptCore/b3/B3SIMDValue.h
@@ -104,8 +104,7 @@ public:
     SIMDInfo simdInfo() const { return m_simdInfo; }
     SIMDLane simdLane() const { return m_simdInfo.lane; }
     SIMDSignMode signMode() const { return m_simdInfo.signMode; }
-    uint8_t immediate(size_t i) const { return imm.u8x16[i]; }
-    const v128_t& immediate() const { return imm; }
+    uint8_t immediate() const { return m_immediate; }
 
     B3_SPECIALIZE_VALUE_FOR_FINAL_SIZE_FIXED_CHILDREN
 
@@ -116,8 +115,8 @@ protected:
     SIMDValue(Origin origin, Kind kind, Type type, SIMDInfo info, uint8_t imm1, Arguments... arguments)
         : Value(CheckedOpcode, kind, type, static_cast<NumChildren>(sizeof...(arguments)), origin, arguments...)
         , m_simdInfo(info)
+        , m_immediate(imm1)
     {
-        imm.u8x16[0] = imm1;
     }
 
     template<typename... Arguments>
@@ -131,16 +130,8 @@ protected:
     SIMDValue(Origin origin, Kind kind, Type type, SIMDLane simdLane, SIMDSignMode signMode, uint8_t imm1, Arguments... arguments)
         : Value(CheckedOpcode, kind, type, static_cast<NumChildren>(sizeof...(arguments)), origin, arguments...)
         , m_simdInfo { simdLane, signMode }
+        , m_immediate(imm1)
     {
-        imm.u8x16[0] = imm1;
-    }
-
-    template<typename... Arguments>
-    SIMDValue(Origin origin, Kind kind, Type type, SIMDLane simdLane, SIMDSignMode signMode, v128_t imm1, Arguments... arguments)
-        : Value(CheckedOpcode, kind, type, static_cast<NumChildren>(sizeof...(arguments)), origin, arguments...)
-        , m_simdInfo { simdLane, signMode }
-    {
-        imm = imm1;
     }
 
     template<typename... Arguments>
@@ -160,9 +151,8 @@ private:
     friend class Procedure;
     friend class Value;
 
-    SIMDInfo m_simdInfo;
-
-    v128_t imm;
+    SIMDInfo m_simdInfo { };
+    uint8_t m_immediate { 0 };
 };
 
 } } // namespace JSC::B3

--- a/Source/JavaScriptCore/b3/B3Value.cpp
+++ b/Source/JavaScriptCore/b3/B3Value.cpp
@@ -889,6 +889,75 @@ ValueKey Value::key() const
         return ValueKey(
             SlotBase, type(),
             static_cast<int64_t>(as<SlotBaseValue>()->slot()->index()));
+    case VectorNot:
+    case VectorSplat:
+    case VectorAbs:
+    case VectorNeg:
+    case VectorPopcnt:
+    case VectorCeil:
+    case VectorFloor:
+    case VectorTrunc:
+    case VectorTruncSat:
+    case VectorConvert:
+    case VectorConvertLow:
+    case VectorNearest:
+    case VectorSqrt:
+    case VectorExtendLow:
+    case VectorExtendHigh:
+    case VectorPromote:
+    case VectorDemote:
+    case VectorBitmask:
+    case VectorAnyTrue:
+    case VectorAllTrue:
+    case VectorExtaddPairwise:
+        numChildrenForKind(kind(), 1);
+        return ValueKey(kind(), type(), as<SIMDValue>()->simdInfo(), child(0));
+    case VectorExtractLane:
+    case VectorDupElement:
+        numChildrenForKind(kind(), 1);
+        return ValueKey(kind(), type(), as<SIMDValue>()->simdInfo(), child(0), as<SIMDValue>()->immediate());
+    case VectorEqual:
+    case VectorNotEqual:
+    case VectorLessThan:
+    case VectorLessThanOrEqual:
+    case VectorBelow:
+    case VectorBelowOrEqual:
+    case VectorGreaterThan:
+    case VectorGreaterThanOrEqual:
+    case VectorAbove:
+    case VectorAboveOrEqual:
+    case VectorAdd:
+    case VectorSub:
+    case VectorAddSat:
+    case VectorSubSat:
+    case VectorMul:
+    case VectorDotProduct:
+    case VectorDiv:
+    case VectorMin:
+    case VectorMax:
+    case VectorPmin:
+    case VectorPmax:
+    case VectorNarrow:
+    case VectorAnd:
+    case VectorAndnot:
+    case VectorOr:
+    case VectorXor:
+    case VectorShl:
+    case VectorShr:
+    case VectorMulSat:
+    case VectorAvgRound:
+        numChildrenForKind(kind(), 2);
+        return ValueKey(kind(), type(), as<SIMDValue>()->simdInfo(), child(0), child(1));
+    case VectorReplaceLane:
+        numChildrenForKind(kind(), 2);
+        return ValueKey(kind(), type(), as<SIMDValue>()->simdInfo(), child(0), child(1), as<SIMDValue>()->immediate());
+    case VectorBitwiseSelect:
+        numChildrenForKind(kind(), 3);
+        return ValueKey(kind(), type(), as<SIMDValue>()->simdInfo(), child(0), child(1), child(2));
+    case VectorSwizzle:
+        if (numChildren() == 2)
+            return ValueKey(kind(), type(), as<SIMDValue>()->simdInfo(), child(0), child(1), nullptr);
+        return ValueKey(kind(), type(), as<SIMDValue>()->simdInfo(), child(0), child(1), child(2));
     default:
         return ValueKey();
     }

--- a/Source/JavaScriptCore/b3/B3Value.h
+++ b/Source/JavaScriptCore/b3/B3Value.h
@@ -684,7 +684,7 @@ private:
         case VectorPromote:
         case VectorDemote:
         case VectorBitmask:
-        case VectorAnyTrue: 
+        case VectorAnyTrue:
         case VectorAllTrue:
         case VectorExtaddPairwise:
         case VectorDupElement:

--- a/Source/JavaScriptCore/b3/B3ValueKey.cpp
+++ b/Source/JavaScriptCore/b3/B3ValueKey.cpp
@@ -126,6 +126,70 @@ Value* ValueKey::materialize(Procedure& proc, Origin origin) const
         return proc.add<ArgumentRegValue>(origin, Reg::fromIndex(static_cast<unsigned>(value())));
     case SlotBase:
         return proc.add<SlotBaseValue>(origin, proc.stackSlots()[value()]);
+    case VectorNot:
+    case VectorSplat:
+    case VectorAbs:
+    case VectorNeg:
+    case VectorPopcnt:
+    case VectorCeil:
+    case VectorFloor:
+    case VectorTrunc:
+    case VectorTruncSat:
+    case VectorConvert:
+    case VectorConvertLow:
+    case VectorNearest:
+    case VectorSqrt:
+    case VectorExtendLow:
+    case VectorExtendHigh:
+    case VectorPromote:
+    case VectorDemote:
+    case VectorBitmask:
+    case VectorAnyTrue:
+    case VectorAllTrue:
+    case VectorExtaddPairwise:
+        return proc.add<SIMDValue>(origin, kind(), type(), simdInfo(), child(proc, 0));
+    case VectorExtractLane:
+    case VectorDupElement:
+        return proc.add<SIMDValue>(origin, kind(), type(), simdInfo(), static_cast<uint8_t>(u.indices[1]), child(proc, 0));
+    case VectorEqual:
+    case VectorNotEqual:
+    case VectorLessThan:
+    case VectorLessThanOrEqual:
+    case VectorBelow:
+    case VectorBelowOrEqual:
+    case VectorGreaterThan:
+    case VectorGreaterThanOrEqual:
+    case VectorAbove:
+    case VectorAboveOrEqual:
+    case VectorAdd:
+    case VectorSub:
+    case VectorAddSat:
+    case VectorSubSat:
+    case VectorMul:
+    case VectorDotProduct:
+    case VectorDiv:
+    case VectorMin:
+    case VectorMax:
+    case VectorPmin:
+    case VectorPmax:
+    case VectorNarrow:
+    case VectorAnd:
+    case VectorAndnot:
+    case VectorOr:
+    case VectorXor:
+    case VectorShl:
+    case VectorShr:
+    case VectorMulSat:
+    case VectorAvgRound:
+        return proc.add<SIMDValue>(origin, kind(), type(), simdInfo(), child(proc, 0), child(proc, 1));
+    case VectorReplaceLane:
+        return proc.add<SIMDValue>(origin, kind(), type(), simdInfo(), static_cast<uint8_t>(u.indices[2]), child(proc, 0), child(proc, 1));
+    case VectorBitwiseSelect:
+        return proc.add<SIMDValue>(origin, kind(), type(), simdInfo(), child(proc, 0), child(proc, 1), child(proc, 2));
+    case VectorSwizzle:
+        if (u.indices[2] == UINT32_MAX)
+            return proc.add<SIMDValue>(origin, kind(), type(), simdInfo(), child(proc, 0), child(proc, 1));
+        return proc.add<SIMDValue>(origin, kind(), type(), simdInfo(), child(proc, 0), child(proc, 1), child(proc, 2));
     default:
         return nullptr;
     }

--- a/Source/JavaScriptCore/b3/B3ValueKey.h
+++ b/Source/JavaScriptCore/b3/B3ValueKey.h
@@ -91,8 +91,15 @@ public:
         u.vectorValue = value;
     }
 
+    ValueKey(Kind, Type, SIMDInfo, Value*);
+    ValueKey(Kind, Type, SIMDInfo, Value*, Value*);
+    ValueKey(Kind, Type, SIMDInfo, Value*, Value*, Value*);
+    ValueKey(Kind, Type, SIMDInfo, Value*, uint8_t);
+    ValueKey(Kind, Type, SIMDInfo, Value*, Value*, uint8_t);
+
     static ValueKey intConstant(Type type, int64_t value);
 
+    SIMDInfo simdInfo() const { return m_simdInfo; }
     Kind kind() const { return m_kind; }
     Opcode opcode() const { return kind().opcode(); }
     Type type() const { return m_type; }
@@ -105,7 +112,8 @@ public:
 
     bool operator==(const ValueKey& other) const
     {
-        return m_kind == other.m_kind
+        return m_simdInfo == other.m_simdInfo
+            && m_kind == other.m_kind
             && m_type == other.m_type
             && u == other.u;
     }
@@ -159,7 +167,8 @@ public:
     }
         
 private:
-    Kind m_kind;
+    SIMDInfo m_simdInfo { };
+    Kind m_kind { };
     Type m_type { Void };
     union U {
         unsigned indices[4];

--- a/Source/JavaScriptCore/b3/B3ValueKeyInlines.h
+++ b/Source/JavaScriptCore/b3/B3ValueKeyInlines.h
@@ -57,6 +57,52 @@ inline ValueKey::ValueKey(Kind kind, Type type, Value* a, Value* b, Value* c)
     u.indices[2] = c->index();
 }
 
+inline ValueKey::ValueKey(Kind kind, Type type, SIMDInfo simdInfo, Value* a)
+    : m_simdInfo(simdInfo)
+    , m_kind(kind)
+    , m_type(type)
+{
+    u.indices[0] = a ? a->index() : UINT32_MAX;
+}
+
+inline ValueKey::ValueKey(Kind kind, Type type, SIMDInfo simdInfo, Value* a, Value* b)
+    : m_simdInfo(simdInfo)
+    , m_kind(kind)
+    , m_type(type)
+{
+    u.indices[0] = a ? a->index() : UINT32_MAX;
+    u.indices[1] = b ? b->index() : UINT32_MAX;
+}
+
+inline ValueKey::ValueKey(Kind kind, Type type, SIMDInfo simdInfo, Value* a, Value* b, Value* c)
+    : m_simdInfo(simdInfo)
+    , m_kind(kind)
+    , m_type(type)
+{
+    u.indices[0] = a ? a->index() : UINT32_MAX;
+    u.indices[1] = b ? b->index() : UINT32_MAX;
+    u.indices[2] = c ? c->index() : UINT32_MAX;
+}
+
+inline ValueKey::ValueKey(Kind kind, Type type, SIMDInfo simdInfo, Value* a, uint8_t immediate)
+    : m_simdInfo(simdInfo)
+    , m_kind(kind)
+    , m_type(type)
+{
+    u.indices[0] = a ? a->index() : UINT32_MAX;
+    u.indices[1] = immediate;
+}
+
+inline ValueKey::ValueKey(Kind kind, Type type, SIMDInfo simdInfo, Value* a, Value* b, uint8_t immediate)
+    : m_simdInfo(simdInfo)
+    , m_kind(kind)
+    , m_type(type)
+{
+    u.indices[0] = a ? a->index() : UINT32_MAX;
+    u.indices[1] = b ? b->index() : UINT32_MAX;
+    u.indices[2] = immediate;
+}
+
 inline Value* ValueKey::child(Procedure& proc, unsigned index) const
 {
     return proc.values()[index];

--- a/Source/JavaScriptCore/jit/SIMDInfo.h
+++ b/Source/JavaScriptCore/jit/SIMDInfo.h
@@ -75,24 +75,43 @@ constexpr v128_t vectorXor(v128_t lhs, v128_t rhs)
 }
 
 enum class SIMDLane : uint8_t {
-    v128,
+    v128 = 0,
     i8x16,
     i16x8,
     i32x4,
     i64x2,
     f32x4,
-    f64x2
+    f64x2,
 };
+static constexpr unsigned bitsOfSIMDLane = 6;
 
 enum class SIMDSignMode : uint8_t {
-    None, 
+    None = 0,
     Signed,
-    Unsigned
+    Unsigned,
 };
+static constexpr unsigned bitsOfSIMDSignMode = 2;
 
 struct SIMDInfo {
-    SIMDLane lane { SIMDLane::v128 };
-    SIMDSignMode signMode { SIMDSignMode::None };
+    SIMDLane lane : bitsOfSIMDLane { SIMDLane::v128 };
+    SIMDSignMode signMode : bitsOfSIMDSignMode { SIMDSignMode::None };
+
+    constexpr SIMDInfo(SIMDLane passedLane, SIMDSignMode passedSignMode)
+        : lane(passedLane)
+        , signMode(passedSignMode)
+    { }
+
+    constexpr SIMDInfo() = default;
+
+    friend bool operator==(const SIMDInfo& lhs, const SIMDInfo& rhs)
+    {
+        return lhs.lane == rhs.lane && lhs.signMode == rhs.signMode;
+    }
+
+    friend bool operator!=(const SIMDInfo& lhs, const SIMDInfo& rhs)
+    {
+        return !(lhs == rhs);
+    }
 };
 
 constexpr uint8_t elementCount(SIMDLane lane)

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -611,6 +611,7 @@ template<typename Context>
 template<bool isReachable, typename>
 auto FunctionParser<Context>::simd(SIMDLaneOperation op, SIMDLane lane, SIMDSignMode signMode, B3::Air::Arg optionalRelation) -> PartialResult
 {
+    UNUSED_PARAM(signMode);
     if (!Context::tierSupportsSIMD)
         WASM_TRY_ADD_TO_CONTEXT(addCrash());
     m_context.notifyFunctionUsesSIMD();


### PR DESCRIPTION
#### 151366fdc3f75b2c11040730e5bfb9dabc9188b9
<pre>
[JSC] Vector operations should work with CSE
<a href="https://bugs.webkit.org/show_bug.cgi?id=252114">https://bugs.webkit.org/show_bug.cgi?id=252114</a>
rdar://105334819

Reviewed by Keith Miller.

This patch integrates Vector operations into B3 CSE by defining Value::key and ValueKey for them.
We also clean up some vector related code for generating code.

* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/B3SIMDValue.h:
* Source/JavaScriptCore/b3/B3Value.cpp:
(JSC::B3::Value::key const):
* Source/JavaScriptCore/b3/B3Value.h:
* Source/JavaScriptCore/b3/B3ValueKey.cpp:
(JSC::B3::ValueKey::materialize const):
* Source/JavaScriptCore/b3/B3ValueKey.h:
(JSC::B3::ValueKey::simdInfo const):
(JSC::B3::ValueKey::operator== const):
* Source/JavaScriptCore/b3/B3ValueKeyInlines.h:
(JSC::B3::ValueKey::ValueKey):
* Source/JavaScriptCore/jit/SIMDInfo.h:
(JSC::SIMDInfo::operator==):
(JSC::SIMDInfo::operator!=):

Canonical link: <a href="https://commits.webkit.org/260223@main">https://commits.webkit.org/260223@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bfb3748d7f52a069e43599d26b4edf8069e3493

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107583 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16639 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40482 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116737 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18064 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7953 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99751 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113341 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/96827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/41303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/95547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/28453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/96905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/9634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/29806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/38/builds/96316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/7647 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10301 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/6704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/38/builds/96316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/15791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/49387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-mips~~](https://ews-build.webkit.org/#/builders/37/builds/105177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11863 "Built successfully") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/37/builds/105177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3834 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->