### PR TITLE
LegacyTileGrid: Proper bounds checking for Legacy Tiles 

### DIFF
--- a/Source/WebCore/platform/ios/LegacyTileGrid.mm
+++ b/Source/WebCore/platform/ios/LegacyTileGrid.mm
@@ -115,10 +115,10 @@ bool LegacyTileGrid::dropDistantTiles(unsigned tilesNeeded, double shortestDista
     unsigned bytesUsed = tileCount() * bytesPerTile;
     unsigned maximumBytes = m_tileCache.tileCapacityForGrid(this);
 
-    int bytesToReclaim = int(bytesUsed) - (int(maximumBytes) - bytesNeeded);
-    if (bytesToReclaim <= 0)
+    if (bytesNeeded > maximumBytes || bytesUsed <= maximumBytes - bytesNeeded)
         return true;
 
+    unsigned bytesToReclaim = bytesUsed - (maximumBytes - bytesNeeded);
     unsigned tilesToRemoveCount = bytesToReclaim / bytesPerTile;
 
     IntRect visibleRect = this->visibleRect();
@@ -138,9 +138,9 @@ bool LegacyTileGrid::dropDistantTiles(unsigned tilesNeeded, double shortestDista
         }
         ALLOW_DEPRECATED_DECLARATIONS_END
     }
-    size_t removeCount = toRemove.size();
-    for (size_t n = 0; n < removeCount; ++n)
-        m_tiles.remove(toRemove[n].second);
+
+    for (const auto& tile : toRemove)
+        m_tiles.remove(tile.second);
 
     if (!shortestDistance)
         return true;
@@ -324,9 +324,9 @@ void LegacyTileGrid::dropInvalidTiles()
         if (expectedTileRect != tileRect || !dropBounds.contains(tileRect))
             toRemove.append(index);
     }
-    unsigned removeCount = toRemove.size();
-    for (unsigned n = 0; n < removeCount; ++n)
-        m_tiles.remove(toRemove[n]);
+
+    for (const auto& tile : toRemove)
+        m_tiles.remove(tile);
 
     m_validBounds = bounds;
 }


### PR DESCRIPTION
#### 08364b92f0ace9b690c3d8a8647a212c1c53b8d9
<pre>
Proper bounds checking for Legacy Tiles
<a href="https://bugs.webkit.org/show_bug.cgi?id=252172">https://bugs.webkit.org/show_bug.cgi?id=252172</a>

Reviewed by NOBODY (OOPS!).

Ensure the result is not greater than 0 before doing the subtraction.

* Source/WebCore/platform/ios/LegacyTileGrid.mm:(dropDistantTiles):
  Compare number of tiles needed and max number of tiles before subtracting
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fcababf9d7994584123ecaafb98e9a5762d234dc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1071 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1100 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1139 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1683 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/947 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1055 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1149 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1180 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1142 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1078 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1001 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/998 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1568 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1041 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/996 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/983 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/977 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1033 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2057 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1022 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/956 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/964 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1005 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1039 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->