### PR TITLE
[WGSL] Replace Expected<T, Error> with Result<T>

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
@@ -36,7 +36,7 @@ bool Visitor::hasError() const
     return !m_expectedError;
 }
 
-Expected<void, Error> Visitor::result()
+Result<void> Visitor::result()
 {
     return m_expectedError;
 }

--- a/Source/WebGPU/WGSL/AST/ASTVisitor.h
+++ b/Source/WebGPU/WGSL/AST/ASTVisitor.h
@@ -122,7 +122,7 @@ public:
     virtual void visit(AST::VariableQualifier&);
 
     bool hasError() const;
-    Expected<void, Error> result();
+    Result<void> result();
 
     template<typename T> void checkErrorAndVisit(T& x)
     {
@@ -144,7 +144,7 @@ protected:
     }
 
 private:
-    Expected<void, Error> m_expectedError;
+    Result<void> m_expectedError;
 };
 
 } // namespace AST

--- a/Source/WebGPU/WGSL/CompilationMessage.h
+++ b/Source/WebGPU/WGSL/CompilationMessage.h
@@ -55,5 +55,7 @@ private:
 
 using Warning = CompilationMessage;
 using Error = CompilationMessage;
+template <typename T>
+using Result = Expected<T, Error>;
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -253,7 +253,7 @@ std::optional<Error> parse(ShaderModule& shaderModule)
 }
 
 template<typename Lexer>
-Expected<AST::Expression::Ref, Error> parseExpression(const String& source)
+Result<AST::Expression::Ref> parseExpression(const String& source)
 {
     ShaderModule shaderModule(source);
     Lexer lexer(shaderModule.source());
@@ -261,7 +261,7 @@ Expected<AST::Expression::Ref, Error> parseExpression(const String& source)
     return parser.parseExpression();
 }
 
-Expected<AST::Expression::Ref, Error> parseExpression(const String& source)
+Result<AST::Expression::Ref> parseExpression(const String& source)
 {
     if (source.is8Bit())
         return parseExpression<Lexer<LChar>>(source);
@@ -286,7 +286,7 @@ void Parser<Lexer>::consume()
 }
 
 template<typename Lexer>
-Expected<void, Error> Parser<Lexer>::parseShader()
+Result<void> Parser<Lexer>::parseShader()
 {
     // FIXME: parse directives here.
 
@@ -300,7 +300,7 @@ Expected<void, Error> Parser<Lexer>::parseShader()
 }
 
 template<typename Lexer>
-Expected<AST::Identifier, Error> Parser<Lexer>::parseIdentifier()
+Result<AST::Identifier> Parser<Lexer>::parseIdentifier()
 {
     START_PARSE();
 
@@ -310,7 +310,7 @@ Expected<AST::Identifier, Error> Parser<Lexer>::parseIdentifier()
 }
 
 template<typename Lexer>
-Expected<void, Error> Parser<Lexer>::parseGlobalDecl()
+Result<void> Parser<Lexer>::parseGlobalDecl()
 {
     START_PARSE();
 
@@ -342,7 +342,7 @@ Expected<void, Error> Parser<Lexer>::parseGlobalDecl()
 }
 
 template<typename Lexer>
-Expected<AST::Attribute::List, Error> Parser<Lexer>::parseAttributes()
+Result<AST::Attribute::List> Parser<Lexer>::parseAttributes()
 {
     AST::Attribute::List attributes;
 
@@ -355,7 +355,7 @@ Expected<AST::Attribute::List, Error> Parser<Lexer>::parseAttributes()
 }
 
 template<typename Lexer>
-Expected<Ref<AST::Attribute>, Error> Parser<Lexer>::parseAttribute()
+Result<Ref<AST::Attribute>> Parser<Lexer>::parseAttribute()
 {
     START_PARSE();
 
@@ -413,7 +413,7 @@ Expected<Ref<AST::Attribute>, Error> Parser<Lexer>::parseAttribute()
 }
 
 template<typename Lexer>
