### PR TITLE
Fix TestWebKitAPI build when including WKFeature.h

### DIFF
--- a/Source/WebKit/UIProcess/API/C/WKFeature.h
+++ b/Source/WebKit/UIProcess/API/C/WKFeature.h
@@ -31,7 +31,7 @@
 extern "C" {
 #endif
 
-WK_EXPORT WKTypeID WKFeatureGetTypeID();
+WK_EXPORT WKTypeID WKFeatureGetTypeID(void);
 
 WK_EXPORT WKStringRef WKFeatureCopyName(WKFeatureRef);
 WK_EXPORT WKStringRef WKFeatureCopyKey(WKFeatureRef);


### PR DESCRIPTION
#### be80c071ab735e9bfd74ab80504590303e235b01
<pre>
Fix TestWebKitAPI build when including WKFeature.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=252143">https://bugs.webkit.org/show_bug.cgi?id=252143</a>
&lt;rdar://105373344&gt;

Unreviewed build fix.

Fixes this warning as error:

    WebKitBuild/Release/WebKit.framework/PrivateHeaders/WKFeature.h:34:38: error: this function declaration is not a prototype [-Werror,-Wstrict-prototypes]
    WK_EXPORT WKTypeID WKFeatureGetTypeID();
                                         ^
                                          void

* Source/WebKit/UIProcess/API/C/WKFeature.h:
(WKFeatureGetTypeID): Fix function declaration.

Canonical link: <a href="https://commits.webkit.org/260176@main">https://commits.webkit.org/260176@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec438424014688ef00b9f7531e15b7d47439d426

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107452 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16513 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40354 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116614 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17937 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7754 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99615 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113213 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13537 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96719 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/41163 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95442 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28345 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82931 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9520 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/29698 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10176 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6597 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15675 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49279 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11736 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3810 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->