### PR TITLE
[JSC] Inline Proxy get trap

### DIFF
--- a/Source/JavaScriptCore/builtins/ProxyHelpers.js
+++ b/Source/JavaScriptCore/builtins/ProxyHelpers.js
@@ -24,9 +24,12 @@
  */
 
 @linkTimeConstant
-function performProxyObjectGet(target, receiver, handler, propertyName)
+function performProxyObjectGet(receiver, propertyName)
 {
     "use strict";
+
+    var target = @getProxyInternalField(this, @proxyFieldTarget);
+    var handler = @getProxyInternalField(this, @proxyFieldHandler);
 
     if (handler === null)
         @throwTypeError("Proxy has already been revoked. No more operations are allowed to be performed on it");

--- a/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h
+++ b/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h
@@ -54,6 +54,7 @@ enum class LinkTimeConstant : int32_t;
     macro(getStringIteratorInternalField) \
     macro(getMapIteratorInternalField) \
     macro(getSetIteratorInternalField) \
+    macro(getProxyInternalField) \
     macro(idWithProfile) \
     macro(isObject) \
     macro(isCallable) \
@@ -130,6 +131,8 @@ enum class LinkTimeConstant : int32_t;
     macro(promiseFlagsIsFirstResolvingFunctionCalled) \
     macro(promiseFieldFlags) \
     macro(promiseFieldReactionsOrResult) \
+    macro(proxyFieldTarget) \
+    macro(proxyFieldHandler) \
     macro(generatorFieldState) \
     macro(generatorFieldNext) \
     macro(generatorFieldThis) \

--- a/Source/JavaScriptCore/bytecode/GetByStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/GetByStatus.cpp
@@ -35,6 +35,7 @@
 #include "IntrinsicGetterAccessCase.h"
 #include "ModuleNamespaceAccessCase.h"
 #include "PolymorphicAccess.h"
+#include "ProxyObjectAccessCase.h"
 #include "StructureStubInfo.h"
 #include <wtf/ListDump.h>
 
@@ -201,6 +202,12 @@ GetByStatus::GetByStatus(const ModuleNamespaceAccessCase& accessCase)
 {
 }
 
+GetByStatus::GetByStatus(const ProxyObjectAccessCase&)
+    : m_state(ProxyObject)
+    , m_wasSeenInJIT(true)
+{
+}
+
 GetByStatus GetByStatus::computeForStubInfoWithoutExitSiteFeedback(
     const ConcurrentJSLocker& locker, CodeBlock* profiledBlock, StructureStubInfo* stubInfo, CallLinkStatus::ExitSiteData callExitSiteData)
 {
@@ -244,6 +251,15 @@ GetByStatus GetByStatus::computeForStubInfoWithoutExitSiteFeedback(
             switch (access.type()) {
             case AccessCase::ModuleNamespaceLoad:
                 return GetByStatus(access.as<ModuleNamespaceAccessCase>());
+            case AccessCase::ProxyObjectLoad: {
+                auto& accessCase = access.as<ProxyObjectAccessCase>();
+                auto status = GetByStatus(accessCase);
+                auto callLinkStatus = makeUnique<CallLinkStatus>();
+                if (CallLinkInfo* callLinkInfo = accessCase.callLinkInfo())
+                    *callLinkStatus = CallLinkStatus::computeFor(locker, profiledBlock, *callLinkInfo, callExitSiteData);
+                status.appendVariant(GetByVariant(accessCase.identifier(), { }, invalidOffset, { }, WTFMove(callLinkStatus)));
+                return status;
+            }
             default:
                 break;
             }
@@ -463,6 +479,7 @@ bool GetByStatus::makesCalls() const
                 return true;
         }
         return false;
+    case ProxyObject:
     case MakesCalls:
     case ObservedSlowPathAndMakesCalls:
         return true;
@@ -498,6 +515,7 @@ void GetByStatus::merge(const GetByStatus& other)
         
     case Simple:
     case Custom:
+    case ProxyObject:
         if (m_state != other.m_state)
             return mergeSlow();
         
@@ -601,6 +619,9 @@ void GetByStatus::dump(PrintStream& out) const
         break;
     case ModuleNamespace:
         out.print("ModuleNamespace");
+        break;
+    case ProxyObject:
+        out.print("ProxyObject");
         break;
     case LikelyTakesSlowPath:
         out.print("LikelyTakesSlowPath");

--- a/Source/JavaScriptCore/bytecode/GetByStatus.h
+++ b/Source/JavaScriptCore/bytecode/GetByStatus.h
@@ -42,6 +42,7 @@ class CodeBlock;
 class JSModuleEnvironment;
 class JSModuleNamespaceObject;
 class ModuleNamespaceAccessCase;
+class ProxyObjectAccessCase;
 class StructureStubInfo;
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(GetByStatus);
@@ -59,6 +60,8 @@ public:
         Custom,
         // It's cached for an access to a module namespace object's binding.
         ModuleNamespace,
+        // It's cached for an access to a proxy object's binding.
+        ProxyObject,
         // It will likely take the slow path.
         LikelyTakesSlowPath,
         // It's known to take slow path. We also observed that the slow path was taken on StructureStubInfo.
@@ -99,6 +102,7 @@ public:
     bool isSimple() const { return m_state == Simple; }
     bool isCustom() const { return m_state == Custom; }
     bool isModuleNamespace() const { return m_state == ModuleNamespace; }
+    bool isProxyObject() const { return m_state == ProxyObject; }
 
     size_t numVariants() const { return m_variants.size(); }
     const Vector<GetByVariant, 1>& variants() const { return m_variants; }
@@ -136,6 +140,7 @@ private:
     
 #if ENABLE(JIT)
     GetByStatus(const ModuleNamespaceAccessCase&);
+    GetByStatus(const ProxyObjectAccessCase&);
     static GetByStatus computeForStubInfoWithoutExitSiteFeedback(
         const ConcurrentJSLocker&, CodeBlock* profiledBlock, StructureStubInfo*, CallLinkStatus::ExitSiteData);
 #endif

--- a/Source/JavaScriptCore/bytecode/InlineCallFrame.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCallFrame.cpp
@@ -115,6 +115,9 @@ void printInternal(PrintStream& out, JSC::InlineCallFrame::Kind kind)
     case JSC::InlineCallFrame::SetterCall:
         out.print("SetterCall");
         return;
+    case JSC::InlineCallFrame::ProxyObjectLoadCall:
+        out.print("ProxyObjectLoadCall");
+        return;
     }
     RELEASE_ASSERT_NOT_REACHED();
 }

