### PR TITLE
[Cocoa] We're unnecessarily asking the system whether fonts we created are the system font or not

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.h
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.h
@@ -63,11 +63,15 @@ struct VariationDefaults {
 
 typedef HashMap<FontTag, VariationDefaults, FourCharacterTagHash, FourCharacterTagHashTraits> VariationDefaultsMap;
 
+enum class FontTypeForPreparation : bool {
+    SystemFont,
+    NonSystemFont
+};
 enum class ApplyTraitsVariations : bool {
     No,
-    Yes,
+    Yes
 };
-RetainPtr<CTFontRef> preparePlatformFont(UnrealizedCoreTextFont&&, const FontDescription&, const FontCreationContext&, ApplyTraitsVariations = ApplyTraitsVariations::Yes);
+RetainPtr<CTFontRef> preparePlatformFont(UnrealizedCoreTextFont&&, const FontDescription&, const FontCreationContext&, FontTypeForPreparation = FontTypeForPreparation::NonSystemFont, ApplyTraitsVariations = ApplyTraitsVariations::Yes);
 enum class ShouldComputePhysicalTraits : bool { No, Yes };
 SynthesisPair computeNecessarySynthesis(CTFontRef, const FontDescription&, ShouldComputePhysicalTraits = ShouldComputePhysicalTraits::No, bool isPlatformFont = false);
 RetainPtr<CTFontRef> platformFontWithFamily(const AtomString& family, FontSelectionRequest, TextRenderingMode, float size);

--- a/Source/WebCore/platform/graphics/cocoa/FontFamilySpecificationCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontFamilySpecificationCoreText.cpp
@@ -53,7 +53,7 @@ FontRanges FontFamilySpecificationCoreText::fontRanges(const FontDescription& fo
         UnrealizedCoreTextFont unrealizedFont = { RetainPtr { m_fontDescriptor } };
         unrealizedFont.setSize(size);
 
-        auto font = preparePlatformFont(WTFMove(unrealizedFont), fontDescription, { });
+        auto font = preparePlatformFont(WTFMove(unrealizedFont), fontDescription, { }, FontTypeForPreparation::SystemFont);
 
         auto [syntheticBold, syntheticOblique] = computeNecessarySynthesis(font.get(), fontDescription, ShouldComputePhysicalTraits::Yes).boldObliquePair();
 


### PR DESCRIPTION
#### ad421fc347f653b7d8926b6f33a93704d8a1bec1
<pre>
[Cocoa] We&apos;re unnecessarily asking the system whether fonts we created are the system font or not
<a href="https://bugs.webkit.org/show_bug.cgi?id=252235">https://bugs.webkit.org/show_bug.cgi?id=252235</a>
rdar://105442047

Reviewed by Alan Baradlay.

We create the fonts in the first place, so we already know whether or not they are
the system font or not. We should just remember the kind of font we created, rather
than having to call into Core Text for them to tell us.

* Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp:
(WebCore::preparePlatformFont):
(WebCore::fontDescriptorWithFamilySpecialCase):
(WebCore::fontWithFamily):
* Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.h:
* Source/WebCore/platform/graphics/cocoa/FontFamilySpecificationCoreText.cpp:
(WebCore::FontFamilySpecificationCoreText::fontRanges const):

Canonical link: <a href="https://commits.webkit.org/260289@main">https://commits.webkit.org/260289@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea5d673e078d72be754458fb04b72a83c968307f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107823 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16877 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40709 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116961 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111713 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/18279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8192 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99998 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113580 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/18279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97001 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/41496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/18279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28642 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/9827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29990 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10522 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/6887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/15980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49574 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7117 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12089 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->