### PR TITLE
[AppleWin] Remove Windows code from PixelDumpSupportCG

### DIFF
--- a/Tools/DumpRenderTree/cg/PixelDumpSupportCG.h
+++ b/Tools/DumpRenderTree/cg/PixelDumpSupportCG.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005, 2006, 2007 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2023 Apple Inc. All rights reserved.
  *           (C) 2007 Graham Dennis (graham.dennis@gmail.com)
  *           (C) 2007 Eric Seidel <eric@webkit.org>
  *
@@ -33,34 +33,18 @@
 #include <wtf/RefCounted.h>
 #include <wtf/RetainPtr.h>
 
-#if PLATFORM(WIN)
-#include <windows.h>
-#endif
-
 typedef struct CGContext* CGContextRef;
 
-#if PLATFORM(COCOA)
-typedef void* PlatformBitmapBuffer;
-#elif PLATFORM(WIN)
-typedef HBITMAP PlatformBitmapBuffer;
-#endif
+using UniqueBitmapBuffer = std::unique_ptr<void, decltype(std::free) *>;
 
 class BitmapContext : public RefCounted<BitmapContext> {
 public:
-    static Ref<BitmapContext> createByAdoptingBitmapAndContext(PlatformBitmapBuffer buffer, RetainPtr<CGContextRef>&& context)
+    static Ref<BitmapContext> createByAdoptingBitmapAndContext(UniqueBitmapBuffer&& buffer, RetainPtr<CGContextRef>&& context)
     {
-        return adoptRef(*new BitmapContext(buffer, WTFMove(context)));
+        return adoptRef(*new BitmapContext(WTFMove(buffer), WTFMove(context)));
     }
 
-    ~BitmapContext()
-    {
-        if (m_buffer)
-#if PLATFORM(COCOA)
-            free(m_buffer);
-#elif PLATFORM(WIN)
-            DeleteObject(m_buffer);
-#endif
-    }
+    ~BitmapContext() = default;
 
     CGContextRef cgContext() const { return m_context.get(); }
     
@@ -69,18 +53,16 @@ public:
 
 private:
 
-    BitmapContext(PlatformBitmapBuffer buffer, RetainPtr<CGContextRef>&& context)
-        : m_buffer(buffer)
+    BitmapContext(UniqueBitmapBuffer&& buffer, RetainPtr<CGContextRef>&& context)
+        : m_buffer(WTFMove(buffer))
         , m_context(WTFMove(context))
     {
     }
 
-    PlatformBitmapBuffer m_buffer;
+    UniqueBitmapBuffer m_buffer;
     RetainPtr<CGContextRef> m_context;
     double m_scaleFactor { 1.0 };
 };
 
-#if PLATFORM(COCOA)
-RefPtr<BitmapContext> createBitmapContext(size_t pixelsWide, size_t pixelsHigh, size_t& rowBytes, void*& buffer);
-#endif
+RefPtr<BitmapContext> createBitmapContext(size_t pixelsWide, size_t pixelsHigh, size_t& rowBytes);
 RefPtr<BitmapContext> createBitmapContextFromWebView(bool onscreen, bool incrementalRepaint, bool sweepHorizontally, bool drawSelectionRect);

--- a/Tools/DumpRenderTree/ios/PixelDumpSupportIOS.mm
+++ b/Tools/DumpRenderTree/ios/PixelDumpSupportIOS.mm
@@ -75,9 +75,8 @@ RefPtr<BitmapContext> createBitmapContextFromWebView(bool onscreen, bool increme
     auto surface = WebCore::IOSurface::create(nullptr, WebCore::expandedIntSize(snapshotSize), WebCore::DestinationColorSpace::SRGB(), snapshotFormat);
     RetainPtr<CGImageRef> cgImage = surface->createImage();
 
-    void* bitmapBuffer = nullptr;
     size_t bitmapRowBytes = 0;
-    auto bitmapContext = createBitmapContext(bufferWidth, bufferHeight, bitmapRowBytes, bitmapBuffer);
+    auto bitmapContext = createBitmapContext(bufferWidth, bufferHeight, bitmapRowBytes);
     if (!bitmapContext)
         return nullptr;
 

--- a/Tools/DumpRenderTree/mac/PixelDumpSupportMac.mm
+++ b/Tools/DumpRenderTree/mac/PixelDumpSupportMac.mm
@@ -99,8 +99,7 @@ RefPtr<BitmapContext> createBitmapContextFromWebView(bool onscreen, bool increme
     size_t pixelsWide = static_cast<size_t>(webViewSize.width * deviceScaleFactor);
     size_t pixelsHigh = static_cast<size_t>(webViewSize.height * deviceScaleFactor);
     size_t rowBytes = 0;
-    void* buffer = nullptr;
-    auto bitmapContext = createBitmapContext(pixelsWide, pixelsHigh, rowBytes, buffer);
+    auto bitmapContext = createBitmapContext(pixelsWide, pixelsHigh, rowBytes);
     if (!bitmapContext)
         return nullptr;
 
@@ -180,11 +179,10 @@ RefPtr<BitmapContext> createPagedBitmapContext()
     int pageHeightInPixels = TestRunner::viewHeight;
     int numberOfPages = [mainFrame numberOfPagesWithPageWidth:pageWidthInPixels pageHeight:pageHeightInPixels];
     size_t rowBytes = 0;
-    void* buffer = nullptr;
 
     int totalHeight = numberOfPages * (pageHeightInPixels + 1) - 1;
 
-    auto bitmapContext = createBitmapContext(pageWidthInPixels, totalHeight, rowBytes, buffer);
+    auto bitmapContext = createBitmapContext(pageWidthInPixels, totalHeight, rowBytes);
     CGContextRef context = bitmapContext->cgContext();
     CGContextTranslateCTM(context, 0, totalHeight);
     CGContextScaleCTM(context, 1, -1);


### PR DESCRIPTION
#### 9c0ec4ce794727ac17dac792da8086fa1a438643
<pre>
[AppleWin] Remove Windows code from PixelDumpSupportCG
<a href="https://bugs.webkit.org/show_bug.cgi?id=252197">https://bugs.webkit.org/show_bug.cgi?id=252197</a>

Reviewed by Don Olmstead and Darin Adler.

The testing code in PixelDumpSupportCG.h/PixelDumpSupportCG.cpp used to build on
Windows. We don&apos;t need this support anymore, and should remove it.

This change also switches from a raw buffer to a unique_ptr to clean up the
code a bit.

* Tools/DumpRenderTree/cg/PixelDumpSupportCG.cpp:
(computeSHA1HashStringForBitmapContext):
(createBitmapContext):
* Tools/DumpRenderTree/cg/PixelDumpSupportCG.h:
(BitmapContext::createByAdoptingBitmapAndContext):
(BitmapContext::BitmapContext):
(BitmapContext::~BitmapContext): Deleted.
* Tools/DumpRenderTree/ios/PixelDumpSupportIOS.mm:
(createBitmapContextFromWebView): Remove unneeded buffer argument.
* Tools/DumpRenderTree/mac/PixelDumpSupportMac.mm:
(createBitmapContextFromWebView): Ditto.
(createPagedBitmapContext): Ditto.

Canonical link: <a href="https://commits.webkit.org/260265@main">https://commits.webkit.org/260265@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7ac18a5cc733022edb147ad8273a302a838c475

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107624 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16677 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40519 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116773 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116179 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111518 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18097 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7991 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99795 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113379 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13666 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96859 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41328 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95578 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28486 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/83171 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9664 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29838 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10339 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6733 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15818 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49420 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7096 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11899 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->