### PR TITLE
[WebGPU] Hook up UnrealizedCoreTextFont to callers

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -35,6 +35,7 @@
 #include "FontPaletteValues.h"
 #include "StyleFontSizeFunctions.h"
 #include "SystemFontDatabaseCoreText.h"
+#include "UnrealizedCoreTextFont.h"
 #include <CoreText/SFNTLayoutTypes.h>
 #include <pal/spi/cf/CoreTextSPI.h>
 #include <pal/spi/cocoa/AccessibilitySupportSPI.h>
@@ -369,7 +370,7 @@ static inline bool shouldEnhanceTextLegibility()
     return overrideEnhanceTextLegibility().value_or(platformShouldEnhanceTextLegibility());
 }
 
-RetainPtr<CTFontRef> preparePlatformFont(CTFontRef originalFont, const FontDescription& fontDescription, const FontCreationContext& fontCreationContext, bool applyWeightWidthSlopeVariations)
+static RetainPtr<CTFontRef> preparePlatformFont(CTFontRef originalFont, const FontDescription& fontDescription, const FontCreationContext& fontCreationContext, bool applyWeightWidthSlopeVariations)
 {
     if (!originalFont)
         return originalFont;
@@ -545,9 +546,9 @@ RetainPtr<CTFontRef> preparePlatformFont(CTFontRef originalFont, const FontDescr
     return adoptCF(CTFontCreateCopyWithAttributes(originalFont, CTFontGetSize(originalFont), nullptr, descriptor.get()));
 }
 
-static RetainPtr<CTFontRef> preparePlatformFont(CTFontDescriptorRef originalFont, const FontDescription& fontDescription, const FontCreationContext& fontCreationContext, bool applyWeightWidthSlopeVariations, float size)
+RetainPtr<CTFontRef> preparePlatformFont(UnrealizedCoreTextFont&& originalFont, const FontDescription& fontDescription, const FontCreationContext& fontCreationContext, bool applyWeightWidthSlopeVariations)
 {
-    return preparePlatformFont(adoptCF(CTFontCreateWithFontDescriptor(originalFont, size, nullptr)).get(), fontDescription, fontCreationContext, applyWeightWidthSlopeVariations);
+    return preparePlatformFont(originalFont.realize().get(), fontDescription, fontCreationContext, applyWeightWidthSlopeVariations);
 }
 
 RefPtr<Font> FontCache::similarFont(const FontDescription& description, const String& family)
@@ -959,7 +960,7 @@ void FontCache::platformInvalidate()
     platformShouldEnhanceTextLegibility() = _AXSEnhanceTextLegibilityEnabled();
 }
 
