### PR TITLE
Import/port core-text Chinese composition tables

### DIFF
--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -667,6 +667,8 @@ platform/text/cocoa/LocalizedDateCache.mm
 platform/text/mac/TextBoundaries.mm
 platform/text/mac/TextCheckingMac.mm
 platform/xr/cocoa/PlatformXRCocoa.mm
+platform/text/mac/CoreTextChineseCompositionEngine.cpp
+platform/text/mac/CoreTextCompositionEngine.cpp
 rendering/AttachmentLayout.mm
 rendering/RenderThemeCocoa.mm
 rendering/RenderThemeIOS.mm

--- a/Source/WebCore/platform/text/mac/CoreTextChineseCompositionEngine.cpp
+++ b/Source/WebCore/platform/text/mac/CoreTextChineseCompositionEngine.cpp
@@ -1,0 +1,182 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CoreTextChineseCompositionEngine.h"
+
+#include <unicode/uchar.h>
+#include <unicode/uscript.h>
+#include <wtf/unicode/CharacterNames.h>
+
+static ChineseCompositionRules::ChineseCharacterClass characterToCharacterClass(UTF32Char character)
+{
+    if (character == zeroWidthSpace)
+        return ChineseCompositionRules::ChineseCharacterClass::Other;
+
+    /* Characters with the UCHAR_EAST_ASIAN_WIDTH enumerable property equal to U_EA_FULLWIDTH or U_EA_WIDE are of width 2. */
+    int width = static_cast<int>(u_getIntPropertyValue(character, UCHAR_EAST_ASIAN_WIDTH));
+    if (width == U_EA_FULLWIDTH || width == U_EA_WIDE)
+        return ChineseCompositionRules::ChineseCharacterClass::FullWidth;
+
+    /* any other characters have width 1 */
+    return ChineseCompositionRules::ChineseCharacterClass::HalfWidth;
+}
+
+static inline bool isDigit(UTF32Char character)
+{
+    return character >= 0x0030 && character <= 0x0039;
+}
+
+static inline bool isNarrowFullWidth(UTF32Char character)
+{
+    return character == 0x6708 /* 月 */ || character == 0x65E5 /* 日 */;
+}
+
+ChineseCompositionRules::ChineseCharacterClass ChineseCompositionRules::characterClass(UTF32Char character, uint32_t generalCategoryMask, CTCompositionLanguage language)
+{
+    switch (character) {
+    case 0x2985: // LEFT WHITE PARENTHESIS
+    case 0x3008: // LEFT ANGLE BRACKET
+    case 0x300A: // LEFT DOUBLE ANGLE BRACKET
+    case 0x300C: // LEFT CORNER BRACKET
+    case 0x300E: // LEFT WHITE CORNER BRACKET
+    case 0x3010: // LEFT BLACK LENTICULAR BRACKET
+    case 0x3014: // LEFT TORTOISE SHELL BRACKET
+    case 0x3016: // LEFT WHITE LENTICULAR BRACKET
+    case 0x3018: // LEFT WHITE TORTOISE SHELL BRACKET
+    case 0x301A: // LEFT WHITE SQUARE BRACKET
+    case 0x301D: // REVERSED DOUBLE PRIME QUOTATION MARK, used vertical composition
+    case 0xFF08: // | FULLWIDTH LEFT PARENTHESIS
+    case 0xFF3B: // | FULLWIDTH LEFT SQUARE BRACKET
+    case 0xFF5B: // | FULLWIDTH LEFT CURLY BRACKET
+    case 0xFF5F: // FULLWIDTH LEFT WHITE PARENTHESIS
+        return Other; // kOpening
+
+    case 0x0028: // LEFT PARENTHESIS
+        return HalfWidthOpening;
+
+    case 0x0029: // RIGHT PARENTHESIS
+        return HalfWidthClosing;
+
+    case 0x2986: // RIGHT WHITE PARENTHESIS
+    case 0x3009: // RIGHT ANGLE BRACKET
+    case 0x300B: // RIGHT DOUBLE ANGLE BRACKET
+    case 0x300D: // RIGHT CORNER BRACKET
+    case 0x300F: // RIGHT WHITE CORNER BRACKET
+    case 0x3011: // RIGHT BLACK LENTICULAR BRACKET
+    case 0x3015: // RIGHT TORTOISE SHELL BRACKET
+    case 0x3017: // RIGHT WHITE LENTICULAR BRACKET
+    case 0x3019: // RIGHT WHITE TORTOISE SHELL BRACKET
+    case 0x301B: // RIGHT WHITE SQUARE BRACKET
+    case 0x301E: // DOUBLE PRIME QUOTATION MARK
+    case 0x301F: // LOW DOUBLE PRIME QUOTATION MARK, used vertical composition
+    case 0xFF09: // | FULLWIDTH RIGHT PARENTHESIS
+    case 0xFF3D: // | FULLWIDTH RIGHT SQUARE BRACKET
+    case 0xFF5D: // | FULLWIDTH RIGHT CURLY BRACKET
+    case 0xFF60: // FULLWIDTH RIGHT WHITE PARENTHESIS
+        return Other; // kClosing
+
+    case 0x3001: // IDEOGRAPHIC COMMA
+    case 0x3002: // IDEOGRAPHIC FULL STOP
+    case 0xFF0C: // FULLWIDTH COMMA
+    case 0xFF0E: // FULLWIDTH FULL STOP
+        return language == kCTCompositionLanguageTraditionalChinese ? Centered : Closing;
+
+    case 0xFF01: // FULLWIDTH EXCLAMATION MARK
+    case 0xFF1A: // FULLWIDTH COLON
+    case 0xFF1B: // FULLWIDTH SEMICOLON
+    case 0xFF1F: // FULLWIDTH QUESTION MARK
+        return (language == kCTCompositionLanguageTraditionalChinese || language == kCTCompositionLanguageJapanese) ? Centered : Closing;
+
+    case 0x22EF: // MIDLINE HORIZONTAL ELLIPSIS
+    case 0xFF5E: // FULLWIDTH TILDE
+        return Other;
+    }
+
+    // Half width punctuations.
+    if ((character != 0x0025 && character != 0x002B && character >= 0x0021 && character <= 0x002E) || (character >= 0x003A && character <= 0x003F) || (character >= 0x005B && character <= 0x0060) || (character >= 0x2010 && character <= 0x2027))
+        return Other;
+
+    if (!generalCategoryMask)
+        generalCategoryMask = U_GET_GC_MASK(character);
+
+    if (generalCategoryMask & (U_GC_LM_MASK | U_GC_SK_MASK | U_GC_MN_MASK | U_GC_ME_MASK | U_GC_CF_MASK |U_GC_CC_MASK | U_GC_SO_MASK ))
+        return Other;
+
+    if (generalCategoryMask & U_GC_ZS_MASK)
+        return Whitespace;
+
+    UErrorCode error = U_ZERO_ERROR;
+    UScriptCode unicodeScript = uscript_getScript(character, &error);
+    if (unicodeScript == USCRIPT_HANGUL)
+        return Other;
+
+    if (character)
+        characterToCharacterClass(character);
+
+    return Other;
+}
+
+CompositionRules::CharacterSpacingType ChineseCompositionRules::characterSpacing(CTCompositionLanguage language, bool isVertical, UTF32Char beforeCharacter, UTF32Char afterCharacter)
+{
+    using namespace CompositionRules;
+
+    static const CompositionRules::CharacterSpacingType chineseSpacingTable[NumClasses][NumClasses] = {
+                    /* Opening,    Closing,    Whitespace, FullWidth,   HalfWidth,   HalfWidthOpen, HalfWidthClose,   Centered    Other */
+/* Opening */       {  _1_4_be_re, _______,    _______,    _______,     _______,     _______,       _______,          _______,    _______    }, // NOLINT
+/* Closing */       {  _1_2_eq_re, _1_4_af_re, _______,    _1_4_af_re,  _1_4_af_re,  _1_4_af_re,    _1_4_af_re,       _1_2_eq_re, _1_4_af_re }, // NOLINT
+/* Whitespace */    {  _1_4_be_re, _______,    _______,    _______,     _______,     _______,       _______,          _______,    _______    }, // NOLINT
+/* FullWidth */     {  _1_4_be_re, _______,    _______,    _______,     _1_8_be,     _1_8_be,       _______,          _______,    _______    }, // NOLINT
+/* HalfWidth */     {  _1_4_be_re, _______,    _______,    _1_8_be,     _______,     _______,       _______,          _______,    _______    }, // NOLINT
+/* HalfWidthOpen */ {  _1_4_be_re, _______,    _______,    _______,     _______,     _______,       _______,          _______,    _______    }, // NOLINT
+/* HalfWidthClose */{  _1_4_be_re, _______,    _______,    _1_8_be,     _______,     _______,       _______,          _______,    _______    }, // NOLINT
+/* Centered */      {  _1_2_eq_re, _______,    _______,    _______,     _______,     _______,       _______,          _______,    _______    }, // NOLINT
+/* Other */         {  _1_4_be_re, _______,    _______,    _______,     _______,     _______,       _______,          _______,    _______    }, // NOLINT
+    };
+    auto beforeGeneralCategoryMask = U_GET_GC_MASK(beforeCharacter);
+    auto afterGeneralCategoryMask = U_GET_GC_MASK(afterCharacter);
+    auto beforeClass = characterClass(beforeCharacter, beforeGeneralCategoryMask, language);
+    auto afterClass = characterClass(beforeCharacter, afterGeneralCategoryMask, language);
+
+    // Only change trailing closing marks for now.
+    if (beforeClass == Closing && afterCharacter && !(afterGeneralCategoryMask & (U_GC_ZL_MASK | U_GC_ZP_MASK)) && afterCharacter != 0x0A)
+        beforeClass = Other;
+
+    if ((isDigit(beforeCharacter) && isNarrowFullWidth(afterCharacter)) || (isDigit(afterCharacter) && isNarrowFullWidth(beforeCharacter)))
+        return _1_25_be;
+
+    // http://www.w3.org/TR/2015/WD-clreq-20150723/#h-compression_of_adjacent_punctuation_marks:
+    // In Simplified Chinese, when one or more closing brackets appear behind a slight-pause comma,
+    // comma or period, a space of half a character width can be reduced. This rule does not apply
+    // to Traditional Chinese.
+    if (language == kCTCompositionLanguageTraditionalChinese && beforeClass == Closing && afterClass == Closing)
+        return _______;
+
+    // Don't increase space between fullwidth and halfwidth text in vertical mode.
+    if (isVertical && (beforeClass == HalfWidth || afterClass == HalfWidth))
+        return _______;
+
+    return chineseSpacingTable[beforeClass][afterClass];
+}

