### PR TITLE
Implement text-spacing-trim parser for auto and space-all

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6254,4 +6254,8 @@ imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/js
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.html [ Skip ]
 
 #Skipping text-spacing tests until the features get implemented.
-imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing [ Skip ]
+imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-autospace-invalid.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-autospace-valid.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-spacing-computed.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-spacing-invalid.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-spacing-valid.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -317,6 +317,7 @@ PASS text-orientation
 PASS text-overflow
 PASS text-rendering
 PASS text-shadow
+PASS text-spacing-trim
 PASS text-transform
 PASS text-underline-offset
 PASS text-underline-position

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
@@ -229,6 +229,9 @@ PASS text-rendering: "optimizeLegibility" onto "optimizeSpeed"
 PASS text-rendering: "optimizeSpeed" onto "optimizeLegibility"
 PASS text-shadow (type: textShadowList) has testAccumulation function
 PASS text-shadow: shadow
+PASS text-spacing-trim (type: discrete) has testAccumulation function
+PASS text-spacing-trim: "space-all" onto "auto"
+PASS text-spacing-trim: "auto" onto "space-all"
 PASS text-transform (type: discrete) has testAccumulation function
 PASS text-transform: "uppercase" onto "capitalize"
 PASS text-transform: "capitalize" onto "uppercase"

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
@@ -229,6 +229,9 @@ PASS text-rendering: "optimizeLegibility" onto "optimizeSpeed"
 PASS text-rendering: "optimizeSpeed" onto "optimizeLegibility"
 PASS text-shadow (type: textShadowList) has testAddition function
 PASS text-shadow: shadow
+PASS text-spacing-trim (type: discrete) has testAddition function
+PASS text-spacing-trim: "space-all" onto "auto"
+PASS text-spacing-trim: "auto" onto "space-all"
 PASS text-transform (type: discrete) has testAddition function
 PASS text-transform: "uppercase" onto "capitalize"
 PASS text-transform: "capitalize" onto "uppercase"

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
@@ -284,6 +284,10 @@ PASS text-shadow: shadow list
 PASS text-shadow: mismatched list length (from longer to shorter)
 PASS text-shadow: mismatched list length (from shorter to longer)
 PASS text-shadow: with currentcolor
+PASS text-spacing-trim (type: discrete) has testInterpolation function
+PASS text-spacing-trim uses discrete animation when animating between "auto" and "space-all" with linear easing
+PASS text-spacing-trim uses discrete animation when animating between "auto" and "space-all" with effect easing
+PASS text-spacing-trim uses discrete animation when animating between "auto" and "space-all" with keyframe easing
 PASS text-transform (type: discrete) has testInterpolation function
 PASS text-transform uses discrete animation when animating between "capitalize" and "uppercase" with linear easing
 PASS text-transform uses discrete animation when animating between "capitalize" and "uppercase" with effect easing

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js
@@ -1327,6 +1327,12 @@ const gCSSProperties2 = {
       return element;
     }
   },
