### PR TITLE
Replace std::optional<WallTime> with Markable<WallTime> to reduce space

### DIFF
--- a/Source/WebCore/Modules/webdatabase/DatabaseDetails.h
+++ b/Source/WebCore/Modules/webdatabase/DatabaseDetails.h
@@ -91,8 +91,8 @@ private:
     String m_displayName;
     uint64_t m_expectedUsage { 0 };
     uint64_t m_currentUsage { 0 };
-    Markable<WallTime, WallTime::MarkableTraits> m_creationTime;
-    Markable<WallTime, WallTime::MarkableTraits> m_modificationTime;
+    Markable<WallTime> m_creationTime;
+    Markable<WallTime> m_modificationTime;
 #if ASSERT_ENABLED
     Ref<Thread> m_thread { Thread::current() };
 #endif

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -2135,7 +2135,7 @@ private:
 
     String m_cachedDOMCookies;
 
-    Markable<WallTime, WallTime::MarkableTraits> m_overrideLastModified;
+    Markable<WallTime> m_overrideLastModified;
 
     WeakHashSet<Element, WeakPtrImplWithEventTargetData> m_associatedFormControls;
 

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1169,7 +1169,7 @@ private:
     String m_userStyleSheetPath;
     mutable String m_userStyleSheet;
     mutable bool m_didLoadUserStyleSheet { false };
-    mutable std::optional<WallTime> m_userStyleSheetModificationTime;
+    mutable Markable<WallTime> m_userStyleSheetModificationTime;
 
     String m_captionUserPreferencesStyleSheet;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -439,7 +439,7 @@ private:
     mutable MediaPlayer::CurrentTimeDidChangeCallback m_currentTimeDidChangeCallback;
     mutable MediaTime m_cachedCurrentMediaTime { -1, 1, 0 };
     mutable MediaTime m_lastPeriodicObserverMediaTime;
-    mutable std::optional<WallTime> m_wallClockAtCachedCurrentTime;
+    mutable Markable<WallTime> m_wallClockAtCachedCurrentTime;
     mutable int m_timeControlStatusAtCachedCurrentTime { 0 };
     mutable double m_requestedRateAtCachedCurrentTime { 0 };
     RefPtr<SharedBuffer> m_keyID;

--- a/Source/WebCore/platform/network/BlobDataFileReference.h
+++ b/Source/WebCore/platform/network/BlobDataFileReference.h
@@ -65,7 +65,7 @@ private:
     bool m_replacementShouldBeGenerated { false };
 #endif
     unsigned long long m_size { 0 };
-    Markable<WallTime, WallTime::MarkableTraits> m_expectedModificationTime;
+    Markable<WallTime> m_expectedModificationTime;
 };
 
 }

--- a/Source/WebCore/platform/network/ResourceResponseBase.h
+++ b/Source/WebCore/platform/network/ResourceResponseBase.h
@@ -308,9 +308,9 @@ protected:
 
 private:
     mutable Markable<Seconds, Seconds::MarkableTraits> m_age;
-    mutable Markable<WallTime, WallTime::MarkableTraits> m_date;
-    mutable Markable<WallTime, WallTime::MarkableTraits> m_expires;
-    mutable Markable<WallTime, WallTime::MarkableTraits> m_lastModified;
+    mutable Markable<WallTime> m_date;
+    mutable Markable<WallTime> m_expires;
+    mutable Markable<WallTime> m_lastModified;
     mutable ParsedContentRange m_contentRange;
     mutable CacheControlDirectives m_cacheControlDirectives;
 

--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
@@ -106,7 +106,7 @@ private:
     RefPtr<QuotaManager> m_quotaManager;
     bool m_persisted { false };
     UnifiedOriginStorageLevel m_level;
-    std::optional<WallTime> m_originFileCreationTimestamp;
+    Markable<WallTime> m_originFileCreationTimestamp;
 #if PLATFORM(IOS_FAMILY)
     bool m_includedInBackup { false };
 #endif

--- a/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.h
+++ b/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.h
@@ -122,7 +122,7 @@ private:
     HistoricalDeltas m_deltaHistoryX;
     HistoricalDeltas m_deltaHistoryY;
 
-    std::optional<WallTime> m_lastScrollTimestamp;
+    Markable<WallTime> m_lastScrollTimestamp;
     std::optional<WebWheelEvent> m_lastIncomingEvent;
     WebCore::RectEdges<bool> m_lastRubberBandableEdges;
     bool m_isInOverriddenPlatformMomentumGesture { false };


### PR DESCRIPTION
#### 5de18c5f31225e51cd124f4587bb04ee192705a2
<pre>
Replace std::optional&lt;WallTime&gt; with Markable&lt;WallTime&gt; to reduce space
<a href="https://bugs.webkit.org/show_bug.cgi?id=252128">https://bugs.webkit.org/show_bug.cgi?id=252128</a>
rdar://105350562

Reviewed by NOBODY (OOPS!).

Markable could be more space efficient.

* Source/WebCore/Modules/webdatabase/DatabaseDetails.h:
* Source/WebCore/dom/Document.h:
* Source/WebCore/page/Page.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h:
* Source/WebCore/platform/network/BlobDataFileReference.h:
* Source/WebCore/platform/network/ResourceResponseBase.h:
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.h:
* Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5de18c5f31225e51cd124f4587bb04ee192705a2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107753 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16809 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40653 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116901 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111643 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18226 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8127 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99933 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113509 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13762 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96961 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41452 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/95670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28602 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9778 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29950 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10463 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6838 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15932 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49534 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7106 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12025 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->