### PR TITLE
Refactor caret painting logic

### DIFF
--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -163,17 +163,37 @@ static inline bool isPageActive(Document* document)
 #import <WebKitAdditions/FrameSelectionAdditions.cpp>
 #else
 #if ENABLE(TEXT_CARET)
-static void fillCaretRect(const Node&, GraphicsContext& context, const FloatRect& caret, const Color&color, const CaretAnimator::PresentationProperties&)
+static void fillCaretRect(const Node&, GraphicsContext& context, const FloatRect& caret, const Color&color, const LayoutPoint&, CaretAnimator*)
 {
     context.fillRect(caret, color);
 }
 #endif
 
-static UniqueRef<CaretAnimator> createCaretAnimator(FrameSelection* frameSelection)
+static UniqueRef<CaretAnimator> createCaretAnimator(FrameSelection* frameSelection, CaretAnimatorType = CaretAnimatorType::Default)
 {
     return makeUniqueRef<SimpleCaretAnimator>(*frameSelection);
 }
+#endif // USE(APPLE_INTERNAL_SDK)
+
+// FIXME: Remove staging once repaintCaretRectForLocalRect is defined in FrameSelectionAdditions.cpp
+#ifndef FRAME_SELECTION_ADDITIONS_REPAINT_CARET_RECT_FOR_LOCAL_RECT_DEFINED
+static LayoutRect repaintCaretRectForLocalRect(LayoutRect rect, CaretAnimator*)
+{
+    return rect;
+}
+
+#if USE(APPLE_INTERNAL_SDK)
+static void fillCaretRect(const Node& node, GraphicsContext& context, const FloatRect& caret, const Color& color, const LayoutPoint&, CaretAnimator* animator)
+{
+    fillCaretRect(node, context, caret, color, animator ? animator->presentationProperties() : CaretAnimator::PresentationProperties());
+}
+
+static UniqueRef<CaretAnimator> createCaretAnimator(FrameSelection* frameSelection, CaretAnimatorType)
+{
+    return createCaretAnimator(frameSelection);
+}
 #endif
+#endif // FRAME_SELECTION_ADDITIONS_REPAINT_CARET_RECT_FOR_LOCAL_RECT_DEFINED
 
 FrameSelection::FrameSelection(Document* document)
     : m_document(document)
@@ -1766,10 +1786,10 @@ IntRect FrameSelection::absoluteCaretBounds(bool* insideFixed)
     return m_absCaretBounds;
 }
 
-static void repaintCaretForLocalRect(Node* node, const LayoutRect& rect)
+static void repaintCaretForLocalRect(Node* node, const LayoutRect& rect, CaretAnimator* caretAnimator)
 {
     if (auto* caretPainter = rendererForCaretPainting(node))
-        caretPainter->repaintRectangle(rect);
+        caretPainter->repaintRectangle(repaintCaretRectForLocalRect(rect, caretAnimator));
 }
 
 bool FrameSelection::recomputeCaretRect()
@@ -1821,9 +1841,9 @@ bool FrameSelection::recomputeCaretRect()
         bool previousOrNewCaretNodeIsContentEditable = m_selection.isContentEditable() || (m_previousCaretNode && m_previousCaretNode->isContentEditable());
         if (shouldRepaintCaret(view, previousOrNewCaretNodeIsContentEditable)) {
             if (m_previousCaretNode)
-                repaintCaretForLocalRect(m_previousCaretNode.get(), oldRect);
+                repaintCaretForLocalRect(m_previousCaretNode.get(), oldRect, m_caretAnimator.ptr());
             m_previousCaretNode = caretNode;
-            repaintCaretForLocalRect(caretNode.get(), newRect);
+            repaintCaretForLocalRect(caretNode.get(), newRect, m_caretAnimator.ptr());
         }
     }
 #endif
@@ -1843,10 +1863,10 @@ void FrameSelection::invalidateCaretRect()
     if (!isCaret())
         return;
 
-    CaretBase::invalidateCaretRect(m_selection.start().deprecatedNode(), recomputeCaretRect());
+    CaretBase::invalidateCaretRect(m_selection.start().deprecatedNode(), recomputeCaretRect(), m_caretAnimator.ptr());
 }
 