-static RetainPtr<CTFontDescriptorRef> fontDescriptorWithFamilySpecialCase(const AtomString& family, const FontDescription& fontDescription, float size, AllowUserInstalledFonts allowUserInstalledFonts)
+static std::optional<UnrealizedCoreTextFont> fontDescriptorWithFamilySpecialCase(const AtomString& family, const FontDescription& fontDescription, float size, AllowUserInstalledFonts allowUserInstalledFonts)
 {
     // FIXME: See comment in FontCascadeDescription::effectiveFamilyAt() in FontDescriptionCocoa.cpp
     std::optional<SystemFontKind> systemDesign;
@@ -981,38 +982,50 @@ static RetainPtr<CTFontDescriptorRef> fontDescriptorWithFamilySpecialCase(const 
     if (systemDesign) {
         auto cascadeList = SystemFontDatabaseCoreText::forCurrentThread().cascadeList(fontDescription, family, *systemDesign, allowUserInstalledFonts);
         if (cascadeList.isEmpty())
-            return nullptr;
-        return cascadeList[0];
+            return std::nullopt;
+        return { RetainPtr { cascadeList[0] } };
     }
 
     if (family.startsWith("UICTFontTextStyle"_s)) {
         const auto& request = fontDescription.fontSelectionRequest();
         CTFontSymbolicTraits traits = (isFontWeightBold(request.weight) ? kCTFontTraitBold : 0) | (isItalic(request.slope) ? kCTFontTraitItalic : 0);
         auto descriptor = adoptCF(CTFontDescriptorCreateWithTextStyle(family.string().createCFString().get(), contentSizeCategory(), fontDescription.computedLocale().string().createCFString().get()));
-        if (traits)
-            descriptor = adoptCF(CTFontDescriptorCreateCopyWithSymbolicTraits(descriptor.get(), traits, traits));
-        return descriptor;
+        if (traits) {
+            // FIXME: rdar://105369379 As far as I can tell, there's no modification to the attributes dictionary that has the same effect as CTFontDescriptorCreateCopyWithSymbolicTraits(),
+            // because there doesn't seem to be a place to specify the bitmask. That's the reason we're creating the derived CTFontDescriptor here, rather than in UnrealizedCoreTextFont::realize().
+            return { adoptCF(CTFontDescriptorCreateCopyWithSymbolicTraits(descriptor.get(), traits, traits)) };
+        }
+        return { WTFMove(descriptor) };
     }
 
     if (equalLettersIgnoringASCIICase(family, "-apple-menu"_s))
-        return adoptCF(CTFontDescriptorCreateForUIType(kCTFontUIFontMenuItem, size, fontDescription.computedLocale().string().createCFString().get()));
+        return { adoptCF(CTFontDescriptorCreateForUIType(kCTFontUIFontMenuItem, size, fontDescription.computedLocale().string().createCFString().get())) };
 
     if (equalLettersIgnoringASCIICase(family, "-apple-status-bar"_s))
-        return adoptCF(CTFontDescriptorCreateForUIType(kCTFontUIFontSystem, size, fontDescription.computedLocale().string().createCFString().get()));
+        return { adoptCF(CTFontDescriptorCreateForUIType(kCTFontUIFontSystem, size, fontDescription.computedLocale().string().createCFString().get())) };
 
     if (equalLettersIgnoringASCIICase(family, "lastresort"_s))
-        return adoptCF(CTFontDescriptorCreateLastResort());
+        return { adoptCF(CTFontDescriptorCreateLastResort()) };
 
     if (equalLettersIgnoringASCIICase(family, "-apple-system-monospaced-numbers"_s)) {
-        int numberSpacingType = kNumberSpacingType;
-        int monospacedNumbersSelector = kMonospacedNumbersSelector;
-        auto numberSpacingNumber = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &numberSpacingType));
-        auto monospacedNumbersNumber = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &monospacedNumbersSelector));
-        auto systemFontDescriptor = adoptCF(CTFontDescriptorCreateForUIType(kCTFontUIFontSystem, size, nullptr));
-        return adoptCF(CTFontDescriptorCreateCopyWithFeature(systemFontDescriptor.get(), numberSpacingNumber.get(), monospacedNumbersNumber.get()));
+        auto systemFontDescriptor = UnrealizedCoreTextFont { adoptCF(CTFontDescriptorCreateForUIType(kCTFontUIFontSystem, size, nullptr)) };
+        systemFontDescriptor.modify([](CFMutableDictionaryRef attributes) {
+            int numberSpacingType = kNumberSpacingType;
+            int monospacedNumbersSelector = kMonospacedNumbersSelector;
+            auto numberSpacingNumber = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &numberSpacingType));
+            auto monospacedNumbersNumber = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &monospacedNumbersSelector));
+            CFTypeRef keys[] = { kCTFontFeatureTypeIdentifierKey, kCTFontFeatureSelectorIdentifierKey };
+            CFTypeRef values[] = { numberSpacingNumber.get(), monospacedNumbersNumber.get() };
+            ASSERT(std::size(keys) == std::size(values));
+            auto settingsDictionary = adoptCF(CFDictionaryCreate(kCFAllocatorDefault, keys, values, std::size(keys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+            CFTypeRef entries[] = { settingsDictionary.get() };
+            auto settingsArray = adoptCF(CFArrayCreate(kCFAllocatorDefault, entries, std::size(entries), &kCFTypeArrayCallBacks));
+            CFDictionaryAddValue(attributes, kCTFontFeatureSettingsAttribute, settingsArray.get());
+        });
+        return systemFontDescriptor;
     }
 
