### PR TITLE
innerHTML fast parser should leverage the same attribute value cache as the full HTML parser

### DIFF
--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
@@ -829,9 +829,9 @@ private:
         // no values have the value set to an empty atom instead.
         AtomString value;
         if (valueSpan.second.empty())
-            value = AtomString(valueSpan.first.data(), static_cast<unsigned>(valueSpan.first.size()));
+            value = HTMLNameCache::makeAttributeValue(valueSpan.first);
         else
-            value = AtomString(valueSpan.second.data(), static_cast<unsigned>(valueSpan.second.size()));
+            value = HTMLNameCache::makeAttributeValue(valueSpan.second);
         if (value.isNull())
             value = emptyAtom();
         return Attribute { WTFMove(name), WTFMove(value) };

--- a/Source/WebCore/html/parser/HTMLNameCache.h
+++ b/Source/WebCore/html/parser/HTMLNameCache.h
@@ -49,6 +49,11 @@ public:
         return makeAtomString(string);
     }
 
+    ALWAYS_INLINE static AtomString makeAttributeValue(Span<const LChar> string)
+    {
+        return makeAtomString(string);
+    }
+
     ALWAYS_INLINE static void clear()
     {
         // FIXME (webkit.org/b/230019): We should try to find more opportunities to clear this cache without hindering this performance optimization.
@@ -57,7 +62,8 @@ public:
     }
 
 private:
-    ALWAYS_INLINE static AtomString makeAtomString(Span<const UChar> string)
+    template<typename CharacterType>
+    ALWAYS_INLINE static AtomString makeAtomString(Span<const CharacterType> string)
     {
         if (string.empty())
             return emptyAtom();


### PR DESCRIPTION
#### 153929d8a8d479703a52fc8a86a8303b0ad64995
<pre>
innerHTML fast parser should leverage the same attribute value cache as the full HTML parser
<a href="https://bugs.webkit.org/show_bug.cgi?id=252116">https://bugs.webkit.org/show_bug.cgi?id=252116</a>

Reviewed by Darin Adler.

innerHTML fast parser should leverage the same attribute value cache as the full
HTML parser. This may be a ~0.3% progression on Speedometer.

* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
(WebCore::HTMLFastPathParser::processAttribute):
* Source/WebCore/html/parser/HTMLNameCache.h:
(WebCore::HTMLNameCache::makeAttributeValue):
(WebCore::HTMLNameCache::makeAtomString):

Canonical link: <a href="https://commits.webkit.org/260165@main">https://commits.webkit.org/260165@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a267d37b07cfa84714cd4765ba05fffb55fd74d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107360 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16420 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40210 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116519 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115947 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111260 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17843 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7659 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99521 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113124 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13460 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96590 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41084 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95364 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/28219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82848 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9435 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29569 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10088 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6510 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15592 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49149 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11645 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3807 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->