-void CaretBase::invalidateCaretRect(Node* node, bool caretRectChanged)
+void CaretBase::invalidateCaretRect(Node* node, bool caretRectChanged, CaretAnimator* caretAnimator)
 {
     // EDIT FIXME: This is an unfortunate hack.
     // Basically, we can't trust this layout position since we 
@@ -1866,14 +1886,14 @@ void CaretBase::invalidateCaretRect(Node* node, bool caretRectChanged)
 
     if (RenderView* view = node->document().renderView()) {
         if (shouldRepaintCaret(view, isEditableNode(*node)))
-            repaintCaretForLocalRect(node, localCaretRectWithoutUpdate());
+            repaintCaretForLocalRect(node, localCaretRectWithoutUpdate(), caretAnimator);
     }
 }
 
 void FrameSelection::paintCaret(GraphicsContext& context, const LayoutPoint& paintOffset, const LayoutRect& clipRect)
 {
     if (m_selection.isCaret() && m_selection.start().deprecatedNode())
-        CaretBase::paintCaret(*m_selection.start().deprecatedNode(), context, paintOffset, clipRect, m_caretAnimator->presentationProperties());
+        CaretBase::paintCaret(*m_selection.start().deprecatedNode(), context, paintOffset, clipRect, m_caretAnimator.ptr());
 }
 
 Color CaretBase::computeCaretColor(const RenderStyle& elementStyle, const Node* node)
@@ -1899,9 +1919,10 @@ Color CaretBase::computeCaretColor(const RenderStyle& elementStyle, const Node* 
 #endif
 }
 