+  'text-spacing-trim': {
+    // https://svgwg.org/svg2-draft/painting.html#TextRenderingProperty
+    types: [
+      { type: 'discrete', options: [ [ 'auto', 'space-all' ] ] }
+    ]
+  },
   'text-transform': {
     // https://drafts.csswg.org/css-text-3/#propdef-text-transform
     types: [

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -317,6 +317,7 @@ PASS text-orientation
 PASS text-overflow
 PASS text-rendering
 PASS text-shadow
+PASS text-spacing-trim
 PASS text-transform
 PASS text-underline-offset
 PASS text-underline-position

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -317,6 +317,7 @@ PASS text-orientation
 PASS text-overflow
 PASS text-rendering
 PASS text-shadow
+PASS text-spacing-trim
 PASS text-transform
 PASS text-underline-offset
 PASS text-underline-position

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -317,6 +317,7 @@ PASS text-overflow
 PASS text-rendering
 PASS text-shadow
 PASS text-transform
+PASS text-spacing-trim
 PASS text-underline-offset
 PASS text-underline-position
 PASS text-wrap

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -317,6 +317,7 @@ PASS text-orientation
 PASS text-overflow
 PASS text-rendering
 PASS text-shadow
+PASS text-spacing-trim
 PASS text-transform
 PASS text-underline-offset
 PASS text-underline-position

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1136,6 +1136,19 @@ CSSTextJustifyEnabled:
     WebCore:
       default: false
 
+CSSTextSpacingEnabled:
+  type: bool
+  status: testable
+  humanReadableName: "CSS text-spacing property"
+  humanReadableDescription: "Enable the property text-spacing, defined in CSS Text 4"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 CSSTextWrapEnabled:
   type: bool
   status: testable

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2012,6 +2012,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/text/TextCheckingRequestIdentifier.h
     platform/text/TextDirection.h
     platform/text/TextFlags.h
+    platform/text/TextSpacing.h
     platform/text/UnicodeBidi.h
     platform/text/WritingMode.h
 

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -66,6 +66,7 @@
 #include "StylePropertyShorthand.h"
 #include "StyleResolver.h"
 #include "TabSize.h"
+#include "TextSpacing.h"
 #include <algorithm>
 #include <memory>
 #include <wtf/MathExtras.h>
@@ -3497,6 +3498,7 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         new DiscretePropertyWrapper<WhiteSpace>(CSSPropertyWhiteSpace, &RenderStyle::whiteSpace, &RenderStyle::setWhiteSpace),
         new DiscretePropertyWrapper<WordBreak>(CSSPropertyWordBreak, &RenderStyle::wordBreak, &RenderStyle::setWordBreak),
         new DiscretePropertyWrapper<OverflowAnchor>(CSSPropertyOverflowAnchor, &RenderStyle::overflowAnchor, &RenderStyle::setOverflowAnchor),
+        new DiscretePropertyWrapper<TextSpacingTrim>(CSSPropertyTextSpacingTrim, &RenderStyle::textSpacingTrim, &RenderStyle::setTextSpacingTrim),
 
 #if ENABLE(CSS_BOX_DECORATION_BREAK)
         new DiscretePropertyWrapper<BoxDecorationBreak>(CSSPropertyWebkitBoxDecorationBreak, &RenderStyle::boxDecorationBreak, &RenderStyle::setBoxDecorationBreak),

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -1146,6 +1146,25 @@
                 "non-canonical-url": "https://drafts.csswg.org/css-size-adjust/#adjustment-control"
             }
         },
+        "text-spacing-trim": {
+            "inherited": true,
+            "values": [
+                "auto",
+                "space-all"
+            ],
+            "codegen-properties": {
+                "settings-flag": "cssTextSpacingEnabled",
+                "converter": "TextSpacingTrim",
+                "parser-function": "consumeTextSpacingTrim",
+                "parser-grammar-unused": "auto | space-all | trim-all | [ allow-end || space-first ]",
+                "parser-grammar-unused-reason": "Needs support for '||' groups."
+            },
+            "status": "experimental",
+            "specification": {
+                "category": "css-text",
+                "non-canonical-url": "https://www.w3.org/TR/css-text-4/#text-spacing-property"
+            }
+        },
         "writing-mode": {
             "inherited": true,
             "values": [

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -1655,3 +1655,6 @@ only
 // inherits
 true
 false
+
+// text-spacing-trim
+space-all

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -365,6 +365,16 @@ static Ref<CSSPrimitiveValue> fontSizeAdjustFromStyle(const RenderStyle& style)
     return CSSPrimitiveValue::create(*adjust);
 }
 
+static Ref<CSSPrimitiveValue> textSpacingTrimFromStyle(const RenderStyle& style)
+{
+    // FIXME: add support for remaining values once spec is stable and we are parsing them.
+    auto textSpacingTrim = style.textSpacingTrim();
+    if (textSpacingTrim.isAuto())
+        return CSSPrimitiveValue::create(CSSValueAuto);
+
+    return CSSPrimitiveValue::create(CSSValueSpaceAll);
+}
+
 static Ref<CSSPrimitiveValue> zoomAdjustedPixelValue(double value, const RenderStyle& style)
 {
     return CSSPrimitiveValue::create(adjustFloatForAbsoluteZoom(value, style), CSSUnitType::CSS_PX);
@@ -3555,6 +3565,8 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
     }
     case CSSPropertyTextShadow:
         return valueForShadow(style.textShadow(), propertyID, style);
+    case CSSPropertyTextSpacingTrim:
+        return textSpacingTrimFromStyle(style);
     case CSSPropertyTextRendering:
         return createConvertingToCSSValueID(style.fontDescription().textRenderingMode());
     case CSSPropertyTextOverflow:

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -1223,6 +1223,8 @@ static constexpr InitialValue initialValueForLonghand(CSSPropertyID longhand)
         return CSSValueAll;
     case CSSPropertyWritingMode:
         return CSSValueHorizontalTb;
+    case CSSPropertyTextSpacingTrim:
+        return CSSValueSpaceAll;
     default:
         RELEASE_ASSERT_NOT_REACHED();
     }

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -8356,5 +8356,17 @@ RefPtr<CSSValue> consumeDeclarationValue(CSSParserTokenRange& range, const CSSPa
     return CSSVariableParser::parseDeclarationValue(nullAtom(), range.consumeAll(), context);
 }
 
