### PR TITLE
Leverage isASCIIAlphanumeric() in the new HTML parsing fast path

### DIFF
--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
@@ -473,8 +473,7 @@ private:
 
     bool isValidUnquotedAttributeValueChar(Char c)
     {
-        // FIXME: We should probably levegate isASCIIAlphanumeric() here.
-        return ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') || ('0' <= c && c <= '9') || c == '_' || c == '-';
+        return isASCIIAlphanumeric(c) || c == '_' || c == '-';
     }
 
     // https://html.spec.whatwg.org/#syntax-attribute-name
@@ -482,8 +481,7 @@ private:
     {
         if (c == '=') // Early return for the most common way to end an attribute.
             return false;
-        // FIXME: We should probably levegate isASCIIAlphanumeric() here.
-        return ('a' <= c && c <= 'z') || c == '-' || ('A' <= c && c <= 'Z') || ('0' <= c && c <= '9');
+        return isASCIIAlphanumeric(c) || c == '-';
     }
 
     bool isCharAfterTagNameOrAttribute(Char c)


### PR DESCRIPTION
#### 49602fccdbc611910c163a7866dbab71b4b82928
<pre>
Leverage isASCIIAlphanumeric() in the new HTML parsing fast path
<a href="https://bugs.webkit.org/show_bug.cgi?id=252135">https://bugs.webkit.org/show_bug.cgi?id=252135</a>

Reviewed by Yusuke Suzuki.

A/B testing for Speedometer came back as neutral.

* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
(WebCore::HTMLFastPathParser::isValidUnquotedAttributeValueChar):
(WebCore::HTMLFastPathParser::isValidAttributeNameChar):

Canonical link: <a href="https://commits.webkit.org/260171@main">https://commits.webkit.org/260171@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/83f8ab2c28ccc9d04d54d6c45c8b87ae486d20fe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107422 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16484 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40325 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116583 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116007 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111322 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17907 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7723 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99585 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113185 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13515 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96696 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41134 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95418 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28322 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82902 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9493 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29675 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10148 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6570 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15649 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49256 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7036 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11706 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->