### PR TITLE
[JSC] Implement SuperSampler code in LLInt

### DIFF
--- a/Source/JavaScriptCore/bytecode/SuperSampler.h
+++ b/Source/JavaScriptCore/bytecode/SuperSampler.h
@@ -31,7 +31,7 @@ namespace JSC {
 
 class MacroAssembler;
 
-extern JS_EXPORT_PRIVATE std::atomic<uint32_t> g_superSamplerCount;
+extern "C" JS_EXPORT_PRIVATE std::atomic<uint32_t> g_superSamplerCount;
 
 void initializeSuperSampler();
 

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -2314,24 +2314,6 @@ LLINT_SLOW_PATH_DECL(slow_path_profile_catch)
     LLINT_END();
 }
 
-LLINT_SLOW_PATH_DECL(slow_path_super_sampler_begin)
-{
-    // FIXME: It seems like we should be able to do this in asm but llint doesn't seem to like global variables.
-    // See: https://bugs.webkit.org/show_bug.cgi?id=179438
-    UNUSED_PARAM(callFrame);
-    g_superSamplerCount++;
-    LLINT_END_IMPL();
-}
-
-LLINT_SLOW_PATH_DECL(slow_path_super_sampler_end)
-{
-    // FIXME: It seems like we should be able to do this in asm but llint doesn't seem to like global variables.
-    // See: https://bugs.webkit.org/show_bug.cgi?id=179438
-    UNUSED_PARAM(callFrame);
-    g_superSamplerCount--;
-    LLINT_END_IMPL();
-}
-
 LLINT_SLOW_PATH_DECL(slow_path_out_of_line_jump_target)
 {
     pc = callFrame->codeBlock()->outOfLineJumpTarget(pc);

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.h
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.h
@@ -146,8 +146,6 @@ LLINT_SLOW_PATH_HIDDEN_DECL(slow_path_retrieve_and_clear_exception_if_catchable)
 LLINT_SLOW_PATH_HIDDEN_DECL(slow_path_profile_catch);
 LLINT_SLOW_PATH_HIDDEN_DECL(slow_path_log_shadow_chicken_prologue);
 LLINT_SLOW_PATH_HIDDEN_DECL(slow_path_log_shadow_chicken_tail);
-LLINT_SLOW_PATH_HIDDEN_DECL(slow_path_super_sampler_begin);
-LLINT_SLOW_PATH_HIDDEN_DECL(slow_path_super_sampler_end);
 LLINT_SLOW_PATH_HIDDEN_DECL(slow_path_out_of_line_jump_target);
 LLINT_SLOW_PATH_HIDDEN_DECL(slow_path_arityCheck);
 extern "C" SlowPathReturnType llint_throw_stack_overflow_error(VM*, ProtoCallFrame*) REFERENCED_FROM_ASM WTF_INTERNAL;

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
@@ -406,6 +406,15 @@ macro dispatchOp(size, opcodeName)
     genericDispatchOpJS(dispatch, size, opcodeName)
 end
 
+macro superSamplerBegin(scratch)
+    leap _g_superSamplerCount, scratch
+    addi 1, [scratch]
+end
+
+macro superSamplerEnd(scratch)
+    leap _g_superSamplerCount, scratch
+    subi 1, [scratch]
+end
 
 macro getu(size, opcodeStruct, fieldName, dst)
     size(getuOperandNarrow, getuOperandWide16JS, getuOperandWide32JS, macro (getu)
@@ -2185,8 +2194,6 @@ llintSlowPathOp(put_getter_setter_by_id)
 llintSlowPathOp(put_setter_by_id)
 llintSlowPathOp(put_setter_by_val)
 llintSlowPathOp(set_function_name)
-llintSlowPathOp(super_sampler_begin)
-llintSlowPathOp(super_sampler_end)
 llintSlowPathOp(throw)
 llintSlowPathOp(get_by_id_with_this)
 
@@ -2508,6 +2515,16 @@ llintOp(op_debug, OpDebug, macro (unused, unused, dispatch)
     dispatch()
 end)
 
+
+llintOp(op_super_sampler_begin, OpSuperSamplerBegin, macro (unused, unused, dispatch)
+    superSamplerBegin(t1)
+    dispatch()
+end)
+
+llintOp(op_super_sampler_end, OpSuperSamplerEnd, macro (unused, unused, dispatch)
+    superSamplerEnd(t1)
+    dispatch()
+end)
 
 op(llint_native_call_trampoline, macro ()
     nativeCallTrampoline(NativeExecutable::m_function)


### PR DESCRIPTION
#### 5f72014c126b4da2334c8636d7f642e50bdaab6b
<pre>
[JSC] Implement SuperSampler code in LLInt
<a href="https://bugs.webkit.org/show_bug.cgi?id=252159">https://bugs.webkit.org/show_bug.cgi?id=252159</a>
rdar://105382358

Reviewed by Keith Miller and Tadeu Zagallo.

This patch implements op_super_sampler_begin and op_super_sampler_end in LLInt asm instead of function calls from LLInt.
This also adds superSamplerBegin / superSamplerEnd LLInt macros, which can be usable to sample LLInt code.

* Source/JavaScriptCore/bytecode/SuperSampler.h:
* Source/JavaScriptCore/llint/LLIntSlowPaths.cpp:
* Source/JavaScriptCore/llint/LLIntSlowPaths.h:
* Source/JavaScriptCore/llint/LowLevelInterpreter.asm:

Canonical link: <a href="https://commits.webkit.org/260205@main">https://commits.webkit.org/260205@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f6a84592bf50bac374b3a70870687113dfff9dc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107481 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16543 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40384 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116644 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116065 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17968 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7785 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99645 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113242 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13567 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96748 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41190 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95472 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28374 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82959 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/96818 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9549 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29727 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/96240 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/7548 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10206 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6626 "Passed tests") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/30808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15705 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49308 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/105088 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11766 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26060 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3826 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->