--- a/Source/WebCore/platform/text/mac/CoreTextChineseCompositionEngine.h
+++ b/Source/WebCore/platform/text/mac/CoreTextChineseCompositionEngine.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CoreTextCompositionEngine.h"
+#include <pal/spi/cf/CoreTextSPI.h>
+
+class ChineseCompositionRules {
+public:
+    typedef enum : uint8_t {
+        Opening = 0,
+        Closing,
+        Whitespace,
+        FullWidth,
+        HalfWidth,
+        HalfWidthOpening,
+        HalfWidthClosing,
+        Centered,
+        Other,
+
+        NumClasses
+    } ChineseCharacterClass;
+
+    static ChineseCharacterClass characterClass(UTF32Char, uint32_t, CTCompositionLanguage);
+    static CompositionRules::CharacterSpacingType characterSpacing(CTCompositionLanguage, bool, UTF32Char, UTF32Char);
+};

--- a/Source/WebCore/platform/text/mac/CoreTextCompositionEngine.cpp
+++ b/Source/WebCore/platform/text/mac/CoreTextCompositionEngine.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CoreTextCompositionEngine.h"
+
+#include "CoreTextChineseCompositionEngine.h"
+
+namespace CompositionRules {
+
+CharacterSpacingType characterSpacing(CTCompositionLanguage language, bool isVertical, UTF32Char beforeCharacter, UTF32Char afterCharacter)
+{
+    // FIXME (rdar://105386292): add support for other languages.
+    return ChineseCompositionRules::characterSpacing(language, isVertical, beforeCharacter, afterCharacter);
+}
+
+} // namespace CompositionRules