--- a/Source/JavaScriptCore/bytecode/InlineCallFrame.h
+++ b/Source/JavaScriptCore/bytecode/InlineCallFrame.h
@@ -52,8 +52,10 @@ struct InlineCallFrame {
         // For these, the stackOffset incorporates the argument count plus the true return PC
         // slot.
         GetterCall,
-        SetterCall
+        SetterCall,
+        ProxyObjectLoadCall,
     };
+    static constexpr unsigned bitWidthOfKind = 4;
 
     static CallMode callModeFor(Kind kind)
     {
@@ -62,6 +64,7 @@ struct InlineCallFrame {
         case CallVarargs:
         case GetterCall:
         case SetterCall:
+        case ProxyObjectLoadCall:
             return CallMode::Regular;
         case TailCall:
         case TailCallVarargs:
@@ -108,6 +111,7 @@ struct InlineCallFrame {
         case TailCallVarargs:
         case GetterCall:
         case SetterCall:
+        case ProxyObjectLoadCall:
             return CodeForCall;
         case Construct:
         case ConstructVarargs:
@@ -179,11 +183,11 @@ struct InlineCallFrame {
     WriteBarrier<CodeBlock> baselineCodeBlock;
     CodeOrigin directCaller;
 
-    unsigned argumentCountIncludingThis : 22; // Do not include fixups.
-    unsigned tmpOffset : 10;
-    signed stackOffset : 28;
-    unsigned kind : 3; // real type is Kind
-    bool isClosureCall : 1; // If false then we know that callee/scope are constants and the DFG won't treat them as variables, i.e. they have to be recovered manually.
+    unsigned argumentCountIncludingThis : 22 { 0 }; // Do not include fixups.
+    unsigned tmpOffset : 10 { 0 };
+    signed stackOffset : 28 { 0 };
+    unsigned kind : bitWidthOfKind { Call }; // real type is Kind
+    bool isClosureCall : 1 { false }; // If false then we know that callee/scope are constants and the DFG won't treat them as variables, i.e. they have to be recovered manually.
     VirtualRegister argumentCountRegister; // Only set when we inline a varargs call.
 
     ValueRecovery calleeRecovery;
@@ -191,14 +195,7 @@ struct InlineCallFrame {
     // There is really no good notion of a "default" set of values for
     // InlineCallFrame's fields. This constructor is here just to reduce confusion if
     // we forgot to initialize explicitly.
-    InlineCallFrame()
-        : argumentCountIncludingThis(0)
-        , tmpOffset(0)
-        , stackOffset(0)
-        , kind(Call)
-        , isClosureCall(false)
-    {
-    }
+    InlineCallFrame() = default;
     
     bool isVarargs() const
     {

--- a/Source/JavaScriptCore/dfg/DFGOSRExitCompilerCommon.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOSRExitCompilerCommon.cpp
@@ -171,7 +171,8 @@ static CodePtr<JSEntryPtrTag> callerReturnPC(CodeBlock* baselineCodeBlockForCall
         case InlineCallFrame::ConstructVarargs:
             jumpTarget = LLINT_RETURN_LOCATION(op_construct_varargs);
             break;
-        case InlineCallFrame::GetterCall: {
+        case InlineCallFrame::GetterCall:
+        case InlineCallFrame::ProxyObjectLoadCall: {
             if (callInstruction.opcodeID() == op_get_by_id)
                 jumpTarget = LLINT_RETURN_LOCATION(op_get_by_id);
             else if (callInstruction.opcodeID() == op_get_by_val)
@@ -212,7 +213,8 @@ static CodePtr<JSEntryPtrTag> callerReturnPC(CodeBlock* baselineCodeBlockForCall
         }
 
         case InlineCallFrame::GetterCall:
-        case InlineCallFrame::SetterCall: {
+        case InlineCallFrame::SetterCall:
+        case InlineCallFrame::ProxyObjectLoadCall: {
             StructureStubInfo* stubInfo = baselineCodeBlockForCaller->findStubInfo(CodeOrigin(callBytecodeIndex));
             RELEASE_ASSERT(stubInfo, callInstruction.opcodeID());
             jumpTarget = stubInfo->doneLocation.retagged<JSEntryPtrTag>();

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -865,6 +865,8 @@ public:
     JSFunction* regExpProtoExecFunction() const;
     JSFunction* typedArrayProtoSort() const { return m_typedArrayProtoSort.get(this); }
     JSFunction* stringProtoSubstringFunction() const;
+    JSFunction* performProxyObjectGetFunction() const;
+    JSFunction* performProxyObjectGetFunctionConcurrently() const;
     JSObject* regExpProtoSymbolReplaceFunction() const { return m_regExpProtoSymbolReplace.get(); }
     GetterSetter* regExpProtoGlobalGetter() const;
     GetterSetter* regExpProtoUnicodeGetter() const;
@@ -1224,12 +1226,21 @@ public:
         return result;
     }
 
+    template<typename Type>
+    Type linkTimeConstantConcurrently(LinkTimeConstant value) const
+    {
+        JSCell* result = m_linkTimeConstants[static_cast<unsigned>(value)].getConcurrently();
+        if (!result)
+            return nullptr;
+        return jsCast<Type>(result);
+    }
+
     WatchpointSet& masqueradesAsUndefinedWatchpointSet() { return m_masqueradesAsUndefinedWatchpointSet.get(); }
     WatchpointSet& havingABadTimeWatchpointSet() { return m_havingABadTimeWatchpointSet.get(); }
     WatchpointSet& varInjectionWatchpointSet() { return m_varInjectionWatchpointSet.get(); }
     WatchpointSet& varReadOnlyWatchpointSet() { return m_varReadOnlyWatchpointSet.get(); }
     WatchpointSet& regExpRecompiledWatchpointSet() { return m_regExpRecompiledWatchpointSet.get(); }
-        
+
     bool isHavingABadTime() const
     {
         return m_havingABadTimeWatchpointSet->hasBeenInvalidated();

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
@@ -192,6 +192,8 @@ inline JSFunction* JSGlobalObject::promiseProtoThenFunction() const { return jsC
 inline JSFunction* JSGlobalObject::performPromiseThenFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::performPromiseThen)); }
 inline JSFunction* JSGlobalObject::regExpProtoExecFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::regExpBuiltinExec)); }
 inline JSFunction* JSGlobalObject::stringProtoSubstringFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::stringSubstring)); }
+inline JSFunction* JSGlobalObject::performProxyObjectGetFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::performProxyObjectGet)); }
+inline JSFunction* JSGlobalObject::performProxyObjectGetFunctionConcurrently() const { return linkTimeConstantConcurrently<JSFunction*>(LinkTimeConstant::performProxyObjectGet); }
 inline GetterSetter* JSGlobalObject::regExpProtoGlobalGetter() const { return bitwise_cast<GetterSetter*>(linkTimeConstant(LinkTimeConstant::regExpProtoGlobalGetter)); }
 inline GetterSetter* JSGlobalObject::regExpProtoUnicodeGetter() const { return bitwise_cast<GetterSetter*>(linkTimeConstant(LinkTimeConstant::regExpProtoUnicodeGetter)); }
 

