### PR TITLE
[web-animations] test failures with multiple font-variation-settings duplicate tags

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-001-expected.txt
@@ -336,7 +336,7 @@ PASS font-variant-position uses discrete animation when animating between "sub" 
 PASS font-variation-settings (type: fontVariationSettings) has testInterpolation function
 PASS font-variation-settings supports animation as float
 PASS font-variation-settings supports animation as float with multiple tags
-FAIL font-variation-settings supports animation as float with multiple duplicate tags assert_array_equals: The computed values should be "wdth" 2,"wght" 1.2 at 250ms expected property 0 to be "\"wdth\" 2" but got "\"wdth\" 1" (expected array ["\"wdth\" 2", "\"wght\" 1.2"] got ["\"wdth\" 1", "\"wght\" 1.1"])
+PASS font-variation-settings supports animation as float with multiple duplicate tags
 PASS font-variation-settings (type: discrete) has testInterpolation function
 FAIL font-variation-settings uses discrete animation when animating between ""wdth" 1, "wght" 1.1" and ""wdth" 5" with linear easing assert_equals: The value should be "wdth" 1, "wght" 1.1 at 0ms expected "\"wdth\" 1, \"wght\" 1.1" but got "\"wght\" 1.1, \"wdth\" 1"
 FAIL font-variation-settings uses discrete animation when animating between ""wdth" 1, "wght" 1.1" and ""wdth" 5" with effect easing assert_equals: The value should be "wdth" 1, "wght" 1.1 at 0ms expected "\"wdth\" 1, \"wght\" 1.1" but got "\"wght\" 1.1, \"wdth\" 1"

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -701,7 +701,7 @@ public:
     {
     }
 
-    T value(const RenderStyle& style) const
+    virtual T value(const RenderStyle& style) const
     {
         return (style.*m_getter)();
     }
@@ -1246,8 +1246,8 @@ private:
 class PropertyWrapperFontVariationSettings final : public PropertyWrapper<FontVariationSettings> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    PropertyWrapperFontVariationSettings(CSSPropertyID property, FontVariationSettings (RenderStyle::*getter)() const, void (RenderStyle::*setter)(FontVariationSettings))
-        : PropertyWrapper(property, getter, setter)
+    PropertyWrapperFontVariationSettings()
+        : PropertyWrapper(CSSPropertyFontVariationSettings, &RenderStyle::fontVariationSettings, &RenderStyle::setFontVariationSettings)
     {
     }
 
@@ -1258,6 +1258,11 @@ private:
         if (&a == &b)
             return true;
         return value(a) == value(b);
+    }
+
+    FontVariationSettings value(const RenderStyle& style) const override
+    {
+        return PropertyWrapper::value(style).deduplicated();
     }
 
     bool canInterpolate(const RenderStyle& from, const RenderStyle& to, CompositeOperation) const final
@@ -3385,7 +3390,7 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         new PropertyWrapperBaselineShift,
         new PropertyWrapper<SVGLengthValue>(CSSPropertyKerning, &RenderStyle::kerning, &RenderStyle::setKerning),
 #if ENABLE(VARIATION_FONTS)
-        new PropertyWrapperFontVariationSettings(CSSPropertyFontVariationSettings, &RenderStyle::fontVariationSettings, &RenderStyle::setFontVariationSettings),
+        new PropertyWrapperFontVariationSettings,
 #endif
         new PropertyWrapperFontSizeAdjust,
         new PropertyWrapperFontWeight,

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -3197,17 +3197,12 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
     }
 #if ENABLE(VARIATION_FONTS)
     case CSSPropertyFontVariationSettings: {
-        auto& variationSettings = style.fontDescription().variationSettings();
+        auto variationSettings = style.fontVariationSettings().deduplicated();
         if (variationSettings.isEmpty())
             return CSSPrimitiveValue::create(CSSValueNormal);
-        HashCountedSet<FontTag, FourCharacterTagHash, FourCharacterTagHashTraits> duplicateTagChecker;
-        for (auto& feature : variationSettings)
-            duplicateTagChecker.add(feature.tag());
         auto list = CSSValueList::createCommaSeparated();
-        for (auto& feature : variationSettings) {
-            if (duplicateTagChecker.remove(feature.tag()))
-                list->append(CSSFontVariationValue::create(feature.tag(), feature.value()));
-        }
+        for (auto& feature : variationSettings)
+            list->append(CSSFontVariationValue::create(feature.tag(), feature.value()));
         return list;
     }
     case CSSPropertyFontOpticalSizing:


### PR DESCRIPTION
#### dd5f2cbaaffbc88e2cf8b38106eafddce69c1e3a
<pre>
[web-animations] test failures with multiple font-variation-settings duplicate tags
<a href="https://bugs.webkit.org/show_bug.cgi?id=252168">https://bugs.webkit.org/show_bug.cgi?id=252168</a>

Reviewed by Myles C. Maxfield.

We failed to deduplicate tags when considering whether to interpolate font-variation-settings
values. We take some deduplication code written for the computed style representation of this
property and expose it via a deduplicate() method on FontTaggedSettings such that we may call
it while blending. This allows us to now compare font-variation-settings values with deduplicated
and sorted tags.

* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-001-expected.txt:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::PropertyWrapperGetter::value const):
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle):
* Source/WebCore/platform/graphics/FontTaggedSettings.h:
(WebCore::FontTaggedSettings&lt;T&gt;::deduplicated const):

Canonical link: <a href="https://commits.webkit.org/260212@main">https://commits.webkit.org/260212@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d30bb4aa38b1312838707ec0549570733afd8b4f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107518 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16579 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40420 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116681 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116102 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111415 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18005 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7822 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99682 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113278 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13600 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96784 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41246 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95507 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28410 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9584 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29763 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10242 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6659 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15741 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49344 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11803 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3829 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->