### PR TITLE
Reduce custom property storage for sites with large numbers of custom properties on the root

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2603,6 +2603,7 @@ rendering/style/StyleCanvasImage.cpp
 rendering/style/StyleContentAlignmentData.cpp
 rendering/style/StyleCrossfadeImage.cpp
 rendering/style/StyleCursorImage.cpp
+rendering/style/StyleCustomPropertyData.cpp
 rendering/style/StyleDeprecatedFlexibleBoxData.cpp
 rendering/style/StyleFilterData.cpp
 rendering/style/StyleFilterImage.cpp

--- a/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
+++ b/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
@@ -146,14 +146,15 @@ String CSSComputedStyleDeclaration::item(unsigned i) const
 
     const auto& inheritedCustomProperties = style->inheritedCustomProperties();
 
-    if (i < exposedComputedCSSPropertyIDs().size() + inheritedCustomProperties.size()) {
-        auto results = copyToVector(inheritedCustomProperties.keys());
-        return results.at(i - exposedComputedCSSPropertyIDs().size());
-    }
+    // FIXME: findKeyAtIndex does a linear search for the property name, so if
+    // we are called in a loop over all item indexes, we'll spend quadratic time
+    // searching for keys.
+
+    if (i < exposedComputedCSSPropertyIDs().size() + inheritedCustomProperties.size())
+        return inheritedCustomProperties.findKeyAtIndex(i - exposedComputedCSSPropertyIDs().size());
 
     const auto& nonInheritedCustomProperties = style->nonInheritedCustomProperties();
-    auto results = copyToVector(nonInheritedCustomProperties.keys());
-    return results.at(i - inheritedCustomProperties.size() - exposedComputedCSSPropertyIDs().size());
+    return nonInheritedCustomProperties.findKeyAtIndex(i - inheritedCustomProperties.size() - exposedComputedCSSPropertyIDs().size());
 }
 
 CSSRule* CSSComputedStyleDeclaration::parentRule() const