+RefPtr<CSSValue> consumeTextSpacingTrim(CSSParserTokenRange& range)
+{
+    // auto | space-all |  trim-all | [ allow-end || space-first ]
+    // FIXME: add remaining values;
+    if (auto value = consumeIdent<CSSValueAuto, CSSValueSpaceAll>(range)) {
+        if (!range.atEnd())
+            return nullptr;
+        return value;
+    }
+    return nullptr;
+}
+
 } // namespace CSSPropertyParserHelpers
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
@@ -308,6 +308,7 @@ RefPtr<CSSValue> consumeTextEmphasisPosition(CSSParserTokenRange&);
 RefPtr<CSSValue> consumeColorScheme(CSSParserTokenRange&);
 #endif
 RefPtr<CSSValue> consumeOffsetRotate(CSSParserTokenRange&, CSSParserMode);
+RefPtr<CSSValue> consumeTextSpacingTrim(CSSParserTokenRange&);
 
 RefPtr<CSSValue> consumeDeclarationValue(CSSParserTokenRange&, const CSSParserContext&);
 

--- a/Source/WebCore/platform/text/TextFlags.cpp
+++ b/Source/WebCore/platform/text/TextFlags.cpp
@@ -28,6 +28,7 @@
 
 #include "FontCascade.h"
 #include "FontFeatureValues.h"
+#include "TextSpacing.h"
 #include <functional>
 #include <numeric>
 #include <wtf/text/TextStream.h>

--- a/Source/WebCore/platform/text/TextSpacing.h
+++ b/Source/WebCore/platform/text/TextSpacing.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+#include <wtf/Forward.h>
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+
+struct TextSpacingTrim {
+
+enum class TrimType: uint8_t {
+    Auto = 0,
+    SpaceAll // equivalent to None in text-spacing shorthand
+};
+
+bool isAuto() const { return m_trim == TrimType::Auto; }
+bool isSpaceAll() const { return m_trim == TrimType::SpaceAll; }
+bool operator==(const TextSpacingTrim& other) const
+{
+    return m_trim == other.m_trim;
+}
+TrimType m_trim { TrimType::SpaceAll };
+};
+
+inline WTF::TextStream& operator<<(WTF::TextStream& ts, const TextSpacingTrim& value)
+{
+    // FIXME: add remaining values;
+    switch (value.m_trim) {
+    case TextSpacingTrim::TrimType::Auto:
+        return ts << "auto";
+    case TextSpacingTrim::TrimType::SpaceAll:
+        return ts << "space-all";
+    }
+    return ts;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -2004,6 +2004,11 @@ float RenderStyle::letterSpacing() const
     return m_inheritedData->fontCascade.letterSpacing();
 }
 
