### PR TITLE
FileSystemSyncAccessHandle should not cast return value of FileSystem::seekFile to int

### DIFF
--- a/LayoutTests/storage/filesystemaccess/resources/sync-access-handle-read-write.js
+++ b/LayoutTests/storage/filesystemaccess/resources/sync-access-handle-read-write.js
@@ -65,13 +65,13 @@ async function test()
         read(accessHandle, totalReadSize, totalWriteSize - totalReadSize, "This is second sentence.");
         read(accessHandle, 0, totalWriteSize, "This is first sentence.This is second sentence.");
 
-        // Wrong offset to read and write.
+        // Invalid offset to read and write.
         totalReadSize = totalWriteSize;
         // File cursor should be updated by last read(), so the next write() should append to file.
         totalWriteSize += write(accessHandle, null, "This is third sentence.");
         read(accessHandle, 0, totalReadSize, "This is first sentence.This is second sentence.");
         read(accessHandle, null, totalWriteSize - totalReadSize, "This is third sentence.");
-        shouldThrow("accessHandle.read(new ArrayBuffer(1), { \"at\" : Number.MAX_SAFE_INTEGER })");
+        shouldNotThrow("accessHandle.read(new ArrayBuffer(1), { \"at\" : Number.MAX_SAFE_INTEGER })");
         shouldThrow("accessHandle.write(new ArrayBuffer(1), { \"at\" : Number.MAX_SAFE_INTEGER })");
 
         debug("test flush():");

--- a/LayoutTests/storage/filesystemaccess/sync-access-handle-read-write-worker-expected.txt
+++ b/LayoutTests/storage/filesystemaccess/sync-access-handle-read-write-worker-expected.txt
@@ -19,8 +19,8 @@ PASS [Worker] readSize is readBuffer.byteLength
 PASS [Worker] readText is "This is first sentence.This is second sentence."
 PASS [Worker] readSize is readBuffer.byteLength
 PASS [Worker] readText is "This is third sentence."
-PASS [Worker] accessHandle.read(new ArrayBuffer(1), { "at" : Number.MAX_SAFE_INTEGER }) threw exception InvalidStateError: Failed to read at offset.
-PASS [Worker] accessHandle.write(new ArrayBuffer(1), { "at" : Number.MAX_SAFE_INTEGER }) threw exception InvalidStateError: Failed to write at offset.
+PASS [Worker] accessHandle.read(new ArrayBuffer(1), { "at" : Number.MAX_SAFE_INTEGER }) did not throw exception.
+PASS [Worker] accessHandle.write(new ArrayBuffer(1), { "at" : Number.MAX_SAFE_INTEGER }) threw exception QuotaExceededError: The quota has been exceeded..
 [Worker] test flush():
 PASS [Worker] fileSize is totalWriteSize
 [Worker] test truncate():

--- a/LayoutTests/storage/filesystemaccess/sync-access-handle-storage-limit-worker.html
+++ b/LayoutTests/storage/filesystemaccess/sync-access-handle-storage-limit-worker.html
@@ -11,7 +11,6 @@ if (window.testRunner) {
     testRunner.setAllowStorageQuotaIncrease(false);
 }
 const worker = startWorker('resources/sync-access-handle-storage-limit.js');
