### PR TITLE
Implement text-autospace parser for auto and no-autospace

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6254,8 +6254,6 @@ imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/js
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.html [ Skip ]
 
 #Skipping text-spacing tests until the features get implemented.
-imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-autospace-invalid.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-autospace-valid.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-spacing-computed.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-spacing-invalid.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-spacing-valid.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -300,6 +300,7 @@ PASS table-layout
 PASS text-align
 PASS text-align-last
 PASS text-anchor
+PASS text-autospace
 PASS text-combine-upright
 PASS text-decoration-color
 PASS text-decoration-line

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
@@ -192,6 +192,9 @@ PASS text-align-last: "start" onto "end"
 PASS text-anchor (type: discrete) has testAccumulation function
 PASS text-anchor: "end" onto "middle"
 PASS text-anchor: "middle" onto "end"
+PASS text-autospace (type: discrete) has testAccumulation function
+PASS text-autospace: "no-autospace" onto "auto"
+PASS text-autospace: "auto" onto "no-autospace"
 PASS text-decoration-color (type: color) has testAccumulation function
 PASS text-decoration-color supports animating as color of rgb() with overflowed  from and to values
 PASS text-decoration-color supports animating as color of #RGB

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
@@ -192,6 +192,9 @@ PASS text-align-last: "start" onto "end"
 PASS text-anchor (type: discrete) has testAddition function
 PASS text-anchor: "end" onto "middle"
 PASS text-anchor: "middle" onto "end"
+PASS text-autospace (type: discrete) has testAddition function
+PASS text-autospace: "no-autospace" onto "auto"
+PASS text-autospace: "auto" onto "no-autospace"
 PASS text-decoration-color (type: color) has testAddition function
 PASS text-decoration-color supports animating as color of rgb() with overflowed  from and to values
 PASS text-decoration-color supports animating as color of #RGB

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
@@ -234,6 +234,10 @@ PASS text-anchor (type: discrete) has testInterpolation function
 PASS text-anchor uses discrete animation when animating between "middle" and "end" with linear easing
 PASS text-anchor uses discrete animation when animating between "middle" and "end" with effect easing
 PASS text-anchor uses discrete animation when animating between "middle" and "end" with keyframe easing
+PASS text-autospace (type: discrete) has testInterpolation function
+PASS text-autospace uses discrete animation when animating between "auto" and "no-autospace" with linear easing
+PASS text-autospace uses discrete animation when animating between "auto" and "no-autospace" with effect easing
+PASS text-autospace uses discrete animation when animating between "auto" and "no-autospace" with keyframe easing
 PASS text-decoration-color (type: color) has testInterpolation function
 PASS text-decoration-color supports animating as color of rgb()
 PASS text-decoration-color supports animating as color of #RGB

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js
@@ -1263,6 +1263,12 @@ const gCSSProperties2 = {
       { type: 'discrete', options: [ [ 'middle', 'end' ] ] }
     ]
   },