-Expected<AST::Structure::Ref, Error> Parser<Lexer>::parseStructure(AST::Attribute::List&& attributes)
+Result<AST::Structure::Ref> Parser<Lexer>::parseStructure(AST::Attribute::List&& attributes)
 {
     START_PARSE();
 
@@ -437,7 +437,7 @@ Expected<AST::Structure::Ref, Error> Parser<Lexer>::parseStructure(AST::Attribut
 }
 
 template<typename Lexer>
-Expected<AST::StructureMember, Error> Parser<Lexer>::parseStructureMember()
+Result<AST::StructureMember> Parser<Lexer>::parseStructureMember()
 {
     START_PARSE();
 
@@ -450,7 +450,7 @@ Expected<AST::StructureMember, Error> Parser<Lexer>::parseStructureMember()
 }
 
 template<typename Lexer>
-Expected<AST::TypeName::Ref, Error> Parser<Lexer>::parseTypeName()
+Result<AST::TypeName::Ref> Parser<Lexer>::parseTypeName()
 {
     START_PARSE();
 
@@ -481,7 +481,7 @@ Expected<AST::TypeName::Ref, Error> Parser<Lexer>::parseTypeName()
 }
 
 template<typename Lexer>
-Expected<AST::TypeName::Ref, Error> Parser<Lexer>::parseTypeNameAfterIdentifier(AST::Identifier&& name, SourcePosition _startOfElementPosition)
+Result<AST::TypeName::Ref> Parser<Lexer>::parseTypeNameAfterIdentifier(AST::Identifier&& name, SourcePosition _startOfElementPosition) // NOLINT
 {
     if (auto kind = AST::ParameterizedTypeName::stringViewToKind(name.id())) {
         CONSUME_TYPE(Lt);
@@ -493,7 +493,7 @@ Expected<AST::TypeName::Ref, Error> Parser<Lexer>::parseTypeNameAfterIdentifier(
 }
 
 template<typename Lexer>
-Expected<AST::TypeName::Ref, Error> Parser<Lexer>::parseArrayType()
+Result<AST::TypeName::Ref> Parser<Lexer>::parseArrayType()
 {
     START_PARSE();
 
@@ -528,13 +528,13 @@ Expected<AST::TypeName::Ref, Error> Parser<Lexer>::parseArrayType()
 }
 
 template<typename Lexer>
-Expected<AST::Variable::Ref, Error> Parser<Lexer>::parseVariable()
+Result<AST::Variable::Ref> Parser<Lexer>::parseVariable()
 {
     return parseVariableWithAttributes(AST::Attribute::List { });
 }
 
 template<typename Lexer>
-Expected<AST::Variable::Ref, Error> Parser<Lexer>::parseVariableWithAttributes(AST::Attribute::List&& attributes)
+Result<AST::Variable::Ref> Parser<Lexer>::parseVariableWithAttributes(AST::Attribute::List&& attributes)
 {
     START_PARSE();
 
@@ -566,7 +566,7 @@ Expected<AST::Variable::Ref, Error> Parser<Lexer>::parseVariableWithAttributes(A
 }
 
 template<typename Lexer>
-Expected<AST::VariableQualifier, Error> Parser<Lexer>::parseVariableQualifier()
+Result<AST::VariableQualifier> Parser<Lexer>::parseVariableQualifier()
 {
     START_PARSE();
 
@@ -587,7 +587,7 @@ Expected<AST::VariableQualifier, Error> Parser<Lexer>::parseVariableQualifier()
 }
 
 template<typename Lexer>
-Expected<AST::StorageClass, Error> Parser<Lexer>::parseStorageClass()
+Result<AST::StorageClass> Parser<Lexer>::parseStorageClass()
 {
     START_PARSE();
 
@@ -616,7 +616,7 @@ Expected<AST::StorageClass, Error> Parser<Lexer>::parseStorageClass()
 }
 
 template<typename Lexer>
-Expected<AST::AccessMode, Error> Parser<Lexer>::parseAccessMode()
+Result<AST::AccessMode> Parser<Lexer>::parseAccessMode()
 {
     START_PARSE();
 
@@ -637,7 +637,7 @@ Expected<AST::AccessMode, Error> Parser<Lexer>::parseAccessMode()
 }
 
 template<typename Lexer>
-Expected<AST::Function, Error> Parser<Lexer>::parseFunction(AST::Attribute::List&& attributes)
+Result<AST::Function> Parser<Lexer>::parseFunction(AST::Attribute::List&& attributes)
 {
     START_PARSE();
 
@@ -672,7 +672,7 @@ Expected<AST::Function, Error> Parser<Lexer>::parseFunction(AST::Attribute::List
 }
 
 template<typename Lexer>
-Expected<AST::ParameterValue, Error> Parser<Lexer>::parseParameterValue()
+Result<AST::ParameterValue> Parser<Lexer>::parseParameterValue()
 {
     START_PARSE();
 
@@ -685,7 +685,7 @@ Expected<AST::ParameterValue, Error> Parser<Lexer>::parseParameterValue()
 }
 
 template<typename Lexer>
-Expected<UniqueRef<AST::Statement>, Error> Parser<Lexer>::parseStatement()
+Result<AST::Statement::Ref> Parser<Lexer>::parseStatement()
 {
     START_PARSE();
 
@@ -721,7 +721,7 @@ Expected<UniqueRef<AST::Statement>, Error> Parser<Lexer>::parseStatement()
 }
 
 template<typename Lexer>
-Expected<AST::CompoundStatement, Error> Parser<Lexer>::parseCompoundStatement()
+Result<AST::CompoundStatement> Parser<Lexer>::parseCompoundStatement()
 {
     START_PARSE();
 
@@ -739,7 +739,7 @@ Expected<AST::CompoundStatement, Error> Parser<Lexer>::parseCompoundStatement()
 }
 
 template<typename Lexer>
-Expected<AST::ReturnStatement, Error> Parser<Lexer>::parseReturnStatement()
+Result<AST::ReturnStatement> Parser<Lexer>::parseReturnStatement()
 {
     START_PARSE();
 
@@ -754,7 +754,7 @@ Expected<AST::ReturnStatement, Error> Parser<Lexer>::parseReturnStatement()
 }
 
 template<typename Lexer>
-Expected<UniqueRef<AST::Expression>, Error> Parser<Lexer>::parseRelationalExpressionPostUnary(AST::Expression::Ref&& lhs)
+Result<AST::Expression::Ref> Parser<Lexer>::parseRelationalExpressionPostUnary(AST::Expression::Ref&& lhs)
 {
     START_PARSE();
     PARSE_MOVE(lhs, ShiftExpressionPostUnary, WTFMove(lhs));
@@ -770,7 +770,7 @@ Expected<UniqueRef<AST::Expression>, Error> Parser<Lexer>::parseRelationalExpres
 }
 
 template<typename Lexer>
-Expected<UniqueRef<AST::Expression>, Error> Parser<Lexer>::parseShiftExpression()
+Result<AST::Expression::Ref> Parser<Lexer>::parseShiftExpression()
 {
     PARSE(unary, UnaryExpression);
     PARSE(shift, ShiftExpressionPostUnary, WTFMove(unary));
@@ -778,7 +778,7 @@ Expected<UniqueRef<AST::Expression>, Error> Parser<Lexer>::parseShiftExpression(
 }
 
 template<typename Lexer>
-Expected<UniqueRef<AST::Expression>, Error> Parser<Lexer>::parseShiftExpressionPostUnary(AST::Expression::Ref&& lhs)
+Result<AST::Expression::Ref> Parser<Lexer>::parseShiftExpressionPostUnary(AST::Expression::Ref&& lhs)
 {
     if (canContinueAdditiveExpression(current()))
         return parseAdditiveExpressionPostUnary(WTFMove(lhs));
@@ -803,7 +803,7 @@ Expected<UniqueRef<AST::Expression>, Error> Parser<Lexer>::parseShiftExpressionP
 }
 
 template<typename Lexer>
-Expected<UniqueRef<AST::Expression>, Error> Parser<Lexer>::parseAdditiveExpressionPostUnary(AST::Expression::Ref&& lhs)
+Result<AST::Expression::Ref> Parser<Lexer>::parseAdditiveExpressionPostUnary(AST::Expression::Ref&& lhs)
 {
     START_PARSE();
     PARSE_MOVE(lhs, MultiplicativeExpressionPostUnary, WTFMove(lhs));
@@ -823,7 +823,7 @@ Expected<UniqueRef<AST::Expression>, Error> Parser<Lexer>::parseAdditiveExpressi
 }
 
 template<typename Lexer>
-Expected<UniqueRef<AST::Expression>, Error> Parser<Lexer>::parseBitwiseExpressionPostUnary(AST::Expression::Ref&& lhs)
+Result<AST::Expression::Ref> Parser<Lexer>::parseBitwiseExpressionPostUnary(AST::Expression::Ref&& lhs)
 {
     START_PARSE();
     const auto op = toBinaryOperation(current());
@@ -838,7 +838,7 @@ Expected<UniqueRef<AST::Expression>, Error> Parser<Lexer>::parseBitwiseExpressio
 }
 
 template<typename Lexer>
-Expected<UniqueRef<AST::Expression>, Error> Parser<Lexer>::parseMultiplicativeExpressionPostUnary(AST::Expression::Ref&& lhs)
+Result<AST::Expression::Ref> Parser<Lexer>::parseMultiplicativeExpressionPostUnary(AST::Expression::Ref&& lhs)
 {
     START_PARSE();
     while (canContinueMultiplicativeExpression(current())) {
@@ -869,7 +869,7 @@ Expected<UniqueRef<AST::Expression>, Error> Parser<Lexer>::parseMultiplicativeEx
 }
 
 template<typename Lexer>
-Expected<UniqueRef<AST::Expression>, Error> Parser<Lexer>::parseUnaryExpression()
+Result<AST::Expression::Ref> Parser<Lexer>::parseUnaryExpression()
 {
     START_PARSE();
 
@@ -884,7 +884,7 @@ Expected<UniqueRef<AST::Expression>, Error> Parser<Lexer>::parseUnaryExpression(
 }
 
 template<typename Lexer>
-Expected<UniqueRef<AST::Expression>, Error> Parser<Lexer>::parseSingularExpression()
+Result<AST::Expression::Ref> Parser<Lexer>::parseSingularExpression()
 {
     START_PARSE();
     PARSE(base, PrimaryExpression);
@@ -892,7 +892,7 @@ Expected<UniqueRef<AST::Expression>, Error> Parser<Lexer>::parseSingularExpressi
 }
 
 template<typename Lexer>
-Expected<UniqueRef<AST::Expression>, Error> Parser<Lexer>::parsePostfixExpression(UniqueRef<AST::Expression>&& base, SourcePosition startPosition)
+Result<AST::Expression::Ref> Parser<Lexer>::parsePostfixExpression(UniqueRef<AST::Expression>&& base, SourcePosition startPosition)
 {
     START_PARSE();
 
@@ -934,7 +934,7 @@ Expected<UniqueRef<AST::Expression>, Error> Parser<Lexer>::parsePostfixExpressio
 //   | paren_expression
 //   | bitcast less_than type_decl greater_than paren_expression
 template<typename Lexer>
-Expected<UniqueRef<AST::Expression>, Error> Parser<Lexer>::parsePrimaryExpression()
+Result<AST::Expression::Ref> Parser<Lexer>::parsePrimaryExpression()
 {
     START_PARSE();
 
@@ -1003,7 +1003,7 @@ Expected<UniqueRef<AST::Expression>, Error> Parser<Lexer>::parsePrimaryExpressio
 }
 
 template<typename Lexer>
-Expected<UniqueRef<AST::Expression>, Error> Parser<Lexer>::parseExpression()
+Result<AST::Expression::Ref> Parser<Lexer>::parseExpression()
 {
     // FIXME: Fill in
     PARSE(lhs, UnaryExpression);
@@ -1014,7 +1014,7 @@ Expected<UniqueRef<AST::Expression>, Error> Parser<Lexer>::parseExpression()
 }
 
 template<typename Lexer>
-Expected<UniqueRef<AST::Expression>, Error> Parser<Lexer>::parseLHSExpression()
+Result<AST::Expression::Ref> Parser<Lexer>::parseLHSExpression()
 {
     START_PARSE();
 
@@ -1024,7 +1024,7 @@ Expected<UniqueRef<AST::Expression>, Error> Parser<Lexer>::parseLHSExpression()
 }
 
 template<typename Lexer>
-Expected<UniqueRef<AST::Expression>, Error> Parser<Lexer>::parseCoreLHSExpression()
+Result<AST::Expression::Ref> Parser<Lexer>::parseCoreLHSExpression()
 {
     START_PARSE();
 
@@ -1047,7 +1047,7 @@ Expected<UniqueRef<AST::Expression>, Error> Parser<Lexer>::parseCoreLHSExpressio
 }
 
 template<typename Lexer>
-Expected<AST::Expression::List, Error> Parser<Lexer>::parseArgumentExpressionList()
+Result<AST::Expression::List> Parser<Lexer>::parseArgumentExpressionList()
 {
     START_PARSE();
     CONSUME_TYPE(ParenLeft);

--- a/Source/WebGPU/WGSL/ParserPrivate.h
+++ b/Source/WebGPU/WGSL/ParserPrivate.h
@@ -50,43 +50,43 @@ public:
     {
     }
 
-    Expected<void, Error> parseShader();
+    Result<void> parseShader();
 
-    // UniqueRef whenever it can return multiple types.
-    Expected<AST::Identifier, Error> parseIdentifier();
-    Expected<void, Error> parseGlobalDecl();
-    Expected<AST::Attribute::List, Error> parseAttributes();
-    Expected<AST::Attribute::Ref, Error> parseAttribute();
-    Expected<AST::Structure::Ref, Error> parseStructure(AST::Attribute::List&&);
-    Expected<AST::StructureMember, Error> parseStructureMember();
-    Expected<AST::TypeName::Ref, Error> parseTypeName();
-    Expected<AST::TypeName::Ref, Error> parseTypeNameAfterIdentifier(AST::Identifier&&, SourcePosition start);
-    Expected<AST::TypeName::Ref, Error> parseArrayType();
-    Expected<AST::Variable::Ref, Error> parseVariable();
-    Expected<AST::Variable::Ref, Error> parseVariableWithAttributes(AST::Attribute::List&&);
-    Expected<AST::VariableQualifier, Error> parseVariableQualifier();
-    Expected<AST::StorageClass, Error> parseStorageClass();
-    Expected<AST::AccessMode, Error> parseAccessMode();
-    Expected<AST::Function, Error> parseFunction(AST::Attribute::List&&);
-    Expected<AST::ParameterValue, Error> parseParameterValue();
-    Expected<AST::Statement::Ref, Error> parseStatement();
-    Expected<AST::CompoundStatement, Error> parseCompoundStatement();
-    Expected<AST::ReturnStatement, Error> parseReturnStatement();
-    Expected<AST::Expression::Ref, Error> parseShortCircuitOrExpression();
-    Expected<AST::Expression::Ref, Error> parseRelationalExpressionPostUnary(AST::Expression::Ref&& lhs);
-    Expected<AST::Expression::Ref, Error> parseShiftExpression();
-    Expected<AST::Expression::Ref, Error> parseShiftExpressionPostUnary(AST::Expression::Ref&& lhs);
-    Expected<AST::Expression::Ref, Error> parseAdditiveExpressionPostUnary(AST::Expression::Ref&& lhs);
-    Expected<AST::Expression::Ref, Error> parseBitwiseExpressionPostUnary(AST::Expression::Ref&& lhs);
-    Expected<AST::Expression::Ref, Error> parseMultiplicativeExpressionPostUnary(AST::Expression::Ref&& lhs);
-    Expected<AST::Expression::Ref, Error> parseUnaryExpression();
-    Expected<AST::Expression::Ref, Error> parseSingularExpression();
-    Expected<AST::Expression::Ref, Error> parsePostfixExpression(AST::Expression::Ref&& base, SourcePosition startPosition);
-    Expected<AST::Expression::Ref, Error> parsePrimaryExpression();
-    Expected<AST::Expression::Ref, Error> parseExpression();
-    Expected<AST::Expression::Ref, Error> parseLHSExpression();
-    Expected<AST::Expression::Ref, Error> parseCoreLHSExpression();
-    Expected<AST::Expression::List, Error> parseArgumentExpressionList();
+    // AST::<type>::Ref whenever it can return multiple types.
+    Result<AST::Identifier> parseIdentifier();
+    Result<void> parseGlobalDecl();
+    Result<AST::Attribute::List> parseAttributes();
+    Result<AST::Attribute::Ref> parseAttribute();
+    Result<AST::Structure::Ref> parseStructure(AST::Attribute::List&&);
+    Result<AST::StructureMember> parseStructureMember();
+    Result<AST::TypeName::Ref> parseTypeName();
+    Result<AST::TypeName::Ref> parseTypeNameAfterIdentifier(AST::Identifier&&, SourcePosition start);
+    Result<AST::TypeName::Ref> parseArrayType();
+    Result<AST::Variable::Ref> parseVariable();
+    Result<AST::Variable::Ref> parseVariableWithAttributes(AST::Attribute::List&&);
+    Result<AST::VariableQualifier> parseVariableQualifier();
+    Result<AST::StorageClass> parseStorageClass();
+    Result<AST::AccessMode> parseAccessMode();
+    Result<AST::Function> parseFunction(AST::Attribute::List&&);
+    Result<AST::ParameterValue> parseParameterValue();
+    Result<AST::Statement::Ref> parseStatement();
+    Result<AST::CompoundStatement> parseCompoundStatement();
+    Result<AST::ReturnStatement> parseReturnStatement();
+    Result<AST::Expression::Ref> parseShortCircuitOrExpression();
+    Result<AST::Expression::Ref> parseRelationalExpressionPostUnary(AST::Expression::Ref&& lhs);
+    Result<AST::Expression::Ref> parseShiftExpression();
+    Result<AST::Expression::Ref> parseShiftExpressionPostUnary(AST::Expression::Ref&& lhs);
+    Result<AST::Expression::Ref> parseAdditiveExpressionPostUnary(AST::Expression::Ref&& lhs);
+    Result<AST::Expression::Ref> parseBitwiseExpressionPostUnary(AST::Expression::Ref&& lhs);
+    Result<AST::Expression::Ref> parseMultiplicativeExpressionPostUnary(AST::Expression::Ref&& lhs);
+    Result<AST::Expression::Ref> parseUnaryExpression();
+    Result<AST::Expression::Ref> parseSingularExpression();
+    Result<AST::Expression::Ref> parsePostfixExpression(AST::Expression::Ref&& base, SourcePosition startPosition);
+    Result<AST::Expression::Ref> parsePrimaryExpression();
+    Result<AST::Expression::Ref> parseExpression();
+    Result<AST::Expression::Ref> parseLHSExpression();
+    Result<AST::Expression::Ref> parseCoreLHSExpression();
+    Result<AST::Expression::List> parseArgumentExpressionList();
 
 private:
     Expected<Token, TokenType> consumeType(TokenType);
@@ -99,6 +99,6 @@ private:
     Token m_current;
 };
 
-Expected<AST::Expression::Ref, Error> parseExpression(const String& source);
+Result<AST::Expression::Ref> parseExpression(const String& source);
 
 } // namespace WGSL


### PR DESCRIPTION
#### e6b88c39b860ecb6310662e559ac7c853beb3bdd
<pre>
[WGSL] Replace Expected&lt;T, Error&gt; with Result&lt;T&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=252201">https://bugs.webkit.org/show_bug.cgi?id=252201</a>
rdar://problem/105420454

Reviewed by Matt Woodrow.

To reduce the verbosity of templated types, add a using alias Result&lt;T&gt; for
Expected&lt;T, Error&gt;.

Also, update parser implementation signatures to match declarations.

Canonical link: <a href="https://commits.webkit.org/260238@main">https://commits.webkit.org/260238@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/00e3c85a2797401f6d23f71e1e992cd01724a9bb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107621 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16674 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40516 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116770 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116176 "Failed to checkout and rebase branch from PR 10063") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18094 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7988 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99792 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113376 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96850 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41324 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95575 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28477 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9661 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29829 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10336 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6729 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15815 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49411 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7077 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11896 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->