### PR TITLE
visibility:hidden fails to hide composited iframe

### DIFF
--- a/LayoutTests/compositing/iframes/composited-iframe-visibility-hidden-ancestor-expected.html
+++ b/LayoutTests/compositing/iframes/composited-iframe-visibility-hidden-ancestor-expected.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        iframe {
+            will-change: transform;
+            display: block;
+            overflow: hidden;
+            border: none;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <iframe scrolling="no" srcdoc="
+            <style>
+            .box {
+                width: 100px;
+                height: 100px;
+                background-color: silver;
+            }
+            </style>
+            <div class='box' style='transform: translateZ(0);'>&nbsp;</div>
+            <div class='box'>&nbsp;</div>
+            "></iframe>
+    </div>
+</body>
+</html>

--- a/LayoutTests/compositing/iframes/composited-iframe-visibility-hidden-ancestor.html
+++ b/LayoutTests/compositing/iframes/composited-iframe-visibility-hidden-ancestor.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        iframe {
+            will-change: transform;
+            display: block;
+            overflow: hidden;
+            border: none;
+            visibility: visible;
+        }
+        .container {
+            visibility: hidden;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <iframe scrolling="no" srcdoc="
+            <style>
+            .box {
+                width: 100px;
+                height: 100px;
+                background-color: silver;
+            }
+            </style>
+            <div class='box' style='transform: translateZ(0);'>&nbsp;</div>
+            <div class='box'>&nbsp;</div>
+            "></iframe>
+    </div>
+</body>
+</html>

--- a/LayoutTests/compositing/iframes/composited-iframe-visibility-hidden-expected.html
+++ b/LayoutTests/compositing/iframes/composited-iframe-visibility-hidden-expected.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html>
+<body>
+</body>
+</html>

--- a/LayoutTests/compositing/iframes/composited-iframe-visibility-hidden.html
+++ b/LayoutTests/compositing/iframes/composited-iframe-visibility-hidden.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        iframe {
+            will-change: transform;
+            display: block;
+            overflow: hidden;
+            border: none;
+        }
+        .container {
+            visibility: hidden;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <iframe scrolling="no" srcdoc="
+            <style>
+            .box {
+                width: 100px;
+                height: 100px;
+                background-color: silver;
+            }
+            </style>
+            <div class='box' style='transform: translateZ(0);'>&nbsp;</div>
+            <div class='box'>&nbsp;</div>
+            "></iframe>
+    </div>
+</body>
+</html>

--- a/LayoutTests/compositing/iframes/composited-iframe-visibility-toggled-expected.html
+++ b/LayoutTests/compositing/iframes/composited-iframe-visibility-toggled-expected.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        iframe {
+            will-change: transform;
+            display: block;
+            overflow: hidden;
+            border: none;
+        }
+        .container {
+            border: 1px solid black;
+            padding: 10px;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <iframe scrolling="no" srcdoc="
+            <style>
+            .box {
+                width: 100px;
+                height: 100px;
+                background-color: silver;
+            }
+            </style>
+            <div class='box' style='transform: translateZ(0);'>&nbsp;</div>
+            <div class='box'>&nbsp;</div>
+            "></iframe>
+    </div>
+</body>
+</html>

--- a/LayoutTests/compositing/iframes/composited-iframe-visibility-toggled.html
+++ b/LayoutTests/compositing/iframes/composited-iframe-visibility-toggled.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        iframe {
+            will-change: transform;
+            display: block;
+            overflow: hidden;
+            border: none;
+        }
+        .container {
+            visibility: hidden;
+            border: 1px solid black;
+            padding: 10px;
+        }
+
+        body.changed .container {
+            visibility: visible;
+        }
+    </style>
+    <script>
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+        window.addEventListener('load', () => {
+            setTimeout(() => {
+                document.body.classList.add('changed');
+               testRunner.notifyDone();
+            }, 0);
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="container">
+        <iframe scrolling="no" srcdoc="
+            <style>
+            .box {
+                width: 100px;
+                height: 100px;
+                background-color: silver;
+            }
+            </style>
+            <div class='box' style='transform: translateZ(0);'>&nbsp;</div>
+            <div class='box'>&nbsp;</div>
+            "></iframe>
+    </div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -2647,6 +2647,9 @@ bool RenderLayerCompositor::requiresCompositingLayer(const RenderLayer& layer, R
         return false;
     }
 
+    if (isHiddenSubframe(renderer))
+        return false;
+
     // The root layer always has a compositing layer, but it may not have backing.
     return requiresCompositingForTransform(renderer)
         || requiresCompositingForAnimation(renderer)
@@ -3333,16 +3336,22 @@ bool RenderLayerCompositor::requiresCompositingForPlugin(RenderLayerModelObject&
     IntRect contentBox = snappedIntRect(pluginRenderer.contentBoxRect());
     return (contentBox.height() * contentBox.width() > 1);
 }
-    
+
+bool RenderLayerCompositor::isHiddenSubframe(RenderLayerModelObject& renderer) const
+{
+    if (!is<RenderWidget>(renderer))
+        return false;
+
+    auto& frameRenderer = downcast<RenderWidget>(renderer);
+    return frameRenderer.style().visibility() != Visibility::Visible;
+}
+
 bool RenderLayerCompositor::requiresCompositingForFrame(RenderLayerModelObject& renderer, RequiresCompositingData& queryData) const
 {
     if (!is<RenderWidget>(renderer))
         return false;
 
     auto& frameRenderer = downcast<RenderWidget>(renderer);
-    if (frameRenderer.style().visibility() != Visibility::Visible)
-        return false;
-
     if (!frameRenderer.requiresAcceleratedCompositing())
         return false;
 

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -570,6 +570,8 @@ private:
 
     void updateCompositingForLayerTreeAsTextDump();
 
+    bool isHiddenSubframe(RenderLayerModelObject&) const;
+
     RenderView& m_renderView;
     Timer m_updateCompositingLayersTimer;
 


### PR DESCRIPTION
#### 172c0c9a864d40d004786767fe4ba00cd7e97fb6
<pre>
visibility:hidden fails to hide composited iframe
<a href="https://bugs.webkit.org/show_bug.cgi?id=220342">https://bugs.webkit.org/show_bug.cgi?id=220342</a>

Reviewed by NOBODY (OOPS!).

Turn off compositing for subframes when they are hidden through
visibility:hidden.

* LayoutTests/compositing/iframes/composited-iframe-visibility-hidden-ancestor-expected.html: Added.
* LayoutTests/compositing/iframes/composited-iframe-visibility-hidden-ancestor.html: Added.
* LayoutTests/compositing/iframes/composited-iframe-visibility-hidden-expected.html: Added.
* LayoutTests/compositing/iframes/composited-iframe-visibility-hidden.html: Added.
* LayoutTests/compositing/iframes/composited-iframe-visibility-toggled-expected.html: Added.
* LayoutTests/compositing/iframes/composited-iframe-visibility-toggled.html: Added.
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::requiresCompositingLayer const):
(WebCore::RenderLayerCompositor::isHiddenSubframe const):
(WebCore::RenderLayerCompositor::requiresCompositingForFrame const):
* Source/WebCore/rendering/RenderLayerCompositor.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/172c0c9a864d40d004786767fe4ba00cd7e97fb6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5775 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5939 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6128 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7333 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6167 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5775 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6161 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5907 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/7943 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5880 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5927 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5219 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7387 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3404 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5203 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13038 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5272 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5280 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7434 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5725 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4698 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5169 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/5133 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9287 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5530 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->