--- a/Source/JavaScriptCore/runtime/ProxyObject.cpp
+++ b/Source/JavaScriptCore/runtime/ProxyObject.cpp
@@ -27,6 +27,7 @@
 #include "ProxyObject.h"
 
 #include "JSCInlines.h"
+#include "JSInternalFieldObjectImplInlines.h"
 #include "ObjectConstructor.h"
 #include "VMInlines.h"
 #include <wtf/NoTailCalls.h>
@@ -77,8 +78,8 @@ void ProxyObject::finishCreation(VM& vm, JSGlobalObject* globalObject, JSValue t
 
     m_isConstructible = targetAsObject->isConstructor();
 
-    m_target.set(vm, this, targetAsObject);
-    m_handler.set(vm, this, handler);
+    internalField(Field::Target).set(vm, this, targetAsObject);
+    internalField(Field::Handler).set(vm, this, handler);
 }
 
 static const ASCIILiteral s_proxyAlreadyRevokedErrorMessage { "Proxy has already been revoked. No more operations are allowed to be performed on it"_s };
@@ -1143,10 +1144,10 @@ JSValue ProxyObject::getPrototype(JSObject* object, JSGlobalObject* globalObject
 }
 
 void ProxyObject::revoke(VM& vm)
-{ 
+{
     // This should only ever be called once and we should strictly transition from Object to null.
-    RELEASE_ASSERT(!m_handler.get().isNull() && m_handler.get().isObject());
-    m_handler.set(vm, this, jsNull());
+    RELEASE_ASSERT(!handler().isNull() && handler().isObject());
+    internalField(Field::Handler).set(vm, this, jsNull());
 }
 
 bool ProxyObject::isRevoked() const
@@ -1157,12 +1158,9 @@ bool ProxyObject::isRevoked() const
 template<typename Visitor>
 void ProxyObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    ProxyObject* thisObject = jsCast<ProxyObject*>(cell);
+    auto* thisObject = jsCast<ProxyObject*>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
-
-    visitor.append(thisObject->m_target);
-    visitor.append(thisObject->m_handler);
 }
 
 DEFINE_VISIT_CHILDREN(ProxyObject);

