### PR TITLE
[WGSL] Implement unary expression parsing

### DIFF
--- a/Source/WebGPU/WGSL/Lexer.cpp
+++ b/Source/WebGPU/WGSL/Lexer.cpp
@@ -216,6 +216,9 @@ Token Lexer<T>::lex()
             return makeLiteralToken(TokenType::DecimalFloatLiteral, literalValue);
         return parseIntegerLiteralSuffix(literalValue);
     }
+    case '~':
+        shift();
+        return makeToken(TokenType::Tilde);
     default:
         if (isASCIIDigit(m_current)) {
             std::optional<uint64_t> value = parseDecimalInteger();

--- a/Source/WebGPU/WGSL/Token.cpp
+++ b/Source/WebGPU/WGSL/Token.cpp
@@ -149,6 +149,8 @@ String toString(TokenType type)
         return "/"_s;
     case TokenType::Star:
         return "*"_s;
+    case TokenType::Tilde:
+        return "~"_s;
     case TokenType::Xor:
         return "^"_s;
     }

--- a/Source/WebGPU/WGSL/Token.h
+++ b/Source/WebGPU/WGSL/Token.h
@@ -101,6 +101,7 @@ enum class TokenType: uint32_t {
     Semicolon,
     Slash,
     Star,
+    Tilde,
     Xor,
     // FIXME: add all the other special tokens
 };

--- a/Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp
@@ -155,6 +155,7 @@ TEST(WGSLLexerTests, SpecialTokens)
     checkSingleToken("&"_s, TokenType::And);
     checkSingleToken("|"_s, TokenType::Or);
     checkSingleToken("^"_s, TokenType::Xor);
+    checkSingleToken("~"_s, TokenType::Tilde);
 }
 
 TEST(WGSLLexerTests, ComputeShader)

--- a/Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp
@@ -452,6 +452,27 @@ TEST(WGSLParserTests, UnaryExpression)
     }
 }
 
+static void testUnaryExpressionX(ASCIILiteral program, WGSL::AST::UnaryOperation op)
+{
+    EXPECT_EXPRESSION(expression, program);
+    EXPECT_TRUE(is<WGSL::AST::UnaryExpression>(expression.get()));
+    auto& unaryExpression = downcast<WGSL::AST::UnaryExpression>(expression.get());
+
+    EXPECT_EQ(unaryExpression.operation(), op);
+    EXPECT_TRUE(is<WGSL::AST::IdentifierExpression>(unaryExpression.expression()));
+    auto& expr = downcast<WGSL::AST::IdentifierExpression>(unaryExpression.expression());
+    EXPECT_EQ(expr.identifier(), "x"_s);
+}
+
+TEST(WGSLParserTests, UnaryExpression2)
+{
+    testUnaryExpressionX("&x"_s, WGSL::AST::UnaryOperation::AddressOf);
+    testUnaryExpressionX("~x"_s, WGSL::AST::UnaryOperation::Complement);
+    testUnaryExpressionX("*x"_s, WGSL::AST::UnaryOperation::Dereference);
+    testUnaryExpressionX("-x"_s, WGSL::AST::UnaryOperation::Negate);
+    testUnaryExpressionX("!x"_s, WGSL::AST::UnaryOperation::Not);
+}
+
 static void testBinaryExpressionXY(ASCIILiteral program, WGSL::AST::BinaryOperation op, const Vector<ASCIILiteral>& ids)
 {
     EXPECT_EQ(ids.size(), 2u);
@@ -469,7 +490,7 @@ static void testBinaryExpressionXY(ASCIILiteral program, WGSL::AST::BinaryOperat
     EXPECT_EQ(rhs.identifier(), ids[1]);
 }
 
-static void testBinaryExpressionXYZ(ASCIILiteral program, const Vector<WGSL::AST::BinaryOperation>& ops, const Vector<String>& ids)
+static void testBinaryExpressionXYZ(ASCIILiteral program, const Vector<WGSL::AST::BinaryOperation>& ops, const Vector<ASCIILiteral>& ids)
 {
     EXPECT_EQ(ops.size(), 2u);
     EXPECT_EQ(ids.size(), 3u);


### PR DESCRIPTION
#### 0141851d63984e07f592074f86cbd70f77705185
<pre>
[WGSL] Implement unary expression parsing
<a href="https://bugs.webkit.org/show_bug.cgi?id=252154">https://bugs.webkit.org/show_bug.cgi?id=252154</a>
rdar://problem/105380466

Reviewed by Tadeu Zagallo.

Handle parsing of unary expressions involving &amp;, ~, *, - and ! according to WGSL
spec.

Canonical link: <a href="https://commits.webkit.org/260232@main">https://commits.webkit.org/260232@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e011c74bc70146ada94e704da1aa8b718ba65c8b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107601 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16655 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40496 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116751 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111494 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18078 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7968 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99771 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113356 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96841 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/41307 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/95561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28468 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9646 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29820 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10317 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/6715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/15802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49402 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7072 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11877 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->