--- a/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp
+++ b/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp
@@ -100,8 +100,9 @@ Vector<StylePropertyMapReadOnly::StylePropertyMapEntry> ComputedStylePropertyMap
     }
 
     for (auto* map : { &nonInheritedCustomProperties, &inheritedCustomProperties }) {
-        for (const auto& it : *map)
+        map->forEach([&](auto& it) {
             values.uncheckedAppend(makeKeyValuePair(it.key, StylePropertyMapReadOnly::reifyValueToVector(const_cast<CSSCustomPropertyValue*>(it.value.get()), std::nullopt, m_element->document())));
+        });
     }
 
     std::sort(values.begin(), values.end(), [](const auto& a, const auto& b) {

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -2707,11 +2707,11 @@ void RenderStyle::setCustomPropertyValue(Ref<const CSSCustomPropertyValue>&& val
 {
     auto& name = value->name();
     if (isInherited) {
-        if (auto* existingValue = m_rareInheritedData->customProperties->values.get(name); !existingValue || !existingValue->equals(value.get()))
-            m_rareInheritedData.access().customProperties.access().setCustomPropertyValue(name, WTFMove(value));
+        if (auto* existingValue = m_rareInheritedData->customProperties->get(name); !existingValue || !existingValue->equals(value.get()))
+            m_rareInheritedData.access().customProperties.access().set(name, WTFMove(value));
     } else {
-        if (auto* existingValue = m_nonInheritedData->rareData->customProperties->values.get(name); !existingValue || !existingValue->equals(value.get()))
-            m_nonInheritedData.access().rareData.access().customProperties.access().setCustomPropertyValue(name, WTFMove(value));
+        if (auto* existingValue = m_nonInheritedData->rareData->customProperties->get(name); !existingValue || !existingValue->equals(value.get()))
+            m_nonInheritedData.access().rareData.access().customProperties.access().set(name, WTFMove(value));
     }
 }
 

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -219,8 +219,8 @@ public:
 
     const PseudoStyleCache* cachedPseudoStyles() const { return m_cachedPseudoStyles.get(); }
 
-    const CustomPropertyValueMap& inheritedCustomProperties() const { return m_rareInheritedData->customProperties->values; }
-    const CustomPropertyValueMap& nonInheritedCustomProperties() const { return m_nonInheritedData->rareData->customProperties->values; }
+    const StyleCustomPropertyData& inheritedCustomProperties() const { return m_rareInheritedData->customProperties.get(); }
+    const StyleCustomPropertyData& nonInheritedCustomProperties() const { return m_nonInheritedData->rareData->customProperties.get(); }
     const CSSCustomPropertyValue* customPropertyValue(const AtomString&) const;
 
     void deduplicateCustomProperties(const RenderStyle&);

--- a/Source/WebCore/rendering/style/StyleCustomPropertyData.cpp
+++ b/Source/WebCore/rendering/style/StyleCustomPropertyData.cpp
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleCustomPropertyData.h"
+
+namespace WebCore {
+
+StyleCustomPropertyData::StyleCustomPropertyData(const StyleCustomPropertyData& other)
+    : RefCounted()
+{
+    // Don't reference `other` if it already has a parent of its own, to avoid
+    // creating a linked list of StyleCustomPropertyData objects.
+    bool shouldReferenceAsParentValues = !other.m_parentValues && !other.m_ownValues.isEmpty();
+
+    if (shouldReferenceAsParentValues) {
+        m_parentValues = &other;
+        m_ownValuesSizeExcludingOverriddenParentValues = 0;
+    } else {
+        m_parentValues = other.m_parentValues.get();
+        m_ownValues = other.m_ownValues;
+        m_ownValuesSizeExcludingOverriddenParentValues = other.m_ownValuesSizeExcludingOverriddenParentValues;
+    }
+}
+
+const CSSCustomPropertyValue* StyleCustomPropertyData::get(const AtomString& name) const
+{
+    if (auto* value = m_ownValues.get(name))
+        return value;
+    if (m_parentValues) {
+        ASSERT(!m_parentValues->m_parentValues);
+        if (auto* value = m_parentValues->m_ownValues.get(name))
+            return value;
+    }
+    return nullptr;
+}
+
+void StyleCustomPropertyData::set(const AtomString& name, Ref<const CSSCustomPropertyValue>&& value)
+{
+    auto addResult = m_ownValues.set(name, WTFMove(value));
+    if (addResult.isNewEntry && (!m_parentValues || !m_parentValues->m_ownValues.contains(name)))
+        ++m_ownValuesSizeExcludingOverriddenParentValues;
+}
+
+bool StyleCustomPropertyData::operator==(const StyleCustomPropertyData& other) const
+{
+    if (size() != other.size())
+        return false;
+
+    for (auto& entry : m_ownValues) {
+        auto* otherValue = other.get(entry.key);
+        if (!otherValue || !entry.value->equals(*otherValue))
+            return false;
+    }
+
+    if (m_parentValues) {
+        ASSERT(!m_parentValues->m_parentValues);
+        for (auto& entry : m_parentValues->m_ownValues) {
+            if (m_ownValues.contains(entry.key))
+                continue;
+            auto* otherValue = other.get(entry.key);
+            if (!otherValue || !entry.value->equals(*otherValue))
+                return false;
+        }
+    }
+
+    return true;
+}
+
+void StyleCustomPropertyData::forEach(const Function<void(const KeyValuePair<AtomString, RefPtr<const CSSCustomPropertyValue>>&)>& callback) const
+{
+    if (m_parentValues) {
+        ASSERT(!m_parentValues->m_parentValues);
+        for (auto& entry : m_parentValues->m_ownValues) {
+            if (!m_ownValues.contains(entry.key))
+                callback(entry);
+        }
+    }
+    for (auto& entry : m_ownValues)
+        callback(entry);
+}
+
+AtomString StyleCustomPropertyData::findKeyAtIndex(unsigned index) const
+{
+    unsigned currentIndex = 0;
+    if (m_parentValues) {
+        ASSERT(!m_parentValues->m_parentValues);
+        for (auto& key : m_parentValues->m_ownValues.keys()) {
+            if (!m_ownValues.contains(key)) {
+                if (currentIndex == index)
+                    return key;
+                ++currentIndex;
+            }
+        }
+    }
+    for (auto& key : m_ownValues.keys()) {
+        if (currentIndex == index)
+            return key;
+        ++currentIndex;
+    }
+    return { };
+}
+
+unsigned StyleCustomPropertyData::size() const
+{
+    return m_ownValuesSizeExcludingOverriddenParentValues + (m_parentValues ? m_parentValues->m_ownValuesSizeExcludingOverriddenParentValues : 0); 
+}
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleMiscNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleMiscNonInheritedData.cpp
@@ -29,6 +29,7 @@
 #include "AnimationList.h"
 #include "ContentData.h"
 #include "FillLayer.h"
+#include "RenderStyle.h"
 #include "StyleDeprecatedFlexibleBoxData.h"
 #include "StyleFilterData.h"
 #include "StyleFlexibleBoxData.h"

--- a/Source/WebCore/rendering/style/StyleMiscNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleMiscNonInheritedData.h
@@ -28,6 +28,11 @@
 #include "LengthPoint.h"
 #include "StyleContentAlignmentData.h"
 #include "StyleSelfAlignmentData.h"
+#include <memory>
+#include <wtf/DataRef.h>
+#include <wtf/RefCounted.h>
+#include <wtf/RefPtr.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 


### PR DESCRIPTION
#### 147e3eca970c1bf4808e592c92d1a94ef2723b2f
<pre>
Reduce custom property storage for sites with large numbers of custom properties on the root
<a href="https://bugs.webkit.org/show_bug.cgi?id=252142">https://bugs.webkit.org/show_bug.cgi?id=252142</a>
&lt;rdar://problem/105372920&gt;

Reviewed by Antti Koivisto and Darin Adler.

Some sites have a large number of custom properties set on the root element,
inheriting into the entire document. When different custom properties or values
are set on descendant elements, we clone all of the inherited properties.

This patch changes the storage in StyleCustomPropertyData so that the
first time we copy() one that has some custom properties in it, we point
the cloned object to the original StyleCustomPropertyData as the source
of inherited custom properties, and leave m_values (now renamed to
m_ownValues) empty. Any subsequent copy() of a StyleCustomPropertyData that
already has a pointer to the inherited custom properties will copy that
pointer, and clone m_ownValues like before.

We don&apos;t generate an unlimited linked list of inherited custom
properties to look up, to avoid custom property lookup time having
worst case linear time in the depth of the tree.

This saves around 800 KB on the youtube.com in Membuster.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSComputedStyleDeclaration.cpp:
(WebCore::CSSComputedStyleDeclaration::item const):
* Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp:
(WebCore::ComputedStylePropertyMapReadOnly::entries const):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::setCustomPropertyValue):
* Source/WebCore/rendering/style/RenderStyle.h:
(WebCore::RenderStyle::inheritedCustomProperties const):
(WebCore::RenderStyle::nonInheritedCustomProperties const):
* Source/WebCore/rendering/style/StyleCustomPropertyData.cpp: Added.
(WebCore::StyleCustomPropertyData::StyleCustomPropertyData):
(WebCore::StyleCustomPropertyData::get const):
(WebCore::StyleCustomPropertyData::set):
(WebCore::StyleCustomPropertyData::operator== const):
(WebCore::StyleCustomPropertyData::forEach const):
(WebCore::StyleCustomPropertyData::findKeyAtIndex const):
(WebCore::StyleCustomPropertyData::size const):
* Source/WebCore/rendering/style/StyleCustomPropertyData.h:
(WebCore::StyleCustomPropertyData::copy const):
(WebCore::StyleCustomPropertyData::operator!= const):
(WebCore::StyleCustomPropertyData::operator== const): Deleted.
(WebCore::StyleCustomPropertyData::setCustomPropertyValue): Deleted.
(WebCore::StyleCustomPropertyData::StyleCustomPropertyData): Deleted.

Canonical link: <a href="https://commits.webkit.org/260319@main">https://commits.webkit.org/260319@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63976f536f0601bd474ac3aa8bbdb84c794a4efe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107871 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16926 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40756 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117009 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116361 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111760 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18321 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8242 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100051 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113631 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13826 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97041 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41532 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95734 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28679 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9858 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30027 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10564 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6922 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16010 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49615 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7139 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12135 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->