### PR TITLE
Save recent searches with name attribute

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -130,8 +130,10 @@ fast/shadow-dom/touch-event-on-text-assigned-to-slot.html [ Skip ]
 fast/forms/attributed-strings.html [ Skip ]
 fast/scrolling/latching [ Skip ]
 
+# These tests rely on search field style on Mac WK2. 
 fast/forms/search/search-padding-cancel-results-buttons.html [ Skip ]
 fast/forms/search/search-results-hidden-crash.html [ Skip ]
+fast/forms/search/search-recent-searches.html [ Skip ]
 
 # Only applicable on platforms with dark mode support
 css-dark-mode [ Skip ]

--- a/LayoutTests/fast/forms/search/search-recent-searches-expected.txt
+++ b/LayoutTests/fast/forms/search/search-recent-searches-expected.txt
@@ -1,0 +1,8 @@
+PASS recentSearches.length is 1
+PASS recentSearches[0] is "searchValue"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+
+

--- a/LayoutTests/fast/forms/search/search-recent-searches.html
+++ b/LayoutTests/fast/forms/search/search-recent-searches.html
@@ -1,0 +1,39 @@
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../resources/common.js"></script>
+</head>
+<body>
+<br>
+<form action="" id="form">
+<input name="searchName" id="searchBox" type="search" results="10" value="searchValue"><br>
+<input type="submit" value="search">
+</form>
+<script>
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+window.onload = function() {
+    if (window.location.href.indexOf('searchName') == -1) {
+        document.getElementById('form').submit();
+        return;
+    }
+
+    var input = document.getElementById('searchBox');
+    document.getElementById('searchBox').value = 'newValue';
+    var position = searchCancelButtonPosition(input);
+    rect = input.getBoundingClientRect();
+    eventSender.mouseMoveTo(position.x, position.y);
+    eventSender.mouseDown();
+    eventSender.mouseUp()
+
+    if (window.internals) {
+        recentSearches = internals.recentSearches(input);
+        shouldBe('recentSearches.length', '1');
+        shouldBeEqualToString('recentSearches[0]', 'searchValue');
+    }
+    testRunner.notifyDone(); 
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/blink/fast/forms/search-popup-crasher.html
+++ b/LayoutTests/imported/blink/fast/forms/search-popup-crasher.html
@@ -17,7 +17,7 @@ window.onload = function()
 
 <p>This page tests that a page with a search popup does not crash, as reported in <a href='https://bugs.webkit.org/show_bug.cgi?id=37141'>this bug</a>. Below is a search input that the test automatically fills then submits. Pass if this does not crash.</p><br><br>
 <FORM action="" id="searchForm">
-<INPUT autosave="my.search" id="searchBox" type="search" results="10" value=""><br>
+<INPUT name="my.search" id="searchBox" type="search" results="10" value=""><br>
 <INPUT type="hidden" name="state" value="formSubmitted"><br>
 <INPUT type="submit" value="Search">
 </FORM>

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -61,6 +61,7 @@ imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navig
 
 fast/forms/search/search-padding-cancel-results-buttons.html [ Pass ]
 fast/forms/search/search-results-hidden-crash.html [ Pass ]
+fast/forms/search/search-recent-searches.html [ Pass ]
 
 fast/url/user-visible [ Pass ]
 fast/images/eps-as-image.html [ Skip ]

--- a/Source/WebCore/platform/cocoa/SearchPopupMenuCocoa.mm
+++ b/Source/WebCore/platform/cocoa/SearchPopupMenuCocoa.mm
@@ -162,6 +162,7 @@ void saveRecentSearches(const String& name, const Vector<RecentSearch>& searchIt
         [itemsDictionary setObject:adoptNS([[NSDictionary alloc] initWithObjectsAndKeys:items.get(), searchesKey, nil]).get() forKey:name];
     }
 
+    [[NSFileManager defaultManager] createDirectoryAtPath:searchFieldRecentSearchesStorageDirectory() withIntermediateDirectories:YES attributes:nil error: nil];
     [recentSearchesPlist writeToFile:searchFieldRecentSearchesPlistPath() atomically:YES];
 }
 

--- a/Source/WebCore/rendering/RenderSearchField.cpp
+++ b/Source/WebCore/rendering/RenderSearchField.cpp
@@ -167,6 +167,17 @@ LayoutUnit RenderSearchField::computeControlLogicalHeight(LayoutUnit lineHeight,
 
     return lineHeight + nonContentHeight;
 }
