### PR TITLE
[Cocoa] Add UnrealizedCoreTextFont to make it easier to make CTFontDescriptor and CTFont transformations more deliberate

### DIFF
--- a/Source/WebCore/PlatformMac.cmake
+++ b/Source/WebCore/PlatformMac.cmake
@@ -323,6 +323,7 @@ list(APPEND WebCore_SOURCES
     platform/graphics/cocoa/IntRectCocoa.mm
     platform/graphics/cocoa/IOSurface.mm
     platform/graphics/cocoa/IOSurfacePoolCocoa.mm
+    platform/graphics/cocoa/UnrealizedCoreTextFont.cpp
     platform/graphics/cocoa/WebActionDisablingCALayerDelegate.mm
     platform/graphics/cocoa/WebCoreCALayerExtras.mm
     platform/graphics/cocoa/WebCoreDecompressionSession.mm

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -425,6 +425,7 @@ platform/graphics/cocoa/SourceBufferParserWebM.cpp
 platform/graphics/cocoa/SystemFontDatabaseCocoa.mm
 platform/graphics/cocoa/SystemFontDatabaseCoreText.cpp
 platform/graphics/cocoa/TextTrackRepresentationCocoa.mm
+platform/graphics/cocoa/UnrealizedCoreTextFont.cpp
 platform/graphics/cocoa/VP9UtilitiesCocoa.mm @no-unify
 platform/graphics/cocoa/WebActionDisablingCALayerDelegate.mm
 platform/graphics/cocoa/WebCoreCALayerExtras.mm

--- a/Source/WebCore/platform/graphics/cocoa/UnrealizedCoreTextFont.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/UnrealizedCoreTextFont.cpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "UnrealizedCoreTextFont.h"
+
+#include "FontCreationContext.h"
+#include "FontDescription.h"
+
+#include <optional>
+
+namespace WebCore {
+
+static std::optional<CGFloat> getCGFloatValue(CFNumberRef number)
+{
+    ASSERT(number);
+    ASSERT(CFGetTypeID(number) == CFNumberGetTypeID());
+    CGFloat value = 0;
+    auto success = CFNumberGetValue(number, kCFNumberCGFloatType, &value);
+    if (success && value)
+        return value;
+    return std::nullopt;
+}
+
+CGFloat UnrealizedCoreTextFont::getSize() const
+{
+    if (auto sizeAttribute = static_cast<CFNumberRef>(CFDictionaryGetValue(m_attributes.get(), kCTFontSizeAttribute))) {
+        if (auto result = getCGFloatValue(sizeAttribute))
+            return *result;
+    }
+
+    auto sizeAttribute = WTF::switchOn(m_baseFont, [](const RetainPtr<CTFontRef>& font) {
+        return adoptCF(static_cast<CFNumberRef>(CTFontCopyAttribute(font.get(), kCTFontSizeAttribute)));
+    }, [](const RetainPtr<CTFontDescriptorRef>& fontDescriptor) {
+        return adoptCF(static_cast<CFNumberRef>(CTFontDescriptorCopyAttribute(fontDescriptor.get(), kCTFontSizeAttribute)));
+    });
+    if (sizeAttribute) {
+        if (auto result = getCGFloatValue(sizeAttribute.get()))
+            return *result;
+    }
+
+    return 0;
+}
+
+RetainPtr<CTFontRef> UnrealizedCoreTextFont::realize() const
+{
+    return WTF::switchOn(m_baseFont, [this](const RetainPtr<CTFontRef>& font) -> RetainPtr<CTFontRef> {
+        if (!font)
+            return nullptr;
+        if (!CFDictionaryGetCount(m_attributes.get()))
+            return font;
+        auto modification = adoptCF(CTFontDescriptorCreateWithAttributes(m_attributes.get()));
+        return adoptCF(CTFontCreateCopyWithAttributes(font.get(), getSize(), nullptr, modification.get()));
+    }, [this](const RetainPtr<CTFontDescriptorRef>& fontDescriptor) -> RetainPtr<CTFontRef> {
+        if (!fontDescriptor)
+            return nullptr;
+        if (!CFDictionaryGetCount(m_attributes.get()))
+            return adoptCF(CTFontCreateWithFontDescriptor(fontDescriptor.get(), getSize(), nullptr));
+        auto updatedFontDescriptor = adoptCF(CTFontDescriptorCreateCopyWithAttributes(fontDescriptor.get(), m_attributes.get()));
+        return adoptCF(CTFontCreateWithFontDescriptor(updatedFontDescriptor.get(), getSize(), nullptr));
+    });
+}
+
+UnrealizedCoreTextFont::operator bool() const
+{
+    return WTF::switchOn(m_baseFont, [](const RetainPtr<CTFontRef>& font) -> bool {
+        return font;
+    }, [](const RetainPtr<CTFontDescriptorRef>& fontDescriptor) -> bool {
+        return fontDescriptor;
+    });
+}
+
+static void modifyFromContext(CFMutableDictionaryRef attributes, const FontDescription& fontDescription, const FontCreationContext& fontCreationContext, bool applyWeightWidthSlopeVariations)
+{
+    // FIXME: Implement this
+    UNUSED_PARAM(attributes);
+    UNUSED_PARAM(fontDescription);
+    UNUSED_PARAM(fontCreationContext);
+    UNUSED_PARAM(applyWeightWidthSlopeVariations);
+}
+
+void UnrealizedCoreTextFont::modifyFromContext(const FontDescription& fontDescription, const FontCreationContext& fontCreationContext, bool applyWeightWidthSlopeVariations)
+{
+    modify([&](CFMutableDictionaryRef attributes) {
+        WebCore::modifyFromContext(attributes, fontDescription, fontCreationContext, applyWeightWidthSlopeVariations);
+    });
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/cocoa/UnrealizedCoreTextFont.h
+++ b/Source/WebCore/platform/graphics/cocoa/UnrealizedCoreTextFont.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <CoreText/CoreText.h>
+#include <variant>
+#include <wtf/RetainPtr.h>
+
+namespace WebCore {
+
+class FontCreationContext;
+class FontDescription;
+
+class UnrealizedCoreTextFont {
+public:
+    UnrealizedCoreTextFont(RetainPtr<CTFontRef>&& baseFont)
+        : m_baseFont(WTFMove(baseFont))
+    {
+    }
+
+    UnrealizedCoreTextFont(RetainPtr<CTFontDescriptorRef>&& baseFont)
+        : m_baseFont(WTFMove(baseFont))
+    {
+    }
+
+    template <typename T>
+    void modify(T&& functor)
+    {
+        if (static_cast<bool>(*this))
+            functor(m_attributes.get());
+    }
+
+    void setSize(CGFloat size)
+    {
+        if (static_cast<bool>(*this))
+            CFDictionarySetValue(m_attributes.get(), kCTFontSizeAttribute, adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberCGFloatType, &size)).get());
+    }
+
+    operator bool() const;
+
+    void modifyFromContext(const FontDescription&, const FontCreationContext&, bool applyWeightWidthSlopeVariations = true);
+    RetainPtr<CTFontRef> realize() const;
+
+private:
+    CGFloat getSize() const;
+
+    std::variant<RetainPtr<CTFontRef>, RetainPtr<CTFontDescriptorRef>> m_baseFont;
+    RetainPtr<CFMutableDictionaryRef> m_attributes { adoptCF(CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks)) };
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateMock.h
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateMock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,6 +28,7 @@
 
 #include "MediaRecorderPrivate.h"
 #include <wtf/Lock.h>
+#include <wtf/MediaTime.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/mediastream/mac/MediaStreamTrackAudioSourceProviderCocoa.h
+++ b/Source/WebCore/platform/mediastream/mac/MediaStreamTrackAudioSourceProviderCocoa.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,6 +30,7 @@
 #include "MediaStreamTrackPrivate.h"
 #include "RealtimeMediaSource.h"
 #include "WebAudioSourceProviderCocoa.h"
+#include <wtf/MediaTime.h>
 
 namespace WebCore {
 


### PR DESCRIPTION
#### 7dff0d1ab2dd4d029978dfecbca85576759d81fb
<pre>
[Cocoa] Add UnrealizedCoreTextFont to make it easier to make CTFontDescriptor and CTFont transformations more deliberate
<a href="https://bugs.webkit.org/show_bug.cgi?id=252150">https://bugs.webkit.org/show_bug.cgi?id=252150</a>
rdar://105378692

Reviewed by Alan Baradlay.

The solution to <a href="https://bugs.webkit.org/show_bug.cgi?id=247987">https://bugs.webkit.org/show_bug.cgi?id=247987</a> requires having explicit locations where we transform
a CTFontDescriptor into a CTFont.

Today, we ping-pong back and forth between CTFontDescriptors and CTFonts without much thought. Not only that, but we
also ping-pong between CTFontDescriptors and modified CTFontDescriptors sometimes too.

At the beginning of a font&apos;s lifetime (at the point it&apos;s looked up by WebKit), it usually begins life as a CTFontDescriptor.
(There is an exception where we fall off the end of the font-family list and ask the platform for _some_ font that supports
the character at hand; the result of that is a CTFont rather than a CTFontDescriptor.) This CTFontDescriptor (or CTFont)
needs to have a bunch of transformations applied to it before we can use it in web content: We need to set up the user-
installed-fonts state, the font features and font variations, the palettes, etc. Instead of handling each one of these
individually, by either modifying a CTFontDescriptor or modifying a CTFont, we should try to be more deliberate about when
the transformations take place, and to batch up all modifications so we can do all the modifications in one go.

This patch is the first step in a design where:

- UnrealizedCoreTextFont is a new class that holds either a CTFont or a CTFontDescriptor, and a CFMutableDictionary of
      modifications to be made to it.
- It has a modify() function that takes a lambda that can modify the CFMutableDictionary. Because these modifications
      never even hit Core Text, they are extremely lightweight.
- There&apos;s a modifyFromContext() which conceptually is like modify(), but is intended to take the place of what
      preparePlatformFont() does now. It&apos;s intentionally unimplemented for now; a future patch will migrate code to it.
- Once WebCore is done modifying the CFMutableDictionary, there&apos;s a realize() function, which produces the final CTFont which
      WebCore can directly use.

* Source/WebCore/PlatformMac.cmake:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/cocoa/UnrealizedCoreTextFont.cpp: Added.
(WebCore::getCGFloatValue):
(WebCore::UnrealizedCoreTextFont::getSize const):
(WebCore::UnrealizedCoreTextFont::realize const):
(WebCore::UnrealizedCoreTextFont::operator bool const):
(WebCore::modifyFromContext):
(WebCore::UnrealizedCoreTextFont::modifyFromContext):
* Source/WebCore/platform/graphics/cocoa/UnrealizedCoreTextFont.h: Added.
(WebCore::UnrealizedCoreTextFont::UnrealizedCoreTextFont):
(WebCore::UnrealizedCoreTextFont::modify):
(WebCore::UnrealizedCoreTextFont::setSize):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateMock.h:
* Source/WebCore/platform/mediastream/mac/MediaStreamTrackAudioSourceProviderCocoa.h:

Canonical link: <a href="https://commits.webkit.org/260208@main">https://commits.webkit.org/260208@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ce062fdb394bbe8cecd00f31d09ef9314b1832a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107466 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16528 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40369 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116629 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116050 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111364 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17953 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7770 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99630 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113227 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13553 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96735 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41176 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95458 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28361 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82946 "Found 1 new API test failure: /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/cut-copy-paste/editable (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9534 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29714 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10191 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6614 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15690 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49295 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7057 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11751 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->