### PR TITLE
[Win] REGRESSION(260060@main) run-webkit-tests doesn't start a browser for results.html

### DIFF
--- a/Tools/Scripts/webkitpy/port/win.py
+++ b/Tools/Scripts/webkitpy/port/win.py
@@ -165,9 +165,6 @@ class WinPort(ApplePort):
             return '--64-bit'
         return None
 
-    def show_results_html_file(self, results_filename):
-        self._run_script('run-safari', [abspath_to_uri(SystemHost.get_default().platform, results_filename)])
-
     def _build_path(self, *comps):
         """Returns the full path to the test driver (DumpRenderTree)."""
         root_directory = self.get_option('_cached_root') or self.get_option('root')

--- a/Tools/Scripts/webkitpy/port/win_unittest.py
+++ b/Tools/Scripts/webkitpy/port/win_unittest.py
@@ -45,17 +45,6 @@ class WinPortTest(port_testcase.PortTestCase):
     port_name = 'win-xp'
     port_maker = WinPort
 
-    def test_show_results_html_file(self):
-        port = self.make_port()
-        port._executive = MockExecutive(should_log=True)
-        with OutputCapture(level=logging.INFO) as captured:
-            port.show_results_html_file('test.html')
-
-        # We can't know for sure what path will be produced by cygpath, but we can assert about
-        # everything else.
-        self.assertTrue(captured.root.log.getvalue().startswith("MOCK run_command: ['Tools/Scripts/run-safari', '--release', '"))
-        self.assertTrue(captured.root.log.getvalue().endswith("test.html'], cwd=/mock-checkout\n"))
-
     def _assert_search_path(self, expected_search_paths, version, use_webkit2=False):
         port = self.make_port(port_name='win', os_version=version, options=MockOptions(webkit_test_runner=use_webkit2))
         absolute_search_paths = list(map(port._webkit_baseline_path, expected_search_paths))


### PR DESCRIPTION
#### 05b9bdf1e05b4e6145b1c68dedf5c3c44bc4a395
<pre>
[Win] REGRESSION(260060@main) run-webkit-tests doesn&apos;t start a browser for results.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=252144">https://bugs.webkit.org/show_bug.cgi?id=252144</a>

Reviewed by Ross Kirsling.

On Windows, run-webkit-tests used run-safari script to start
MiniBrowser to show results.html. run-safari didn&apos;t work after
260060@main changed the default Windows port name to WinCairo.

Use show_results_html_file of base.py to use the system&apos;s default
browser.

* Tools/Scripts/webkitpy/port/win.py:
(WinPort._port_flag_for_scripts):
(WinPort.show_results_html_file): Deleted.
* Tools/Scripts/webkitpy/port/win_unittest.py:
(WinPortTest):
(WinPortTest.test_show_results_html_file): Deleted.

Canonical link: <a href="https://commits.webkit.org/260178@main">https://commits.webkit.org/260178@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0990fd00a3f230e379aa59bf57f377d89a82bd2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107453 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16514 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40355 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116615 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116036 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111351 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17938 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7755 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99616 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113214 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13539 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96720 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41165 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/110957 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95444 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28346 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82934 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9521 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29699 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10177 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6598 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15676 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49280 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11737 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3811 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->