### PR TITLE
Fix TestWGSLAPI test failures after 260237@main

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WGSL/ConstLiteralTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/ConstLiteralTests.cpp
@@ -65,7 +65,7 @@ TEST(WGSLConstLiteralTests, BoolLiteral)
         const auto& intLiteral = downcast<AST::BoolLiteral>(expr.get());
         EXPECT_EQ(intLiteral.value(), testCase.expectedValue);
         auto inputLength = testCase.input.length();
-        EXPECT_EQ(intLiteral.span(), SourceSpan(0, inputLength, inputLength, 0));
+        EXPECT_EQ(intLiteral.span(), SourceSpan(1, inputLength, inputLength, 0));
     }
 }
 
@@ -89,7 +89,7 @@ TEST(WGSLConstLiteralTests, AbstractIntegerLiteralDecimal)
         const auto& intLiteral = downcast<AST::AbstractIntegerLiteral>(expr.get());
         EXPECT_EQ(intLiteral.value(), testCase.expectedValue);
         auto inputLength = testCase.input.length();
-        EXPECT_EQ(intLiteral.span(), SourceSpan(0, inputLength, inputLength, 0));
+        EXPECT_EQ(intLiteral.span(), SourceSpan(1, inputLength, inputLength, 0));
     }
 }
 
@@ -113,7 +113,7 @@ TEST(WGSLConstLiteralTests, AbstractIntegerLiteralHex)
         const auto& intLiteral = downcast<AST::AbstractIntegerLiteral>(expr.get());
         EXPECT_EQ(intLiteral.value(), testCase.expectedValue);
         auto inputLength = testCase.input.length();
-        EXPECT_EQ(intLiteral.span(), WGSL::SourceSpan(0, inputLength, inputLength, 0));
+        EXPECT_EQ(intLiteral.span(), WGSL::SourceSpan(1, inputLength, inputLength, 0));
     }
 }
 
@@ -142,7 +142,7 @@ TEST(WGSLConstLiteralTests, AbstractFloatLiteralDec)
         const auto& floatLiteral = downcast<AST::AbstractFloatLiteral>(expr.get());
         EXPECT_EQ(floatLiteral.value(), testCase.expectedValue);
         auto inputLength = testCase.input.length();
-        EXPECT_EQ(floatLiteral.span(), SourceSpan(0, inputLength, inputLength, 0));
+        EXPECT_EQ(floatLiteral.span(), SourceSpan(1, inputLength, inputLength, 0));
     }
 }
 

--- a/Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp
@@ -173,7 +173,7 @@ TEST(WGSLLexerTests, ComputeShader)
         "    x.a = 42;\n"
         "}"_s);
 
-    unsigned lineNumber = 0;
+    unsigned lineNumber = 1;
     // @block struct B {
     checkNextTokenIs(lexer, WGSL::TokenType::Attribute, lineNumber);
     checkNextTokenIsIdentifier(lexer, "block"_s, lineNumber);
@@ -259,7 +259,7 @@ TEST(WGSLLexerTests, GraphicsShader)
         "    return vec4<f32>(0.4, 0.4, 0.8, 1.0);\n"
         "}"_s);
 
-    unsigned lineNumber = 0;
+    unsigned lineNumber = 1;
 
     // @vertex
     checkNextTokenIs(lexer, WGSL::TokenType::Attribute, lineNumber);
@@ -366,7 +366,7 @@ TEST(WGSLLexerTests, TriangleVert)
         "    return vec4<f32>(pos[VertexIndex] + vec2<f32>(0.5, 0.5), 0.0, 1.0);\n"
         "}\n"_s);
 
-    unsigned lineNumber = 0;
+    unsigned lineNumber = 1;
 
     // @vertex
     checkNextTokenIs(lexer, WGSL::TokenType::Attribute, lineNumber);


### PR DESCRIPTION
#### 730b03dfd0d8d108cd83f5cbcea37c40933d2364
<pre>
Fix TestWGSLAPI test failures after 260237@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=252227">https://bugs.webkit.org/show_bug.cgi?id=252227</a>
rdar://problem/105434119

Unreviewed build fix.

Update line numbers to match correct lines

* Tools/TestWebKitAPI/Tests/WGSL/ConstLiteralTests.cpp:
(TestWGSLAPI::TEST):
* Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp:
(TestWGSLAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/260240@main">https://commits.webkit.org/260240@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ca634cc70277192927ac56950439753bb059e91

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107651 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16702 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40546 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116798 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111543 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18124 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8020 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99822 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113405 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/96880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/41353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/95605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/28510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9689 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/29859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10364 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/6752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15840 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/49444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11924 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3840 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->