### PR TITLE
Adding WPT tentative tests for text-spacing and its longhands

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6264,3 +6264,6 @@ imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/js
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/load-error-events.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/module.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.html [ Skip ]
+
+#Skipping text-spacing tests until the features get implemented.
+imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-autospace-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-autospace-invalid-expected.txt
@@ -1,0 +1,4 @@
+
+PASS e.style['text-autospace'] = "auto no-autospace" should not set the property value
+PASS e.style['text-autospace'] = "no-autospace auto" should not set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-autospace-invalid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-autospace-invalid.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Fonts Module Level 4: parsing text-spacing with valid values</title>
+<link rel="help" href="https://www.w3.org/TR/css-text-4/#text-spacing-property">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value('text-autospace', 'auto no-autospace');
+test_invalid_value('text-autospace', 'no-autospace auto');
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-autospace-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-autospace-valid-expected.txt
@@ -1,0 +1,4 @@
+
+PASS e.style['text-autospace'] = "auto" should set the property value
+PASS e.style['text-autospace'] = "no-autospace" should set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-autospace-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-autospace-valid.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Fonts Module Level 4: parsing text-spacing with valid values</title>
+<link rel="help" href="https://www.w3.org/TR/css-text-4/#text-spacing-property">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value('text-autospace', 'auto');
+test_valid_value('text-autospace', 'no-autospace');
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-spacing-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-spacing-computed-expected.txt
@@ -1,0 +1,10 @@
+
+PASS Property text-spacing value 'auto'
+PASS Property text-spacing value 'none'
+PASS Property text-spacing value 'no-autospace auto'
+PASS Property text-spacing value 'auto no-autospace'
+PASS Property text-spacing value 'no-autospace space-all'
+PASS Property text-spacing value 'space-all no-autospace'
+PASS Property text-spacing value 'auto space-all'
+PASS Property text-spacing value 'space-all auto'
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-spacing-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-spacing-computed.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Fonts Module Level 4: parsing text-autospace with valid values</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+</head>
+<body>
+<div id="target"></div>
+<script>
+test_computed_value('text-spacing', 'auto');
+test_computed_value('text-spacing', 'none');
+test_computed_value('text-spacing', 'no-autospace auto');
+test_computed_value('text-spacing', 'auto no-autospace', 'no-autospace auto');
+test_computed_value('text-spacing', 'no-autospace space-all', 'none');
+test_computed_value('text-spacing', 'space-all no-autospace', 'none');
+test_computed_value('text-spacing', 'auto space-all');
+test_computed_value('text-spacing', 'space-all auto', 'auto space-all');
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-spacing-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-spacing-invalid-expected.txt
@@ -1,0 +1,8 @@
+
+PASS e.style['text-spacing'] = "auto none" should not set the property value
+PASS e.style['text-spacing'] = "none auto" should not set the property value
+PASS e.style['text-spacing'] = "none garbage" should not set the property value
+PASS e.style['text-spacing'] = "auto garbage" should not set the property value
+PASS e.style['text-spacing'] = "garbage auto" should not set the property value
+PASS e.style['text-spacing'] = "garbage none" should not set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-spacing-invalid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-spacing-invalid.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Fonts Module Level 4: parsing text-autospace with valid values</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value('text-spacing', 'auto none');
+test_invalid_value('text-spacing', 'none auto');
+test_invalid_value('text-spacing', 'none garbage');
+test_invalid_value('text-spacing', 'auto garbage');
+test_invalid_value('text-spacing', 'garbage auto');
+test_invalid_value('text-spacing', 'garbage none');
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-spacing-trim-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-spacing-trim-invalid-expected.txt
@@ -1,0 +1,4 @@
+
+PASS e.style['text-spacing-trim'] = "auto space-all" should not set the property value
+PASS e.style['text-spacing-trim'] = "space-all auto" should not set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-spacing-trim-invalid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-spacing-trim-invalid.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Fonts Module Level 4: parsing text-spacing-trim with valid values</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value('text-spacing-trim', 'auto space-all');
+test_invalid_value('text-spacing-trim', 'space-all auto');
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-spacing-trim-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-spacing-trim-valid-expected.txt
@@ -1,0 +1,4 @@
+
+PASS e.style['text-spacing-trim'] = "auto" should set the property value
+PASS e.style['text-spacing-trim'] = "space-all" should set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-spacing-trim-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-spacing-trim-valid.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Fonts Module Level 4: parsing text-spacing-trim with valid values</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value('text-spacing-trim', 'auto');
+test_valid_value('text-spacing-trim', 'space-all');
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-spacing-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-spacing-valid-expected.txt
@@ -1,0 +1,10 @@
+
+PASS e.style['text-spacing'] = "auto" should set the property value
+PASS e.style['text-spacing'] = "none" should set the property value
+PASS e.style['text-spacing'] = "no-autospace auto" should set the property value
+PASS e.style['text-spacing'] = "auto no-autospace" should set the property value
+PASS e.style['text-spacing'] = "no-autospace space-all" should set the property value
+PASS e.style['text-spacing'] = "space-all no-autospace" should set the property value
+PASS e.style['text-spacing'] = "auto space-all" should set the property value
+PASS e.style['text-spacing'] = "space-all auto" should set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-spacing-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-spacing-valid.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Fonts Module Level 4: parsing text-autospace with valid values</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value('text-spacing', 'auto');
+test_valid_value('text-spacing', 'none');
+test_valid_value('text-spacing', 'no-autospace auto');
+test_valid_value('text-spacing', 'auto no-autospace', 'no-autospace auto');
+test_valid_value('text-spacing', 'no-autospace space-all', 'none');
+test_valid_value('text-spacing', 'space-all no-autospace', 'none');
+test_valid_value('text-spacing', 'auto space-all');
+test_valid_value('text-spacing', 'space-all auto', 'auto space-all');
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### d44ac72400dc3c5021dfa99accaf0610058fa576
<pre>
Adding WPT tentative tests for text-spacing and its longhands
<a href="https://bugs.webkit.org/show_bug.cgi?id=252117">https://bugs.webkit.org/show_bug.cgi?id=252117</a>
rdar://105338290