+  'text-autospace': {
+    // https://www.w3.org/TR/css-text-4/#text-spacing-property
+    types: [
+      { type: 'discrete', options: [ [ 'auto', 'no-autospace' ] ] }
+    ]
+  },
   'text-decoration-color': {
     // https://drafts.csswg.org/css-text-decor-3/#propdef-text-decoration-color
     types: [ 'color' ]

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -300,6 +300,7 @@ PASS table-layout
 PASS text-align
 PASS text-align-last
 PASS text-anchor
+PASS text-autospace
 PASS text-combine-upright
 PASS text-decoration-color
 PASS text-decoration-line

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -300,6 +300,7 @@ PASS table-layout
 PASS text-align
 PASS text-align-last
 PASS text-anchor
+PASS text-autospace
 PASS text-combine-upright
 PASS text-decoration-color
 PASS text-decoration-line

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -299,6 +299,7 @@ PASS table-layout
 PASS text-align
 PASS text-align-last
 PASS text-anchor
+PASS text-autospace
 PASS text-combine-upright
 PASS text-decoration-color
 PASS text-decoration-line

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
@@ -189,6 +189,9 @@ PASS text-align-last: "start" onto "end"
 PASS text-anchor (type: discrete) has testAccumulation function
 PASS text-anchor: "end" onto "middle"
 PASS text-anchor: "middle" onto "end"
+PASS text-autospace (type: discrete) has testAccumulation function
+PASS text-autospace: "no-autospace" onto "auto"
+PASS text-autospace: "auto" onto "no-autospace"
 PASS text-decoration-color (type: color) has testAccumulation function
 PASS text-decoration-color supports animating as color of rgb() with overflowed  from and to values
 PASS text-decoration-color supports animating as color of #RGB

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
@@ -189,6 +189,9 @@ PASS text-align-last: "start" onto "end"
 PASS text-anchor (type: discrete) has testAddition function
 PASS text-anchor: "end" onto "middle"
 PASS text-anchor: "middle" onto "end"
+PASS text-autospace (type: discrete) has testAddition function
+PASS text-autospace: "no-autospace" onto "auto"
+PASS text-autospace: "auto" onto "no-autospace"
 PASS text-decoration-color (type: color) has testAddition function
 PASS text-decoration-color supports animating as color of rgb() with overflowed  from and to values
 PASS text-decoration-color supports animating as color of #RGB

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
@@ -230,6 +230,10 @@ PASS text-anchor (type: discrete) has testInterpolation function
 PASS text-anchor uses discrete animation when animating between "middle" and "end" with linear easing
 PASS text-anchor uses discrete animation when animating between "middle" and "end" with effect easing
 PASS text-anchor uses discrete animation when animating between "middle" and "end" with keyframe easing
+PASS text-autospace (type: discrete) has testInterpolation function
+PASS text-autospace uses discrete animation when animating between "auto" and "no-autospace" with linear easing
+PASS text-autospace uses discrete animation when animating between "auto" and "no-autospace" with effect easing
+PASS text-autospace uses discrete animation when animating between "auto" and "no-autospace" with keyframe easing
 PASS text-decoration-color (type: color) has testInterpolation function
 PASS text-decoration-color supports animating as color of rgb()
 PASS text-decoration-color supports animating as color of #RGB

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -300,6 +300,7 @@ PASS table-layout
 PASS text-align
 PASS text-align-last
 PASS text-anchor
+PASS text-autospace
 PASS text-combine-upright
 PASS text-decoration-color
 PASS text-decoration-line

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -3494,6 +3494,7 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         new DiscretePropertyWrapper<WordBreak>(CSSPropertyWordBreak, &RenderStyle::wordBreak, &RenderStyle::setWordBreak),
         new DiscretePropertyWrapper<OverflowAnchor>(CSSPropertyOverflowAnchor, &RenderStyle::overflowAnchor, &RenderStyle::setOverflowAnchor),
         new DiscretePropertyWrapper<TextSpacingTrim>(CSSPropertyTextSpacingTrim, &RenderStyle::textSpacingTrim, &RenderStyle::setTextSpacingTrim),
+        new DiscretePropertyWrapper<TextAutospace>(CSSPropertyTextAutospace, &RenderStyle::textAutospace, &RenderStyle::setTextAutospace),
 
 #if ENABLE(CSS_BOX_DECORATION_BREAK)
         new DiscretePropertyWrapper<BoxDecorationBreak>(CSSPropertyWebkitBoxDecorationBreak, &RenderStyle::boxDecorationBreak, &RenderStyle::setBoxDecorationBreak),

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -1165,6 +1165,25 @@
                 "non-canonical-url": "https://www.w3.org/TR/css-text-4/#text-spacing-property"
             }
         },
