### PR TITLE
Adopt ASCIILiterals in makeString, tryMakeString, operator+ calls inside JavaScriptCore

### DIFF
--- a/Source/JavaScriptCore/API/glib/JSCCallbackFunction.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCCallbackFunction.cpp
@@ -226,7 +226,7 @@ JSObjectRef JSCCallbackFunction::construct(JSContextRef callerContext, size_t ar
         *exception = toRef(JSC::createTypeError(toJS(jsContext), "constructor returned null"_s));
         break;
     default:
-        *exception = toRef(JSC::createTypeError(toJS(jsContext), makeString("invalid type ", g_type_name(G_VALUE_TYPE(&returnValue)), " returned by constructor")));
+        *exception = toRef(JSC::createTypeError(toJS(jsContext), makeString("invalid type "_s, g_type_name(G_VALUE_TYPE(&returnValue)), " returned by constructor"_s)));
         break;
     }
     g_value_unset(&returnValue);

--- a/Source/JavaScriptCore/API/glib/JSCContext.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCContext.cpp
@@ -294,7 +294,7 @@ JSValueRef jscContextGArrayToJSArray(JSCContext* context, GPtrArray* gArray, JSV
         else if (JSC_IS_VALUE(item))
             JSObjectSetPropertyAtIndex(priv->jsContext.get(), jsArrayObject, i, jscValueGetJSValue(JSC_VALUE(item)), exception);
         else
-            *exception = toRef(JSC::createTypeError(globalObject, makeString("invalid item type in GPtrArray")));
+            *exception = toRef(JSC::createTypeError(globalObject, "invalid item type in GPtrArray"_s));
 
         if (*exception)
             return JSValueMakeUndefined(priv->jsContext.get());
@@ -313,7 +313,7 @@ static GRefPtr<GPtrArray> jscContextJSArrayToGArray(JSCContext* context, JSValue
         return nullptr;
 
     if (!JSValueIsArray(priv->jsContext.get(), jsArray)) {
-        *exception = toRef(JSC::createTypeError(globalObject, makeString("invalid js type for GPtrArray")));
+        *exception = toRef(JSC::createTypeError(globalObject, "invalid js type for GPtrArray"_s));
         return nullptr;
     }
 
@@ -352,7 +352,7 @@ GUniquePtr<char*> jscContextJSArrayToGStrv(JSCContext* context, JSValueRef jsArr
         return nullptr;
 
     if (!JSValueIsArray(priv->jsContext.get(), jsArray)) {
-        *exception = toRef(JSC::createTypeError(globalObject, makeString("invalid js type for GStrv")));
+        *exception = toRef(JSC::createTypeError(globalObject, "invalid js type for GStrv"_s));
         return nullptr;
     }
 
@@ -377,7 +377,7 @@ GUniquePtr<char*> jscContextJSArrayToGStrv(JSCContext* context, JSValueRef jsArr
 
         auto jsValueItem = jscContextGetOrCreateValue(context, jsItem);
         if (!jsc_value_is_string(jsValueItem.get())) {
-            *exception = toRef(JSC::createTypeError(globalObject, makeString("invalid js type for GStrv: item ", String::number(i), " is not a string")));
+            *exception = toRef(JSC::createTypeError(globalObject, makeString("invalid js type for GStrv: item "_s, i, " is not a string"_s)));
             return nullptr;
         }
 
@@ -459,7 +459,7 @@ JSValueRef jscContextGValueToJSValue(JSCContext* context, const GValue* value, J
         break;
     }
 
-    *exception = toRef(JSC::createTypeError(globalObject, makeString("unsupported type ", g_type_name(G_VALUE_TYPE(value)))));
+    *exception = toRef(JSC::createTypeError(globalObject, makeString("unsupported type "_s, g_type_name(G_VALUE_TYPE(value)))));
     return JSValueMakeUndefined(priv->jsContext.get());
 }
 
@@ -579,7 +579,7 @@ void jscContextJSValueToGValue(JSCContext* context, JSValueRef jsValue, GType ty
     case G_TYPE_INTERFACE:
     case G_TYPE_VARIANT:
     default:
-        *exception = toRef(JSC::createTypeError(globalObject, makeString("unsupported type ", g_type_name(G_VALUE_TYPE(value)))));
+        *exception = toRef(JSC::createTypeError(globalObject, makeString("unsupported type "_s, g_type_name(G_VALUE_TYPE(value)))));
         break;
     }
 }

--- a/Source/JavaScriptCore/API/glib/JSCValue.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCValue.cpp
@@ -497,7 +497,7 @@ JSCValue* jsc_value_new_array(JSCContext* context, GType firstItemType, ...)
         GUniqueOutPtr<char> error;
         G_VALUE_COLLECT_INIT(&item, itemType, args, G_VALUE_NOCOPY_CONTENTS, &error.outPtr());
         if (error) {
-            exception = toRef(JSC::createTypeError(globalObject, makeString("failed to collect array item: ", error.get())));
+            exception = toRef(JSC::createTypeError(globalObject, makeString("failed to collect array item: "_s, error.get())));
             jscContextHandleExceptionIfNeeded(context, exception);
             jsArray = nullptr;
             break;
@@ -893,7 +893,7 @@ static GRefPtr<JSCValue> jscValueCallFunction(JSCValue* value, JSObjectRef funct
         GUniqueOutPtr<char> error;
         G_VALUE_COLLECT_INIT(&parameter, parameterType, args, G_VALUE_NOCOPY_CONTENTS, &error.outPtr());
         if (error) {
-            exception = toRef(JSC::createTypeError(globalObject, makeString("failed to collect function paramater: ", error.get())));
+            exception = toRef(JSC::createTypeError(globalObject, makeString("failed to collect function paramater: "_s, error.get())));
             jscContextHandleExceptionIfNeeded(priv->context.get(), exception);
             return adoptGRef(jsc_value_new_undefined(priv->context.get()));
         }

--- a/Source/JavaScriptCore/API/tests/ExecutionTimeLimitTest.cpp
+++ b/Source/JavaScriptCore/API/tests/ExecutionTimeLimitTest.cpp
@@ -228,10 +228,10 @@ int testExecutionTimeLimit()
                     "var startTime = currentCPUTime();"
                     "while (true) {"
                         "for (var i = 0; i < 1000; i++);"
-                        "if (currentCPUTime() - startTime > ", timeAfterWatchdogShouldHaveFired.seconds(), ") break;"
+                        "if (currentCPUTime() - startTime > "_s, timeAfterWatchdogShouldHaveFired.seconds(), ") break;"
                     "}"
                 "}"
-                "foo();"
+                "foo();"_s
             ).utf8();
 
             JSStringRef script = JSStringCreateWithUTF8CString(scriptText.data());
@@ -271,10 +271,10 @@ int testExecutionTimeLimit()
                 "function recurse(i) {"
                     "'use strict';"
                     "if (i % 1000 === 0) {"
-                        "if (currentCPUTime() - startTime >", timeAfterWatchdogShouldHaveFired.seconds(), ") { return; }"
+                        "if (currentCPUTime() - startTime >"_s, timeAfterWatchdogShouldHaveFired.seconds(), ") { return; }"
                     "}"
                 "return recurse(i + 1); }"
-                "recurse(0);"
+                "recurse(0);"_s
             ).utf8();
 
             JSStringRef script = JSStringCreateWithUTF8CString(scriptText.data());
@@ -315,11 +315,11 @@ int testExecutionTimeLimit()
                     "try {"
                         "while (true) {"
                             "for (var i = 0; i < 1000; i++);"
-                                "if (currentCPUTime() - startTime > ", timeAfterWatchdogShouldHaveFired.seconds(), ") break;"
+                                "if (currentCPUTime() - startTime > "_s, timeAfterWatchdogShouldHaveFired.seconds(), ") break;"
                         "}"
                     "} catch(e) { }"
                 "}"
-                "foo();"
+                "foo();"_s
             ).utf8();
 
             JSStringRef script = JSStringCreateWithUTF8CString(scriptText.data());
@@ -361,10 +361,10 @@ int testExecutionTimeLimit()
                     "var startTime = currentCPUTime();"
                     "while (true) {"
                         "for (var i = 0; i < 1000; i++);"
-                            "if (currentCPUTime() - startTime > ", timeAfterWatchdogShouldHaveFired.seconds(), ") break;"
+                            "if (currentCPUTime() - startTime > "_s, timeAfterWatchdogShouldHaveFired.seconds(), ") break;"
                     "}"
                 "}"
-                "foo();"
+                "foo();"_s
             ).utf8();
             
             JSStringRef script = JSStringCreateWithUTF8CString(scriptText.data());
@@ -406,10 +406,10 @@ int testExecutionTimeLimit()
                     "var startTime = currentCPUTime();"
                     "while (true) {"
                         "for (var i = 0; i < 1000; i++);"
-                            "if (currentCPUTime() - startTime > ", timeAfterWatchdogShouldHaveFired.seconds(), ") break;"
+                            "if (currentCPUTime() - startTime > "_s, timeAfterWatchdogShouldHaveFired.seconds(), ") break;"
                     "}"
                 "}"
-                "foo();"
+                "foo();"_s
             ).utf8();
 
             JSStringRef script = JSStringCreateWithUTF8CString(scriptText.data());
@@ -451,10 +451,10 @@ int testExecutionTimeLimit()
                     "var startTime = currentCPUTime();"
                     "while (true) {"
                         "for (var i = 0; i < 1000; i++);"
-                            "if (currentCPUTime() - startTime > ", maxBusyLoopTime.seconds(), ") break;"
+                            "if (currentCPUTime() - startTime > "_s, maxBusyLoopTime.seconds(), ") break;"
                     "}"
                 "}"
-                "foo();"
+                "foo();"_s
             ).utf8();
 
             JSStringRef script = JSStringCreateWithUTF8CString(scriptText.data());

--- a/Source/JavaScriptCore/API/tests/testapi.cpp
+++ b/Source/JavaScriptCore/API/tests/testapi.cpp
@@ -664,13 +664,13 @@ void TestAPI::markedJSValueArrayAndGC()
         JSC::JSLockHolder locker(globalObject->vm());
         JSC::MarkedJSValueRefArray values(context, count);
         for (unsigned index = 0; index < count; ++index) {
-            JSValueRef string = JSValueMakeString(context, APIString(makeString("Prefix", index)));
+            JSValueRef string = JSValueMakeString(context, APIString(makeString("Prefix"_s, index)));
             values[index] = string;
         }
         JSSynchronousGarbageCollectForDebugging(context);
         bool ok = true;
         for (unsigned index = 0; index < count; ++index) {
-            JSValueRef string = JSValueMakeString(context, APIString(makeString("Prefix", index)));
+            JSValueRef string = JSValueMakeString(context, APIString(makeString("Prefix"_s, index)));
             if (!JSValueIsStrictEqual(context, values[index], string))
                 ok = false;
         }

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -635,7 +635,7 @@ void SpeculativeJIT::runSlowPathGenerators(PCToCodeOriginMapBuilder& pcToCodeOri
     auto markSlowPathIfNeeded = [&] (Node* node) {
         std::optional<JITSizeStatistics::Marker> sizeMarker;
         if (UNLIKELY(Options::dumpDFGJITSizeStatistics())) {
-            String id = makeString("DFG_slow_", m_graph.opName(node->op()));
+            String id = makeString("DFG_slow_"_s, m_graph.opName(node->op()));
             sizeMarker = vm().jitSizeStatistics->markStart(id, *this);
         }
         return sizeMarker;
@@ -2580,7 +2580,7 @@ void SpeculativeJIT::compileCurrentBlock()
 
         std::optional<JITSizeStatistics::Marker> sizeMarker;
         if (UNLIKELY(Options::dumpDFGJITSizeStatistics())) {
-            String id = makeString("DFG_fast_", m_graph.opName(m_currentNode->op()));
+            String id = makeString("DFG_fast_"_s, m_graph.opName(m_currentNode->op()));
             sizeMarker = vm().jitSizeStatistics->markStart(id, *this);
         }
 

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -19556,7 +19556,7 @@ IGNORE_CLANG_WARNINGS_END
             return result;
         }
         
-        DFG_CRASH(m_graph, m_node, makeString("Value not defined: ", String::number(edge.node()->index())).ascii().data());
+        DFG_CRASH(m_graph, m_node, makeString("Value not defined: "_s, edge.node()->index()).ascii().data());
         return nullptr;
     }
 