+    
+Span<const RecentSearch> RenderSearchField::recentSearches()
+{
+    if (!m_searchPopup)
+        m_searchPopup = page().chrome().createSearchPopupMenu(*this);
+
+    const AtomString& name = autosaveName();
+    m_searchPopup->loadRecentSearches(name, m_recentSearches);
+
+    return m_recentSearches.span();
+}
 
 void RenderSearchField::updateFromElement()
 {
@@ -202,7 +213,7 @@ Visibility RenderSearchField::visibilityForCancelButton() const
 
 const AtomString& RenderSearchField::autosaveName() const
 {
-    return inputElement().attributeWithoutSynchronization(autosaveAttr);
+    return inputElement().attributeWithoutSynchronization(nameAttr);
 }
 
 // PopupMenuClient methods

--- a/Source/WebCore/rendering/RenderSearchField.h
+++ b/Source/WebCore/rendering/RenderSearchField.h
@@ -44,6 +44,7 @@ public:
     bool popupIsVisible() const { return m_searchPopupIsVisible; }
     void showPopup();
     void hidePopup();
+    WEBCORE_EXPORT Span<const RecentSearch> recentSearches();
 
 private:
     bool isSearchField() const final { return true; }

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -182,6 +182,7 @@
 #include "RenderLayerScrollableArea.h"
 #include "RenderListBox.h"
 #include "RenderMenuList.h"
+#include "RenderSearchField.h"
 #include "RenderTheme.h"
 #include "RenderThemeIOS.h"
 #include "RenderTreeAsText.h"
@@ -2226,6 +2227,24 @@ auto Internals::autoFillButtonType(const HTMLInputElement& element) -> AutoFillB
 auto Internals::lastAutoFillButtonType(const HTMLInputElement& element) -> AutoFillButtonType
 {
     return toInternalsAutoFillButtonType(element.lastAutoFillButtonType());
+}
+
+Vector<String> Internals::recentSearches(const HTMLInputElement& element)
+{
+    if (!element.isSearchField())
+        return { };
+
+    element.document().updateLayoutIgnorePendingStylesheets();
+    auto* renderer = element.renderer();
+    if (!is<RenderSearchField>(renderer))
+        return { };
+
+    Vector<String> result;
+    auto& searchField = downcast<RenderSearchField>(*renderer);
+    for (auto search : searchField.recentSearches())
+        result.append(search.string);
+
+    return result;
 }
 
 ExceptionOr<void> Internals::scrollElementToRect(Element& element, int x, int y, int w, int h)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -355,6 +355,7 @@ public:
     void setShowAutoFillButton(HTMLInputElement&, AutoFillButtonType);
     AutoFillButtonType autoFillButtonType(const HTMLInputElement&);
     AutoFillButtonType lastAutoFillButtonType(const HTMLInputElement&);
+    Vector<String> recentSearches(const HTMLInputElement&);
     ExceptionOr<void> scrollElementToRect(Element&, int x, int y, int w, int h);
 
     ExceptionOr<String> autofillFieldName(Element&);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -478,6 +478,7 @@ typedef (FetchRequest or FetchResponse) FetchObject;
     undefined setShowAutoFillButton(HTMLInputElement inputElement, AutoFillButtonType autoFillButtonType);
     AutoFillButtonType autoFillButtonType(HTMLInputElement inputElement);
     AutoFillButtonType lastAutoFillButtonType(HTMLInputElement inputElement);
+    sequence<DOMString> recentSearches(HTMLInputElement inputElement);
 
     undefined setCanShowPlaceholder(Element element, boolean canShowPlaceholder);
 


### PR DESCRIPTION
#### c58c088437779ba48d081ebc83242e3b71f34ca7
<pre>
Save recent searches with name attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=252139">https://bugs.webkit.org/show_bug.cgi?id=252139</a>
rdar://105369635

Reviewed by Darin Adler.

autosave attribute is non-standard and is not tracked in any active proposal, so we should stop using it to decide
whether a search item can be saved. This patch changes the logic to use name attribute to match Chrome and Firefox&apos;s
behavior.

New test: fast/forms/search/search-recent-searches.html

* LayoutTests/TestExpectations:
* LayoutTests/fast/forms/search/search-recent-searches-expected.txt: Added.
* LayoutTests/fast/forms/search/search-recent-searches.html: Added.
* LayoutTests/imported/blink/fast/forms/search-popup-crasher.html:
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/platform/cocoa/SearchPopupMenuCocoa.mm:
(WebCore::saveRecentSearches):
* Source/WebCore/rendering/RenderSearchField.cpp:
(WebCore::RenderSearchField::recentSearches):
(WebCore::RenderSearchField::autosaveName const):
* Source/WebCore/rendering/RenderSearchField.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::recentSearches):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/260316@main">https://commits.webkit.org/260316@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/021957337364adcb76a61ee5079635e24e92d9db

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/107951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/17012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/40837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/117086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/111839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/18398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/8329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/100143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/113714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/18398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/40837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/100143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/18398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/40837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/100143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/9931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/40837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/10638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/8329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/16083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/40837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/12212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->