### PR TITLE
[browserperfdash-benchmark] Support configuring a specific set of plans and default config values on the config file

### DIFF
--- a/Tools/CISupport/build-webkit-org/steps.py
+++ b/Tools/CISupport/build-webkit-org/steps.py
@@ -1157,7 +1157,7 @@ class RunBenchmarkTests(shell.Test):
     name = "benchmark-test"
     description = ["benchmark tests running"]
     descriptionDone = ["benchmark tests"]
-    command = ["python3", "Tools/Scripts/browserperfdash-benchmark", "--allplans",
+    command = ["python3", "Tools/Scripts/browserperfdash-benchmark", "--plans-from-config",
                "--config-file", "../../browserperfdash-benchmark-config.txt",
                "--browser-version", WithProperties("%(archive_revision)s")]
 

--- a/Tools/Scripts/webkitpy/browserperfdash/browserperfdash_runner.py
+++ b/Tools/Scripts/webkitpy/browserperfdash/browserperfdash_runner.py
@@ -23,17 +23,20 @@
 
 import argparse
 import configparser
+import hashlib
 import json
 import logging
 import os
+import re
 import tempfile
 import urllib
 from datetime import datetime
 
 from webkitpy.benchmark_runner.benchmark_runner import BenchmarkRunner
 from webkitpy.benchmark_runner.browser_driver.browser_driver_factory import BrowserDriverFactory
-from webkitpy.benchmark_runner.webserver_benchmark_runner import WebServerBenchmarkRunner
 from webkitpy.benchmark_runner.run_benchmark import default_browser, default_platform, benchmark_runner_subclasses
+from webkitpy.benchmark_runner.utils import get_path_from_project_root
+from webkitpy.benchmark_runner.webserver_benchmark_runner import WebServerBenchmarkRunner
 
 _log = logging.getLogger(__name__)
 
@@ -45,15 +48,16 @@ def parse_args():
     parser.add_argument('--browser-version', dest='browser_version', default=None, required=True, help='A string that identifies the browser version.')
     # arguments shared with run-benchmark.
     parser.add_argument('--build-directory', dest='buildDir', help='Path to the browser executable (e.g. WebKitBuild/Release/).')
-    parser.add_argument('--platform', dest='platform', default=default_platform(), choices=BrowserDriverFactory.available_platforms())
-    parser.add_argument('--browser', dest='browser', default=default_browser(), choices=BrowserDriverFactory.available_browsers())
-    parser.add_argument('--driver', default=WebServerBenchmarkRunner.name, choices=benchmark_runner_subclasses.keys(), help='Use the specified benchmark driver. Defaults to %s.' % WebServerBenchmarkRunner.name)
+    parser.add_argument('--platform', dest='platform', default=None, choices=BrowserDriverFactory.available_platforms())
+    parser.add_argument('--browser', dest='browser', default=None, choices=BrowserDriverFactory.available_browsers())
+    parser.add_argument('--driver', default=None, choices=benchmark_runner_subclasses.keys(), help='Use the specified benchmark driver. Defaults to %s.' % WebServerBenchmarkRunner.name)
     parser.add_argument('--local-copy', dest='localCopy', help='Path to a local copy of the benchmark (e.g. PerformanceTests/SunSpider/).')
     parser.add_argument('--count', dest='countOverride', type=int, help='Number of times to run the benchmark (e.g. 5).')
     parser.add_argument('--timeout', dest='timeoutOverride', type=int, help='Number of seconds to wait for the benchmark to finish (e.g. 600).')
     parser.add_argument('--timestamp', dest='timestamp', type=int, help='Date of when the benchmark was run that will be sent to the performance dashboard server. Format is Unix timestamp (second since epoch). Optional. The server will use as date "now" if not specified.')
     mutual_group = parser.add_mutually_exclusive_group(required=True)
     mutual_group.add_argument('--plan', dest='plan', help='Benchmark plan to run. e.g. speedometer, jetstream')
+    mutual_group.add_argument('--plans-from-config', action='store_true', help='Run the list of plans specified in the config file.')
     mutual_group.add_argument('--allplans', action='store_true', help='Run all available benchmark plans sequentially')
     args = parser.parse_args()
     return args
@@ -68,6 +72,7 @@ class BrowserPerfDashRunner(object):
         if not os.path.isdir(self._plandir):
             raise Exception('Cant find plandir: {plandir}'.format(plandir=self._plandir))
         self._parse_config_file(self._args.config_file)
+        self._set_args_default_values_from_config_file()
         # This is the dictionary that will be sent as the HTTP POST request that browserperfdash expects
         # (as defined in https://github.com/Igalia/browserperfdash/blob/master/docs/design-document.md)
         # - The bot_* data its obtained from the config file
@@ -85,22 +90,68 @@ class BrowserPerfDashRunner(object):
             date_str = datetime.fromtimestamp(self._result_data['timestamp']).isoformat()
             _log.info('Will send the benchmark data as if it was generated on date: {date}'.format(date=date_str))
 
+    # The precedence order for setting the value for the arguments is:
+    # 1 - What the user defines via command line switches (current_value is not None).
+    # 2 - What is defined on the config file inside the "[settings]" section.
+    # 3 - The default_value passed here or None.
+    def _get_value_from_current_or_settings_or_default(self, current_value, variable_name, default_value=None, allowed_value_list=None, check_if_is_int=False):
+        if current_value is not None:
+            return current_value
+        if self._config_parser.has_option('settings', variable_name):
+            settings_value = self._config_parser.get('settings', variable_name)
+            if allowed_value_list is not None:
+                if settings_value not in allowed_value_list:
+                    raise ValueError('The "{variable_name}" value "{settings_value}" defined in the config file "{config_file}" is not valid. Allowed values are: "{allowed_values}"'.format(
+                                     variable_name=variable_name, settings_value=settings_value, config_file=self._args.config_file, allowed_values=' '.join(allowed_value_list)))
+            if check_if_is_int:
+                if not settings_value.isdigit():
+                    raise ValueError('The "{variable_name}" value "{settings_value}" defined in the config file "{config_file}" is not valid. Only integer values are allowed'.format(
+                                     variable_name=variable_name, settings_value=settings_value, config_file=self._args.config_file))
+                settings_value = int(settings_value)
+            return settings_value
+        return default_value
+
+    def _set_args_default_values_from_config_file(self):
+        self._args.timeoutOverride = self._get_value_from_current_or_settings_or_default(self._args.timeoutOverride, 'timeout', check_if_is_int=True)
+        self._args.countOverride = self._get_value_from_current_or_settings_or_default(self._args.countOverride, 'count', check_if_is_int=True)
+        self._args.platform = self._get_value_from_current_or_settings_or_default(self._args.platform, 'platform', default_value=default_platform(), allowed_value_list=BrowserDriverFactory.available_platforms())
+        self._args.browser = self._get_value_from_current_or_settings_or_default(self._args.browser, 'browser', default_value=default_browser(), allowed_value_list=BrowserDriverFactory.available_browsers())
+        self._args.driver = self._get_value_from_current_or_settings_or_default(self._args.driver, 'driver', default_value=WebServerBenchmarkRunner.name, allowed_value_list=benchmark_runner_subclasses.keys())
+
     def _parse_config_file(self, config_file):
         if not os.path.isfile(config_file):
             raise Exception('Can not open config file for uploading results at: {config_file}'.format(config_file=config_file))
         self._config_parser = configparser.RawConfigParser()
         self._config_parser.read(config_file)
+        # Validate the data
+        found_one_valid_server = False
+        for section in self._config_parser.sections():
+            if section == 'settings':
+                continue
+            found_one_valid_server = True
+            for required_key in ['bot_id', 'bot_password', 'post_url']:
+                if not self._config_parser.has_option(section, required_key):
+                    raise ValueError('Missed key "{required_key}" for server "{server_name}" in config file "{config_file}"'.format(
+                                     required_key=required_key, server_name=section, config_file=config_file))
+        if not found_one_valid_server:
+            raise ValueError('At least one server should be defined on the config file "{config_file}"'.format(config_file=config_file))
 
+    # As version of the test we calculate a hash of the contents of the plan and patch files
     def _get_test_version_string(self, plan_name):
+        version_hash = hashlib.md5()
         plan_file_path = os.path.join(self._plandir, '{plan_name}.plan'.format(plan_name=plan_name))
         with open(plan_file_path, 'r') as plan_fd:
-            plan_json = json.load(plan_fd)
-            if 'svn_source' in plan_json:
-                return plan_json['svn_source']
-            elif 'remote_archive' in plan_json:
-                return plan_json['remote_archive']
-            else:
-                raise Exception('Can not upload results because is not possible to determine test version for test plan: {plan_file_path}'.format(plan_file_path=plan_file_path))
+            plan_content = plan_fd.read().encode('utf-8', errors='ignore')
+            version_hash.update(plan_content)
+            plan_dict = json.loads(plan_content)
+            for plan_key in plan_dict:
+                if plan_key.endswith('_patch'):
+                    patch_file_path = get_path_from_project_root(plan_dict[plan_key])
+                    if not os.path.isfile(patch_file_path):
+                        raise Exception('Can not find patch file "{patch_file_path}" referenced in plan "{plan_file_path}"'.format(patch_file_path=patch_file_path, plan_file_path=plan_file_path))
+                    with open(patch_file_path, 'r') as patch_fd:
+                        version_hash.update(patch_fd.read().encode('utf-8', errors='ignore'))
+        return version_hash.hexdigest()
 
     def _get_test_data_json_string(self, temp_result_file):
         temp_result_file.flush()
@@ -122,6 +173,8 @@ class BrowserPerfDashRunner(object):
     def _upload_result(self):
         upload_failed = False
         for server in self._config_parser.sections():
+            if server == 'settings':
+                continue
             self._result_data['bot_id'] = self._config_parser.get(server, 'bot_id')
             self._result_data['bot_password'] = self._config_parser.get(server, 'bot_password')
             post_data = urllib.parse.urlencode(self._result_data).encode('utf-8')
@@ -145,32 +198,47 @@ class BrowserPerfDashRunner(object):
         failed = []
         worked = []
         skipped = []
-        planlist = []
+        plan_list = []
         if self._args.plan:
             if not os.path.isfile(os.path.join(self._plandir, '{plan_name}.plan'.format(plan_name=self._args.plan))):
-                raise Exception('Cant find a file named {plan_name}.plan in directory {plan_directory}'.format(plan_name=self._args.plan, plan_directory=self._plandir))
-            planlist = [self._args.plan]
+                raise Exception('Can\'t find a file named {plan_name}.plan in directory {plan_directory}'.format(plan_name=self._args.plan, plan_directory=self._plandir))
+            plan_list = [self._args.plan]
         elif self._args.allplans:
-            planlist = BenchmarkRunner.available_plans()
+            plan_list = sorted(BenchmarkRunner.available_plans())
             skippedfile = os.path.join(self._plandir, 'Skipped')
-            if not planlist:
-                raise Exception('Cant find any plan in the directory {plan_directory}'.format(plan_directory=self._plandir))
+            if not plan_list:
+                raise Exception('Can\'t find any plan in the directory {plan_directory}'.format(plan_directory=self._plandir))
             if os.path.isfile(skippedfile):
                 skipped = [line.strip() for line in open(skippedfile) if not line.startswith('#') and len(line) > 1]
+        elif self._args.plans_from_config:
+            if not self._config_parser.has_option('settings', 'plan_list'):
+                raise Exception('Can\'t find a "plan_list" key inside a "settings" section on the config file.')
+            plan_list_from_config_str = self._config_parser.get('settings', 'plan_list')
+            plan_list_from_config = plan_list_from_config_str.split()
+            _log.info('Read a list of {number_plans} plans from the config file: "{plan_list}"'.format(number_plans=len(plan_list_from_config), plan_list=' '.join(plan_list_from_config)))
+            available_plans = BenchmarkRunner.available_plans()
+            for plan in plan_list_from_config:
+                if plan in available_plans:
+                    if plan not in plan_list:
+                        plan_list.append(plan)
+                else:
+                    _log.error('Plan "{plan}" is not in the list of known plans: "{known_plan_list}"'.format(plan=plan, known_plan_list=' '.join(available_plans)))
+                    failed.append(plan)
+            _log.info('Running {number_plans} plans: "{plan_list}"'.format(number_plans=len(plan_list), plan_list=' '.join(plan_list)))
 
-        if len(planlist) < 1:
+        if len(plan_list) < 1:
             _log.error('No benchmarks plans available to run in directory {plan_directory}'.format(plan_directory=self._plandir))
-            return 1
+            return max(1, len(failed))
 
         _log.info('Starting benchmark for browser {browser} and version {browser_version}'.format(browser=self._args.browser, browser_version=self._args.browser_version))
 
         iteration_count = 0
-        for plan in sorted(planlist):
+        for plan in plan_list:
             iteration_count += 1
             if plan in skipped:
-                _log.info('Skipping benchmark plan: {plan_name} because is listed on the Skipped file [benchmark {iteration} of {total}]'.format(plan_name=plan, iteration=iteration_count, total=len(planlist)))
+                _log.info('Skipping benchmark plan: {plan_name} because is listed on the Skipped file [benchmark {iteration} of {total}]'.format(plan_name=plan, iteration=iteration_count, total=len(plan_list)))
                 continue
-            _log.info('Starting benchmark plan: {plan_name} [benchmark {iteration} of {total}]'.format(plan_name=plan, iteration=iteration_count, total=len(planlist)))
+            _log.info('Starting benchmark plan: {plan_name} [benchmark {iteration} of {total}]'.format(plan_name=plan, iteration=iteration_count, total=len(plan_list)))
             try:
                 # Run test and save test info
                 with tempfile.NamedTemporaryFile() as temp_result_file:

--- a/Tools/Scripts/webkitpy/browserperfdash/config-file-example.txt
+++ b/Tools/Scripts/webkitpy/browserperfdash/config-file-example.txt
@@ -17,6 +17,30 @@
 # 'bot_password' : The password of this bot on the server.
 # 'post_url'     : The POST URL (typically ${BASE_URI}/dash/bot-report)
 #
+# There is a special section named 'settings' where you can specify a
+# list of plans to be run when the flag '--plans-from-config' is passed,
+# or specify default values for different options.
+# The settings that can be configured in this section are:
+#   plan_list = (Optional) list of plans to run when the flag --plans-from-config is specified
+#   timeout = (Optional) default value that will be used if no parameter "--timeout" is specified
+#   count = (Optional) default value that will be used if no parameter "--count" is specified
+#   platform = (Optional) default value that will be used if no parameter "--platform" is specified
+#   browser = (Optional) default value that will be used if no parameter "--browser" is specified
+#   driver = (Optional) default value that will be used if no parameter "--driver" is specified
+#
+
+#
+# Example of configuration file
+#
+
+## Configuration of plans to run and default settings values
+#[settings]
+#plan_list = ares6 dromaeo-cssquery dromaeo-dom dromaeo-jslib jetstream2 jsbench kraken motionmark octane speedometer stylebench sunspider
+#timeout = 900
+#count = 1
+#platform = linux
+#driver = webdriver
+#browser = cog
 
 ## Configuration for dashboard browserperfdash.igalia.org
 #[browserperfdash.igalia.org]


### PR DESCRIPTION
#### 76fca0c6015a36a03d7318b949f9db4bec57a414
<pre>
[browserperfdash-benchmark] Support configuring a specific set of plans and default config values on the config file
<a href="https://bugs.webkit.org/show_bug.cgi?id=252134">https://bugs.webkit.org/show_bug.cgi?id=252134</a>

Reviewed by Carlos Garcia Campos.

Implement support for allowing to define on the config file a subset of plans
that will be run and default values for the configuration options.

This is useful to define different configurations per bot without having to
use different command line arguments per bot when executing the buildbot step.

The values passed via command line arguments have precedence, so the values
defined on the config file are used only as default values.

* Tools/CISupport/build-webkit-org/steps.py:
(RunBenchmarkTests):
* Tools/Scripts/webkitpy/browserperfdash/browserperfdash_runner.py:
(parse_args):
(BrowserPerfDashRunner._parse_config_file):
(BrowserPerfDashRunner):
(BrowserPerfDashRunner._get_test_version_string):
(BrowserPerfDashRunner._upload_result):
(BrowserPerfDashRunner.run):
* Tools/Scripts/webkitpy/browserperfdash/config-file-example.txt:

Canonical link: <a href="https://commits.webkit.org/260997@main">https://commits.webkit.org/260997@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ec5c72ba09c916a8ee2d913589f83367a441cf6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108258 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17348 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41123 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117377 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116733 "Hash 5ec5c72b for PR 10003 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112145 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18892 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8627 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100472 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114027 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14176 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97318 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42035 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/111791 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96154 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28960 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/83715 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10193 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30305 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10929 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7211 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/107051 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16342 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49901 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12515 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4147 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->