+        "text-autospace": {
+            "inherited": true,
+            "values": [
+                "auto",
+                "no-autospace"
+            ],
+            "codegen-properties": {
+                "settings-flag": "cssTextSpacingEnabled",
+                "converter": "TextAutospace",
+                "parser-function": "consumeTextAutospace",
+                "parser-grammar-unused": "normal | auto | no-autospace | [ [ ideograph-alpha || ideograph-numeric || punctuation ] || [ insert | replace ] ]",
+                "parser-grammar-unused-reason": "Needs support for '||' groups."
+            },
+            "status": "experimental",
+            "specification": {
+                "category": "css-text",
+                "non-canonical-url": "https://www.w3.org/TR/css-text-4/#text-spacing-property"
+            }
+        },
         "writing-mode": {
             "inherited": true,
             "values": [

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -1658,3 +1658,5 @@ false
 
 // text-spacing-trim
 space-all
+// text-autospace
+no-autospace

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -375,6 +375,16 @@ static Ref<CSSPrimitiveValue> textSpacingTrimFromStyle(const RenderStyle& style)
     return CSSPrimitiveValue::create(CSSValueSpaceAll);
 }
 
+static Ref<CSSPrimitiveValue> textAutospaceFromStyle(const RenderStyle& style)
+{
+    // FIXME: add support for remaining values once spec is stable and we are parsing them.
+    auto textAutospace = style.textAutospace();
+    if (textAutospace.isAuto())
+        return CSSPrimitiveValue::create(CSSValueAuto);
+
+    return CSSPrimitiveValue::create(CSSValueNoAutospace);
+}
+
 static Ref<CSSPrimitiveValue> zoomAdjustedPixelValue(double value, const RenderStyle& style)
 {
     return CSSPrimitiveValue::create(adjustFloatForAbsoluteZoom(value, style), CSSUnitType::CSS_PX);
@@ -3567,6 +3577,8 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
         return valueForShadow(style.textShadow(), propertyID, style);
     case CSSPropertyTextSpacingTrim:
         return textSpacingTrimFromStyle(style);
+    case CSSPropertyTextAutospace:
+        return textAutospaceFromStyle(style);
     case CSSPropertyTextRendering:
         return createConvertingToCSSValueID(style.fontDescription().textRenderingMode());
     case CSSPropertyTextOverflow:

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -1225,6 +1225,8 @@ static constexpr InitialValue initialValueForLonghand(CSSPropertyID longhand)
         return CSSValueHorizontalTb;
     case CSSPropertyTextSpacingTrim:
         return CSSValueSpaceAll;
+    case CSSPropertyTextAutospace:
+        return CSSValueNoAutospace;
     default:
         RELEASE_ASSERT_NOT_REACHED();
     }

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -8368,5 +8368,17 @@ RefPtr<CSSValue> consumeTextSpacingTrim(CSSParserTokenRange& range)
     return nullptr;
 }
 
+RefPtr<CSSValue> consumeTextAutospace(CSSParserTokenRange& range)
+{
+    //  normal | auto | no-autospace | [ ideograph-alpha || ideograph-numeric || punctuation ] || [ insert | replace ]
+    // FIXME: add remaining values;
+    if (auto value = consumeIdent<CSSValueAuto, CSSValueNoAutospace>(range)) {
+        if (!range.atEnd())
+            return nullptr;
+        return value;
+    }
+    return nullptr;
+}
+
 } // namespace CSSPropertyParserHelpers
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
@@ -309,6 +309,7 @@ RefPtr<CSSValue> consumeColorScheme(CSSParserTokenRange&);
 #endif
 RefPtr<CSSValue> consumeOffsetRotate(CSSParserTokenRange&, CSSParserMode);
 RefPtr<CSSValue> consumeTextSpacingTrim(CSSParserTokenRange&);
+RefPtr<CSSValue> consumeTextAutospace(CSSParserTokenRange&);
 
 RefPtr<CSSValue> consumeDeclarationValue(CSSParserTokenRange&, const CSSParserContext&);
 

--- a/Source/WebCore/platform/text/TextSpacing.h
+++ b/Source/WebCore/platform/text/TextSpacing.h
@@ -57,4 +57,30 @@ inline WTF::TextStream& operator<<(WTF::TextStream& ts, const TextSpacingTrim& v
     return ts;
 }
 
