### PR TITLE
Prefer default allocator over nullptr

### DIFF
--- a/Source/WebCore/platform/LocalizedStrings.cpp
+++ b/Source/WebCore/platform/LocalizedStrings.cpp
@@ -67,7 +67,7 @@ ALLOW_NONLITERAL_FORMAT_END
 String formatLocalizedString(const char* format, ...)
 {
 #if USE(CF) && PLATFORM(WIN)
-    auto cfFormat = adoptCF(CFStringCreateWithCStringNoCopy(nullptr, format, kCFStringEncodingUTF8, kCFAllocatorNull));
+    auto cfFormat = adoptCF(CFStringCreateWithCStringNoCopy(kCFAllocatorDefault, format, kCFStringEncodingUTF8, kCFAllocatorNull));
     va_list arguments;
     va_start(arguments, format);
     auto localizedFormat = copyLocalizedString(cfFormat.get());
@@ -135,7 +135,7 @@ String localizedString(CFStringRef key)
 String localizedString(const char* key)
 {
 #if USE(CF)
-    auto keyString = adoptCF(CFStringCreateWithCStringNoCopy(nullptr, key, kCFStringEncodingUTF8, kCFAllocatorNull));
+    auto keyString = adoptCF(CFStringCreateWithCStringNoCopy(kCFAllocatorDefault, key, kCFStringEncodingUTF8, kCFAllocatorNull));
     return copyLocalizedString(keyString.get()).get();
 #else
     return String::fromUTF8(key, strlen(key));

--- a/Source/WebKitLegacy/mac/Misc/WebLocalizableStrings.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebLocalizableStrings.mm
@@ -55,7 +55,7 @@ NSString *WebLocalizedString(WebLocalizableStringsBundle *stringsBundle, const c
         }
     }
     NSString *notFound = @"localized string not found";
-    auto keyString = adoptCF(CFStringCreateWithCStringNoCopy(NULL, key, kCFStringEncodingUTF8, kCFAllocatorNull));
+    auto keyString = adoptCF(CFStringCreateWithCStringNoCopy(kCFAllocatorDefault, key, kCFStringEncodingUTF8, kCFAllocatorNull));
     NSString *result = [bundle localizedStringForKey:(__bridge NSString *)keyString.get() value:notFound table:nil];
     ASSERT_WITH_MESSAGE(result != notFound, "could not find localizable string %s in bundle", key);
     return result;

--- a/Source/WebKitLegacy/mac/Misc/WebNSDataExtras.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebNSDataExtras.mm
@@ -83,9 +83,9 @@
     }
     if (somethingChanged) {
         if (useUniCharPtr)
-            result = adoptCF(CFStringCreateWithCharactersNoCopy(kCFAllocatorDefault, uniCharPtr, len, nullptr)).bridgingAutorelease();
+            result = adoptCF(CFStringCreateWithCharactersNoCopy(kCFAllocatorDefault, uniCharPtr, len, kCFAllocatorDefault)).bridgingAutorelease();
         else
-            result = adoptCF(CFStringCreateWithCStringNoCopy(kCFAllocatorDefault, charPtr, kCFStringEncodingISOLatin1, nullptr)).bridgingAutorelease();
+            result = adoptCF(CFStringCreateWithCStringNoCopy(kCFAllocatorDefault, charPtr, kCFStringEncodingISOLatin1, kCFAllocatorDefault)).bridgingAutorelease();
     } else
         result = self;
 


### PR DESCRIPTION
#### 0bd425f2bd48d64caffb4f3fcc63b2b126c7a98c
<pre>
Prefer default allocator over nullptr
<a href="https://bugs.webkit.org/show_bug.cgi?id=252169">https://bugs.webkit.org/show_bug.cgi?id=252169</a>

Reviewed by NOBODY (OOPS!).

Prefer the default allocate over nullptr when passing to CF
allocation functions.

*Source\WebCore\platform\LocalizedStrings.cpp:
*Source\WebKitLegacy\mac\Misc\WebLocalizableStrings.mm:
*Source\WebKitLegacy\mac\Misc\WebNSDataExtras.mm:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ca14f0ceb4b46c55a4ca726aee51ba6f72d2c2e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107768 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16824 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40665 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116913 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116294 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111658 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18238 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8140 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99947 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113525 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13770 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96969 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41471 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95677 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28610 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/83313 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9788 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29958 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10475 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6852 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15942 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49542 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12038 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->