-void CaretBase::paintCaret(const Node& node, GraphicsContext& context, const LayoutPoint& paintOffset, const LayoutRect& clipRect, const CaretAnimator::PresentationProperties& caretPresentationProperties) const
+void CaretBase::paintCaret(const Node& node, GraphicsContext& context, const LayoutPoint& paintOffset, const LayoutRect& clipRect, CaretAnimator* caretAnimator) const
 {
 #if ENABLE(TEXT_CARET)
+    auto caretPresentationProperties = caretAnimator ? caretAnimator->presentationProperties() : CaretAnimator::PresentationProperties();
     if (m_caretVisibility == Hidden || caretPresentationProperties.blinkState == CaretAnimator::PresentationProperties::BlinkState::Off)
         return;
 
@@ -1919,13 +1940,13 @@ void CaretBase::paintCaret(const Node& node, GraphicsContext& context, const Lay
         caretColor = CaretBase::computeCaretColor(element->renderer()->style(), &node);
 
     auto pixelSnappedCaretRect = snapRectToDevicePixels(caret, node.document().deviceScaleFactor());
-    fillCaretRect(node, context, pixelSnappedCaretRect, caretColor, caretPresentationProperties);
+    fillCaretRect(node, context, pixelSnappedCaretRect, caretColor, paintOffset, caretAnimator);
 #else
     UNUSED_PARAM(node);
     UNUSED_PARAM(context);
     UNUSED_PARAM(paintOffset);
     UNUSED_PARAM(clipRect);
-    UNUSED_PARAM(caretPresentationProperties);
+    UNUSED_PARAM(caretAnimator);
 #endif
 }
 
@@ -1942,6 +1963,11 @@ bool FrameSelection::isCaretBlinkingSuspended() const
 void FrameSelection::caretAnimationDidUpdate(CaretAnimator&)
 {
     invalidateCaretRect();
+}
+
+void FrameSelection::caretAnimatorInvalidated(CaretAnimator&, CaretAnimatorType newCaretType)
+{
+    m_caretAnimator = createCaretAnimator(this, newCaretType);
 }
 
 Document* FrameSelection::document()
@@ -2344,7 +2370,7 @@ void DragCaretController::paintDragCaret(Frame* frame, GraphicsContext& p, const
 {
 #if ENABLE(TEXT_CARET)
     if (m_position.deepEquivalent().deprecatedNode() && m_position.deepEquivalent().deprecatedNode()->document().frame() == frame)
-        paintCaret(*m_position.deepEquivalent().deprecatedNode(), p, paintOffset, clipRect, { });
+        paintCaret(*m_position.deepEquivalent().deprecatedNode(), p, paintOffset, clipRect);
 #else
     UNUSED_PARAM(frame);
     UNUSED_PARAM(p);

--- a/Source/WebCore/editing/FrameSelection.h
+++ b/Source/WebCore/editing/FrameSelection.h
@@ -64,11 +64,11 @@ protected:
     enum CaretVisibility { Visible, Hidden };
     explicit CaretBase(CaretVisibility = Hidden);
 
-    void invalidateCaretRect(Node*, bool caretRectChanged = false);
+    void invalidateCaretRect(Node*, bool caretRectChanged = false, CaretAnimator* = nullptr);
     void clearCaretRect();
     bool updateCaretRect(Document&, const VisiblePosition& caretPosition);
     bool shouldRepaintCaret(const RenderView*, bool isContentEditable) const;
-    void paintCaret(const Node&, GraphicsContext&, const LayoutPoint&, const LayoutRect& clipRect, const CaretAnimator::PresentationProperties&) const;
+    void paintCaret(const Node&, GraphicsContext&, const LayoutPoint&, const LayoutRect& clipRect, CaretAnimator* = nullptr) const;
 
     const LayoutRect& localCaretRectWithoutUpdate() const { return m_caretLocalRect; }
 
@@ -320,6 +320,7 @@ private:
     void invalidateCaretRect();
 
     void caretAnimationDidUpdate(CaretAnimator&) final;
+    void caretAnimatorInvalidated(CaretAnimator&, CaretAnimatorType) final;
 
     Document* document() final;
 
@@ -330,6 +331,7 @@ private:
 #endif
 
     void updateAssociatedLiveRange();
+    LayoutRect localCaretRect() const final { return localCaretRectWithoutUpdate(); }
 
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
     RefPtr<Range> m_associatedLiveRange;

--- a/Source/WebCore/platform/CaretAnimator.h
+++ b/Source/WebCore/platform/CaretAnimator.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "LayoutRect.h"
 #include "ReducedResolutionSeconds.h"
 #include "Timer.h"
 
@@ -34,11 +35,18 @@ class CaretAnimator;
 class Document;
 class Page;
 
+enum class CaretAnimatorType {
+    Default,
+    Alternate
+};
+
 class CaretAnimationClient {
 public:
     virtual ~CaretAnimationClient() = default;
 
     virtual void caretAnimationDidUpdate(CaretAnimator&) { }
+    virtual void caretAnimatorInvalidated(CaretAnimator&, CaretAnimatorType) { }
+    virtual LayoutRect localCaretRect() const = 0;
 
     virtual Document* document() = 0;
 };
@@ -78,6 +86,7 @@ public:
     virtual void setVisible(bool) = 0;
 
     PresentationProperties presentationProperties() const { return m_presentationProperties; }
+    virtual CaretAnimatorType type() const { return CaretAnimatorType::Default; }
 
 protected:
     explicit CaretAnimator(CaretAnimationClient& client)

--- a/Source/WebCore/rendering/RenderBlock.h
+++ b/Source/WebCore/rendering/RenderBlock.h
@@ -450,6 +450,7 @@ private:
     virtual void paintColumnRules(PaintInfo&, const LayoutPoint&) { };
     void paintSelection(PaintInfo&, const LayoutPoint&);
     void paintCaret(PaintInfo&, const LayoutPoint&, CaretType);
+    void paintCarets(PaintInfo&, const LayoutPoint&);
 
     virtual bool hitTestContents(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction);
     // FIXME-BLOCKFLOW: Remove virtualization when all callers have moved to RenderBlockFlow


### PR DESCRIPTION
#### e314f573db05b5bdbed3b794661dc0144f32ba16
<pre>
Refactor caret painting logic
<a href="https://bugs.webkit.org/show_bug.cgi?id=252148">https://bugs.webkit.org/show_bug.cgi?id=252148</a>
&lt;radar://104975415&gt;

Reviewed by Ryosuke Niwa and Aditya Keerthi.

Continue previous refactorings to the caret painting
logic to allow some additional flexibility.

* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::fillCaretRect):
Pass not just the presentation properties but the entire
animator to allow for additional flexibility.

(WebCore::repaintCaretRectForLocalRect):
(WebCore::repaintCaretForLocalRect):
Allow the animator to influence the repaint rect.

(WebCore::FrameSelection::invalidateCaretRect):
(WebCore::CaretBase::invalidateCaretRect):
(WebCore::FrameSelection::paintCaret):
(WebCore::CaretBase::paintCaret const):
(WebCore::DragCaretController::paintDragCaret const):
* Source/WebCore/editing/FrameSelection.h:
Pass the caret animator instead of just its properties.

* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::renderCaretInsideContentsClip):
(WebCore::RenderBlock::paint):
(WebCore::RenderBlock::paintObject):
Allow rendering the caret outside the element&apos;s clipping rectangle.

Canonical link: <a href="https://commits.webkit.org/260775@main">https://commits.webkit.org/260775@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1832b987e2206700c1d14fea1c6f8be6b0ede6b3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109322 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18401 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42136 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/829 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118533 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113205 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19845 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9686 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101559 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115077 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14872 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98103 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43059 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96844 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29756 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84822 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11172 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/31099 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11909 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8029 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/17276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50702 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7455 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13526 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->