+struct TextAutospace {
+enum class TextAutospaceType: uint8_t {
+    Auto = 0,
+    NoAutospace // equivalent to None in text-spacing shorthand
+};
+
+bool isAuto() const { return m_autoSpace == TextAutospaceType::Auto; }
+bool isNoAutospace() const { return m_autoSpace == TextAutospaceType::NoAutospace; }
+bool operator==(const TextAutospace& other) const
+{
+    return m_autoSpace == other.m_autoSpace;
+}
+TextAutospaceType m_autoSpace { TextAutospaceType::NoAutospace };
+};
+
+inline WTF::TextStream& operator<<(WTF::TextStream& ts, const TextAutospace& value)
+{
+    // FIXME: add remaining values;
+    switch (value.m_autoSpace) {
+    case TextAutospace::TextAutospaceType::Auto:
+        return ts << "auto";
+    case TextAutospace::TextAutospaceType::NoAutospace:
+        return ts << "no-autospace";
+    }
+    return ts;
+}
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -2009,6 +2009,11 @@ TextSpacingTrim RenderStyle::textSpacingTrim() const
     return m_rareInheritedData->textSpacingTrim;
 }
 
+TextAutospace RenderStyle::textAutospace() const
+{
+    return m_rareInheritedData->textAutospace;
+}
+
 bool RenderStyle::setFontDescription(FontCascadeDescription&& description)
 {
     if (m_inheritedData->fontCascade.fontDescription() == description)

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -435,6 +435,7 @@ public:
     const Length& wordSpacing() const;
     float letterSpacing() const;
     TextSpacingTrim textSpacingTrim() const;
+    TextAutospace textAutospace() const;
 
 
     float zoom() const { return m_nonInheritedData->rareData->zoom; }
@@ -1676,6 +1677,7 @@ public:
     void setMathStyle(const MathStyle& v) { SET_VAR(m_rareInheritedData, mathStyle, static_cast<unsigned>(v)); }
 
     void setTextSpacingTrim(TextSpacingTrim v) { SET_VAR(m_rareInheritedData, textSpacingTrim, v); }
+    void setTextAutospace(TextAutospace v) { SET_VAR(m_rareInheritedData, textAutospace, v); }
 
     // Initial values for all the properties
     static Overflow initialOverflowX() { return Overflow::Visible; }
@@ -1705,6 +1707,7 @@ public:
     static TextCombine initialTextCombine() { return TextCombine::None; }
     static TextOrientation initialTextOrientation() { return TextOrientation::Mixed; }
     static TextSpacingTrim initialTextSpacingTrim() { return { }; }
+    static TextAutospace initialTextAutospace() { return { }; }
     static ObjectFit initialObjectFit() { return ObjectFit::Fill; }
     static LengthPoint initialObjectPosition() { return LengthPoint(Length(50.0f, LengthType::Percent), Length(50.0f, LengthType::Percent)); }
     static EmptyCell initialEmptyCells() { return EmptyCell::Show; }

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
@@ -70,6 +70,7 @@ struct GreaterThanOrSameSizeAsStyleRareInheritedData : public RefCounted<Greater
     StyleColorScheme colorScheme;
 #endif
     TextSpacingTrim textSpacingTrim;
+    TextAutospace textAutospace;
 };
 
 static_assert(sizeof(StyleRareInheritedData) <= sizeof(GreaterThanOrSameSizeAsStyleRareInheritedData), "StyleRareInheritedData should bit pack");
@@ -169,6 +170,7 @@ StyleRareInheritedData::StyleRareInheritedData()
     , tapHighlightColor(RenderStyle::initialTapHighlightColor())
 #endif
     , textSpacingTrim(RenderStyle::initialTextSpacingTrim())
+    , textAutospace(RenderStyle::initialTextAutospace())
 {
 }
 
