### PR TITLE
[WGSL] Handle lexing of line and block comments

### DIFF
--- a/Source/WebGPU/WGSL/Lexer.h
+++ b/Source/WebGPU/WGSL/Lexer.h
@@ -71,9 +71,12 @@ private:
         return { WGSL::TokenType::Identifier, m_tokenStartingPosition, currentTokenLength(), WTFMove(identifier) };
     }
 
-    void shift();
-    T peek(unsigned);
-    void skipWhitespace();
+    T shift(unsigned = 1);
+    T peek(unsigned = 0);
+    void newLine();
+    void skipBlockComments();
+    void skipLineComment();
+    void skipWhitespaceAndComments();
 
     // Reads [0-9]+
     std::optional<uint64_t> parseDecimalInteger();

--- a/Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp
@@ -75,6 +75,19 @@ static void checkNextTokensAreBuiltinAttr(WGSL::Lexer<T>& lexer, const String& a
     checkNextTokenIs(lexer, WGSL::TokenType::ParenRight, lineNumber);
 };
 
+TEST(WGSLLexerTests, Comments)
+{
+    using WGSL::TokenType;
+
+    checkSingleToken("// This is line-ending comment.\n"
+        "/* This is a block comment\n"
+        "   that spans lines.\n"
+        "   /* Block comments can nest.\n"
+        "    */\n"
+        "   But all block comments must terminate.\n"
+        "*/"_s, TokenType::EndOfFile);
+}
+
 TEST(WGSLLexerTests, SingleTokens)
 {
     using WGSL::TokenType;


### PR DESCRIPTION
#### 4c345f6c899172244aae4b9087c732afa7d01cab
<pre>
[WGSL] Handle lexing of line and block comments
<a href="https://bugs.webkit.org/show_bug.cgi?id=252224">https://bugs.webkit.org/show_bug.cgi?id=252224</a>
rdar://105430947

Reviewed by Myles C. Maxfield and Tadeu Zagallo.

WGSL supports single-line comments prefixed with // and block-comments delimited
by /* and */. Block comments can be nested so, unlike in C &amp; C++, /* /* */ */ is
valid.

Detection of and reporting diagnostics of unbalanced block comments isn&apos;t
supported and will be implemented in another patch.

* Source/WebGPU/WGSL/Lexer.cpp:
(WGSL::Lexer&lt;T&gt;::lex):
(WGSL::Lexer&lt;T&gt;::shift):
(WGSL::Lexer&lt;T&gt;::newLine):
(WGSL::Lexer&lt;T&gt;::skipBlockComments):
(WGSL::Lexer&lt;T&gt;::skipLineComment):
(WGSL::Lexer&lt;T&gt;::skipWhitespaceAndComments):
(WGSL::Lexer&lt;T&gt;::skipWhitespace): Deleted.
* Source/WebGPU/WGSL/Lexer.h:
* Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp:
(TestWGSLAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/260277@main">https://commits.webkit.org/260277@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34ef6eb26621569c1b5aa9b3d406af4977de7319

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107669 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16721 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40565 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116817 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116214 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111560 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18143 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8039 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99842 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113423 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13695 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96892 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41370 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95611 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28528 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/83209 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9704 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29877 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10381 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6764 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15857 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49462 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7110 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11941 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->