--- a/Source/JavaScriptCore/runtime/ProxyObject.h
+++ b/Source/JavaScriptCore/runtime/ProxyObject.h
@@ -30,11 +30,24 @@
 
 namespace JSC {
 
-class ProxyObject final : public JSNonFinalObject {
+class ProxyObject final : public JSInternalFieldObjectImpl<2> {
 public:
-    typedef JSNonFinalObject Base;
+    using Base = JSInternalFieldObjectImpl<2>;
 
     static constexpr unsigned StructureFlags = Base::StructureFlags | OverridesGetOwnPropertySlot | OverridesGetOwnPropertyNames | OverridesGetPrototype | OverridesGetCallData | OverridesPut | InterceptsGetOwnPropertySlotByIndexEvenWhenLengthIsNotZero | ProhibitsPropertyCaching;
+
+    enum class Field : uint32_t {
+        Target = 0,
+        Handler,
+    };
+    static_assert(numberOfInternalFields == 2);
+    static std::array<JSValue, numberOfInternalFields> initialValues()
+    {
+        return { {
+            jsNull(),
+            jsUndefined(),
+        } };
+    }
 
     template<typename CellType, SubspaceAccess mode>
     static GCClient::IsoSubspace* subspaceFor(VM& vm)
@@ -64,8 +77,8 @@ public:
 
     DECLARE_EXPORT_INFO;
 
-    JSObject* target() const { return m_target.get(); }
-    JSValue handler() const { return m_handler.get(); }
+    JSObject* target() const { return jsCast<JSObject*>(internalField(Field::Target).get()); }
+    JSValue handler() const { return internalField(Field::Handler).get(); }
 
     static bool put(JSCell*, JSGlobalObject*, PropertyName, JSValue, PutPropertySlot&);
     static bool putByIndex(JSCell*, JSGlobalObject*, unsigned propertyName, JSValue, bool shouldThrow);
@@ -74,8 +87,8 @@ public:
     void revoke(VM&);
     bool isRevoked() const;
 
-    static ptrdiff_t offsetOfTarget() { return OBJECT_OFFSETOF(ProxyObject, m_target); }
-    static ptrdiff_t offsetOfHandler() { return OBJECT_OFFSETOF(ProxyObject, m_handler); }
+    const WriteBarrier<Unknown>& internalField(Field field) const { return Base::internalField(static_cast<uint32_t>(field)); }
+    WriteBarrier<Unknown>& internalField(Field field) { return Base::internalField(static_cast<uint32_t>(field)); }
 
 private:
     JS_EXPORT_PRIVATE ProxyObject(VM&, Structure*);
@@ -111,10 +124,8 @@ private:
     void performGetOwnEnumerablePropertyNames(JSGlobalObject*, PropertyNameArray&);
     bool performSetPrototype(JSGlobalObject*, JSValue prototype, bool shouldThrowIfCantSet);
 
-    WriteBarrier<JSObject> m_target;
-    WriteBarrier<Unknown> m_handler;
-    bool m_isCallable : 1;
-    bool m_isConstructible : 1;
+    bool m_isCallable : 1 { false };
+    bool m_isConstructible : 1 { false };
 };
 
 } // namespace JSC


### PR DESCRIPTION
#### fbc9cd14c68a3a4f93790bf31543dcf5180da4f3
<pre>
[JSC] Inline Proxy get trap
<a href="https://bugs.webkit.org/show_bug.cgi?id=252229">https://bugs.webkit.org/show_bug.cgi?id=252229</a>

Reviewed by Alexey Shvayka.

This patch teaches DFG to allow inlining of Proxy [[Get]] traps.
GetByStatus now can successfully recognize ProxyObjectAccessCase, and it reports
this inlining&apos;s availability to DFG. We get handler and target from ProxyObject
in performProxyObjectGet so that we can just pass ProxyObject from the caller side,
which can be easily checked in DFG layer (by using ProxyObjectUse edge).
We add ProxyObjectLoadCall call types to InlineCallFrame to handle this inlined call frame
correctly for DFG / FTL OSR exit.
This offers Proxy [[Get]] trap performance improvement.

                                                        ToT                     Patched

    put-slow-no-cache-js-proxy                    13.5997+-0.1658     ^     13.3062+-0.0542        ^ definitely 1.0221x faster
    proxy-get                                    146.0271+-0.4420     ^    106.2325+-2.4139        ^ definitely 1.3746x faster
    proxy-get-miss-handler                        48.6311+-0.1538     ^     16.5862+-0.0612        ^ definitely 2.9320x faster

* Source/JavaScriptCore/builtins/ProxyHelpers.js:
(linkTimeConstant.performProxyObjectGet):
* Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h:
* Source/JavaScriptCore/bytecode/GetByStatus.cpp:
(JSC::GetByStatus::GetByStatus):
(JSC::GetByStatus::computeForStubInfoWithoutExitSiteFeedback):
(JSC::GetByStatus::makesCalls const):
(JSC::GetByStatus::merge):
(JSC::GetByStatus::dump const):
* Source/JavaScriptCore/bytecode/GetByStatus.h:
* Source/JavaScriptCore/bytecode/InlineCallFrame.cpp:
(WTF::printInternal):
* Source/JavaScriptCore/bytecode/InlineCallFrame.h:
(JSC::InlineCallFrame::callModeFor):
(JSC::InlineCallFrame::specializationKindFor):
(JSC::InlineCallFrame::InlineCallFrame): Deleted.
* Source/JavaScriptCore/bytecode/ProxyObjectAccessCase.cpp:
(JSC::ProxyObjectAccessCase::emit):
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::proxyInternalFieldIndex):
(JSC::BytecodeIntrinsicNode::emit_intrinsic_getProxyInternalField):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::inlineCall):
(JSC::DFG::ByteCodeParser::handleProxyObjectLoad):
(JSC::DFG::ByteCodeParser::handleGetById):
* Source/JavaScriptCore/dfg/DFGOSRExitCompilerCommon.cpp:
(JSC::DFG::callerReturnPC):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
(JSC::JSGlobalObject::linkTimeConstantConcurrently const):
* Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h:
(JSC::JSGlobalObject::performProxyObjectGetFunction const):
(JSC::JSGlobalObject::performProxyObjectGetFunctionConcurrently const):
* Source/JavaScriptCore/runtime/ProxyObject.cpp:
(JSC::ProxyObject::finishCreation):
(JSC::ProxyObject::revoke):
(JSC::ProxyObject::visitChildrenImpl):
* Source/JavaScriptCore/runtime/ProxyObject.h:

Canonical link: <a href="https://commits.webkit.org/260282@main">https://commits.webkit.org/260282@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6850493c8dc3e5d26a82679bfd87454b3055c5f5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107812 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16867 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/40701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/116953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/18271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8183 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/99990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113569 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/18271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/40701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/99990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/18271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/40701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/99990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/97084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/9819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/40701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/38/builds/96476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/83/builds/7869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/10514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/6881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/38/builds/96476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/15972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/40701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-mips~~](https://ews-build.webkit.org/#/builders/37/builds/105452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12080 "Built successfully") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/37/builds/105452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3859 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->