### PR TITLE
Support SpiderMonkey shell in JetStream2 CLI

### DIFF
--- a/PerformanceTests/JetStream2/JetStreamDriver.js
+++ b/PerformanceTests/JetStream2/JetStreamDriver.js
@@ -332,6 +332,10 @@ class Driver {
                     return Realm.eval(realm, s);
                 };
                 globalObject.readFile = read;
+            } else if (isSpiderMonkey) {
+                globalObject = newGlobal();
+                globalObject.loadString = globalObject.evaluate;
+                globalObject.readFile = globalObject.readRelativeToScript;
             } else
                 globalObject = runString("");
 

--- a/PerformanceTests/JetStream2/cli.js
+++ b/PerformanceTests/JetStream2/cli.js
@@ -30,7 +30,10 @@ console = {
 
 const isD8 = typeof Realm !== "undefined";
 if (isD8)
-    readFile = read;
+    globalThis.readFile = read;
+const isSpiderMonkey = typeof newGlobal !== "undefined";
+if (isSpiderMonkey)
+    globalThis.readFile = readRelativeToScript;
 
 if (typeof testList === "undefined")
     testList = undefined;

--- a/PerformanceTests/JetStream2/index.html
+++ b/PerformanceTests/JetStream2/index.html
@@ -35,6 +35,7 @@
     <script>
     const isInBrowser = true;
     const isD8 = false;
+    const isSpiderMonkey = false;
     var allIsGood = true;
     window.onerror = function(e) {
         if (e == "Script error.") {


### PR DESCRIPTION
#### b42bc97647b1a174a8e4b1b505484d4096e9065c
<pre>
Support SpiderMonkey shell in JetStream2 CLI
<a href="https://bugs.webkit.org/show_bug.cgi?id=252155">https://bugs.webkit.org/show_bug.cgi?id=252155</a>
rdar://105380561

Reviewed by Tadeu Zagallo.

This is nice if we can quickly run JetStream2 CLI with SpiderMonkey shell too to see the difference with JSC.
This patch extends JetStream2 CLI driver to support SpiderMonkey shell.
CAUTION: This CLI is used just for ease. This CLI is not attempting to make every environment run under the strictly same condition.
Each shell is using its own readFile, runString etc. implementations and only browser run can offer strictly comparable data.
But still CLI is useful for quick investigation.

* PerformanceTests/JetStream2/JetStreamDriver.js:
(Driver.prototype.runCode):
(typeof): Deleted.
(prototype.else): Deleted.
* PerformanceTests/JetStream2/cli.js:

Canonical link: <a href="https://commits.webkit.org/260185@main">https://commits.webkit.org/260185@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc0465d7a4435aa1673b77bf772fe1b01431ab0f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107477 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16539 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40380 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116640 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116061 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17964 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7781 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99641 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113238 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/96742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/41185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/95468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/28368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9545 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/29721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10202 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/6623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15701 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/49302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11762 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3815 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->