### PR TITLE
Make CachedSubimage part of PDFDocumentImage

### DIFF
--- a/Source/WebCore/platform/graphics/CachedSubimage.h
+++ b/Source/WebCore/platform/graphics/CachedSubimage.h
@@ -32,16 +32,21 @@
 namespace WebCore {
 
 class GraphicsContext;
-class Image;
 class ImageBuffer;
 struct ImagePaintingOptions;
 
 class CachedSubimage {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static std::unique_ptr<CachedSubimage> create(Image&, GraphicsContext&, const FloatRect& destinationRect, const FloatRect& sourceRect, const ImagePaintingOptions&);
+    static std::unique_ptr<CachedSubimage> create(GraphicsContext&, const FloatSize& imageSize, const FloatRect& destinationRect, const FloatRect& sourceRect);
+    static std::unique_ptr<CachedSubimage> createPixelated(GraphicsContext&, const FloatRect& destinationRect, const FloatRect& sourceRect);
 
     CachedSubimage(Ref<ImageBuffer>&&, const FloatSize& scaleFactor, const FloatRect& destinationRect, const FloatRect& sourceRect);
+
+    ImageBuffer& imageBuffer() const { return m_imageBuffer; }
+    FloatSize scaleFactor() const { return m_scaleFactor; }
+    FloatRect destinationRect() const { return m_destinationRect; }
+    FloatRect sourceRect() const { return m_sourceRect; }
 
     bool canBeUsed(GraphicsContext&, const FloatRect& destinationRect, const FloatRect& sourceRect) const;
     void draw(GraphicsContext&, const FloatRect& destinationRect, const FloatRect& sourceRect);
@@ -52,9 +57,6 @@ public:
     static constexpr float maxArea = maxSide * maxSide;
 
 private:
-    static std::unique_ptr<CachedSubimage> createCachedSubimage(Image&, GraphicsContext&, const FloatRect& destinationRect, const FloatRect& sourceRect, const ImagePaintingOptions&);
-    static std::unique_ptr<CachedSubimage> createPixelatedCachedSubimage(Image&, GraphicsContext&, const FloatRect& destinationRect, const FloatRect& sourceRect, const ImagePaintingOptions&);
-
     Ref<ImageBuffer> m_imageBuffer;
     FloatSize m_scaleFactor;
     FloatRect m_destinationRect;

--- a/Source/WebCore/platform/graphics/GraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContext.cpp
@@ -294,18 +294,6 @@ ImageDrawResult GraphicsContext::drawImage(Image& image, const FloatRect& destin
 ImageDrawResult GraphicsContext::drawImage(Image& image, const FloatRect& destination, const FloatRect& source, const ImagePaintingOptions& options)
 {
     InterpolationQualityMaintainer interpolationQualityForThisScope(*this, options.interpolationQuality());
-
-    auto result = image.drawCachedSubimage(*this, destination, source, options);
-    if (result != ImageDrawResult::DidNothing)
-        return result;
-
-    ASSERT_IMPLIES(image.mustDrawFromCachedSubimage(*this), image.shouldDrawFromCachedSubimage(*this));
-
-    if (image.mustDrawFromCachedSubimage(*this)) {
-        LOG_ERROR("ERROR ImageDrawResult GraphicsContext::drawImage() cached subimage could not been drawn");
-        return ImageDrawResult::DidNothing;
-    }
-
     return image.draw(*this, destination, source, options);
 }
 

--- a/Source/WebCore/platform/graphics/Image.h
+++ b/Source/WebCore/platform/graphics/Image.h
@@ -26,7 +26,6 @@
 
 #pragma once
 
-#include "CachedSubimage.h"
 #include "Color.h"
 #include "DecodingOptions.h"
 #include "FloatRect.h"
@@ -135,7 +134,7 @@ public:
     virtual String filenameExtension() const { return String(); } // null string if unknown
     virtual String accessibilityDescription() const { return String(); } // null string if unknown
 
-    virtual void destroyDecodedData(bool destroyAll = true);
+    virtual void destroyDecodedData(bool /*destroyAll*/ = true) { }
 
     FragmentedSharedBuffer* data() { return m_encodedImageData.get(); }
     const FragmentedSharedBuffer* data() const { return m_encodedImageData.get(); }
@@ -159,9 +158,6 @@ public:
     URL sourceURL() const;
     WEBCORE_EXPORT String mimeType() const;
     long long expectedContentLength() const;
-
-    unsigned cachedSubimageCreateCountForTesting() const { return m_cachedSubimageCreateCountForTesting; }
-    unsigned cachedSubimageDrawCountForTesting() const { return m_cachedSubimageDrawCountForTesting; }
 
     enum TileRule { StretchTile, RoundTile, SpaceTile, RepeatTile };
 
@@ -212,7 +208,6 @@ protected:
     virtual bool shouldDrawFromCachedSubimage(GraphicsContext&) const { return false; }
     virtual bool mustDrawFromCachedSubimage(GraphicsContext&) const { return false; }
     virtual ImageDrawResult draw(GraphicsContext&, const FloatRect& dstRect, const FloatRect& srcRect, const ImagePaintingOptions& = { }) = 0;
-    ImageDrawResult drawCachedSubimage(GraphicsContext&, const FloatRect& dstRect, const FloatRect& srcRect, const ImagePaintingOptions& = { });
     ImageDrawResult drawTiled(GraphicsContext&, const FloatRect& dstRect, const FloatPoint& srcPoint, const FloatSize& tileSize, const FloatSize& spacing, const ImagePaintingOptions& = { });
     ImageDrawResult drawTiled(GraphicsContext&, const FloatRect& dstRect, const FloatRect& srcRect, const FloatSize& tileScaleFactor, TileRule hRule, TileRule vRule, const ImagePaintingOptions& = { });
 
@@ -226,10 +221,6 @@ private:
     // A value of true or false will override the default Page::imageAnimationEnabled state.
     std::optional<bool> m_allowsAnimation { std::nullopt };
     std::unique_ptr<Timer> m_animationStartTimer;
-
-    std::unique_ptr<CachedSubimage> m_cachedSubimage;
-    unsigned m_cachedSubimageCreateCountForTesting { 0 };
-    unsigned m_cachedSubimageDrawCountForTesting { 0 };
 };
 
 WTF::TextStream& operator<<(WTF::TextStream&, const Image&);

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1028,6 +1028,13 @@ static BitmapImage* bitmapImageFromImageElement(HTMLImageElement& element)
     return dynamicDowncast<BitmapImage>(imageFromImageElement(element));
 }
 
+#if USE(CG)
+static PDFDocumentImage* pdfDocumentImageFromImageElement(HTMLImageElement& element)
+{
+    return dynamicDowncast<PDFDocumentImage>(imageFromImageElement(element));
+}
+#endif
+
 unsigned Internals::imageFrameIndex(HTMLImageElement& element)
 {
     auto* bitmapImage = bitmapImageFromImageElement(element);
@@ -1101,8 +1108,13 @@ unsigned Internals::imageDecodeCount(HTMLImageElement& element)
 
 unsigned Internals::imageCachedSubimageCreateCount(HTMLImageElement& element)
 {
-    auto* image = imageFromImageElement(element);
-    return image ? image->cachedSubimageCreateCountForTesting() : 0;
+#if USE(CG)
+    if (auto* pdfDocumentImage = pdfDocumentImageFromImageElement(element))
+        return pdfDocumentImage->cachedSubimageCreateCountForTesting();
+#else
+    UNUSED_PARAM(element);
+#endif
+    return 0;
 }
 
 unsigned Internals::remoteImagesCountForTesting() const


### PR DESCRIPTION
#### 6f7d211e4d86c1f971e681af47732554e88fd49d
<pre>
Make CachedSubimage part of PDFDocumentImage
<a href="https://bugs.webkit.org/show_bug.cgi?id=252129">https://bugs.webkit.org/show_bug.cgi?id=252129</a>
rdar://105351788

Reviewed by Simon Fraser.

It makes sense for now to have CachedSubimage be part of PDFDocumentImage only.
It can&apos;t be part of BitmapImage since it may display multiple NativeImages. So
in future patches, CachedSubimage will be made part of the NativeImage as well.

* Source/WebCore/platform/graphics/CachedSubimage.cpp:
(WebCore::CachedSubimage::create):
(WebCore::CachedSubimage::createPixelated):
(WebCore::CachedSubimage::createCachedSubimage): Deleted.
(WebCore::CachedSubimage::createPixelatedCachedSubimage): Deleted.
* Source/WebCore/platform/graphics/CachedSubimage.h:
(WebCore::CachedSubimage::imageBuffer const):
(WebCore::CachedSubimage::scaleFactor const):
(WebCore::CachedSubimage::destinationRect const):
(WebCore::CachedSubimage::sourceRect const):
* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::GraphicsContext::drawImage):
* Source/WebCore/platform/graphics/Image.cpp:
(WebCore::Image::drawCachedSubimage): Deleted.
(WebCore::Image::destroyDecodedData): Deleted.
* Source/WebCore/platform/graphics/Image.h:
(WebCore::Image::destroyDecodedData):
(WebCore::Image::draw):
(WebCore::Image::cachedSubimageCreateCountForTesting const): Deleted.
(WebCore::Image::cachedSubimageDrawCountForTesting const): Deleted.
(WebCore::Image::drawCachedSubimage): Deleted.
* Source/WebCore/platform/graphics/cg/PDFDocumentImage.cpp:
(WebCore::PDFDocumentImage::createCachedSubimage):
(WebCore::PDFDocumentImage::drawPDFDocument):
(WebCore::PDFDocumentImage::drawFromCachedSubimage):
(WebCore::PDFDocumentImage::draw):
(WebCore::PDFDocumentImage::destroyDecodedData):
* Source/WebCore/platform/graphics/cg/PDFDocumentImage.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::pdfDocumentImageFromImageElement):
(WebCore::Internals::imageCachedSubimageCreateCount):

Canonical link: <a href="https://commits.webkit.org/260236@main">https://commits.webkit.org/260236@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/760c6db59a17c9e25ec7209147932587aec880a2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107613 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16667 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40508 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116763 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111506 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18089 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7980 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99784 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113368 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96848 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/41322 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95565 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28475 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9656 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29827 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10329 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/6725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15811 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49409 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7075 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11889 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->