### PR TITLE
[IFC][Pagination] Pass pagination adjustments to renderer positioning code

### DIFF
--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h
@@ -58,6 +58,7 @@ class InlineDamage;
 namespace LayoutIntegration {
 
 struct InlineContent;
+struct LineAdjustment;
 
 class LineLayout : public CanMakeCheckedPtr {
     WTF_MAKE_FAST_ALLOCATED;
@@ -135,6 +136,9 @@ private:
     void prepareLayoutState();
     void prepareFloatingState();
     void constructContent();
+    Vector<LineAdjustment> adjustContent();
+    void updateRenderTreePositions(const Vector<LineAdjustment>&);
+
     InlineContent& ensureInlineContent();
     void updateLayoutBoxDimensions(const RenderBox&);
 

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationPagination.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationPagination.h
@@ -32,8 +32,14 @@ namespace WebCore {
 class RenderBlockFlow;
 
 namespace LayoutIntegration {
-    
-std::unique_ptr<InlineContent> adjustLinePositionsForPagination(const InlineContent&, RenderBlockFlow&);
+
+struct LineAdjustment {
+    LayoutUnit offset { 0 };
+    bool isFirstAfterPageBreak { false };
+};
+
+Vector<LineAdjustment> computeAdjustmentsForPagination(const InlineContent&, RenderBlockFlow&);
+void adjustLinePositionsForPagination(InlineContent&, const Vector<LineAdjustment>&);
 
 }
 }

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -3959,9 +3959,6 @@ void RenderBlockFlow::layoutModernLines(bool relayoutChildren, LayoutUnit& repai
 
     layoutFormattingContextLineLayout.layout();
 
-    if (layoutState.isPaginated())
-        layoutFormattingContextLineLayout.adjustForPagination();
-
     auto newBorderBoxBottom = computeBorderBoxBottom();
 
     auto updateRepaintTopAndBottomIfNeeded = [&] {


### PR DESCRIPTION
#### 5a049809955a360f7ec43aa244acc1e65b4b70e6
<pre>
[IFC][Pagination] Pass pagination adjustments to renderer positioning code
<a href="https://bugs.webkit.org/show_bug.cgi?id=252165">https://bugs.webkit.org/show_bug.cgi?id=252165</a>
&lt;rdar://problem/105390360&gt;

Reviewed by Alan Baradlay.

Renderer positioning code needs to take pagination into account.

This patch doesn&apos;t enable any new content so there are no test changes.

* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::layout):

Split into constructContent/adjustContent/updateRenderTreePositions.
Apply pagination adjustments before updating render tree positions. Before it was applied after, by the flow.

(WebCore::LayoutIntegration::LineLayout::constructContent):
(WebCore::LayoutIntegration::LineLayout::updateRenderTreePositions):

Traverse the display boxes so we know which line the renderer is on and can apply adjustments.

(WebCore::LayoutIntegration::LineLayout::adjustContent):
(WebCore::LayoutIntegration::LineLayout::adjustForPagination): Deleted.
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h:
* Source/WebCore/layout/integration/inline/LayoutIntegrationPagination.cpp:
(WebCore::LayoutIntegration::computeLineTopAndBottomWithOverflow):
(WebCore::LayoutIntegration::computeLineBreakIndex):
(WebCore::LayoutIntegration::setPageBreakForLine):
(WebCore::LayoutIntegration::computeAdjustmentsForPagination):

Separate adjustment computation from applying adjustments.
Remove page indexed Strut vector, instead use an adjustment vector with entry per line. This simplifies the code.

(WebCore::LayoutIntegration::adjustLinePositionsForPagination):

Apply adjustments to inline content.

(WebCore::LayoutIntegration::makeAdjustedContent): Deleted.
* Source/WebCore/layout/integration/inline/LayoutIntegrationPagination.h:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::layoutModernLines):

Pagination is now handled in LineLayout::layout.

Canonical link: <a href="https://commits.webkit.org/260524@main">https://commits.webkit.org/260524@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8f8b9d232c7a9ae3412e6d8782508ac4ddd0098

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108578 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17677 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41430 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117686 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/117885 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112461 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19128 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8954 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100808 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114345 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14335 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97564 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42305 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96312 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/29205 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84019 "Found 2 new API test failures: /TestWebKit:WebKit.OnDeviceChangeCrash, /TestWebKit:WebKit.PrivateBrowsingPushStateNoHistoryCallback (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10487 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/30554 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11243 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7468 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16634 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50149 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7270 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12832 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->