--- a/Source/WebCore/platform/text/mac/CoreTextCompositionEngine.h
+++ b/Source/WebCore/platform/text/mac/CoreTextCompositionEngine.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+using CharacterClass = uint8_t;
+
+namespace CompositionRules {
+
+typedef enum : uint8_t {
+    _______ = 0,
+    _1_4_be,
+    _1_4_af,
+    _1_8_be,
+    _1_8_af,
+    _1_25_be,
+    _1_2_be,
+    _1_2_af,
+    _note3_,
+    _note5_,
+    _1_4_af_re, // Reduce 1/4 em after previous char.
+    _1_4_be_re, // Reduce 1/4 em before current char.
+    _1_2_eq_re, // Reduce 1/4 em after previous char and reduce 1/4 em before current char.
+} CharacterSpacingType;
+
+CharacterSpacingType characterSpacing(CTCompositionLanguage, bool, UTF32Char, UTF32Char);
+
+} // namespace CompositionRules


### PR DESCRIPTION
#### af11c789096b362380e9b0a32e96f5b00c25110a
<pre>
Import/port core-text Chinese composition tables
<a href="https://bugs.webkit.org/show_bug.cgi?id=252171">https://bugs.webkit.org/show_bug.cgi?id=252171</a>
rdar://105386285

Reviewed by Brent Fulgham.

This is a preparation for text-spacing implementation.
We need to import CoreText&apos;s tables and types to WebKit to mimic
CoreText&apos;s behavior when text-spacing is set to ‘auto’ for Chinese text.

* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/text/mac/CoreTextChineseCompositionEngine.cpp: Added.
(characterToCharacterClass):
(isDigit):
(isNarrowFullWidth):
(ChineseCompositionRules::characterClass):
(ChineseCompositionRules::characterSpacing):
* Source/WebCore/platform/text/mac/CoreTextChineseCompositionEngine.h: Added.
* Source/WebCore/platform/text/mac/CoreTextCompositionEngine.cpp: Added.
(CompositionRules::characterSpacing):
* Source/WebCore/platform/text/mac/CoreTextCompositionEngine.h: Added.

Canonical link: <a href="https://commits.webkit.org/260534@main">https://commits.webkit.org/260534@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3233705a414934650b33a7ccf82ad96c8e181cd2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108358 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17453 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41223 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117474 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116846 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112245 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18957 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8732 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100581 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114126 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14212 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97398 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42121 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96190 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29043 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/83801 "Found 1 new API test failure: /TestWebKit:WebKit.PrivateBrowsingPushStateNoHistoryCallback (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10285 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30387 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11027 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7291 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16435 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49984 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7280 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12614 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->