-    return nullptr;
+    return std::nullopt;
 }
 
 static RetainPtr<CTFontRef> fontWithFamily(FontDatabase& fontDatabase, const AtomString& family, const FontDescription& fontDescription, const FontCreationContext& fontCreationContext, float size)
@@ -1022,12 +1035,17 @@ static RetainPtr<CTFontRef> fontWithFamily(FontDatabase& fontDatabase, const Ato
     if (family.isEmpty())
         return nullptr;
 
-    if (auto fontDescriptor = fontDescriptorWithFamilySpecialCase(family, fontDescription, size, fontDescription.shouldAllowUserInstalledFonts())) {
-        auto font = createFontForInstalledFonts(fontDescriptor.get(), size, fontDescription.shouldAllowUserInstalledFonts());
-        return preparePlatformFont(font.get(), fontDescription, fontCreationContext, true);
+    if (auto unrealizedFont = fontDescriptorWithFamilySpecialCase(family, fontDescription, size, fontDescription.shouldAllowUserInstalledFonts())) {
+        unrealizedFont->setSize(size);
+        unrealizedFont->modify([&](CFMutableDictionaryRef attributes) {
+            addAttributesForInstalledFonts(attributes, fontDescription.shouldAllowUserInstalledFonts());
+        });
+        return preparePlatformFont(WTFMove(*unrealizedFont), fontDescription, fontCreationContext, true);
     }
     auto fontLookup = platformFontLookupWithFamily(fontDatabase, family, fontDescription.fontSelectionRequest());
-    return preparePlatformFont(fontLookup.result.get(), fontDescription, fontCreationContext, !fontLookup.createdFromPostScriptName, size);
+    UnrealizedCoreTextFont unrealizedFont = { WTFMove(fontLookup.result) };
+    unrealizedFont.setSize(size);
+    return preparePlatformFont(WTFMove(unrealizedFont), fontDescription, fontCreationContext, !fontLookup.createdFromPostScriptName);
 }
 
 #if PLATFORM(MAC)
@@ -1166,7 +1184,7 @@ RefPtr<Font> FontCache::systemFallbackForCharacters(const FontDescription& descr
         m_fontNamesRequiringSystemFallbackForPrewarming.add(fullName);
 
     auto result = lookupFallbackFont(platformData.font(), description.weight(), description.computedLocale(), description.shouldAllowUserInstalledFonts(), characters, length);
-    result = preparePlatformFont(result.get(), description, { });
+    result = preparePlatformFont(UnrealizedCoreTextFont { WTFMove(result) }, description, { });
 
     if (!result)
         return lastResortFallbackFont(description);

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.h
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2022 Apple Inc.  All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,6 +36,7 @@
 namespace WebCore {
 
 class FontCreationContext;
+class UnrealizedCoreTextFont;
 
 struct SynthesisPair {
     explicit SynthesisPair(bool needsSyntheticBold, bool needsSyntheticOblique)
@@ -62,7 +63,7 @@ struct VariationDefaults {
 
 typedef HashMap<FontTag, VariationDefaults, FourCharacterTagHash, FourCharacterTagHashTraits> VariationDefaultsMap;
 
-RetainPtr<CTFontRef> preparePlatformFont(CTFontRef, const FontDescription&, const FontCreationContext&, bool applyWeightWidthSlopeVariations = true);
+RetainPtr<CTFontRef> preparePlatformFont(UnrealizedCoreTextFont&&, const FontDescription&, const FontCreationContext&, bool applyWeightWidthSlopeVariations = true);
 enum class ShouldComputePhysicalTraits : bool { No, Yes };
 SynthesisPair computeNecessarySynthesis(CTFontRef, const FontDescription&, ShouldComputePhysicalTraits = ShouldComputePhysicalTraits::No, bool isPlatformFont = false);
 RetainPtr<CTFontRef> platformFontWithFamily(const AtomString& family, FontSelectionRequest, TextRenderingMode, float size);

--- a/Source/WebCore/platform/graphics/cocoa/FontFamilySpecificationCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontFamilySpecificationCoreText.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,6 +30,7 @@
 #include "FontFamilySpecificationCoreTextCache.h"
 #include "FontSelector.h"
 #include "StyleFontSizeFunctions.h"
+#include "UnrealizedCoreTextFont.h"
 #include <pal/spi/cf/CoreTextSPI.h>
 #include <wtf/HashFunctions.h>
 #include <wtf/HashMap.h>
@@ -49,10 +50,10 @@ FontRanges FontFamilySpecificationCoreText::fontRanges(const FontDescription& fo
 {
     auto size = fontDescription.computedSize();
     auto& originalPlatformData = FontFamilySpecificationCoreTextCache::forCurrentThread().ensure(FontFamilySpecificationKey(m_fontDescriptor.get(), fontDescription), [&]() {
+        UnrealizedCoreTextFont unrealizedFont = { RetainPtr { m_fontDescriptor } };
+        unrealizedFont.setSize(size);
 
-        auto font = adoptCF(CTFontCreateWithFontDescriptor(m_fontDescriptor.get(), size, nullptr));
-
-        font = preparePlatformFont(font.get(), fontDescription, { });
+        auto font = preparePlatformFont(WTFMove(unrealizedFont), fontDescription, { });
 
         auto [syntheticBold, syntheticOblique] = computeNecessarySynthesis(font.get(), fontDescription, ShouldComputePhysicalTraits::Yes).boldObliquePair();
 


### PR DESCRIPTION
#### 3563129ef78f532b8395346823cd2d4f186fd499
<pre>
[WebGPU] Hook up UnrealizedCoreTextFont to callers
<a href="https://bugs.webkit.org/show_bug.cgi?id=252221">https://bugs.webkit.org/show_bug.cgi?id=252221</a>

Reviewed by Cameron McCormack.

The solution to <a href="https://bugs.webkit.org/show_bug.cgi?id=247987">https://bugs.webkit.org/show_bug.cgi?id=247987</a> requires having explicit locations where we transform
a CTFontDescriptor into a CTFont. UnrealizedCoreTextFont is the critical object in a design which enforces this: It
holds the original CTFontDescriptor/CTFont which Core Text gave us originally, plus a CFMutableDictionary of
modifications to be made to it. Updating the modifications never hits Core Text, and are as such very lightweight.
Once we&apos;re done setting the modifications, there&apos;s a &quot;commit&quot; step where we finally make the final CTFont. This
means that we avoid ping-ponging between CTFontDescriptors and CTFonts unnecessarily.

Eventually, preparePlatformFont() will be integrated into this object, but that&apos;s too big for a single patch. This
patch just hooks up callers of preparePlatformFont() to use this object, which will temporarily be resolved to a
CTFont just before calling preparePlatformFont. The next few patches will be updating preparePlatformFont() to be
able to represent it as a pure modification to the UnrealizedCoreTextFont.

* Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp:
(WebCore::preparePlatformFont):
(WebCore::fontDescriptorWithFamilySpecialCase):
(WebCore::fontWithFamily):
(WebCore::FontCache::systemFallbackForCharacters):
* Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.h:
* Source/WebCore/platform/graphics/cocoa/FontFamilySpecificationCoreText.cpp:
(WebCore::FontFamilySpecificationCoreText::fontRanges const):
* Source/WebCore/platform/graphics/mac/FontCustomPlatformDataMac.cpp:
(WebCore::FontCustomPlatformData::fontPlatformData):

Canonical link: <a href="https://commits.webkit.org/260241@main">https://commits.webkit.org/260241@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea39c78caca731a8eba2235ffea0bc34bb0f34f1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107655 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16707 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40551 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116803 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111547 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18129 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8025 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99828 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113409 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13685 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/96884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/41357 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/95601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28515 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9693 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29864 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10368 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/6756 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15844 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49449 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7078 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11928 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->