+TextSpacingTrim RenderStyle::textSpacingTrim() const
+{
+    return m_rareInheritedData->textSpacingTrim;
+}
+
 bool RenderStyle::setFontDescription(FontCascadeDescription&& description)
 {
     if (m_inheritedData->fontCascade.fontDescription() == description)

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -69,6 +69,7 @@
 #include "StyleTransformData.h"
 #include "StyleVisitedLinkColorData.h"
 #include "TextFlags.h"
+#include "TextSpacing.h"
 #include "ThemeTypes.h"
 #include "TouchAction.h"
 #include "TransformOperations.h"
@@ -433,6 +434,8 @@ public:
 
     const Length& wordSpacing() const;
     float letterSpacing() const;
+    TextSpacingTrim textSpacingTrim() const;
+
 
     float zoom() const { return m_nonInheritedData->rareData->zoom; }
     float effectiveZoom() const { return m_rareInheritedData->effectiveZoom; }
@@ -1672,6 +1675,8 @@ public:
 
     void setMathStyle(const MathStyle& v) { SET_VAR(m_rareInheritedData, mathStyle, static_cast<unsigned>(v)); }
 
+    void setTextSpacingTrim(TextSpacingTrim v) { SET_VAR(m_rareInheritedData, textSpacingTrim, v); }
+
     // Initial values for all the properties
     static Overflow initialOverflowX() { return Overflow::Visible; }
     static Overflow initialOverflowY() { return Overflow::Visible; }
@@ -1699,6 +1704,7 @@ public:
     static WritingMode initialWritingMode() { return WritingMode::TopToBottom; }
     static TextCombine initialTextCombine() { return TextCombine::None; }
     static TextOrientation initialTextOrientation() { return TextOrientation::Mixed; }
+    static TextSpacingTrim initialTextSpacingTrim() { return { }; }
     static ObjectFit initialObjectFit() { return ObjectFit::Fill; }
     static LengthPoint initialObjectPosition() { return LengthPoint(Length(50.0f, LengthType::Percent), Length(50.0f, LengthType::Percent)); }
     static EmptyCell initialEmptyCells() { return EmptyCell::Show; }

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
@@ -69,6 +69,7 @@ struct GreaterThanOrSameSizeAsStyleRareInheritedData : public RefCounted<Greater
 #if ENABLE(DARK_MODE_CSS)
     StyleColorScheme colorScheme;
 #endif
+    TextSpacingTrim textSpacingTrim;
 };
 
 static_assert(sizeof(StyleRareInheritedData) <= sizeof(GreaterThanOrSameSizeAsStyleRareInheritedData), "StyleRareInheritedData should bit pack");
@@ -167,6 +168,7 @@ StyleRareInheritedData::StyleRareInheritedData()
 #if ENABLE(TOUCH_EVENTS)
     , tapHighlightColor(RenderStyle::initialTapHighlightColor())
 #endif
+    , textSpacingTrim(RenderStyle::initialTextSpacingTrim())
 {
 }
 
@@ -272,6 +274,7 @@ inline StyleRareInheritedData::StyleRareInheritedData(const StyleRareInheritedDa
 #if ENABLE(TOUCH_EVENTS)
     , tapHighlightColor(o.tapHighlightColor)
 #endif
+    , textSpacingTrim(o.textSpacingTrim)
 {
 }
 
@@ -383,7 +386,8 @@ bool StyleRareInheritedData::operator==(const StyleRareInheritedData& o) const
         && visitedLinkStrokeColor == o.visitedLinkStrokeColor
         && customProperties == o.customProperties
         && arePointingToEqualData(listStyleImage, o.listStyleImage)
-        && listStyleStringValue == o.listStyleStringValue;
+        && listStyleStringValue == o.listStyleStringValue
+        && textSpacingTrim == o.textSpacingTrim;
 }
 
 bool StyleRareInheritedData::hasColorFilters() const

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.h
@@ -30,6 +30,7 @@
 #include "StyleCustomPropertyData.h"
 #include "StyleTextEdge.h"
 #include "TabSize.h"