-// worker.postMessage({ name:"quota", quota:quota });
 worker.postMessage(quota);
 </script>
 </body>

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.cpp
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.cpp
@@ -113,7 +113,7 @@ ExceptionOr<unsigned long long> FileSystemSyncAccessHandle::read(BufferSource&& 
         return Exception { InvalidStateError, "AccessHandle is closed"_s };
 
     if (options.at) {
-        int result = FileSystem::seekFile(m_file.handle(), options.at.value(), FileSystem::FileSeekOrigin::Beginning);
+        auto result = FileSystem::seekFile(m_file.handle(), options.at.value(), FileSystem::FileSeekOrigin::Beginning);
         if (result == -1)
             return Exception { InvalidStateError, "Failed to read at offset"_s };
     }
@@ -131,11 +131,11 @@ ExceptionOr<unsigned long long> FileSystemSyncAccessHandle::write(BufferSource&&
         return Exception { InvalidStateError, "AccessHandle is closed"_s };
 
     if (options.at) {
-        int result = FileSystem::seekFile(m_file.handle(), options.at.value(), FileSystem::FileSeekOrigin::Beginning);
+        auto result = FileSystem::seekFile(m_file.handle(), options.at.value(), FileSystem::FileSeekOrigin::Beginning);
         if (result == -1)
             return Exception { InvalidStateError, "Failed to write at offset"_s };
     } else {
-        int result = FileSystem::seekFile(m_file.handle(), 0, FileSystem::FileSeekOrigin::Current);
+        auto result = FileSystem::seekFile(m_file.handle(), 0, FileSystem::FileSeekOrigin::Current);
         if (result == -1)
             return Exception { InvalidStateError, "Failed to get offset"_s };
         options.at = result;

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp
@@ -41,6 +41,7 @@ constexpr char pathSeparator = '/';
 constexpr uint64_t defaultInitialCapacity = 1 * MB;
 constexpr uint64_t defaultMaxCapacityForExponentialGrowth = 256 * MB;
 constexpr uint64_t defaultCapacityStep = 128 * MB;
+constexpr uint64_t defaultMaxCapacity = 16 * GB;
 
 std::unique_ptr<FileSystemStorageHandle> FileSystemStorageHandle::create(FileSystemStorageManager& manager, Type type, String&& path, String&& name)
 {
@@ -72,6 +73,7 @@ FileSystemStorageHandle::FileSystemStorageHandle(FileSystemStorageManager& manag
     , m_path(WTFMove(path))
     , m_name(WTFMove(name))
 {
+    WTFLogAlways("sihuil: [%p]FileSystemStorageHandle::FileSystemStorageHandle m_path[%s]", this, m_path.utf8().data());
     ASSERT(!m_path.isEmpty());
 }
 
@@ -303,6 +305,9 @@ void FileSystemStorageHandle::requestNewCapacityForSyncAccessHandle(WebCore::Fil
         return completionHandler(currentCapacity);
 
     if (!m_manager)
+        return completionHandler(std::nullopt);
+
+    if (newCapacity > defaultMaxCapacity)
         return completionHandler(std::nullopt);
 
     if (newCapacity < defaultInitialCapacity)


### PR DESCRIPTION
#### 644136eded86c788741c1e011630d0a1c56554a7
<pre>
FileSystemSyncAccessHandle should not cast return value of FileSystem::seekFile to int
<a href="https://bugs.webkit.org/show_bug.cgi?id=252145">https://bugs.webkit.org/show_bug.cgi?id=252145</a>
rdar://105373703

Reviewed by Youenn Fablet.

FileSystemSyncAccessHandle currently casts the return value of seek from long long to int, which would make read() and
write() return error when the offset might be accepted by FileSystem functions(e.g. 4GB), so let&apos;s make sure we check
long long value of the result. Also, this patch adds a 16GB limit on each file to avoid offset getting too big. This
value might be changed later.

* LayoutTests/storage/filesystemaccess/resources/sync-access-handle-read-write.js:
(async test):
* LayoutTests/storage/filesystemaccess/sync-access-handle-read-write-worker-expected.txt:
* LayoutTests/storage/filesystemaccess/sync-access-handle-storage-limit-worker.html:
* Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.cpp:
(WebCore::FileSystemSyncAccessHandle::read):
(WebCore::FileSystemSyncAccessHandle::write):
* Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp:
(WebKit::FileSystemStorageHandle::FileSystemStorageHandle):
(WebKit::FileSystemStorageHandle::requestNewCapacityForSyncAccessHandle):

Canonical link: <a href="https://commits.webkit.org/260377@main">https://commits.webkit.org/260377@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b60634031d7ce9e977f6ee78115b9b349a340e9d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107454 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16515 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40356 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116616 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116037 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111352 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17939 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7756 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99617 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113215 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13541 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96723 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41166 "Found 3 new test failures: imported/w3c/web-platform-tests/fetch/stale-while-revalidate/stale-css.html, imported/w3c/web-platform-tests/fetch/stale-while-revalidate/stale-image.html, imported/w3c/web-platform-tests/fetch/stale-while-revalidate/stale-script.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95446 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28349 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82935 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9522 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29702 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10178 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6599 "Found 1 new test failure: fast/events/blur-remove-parent-crash.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15677 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49283 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7182 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11738 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->