We need to add tentative wpt tests for text-spacing and its longhands
(text-autospace and text-spacing-trim) for the &apos;auto&apos; and &apos;none&apos;
values only.
We will progressively iterate from these values.
The text-spacing spec is in flux and we are using the following CSSWG
reference: Reference: <a href="https://github.com/w3c/csswg-drafts/issues/4246#issuecomment-1404738513">https://github.com/w3c/csswg-drafts/issues/4246#issuecomment-1404738513</a>

Syntax being tested:
text-spacing: auto | none | &lt;text-autospace&gt; || &lt;text-spacing-trim&gt;
text-autospace: auto | no-autospace
text-spacing-trim: auto | space-all
Reviewed by Alan Baradlay.

* LayoutTests/TestExpectations:
Skipping tests until the parsers get merged.

* LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-autospace-invalid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-autospace-invalid.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-autospace-valid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-autospace-valid.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-spacing-computed-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-spacing-computed.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-spacing-invalid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-spacing-invalid.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-spacing-trim-invalid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-spacing-trim-invalid.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-spacing-trim-valid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-spacing-trim-valid.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-spacing-valid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-spacing-valid.html: Added.

Canonical link: <a href="https://commits.webkit.org/260162@main">https://commits.webkit.org/260162@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ca3d4d04e58ac20c744104c245d3c04a66c9ce3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107361 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16421 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40211 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116520 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115952 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17844 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7660 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99522 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113125 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13455 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96592 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41083 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95359 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/28221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82847 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9436 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29571 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10089 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6511 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15593 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49151 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7029 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11646 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->