### PR TITLE
[IFC] Save memory by rearranging InlineDisplay::Box fields

### DIFF
--- a/Source/WebCore/display/DisplayTreeBuilder.cpp
+++ b/Source/WebCore/display/DisplayTreeBuilder.cpp
@@ -307,7 +307,7 @@ void TreeBuilder::buildInlineDisplayTree(const Layout::LayoutState& layoutState,
             continue;
         }
 
-        if (box.text()) {
+        if (box.isTextOrSoftLineBreak()) {
             auto& lineGeometry = inlineFormattingState.lines().at(box.lineIndex());
             auto textBox = m_boxFactory.displayBoxForTextRun(box, lineGeometry, positioningContext().inFlowContainingBlockContext());
             insert(WTFMove(textBox), insertionPosition);

--- a/Source/WebCore/display/css/DisplayBoxFactory.cpp
+++ b/Source/WebCore/display/css/DisplayBoxFactory.cpp
@@ -144,7 +144,7 @@ std::unique_ptr<Box> BoxFactory::displayBoxForLayoutBox(const Layout::Box& layou
 std::unique_ptr<Box> BoxFactory::displayBoxForTextRun(const InlineDisplay::Box& box, const InlineDisplay::Line& line, const ContainingBlockContext& containingBlockContext) const
 {
     UNUSED_PARAM(line);
-    ASSERT(box.text());
+    ASSERT(box.isTextOrSoftLineBreak());
 
     auto boxRect = LayoutRect { box.left(), box.top(), box.width(), box.height() };
     boxRect.move(containingBlockContext.offsetFromRoot);

--- a/Source/WebCore/display/css/DisplayTextBox.cpp
+++ b/Source/WebCore/display/css/DisplayTextBox.cpp
@@ -37,7 +37,7 @@ DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(TextBox);
 TextBox::TextBox(Tree& tree, UnadjustedAbsoluteFloatRect borderBox, Style&& displayStyle, const InlineDisplay::Box& box)
     : Box(tree, borderBox, WTFMove(displayStyle), { TypeFlags::TextBox })
     , m_expansion(box.expansion())
-    , m_text(box.text().value())
+    , m_text(box.text())
 {
 }
 

--- a/Source/WebCore/layout/Verification.cpp
+++ b/Source/WebCore/layout/Verification.cpp
@@ -80,13 +80,13 @@ static bool checkForMatchingNonTextRuns(const InlineDisplay::Box& box, const Web
 
 static bool checkForMatchingTextRuns(InlineDisplay::Box& box, const WebCore::LegacyInlineTextBox& inlineTextBox)
 {
-    if (!box.text())
+    if (!box.isTextOrSoftLineBreak())
         return false;
     return areEssentiallyEqual(inlineTextBox.left(), box.left())
         && areEssentiallyEqual(inlineTextBox.right(), box.right())
         && areEssentiallyEqual(inlineTextBox.top(), box.top())
         && areEssentiallyEqual(inlineTextBox.bottom(), box.bottom())
-        && (inlineTextBox.isLineBreak() || (inlineTextBox.start() == box.text()->start() && inlineTextBox.end() == box.text()->end()));
+        && (inlineTextBox.isLineBreak() || (inlineTextBox.start() == box.text().start() && inlineTextBox.end() == box.text().end()));
 }
 
 static void collectFlowBoxSubtree(const LegacyInlineFlowBox& flowbox, Vector<WebCore::LegacyInlineBox*>& inlineBoxes)
@@ -152,8 +152,8 @@ static bool outputMismatchingComplexLineInformationIfNeeded(TextStream& stream, 
             stream << " (" << inlineBox->logicalLeft() << ", " << inlineBox->logicalTop() << ") (" << inlineBox->logicalWidth() << "x" << inlineBox->logicalHeight() << ")";
 
             stream << " inline box";
-            if (box.text())
-                stream << " (" << box.text()->start() << ", " << box.text()->end() << ")";
+            if (box.isTextOrSoftLineBreak())
+                stream << " (" << box.text().start() << ", " << box.text().end() << ")";
             stream << " (" << box.left() << ", " << box.top() << ") (" << box.width() << "x" << box.height() << ")";
             stream.nextLine();
             mismatched = true;

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayBox.h
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayBox.h
@@ -36,34 +36,49 @@ namespace InlineDisplay {
 
 struct Box {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
+
+#pragma pack(push, 4)
     struct Text {
-        WTF_MAKE_STRUCT_FAST_ALLOCATED;
     public:
+        Text() = default;
         Text(size_t position, size_t length, const String& originalContent, String adjustedContentToRender = String(), bool hasHyphen = false);
 
         size_t start() const { return m_start; }
         size_t end() const { return start() + length(); }
         size_t length() const { return m_length; }
-        std::optional<size_t> partiallyVisibleContentLength() const { return m_partiallyVisibleContentLength; }
         StringView originalContent() const { return StringView(m_originalContent).substring(m_start, m_length); }
         StringView renderedContent() const { return m_adjustedContentToRender.isNull() ? originalContent() : m_adjustedContentToRender; }
 
         bool hasHyphen() const { return m_hasHyphen; }
 
-        void setPartiallyVisibleContentLength(size_t truncatedLength) { m_partiallyVisibleContentLength = truncatedLength; }
+        std::optional<size_t> partiallyVisibleContentLength() const
+        {
+            if (!m_hasPartiallyVisibleContentLength)
+                return { };
+            return m_partiallyVisibleContentLength;
+        }
+
+        void setPartiallyVisibleContentLength(size_t truncatedLength)
+        {
+            m_partiallyVisibleContentLength = truncatedLength;
+            m_hasPartiallyVisibleContentLength = true;
+        }
 
     private:
         friend struct Box;
 
-        size_t m_start { 0 };
-        size_t m_length { 0 };
-        std::optional<size_t> m_partiallyVisibleContentLength { };
-        bool m_hasHyphen { false };
         String m_originalContent;
         String m_adjustedContentToRender;
-    };
 
-    enum class Type {
+        unsigned m_start { 0 };
+        unsigned m_length { 0 };
+        unsigned m_partiallyVisibleContentLength : 30 { };
+        bool m_hasPartiallyVisibleContentLength : 1 { false };
+        bool m_hasHyphen : 1 { false };
+    };
+#pragma pack(pop)
+
+    enum class Type : uint8_t {
         Text,
         WordSeparator,
         Ellipsis,
@@ -75,7 +90,7 @@ struct Box {
         GenericInlineLevelBox
     };
     struct Expansion;
-    enum class PositionWithinInlineLevelBox {
+    enum class PositionWithinInlineLevelBox : uint8_t {
         First = 1 << 0,
         Last  = 1 << 1
     };
@@ -160,14 +175,14 @@ struct Box {
     void setHasContent() { m_hasContent = true; }
     void setIsFullyTruncated() { m_isFullyTruncated = true; }
 
-    std::optional<Text>& text() { return m_text; }
-    const std::optional<Text>& text() const { return m_text; }
+    Text& text() { ASSERT(isTextOrSoftLineBreak()); return m_text; }
+    const Text& text() const { ASSERT(isTextOrSoftLineBreak()); return m_text; }
 
     struct Expansion {
-        ExpansionBehavior behavior = ExpansionBehavior::defaultBehavior();
+        ExpansionBehavior behavior { ExpansionBehavior::defaultBehavior() };
         float horizontalExpansion { 0 };
     };
-    Expansion expansion() const { return m_expansion; }
+    Expansion expansion() const { return { m_expansionBehavior, m_horizontalExpansion }; }
 
     const Layout::Box& layoutBox() const { return m_layoutBox; }
     const RenderStyle& style() const { return !lineIndex() ? layoutBox().firstLineStyle() : layoutBox().style(); }
@@ -182,42 +197,48 @@ struct Box {
     void setIsLastForLayoutBox(bool isLastBox) { m_isLastForLayoutBox = isLastBox; }
 
 private:
-    const size_t m_lineIndex { 0 };
-    const Type m_type { Type::GenericInlineLevelBox };
     CheckedRef<const Layout::Box> m_layoutBox;
-    UBiDiLevel m_bidiLevel { UBIDI_DEFAULT_LTR };
     FloatRect m_unflippedVisualRect;
     FloatRect m_inkOverflow;
-    bool m_hasContent : 1;
-    bool m_isFirstForLayoutBox : 1;
-    bool m_isLastForLayoutBox : 1;
-    bool m_isFullyTruncated : 1;
-    Expansion m_expansion;
-    std::optional<Text> m_text;
+
+    const unsigned m_lineIndex { 0 };
+
+    float m_horizontalExpansion { 0 };
+    
+    ExpansionBehavior m_expansionBehavior { ExpansionBehavior::defaultBehavior() };
+
+    UBiDiLevel m_bidiLevel { UBIDI_DEFAULT_LTR };
+    const Type m_type : 4 { Type::GenericInlineLevelBox };
+    bool m_hasContent : 1 { false };
+    bool m_isFirstForLayoutBox : 1 { false };
+    bool m_isLastForLayoutBox : 1 { false };
+    bool m_isFullyTruncated : 1 { false };
+
+    Text m_text;
 };
 
 inline Box::Box(size_t lineIndex, Type type, const Layout::Box& layoutBox, UBiDiLevel bidiLevel, const FloatRect& physicalRect, const FloatRect& inkOverflow, Expansion expansion, std::optional<Text> text, bool hasContent, OptionSet<PositionWithinInlineLevelBox> positionWithinInlineLevelBox)
-    : m_lineIndex(lineIndex)
-    , m_type(type)
-    , m_layoutBox(layoutBox)
-    , m_bidiLevel(bidiLevel)
+    : m_layoutBox(layoutBox)
     , m_unflippedVisualRect(physicalRect)
     , m_inkOverflow(inkOverflow)
+    , m_lineIndex(lineIndex)
+    , m_horizontalExpansion(expansion.horizontalExpansion)
+    , m_expansionBehavior(expansion.behavior)
+    , m_bidiLevel(bidiLevel)
+    , m_type(type)
     , m_hasContent(hasContent)
     , m_isFirstForLayoutBox(positionWithinInlineLevelBox.contains(PositionWithinInlineLevelBox::First))
     , m_isLastForLayoutBox(positionWithinInlineLevelBox.contains(PositionWithinInlineLevelBox::Last))
-    , m_isFullyTruncated(false)
-    , m_expansion(expansion)
-    , m_text(text)
+    , m_text(text ? WTFMove(*text) : Text { })
 {
 }
 
 inline Box::Text::Text(size_t start, size_t length, const String& originalContent, String adjustedContentToRender, bool hasHyphen)
-    : m_start(start)
+    : m_originalContent(originalContent)
+    , m_adjustedContentToRender(adjustedContentToRender)
+    , m_start(start)
     , m_length(length)
     , m_hasHyphen(hasHyphen)
-    , m_originalContent(originalContent)
-    , m_adjustedContentToRender(adjustedContentToRender)
 {
 }
 

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLineBuilder.cpp
@@ -176,18 +176,18 @@ static float truncateOverflowingDisplayBoxes(const InlineDisplay::Line& displayL
 
             auto& inlineTextBox = downcast<InlineTextBox>(displayBox.layoutBox());
             auto& textContent = displayBox.text();
-            auto leftSide = TextUtil::breakWord(inlineTextBox, textContent->start(), textContent->length(), width(displayBox), visibleWidth, { }, displayBox.style().fontCascade());
+            auto leftSide = TextUtil::breakWord(inlineTextBox, textContent.start(), textContent.length(), width(displayBox), visibleWidth, { }, displayBox.style().fontCascade());
             if (leftSide.length) {
-                textContent->setPartiallyVisibleContentLength(leftSide.length);
+                textContent.setPartiallyVisibleContentLength(leftSide.length);
                 return isLeftToRightDirection ? left(displayBox) + leftSide.logicalWidth : right(displayBox) - leftSide.logicalWidth;
             }
             if (canFullyTruncate) {
                 displayBox.setIsFullyTruncated();
                 return isLeftToRightDirection ? left(displayBox) : right(displayBox);
             }
-            auto firstCharacterLength = TextUtil::firstUserPerceivedCharacterLength(inlineTextBox, textContent->start(), textContent->length());
-            auto firstCharacterWidth = TextUtil::width(inlineTextBox, displayBox.style().fontCascade(), textContent->start(), textContent->start() + firstCharacterLength, { }, TextUtil::UseTrailingWhitespaceMeasuringOptimization::No);
-            textContent->setPartiallyVisibleContentLength(firstCharacterLength);
+            auto firstCharacterLength = TextUtil::firstUserPerceivedCharacterLength(inlineTextBox, textContent.start(), textContent.length());
+            auto firstCharacterWidth = TextUtil::width(inlineTextBox, displayBox.style().fontCascade(), textContent.start(), textContent.start() + firstCharacterLength, { }, TextUtil::UseTrailingWhitespaceMeasuringOptimization::No);
+            textContent.setPartiallyVisibleContentLength(firstCharacterLength);
             return isLeftToRightDirection ? left(displayBox) + firstCharacterWidth : right(displayBox) - firstCharacterWidth;
         }
         if (canFullyTruncate) {

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxTree.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxTree.cpp
@@ -385,7 +385,7 @@ void showInlineContent(TextStream& stream, const InlineContent& inlineContent, s
                     runStream << "Generic inline level box";
                 runStream << " at (" << box.left() << "," << box.top() << ") size " << box.width() << "x" << box.height();
                 if (box.isText())
-                    runStream << " run(" << box.text()->start() << ", " << box.text()->end() << ")";
+                    runStream << " run(" << box.text().start() << ", " << box.text().end() << ")";
                 runStream << " renderer->(" << &inlineContent.rendererForLayoutBox(box.layoutBox()) << ")";
                 runStream.nextLine();
             }

--- a/Source/WebCore/layout/integration/inline/InlineIteratorBoxModernPath.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorBoxModernPath.h
@@ -60,22 +60,22 @@ public:
 
     unsigned char bidiLevel() const { return box().bidiLevel(); }
 
-    bool hasHyphen() const { return box().text()->hasHyphen(); }
-    StringView originalText() const { return box().text()->originalContent(); }
-    unsigned start() const { return box().text()->start(); }
-    unsigned end() const { return box().text()->end(); }
-    unsigned length() const { return box().text()->length(); }
+    bool hasHyphen() const { return box().text().hasHyphen(); }
+    StringView originalText() const { return box().text().originalContent(); }
+    unsigned start() const { return box().text().start(); }
+    unsigned end() const { return box().text().end(); }
+    unsigned length() const { return box().text().length(); }
 
     TextBoxSelectableRange selectableRange() const
     {
         auto& box = this->box();
         auto& textContent = box.text();
         auto extraTrailingLength = [&] () -> unsigned {
-            if (textContent->hasHyphen())
+            if (textContent.hasHyphen())
                 return box.style().hyphenString().length();
             if (downcast<Layout::InlineTextBox>(box.layoutBox()).isCombined()) {
-                ASSERT(textContent->renderedContent().length() >= length());
-                return textContent->renderedContent().length() - length();
+                ASSERT(textContent.renderedContent().length() >= length());
+                return textContent.renderedContent().length() - length();
             }
             return 0;
         };
@@ -84,7 +84,7 @@ public:
             length(),
             extraTrailingLength(),
             box.isLineBreak(),
-            textContent->partiallyVisibleContentLength()
+            textContent.partiallyVisibleContentLength()
         };
     }
 
@@ -98,7 +98,7 @@ public:
             return line().lineBoxRight() - (visualRectIgnoringBlockDirection().maxX() + line().contentLogicalLeft());
         };
         auto characterScanForCodePath = isText() && !renderText().canUseSimpleFontCodePath();
-        auto textRun = TextRun { mode == TextRunMode::Editing ? originalText() : box().text()->renderedContent(), logicalLeft(), expansion.horizontalExpansion, expansion.behavior, direction(), style.rtlOrdering() == Order::Visual, characterScanForCodePath };
+        auto textRun = TextRun { mode == TextRunMode::Editing ? originalText() : box().text().renderedContent(), logicalLeft(), expansion.horizontalExpansion, expansion.behavior, direction(), style.rtlOrdering() == Order::Visual, characterScanForCodePath };
         textRun.setTabSize(!style.collapseWhiteSpace(), style.tabSize());
         return textRun;
     };

--- a/Source/WebCore/layout/integration/inline/InlineIteratorTextBox.cpp
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorTextBox.cpp
@@ -162,7 +162,7 @@ TextBoxIterator textBoxFor(const LayoutIntegration::InlineContent& content, cons
 
 TextBoxIterator textBoxFor(const LayoutIntegration::InlineContent& content, size_t boxIndex)
 {
-    ASSERT(content.boxes[boxIndex].text());
+    ASSERT(content.boxes[boxIndex].isTextOrSoftLineBreak());
     return { BoxModernPath { content, boxIndex } };
 }
 

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.cpp
@@ -88,7 +88,7 @@ void InlineContentPainter::paintDisplayBox(const InlineDisplay::Box& box)
     }
 
     if (box.isText()) {
-        auto hasVisibleDamage = box.text()->length() && box.isVisible() && hasDamage(box); 
+        auto hasVisibleDamage = box.text().length() && box.isVisible() && hasDamage(box); 
         if (!hasVisibleDamage)
             return;
 

--- a/Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp
@@ -409,13 +409,13 @@ void showInlineTreeAndRuns(TextStream& stream, const LayoutState& layoutState, c
                 continue;
             addSpacing();
             stream << "    ";
-            if (box.text())
+            if (box.isTextOrSoftLineBreak())
                 stream << "text box";
             else
                 stream << "box box";
             stream << " at (" << box.left() << "," << box.top() << ") size " << box.width() << "x" << box.height();
-            if (box.text())
-                stream << " box(" << box.text()->start() << ", " << box.text()->end() << ")";
+            if (box.isTextOrSoftLineBreak())
+                stream << " box(" << box.text().start() << ", " << box.text().end() << ")";
             stream.nextLine();
         }
 


### PR DESCRIPTION
#### de86b9514094c624d049e72b92ff12f5af21286c
<pre>
[IFC] Save memory by rearranging InlineDisplay::Box fields
<a href="https://bugs.webkit.org/show_bug.cgi?id=252173">https://bugs.webkit.org/show_bug.cgi?id=252173</a>
rdar://105396411

Reviewed by Simon Fraser.

Mechanical savings:

- rearrange fields to minimize space
- add more fields to the bitfields
- replace std::optionals with plain values and a bitfield bits
- replace size_t index fields with unsigned
- use #pragma pack(push, 4) to avoid the Text struct being padded to 8 bytes

InlineDisplay::Box goes from

Total byte size: 136
Total pad bytes: 19
Padding percentage: 14.61 %

Total byte size: 80
Total pad bytes: 1
Padding percentage: 1.25 %

* Source/WebCore/display/DisplayTreeBuilder.cpp:
(WebCore::Display::TreeBuilder::buildInlineDisplayTree):
* Source/WebCore/display/css/DisplayBoxFactory.cpp:
(WebCore::Display::BoxFactory::displayBoxForTextRun const):
* Source/WebCore/display/css/DisplayTextBox.cpp:
(WebCore::Display::m_text):
* Source/WebCore/layout/Verification.cpp:
(WebCore::Layout::checkForMatchingTextRuns):
(WebCore::Layout::outputMismatchingComplexLineInformationIfNeeded):
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayBox.h:
(WebCore::InlineDisplay::Box::Text::length const):
(WebCore::InlineDisplay::Box::Text::partiallyVisibleContentLength const):
(WebCore::InlineDisplay::Box::Text::setPartiallyVisibleContentLength):
(WebCore::InlineDisplay::Box::text):
(WebCore::InlineDisplay::Box::text const):
(WebCore::InlineDisplay::Box::expansion const):
(WebCore::InlineDisplay::Box::Box):
(WebCore::InlineDisplay::m_isFullyTruncated):
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLineBuilder.cpp:
(WebCore::Layout::truncateOverflowingDisplayBoxes):
* Source/WebCore/layout/integration/LayoutIntegrationBoxTree.cpp:
(WebCore::LayoutIntegration::showInlineContent):
* Source/WebCore/layout/integration/inline/InlineIteratorBoxModernPath.h:
(WebCore::InlineIterator::BoxModernPath::hasHyphen const):
(WebCore::InlineIterator::BoxModernPath::originalText const):
(WebCore::InlineIterator::BoxModernPath::start const):
(WebCore::InlineIterator::BoxModernPath::end const):
(WebCore::InlineIterator::BoxModernPath::length const):
(WebCore::InlineIterator::BoxModernPath::selectableRange const):
(WebCore::InlineIterator::BoxModernPath::textRun const):
* Source/WebCore/layout/integration/inline/InlineIteratorTextBox.cpp:
(WebCore::InlineIterator::textBoxFor):
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.cpp:
(WebCore::LayoutIntegration::InlineContentPainter::paintDisplayBox):
* Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp:
(WebCore::Layout::showInlineTreeAndRuns):

Canonical link: <a href="https://commits.webkit.org/260211@main">https://commits.webkit.org/260211@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ea51b35b7e74c1e7f8c0b3cf8299064c0210e6c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107542 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16601 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40445 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116705 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111438 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18028 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7846 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99710 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113301 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96802 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/41268 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95524 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28428 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/9606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29781 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10264 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/6676 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15763 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49362 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7058 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11825 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->