--- a/Source/JavaScriptCore/inspector/IdentifiersFactory.cpp
+++ b/Source/JavaScriptCore/inspector/IdentifiersFactory.cpp
@@ -37,7 +37,7 @@ static unsigned long s_lastUsedIdentifier = 0;
 
 static String addPrefixToIdentifier(unsigned long identifier)
 {
-    return makeString("0.", identifier);
+    return makeString("0."_s, identifier);
 }
 
 String IdentifiersFactory::createIdentifier()

--- a/Source/JavaScriptCore/inspector/InjectedScriptBase.cpp
+++ b/Source/JavaScriptCore/inspector/InjectedScriptBase.cpp
@@ -95,7 +95,7 @@ Ref<JSON::Value> InjectedScriptBase::makeCall(Deprecated::ScriptFunctionCall& fu
 
     auto resultJSONValue = toInspectorValue(globalObject, value);
     if (!resultJSONValue)
-        return JSON::Value::create(makeString("Object has too long reference chain (must not be longer than ", JSON::Value::maxDepth, ')'));
+        return JSON::Value::create(makeString("Object has too long reference chain (must not be longer than "_s, JSON::Value::maxDepth, ')'));
 
     return resultJSONValue.releaseNonNull();
 }
@@ -125,7 +125,7 @@ void InjectedScriptBase::makeAsyncCall(Deprecated::ScriptFunctionCall& function,
             else if (auto resultJSONValue = toInspectorValue(globalObject, callFrame->argument(0)))
                 checkAsyncCallResult(resultJSONValue, callback);
             else
-                checkAsyncCallResult(JSON::Value::create(makeString("Object has too long reference chain (must not be longer than ", JSON::Value::maxDepth, ')')), callback);
+                checkAsyncCallResult(JSON::Value::create(makeString("Object has too long reference chain (must not be longer than "_s, JSON::Value::maxDepth, ')')), callback);
             return JSC::JSValue::encode(JSC::jsUndefined());
         });
     }

--- a/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.cpp
+++ b/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.cpp
@@ -174,7 +174,7 @@ void BackendDispatcher::dispatch(const String& message)
         String domain = domainAndMethod[0];
         SupplementalBackendDispatcher* domainDispatcher = m_dispatchers.get(domain);
         if (!domainDispatcher) {
-            reportProtocolError(MethodNotFound, "'" + domain + "' domain was not found");
+            reportProtocolError(MethodNotFound, makeString('\'', domain, "' domain was not found"_s));
             sendPendingErrors();
             return;
         }
@@ -294,21 +294,21 @@ T BackendDispatcher::getPropertyValue(JSON::Object* params, const String& name, 
 
     if (!params) {
         if (required)
-            reportProtocolError(BackendDispatcher::InvalidParams, makeString("'params' object must contain required parameter '", name, "' with type '", typeName, "'."));
+            reportProtocolError(BackendDispatcher::InvalidParams, makeString("'params' object must contain required parameter '"_s, name, "' with type '"_s, typeName, "'."_s));
         return result;
     }
 
     auto findResult = params->find(name);
     if (findResult == params->end()) {
         if (required)
-            reportProtocolError(BackendDispatcher::InvalidParams, makeString("Parameter '", name, "' with type '", typeName, "' was not found."));
+            reportProtocolError(BackendDispatcher::InvalidParams, makeString("Parameter '"_s, name, "' with type '"_s, typeName, "' was not found."_s));
         return result;
     }
 
     result = converter(findResult->value);
 
     if (!result)
-        reportProtocolError(BackendDispatcher::InvalidParams, makeString("Parameter '", name, "' has wrong type. It must be '", typeName, "'."));
+        reportProtocolError(BackendDispatcher::InvalidParams, makeString("Parameter '"_s, name, "' has wrong type. It must be '"_s, typeName, "'."_s));
 
     return result;
 }