@@ -275,6 +277,7 @@ inline StyleRareInheritedData::StyleRareInheritedData(const StyleRareInheritedDa
     , tapHighlightColor(o.tapHighlightColor)
 #endif
     , textSpacingTrim(o.textSpacingTrim)
+    , textAutospace(o.textAutospace)
 {
 }
 
@@ -387,7 +390,8 @@ bool StyleRareInheritedData::operator==(const StyleRareInheritedData& o) const
         && customProperties == o.customProperties
         && arePointingToEqualData(listStyleImage, o.listStyleImage)
         && listStyleStringValue == o.listStyleStringValue
-        && textSpacingTrim == o.textSpacingTrim;
+        && textSpacingTrim == o.textSpacingTrim
+        && textAutospace == o.textAutospace;
 }
 
 bool StyleRareInheritedData::hasColorFilters() const

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.h
@@ -210,6 +210,7 @@ public:
     StyleColor tapHighlightColor;
 #endif
     TextSpacingTrim textSpacingTrim;
+    TextAutospace textAutospace;
 
 private:
     StyleRareInheritedData();

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -189,6 +189,7 @@ public:
     static OptionSet<MarginTrimType> convertMarginTrim(BuilderState&, const CSSValue&);
 
     static TextSpacingTrim convertTextSpacingTrim(BuilderState&, const CSSValue&);
+    static TextAutospace convertTextAutospace(BuilderState&, const CSSValue&);
 
 private:
     friend class BuilderCustom;
@@ -1825,6 +1826,15 @@ inline TextSpacingTrim BuilderConverter::convertTextSpacingTrim(BuilderState&, c
     if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
         if (primitiveValue->valueID() == CSSValueAuto)
             return { .m_trim = TextSpacingTrim::TrimType::Auto };
+    }
+    return { };
+}
+
+inline TextAutospace BuilderConverter::convertTextAutospace(BuilderState&, const CSSValue& value)
+{
+    if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
+        if (primitiveValue->valueID() == CSSValueAuto)
+            return { .m_autoSpace = TextAutospace::TextAutospaceType::Auto };
     }
     return { };
 }


### PR DESCRIPTION
#### a9febb26c871be962432254ecb980a9a36ac7f13
<pre>
Implement text-autospace parser for auto and no-autospace
<a href="https://bugs.webkit.org/show_bug.cgi?id=252119">https://bugs.webkit.org/show_bug.cgi?id=252119</a>
rdar://105340814

Reviewed by Myles C. Maxfield.

text-spacing longhand: text-autospace parser for auto and no-autospace

Reference: <a href="https://github.com/w3c/csswg-drafts/issues/4246#issuecomment-1404738513">https://github.com/w3c/csswg-drafts/issues/4246#issuecomment-1404738513</a>

Implement a parser for text-autospace (text-spacing longhand) for none
and auto-space values. We can then iterate from here add remaining values.
Syntax:
text-autospace: auto | no-autospace

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::textAutospaceFromStyle):
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle):
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::initialValueForLonghand):
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeTextAutospace):
* Source/WebCore/css/parser/CSSPropertyParserHelpers.h:
* Source/WebCore/platform/text/TextSpacing.h:
(WebCore::TextAutospace::isAuto const):
(WebCore::TextAutospace::isNoAutospace const):
(WebCore::TextAutospace::operator== const):
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::textAutospace const):
* Source/WebCore/rendering/style/RenderStyle.h:
(WebCore::RenderStyle::setTextAutospace):
(WebCore::RenderStyle::initialTextAutospace):
* Source/WebCore/rendering/style/StyleRareInheritedData.cpp:
(WebCore::StyleRareInheritedData::StyleRareInheritedData):
(WebCore::StyleRareInheritedData::operator== const):
* Source/WebCore/rendering/style/StyleRareInheritedData.h:
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertTextAutospace):

Canonical link: <a href="https://commits.webkit.org/260306@main">https://commits.webkit.org/260306@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a7fb3ae488656e79884fd753a1866a000a3fea93

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107902 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16957 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40785 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117035 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116384 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111789 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18346 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8274 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100087 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113664 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97067 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41666 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95762 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28704 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9882 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30052 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10589 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6944 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16034 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49641 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7130 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12161 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->