### PR TITLE
Save memory when StyleRule doesn't need nesting support

### DIFF
--- a/Source/WebCore/bindings/js/JSCSSRuleCustom.cpp
+++ b/Source/WebCore/bindings/js/JSCSSRuleCustom.cpp
@@ -79,6 +79,8 @@ JSValue toJSNewlyCreated(JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<C
     switch (rule->styleRuleType()) {
     case StyleRuleType::Style:
         return createWrapper<CSSStyleRule>(globalObject, WTFMove(rule));
+    case StyleRuleType::StyleWithNesting:
+        return createWrapper<CSSStyleRule>(globalObject, WTFMove(rule));
     case StyleRuleType::Media:
         return createWrapper<CSSMediaRule>(globalObject, WTFMove(rule));
     case StyleRuleType::FontFace:

--- a/Source/WebCore/css/CSSSelectorList.cpp
+++ b/Source/WebCore/css/CSSSelectorList.cpp
@@ -185,4 +185,12 @@ bool CSSSelectorList::hasInvalidSelector() const
     return forEachSelector(functor, this);
 }
 
+bool CSSSelectorList::hasExplicitNestingParent() const
+{
+    auto functor = [](auto* selector) {
+        return selector->hasExplicitNestingParent();
+    };
+
+    return forEachSelector(functor, this);
+}
 } // namespace WebCore

--- a/Source/WebCore/css/CSSSelectorList.h
+++ b/Source/WebCore/css/CSSSelectorList.h
@@ -59,6 +59,7 @@ public:
 
     bool selectorsNeedNamespaceResolution();
     bool hasInvalidSelector() const;
+    bool hasExplicitNestingParent() const;
 
     String selectorsText() const;
     void buildSelectorsText(StringBuilder&) const;

--- a/Source/WebCore/css/CSSStyleRule.h
+++ b/Source/WebCore/css/CSSStyleRule.h
@@ -32,10 +32,12 @@ class DeclaredStylePropertyMap;
 class StylePropertyMap;
 class StyleRuleCSSStyleDeclaration;
 class StyleRule;
+class StyleRuleWithNesting;
 
 class CSSStyleRule final : public CSSRule, public CanMakeWeakPtr<CSSStyleRule> {
 public:
     static Ref<CSSStyleRule> create(StyleRule& rule, CSSStyleSheet* sheet) { return adoptRef(*new CSSStyleRule(rule, sheet)); }
+    static Ref<CSSStyleRule> create(StyleRuleWithNesting& rule, CSSStyleSheet* sheet) { return adoptRef(* new CSSStyleRule(rule, sheet)); };
 
     virtual ~CSSStyleRule();
 
@@ -55,12 +57,14 @@ public:
 
 private:
     CSSStyleRule(StyleRule&, CSSStyleSheet*);
+    CSSStyleRule(StyleRuleWithNesting&, CSSStyleSheet*);
 
     StyleRuleType styleRuleType() const final { return StyleRuleType::Style; }
     String cssText() const final;
     void reattach(StyleRuleBase&) final;
 
     String generateSelectorText() const;
+    Vector<Ref<StyleRuleBase>> nestedRules() const;
 
     Ref<StyleRule> m_styleRule;
     Ref<DeclaredStylePropertyMap> m_styleMap;

--- a/Source/WebCore/css/StyleRule.h
+++ b/Source/WebCore/css/StyleRule.h
@@ -64,7 +64,8 @@ public:
     bool isNamespaceRule() const { return type() == StyleRuleType::Namespace; }
     bool isMediaRule() const { return type() == StyleRuleType::Media; }
     bool isPageRule() const { return type() == StyleRuleType::Page; }
-    bool isStyleRule() const { return type() == StyleRuleType::Style; }
+    bool isStyleRule() const { return type() == StyleRuleType::Style || type() == StyleRuleType::StyleWithNesting; }
+    bool isStyleRuleWithNesting() const { return type() == StyleRuleType::StyleWithNesting; }
     bool isGroupRule() const { return type() == StyleRuleType::Media || type() == StyleRuleType::Supports || type() == StyleRuleType::LayerBlock || type() == StyleRuleType::Container; }
     bool isSupportsRule() const { return type() == StyleRuleType::Supports; }
     bool isImportRule() const { return type() == StyleRuleType::Import; }
@@ -88,6 +89,7 @@ protected:
     StyleRuleBase(const StyleRuleBase&);
 
     bool hasDocumentSecurityOrigin() const { return m_hasDocumentSecurityOrigin; }
+    void setType(StyleRuleType type) { m_type = static_cast<unsigned>(type); }
 
 private:
     template<typename Visitor> constexpr decltype(auto) visitDerived(Visitor&&);
@@ -101,33 +103,17 @@ private:
     unsigned m_hasDocumentSecurityOrigin : 1;
 };
 
-DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleRuleRareData);
-struct StyleRuleRareData {
-    WTF_MAKE_STRUCT_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(StyleRuleRareData);
-
-    static std::unique_ptr<StyleRuleRareData> createIfNeeded(Vector<Ref<StyleRuleBase>>, CSSSelectorList = { });
-
-    Vector<Ref<StyleRuleBase>> nestedRules;
-    CSSSelectorList resolvedSelectorList;
-};
-
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleRule);
-class StyleRule final : public StyleRuleBase {
+class StyleRule : public StyleRuleBase {
     WTF_MAKE_STRUCT_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(StyleRule);
 public:
-    static Ref<StyleRule> create(bool hasDocumentSecurityOrigin, CSSSelectorList&&);
-    static Ref<StyleRule> create(Ref<StyleProperties>&&, bool hasDocumentSecurityOrigin, CSSSelectorList&&, Vector<Ref<StyleRuleBase>>&& nestedRules);
+    static Ref<StyleRule> create(Ref<StyleProperties>&&, bool hasDocumentSecurityOrigin, CSSSelectorList&&);
     Ref<StyleRule> copy() const;
     ~StyleRule();
 
     const CSSSelectorList& selectorList() const { return m_selectorList; }
-    const CSSSelectorList& resolvedSelectorList() const
-    {
-        if (m_rareData && !m_rareData->resolvedSelectorList.isEmpty())
-            return m_rareData->resolvedSelectorList;
-        return m_selectorList;
-    }
-
+    const CSSSelectorList& resolvedSelectorList() const;
+    
     const StyleProperties& properties() const { return m_properties.get(); }
     MutableStyleProperties& mutableProperties();
 
@@ -149,30 +135,38 @@ public:
 
     static unsigned averageSizeInBytes();
     void setProperties(Ref<StyleProperties>&&);
-    void setNestedRules(Vector<Ref<StyleRuleBase>>);
-    void setResolvedSelectorList(CSSSelectorList&&) const;
-    const Vector<Ref<StyleRuleBase>>& nestedRules() const;
-    void appendNestedRule(Ref<StyleRuleBase>&& rule) { rareData().nestedRules.append(WTFMove(rule)); }
 
-private:
-    StyleRule(Ref<StyleProperties>&&, bool hasDocumentSecurityOrigin, CSSSelectorList&&, Vector<Ref<StyleRuleBase>>&&);
-    StyleRule(bool hasDocumentSecurityOrigin, CSSSelectorList&&);
+protected:
+    StyleRule(Ref<StyleProperties>&&, bool hasDocumentSecurityOrigin, CSSSelectorList&&);
     StyleRule(const StyleRule&);
 
+private:
     static Ref<StyleRule> createForSplitting(const Vector<const CSSSelector*>&, Ref<StyleProperties>&&, bool hasDocumentSecurityOrigin);
-
-    StyleRuleRareData& rareData() const;
 
     bool m_isSplitRule { false };
     bool m_isLastRuleInSplitRule { false };
 
     mutable Ref<StyleProperties> m_properties;
     CSSSelectorList m_selectorList;
-    mutable std::unique_ptr<StyleRuleRareData> m_rareData;
-
 #if ENABLE(CSS_SELECTOR_JIT)
     mutable UniqueArray<CompiledSelector> m_compiledSelectors;
 #endif
+};
+
+class StyleRuleWithNesting final : public StyleRule {
+public:
+    static Ref<StyleRuleWithNesting> create(Ref<StyleProperties>&&, bool hasDocumentSecurityOrigin, CSSSelectorList&&, Vector<Ref<StyleRuleBase>>&& nestedRules);
+
+    const Vector<Ref<StyleRuleBase>>& nestedRules() const { return m_nestedRules; }
+    const CSSSelectorList& resolvedSelectorList() const { return m_resolvedSelectorList; }
+    void setResolvedSelectorList(CSSSelectorList&&) const;
+    StyleRuleWithNesting(const StyleRuleWithNesting&) = delete;
+
+private:
+    StyleRuleWithNesting(Ref<StyleProperties>&&, bool hasDocumentSecurityOrigin, CSSSelectorList&&, Vector<Ref<StyleRuleBase>>&& nestedRules);
+
+    Vector<Ref<StyleRuleBase>> m_nestedRules;
+    mutable CSSSelectorList m_resolvedSelectorList;
 };
 
 class StyleRuleFontFace final : public StyleRuleBase {
@@ -439,7 +433,11 @@ inline CompiledSelector& StyleRule::compiledSelectorForListIndex(unsigned index)
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::StyleRule)
-    static bool isType(const WebCore::StyleRuleBase& rule) { return rule.isStyleRule(); }
+    static bool isType(const WebCore::StyleRuleBase& rule) { return rule.type() == WebCore::StyleRuleType::Style; }
+SPECIALIZE_TYPE_TRAITS_END()
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::StyleRuleWithNesting)
+    static bool isType(const WebCore::StyleRuleBase& rule) { return rule.type() == WebCore::StyleRuleType::StyleWithNesting; }
 SPECIALIZE_TYPE_TRAITS_END()
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::StyleRuleGroup)