--- a/Source/JavaScriptCore/inspector/JSGlobalObjectConsoleClient.cpp
+++ b/Source/JavaScriptCore/inspector/JSGlobalObjectConsoleClient.cpp
@@ -102,7 +102,7 @@ void JSGlobalObjectConsoleClient::profile(JSC::JSGlobalObject*, const String& ti
         for (auto& existingTitle : m_profiles) {
             if (existingTitle == title) {
                 // FIXME: Send an enum to the frontend for localization?
-                String warning = title.isEmpty() ? "Unnamed Profile already exists"_s : makeString("Profile \"", ScriptArguments::truncateStringForConsoleMessage(title), "\" already exists");
+                String warning = title.isEmpty() ? "Unnamed Profile already exists"_s : makeString("Profile \""_s, ScriptArguments::truncateStringForConsoleMessage(title), "\" already exists"_s);
                 m_consoleAgent->addMessageToConsole(makeUnique<ConsoleMessage>(MessageSource::ConsoleAPI, MessageType::Profile, MessageLevel::Warning, warning));
                 return;
             }
@@ -130,7 +130,7 @@ void JSGlobalObjectConsoleClient::profileEnd(JSC::JSGlobalObject*, const String&
     }
 
     // FIXME: Send an enum to the frontend for localization?
-    String warning = title.isEmpty() ? "No profiles exist"_s : makeString("Profile \"", title, "\" does not exist");
+    String warning = title.isEmpty() ? "No profiles exist"_s : makeString("Profile \""_s, title, "\" does not exist"_s);
     m_consoleAgent->addMessageToConsole(makeUnique<ConsoleMessage>(MessageSource::ConsoleAPI, MessageType::ProfileEnd, MessageLevel::Warning, warning));
 }
 
@@ -220,7 +220,7 @@ void JSGlobalObjectConsoleClient::screenshot(JSGlobalObject*, Ref<ScriptArgument
 
 void JSGlobalObjectConsoleClient::warnUnimplemented(const String& method)
 {
-    String message = method + " is currently ignored in JavaScript context inspection.";
+    String message = method + " is currently ignored in JavaScript context inspection."_s;
     m_consoleAgent->addMessageToConsole(makeUnique<ConsoleMessage>(MessageSource::ConsoleAPI, MessageType::Log, MessageLevel::Warning, message));
 }
 

--- a/Source/JavaScriptCore/inspector/agents/InspectorAuditAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorAuditAgent.cpp
@@ -92,7 +92,7 @@ Protocol::ErrorStringOr<std::tuple<Ref<Protocol::Runtime::RemoteObject>, std::op
     if (injectedScript.hasNoValue())
         return makeUnexpected(errorString);
 
-    auto functionString = makeString("(function(WebInspectorAudit) { \"use strict\"; return eval(`(", makeStringByReplacingAll(test, '`', "\\`"_s), ")`)(WebInspectorAudit); })");
+    auto functionString = makeString("(function(WebInspectorAudit) { \"use strict\"; return eval(`("_s, makeStringByReplacingAll(test, '`', "\\`"_s), ")`)(WebInspectorAudit); })"_s);
 
     InjectedScript::ExecuteOptions options;
     options.objectGroup = "audit"_s;

--- a/Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.cpp
@@ -71,7 +71,7 @@ Protocol::ErrorStringOr<void> InspectorConsoleAgent::enable()
     m_enabled = true;
 
     if (m_expiredConsoleMessageCount) {
-        ConsoleMessage expiredMessage(MessageSource::Other, MessageType::Log, MessageLevel::Warning, makeString(m_expiredConsoleMessageCount, " console messages are not shown."));
+        ConsoleMessage expiredMessage(MessageSource::Other, MessageType::Log, MessageLevel::Warning, makeString(m_expiredConsoleMessageCount, " console messages are not shown."_s));
         expiredMessage.addToFrontend(*m_frontendDispatcher, m_injectedScriptManager, false);
     }
 
@@ -138,7 +138,7 @@ void InspectorConsoleAgent::startTiming(JSC::JSGlobalObject* globalObject, const
 
     if (!result.isNewEntry) {
         // FIXME: Send an enum to the frontend for localization?
-        auto warning = makeString("Timer \"", ScriptArguments::truncateStringForConsoleMessage(label), "\" already exists");
+        auto warning = makeString("Timer \""_s, ScriptArguments::truncateStringForConsoleMessage(label), "\" already exists"_s);
         addMessageToConsole(makeUnique<ConsoleMessage>(MessageSource::ConsoleAPI, MessageType::Timing, MessageLevel::Warning, warning, createScriptCallStackForConsole(globalObject, 1)));
     }
 }
@@ -154,14 +154,14 @@ void InspectorConsoleAgent::logTiming(JSC::JSGlobalObject* globalObject, const S
     auto it = m_times.find(label);
     if (it == m_times.end()) {
         // FIXME: Send an enum to the frontend for localization?
-        auto warning = makeString("Timer \"", ScriptArguments::truncateStringForConsoleMessage(label), "\" does not exist");
+        auto warning = makeString("Timer \""_s, ScriptArguments::truncateStringForConsoleMessage(label), "\" does not exist"_s);
         addMessageToConsole(makeUnique<ConsoleMessage>(MessageSource::ConsoleAPI, MessageType::Timing, MessageLevel::Warning, warning, WTFMove(callStack)));
         return;
     }
 
     MonotonicTime startTime = it->value;
     Seconds elapsed = MonotonicTime::now() - startTime;
-    auto message = makeString(ScriptArguments::truncateStringForConsoleMessage(label), ": ", FormattedNumber::fixedWidth(elapsed.milliseconds(), 3), "ms");
+    auto message = makeString(ScriptArguments::truncateStringForConsoleMessage(label), ": "_s, FormattedNumber::fixedWidth(elapsed.milliseconds(), 3), "ms"_s);
     addMessageToConsole(makeUnique<ConsoleMessage>(MessageSource::ConsoleAPI, MessageType::Timing, MessageLevel::Debug, message, WTFMove(arguments), WTFMove(callStack)));
 }
 
@@ -176,14 +176,14 @@ void InspectorConsoleAgent::stopTiming(JSC::JSGlobalObject* globalObject, const 
     auto it = m_times.find(label);
     if (it == m_times.end()) {
         // FIXME: Send an enum to the frontend for localization?
-        auto warning = makeString("Timer \"", ScriptArguments::truncateStringForConsoleMessage(label), "\" does not exist");
+        auto warning = makeString("Timer \""_s, ScriptArguments::truncateStringForConsoleMessage(label), "\" does not exist"_s);
         addMessageToConsole(makeUnique<ConsoleMessage>(MessageSource::ConsoleAPI, MessageType::Timing, MessageLevel::Warning, warning, WTFMove(callStack)));
         return;
     }
 
     MonotonicTime startTime = it->value;
     Seconds elapsed = MonotonicTime::now() - startTime;
-    auto message = makeString(ScriptArguments::truncateStringForConsoleMessage(label), ": ", FormattedNumber::fixedWidth(elapsed.milliseconds(), 3), "ms");
+    auto message = makeString(ScriptArguments::truncateStringForConsoleMessage(label), ": "_s, FormattedNumber::fixedWidth(elapsed.milliseconds(), 3), "ms"_s);
     addMessageToConsole(makeUnique<ConsoleMessage>(MessageSource::ConsoleAPI, MessageType::Timing, MessageLevel::Debug, message, WTFMove(callStack)));
 
     m_times.remove(it);
@@ -210,7 +210,7 @@ void InspectorConsoleAgent::count(JSC::JSGlobalObject* globalObject, const Strin
 
     // FIXME: Web Inspector should have a better UI for counters, but for now we just log an updated counter value.
 
-    auto message = makeString(ScriptArguments::truncateStringForConsoleMessage(label), ": ", result.iterator->value);
+    auto message = makeString(ScriptArguments::truncateStringForConsoleMessage(label), ": "_s, result.iterator->value);
     addMessageToConsole(makeUnique<ConsoleMessage>(MessageSource::ConsoleAPI, MessageType::Log, MessageLevel::Debug, message, createScriptCallStackForConsole(globalObject, 1)));
 }
 
@@ -219,7 +219,7 @@ void InspectorConsoleAgent::countReset(JSC::JSGlobalObject* globalObject, const 
     auto it = m_counts.find(label);
     if (it == m_counts.end()) {
         // FIXME: Send an enum to the frontend for localization?
-        auto warning = makeString("Counter \"", ScriptArguments::truncateStringForConsoleMessage(label), "\" does not exist");
+        auto warning = makeString("Counter \""_s, ScriptArguments::truncateStringForConsoleMessage(label), "\" does not exist"_s);
         addMessageToConsole(makeUnique<ConsoleMessage>(MessageSource::ConsoleAPI, MessageType::Log, MessageLevel::Warning, warning, createScriptCallStackForConsole(globalObject, 1)));
         return;
     }

--- a/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp
@@ -66,7 +66,7 @@ const ASCIILiteral InspectorDebuggerAgent::backtraceObjectGroup = "backtrace"_s;
 // create objects in the same group.
 static String objectGroupForBreakpointAction(JSC::BreakpointActionID id)
 {
-    return makeString("breakpoint-action-", id);
+    return makeString("breakpoint-action-"_s, id);
 }
 
 static bool isWebKitInjectedScript(const String& sourceURL)
@@ -184,7 +184,7 @@ InspectorDebuggerAgent::ProtocolBreakpoint::ProtocolBreakpoint(JSC::SourceID sou
 }
 
 InspectorDebuggerAgent::ProtocolBreakpoint::ProtocolBreakpoint(const String& url, bool isRegex, unsigned lineNumber, unsigned columnNumber, const String& condition, JSC::Breakpoint::ActionsVector&& actions, bool autoContinue, size_t ignoreCount)
-    : m_id(makeString(isRegex ? "/" : "", url, isRegex ? "/" : "", ':', lineNumber, ':', columnNumber))
+    : m_id(makeString(isRegex ? "/"_s : ""_s, url, isRegex ? "/"_s : ""_s, ':', lineNumber, ':', columnNumber))
     , m_url(url)
     , m_isRegex(isRegex)
     , m_lineNumber(lineNumber)

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -1296,7 +1296,7 @@ JSValue Interpreter::executeEval(EvalExecutable* eval, JSValue thisValue, JSScop
             const Identifier& ident = unlinkedCodeBlock->variable(i);
             PropertySlot slot(globalLexicalEnvironment, PropertySlot::InternalMethodType::VMInquiry, &vm);
             if (JSGlobalLexicalEnvironment::getOwnPropertySlot(globalLexicalEnvironment, globalObject, ident, slot)) {
-                return throwTypeError(globalObject, throwScope, makeString("Can't create duplicate global variable in eval: '", String(ident.impl()), "'"));
+                return throwTypeError(globalObject, throwScope, makeString("Can't create duplicate global variable in eval: '"_s, StringView(ident.impl()), '\''));
             }
         }
 
@@ -1304,7 +1304,7 @@ JSValue Interpreter::executeEval(EvalExecutable* eval, JSValue thisValue, JSScop
             FunctionExecutable* function = codeBlock->functionDecl(i);
             PropertySlot slot(globalLexicalEnvironment, PropertySlot::InternalMethodType::VMInquiry, &vm);
             if (JSGlobalLexicalEnvironment::getOwnPropertySlot(globalLexicalEnvironment, globalObject, function->name(), slot)) {
-                return throwTypeError(globalObject, throwScope, makeString("Can't create duplicate global variable in eval: '", String(function->name().impl()), "'"));
+                return throwTypeError(globalObject, throwScope, makeString("Can't create duplicate global variable in eval: '"_s, StringView(function->name().impl()), '\''));
             }
         }
     }
@@ -1344,7 +1344,7 @@ JSValue Interpreter::executeEval(EvalExecutable* eval, JSValue thisValue, JSScop
                 JSValue resolvedScope = JSScope::resolveScopeForHoistingFuncDeclInEval(globalObject, scope, function->name());
                 RETURN_IF_EXCEPTION(throwScope, throwScope.exception());
                 if (resolvedScope.isUndefined())
-                    return throwSyntaxError(globalObject, throwScope, makeString("Can't create duplicate variable in eval: '", String(function->name().impl()), "'"));
+                    return throwSyntaxError(globalObject, throwScope, makeString("Can't create duplicate variable in eval: '"_s, StringView(function->name().impl()), '\''));
                 PutPropertySlot slot(variableObject);
                 // We need create this variables because it will be used to emits code by bytecode generator
                 variableObject->methodTable()->put(variableObject, globalObject, function->name(), jsUndefined(), slot);

--- a/Source/JavaScriptCore/jit/JIT.cpp
+++ b/Source/JavaScriptCore/jit/JIT.cpp
@@ -224,7 +224,7 @@ void JIT::privateCompileMainPass()
 
         std::optional<JITSizeStatistics::Marker> sizeMarker;
         if (UNLIKELY(m_bytecodeIndex >= startBytecodeIndex && Options::dumpBaselineJITSizeStatistics())) {
-            String id = makeString("Baseline_fast_", opcodeNames[opcodeID]);
+            String id = makeString("Baseline_fast_"_s, opcodeNames[opcodeID]);
             sizeMarker = m_vm->jitSizeStatistics->markStart(id, *this);
         }
 
@@ -523,7 +523,7 @@ void JIT::privateCompileSlowCases()
 
         std::optional<JITSizeStatistics::Marker> sizeMarker;
         if (UNLIKELY(Options::dumpBaselineJITSizeStatistics())) {
-            String id = makeString("Baseline_slow_", opcodeNames[opcodeID]);
+            String id = makeString("Baseline_slow_"_s, opcodeNames[opcodeID]);
             sizeMarker = m_vm->jitSizeStatistics->markStart(id, *this);
         }
 

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -918,7 +918,7 @@ JSInternalPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* global
     RETURN_IF_EXCEPTION(scope, promise->rejectWithCaughtException(globalObject, scope));
 
     if (!referrer.isLocalFile())
-        RELEASE_AND_RETURN(scope, rejectWithError(createError(globalObject, makeString("Could not resolve the referrer's path '", referrer.string(), "', while trying to resolve module '", specifier, "'."))));
+        RELEASE_AND_RETURN(scope, rejectWithError(createError(globalObject, makeString("Could not resolve the referrer's path '"_s, referrer.string(), "', while trying to resolve module '"_s, specifier, "'."_s))));
 
     auto assertions = JSC::retrieveAssertionsFromDynamicImportOptions(globalObject, parameters, { vm.propertyNames->type.impl() });
     RETURN_IF_EXCEPTION(scope, promise->rejectWithCaughtException(globalObject, scope));
@@ -957,13 +957,13 @@ Identifier GlobalObject::moduleLoaderResolve(JSGlobalObject* globalObject, JSMod
         }
 
         if (!directoryURL.isLocalFile()) {
-            throwException(globalObject, scope, createError(globalObject, makeString("Could not resolve the referrer's path: ", directoryURL.string())));
+            throwException(globalObject, scope, createError(globalObject, makeString("Could not resolve the referrer's path: "_s, directoryURL.string())));
             return { };
         }
 
         auto resolvedURL = specifierIsAbsolute ? URL::fileURLWithFileSystemPath(specifier) : URL(directoryURL, specifier);
         if (!resolvedURL.isValid()) {
-            throwException(globalObject, scope, createError(globalObject, makeString("Resolved module url is not valid: ", resolvedURL.string())));
+            throwException(globalObject, scope, createError(globalObject, makeString("Resolved module url is not valid: "_s, resolvedURL.string())));
             return { };
         }
         ASSERT(resolvedURL.isLocalFile());
@@ -1275,7 +1275,7 @@ JSInternalPromise* GlobalObject::moduleLoaderFetch(JSGlobalObject* globalObject,
 
     Vector<uint8_t> buffer;
     if (!fetchModuleFromLocalFileSystem(moduleURL, buffer))
-        RELEASE_AND_RETURN(scope, rejectWithError(createError(globalObject, makeString("Could not open file '", moduleKey, "'."))));
+        RELEASE_AND_RETURN(scope, rejectWithError(createError(globalObject, makeString("Could not open file '"_s, moduleKey, "'."_s))));
 
 #if ENABLE(WEBASSEMBLY)
     // FileSystem does not have mime-type header. The JSC shell recognizes WebAssembly's magic header.
@@ -1494,7 +1494,7 @@ public:
 
     IterationStatus operator()(StackVisitor& visitor) const
     {
-        m_trace.append(makeString("    ", visitor->index(), "   ", visitor->toString(), '\n'));
+        m_trace.append(makeString("    "_s, visitor->index(), "   "_s, visitor->toString(), '\n'));
         return IterationStatus::Continue;
     }
 
@@ -1719,7 +1719,7 @@ static URL computeFilePath(VM& vm, JSGlobalObject* globalObject, CallFrame* call
     if (callerRelative) {
         path = URL(callFrame->callerSourceOrigin(vm).url(), fileName);
         if (!path.isLocalFile()) {
-            throwException(globalObject, scope, createURIError(globalObject, makeString("caller relative URL path is not a local file: ", path.string())));
+            throwException(globalObject, scope, createURIError(globalObject, makeString("caller relative URL path is not a local file: "_s, path.string())));
             return URL();
         }
     } else

--- a/Source/JavaScriptCore/parser/Lexer.cpp
+++ b/Source/JavaScriptCore/parser/Lexer.cpp
@@ -528,7 +528,7 @@ String Lexer<T>::invalidCharacterMessage() const
     case 96:
         return "Invalid character: '`'"_s;
     default:
-        return makeString("Invalid character '\\u", hex(m_current, 4, Lowercase), '\'');
+        return makeString("Invalid character '\\u"_s, hex(m_current, 4, Lowercase), '\'');
     }
 }
 
@@ -987,7 +987,7 @@ template <bool shouldCreateIdentifier> ALWAYS_INLINE JSTokenType Lexer<LChar>::p
             ident = makeIdentifier(identifierStart, identifierLength);
             if (m_parsingBuiltinFunction) {
                 if (!isSafeBuiltinIdentifier(m_vm, ident)) {
-                    m_lexErrorMessage = makeString("The use of '", ident->string(), "' is disallowed in builtin functions.");
+                    m_lexErrorMessage = makeString("The use of '"_s, ident->string(), "' is disallowed in builtin functions."_s);
                     return ERRORTOK;
                 }
                 if (*ident == m_vm.propertyNames->undefinedKeyword)
@@ -2630,7 +2630,7 @@ JSTokenType Lexer<T>::scanRegExp(JSToken* tokenRecord, UChar patternPrefix)
             JSTokenType token = UNTERMINATED_REGEXP_LITERAL_ERRORTOK;
             fillTokenInfo(tokenRecord, token, m_lineNumber, currentOffset(), currentLineStartOffset(), currentPosition());
             m_error = true;
-            m_lexErrorMessage = makeString("Unterminated regular expression literal '", getToken(*tokenRecord), "'");
+            m_lexErrorMessage = makeString("Unterminated regular expression literal '"_s, getToken(*tokenRecord), '\'');
             return token;
         }
 
@@ -2680,7 +2680,7 @@ JSTokenType Lexer<T>::scanRegExp(JSToken* tokenRecord, UChar patternPrefix)
         String codePoint = String::fromCodePoint(currentCodePoint());
         if (!codePoint)
             codePoint = "`invalid unicode character`"_s;
-        m_lexErrorMessage = makeString("Invalid non-latin character in RexExp literal's flags '", getToken(*tokenRecord), codePoint, "'");
+        m_lexErrorMessage = makeString("Invalid non-latin character in RexExp literal's flags '"_s, getToken(*tokenRecord), codePoint, '\'');
         return token;
     }
 

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -306,7 +306,7 @@ Expected<typename Parser<LexerType>::ParseInnerResult, String> Parser<LexerType>
                 return IterationStatus::Continue;
             if (scope->lexicalVariables().contains(impl))
                 return IterationStatus::Continue;
-            errorMessage = makeString("Cannot reference undeclared private names: \"", String(impl), "\"");
+            errorMessage = makeString("Cannot reference undeclared private names: \""_s, StringView(impl), '"');
             return IterationStatus::Done;
         });
         if (!errorMessage.isNull())

--- a/Source/JavaScriptCore/parser/Parser.h
+++ b/Source/JavaScriptCore/parser/Parser.h
@@ -1658,7 +1658,7 @@ private:
     
     NEVER_INLINE void updateErrorWithNameAndMessage(const char* beforeMessage, const String& name, const char* afterMessage)
     {
-        m_errorMessage = makeString(beforeMessage, " '", name, "' ", afterMessage);
+        m_errorMessage = makeString(beforeMessage, " '"_s, name, "' "_s, afterMessage);
     }
     
     NEVER_INLINE void updateErrorMessage(const char* msg)

--- a/Source/JavaScriptCore/runtime/AbstractModuleRecord.cpp
+++ b/Source/JavaScriptCore/runtime/AbstractModuleRecord.cpp
@@ -764,11 +764,11 @@ JSModuleNamespaceObject* AbstractModuleRecord::getModuleNamespace(JSGlobalObject
         RETURN_IF_EXCEPTION(scope, nullptr);
         switch (resolution.type) {
         case Resolution::Type::NotFound:
-            throwSyntaxError(globalObject, scope, makeString("Exported binding name '", String(name.get()), "' is not found."));
+            throwSyntaxError(globalObject, scope, makeString("Exported binding name '"_s, StringView(name.get()), "' is not found."_s));
             return nullptr;
 
         case Resolution::Type::Error:
-            throwSyntaxError(globalObject, scope, makeString("Exported binding name 'default' cannot be resolved by star export entries."));
+            throwSyntaxError(globalObject, scope, "Exported binding name 'default' cannot be resolved by star export entries."_s);
             return nullptr;
 
         case Resolution::Type::Ambiguous:
@@ -858,7 +858,7 @@ static String printableName(const RefPtr<UniquedStringImpl>& uid)
 {
     if (uid->isSymbol())
         return uid.get();
-    return WTF::makeString("'", String(uid.get()), "'");
+    return WTF::makeString('\'', StringView(uid.get()), '\'');
 }
 
 static String printableName(const Identifier& ident)

--- a/Source/JavaScriptCore/runtime/BytecodeCacheError.cpp
+++ b/Source/JavaScriptCore/runtime/BytecodeCacheError.cpp
@@ -47,7 +47,7 @@ bool BytecodeCacheError::WriteError::isValid() const
 
 String BytecodeCacheError::WriteError::message() const
 {
-    return makeString("Could not write the full cache file to disk. Only wrote ", String::number(m_written), " of the expected ", String::number(m_expected), " bytes.");
+    return makeString("Could not write the full cache file to disk. Only wrote "_s, m_written, " of the expected "_s, m_expected, " bytes."_s);
 }
 
 BytecodeCacheError& BytecodeCacheError::operator=(const ParserError& error)

--- a/Source/JavaScriptCore/runtime/Error.cpp
+++ b/Source/JavaScriptCore/runtime/Error.cpp
@@ -286,17 +286,17 @@ JSObject* createTypeErrorCopy(JSGlobalObject* globalObject, JSValue error)
 
 String makeDOMAttributeGetterTypeErrorMessage(const char* interfaceName, const String& attributeName)
 {
-    return makeString("The ", interfaceName, '.', attributeName, " getter can only be used on instances of ", interfaceName);
+    return makeString("The "_s, interfaceName, '.', attributeName, " getter can only be used on instances of "_s, interfaceName);
 }
 
 String makeDOMAttributeSetterTypeErrorMessage(const char* interfaceName, const String& attributeName)
 {
-    return makeString("The ", interfaceName, '.', attributeName, " setter can only be used on instances of ", interfaceName);
+    return makeString("The "_s, interfaceName, '.', attributeName, " setter can only be used on instances of "_s, interfaceName);
 }
 
 Exception* throwConstructorCannotBeCalledAsFunctionTypeError(JSGlobalObject* globalObject, ThrowScope& scope, const char* constructorName)
 {
-    return throwTypeError(globalObject, scope, makeString("calling ", constructorName, " constructor without new is invalid"));
+    return throwTypeError(globalObject, scope, makeString("calling "_s, constructorName, " constructor without new is invalid"_s));
 }
 
 Exception* throwTypeError(JSGlobalObject* globalObject, ThrowScope& scope)
@@ -395,7 +395,7 @@ JSObject* createOutOfMemoryError(JSGlobalObject* globalObject, const String& mes
 {
     if (message.isEmpty())
         return createOutOfMemoryError(globalObject);
-    auto* error = createRangeError(globalObject, makeString("Out of memory: ", message), nullptr);
+    auto* error = createRangeError(globalObject, makeString("Out of memory: "_s, message), nullptr);
     jsCast<ErrorInstance*>(error)->setOutOfMemoryError();
     return error;
 }

--- a/Source/JavaScriptCore/runtime/ErrorInstance.cpp
+++ b/Source/JavaScriptCore/runtime/ErrorInstance.cpp
@@ -203,7 +203,7 @@ String ErrorInstance::sanitizedToString(JSGlobalObject* globalObject)
     String messageString = sanitizedMessageString(globalObject);
     RETURN_IF_EXCEPTION(scope, String());
 
-    return makeString(nameString, nameString.isEmpty() || messageString.isEmpty() ? "" : ": ", messageString);
+    return makeString(nameString, nameString.isEmpty() || messageString.isEmpty() ? ""_s : ": "_s, messageString);
 }
 
 void ErrorInstance::finalizeUnconditionally(VM& vm)

--- a/Source/JavaScriptCore/runtime/ExceptionHelpers.cpp
+++ b/Source/JavaScriptCore/runtime/ExceptionHelpers.cpp
@@ -49,8 +49,8 @@ JSObject* createStackOverflowError(JSGlobalObject* globalObject)
 JSObject* createUndefinedVariableError(JSGlobalObject* globalObject, const Identifier& ident)
 {
     if (ident.isPrivateName())
-        return createReferenceError(globalObject, makeString("Can't find private variable: PrivateSymbol.", ident.string()));
-    return createReferenceError(globalObject, makeString("Can't find variable: ", ident.string()));
+        return createReferenceError(globalObject, makeString("Can't find private variable: PrivateSymbol."_s, ident.string()));
+    return createReferenceError(globalObject, makeString("Can't find variable: "_s, ident.string()));
 }
     
 String errorDescriptionForValue(JSGlobalObject* globalObject, JSValue v)
@@ -83,7 +83,7 @@ static StringView clampErrorMessage(const String& originalMessage)
 
 static String defaultApproximateSourceError(const String& originalMessage, StringView sourceText)
 {
-    return makeString(clampErrorMessage(originalMessage), " (near '...", sourceText, "...')");
+    return makeString(clampErrorMessage(originalMessage), " (near '..."_s, sourceText, "...')"_s);
 }
 
 String defaultSourceAppender(const String& originalMessage, StringView sourceText, RuntimeType, ErrorInstance::SourceTextWhereErrorOccurred occurrence)
@@ -92,7 +92,7 @@ String defaultSourceAppender(const String& originalMessage, StringView sourceTex
         return defaultApproximateSourceError(originalMessage, sourceText);
 
     ASSERT(occurrence == ErrorInstance::FoundExactSource);
-    return makeString(clampErrorMessage(originalMessage), " (evaluating '", sourceText, "')");
+    return makeString(clampErrorMessage(originalMessage), " (evaluating '"_s, sourceText, "')"_s);
 }
 
 static StringView functionCallBase(StringView sourceText)
@@ -205,11 +205,11 @@ static String invalidParameterInSourceAppender(const String& originalMessage, St
         return originalMessage;
     }
     if (sourceText.find("in"_s) != inIndex)
-        return makeString(originalMessage, " (evaluating '", sourceText, "')");
+        return makeString(originalMessage, " (evaluating '"_s, sourceText, "')"_s);
 
     static constexpr unsigned inLength = 2;
     StringView rightHandSide = sourceText.substring(inIndex + inLength).stripLeadingAndTrailingMatchedCharacters(isSpaceOrNewline);
-    return makeString(rightHandSide, " is not an Object. (evaluating '", sourceText, "')");
+    return makeString(rightHandSide, " is not an Object. (evaluating '"_s, sourceText, "')"_s);
 }
 
 inline String invalidParameterInstanceofSourceAppender(const String& content, const String& originalMessage, StringView sourceText, RuntimeType, ErrorInstance::SourceTextWhereErrorOccurred occurrence)
@@ -224,11 +224,11 @@ inline String invalidParameterInstanceofSourceAppender(const String& content, co
         return originalMessage;
 
     if (sourceText.find("instanceof"_s) != instanceofIndex)
-        return makeString(originalMessage, " (evaluating '", sourceText, "')");
+        return makeString(originalMessage, " (evaluating '"_s, sourceText, "')"_s);
 
     static constexpr unsigned instanceofLength = 10;
     StringView rightHandSide = sourceText.substring(instanceofIndex + instanceofLength).stripLeadingAndTrailingMatchedCharacters(isSpaceOrNewline);
-    return makeString(rightHandSide, content, ". (evaluating '", sourceText, "')");
+    return makeString(rightHandSide, content, ". (evaluating '"_s, sourceText, "')"_s);
 }
 
 static String invalidParameterInstanceofNotFunctionSourceAppender(const String& originalMessage, StringView sourceText, RuntimeType runtimeType, ErrorInstance::SourceTextWhereErrorOccurred occurrence)
@@ -248,7 +248,7 @@ static String invalidPrototypeSourceAppender(const String& originalMessage, Stri
 
     auto extendsIndex = sourceText.reverseFind("extends"_s);
     if (extendsIndex == notFound || sourceText.find("extends"_s) != extendsIndex)
-        return makeString(originalMessage, " (evaluating '", sourceText, "')");
+        return makeString(originalMessage, " (evaluating '"_s, sourceText, "')"_s);
 
     return "The value of the superclass's prototype property is not an object or null."_s;
 }
@@ -319,7 +319,7 @@ JSObject* createInvalidPrototypeError(JSGlobalObject* globalObject, JSValue valu
 
 JSObject* createErrorForInvalidGlobalAssignment(JSGlobalObject* globalObject, const String& propertyName)
 {
-    return createReferenceError(globalObject, makeString("Strict mode forbids implicit creation of global property '", propertyName, '\''));
+    return createReferenceError(globalObject, makeString("Strict mode forbids implicit creation of global property '"_s, propertyName, '\''));
 }
 
 JSObject* createTDZError(JSGlobalObject* globalObject)

--- a/Source/JavaScriptCore/runtime/FunctionConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/FunctionConstructor.cpp
@@ -88,11 +88,11 @@ static String stringifyFunction(JSGlobalObject* globalObject, const ArgList& arg
     String program;
     functionConstructorParametersEndPosition = std::nullopt;
     if (args.isEmpty())
-        program = makeString(prefix, functionName.string(), "() {\n\n}");
+        program = makeString(prefix, functionName.string(), "() {\n\n}"_s);
     else if (args.size() == 1) {
         auto body = args.at(0).toWTFString(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
-        program = tryMakeString(prefix, functionName.string(), "() {\n", body, "\n}");
+        program = tryMakeString(prefix, functionName.string(), "() {\n"_s, body, "\n}"_s);
         if (UNLIKELY(!program)) {
             throwOutOfMemoryError(globalObject, scope);
             return { };

--- a/Source/JavaScriptCore/runtime/IntlCollator.cpp
+++ b/Source/JavaScriptCore/runtime/IntlCollator.cpp
@@ -228,14 +228,14 @@ void IntlCollator::initializeCollator(JSGlobalObject* globalObject, JSValue loca
         if (collation.isNull())
             dataLocaleWithExtensions = resolved.dataLocale.utf8();
         else
-            dataLocaleWithExtensions = makeString(resolved.dataLocale, "-u-co-", m_collation).utf8();
+            dataLocaleWithExtensions = makeString(resolved.dataLocale, "-u-co-"_s, m_collation).utf8();
         break;
     case Usage::Search:
         // searchLocaleData filters out "co" unicode extension. However, we need to pass "co" to ICU when Usage::Search is specified.
         // So we need to pass "co" unicode extension through locale. Since the other relevant extensions are handled via ucol_setAttribute,
         // we can just use dataLocale
         // Since searchLocaleData filters out "co" unicode extension, "collation" option is just ignored.
-        dataLocaleWithExtensions = makeString(resolved.dataLocale, "-u-co-search").utf8();
+        dataLocaleWithExtensions = makeString(resolved.dataLocale, "-u-co-search"_s).utf8();
         break;
     }
     dataLogLnIf(IntlCollatorInternal::verbose, "locale:(", resolved.locale, "),dataLocaleWithExtensions:(", dataLocaleWithExtensions, ")");

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
@@ -659,7 +659,7 @@ void IntlDateTimeFormat::initializeDateTimeFormat(JSGlobalObject* globalObject, 
     hourCycle = parseHourCycle(resolved.extensions[static_cast<unsigned>(RelevantExtensionKey::Hc)]);
     m_numberingSystem = resolved.extensions[static_cast<unsigned>(RelevantExtensionKey::Nu)];
     m_dataLocale = resolved.dataLocale;
-    CString dataLocaleWithExtensions = makeString(m_dataLocale, "-u-ca-", m_calendar, "-nu-", m_numberingSystem).utf8();
+    CString dataLocaleWithExtensions = makeString(m_dataLocale, "-u-ca-"_s, m_calendar, "-nu-"_s, m_numberingSystem).utf8();
 
     JSValue tzValue = options->get(globalObject, vm.propertyNames->timeZone);
     RETURN_IF_EXCEPTION(scope, void());
@@ -669,7 +669,7 @@ void IntlDateTimeFormat::initializeDateTimeFormat(JSGlobalObject* globalObject, 
         RETURN_IF_EXCEPTION(scope, void());
         tz = canonicalizeTimeZoneName(originalTz);
         if (tz.isNull()) {
-            throwRangeError(globalObject, scope, "invalid time zone: " + originalTz);
+            throwRangeError(globalObject, scope, "invalid time zone: "_s + originalTz);
             return;
         }
     } else

--- a/Source/JavaScriptCore/runtime/IntlDurationFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDurationFormat.cpp
@@ -217,7 +217,7 @@ void IntlDurationFormat::initializeDurationFormat(JSGlobalObject* globalObject, 
     }
 
     m_numberingSystem = resolved.extensions[static_cast<unsigned>(RelevantExtensionKey::Nu)];
-    m_dataLocaleWithExtensions = makeString(resolved.dataLocale, "-u-nu-", m_numberingSystem).utf8();
+    m_dataLocaleWithExtensions = makeString(resolved.dataLocale, "-u-nu-"_s, m_numberingSystem).utf8();
 
     m_style = intlOption<Style>(globalObject, options, vm.propertyNames->style, { { "long"_s, Style::Long }, { "short"_s, Style::Short }, { "narrow"_s, Style::Narrow }, { "digital"_s, Style::Digital } }, "style must be either \"long\", \"short\", \"narrow\", or \"digital\""_s, Style::Short);
     RETURN_IF_EXCEPTION(scope, void());

--- a/Source/JavaScriptCore/runtime/IntlNumberFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormat.cpp
@@ -433,7 +433,7 @@ void IntlNumberFormat::initializeNumberFormat(JSGlobalObject* globalObject, JSVa
         }, "roundingMode must be either \"ceil\", \"floor\", \"expand\", \"trunc\", \"halfCeil\", \"halfFloor\", \"halfExpand\", \"halfTrunc\", or \"halfEven\""_s, RoundingMode::HalfExpand);
     RETURN_IF_EXCEPTION(scope, void());
 
-    CString dataLocaleWithExtensions = makeString(resolved.dataLocale, "-u-nu-", m_numberingSystem).utf8();
+    CString dataLocaleWithExtensions = makeString(resolved.dataLocale, "-u-nu-"_s, m_numberingSystem).utf8();
     dataLogLnIf(IntlNumberFormatInternal::verbose, "dataLocaleWithExtensions:(", dataLocaleWithExtensions , ")");
 
     // Options are obtained. Configure formatter here.

--- a/Source/JavaScriptCore/runtime/IntlObject.cpp
+++ b/Source/JavaScriptCore/runtime/IntlObject.cpp
@@ -695,7 +695,7 @@ unsigned intlDefaultNumberOption(JSGlobalObject* globalObject, JSValue value, Pr
         RETURN_IF_EXCEPTION(scope, 0);
 
         if (!(doubleValue >= minimum && doubleValue <= maximum)) {
-            throwException(globalObject, scope, createRangeError(globalObject, *property.publicName() + " is out of range"));
+            throwException(globalObject, scope, createRangeError(globalObject, *property.publicName() + " is out of range"_s));
             return 0;
         }
         return static_cast<unsigned>(doubleValue);
@@ -808,7 +808,7 @@ Vector<String> canonicalizeLocaleList(JSGlobalObject* globalObject, JSValue loca
                 }
             }
 
-            String errorMessage = tryMakeString("invalid language tag: ", tag);
+            String errorMessage = tryMakeString("invalid language tag: "_s, tag);
             if (UNLIKELY(!errorMessage)) {
                 throwException(globalObject, scope, createOutOfMemoryError(globalObject));
                 return { };

--- a/Source/JavaScriptCore/runtime/IntlRelativeTimeFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlRelativeTimeFormat.cpp
@@ -115,7 +115,7 @@ void IntlRelativeTimeFormat::initializeRelativeTimeFormat(JSGlobalObject* global
     }
 
     m_numberingSystem = resolved.extensions[static_cast<unsigned>(RelevantExtensionKey::Nu)];
-    CString dataLocaleWithExtensions = makeString(resolved.dataLocale, "-u-nu-", m_numberingSystem).utf8();
+    CString dataLocaleWithExtensions = makeString(resolved.dataLocale, "-u-nu-"_s, m_numberingSystem).utf8();
 
     m_style = intlOption<Style>(globalObject, options, vm.propertyNames->style, { { "long"_s, Style::Long }, { "short"_s, Style::Short }, { "narrow"_s, Style::Narrow } }, "style must be either \"long\", \"short\", or \"narrow\""_s, Style::Long);
     RETURN_IF_EXCEPTION(scope, void());

--- a/Source/JavaScriptCore/runtime/JSCJSValueInlines.h
+++ b/Source/JavaScriptCore/runtime/JSCJSValueInlines.h
@@ -66,7 +66,7 @@ inline uint32_t JSValue::toIndex(JSGlobalObject* globalObject, const char* error
     double d = toNumber(globalObject);
     RETURN_IF_EXCEPTION(scope, 0);
     if (d <= -1) {
-        throwException(globalObject, scope, createRangeError(globalObject, makeString(errorName, " cannot be negative")));
+        throwException(globalObject, scope, createRangeError(globalObject, makeString(errorName, " cannot be negative"_s)));
         return 0;
     }
 
@@ -74,7 +74,7 @@ inline uint32_t JSValue::toIndex(JSGlobalObject* globalObject, const char* error
         return asInt32();
 
     if (d > static_cast<double>(std::numeric_limits<unsigned>::max())) {
-        throwException(globalObject, scope, createRangeError(globalObject, makeString(errorName, " too large")));
+        throwException(globalObject, scope, createRangeError(globalObject, makeString(errorName, " too large"_s)));
         return 0;
     }
 
@@ -89,7 +89,7 @@ inline size_t JSValue::toTypedArrayIndex(JSGlobalObject* globalObject, ASCIILite
     double d = toNumber(globalObject);
     RETURN_IF_EXCEPTION(scope, 0);
     if (d <= -1) {
-        throwException(globalObject, scope, createRangeError(globalObject, makeString(errorName, " cannot be negative")));
+        throwException(globalObject, scope, createRangeError(globalObject, makeString(errorName, " cannot be negative"_s)));
         return 0;
     }
 
@@ -97,7 +97,7 @@ inline size_t JSValue::toTypedArrayIndex(JSGlobalObject* globalObject, ASCIILite
         return asInt32();
 
     if (d > static_cast<double>(MAX_ARRAY_BUFFER_SIZE)) {
-        throwException(globalObject, scope, createRangeError(globalObject, makeString(errorName, " too large")));
+        throwException(globalObject, scope, createRangeError(globalObject, makeString(errorName, " too large"_s)));
         return 0;
     }
 

--- a/Source/JavaScriptCore/runtime/JSCustomGetterFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSCustomGetterFunction.cpp
@@ -67,7 +67,7 @@ JSCustomGetterFunction* JSCustomGetterFunction::create(VM& vm, JSGlobalObject* g
     JSCustomGetterFunction* function = new (NotNull, allocateCell<JSCustomGetterFunction>(vm)) JSCustomGetterFunction(vm, executable, globalObject, structure, propertyName, getter, domAttribute);
 
     // Can't do this during initialization because getHostFunction might do a GC allocation.
-    auto name = makeString("get ", propertyName.publicName());
+    auto name = makeString("get "_s, propertyName.publicName());
     function->finishCreation(vm, executable, 0, name);
     return function;
 }

--- a/Source/JavaScriptCore/runtime/JSCustomSetterFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSCustomSetterFunction.cpp
@@ -57,7 +57,7 @@ JSCustomSetterFunction* JSCustomSetterFunction::create(VM& vm, JSGlobalObject* g
     JSCustomSetterFunction* function = new (NotNull, allocateCell<JSCustomSetterFunction>(vm)) JSCustomSetterFunction(vm, executable, globalObject, structure, propertyName, setter);
 
     // Can't do this during initialization because getHostFunction might do a GC allocation.
-    auto name = makeString("set ", propertyName.publicName());
+    auto name = makeString("set "_s, propertyName.publicName());
     function->finishCreation(vm, executable, 1, name);
     return function;
 }

--- a/Source/JavaScriptCore/runtime/JSFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSFunction.cpp
@@ -517,7 +517,7 @@ ALWAYS_INLINE String makeNameWithOutOfMemoryCheck(JSGlobalObject* globalObject, 
 {
     String name = tryMakeString(strings...);
     if (UNLIKELY(!name)) {
-        throwOutOfMemoryError(globalObject, throwScope, makeString(messagePrefix, "name is too long"));
+        throwOutOfMemoryError(globalObject, throwScope, makeString(messagePrefix, "name is too long"_s));
         return String();
     }
     return name;

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -875,8 +875,8 @@ void JSGlobalObject::init(VM& vm)
     // We have to manually set this here because we make it a prototype without transition below.
     m_objectPrototype.get()->didBecomePrototype();
     GetterSetter* protoAccessor = GetterSetter::create(vm, this,
-        JSFunction::create(vm, this, 0, makeString("get ", vm.propertyNames->underscoreProto.string()), globalFuncProtoGetter, ImplementationVisibility::Public, UnderscoreProtoIntrinsic),
-        JSFunction::create(vm, this, 0, makeString("set ", vm.propertyNames->underscoreProto.string()), globalFuncProtoSetter, ImplementationVisibility::Public));
+        JSFunction::create(vm, this, 0, makeString("get "_s, vm.propertyNames->underscoreProto.string()), globalFuncProtoGetter, ImplementationVisibility::Public, UnderscoreProtoIntrinsic),
+        JSFunction::create(vm, this, 0, makeString("set "_s, vm.propertyNames->underscoreProto.string()), globalFuncProtoSetter, ImplementationVisibility::Public));
     m_objectPrototype->putDirectNonIndexAccessorWithoutTransition(vm, vm.propertyNames->underscoreProto, protoAccessor, PropertyAttribute::Accessor | PropertyAttribute::DontEnum);
     m_functionPrototype->structure()->setPrototypeWithoutTransition(vm, m_objectPrototype.get());
     m_objectStructureForObjectConstructor.set(vm, this, m_structureCache.emptyObjectStructureForPrototype(this, m_objectPrototype.get(), JSFinalObject::defaultInlineCapacity));

--- a/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
@@ -251,7 +251,7 @@ JSInternalPromise* JSModuleLoader::importModule(JSGlobalObject* globalObject, JS
     RETURN_IF_EXCEPTION(scope, promise->rejectWithCaughtException(globalObject, scope));
 
     scope.release();
-    promise->reject(globalObject, createError(globalObject, makeString("Could not import the module '", WTFMove(moduleNameString), "'.")));
+    promise->reject(globalObject, createError(globalObject, makeString("Could not import the module '"_s, moduleNameString, "'."_s)));
     return promise;
 }
 
@@ -279,7 +279,7 @@ JSInternalPromise* JSModuleLoader::fetch(JSGlobalObject* globalObject, JSValue k
     RETURN_IF_EXCEPTION(scope, promise->rejectWithCaughtException(globalObject, scope));
 
     scope.release();
-    promise->reject(globalObject, createError(globalObject, makeString("Could not open the module '", moduleKey, "'.")));
+    promise->reject(globalObject, createError(globalObject, makeString("Could not open the module '"_s, moduleKey, "'."_s)));
     return promise;
 }
 

--- a/Source/JavaScriptCore/runtime/JSModuleRecord.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleRecord.cpp
@@ -126,15 +126,15 @@ void JSModuleRecord::instantiateDeclarations(JSGlobalObject* globalObject, Modul
             RETURN_IF_EXCEPTION(scope, void());
             switch (resolution.type) {
             case Resolution::Type::NotFound:
-                throwSyntaxError(globalObject, scope, makeString("Indirectly exported binding name '", String(exportEntry.exportName.impl()), "' is not found."));
+                throwSyntaxError(globalObject, scope, makeString("Indirectly exported binding name '"_s, StringView(exportEntry.exportName.impl()), "' is not found."_s));
                 return;
 
             case Resolution::Type::Ambiguous:
-                throwSyntaxError(globalObject, scope, makeString("Indirectly exported binding name '", String(exportEntry.exportName.impl()), "' cannot be resolved due to ambiguous multiple bindings."));
+                throwSyntaxError(globalObject, scope, makeString("Indirectly exported binding name '"_s, StringView(exportEntry.exportName.impl()), "' cannot be resolved due to ambiguous multiple bindings."_s));
                 return;
 
             case Resolution::Type::Error:
-                throwSyntaxError(globalObject, scope, makeString("Indirectly exported binding name 'default' cannot be resolved by star export entries."));
+                throwSyntaxError(globalObject, scope, "Indirectly exported binding name 'default' cannot be resolved by star export entries."_s);
                 return;
 
             case Resolution::Type::Resolved:
@@ -167,15 +167,15 @@ void JSModuleRecord::instantiateDeclarations(JSGlobalObject* globalObject, Modul
             RETURN_IF_EXCEPTION(scope, void());
             switch (resolution.type) {
             case Resolution::Type::NotFound:
-                throwSyntaxError(globalObject, scope, makeString("Importing binding name '", String(importEntry.importName.impl()), "' is not found."));
+                throwSyntaxError(globalObject, scope, makeString("Importing binding name '"_s, StringView(importEntry.importName.impl()), "' is not found."_s));
                 return;
 
             case Resolution::Type::Ambiguous:
-                throwSyntaxError(globalObject, scope, makeString("Importing binding name '", String(importEntry.importName.impl()), "' cannot be resolved due to ambiguous multiple bindings."));
+                throwSyntaxError(globalObject, scope, makeString("Importing binding name '"_s, StringView(importEntry.importName.impl()), "' cannot be resolved due to ambiguous multiple bindings."_s));
                 return;
 
             case Resolution::Type::Error:
-                throwSyntaxError(globalObject, scope, makeString("Importing binding name 'default' cannot be resolved by star export entries."));
+                throwSyntaxError(globalObject, scope, "Importing binding name 'default' cannot be resolved by star export entries."_s);
                 return;
 
             case Resolution::Type::Resolved: {

--- a/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -3400,14 +3400,14 @@ bool JSObject::putDirectIndexSlowOrBeyondVectorLength(JSGlobalObject* globalObje
 
 bool JSObject::putDirectNativeIntrinsicGetter(VM& vm, JSGlobalObject* globalObject, Identifier name, NativeFunction nativeFunction, Intrinsic intrinsic, unsigned attributes)
 {
-    JSFunction* function = JSFunction::create(vm, globalObject, 0, makeString("get ", name.string()), nativeFunction, ImplementationVisibility::Public, intrinsic);
+    JSFunction* function = JSFunction::create(vm, globalObject, 0, makeString("get "_s, name.string()), nativeFunction, ImplementationVisibility::Public, intrinsic);
     GetterSetter* accessor = GetterSetter::create(vm, globalObject, function, nullptr);
     return putDirectNonIndexAccessor(vm, name, accessor, attributes);
 }
 
 void JSObject::putDirectNativeIntrinsicGetterWithoutTransition(VM& vm, JSGlobalObject* globalObject, Identifier name, NativeFunction nativeFunction, Intrinsic intrinsic, unsigned attributes)
 {
-    JSFunction* function = JSFunction::create(vm, globalObject, 0, makeString("get ", name.string()), nativeFunction, ImplementationVisibility::Public, intrinsic);
+    JSFunction* function = JSFunction::create(vm, globalObject, 0, makeString("get "_s, name.string()), nativeFunction, ImplementationVisibility::Public, intrinsic);
     GetterSetter* accessor = GetterSetter::create(vm, globalObject, function, nullptr);
     putDirectNonIndexAccessorWithoutTransition(vm, name, accessor, attributes);
 }

--- a/Source/JavaScriptCore/runtime/LiteralParser.cpp
+++ b/Source/JavaScriptCore/runtime/LiteralParser.cpp
@@ -787,7 +787,7 @@ ALWAYS_INLINE TokenType LiteralParser<CharType>::Lexer::lex(LiteralParserToken<C
             return tokenType;
         }
     }
-    m_lexErrorMessage = makeString("Unrecognized token '", StringView { m_ptr, 1 }, '\'');
+    m_lexErrorMessage = makeString("Unrecognized token '"_s, StringView { m_ptr, 1 }, '\'');
     return TokError;
 }
 
@@ -954,7 +954,7 @@ slowPathBegin:
                     } // uNNNN == 5 characters
                     for (int i = 1; i < 5; i++) {
                         if (!isASCIIHexDigit(m_ptr[i])) {
-                            m_lexErrorMessage = makeString("\"\\", StringView { m_ptr, 5 }, "\" is not a valid unicode escape");
+                            m_lexErrorMessage = makeString("\"\\"_s, StringView { m_ptr, 5 }, "\" is not a valid unicode escape"_s);
                             return TokError;
                         }
                     }
@@ -968,7 +968,7 @@ slowPathBegin:
                         m_ptr++;
                         break;
                     }
-                    m_lexErrorMessage = makeString("Invalid escape character ", StringView { m_ptr, 1 });
+                    m_lexErrorMessage = makeString("Invalid escape character "_s, StringView { m_ptr, 1 });
                     return TokError;
             }
         }
@@ -1149,8 +1149,8 @@ ALWAYS_INLINE JSValue LiteralParser<CharType>::parsePrimitiveValue(VM& vm)
         auto tryMakeErrorString = [&] (unsigned length) -> String {
             bool addEllipsis = length != token->stringLength;
             if (token->stringIs8Bit)
-                return tryMakeString("Unexpected identifier \"", StringView { token->stringToken8, length }, addEllipsis ? "..." : "", '"');
-            return tryMakeString("Unexpected identifier \"", StringView { token->stringToken16, length }, addEllipsis ? "..." : "", '"');
+                return tryMakeString("Unexpected identifier \""_s, StringView { token->stringToken8, length }, addEllipsis ? "..."_s : ""_s, '"');
+            return tryMakeString("Unexpected identifier \""_s, StringView { token->stringToken16, length }, addEllipsis ? "..."_s : ""_s, '"');
         };
 
         constexpr unsigned maxLength = 200;

--- a/Source/JavaScriptCore/runtime/LiteralParser.h
+++ b/Source/JavaScriptCore/runtime/LiteralParser.h
@@ -106,9 +106,9 @@ public:
     String getErrorMessage()
     { 
         if (!m_lexer.getErrorMessage().isEmpty())
-            return "JSON Parse error: " + m_lexer.getErrorMessage();
+            return "JSON Parse error: "_s + m_lexer.getErrorMessage();
         if (!m_parseErrorMessage.isEmpty())
-            return "JSON Parse error: " + m_parseErrorMessage;
+            return "JSON Parse error: "_s + m_parseErrorMessage;
         return "JSON Parse error: Unable to parse JSON string"_s;
     }
     

--- a/Source/JavaScriptCore/runtime/NumberPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/NumberPrototype.cpp
@@ -106,7 +106,7 @@ static ALWAYS_INLINE EncodedJSValue throwVMToThisNumberError(JSGlobalObject* glo
 {
     auto typeString = jsTypeStringForValue(globalObject, thisValue)->value(globalObject);
     scope.assertNoException();
-    return throwVMTypeError(globalObject, scope, WTF::makeString("thisNumberValue called on incompatible ", typeString));
+    return throwVMTypeError(globalObject, scope, WTF::makeString("thisNumberValue called on incompatible "_s, typeString));
 }
 
 // The largest finite floating point number is 1.mantissa * 2^(0x7fe-0x3ff).

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -1028,7 +1028,7 @@ bool Options::setAliasedOption(const char* arg, bool verify)
             auto* invertedValueStr = invertBoolOptionValue(equalStr + 1); \
             if (!invertedValueStr)                                      \
                 return false;                                           \
-            unaliasedOption = unaliasedOption + "=" + invertedValueStr; \
+            unaliasedOption = makeString(unaliasedOption, '=', invertedValueStr); \
         }                                                               \
         return setOptionWithoutAlias(unaliasedOption.utf8().data(), verify);    \
     }

--- a/Source/JavaScriptCore/runtime/ProgramExecutable.cpp
+++ b/Source/JavaScriptCore/runtime/ProgramExecutable.cpp
@@ -101,7 +101,7 @@ JSObject* ProgramExecutable::initializeGlobalProperties(VM& vm, JSGlobalObject* 
         // Check for intersection of "var" and "let"/"const"/"class"
         for (auto& entry : lexicalDeclarations) {
             if (variableDeclarations.contains(entry.key))
-                return createSyntaxError(globalObject, makeString("Can't create duplicate variable: '", String(entry.key.get()), "'"));
+                return createSyntaxError(globalObject, makeString("Can't create duplicate variable: '"_s, StringView(entry.key.get()), '\''));
         }
 
         // Check if any new "let"/"const"/"class" will shadow any pre-existing global property names (with configurable = false), or "var"/"let"/"const" variables.
@@ -112,7 +112,7 @@ JSObject* ProgramExecutable::initializeGlobalProperties(VM& vm, JSGlobalObject* 
             RETURN_IF_EXCEPTION(throwScope, nullptr);
             switch (status) {
             case GlobalPropertyLookUpStatus::NonConfigurable:
-                return createSyntaxError(globalObject, makeString("Can't create duplicate variable that shadows a global property: '", String(entry.key.get()), "'"));
+                return createSyntaxError(globalObject, makeString("Can't create duplicate variable that shadows a global property: '"_s, StringView(entry.key.get()), '\''));
             case GlobalPropertyLookUpStatus::Configurable:
                 // Lexical bindings can shadow global properties if the given property's attribute is configurable.
                 // https://tc39.github.io/ecma262/#sec-globaldeclarationinstantiation step 5-c, `hasRestrictedGlobal` becomes false
@@ -134,7 +134,7 @@ JSObject* ProgramExecutable::initializeGlobalProperties(VM& vm, JSGlobalObject* 
                     if (globalLexicalEnvironment->isConstVariable(entry.key.get()))
                         continue;
                 }
-                return createSyntaxError(globalObject, makeString("Can't create duplicate variable: '", String(entry.key.get()), "'"));
+                return createSyntaxError(globalObject, makeString("Can't create duplicate variable: '"_s, StringView(entry.key.get()), '\''));
             }
         }
 
@@ -145,7 +145,7 @@ JSObject* ProgramExecutable::initializeGlobalProperties(VM& vm, JSGlobalObject* 
                 bool hasProperty = globalLexicalEnvironment->hasProperty(globalObject, entry.key.get());
                 RETURN_IF_EXCEPTION(throwScope, nullptr);
                 if (hasProperty)
-                    return createSyntaxError(globalObject, makeString("Can't create duplicate variable: '", String(entry.key.get()), "'"));
+                    return createSyntaxError(globalObject, makeString("Can't create duplicate variable: '"_s, StringView(entry.key.get()), '\''));
             }
         }
     }

--- a/Source/JavaScriptCore/runtime/ProxyObject.cpp
+++ b/Source/JavaScriptCore/runtime/ProxyObject.cpp
@@ -456,7 +456,7 @@ bool ProxyObject::validateSetTrapResult(JSGlobalObject* globalObject, JSValue tr
     RETURN_IF_EXCEPTION(scope, false);
     if (!trapResultAsBool) {
         if (shouldThrow)
-            throwTypeError(globalObject, scope, makeString("Proxy object's 'set' trap returned falsy value for property '", String(propertyName.uid()), "'"));
+            throwTypeError(globalObject, scope, makeString("Proxy object's 'set' trap returned falsy value for property '"_s, StringView(propertyName.uid()), '\''));
         return false;
     }
 
@@ -857,7 +857,7 @@ bool ProxyObject::performDefineOwnProperty(JSGlobalObject* globalObject, Propert
 
     if (!trapResultAsBool) {
         if (shouldThrow)
-            throwTypeError(globalObject, scope, makeString("Proxy's 'defineProperty' trap returned falsy value for property '", String(propertyName.uid()), "'"));
+            throwTypeError(globalObject, scope, makeString("Proxy's 'defineProperty' trap returned falsy value for property '"_s, StringView(propertyName.uid()), '\''));
         return false;
     }
 
@@ -990,7 +990,7 @@ void ProxyObject::performGetOwnPropertyNames(JSGlobalObject* globalObject, Prope
 
     for (UniquedStringImpl* impl : targetNonConfigurableKeys) {
         if (!uncheckedResultKeys.remove(impl)) {
-            throwTypeError(globalObject, scope, makeString("Proxy object's 'target' has the non-configurable property '", String(impl), "' that was not in the result from the 'ownKeys' trap"));
+            throwTypeError(globalObject, scope, makeString("Proxy object's 'target' has the non-configurable property '"_s, StringView(impl), "' that was not in the result from the 'ownKeys' trap"_s));
             return;
         }
     }
@@ -998,7 +998,7 @@ void ProxyObject::performGetOwnPropertyNames(JSGlobalObject* globalObject, Prope
     if (!targetIsExensible) {
         for (UniquedStringImpl* impl : targetConfigurableKeys) {
             if (!uncheckedResultKeys.remove(impl)) {
-                throwTypeError(globalObject, scope, makeString("Proxy object's non-extensible 'target' has configurable property '", String(impl), "' that was not in the result from the 'ownKeys' trap"));
+                throwTypeError(globalObject, scope, makeString("Proxy object's non-extensible 'target' has configurable property '"_s, StringView(impl), "' that was not in the result from the 'ownKeys' trap"_s));
                 return;
             }
         }

--- a/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
+++ b/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
@@ -1228,7 +1228,7 @@ void SamplingProfiler::reportTopBytecodes(PrintStream& out)
         StackFrame& frame = stackTrace.frames.first();
         auto frameDescription = makeString(frame.displayName(m_vm), descriptionForLocation(frame.semanticLocation, frame.wasmCompilationMode, frame.wasmOffset));
         if (std::optional<std::pair<StackFrame::CodeLocation, CodeBlock*>> machineLocation = frame.machineLocation) {
-            frameDescription = makeString(frameDescription, " <-- ",
+            frameDescription = makeString(frameDescription, " <-- "_s,
                 machineLocation->second->inferredName().data(), descriptionForLocation(machineLocation->first, std::nullopt, BytecodeIndex()));
         }
         bytecodeCounts.add(frameDescription, 0).iterator->value++;

--- a/Source/JavaScriptCore/runtime/Symbol.cpp
+++ b/Source/JavaScriptCore/runtime/Symbol.cpp
@@ -85,7 +85,7 @@ void Symbol::destroy(JSCell* cell)
 
 String Symbol::descriptiveString() const
 {
-    return makeString("Symbol(", String(m_privateName.uid()), ')');
+    return makeString("Symbol("_s, StringView(m_privateName.uid()), ')');
 }
 
 String Symbol::description() const

--- a/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
@@ -169,7 +169,7 @@ void BBQPlan::work(CompilationEffort effort)
     LinkBuffer linkBuffer(*context.wasmEntrypointJIT, nullptr, LinkBuffer::Profile::Wasm, JITCompilationCanFail);
     if (UNLIKELY(linkBuffer.didFailToAllocate())) {
         Locker locker { m_lock };
-        Base::fail(makeString("Out of executable memory while tiering up function at index ", String::number(m_functionIndex)));
+        Base::fail(makeString("Out of executable memory while tiering up function at index "_s, m_functionIndex));
         return;
     }
 
@@ -294,7 +294,7 @@ std::unique_ptr<InternalFunction> BBQPlan::compileFunction(uint32_t functionInde
         Locker locker { m_lock };
         if (!m_errorMessage) {
             // Multiple compiles could fail simultaneously. We arbitrarily choose the first.
-            fail(makeString(parseAndCompileResult.error(), ", in function at index ", String::number(functionIndex))); // FIXME make this an Expected.
+            fail(makeString(parseAndCompileResult.error(), ", in function at index "_s, functionIndex)); // FIXME make this an Expected.
         }
         m_currentIndex = m_moduleInformation->functions.size();
         return nullptr;
@@ -314,7 +314,7 @@ void BBQPlan::didCompleteCompilation()
         {
             InternalFunction* function = m_wasmInternalFunctions[functionIndex].get();
             if (!m_wasmInternalFunctionLinkBuffers[functionIndex]) {
-                Base::fail(makeString("Out of executable memory in function at index ", String::number(functionIndex)));
+                Base::fail(makeString("Out of executable memory in function at index "_s, functionIndex));
                 return;
             }
             
@@ -340,7 +340,7 @@ void BBQPlan::didCompleteCompilation()
                 const auto& jsToWasmInternalFunction = std::get<2>(iter->value);
 
                 if (linkBuffer.didFailToAllocate()) {
-                    Base::fail(makeString("Out of executable memory in function entrypoint at index ", String::number(functionIndex)));
+                    Base::fail(makeString("Out of executable memory in function entrypoint at index "_s, functionIndex));
                     return;
                 }
 

--- a/Source/JavaScriptCore/wasm/WasmEntryPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmEntryPlan.cpp
@@ -132,7 +132,7 @@ void EntryPlan::prepare()
             switch (binding.error()) {
             case BindingFailure::OutOfMemory: {
                 Locker locker { m_lock };
-                return fail(makeString("Out of executable memory at import ", String::number(importIndex)));
+                return fail(makeString("Out of executable memory at import "_s, importIndex));
             }
             }
             RELEASE_ASSERT_NOT_REACHED();

--- a/Source/JavaScriptCore/wasm/WasmEntryPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmEntryPlan.h
@@ -107,7 +107,7 @@ protected:
     {
         if (UNLIKELY(!vector.tryReserveCapacity(size))) {
             Locker locker { m_lock };
-            fail(WTF::makeString("Failed allocating enough space for ", size, what));
+            fail(WTF::makeString("Failed allocating enough space for "_s, size, what));
             return false;
         }
         return true;

--- a/Source/JavaScriptCore/wasm/WasmIndexOrName.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIndexOrName.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "WasmIndexOrName.h"
 
+#include <wtf/text/StringConcatenateNumbers.h>
+
 namespace JSC { namespace Wasm {
 
 IndexOrName::IndexOrName(Index index, std::pair<const Name*, RefPtr<NameSection>>&& name)
@@ -56,8 +58,8 @@ String makeString(const IndexOrName& ion)
         return "wasm-stub"_s;
     const String moduleName = ion.nameSection()->moduleName.size() ? String(ion.nameSection()->moduleName.data(), ion.nameSection()->moduleName.size()) : String(ion.nameSection()->moduleHash.data(), ion.nameSection()->moduleHash.size());
     if (ion.isIndex())
-        return makeString(moduleName, ".wasm-function[", String::number(ion.index()), ']');
-    return makeString(moduleName, ".wasm-function[", String(ion.name()->data(), ion.name()->size()), ']');
+        return makeString(moduleName, ".wasm-function["_s, ion.index(), ']');
+    return makeString(moduleName, ".wasm-function["_s, StringView(ion.name()->data(), ion.name()->size()), ']');
 }
 
 } } // namespace JSC::Wasm

--- a/Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp
@@ -92,7 +92,7 @@ void LLIntPlan::compileFunction(uint32_t functionIndex)
         Locker locker { m_lock };
         if (!m_errorMessage) {
             // Multiple compiles could fail simultaneously. We arbitrarily choose the first.
-            fail(makeString(parseAndCompileResult.error(), ", in function at index ", String::number(functionIndex))); // FIXME make this an Expected.
+            fail(makeString(parseAndCompileResult.error(), ", in function at index "_s, functionIndex)); // FIXME make this an Expected.
         }
         m_currentIndex = m_moduleInformation->functions.size();
         return;
@@ -174,7 +174,7 @@ void LLIntPlan::didCompleteCompilation()
 
             LinkBuffer linkBuffer(jit, nullptr, LinkBuffer::Profile::Wasm, JITCompilationCanFail);
             if (UNLIKELY(linkBuffer.didFailToAllocate())) {
-                Base::fail(makeString("Out of executable memory in function entrypoint at index ", String::number(functionIndex)));
+                Base::fail(makeString("Out of executable memory in function entrypoint at index "_s, functionIndex));
                 return;
             }
 

--- a/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
@@ -103,7 +103,7 @@ void OMGPlan::work(CompilationEffort)
 
     if (UNLIKELY(!parseAndCompileResult)) {
         Locker locker { m_lock };
-        fail(makeString(parseAndCompileResult.error(), "when trying to tier up ", String::number(m_functionIndex)));
+        fail(makeString(parseAndCompileResult.error(), "when trying to tier up "_s, m_functionIndex));
         return;
     }
 
@@ -111,7 +111,7 @@ void OMGPlan::work(CompilationEffort)
     LinkBuffer linkBuffer(*context.wasmEntrypointJIT, nullptr, LinkBuffer::Profile::Wasm, JITCompilationCanFail);
     if (UNLIKELY(linkBuffer.didFailToAllocate())) {
         Locker locker { m_lock };
-        Base::fail(makeString("Out of executable memory while tiering up function at index ", String::number(m_functionIndex)));
+        Base::fail(makeString("Out of executable memory while tiering up function at index "_s, m_functionIndex));
         return;
     }
 

--- a/Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp
@@ -107,7 +107,7 @@ void OSREntryPlan::work(CompilationEffort)
 
     if (UNLIKELY(!parseAndCompileResult)) {
         Locker locker { m_lock };
-        fail(makeString(parseAndCompileResult.error(), "when trying to tier up ", String::number(m_functionIndex)));
+        fail(makeString(parseAndCompileResult.error(), "when trying to tier up "_s, m_functionIndex));
         return;
     }
 
@@ -115,7 +115,7 @@ void OSREntryPlan::work(CompilationEffort)
     LinkBuffer linkBuffer(*context.wasmEntrypointJIT, nullptr, LinkBuffer::Profile::Wasm, JITCompilationCanFail);
     if (UNLIKELY(linkBuffer.didFailToAllocate())) {
         Locker locker { m_lock };
-        Base::fail(makeString("Out of executable memory while tiering up function at index ", String::number(m_functionIndex)));
+        Base::fail(makeString("Out of executable memory while tiering up function at index "_s, m_functionIndex));
         return;
     }
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyExceptionPrototype.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyExceptionPrototype.cpp
@@ -98,7 +98,7 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyExceptionProtoFuncGetArg, (JSGlobalObject* g
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
     const auto& formatMessage = [&](const auto& message) {
-        return makeString("WebAssembly.Exception.getArg(): ", message);
+        return makeString("WebAssembly.Exception.getArg(): "_s, message);
     };
 
     JSWebAssemblyException* jsException = getException(globalObject, callFrame->thisValue());

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -129,7 +129,7 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
     };
 
     auto importFailMessage = [&] (const Wasm::Import& import, const char* before, const char* after) {
-        return makeString(before, " ", String::fromUTF8(import.module), ":", String::fromUTF8(import.field), " ", after);
+        return makeString(before, ' ', String::fromUTF8(import.module), ':', String::fromUTF8(import.field), ' ', after);
     };
 
     for (const auto& import : moduleInformation.imports) {
@@ -155,15 +155,15 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
             RETURN_IF_EXCEPTION(scope, void());
             switch (resolution.type) {
             case Resolution::Type::NotFound:
-                throwSyntaxError(globalObject, scope, makeString("Importing binding name '", String(fieldName.impl()), "' is not found."));
+                throwSyntaxError(globalObject, scope, makeString("Importing binding name '"_s, StringView(fieldName.impl()), "' is not found."_s));
                 return;
 
             case Resolution::Type::Ambiguous:
-                throwSyntaxError(globalObject, scope, makeString("Importing binding name '", String(fieldName.impl()), "' cannot be resolved due to ambiguous multiple bindings."));
+                throwSyntaxError(globalObject, scope, makeString("Importing binding name '"_s, StringView(fieldName.impl()), "' cannot be resolved due to ambiguous multiple bindings."_s));
                 return;
 
             case Resolution::Type::Error:
-                throwSyntaxError(globalObject, scope, makeString("Importing binding name 'default' cannot be resolved by star export entries."));
+                throwSyntaxError(globalObject, scope, "Importing binding name 'default' cannot be resolved by star export entries."_s);
                 return;
 
             case Resolution::Type::Resolved:


### PR DESCRIPTION
#### cb3a9da0118c397a5d2eb134f6cdc32509e93147
<pre>
Adopt ASCIILiterals in makeString, tryMakeString, operator+ calls inside JavaScriptCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=252167">https://bugs.webkit.org/show_bug.cgi?id=252167</a>

Reviewed by Darin Adler.

Convert different cases of makeString(), tryMakeString() and StringAppend-producing
operator+ calls from using native C string literals to using more-desired ASCIILiterals.

* Source/JavaScriptCore/API/glib/JSCCallbackFunction.cpp:
(JSC::JSCCallbackFunction::construct):
* Source/JavaScriptCore/API/glib/JSCContext.cpp:
(jscContextGArrayToJSArray):
(jscContextJSArrayToGArray):
(jscContextGValueToJSValue):
(jscContextJSValueToGValue):
* Source/JavaScriptCore/API/glib/JSCValue.cpp:
(jsc_value_new_array):
(jscValueCallFunction):
* Source/JavaScriptCore/API/tests/ExecutionTimeLimitTest.cpp:
(testExecutionTimeLimit):
* Source/JavaScriptCore/API/tests/testapi.cpp:
(TestAPI::markedJSValueArrayAndGC):
* Source/JavaScriptCore/assembler/LinkBuffer.cpp:
(JSC::LinkBuffer::linkComments):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::runSlowPathGenerators):
(JSC::DFG::SpeculativeJIT::compileCurrentBlock):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/inspector/IdentifiersFactory.cpp:
(Inspector::addPrefixToIdentifier):
* Source/JavaScriptCore/inspector/InjectedScriptBase.cpp:
(Inspector::InjectedScriptBase::makeCall):
(Inspector::InjectedScriptBase::makeAsyncCall):
* Source/JavaScriptCore/inspector/InspectorBackendDispatcher.cpp:
(Inspector::BackendDispatcher::dispatch):
(Inspector::BackendDispatcher::getPropertyValue):
* Source/JavaScriptCore/inspector/JSGlobalObjectConsoleClient.cpp:
(Inspector::JSGlobalObjectConsoleClient::profile):
(Inspector::JSGlobalObjectConsoleClient::profileEnd):
(Inspector::JSGlobalObjectConsoleClient::warnUnimplemented):
* Source/JavaScriptCore/inspector/agents/InspectorAuditAgent.cpp:
(Inspector::InspectorAuditAgent::run):
* Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.cpp:
(Inspector::InspectorConsoleAgent::enable):
(Inspector::InspectorConsoleAgent::startTiming):
(Inspector::InspectorConsoleAgent::logTiming):
(Inspector::InspectorConsoleAgent::stopTiming):
(Inspector::InspectorConsoleAgent::count):
(Inspector::InspectorConsoleAgent::countReset):
* Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp:
(Inspector::objectGroupForBreakpointAction):
(Inspector::InspectorDebuggerAgent::ProtocolBreakpoint::ProtocolBreakpoint):
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::Interpreter::executeEval):
* Source/JavaScriptCore/jit/JIT.cpp:
(JSC::JIT::privateCompileMainPass):
(JSC::JIT::privateCompileSlowCases):
* Source/JavaScriptCore/jsc.cpp:
(GlobalObject::moduleLoaderImportModule):
(GlobalObject::moduleLoaderResolve):
(GlobalObject::moduleLoaderFetch):
(FunctionJSCStackFunctor::operator() const):
(computeFilePath):
* Source/JavaScriptCore/parser/Lexer.cpp:
(JSC::Lexer&lt;T&gt;::invalidCharacterMessage const):
(JSC::Lexer&lt;LChar&gt;::parseIdentifier):
(JSC::Lexer&lt;T&gt;::scanRegExp):
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::parseInner):
* Source/JavaScriptCore/parser/Parser.h:
(JSC::Parser::updateErrorWithNameAndMessage):
* Source/JavaScriptCore/runtime/AbstractModuleRecord.cpp:
(JSC::AbstractModuleRecord::getModuleNamespace):
(JSC::printableName):
* Source/JavaScriptCore/runtime/BytecodeCacheError.cpp:
(JSC::BytecodeCacheError::WriteError::message const):
* Source/JavaScriptCore/runtime/Error.cpp:
(JSC::makeDOMAttributeGetterTypeErrorMessage):
(JSC::makeDOMAttributeSetterTypeErrorMessage):
(JSC::throwConstructorCannotBeCalledAsFunctionTypeError):
(JSC::createOutOfMemoryError):
* Source/JavaScriptCore/runtime/ErrorInstance.cpp:
(JSC::ErrorInstance::sanitizedToString):
* Source/JavaScriptCore/runtime/ExceptionHelpers.cpp:
(JSC::createUndefinedVariableError):
(JSC::defaultApproximateSourceError):
(JSC::defaultSourceAppender):
(JSC::invalidParameterInSourceAppender):
(JSC::invalidParameterInstanceofSourceAppender):
(JSC::invalidPrototypeSourceAppender):
(JSC::createErrorForInvalidGlobalAssignment):
* Source/JavaScriptCore/runtime/FunctionConstructor.cpp:
(JSC::stringifyFunction):
* Source/JavaScriptCore/runtime/IntlCollator.cpp:
(JSC::IntlCollator::initializeCollator):
* Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp:
(JSC::IntlDateTimeFormat::initializeDateTimeFormat):
* Source/JavaScriptCore/runtime/IntlDurationFormat.cpp:
(JSC::IntlDurationFormat::initializeDurationFormat):
* Source/JavaScriptCore/runtime/IntlNumberFormat.cpp:
(JSC::IntlNumberFormat::initializeNumberFormat):
* Source/JavaScriptCore/runtime/IntlObject.cpp:
(JSC::intlDefaultNumberOption):
(JSC::canonicalizeLocaleList):
* Source/JavaScriptCore/runtime/IntlRelativeTimeFormat.cpp:
(JSC::IntlRelativeTimeFormat::initializeRelativeTimeFormat):
* Source/JavaScriptCore/runtime/JSCJSValueInlines.h:
(JSC::JSValue::toIndex const):
(JSC::JSValue::toTypedArrayIndex const):
* Source/JavaScriptCore/runtime/JSCustomGetterFunction.cpp:
(JSC::JSCustomGetterFunction::create):
* Source/JavaScriptCore/runtime/JSCustomSetterFunction.cpp:
(JSC::JSCustomSetterFunction::create):
* Source/JavaScriptCore/runtime/JSFunction.cpp:
(JSC::makeNameWithOutOfMemoryCheck):
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
* Source/JavaScriptCore/runtime/JSModuleLoader.cpp:
(JSC::JSModuleLoader::importModule):
(JSC::JSModuleLoader::fetch):
* Source/JavaScriptCore/runtime/JSModuleRecord.cpp:
(JSC::JSModuleRecord::instantiateDeclarations):
* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::JSObject::putDirectNativeIntrinsicGetter):
(JSC::JSObject::putDirectNativeIntrinsicGetterWithoutTransition):
* Source/JavaScriptCore/runtime/LiteralParser.cpp:
(JSC::LiteralParser&lt;CharType&gt;::Lexer::lex):
(JSC::LiteralParser&lt;CharType&gt;::Lexer::lexStringSlow):
(JSC::LiteralParser&lt;CharType&gt;::parsePrimitiveValue):
* Source/JavaScriptCore/runtime/LiteralParser.h:
(JSC::LiteralParser::getErrorMessage):
* Source/JavaScriptCore/runtime/NumberPrototype.cpp:
(JSC::throwVMToThisNumberError):
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::Options::setAliasedOption):
* Source/JavaScriptCore/runtime/ProgramExecutable.cpp:
(JSC::ProgramExecutable::initializeGlobalProperties):
* Source/JavaScriptCore/runtime/ProxyObject.cpp:
(JSC::ProxyObject::performPut):
(JSC::ProxyObject::performDefineOwnProperty):
(JSC::ProxyObject::performGetOwnPropertyNames):
* Source/JavaScriptCore/runtime/SamplingProfiler.cpp:
(JSC::SamplingProfiler::reportTopBytecodes):
* Source/JavaScriptCore/runtime/Symbol.cpp:
(JSC::Symbol::descriptiveString const):
* Source/JavaScriptCore/wasm/WasmBBQPlan.cpp:
(JSC::Wasm::BBQPlan::work):
(JSC::Wasm::BBQPlan::compileFunction):
(JSC::Wasm::BBQPlan::didCompleteCompilation):
* Source/JavaScriptCore/wasm/WasmEntryPlan.cpp:
(JSC::Wasm::EntryPlan::prepare):
* Source/JavaScriptCore/wasm/WasmEntryPlan.h:
(JSC::Wasm::EntryPlan::tryReserveCapacity):
* Source/JavaScriptCore/wasm/WasmIndexOrName.cpp:
(JSC::Wasm::makeString):
* Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp:
(JSC::Wasm::LLIntPlan::compileFunction):
(JSC::Wasm::LLIntPlan::didCompleteCompilation):
* Source/JavaScriptCore/wasm/WasmOMGPlan.cpp:
(JSC::Wasm::OMGPlan::work):
* Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp:
(JSC::Wasm::OSREntryPlan::work):
* Source/JavaScriptCore/wasm/js/WebAssemblyExceptionPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
(JSC::WebAssemblyModuleRecord::initializeImports):

Canonical link: <a href="https://commits.webkit.org/261376@main">https://commits.webkit.org/261376@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7660608604b2969cb185fa2b16ac98b127907fed

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111467 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20603 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/99 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3261 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120251 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21973 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11707 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/2677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117230 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99484 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104197 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98270 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/67 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45013 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/99996 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13101 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/65 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86812 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/11214 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13605 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9493 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/101186 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19050 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52048 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31508 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7910 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15572 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/109224 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26911 "Passed tests") | 
<!--EWS-Status-Bubble-End-->