+#include "TextSpacing.h"
 #include "TextUnderlineOffset.h"
 #include "TouchAction.h"
 #include <wtf/DataRef.h>
@@ -208,6 +209,7 @@ public:
 #if ENABLE(TOUCH_EVENTS)
     StyleColor tapHighlightColor;
 #endif
+    TextSpacingTrim textSpacingTrim;
 
 private:
     StyleRareInheritedData();

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -65,6 +65,7 @@
 #include "StyleScrollSnapPoints.h"
 #include "StyleTextEdge.h"
 #include "TabSize.h"
+#include "TextSpacing.h"
 #include "TouchAction.h"
 #include "TransformFunctions.h"
 
@@ -186,7 +187,9 @@ public:
     static Vector<AtomString> convertContainerName(BuilderState&, const CSSValue&);
 
     static OptionSet<MarginTrimType> convertMarginTrim(BuilderState&, const CSSValue&);
-    
+
+    static TextSpacingTrim convertTextSpacingTrim(BuilderState&, const CSSValue&);
+
 private:
     friend class BuilderCustom;
 
@@ -1817,6 +1820,15 @@ inline OptionSet<MarginTrimType> BuilderConverter::convertMarginTrim(BuilderStat
             marginTrim.add(MarginTrimType::InlineEnd);
     }
     return marginTrim;
+}
+
+inline TextSpacingTrim BuilderConverter::convertTextSpacingTrim(BuilderState&, const CSSValue& value)
+{
+    if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
+        if (primitiveValue->valueID() == CSSValueAuto)
+            return { .m_trim = TextSpacingTrim::TrimType::Auto };
+    }
+    return { };
 }
 
 } // namespace Style


### PR DESCRIPTION
#### 4cee70d5419a516eece4a7ecc4a32df74b4edd2c
<pre>
Implement text-spacing-trim parser for auto and space-all
<a href="https://bugs.webkit.org/show_bug.cgi?id=252124">https://bugs.webkit.org/show_bug.cgi?id=252124</a>
rdar://105342875

Reference: <a href="https://github.com/w3c/csswg-drafts/issues/4246#issuecomment-1404738513">https://github.com/w3c/csswg-drafts/issues/4246#issuecomment-1404738513</a>

Implement a partial parser for text-spacing-trim (text-spacing longhand)
for auto and space-all values. We can then iterate from here adding
the remaining values once we commit to handle them.

Syntax:
text-spacing-trim: auto | space-all

Reviewed by Myles C. Maxfield.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::textSpacingTrimFromStyle):
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle):
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::initialValueForLonghand):
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeTextSpacingTrim):
* Source/WebCore/css/parser/CSSPropertyParserHelpers.h:
* Source/WebCore/platform/text/TextSpacing.h: Added.
(WebCore::TextSpacingTrim::isAuto const):
(WebCore::TextSpacingTrim::isSpaceAll const):
(WebCore::TextSpacingTrim::operator== const):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::textSpacingTrim const):
* Source/WebCore/rendering/style/RenderStyle.h:
(WebCore::RenderStyle::setTextSpacingTrim):
(WebCore::RenderStyle::initialTextSpacingTrim):
* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/style/RenderStyleConstants.h:
* Source/WebCore/rendering/style/StyleRareInheritedData.cpp:
(WebCore::StyleRareInheritedData::StyleRareInheritedData):
(WebCore::StyleRareInheritedData::operator== const):
* Source/WebCore/rendering/style/StyleRareInheritedData.h:
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertTextSpacingTrim):

Canonical link: <a href="https://commits.webkit.org/260288@main">https://commits.webkit.org/260288@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22c877745745e6aa116d0ba0bf4e23472b4adb44

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107803 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16859 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40694 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116946 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111693 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18264 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8174 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99982 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113560 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96993 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/41484 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/95694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/28634 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/97077 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9812 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29982 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/38/builds/96470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/7862 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10507 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/6875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/38/builds/96470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/15966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49566 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/105445 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7116 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12072 "Built successfully") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/26120 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | | | | 
<!--EWS-Status-Bubble-End-->