### PR TITLE
[Cocoa] Inline an unnecessary one-line lambda within preparePlatformFont()

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -395,10 +395,6 @@ static RetainPtr<CTFontRef> preparePlatformFont(CTFontRef originalFont, const Fo
 
     bool needsConversion = fontType.variationType == FontType::VariationType::TrueTypeGX;
 
-    auto applyVariation = [&](const FontTag& tag, float value) {
-        variationsToBeApplied.set(tag, value);
-    };
-
     // Step 1: CoreText handles default features (such as required ligatures).
 
     // Step 2: font-weight, font-stretch, and font-style
@@ -427,12 +423,12 @@ static RetainPtr<CTFontRef> preparePlatformFont(CTFontRef originalFont, const Fo
             width = denormalizeVariationWidth(width);
             slope = denormalizeSlope(slope);
         }
-        applyVariation({{'w', 'g', 'h', 't'}}, weight);
-        applyVariation({{'w', 'd', 't', 'h'}}, width);
+        variationsToBeApplied.set({ { 'w', 'g', 'h', 't' } }, weight);
+        variationsToBeApplied.set({ { 'w', 'd', 't', 'h' } }, width);
         if (fontStyleAxis == FontStyleAxis::ital)
-            applyVariation({{'i', 't', 'a', 'l'}}, 1);
+            variationsToBeApplied.set({ { 'i', 't', 'a', 'l' } }, 1);
         else
-            applyVariation({{'s', 'l', 'n', 't'}}, slope);
+            variationsToBeApplied.set({ { 's', 'l', 'n', 't' } }, slope);
     }
 
     // FIXME: Implement Step 5: font-named-instance
@@ -473,7 +469,7 @@ static RetainPtr<CTFontRef> preparePlatformFont(CTFontRef originalFont, const Fo
 
     // Step 12: font-variation-settings
     for (auto& newVariation : variations)
-        applyVariation(newVariation.tag(), newVariation.value());
+        variationsToBeApplied.set(newVariation.tag(), newVariation.value());
 
     auto attributes = adoptCF(CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
     if (!featuresToBeApplied.isEmpty()) {


### PR DESCRIPTION
#### b323e68196e945348aaa29340f77036d13ccdbb9
<pre>
[Cocoa] Inline an unnecessary one-line lambda within preparePlatformFont()
<a href="https://bugs.webkit.org/show_bug.cgi?id=252231">https://bugs.webkit.org/show_bug.cgi?id=252231</a>
rdar://105438464

Reviewed by Tim Nguyen.

There&apos;s no reason for it to exist.

* Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp:
(WebCore::preparePlatformFont):

Canonical link: <a href="https://commits.webkit.org/260248@main">https://commits.webkit.org/260248@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96f215af28470b8e1b75bd1180509f5ea041485d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107674 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16726 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40570 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116822 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111565 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18148 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8044 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99847 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113428 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13698 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/96895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/41375 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/95614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28531 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9709 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29880 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10386 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6769 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15862 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49465 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7083 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11946 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->