### PR TITLE
Leverage isASCIILower() / toASCIILower() in the new HTML parsing fast path

### DIFF
--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
@@ -556,7 +556,7 @@ private:
     CharSpan scanTagName()
     {
         const Char* start = m_position;
-        while (m_position != m_end && 'a' <= *m_position && *m_position <= 'z')
+        while (m_position != m_end && isASCIILower(*m_position))
             ++m_position;
 
         if (m_position == m_end || !isCharAfterTagNameOrAttribute(*m_position)) {
@@ -565,9 +565,9 @@ private:
             m_position = start;
             while (m_position != m_end) {
                 Char c = *m_position;
-                if ('A' <= c && c <= 'Z')
-                    c = c - ('A' - 'a');
-                else if (!('a' <= c && c <= 'z'))
+                if (isASCIIUpper(c))
+                    c = toASCIILowerUnchecked(c);
+                else if (!isASCIILower(c))
                     break;
                 ++m_position;
                 m_charBuffer.append(c);
@@ -588,7 +588,7 @@ private:
         // input. This path could handle other valid attribute name chars, but they
         // are not as common, so it only looks for lowercase.
         const Char* start = m_position;
-        while (m_position != m_end && *m_position >= 'a' && *m_position <= 'z')
+        while (m_position != m_end && isASCIILower(*m_position))
             ++m_position;
         if (UNLIKELY(m_position == m_end))
             return didFail(HTMLFastPathResult::FailedEndOfInputReached, CharSpan());
@@ -601,8 +601,8 @@ private:
         m_attributeNameBuffer.resize(0);
         // isValidAttributeNameChar() returns false if end of input is reached.
         for (Char c = peekNext(); isValidAttributeNameChar(c); c = peekNext()) {
-            if ('A' <= c && c <= 'Z')
-                c = c - ('A' - 'a');
+            if (isASCIIUpper(c))
+                c = toASCIILowerUnchecked(c);
             m_attributeNameBuffer.append(c);
             ++m_position;
         }


### PR DESCRIPTION
#### 74372cf946b02d7e1bc743a18125db5aea966870
<pre>
Leverage isASCIILower() / toASCIILower() in the new HTML parsing fast path
<a href="https://bugs.webkit.org/show_bug.cgi?id=252136">https://bugs.webkit.org/show_bug.cgi?id=252136</a>

Reviewed by Yusuke Suzuki.

A/B testing for Speedometer came back as perf-neutral.

* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
(WebCore::HTMLFastPathParser::scanTagName):
(WebCore::HTMLFastPathParser::scanAttributeName):

Canonical link: <a href="https://commits.webkit.org/260170@main">https://commits.webkit.org/260170@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2e2817aee6d0d259c131b96187d26d6636c3102

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107424 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16486 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40327 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116585 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116009 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111324 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17909 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7725 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99587 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113187 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13513 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96698 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41135 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95416 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/28324 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82899 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9495 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/29677 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10150 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/6573 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15651 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49258 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7035 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11708 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->