--- a/Source/WebCore/css/StyleRuleType.h
+++ b/Source/WebCore/css/StyleRuleType.h
@@ -51,6 +51,7 @@ enum class StyleRuleType : uint8_t {
     FontPaletteValues,
     FontFeatureValuesBlock,
     Property,
+    StyleWithNesting,
 };
 
 static constexpr auto firstUnexposedStyleRuleType = StyleRuleType::LayerBlock;

--- a/Source/WebCore/css/StyleSheetContents.cpp
+++ b/Source/WebCore/css/StyleSheetContents.cpp
@@ -498,6 +498,8 @@ bool StyleSheetContents::traverseSubresources(const Function<bool(const CachedRe
         switch (rule.type()) {
         case StyleRuleType::Style:
             return downcast<StyleRule>(rule).properties().traverseSubresources(handler);
+        case StyleRuleType::StyleWithNesting:
+            return downcast<StyleRuleWithNesting>(rule).properties().traverseSubresources(handler);
         case StyleRuleType::FontFace:
             return downcast<StyleRuleFontFace>(rule).properties().traverseSubresources(handler);
         case StyleRuleType::Import:

--- a/Source/WebCore/css/parser/CSSParserImpl.h
+++ b/Source/WebCore/css/parser/CSSParserImpl.h
@@ -155,7 +155,7 @@ private:
     RefPtr<StyleRuleProperty> consumePropertyRule(CSSParserTokenRange prelude, CSSParserTokenRange block);
 
     RefPtr<StyleRuleKeyframe> consumeKeyframeStyleRule(CSSParserTokenRange prelude, CSSParserTokenRange block);
-    RefPtr<StyleRule> consumeStyleRule(CSSParserTokenRange prelude, CSSParserTokenRange block);
+    RefPtr<StyleRuleBase> consumeStyleRule(CSSParserTokenRange prelude, CSSParserTokenRange block);
     ParsedPropertyVector consumeDeclarationListInNewNestingContext(CSSParserTokenRange, StyleRuleType);
 
     enum class OnlyDeclarations {

--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -87,6 +87,7 @@ static RuleFlatteningStrategy flatteningStrategyForStyleRuleType(StyleRuleType s
 {
     switch (styleRuleType) {
     case StyleRuleType::Style:
+    case StyleRuleType::StyleWithNesting:
     case StyleRuleType::Media:
     case StyleRuleType::Supports:
     case StyleRuleType::LayerBlock:

--- a/Source/WebCore/style/RuleSetBuilder.h
+++ b/Source/WebCore/style/RuleSetBuilder.h
@@ -39,10 +39,12 @@ public:
 private:
     RuleSetBuilder(const MQ::MediaQueryEvaluator&);
 
+    void addStyleRule(const StyleRuleWithNesting&);
     void addRulesFromSheetContents(const StyleSheetContents&);
     void addChildRules(const Vector<RefPtr<StyleRuleBase>>&);
     void addChildRule(RefPtr<StyleRuleBase>);
     void disallowDynamicMediaQueryEvaluationIfNeeded();
+    void addStyleRuleWithSelectorList(const CSSSelectorList&, const StyleRule&);
 
     void registerLayers(const Vector<CascadeLayerName>&);
     void pushCascadeLayer(const CascadeLayerName&);
@@ -51,7 +53,7 @@ private:
     
     void addMutatingRulesToResolver();
     void updateDynamicMediaQueries();
-    void populateStyleRuleResolvedSelectorList(const StyleRule&);
+    void populateStyleRuleResolvedSelectorList(const StyleRuleWithNesting&);
 
     struct MediaQueryCollector {
         ~MediaQueryCollector();


### PR DESCRIPTION
#### 9db1de406e2b5f350982be72632decc09b81e33f
<pre>
Save memory when StyleRule doesn&apos;t need nesting support
<a href="https://bugs.webkit.org/show_bug.cgi?id=252176">https://bugs.webkit.org/show_bug.cgi?id=252176</a>
rdar://105399781

Reviewed by Antti Koivisto.

Support for CSS Nesting has added 2 members to the StyleRule class
(the resolved selector list, and the list of children rules),
which created a memory regression of Membuster.

This patch creates a separate StyleWithNestingRule to be used when we actually
need the CSS Nesting feature (which is determined at parsing time).

When we don&apos;t need the CSS Nesting feature, it has exactly zero memory cost.

* Source/WebCore/bindings/js/JSCSSRuleCustom.cpp:
(WebCore::toJSNewlyCreated):
* Source/WebCore/css/CSSSelectorList.cpp:
(WebCore::CSSSelectorList::hasExplicitNestingParent const):
* Source/WebCore/css/CSSSelectorList.h:
* Source/WebCore/css/CSSStyleRule.cpp:
(WebCore::CSSStyleRule::CSSStyleRule):
(WebCore::CSSStyleRule::nestedRules const):
(WebCore::CSSStyleRule::cssText const):
(WebCore::CSSStyleRule::length const):
(WebCore::CSSStyleRule::item const):
* Source/WebCore/css/CSSStyleRule.h:
* Source/WebCore/css/StyleRule.cpp:
(WebCore::StyleRuleBase::visitDerived):
(WebCore::StyleRuleBase::createCSSOMWrapper const):
(WebCore::StyleRule::StyleRule):
(WebCore::StyleRule::create):
(WebCore::StyleRule::createForSplitting):
(WebCore::StyleRule::resolvedSelectorList const):
(WebCore::StyleRuleWithNesting::create):
(WebCore::StyleRuleWithNesting::StyleRuleWithNesting):
(WebCore::StyleRuleWithNesting::setResolvedSelectorList const):
(WebCore::StyleRuleGroup::StyleRuleGroup):
(WebCore::StyleRuleRareData::createIfNeeded): Deleted.
(WebCore::StyleRule::rareData const): Deleted.
(WebCore::StyleRule::setNestedRules): Deleted.
(WebCore::StyleRule::setResolvedSelectorList const): Deleted.
(WebCore::emptyRuleVector): Deleted.
(WebCore::StyleRule::nestedRules const): Deleted.
* Source/WebCore/css/StyleRule.h:
(WebCore::StyleRuleBase::isStyleRule const):
(WebCore::StyleRuleBase::isStyleRuleWithNesting const):
(WebCore::StyleRuleBase::setType):
(isType):
(WebCore::StyleRuleRareData::createIfNeeded): Deleted.
* Source/WebCore/css/StyleRuleType.h:
* Source/WebCore/css/StyleSheetContents.cpp:
(WebCore::StyleSheetContents::traverseSubresources const):
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::createNestingParentRule):
(WebCore::CSSParserImpl::consumeStyleRule):
* Source/WebCore/css/parser/CSSParserImpl.h:
* Source/WebCore/inspector/InspectorStyleSheet.cpp:
(WebCore::flatteningStrategyForStyleRuleType):
* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::addChildRule):
(WebCore::Style::RuleSetBuilder::populateStyleRuleResolvedSelectorList):
(WebCore::Style::RuleSetBuilder::addStyleRuleWithSelectorList):
(WebCore::Style::RuleSetBuilder::addStyleRule):
* Source/WebCore/style/RuleSetBuilder.h:

Canonical link: <a href="https://commits.webkit.org/260281@main">https://commits.webkit.org/260281@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77fd382be22b4e273f5c0e9a37a3e8ab08d08c43

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107719 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16772 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40615 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116866 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116256 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111609 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18192 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8091 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99895 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113473 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13742 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96940 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41427 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95649 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28580 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/97017 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9748 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29928 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/96411 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/7784 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10429 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6815 "Passed tests") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/30844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15901 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49509 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/105391 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7113 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11991 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26113 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->