### PR TITLE
Should <button> have `user-select: none;` by default?

### DIFF
--- a/LayoutTests/accessibility/mac/search-predicate-from-ignored-element-expected.txt
+++ b/LayoutTests/accessibility/mac/search-predicate-from-ignored-element-expected.txt
@@ -1,7 +1,6 @@
 This tests the ability to search for accessible elements from an ignored element.
 
 PASS: element.stringForTextMarkerRange(range) === 'First line of text'
-PASS: element.stringForTextMarkerRange(range) === 'button'
 PASS: resultElement.stringValue === 'AXValue: Third line of text'
 PASS: resultElement.stringValue === 'AXValue: First line of text'
 

--- a/LayoutTests/accessibility/mac/search-predicate-from-ignored-element.html
+++ b/LayoutTests/accessibility/mac/search-predicate-from-ignored-element.html
@@ -26,7 +26,6 @@
         marker = element.nextTextMarker(marker);
         marker = element.nextTextMarker(marker);
         range = element.lineTextMarkerRangeForTextMarker(marker);
-        output += expect("element.stringForTextMarkerRange(range)", "'button'");
 
         marker = element.startTextMarkerForTextMarkerRange(range);
         var startElement = element.accessibilityElementForTextMarker(marker);

--- a/LayoutTests/accessibility/mac/textmarker-range-for-range-expected.txt
+++ b/LayoutTests/accessibility/mac/textmarker-range-for-range-expected.txt
@@ -132,90 +132,62 @@ underline last!'
 52 'Think different Apple
 
 bold italic
-underline last!
-
-￼'
+underline last!'
 53 'Think different Apple
 
 bold italic
-underline last!
-
-￼H'
+underline last!'
 54 'Think different Apple
 
 bold italic
-underline last!
-
-￼He'
+underline last!'
 55 'Think different Apple
 
 bold italic
-underline last!
-
-￼Hel'
+underline last!'
 56 'Think different Apple
 
 bold italic
-underline last!
-
-￼Hell'
+underline last!'
 57 'Think different Apple
 
 bold italic
-underline last!
-
-￼Hello'
+underline last!'
 58 'Think different Apple
 
 bold italic
-underline last!
-
-￼Hello '
+underline last!'
 59 'Think different Apple
 
 bold italic
-underline last!
-
-￼Hello W'
+underline last!'
 60 'Think different Apple
 
 bold italic
-underline last!
-
-￼Hello Wo'
+underline last!'
 61 'Think different Apple
 
 bold italic
-underline last!
-
-￼Hello Wor'
+underline last!'
 62 'Think different Apple
 
 bold italic
-underline last!
-
-￼Hello Worl'
+underline last!'
 63 'Think different Apple
 
 bold italic
-underline last!
-
-￼Hello World'
+underline last!'
 64 'Think different Apple
 
 bold italic
-underline last!
-
-￼Hello World!'
+underline last!'
 Get the range for the word Apple:
 'Apple'
 Out of range values:
 'Think different Apple
 
 bold italic
-underline last!
-
-￼Hello World!'
+underline last!'
 ''
 
 PASS successfullyParsed is true

--- a/LayoutTests/editing/pasteboard/paste-noscript-expected.txt
+++ b/LayoutTests/editing/pasteboard/paste-noscript-expected.txt
@@ -3,19 +3,19 @@ Hello
 CNN Hello
 This is a form
 Submit.
-Hello 
+ 
 CNN Hello  
 This is a form
-Submit.
+
 <button id="button1" onclick="sayHello()" ondblclick="sayHello()" style="width: 100px;">Hello</button>
-<button id="button1" style="width: 100px;">Hello</button>
+undefined
 <a id="anchor1" href="http://www.cnn.com/">CNN</a>
-<a id="anchor1" href="http://www.cnn.com/">CNN</a>
+undefined
 <a id="anchor2" href="javascript:sayHello()">Hello</a>
-<a id="anchor2">Hello</a>
+undefined
 <iframe id="iframe1" src="javascript:var x = 1;" style="width: 200px; height: 100px; background-color:#cee;"></iframe>
-<iframe id="iframe1" style="width: 200px; height: 100px; background-color: rgb(204, 238, 238);"></iframe>
+undefined
 <iframe id="iframe2" srcdoc="<script>var x = 1;</script>" style="width: 200px; height: 100px; background-color:#cee;"></iframe>
