### PR TITLE
[JSC] Introduce VectorMulByElement

### DIFF
--- a/Source/JavaScriptCore/assembler/ARM64Assembler.h
+++ b/Source/JavaScriptCore/assembler/ARM64Assembler.h
@@ -1712,6 +1712,32 @@ public:
         insn(0b01101110001000001111110000000000 | (sizeForFloatingPointSIMDOp(lane) << 22) | (vm << 16) | (vn << 5) | vd);
     }
 
+    static uint32_t encodeLaneAndIndexToHLM(SIMDLane lane, uint32_t laneIndex)
+    {
+        switch (elementByteSize(lane)) {
+        case 1:
+            RELEASE_ASSERT_NOT_REACHED();
+        case 2:
+            RELEASE_ASSERT_NOT_REACHED();
+        case 4:
+            ASSERT(laneIndex < 4);
+            return (((laneIndex & 0b10) >> 1) << 11) | ((laneIndex & 0b01) << 21);
+        case 8:
+            ASSERT(laneIndex < 2);
+            return laneIndex << 11;
+        case 16:
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+        return 0;
+    }
+
+    ALWAYS_INLINE void vectorFmulByElement(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, SIMDLane lane, uint32_t laneIndex)
+    {
+        // https://developer.arm.com/documentation/dui0801/g/A64-SIMD-Vector-Instructions/FMUL--vector--by-element-
+        insn(0b010'01111'1000'0000'1001'0'0'00000'00000 | (sizeForFloatingPointSIMDOp(lane) << 22) | encodeLaneAndIndexToHLM(lane, laneIndex) | (vm << 16) | (vn << 5) | vd);
+    }
+
     ALWAYS_INLINE void umax(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, SIMDLane lane)
     {
         insn(0b01101110001000000110010000000000 | (sizeForIntegralSIMDOp(lane) << 22) | (vm << 16) | (vn << 5) | vd);

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -5076,6 +5076,16 @@ public:
             m_assembler.vectorMul(dest, left, right, simdInfo.lane);
     }
 
+    void vectorMulByElementFloat32(FPRegisterID left, FPRegisterID right, TrustedImm32 lane, FPRegisterID dest)
+    {
+        m_assembler.vectorFmulByElement(dest, left, right, SIMDLane::f32x4, lane.m_value);
+    }
+
+    void vectorMulByElementFloat64(FPRegisterID left, FPRegisterID right, TrustedImm32 lane, FPRegisterID dest)
+    {
+        m_assembler.vectorFmulByElement(dest, left, right, SIMDLane::f64x2, lane.m_value);
+    }
+
     void vectorDiv(SIMDInfo simdInfo, FPRegisterID left, FPRegisterID right, FPRegisterID dest)
     {
         ASSERT(scalarTypeIsFloatingPoint(simdInfo.lane));

--- a/Source/JavaScriptCore/b3/B3LowerToAir.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir.cpp
@@ -3813,6 +3813,25 @@ private:
             return;
         }
 
+        case B3::VectorMulByElement: {
+            ASSERT(isARM64());
+            SIMDValue* value = m_value->as<SIMDValue>();
+            auto lane = value->simdLane();
+            Air::Opcode op;
+            switch (lane) {
+            case SIMDLane::f32x4:
+                op = VectorMulByElementFloat32;
+                break;
+            case SIMDLane::f64x2:
+                op = VectorMulByElementFloat64;
+                break;
+            default:
+                RELEASE_ASSERT_NOT_REACHED();
+            }
+            append(op, tmp(value->child(0)), tmp(value->child(1)), Arg::imm(value->immediate()), tmp(value));
+            return;
+        }
+
         case B3::VectorSplat: {
             SIMDValue* value = m_value->as<SIMDValue>();
             SIMDLane lane = value->simdLane();

--- a/Source/JavaScriptCore/b3/B3Opcode.cpp
+++ b/Source/JavaScriptCore/b3/B3Opcode.cpp
@@ -525,6 +525,9 @@ void printInternal(PrintStream& out, Opcode opcode)
     case VectorSwizzle:
         out.print("VectorSwizzle");
         return;
+    case VectorMulByElement:
+        out.print("VectorMulByElement");
+        return;
     case Upsilon:
         out.print("Upsilon");
         return;

--- a/Source/JavaScriptCore/b3/B3Opcode.h
+++ b/Source/JavaScriptCore/b3/B3Opcode.h
@@ -347,7 +347,10 @@ enum Opcode : uint8_t {
     // SIMD instructions
     VectorExtractLane,
     VectorReplaceLane,
-    VectorDupElement, // Currently only some architectures support this.
+
+    // Currently only some architectures support this.
+    // FIXME: Expand this to identical instructions for the other architectures as a macro.
+    VectorDupElement,
 
     VectorSplat,
 
@@ -411,6 +414,10 @@ enum Opcode : uint8_t {
     VectorExtaddPairwise,
     VectorMulSat,
     VectorSwizzle,
+
+    // Currently only some architectures support this.
+    // FIXME: Expand this to identical instructions for the other architectures as a macro.
+    VectorMulByElement,
 
     // SSA support, in the style of DFG SSA.
     Upsilon, // This uses the UpsilonValue class.

--- a/Source/JavaScriptCore/b3/B3SIMDValue.h
+++ b/Source/JavaScriptCore/b3/B3SIMDValue.h
@@ -92,6 +92,7 @@ public:
         case VectorExtaddPairwise:
         case VectorMulSat:
         case VectorSwizzle:
+        case VectorMulByElement:
         case VectorDotProduct:
             return true;
         default:

--- a/Source/JavaScriptCore/b3/B3Validate.cpp
+++ b/Source/JavaScriptCore/b3/B3Validate.cpp
@@ -467,6 +467,7 @@ public:
                 VALIDATE(value->numChildren() == 1, ("At ", *value));
                 VALIDATE(value->child(0)->type() == V128, ("At ", *value));
                 VALIDATE(value->type() == V128, ("At ", *value));
+                VALIDATE(value->asSIMDValue()->immediate() < (16 / elementByteSize(value->asSIMDValue()->simdLane())), ("At ", *value));
                 break;
             case VectorNot:
             case VectorAbs:
@@ -509,6 +510,15 @@ public:
                 VALIDATE(value->child(1)->type() == V128, ("At ", *value));
                 VALIDATE(value->numChildren() == 2 || value->child(2)->type() == V128, ("At ", *value));
                 VALIDATE(value->asSIMDValue()->simdLane() == SIMDLane::i8x16, ("At ", *value));
+                break;
+
+            case VectorMulByElement:
+                VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));
+                VALIDATE(value->numChildren() == 2, ("At ", *value));
+                VALIDATE(value->child(0)->type() == V128, ("At ", *value));
+                VALIDATE(value->type() == V128, ("At ", *value));
+                VALIDATE(value->asSIMDValue()->simdLane() == SIMDLane::f64x2 || value->asSIMDValue()->simdLane() == SIMDLane::f32x4, ("At ", *value));
+                VALIDATE(value->asSIMDValue()->immediate() < (16 / elementByteSize(value->asSIMDValue()->simdLane())), ("At ", *value));
                 break;
 
             case VectorBitmask:

--- a/Source/JavaScriptCore/b3/B3Value.cpp
+++ b/Source/JavaScriptCore/b3/B3Value.cpp
@@ -703,6 +703,7 @@ Effects Value::effects() const
     case VectorExtaddPairwise:
     case VectorMulSat:
     case VectorSwizzle:
+    case VectorMulByElement:
         break;
     case Div:
     case UDiv:
@@ -949,6 +950,7 @@ ValueKey Value::key() const
         numChildrenForKind(kind(), 2);
         return ValueKey(kind(), type(), as<SIMDValue>()->simdInfo(), child(0), child(1));
     case VectorReplaceLane:
+    case VectorMulByElement:
         numChildrenForKind(kind(), 2);
         return ValueKey(kind(), type(), as<SIMDValue>()->simdInfo(), child(0), child(1), as<SIMDValue>()->immediate());
     case VectorBitwiseSelect:

--- a/Source/JavaScriptCore/b3/B3Value.h
+++ b/Source/JavaScriptCore/b3/B3Value.h
@@ -536,6 +536,7 @@ protected:
         case VectorShr:
         case VectorMulSat:
         case VectorAvgRound:
+        case VectorMulByElement:
             return 2 * sizeof(Value*);
         case Select:
         case AtomicWeakCAS:
@@ -750,6 +751,7 @@ private:
         case VectorShr:
         case VectorMulSat:
         case VectorAvgRound:
+        case VectorMulByElement:
             if (UNLIKELY(numArgs != 2))
                 badKind(kind, numArgs);
             return Two;

--- a/Source/JavaScriptCore/b3/B3ValueInlines.h
+++ b/Source/JavaScriptCore/b3/B3ValueInlines.h
@@ -228,6 +228,7 @@ namespace JSC { namespace B3 {
     case VectorExtaddPairwise: \
     case VectorMulSat: \
     case VectorSwizzle: \
+    case VectorMulByElement: \
         return MACRO(SIMDValue); \
     default: \
         RELEASE_ASSERT_NOT_REACHED(); \

--- a/Source/JavaScriptCore/b3/B3ValueKey.cpp
+++ b/Source/JavaScriptCore/b3/B3ValueKey.cpp
@@ -183,6 +183,7 @@ Value* ValueKey::materialize(Procedure& proc, Origin origin) const
     case VectorAvgRound:
         return proc.add<SIMDValue>(origin, kind(), type(), simdInfo(), child(proc, 0), child(proc, 1));
     case VectorReplaceLane:
+    case VectorMulByElement:
         return proc.add<SIMDValue>(origin, kind(), type(), simdInfo(), static_cast<uint8_t>(u.indices[2]), child(proc, 0), child(proc, 1));
     case VectorBitwiseSelect:
         return proc.add<SIMDValue>(origin, kind(), type(), simdInfo(), child(proc, 0), child(proc, 1), child(proc, 2));

--- a/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
+++ b/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
@@ -1758,6 +1758,12 @@ arm64: VectorUnsignedMin U:G:Ptr, U:F:128, D:F:128
 64: VectorMul U:G:Ptr, U:F:128, U:F:128, D:F:128
     SIMDInfo, Tmp, Tmp, Tmp
 
+arm64: VectorMulByElementFloat32 U:F:128, U:F:128, U:G:8, D:F:128
+    Tmp, Tmp, Imm, Tmp
+
+arm64: VectorMulByElementFloat64 U:F:128, U:F:128, U:G:8, D:F:128
+    Tmp, Tmp, Imm, Tmp
+
 64: VectorDiv U:G:Ptr, U:F:128, U:F:128, D:F:128
     SIMDInfo, Tmp, Tmp, Tmp
 

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -1213,5 +1213,7 @@ void testVectorXorAndAllOnesToVectorOrXor();
 void testVectorXorOrAllOnesConstantToVectorAndXor(v128_t);
 void testVectorXorAndAllOnesConstantToVectorOrXor(v128_t);
 void testVectorAndConstantConstant(v128_t, v128_t);
+void testVectorFmulByElementFloat();
+void testVectorFmulByElementDouble();
 
 #endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -877,6 +877,10 @@ void run(const char* filter)
         RUN_BINARY(testVectorAndConstants, v128Operands(), v128Operands());
         RUN_BINARY(testVectorXorConstants, v128Operands(), v128Operands());
         RUN_BINARY(testVectorAndConstantConstant, v128Operands(), v128Operands());
+        if (isARM64()) {
+            RUN(testVectorFmulByElementFloat());
+            RUN(testVectorFmulByElementDouble());
+        }
     }
 
     if (tasks.isEmpty())

--- a/Source/JavaScriptCore/jit/SIMDInfo.h
+++ b/Source/JavaScriptCore/jit/SIMDInfo.h
@@ -220,10 +220,10 @@ constexpr unsigned elementByteSize(SIMDLane simdLane)
 
 namespace WTF {
 
-void printInternal(PrintStream& out, JSC::SIMDLane lane);
+JS_EXPORT_PRIVATE void printInternal(PrintStream& out, JSC::SIMDLane);
 
-void printInternal(PrintStream& out, JSC::SIMDSignMode mode);
+JS_EXPORT_PRIVATE void printInternal(PrintStream& out, JSC::SIMDSignMode);
 
-void printInternal(PrintStream& out, JSC::v128_t v);
+JS_EXPORT_PRIVATE void printInternal(PrintStream& out, JSC::v128_t);
 
 } // namespace WTF


### PR DESCRIPTION
#### da65f1c74056973e16c01c79dbf84e844e1811a8
<pre>
[JSC] Introduce VectorMulByElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=252222">https://bugs.webkit.org/show_bug.cgi?id=252222</a>
rdar://problem/105428458

Reviewed by Mark Lam.

ARM64 has FMUL by element, which is `fmul.4s v0, v1, v0[0]` for example.
In the above case,

   v0[0] = v1[0] * v0[0]
   v0[1] = v1[1] * v0[0]
   v0[2] = v1[2] * v0[0]
   v0[3] = v1[3] * v0[0]

is done. This is useful since we do not dup-element vector before performing VectorMul.
So, instead of doing,

    VectorMul(@a, VectorDupElement(@b, 0))

we can now convert it to

    VectorMulByElement(@a, @b, 0)

And since (1) now we detect VectorDupElement pattern from VectorSwizzle on ARM64, we can easily do
pattern matching for this case and (2) VectorDupElement is anyway slow (faster than VectorSwizzle,
but still slow instruction). So we can get much faster performance by converting it to VectorMulByElement.

This improves tfjs-wasm-simd by 10%.

* Source/JavaScriptCore/assembler/ARM64Assembler.h:
* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::vectorMulByElementFloat32):
(JSC::MacroAssemblerARM64::vectorMulByElementFloat64):
* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/B3Opcode.cpp:
(WTF::printInternal):
* Source/JavaScriptCore/b3/B3Opcode.h:
* Source/JavaScriptCore/b3/B3ReduceStrength.cpp:
* Source/JavaScriptCore/b3/B3SIMDValue.h:
* Source/JavaScriptCore/b3/B3Validate.cpp:
* Source/JavaScriptCore/b3/B3Value.cpp:
(JSC::B3::Value::effects const):
(JSC::B3::Value::key const):
* Source/JavaScriptCore/b3/B3Value.h:
* Source/JavaScriptCore/b3/B3ValueInlines.h:
* Source/JavaScriptCore/b3/B3ValueKey.cpp:
(JSC::B3::ValueKey::materialize const):
* Source/JavaScriptCore/b3/air/AirOpcode.opcodes:
* Source/JavaScriptCore/b3/testb3.h:
* Source/JavaScriptCore/b3/testb3_1.cpp:
(run):
* Source/JavaScriptCore/b3/testb3_7.cpp:
(testVectorFmulByElementFloat):
(testVectorFmulByElementDouble):
* Source/JavaScriptCore/jit/SIMDInfo.h:

Canonical link: <a href="https://commits.webkit.org/260239@main">https://commits.webkit.org/260239@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a74a4d31e11ab303b4db6236bf4c118a0ca2ffb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107635 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16687 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40530 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116782 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18108 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8002 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99805 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113390 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/96866 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41339 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/95589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28495 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/96940 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9674 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29844 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/96350 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/7701 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10349 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6739 "Passed tests") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/30826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15825 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49429 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/105221 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11909 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26088 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3839 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->