-<iframe id="iframe2" style="width: 200px; height: 100px; background-color: rgb(204, 238, 238);"></iframe>
+<form id="form1" formaction="javascript:sayHello()" style="width: 200px; height: 150px; background-color: rgb(204, 238, 238);">This is a form<br><img src="../resources/abe.png"></form>
 <form id="form1" action="javascript:sayHello()" formaction="javascript:sayHello()" style="width: 200px; height: 150px; background-color:#cee;">This is a form<br><img src="../resources/abe.png"><button formaction="javascript:sayHello()">Submit.</button></form>
-<form id="form1" formaction="javascript:sayHello()" style="width: 200px; height: 150px; background-color: rgb(204, 238, 238);">This is a form<br><img src="../resources/abe.png"><button>Submit.</button></form>
+undefined

--- a/LayoutTests/editing/pasteboard/paste-noscript-xhtml-expected.txt
+++ b/LayoutTests/editing/pasteboard/paste-noscript-xhtml-expected.txt
@@ -51,10 +51,6 @@ FRAME 0:
 | <body>
 
 Pasted content:
-| <button>
-|   id="button1"
-|   style="width: 100px;"
-|   "Hello"
 | <a>
 |   href="http://www.bing.com/search?q=cnn"
 |   id="anchor1"
@@ -69,10 +65,7 @@ Pasted content:
 |   formaction="javascript:sayHello()"
 |   id="form1"
 |   style="width: 200px; height: 150px; background-color: rgb(204, 238, 238);"
-|   "This is a form."
-|   " "
-|   <button>
-|     "Submit."
+|   "This is a form. "
 
 FRAME 0:
 | <head>

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -404,6 +404,11 @@ select, button, meter, progress, input:is([type="button"], [type="submit"], [typ
     writing-mode: horizontal-tb !important;
 }
 
+/* FIXME: Unprefix when https://bugs.webkit.org/show_bug.cgi?id=208677 is fixed. */
+button, meter, progress, select {
+    -webkit-user-select: none;
+}
+
 input, textarea, select, button {
     margin: 0__qem;
 #if !(defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY)


### PR DESCRIPTION
#### c73eea082ab652d680f34de6924a4c9829aaa3ea
<pre>
Should &lt;button&gt; have `user-select: none;` by default?
<a href="https://bugs.webkit.org/show_bug.cgi?id=244448">https://bugs.webkit.org/show_bug.cgi?id=244448</a>
rdar://99262559

Reviewed by NOBODY (OOPS!).

In the section 6.1. Controlling content selection had this
recommendation for the UA stylesheet for HTML.
button, meter, progress, select { user-select: none; }
<a href="https://drafts.csswg.org/css-ui/#content-selection">https://drafts.csswg.org/css-ui/#content-selection</a>
seeAlso <a href="https://github.com/whatwg/html/issues/8228">https://github.com/whatwg/html/issues/8228</a>
This will need to be unprefixed once Bug 208677 is fixed
<a href="https://bugs.webkit.org/show_bug.cgi?id=208677">https://bugs.webkit.org/show_bug.cgi?id=208677</a>

* LayoutTests/accessibility/mac/search-predicate-from-ignored-element-expected.txt:
* LayoutTests/accessibility/mac/search-predicate-from-ignored-element.html:
* LayoutTests/accessibility/mac/textmarker-range-for-range-expected.txt:
* LayoutTests/editing/pasteboard/paste-noscript-expected.txt:
* LayoutTests/editing/pasteboard/paste-noscript-xhtml-expected.txt:
* Source/WebCore/css/html.css:
(button, meter, progress, select):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c73eea082ab652d680f34de6924a4c9829aaa3ea

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107645 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16696 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40540 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116792 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116196 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111537 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18118 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8014 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99816 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113399 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13674 "Found 2 new test failures: editing/pasteboard/paste-content-with-overflow-auto-parent-across-origin.html, fast/mediastream/mock-media-source-webaudio.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96875 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41346 "Found 1 new test failure: editing/pasteboard/paste-content-with-overflow-auto-parent-across-origin.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95588 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28505 "Found 1 new test failure: editing/pasteboard/paste-content-with-overflow-auto-parent-across-origin.html (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/83190 "Found 3 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/replaced-objects, /WebKitGTK/TestDownloads:/webkit/Downloads/local-file-error (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9683 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29854 "Found 1 new test failure: editing/pasteboard/paste-content-with-overflow-auto-parent-across-origin.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10358 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6745 "Found 1 new test failure: editing/pasteboard/paste-content-with-overflow-auto-parent-across-origin.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15834 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49439 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11918 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->