### PR TITLE
[css-fonts] font-feature-settings and font-variation-settings should sort their tags alphabetically

### DIFF
--- a/LayoutTests/animations/font-variations/font-variation-settings-order-expected.txt
+++ b/LayoutTests/animations/font-variations/font-variation-settings-order-expected.txt
@@ -1,5 +1,5 @@
 Hello
-PASS - "font-variation-settings" property for "box" element at 0.5s saw something close to: "wdth" 566.6666, "hght" 466.6666
-PASS - "font-variation-settings" property for "box" element at 1s saw something close to: "wdth" 633.3333, "hght" 533.3333
-PASS - "font-variation-settings" property for "box" element at 2s saw something close to: "wdth" 766.6666, "hght" 666.6666
+PASS - "font-variation-settings" property for "box" element at 0.5s saw something close to: "hght" 466.6666, "wdth" 566.6666
+PASS - "font-variation-settings" property for "box" element at 1s saw something close to: "hght" 533.3333, "wdth" 633.3333
+PASS - "font-variation-settings" property for "box" element at 2s saw something close to: "hght" 666.6666, "wdth" 766.6666
 

--- a/LayoutTests/animations/font-variations/font-variation-settings-order.html
+++ b/LayoutTests/animations/font-variations/font-variation-settings-order.html
@@ -30,9 +30,9 @@
 <script>
 var expectedValues = [
     // [animation-name, time, element-id, property, expected-value, tolerance]
-    ["TheAnimation", 0.5, "box", "font-variation-settings", "\"wdth\" 566.6666, \"hght\" 466.6666", 5],
-    ["TheAnimation", 1.0, "box", "font-variation-settings", "\"wdth\" 633.3333, \"hght\" 533.3333", 5],
-    ["TheAnimation", 2.0, "box", "font-variation-settings", "\"wdth\" 766.6666, \"hght\" 666.6666", 5],
+    ["TheAnimation", 0.5, "box", "font-variation-settings", "\"hght\" 466.6666, \"wdth\" 566.6666", 5],
+    ["TheAnimation", 1.0, "box", "font-variation-settings", "\"hght\" 533.3333, \"wdth\" 633.3333", 5],
+    ["TheAnimation", 2.0, "box", "font-variation-settings", "\"hght\" 666.6666, \"wdth\" 766.6666", 5],
 ];
 
 document.fonts.ready.then(function() {

--- a/LayoutTests/fast/text/variations/getComputedStyle-expected.txt
+++ b/LayoutTests/fast/text/variations/getComputedStyle-expected.txt
@@ -1,6 +1,6 @@
 PASS window.getComputedStyle(document.getElementById('test0')).getPropertyValue('font-variation-settings') is "\"hght\" 400"
 PASS window.getComputedStyle(document.getElementById('test1')).getPropertyValue('font-variation-settings') is "\"hght\" 500"
-PASS window.getComputedStyle(document.getElementById('test2')).getPropertyValue('font-variation-settings') is "\"wdth\" 500, \"hght\" 400"
+PASS window.getComputedStyle(document.getElementById('test2')).getPropertyValue('font-variation-settings') is "\"hght\" 400, \"wdth\" 500"
 PASS window.getComputedStyle(document.getElementById('test3')).getPropertyValue('font-variation-settings') is window.getComputedStyle(document.getElementById('test2')).getPropertyValue('font-variation-settings')
 PASS window.getComputedStyle(document.getElementById('test4')).getPropertyValue('font-variation-settings') is "normal"
 PASS window.getComputedStyle(document.getElementById('test5')).getPropertyValue('font-variation-settings') is "normal"

--- a/LayoutTests/fast/text/variations/getComputedStyle.html
+++ b/LayoutTests/fast/text/variations/getComputedStyle.html
@@ -22,7 +22,7 @@
 <script>
 shouldBeEqualToString("window.getComputedStyle(document.getElementById('test0')).getPropertyValue('font-variation-settings')", "\"hght\" 400");
 shouldBeEqualToString("window.getComputedStyle(document.getElementById('test1')).getPropertyValue('font-variation-settings')", "\"hght\" 500");
-shouldBeEqualToString("window.getComputedStyle(document.getElementById('test2')).getPropertyValue('font-variation-settings')", "\"wdth\" 500, \"hght\" 400");
+shouldBeEqualToString("window.getComputedStyle(document.getElementById('test2')).getPropertyValue('font-variation-settings')", "\"hght\" 400, \"wdth\" 500");
 shouldBe("window.getComputedStyle(document.getElementById('test3')).getPropertyValue('font-variation-settings')", "window.getComputedStyle(document.getElementById('test2')).getPropertyValue('font-variation-settings')");
 shouldBeEqualToString("window.getComputedStyle(document.getElementById('test4')).getPropertyValue('font-variation-settings')", "normal");
 shouldBeEqualToString("window.getComputedStyle(document.getElementById('test5')).getPropertyValue('font-variation-settings')", "normal");

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/inheritance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/inheritance-expected.txt
@@ -1,7 +1,7 @@
 
 FAIL Property font-family inherits assert_not_equals: got disallowed value "\"Not Initial!\""
 PASS Property font-feature-settings has initial value normal
-FAIL Property font-feature-settings inherits assert_equals: expected "\"smcp\", \"swsh\" 2" but got "\"swsh\" 2, \"smcp\""
+FAIL Property font-feature-settings inherits assert_not_equals: got disallowed value "\"smcp\", \"swsh\" 2"
 PASS Property font-kerning has initial value auto
 PASS Property font-kerning inherits
 FAIL Property font-language-override has initial value normal assert_true: font-language-override doesn't seem to be supported in the computed style expected true got false

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-feature-settings-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-feature-settings-computed-expected.txt
@@ -6,5 +6,5 @@ PASS Property font-feature-settings value '"c2sc"'
 PASS Property font-feature-settings value '"liga" 0'
 PASS Property font-feature-settings value '"tnum", "hist"'
 FAIL Property font-feature-settings value '"PKRN"' assert_equals: expected "\"PKRN\"" but got "\"pkrn\""
-FAIL Property font-feature-settings value '"dlig", "smcp", "dlig" 0' assert_equals: expected "\"dlig\", \"smcp\", \"dlig\" 0" but got "\"smcp\", \"dlig\", \"dlig\" 0"
+PASS Property font-feature-settings value '"dlig", "smcp", "dlig" 0'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-feature-settings-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-feature-settings-computed.html
@@ -18,11 +18,13 @@ test_computed_value('font-feature-settings', '"dlig"');
 test_computed_value('font-feature-settings', '"smcp"');
 test_computed_value('font-feature-settings', '"c2sc"');
 test_computed_value('font-feature-settings', '"liga" 0');
-test_computed_value('font-feature-settings', '"tnum", "hist"');
+test_computed_value('font-feature-settings', '"tnum", "hist"',
+                    ['"tnum", "hist"', '"hist", "tnum"']);
 
 test_computed_value('font-feature-settings', '"PKRN"');
 
-test_computed_value('font-feature-settings', '"dlig", "smcp", "dlig" 0');
+test_computed_value('font-feature-settings', '"dlig", "smcp", "dlig" 0',
+                    ['"smcp", "dlig" 0', '"dlig" 0, "smcp"']);
 </script>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-variation-settings-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-variation-settings-computed-expected.txt
@@ -4,5 +4,7 @@ PASS Property font-variation-settings value '"wght" 700'
 PASS Property font-variation-settings value '"AB@D" 0.5'
 PASS Property font-variation-settings value '"wght" 700, "wght" 500' duplicate values should be removed, keeping the rightmost occurrence.
 PASS Property font-variation-settings value '"wght" 700, "XHGT" 0.7'
+PASS Property font-variation-settings value '"wght" 100, "wdth" 200' values should be sorted alphabetically by tag.
+PASS Property font-variation-settings value '"wght" 100, "wdth" 200, "wght" 300, "wdth" 400' duplicate values should be removed, keeping the rightmost occurrence, and sorted alphabetically by tag.
 PASS Property font-variation-settings value '"XHGT" calc(0.4 + 0.3)'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-variation-settings-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-variation-settings-computed.html
@@ -23,6 +23,12 @@ test_computed_value('font-variation-settings', '"wght" 700, "wght" 500', '"wght"
 test_computed_value('font-variation-settings', '"wght" 700, "XHGT" 0.7',
     ['"wght" 700, "XHGT" 0.7', '"XHGT" 0.7, "wght" 700']);
 
+test_computed_value('font-variation-settings', '"wght" 100, "wdth" 200', '"wdth" 200, "wght" 100',
+    "values should be sorted alphabetically by tag.");
+
+test_computed_value('font-variation-settings', '"wght" 100, "wdth" 200, "wght" 300, "wdth" 400', '"wdth" 400, "wght" 300',
+    "duplicate values should be removed, keeping the rightmost occurrence, and sorted alphabetically by tag.");
+
 test_computed_value('font-variation-settings', '"XHGT" calc(0.4 + 0.3)', '"XHGT" 0.7');
 </script>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-001-expected.txt
@@ -276,7 +276,7 @@ PASS font-variation-settings (type: fontVariationSettings) has testAccumulation 
 FAIL font-variation-settings with composite type accumulate assert_equals: The value should be "wght" 2.2 at 250ms expected "\"wght\" 2.2" but got "\"wght\" 2.1999998"
 PASS font-variation-settings (type: discrete) has testAccumulation function
 PASS font-variation-settings: ""wdth" 5" onto ""wdth" 1, "wght" 1.1"
-FAIL font-variation-settings: ""wdth" 1, "wght" 1.1" onto ""wdth" 5" assert_equals: The value should be "wdth" 1, "wght" 1.1 at 0ms expected "\"wdth\" 1, \"wght\" 1.1" but got "\"wght\" 1.1, \"wdth\" 1"
+PASS font-variation-settings: ""wdth" 1, "wght" 1.1" onto ""wdth" 5"
 PASS font-variation-settings: "normal" onto ""wdth" 5"
 PASS font-variation-settings: ""wdth" 5" onto "normal"
 PASS grid-auto-columns (type: discrete) has testAccumulation function

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-001-expected.txt
@@ -276,7 +276,7 @@ PASS font-variation-settings (type: fontVariationSettings) has testAddition func
 FAIL font-variation-settings with composite type add assert_equals: The value should be "wght" 2.2 at 250ms expected "\"wght\" 2.2" but got "\"wght\" 2.1999998"
 PASS font-variation-settings (type: discrete) has testAddition function
 PASS font-variation-settings: ""wdth" 5" onto ""wdth" 1, "wght" 1.1"
-FAIL font-variation-settings: ""wdth" 1, "wght" 1.1" onto ""wdth" 5" assert_equals: The value should be "wdth" 1, "wght" 1.1 at 0ms expected "\"wdth\" 1, \"wght\" 1.1" but got "\"wght\" 1.1, \"wdth\" 1"
+PASS font-variation-settings: ""wdth" 1, "wght" 1.1" onto ""wdth" 5"
 PASS font-variation-settings: "normal" onto ""wdth" 5"
 PASS font-variation-settings: ""wdth" 5" onto "normal"
 PASS grid-auto-columns (type: discrete) has testAddition function

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-001-expected.txt
@@ -338,9 +338,9 @@ PASS font-variation-settings supports animation as float
 PASS font-variation-settings supports animation as float with multiple tags
 PASS font-variation-settings supports animation as float with multiple duplicate tags
 PASS font-variation-settings (type: discrete) has testInterpolation function
-FAIL font-variation-settings uses discrete animation when animating between ""wdth" 1, "wght" 1.1" and ""wdth" 5" with linear easing assert_equals: The value should be "wdth" 1, "wght" 1.1 at 0ms expected "\"wdth\" 1, \"wght\" 1.1" but got "\"wght\" 1.1, \"wdth\" 1"
-FAIL font-variation-settings uses discrete animation when animating between ""wdth" 1, "wght" 1.1" and ""wdth" 5" with effect easing assert_equals: The value should be "wdth" 1, "wght" 1.1 at 0ms expected "\"wdth\" 1, \"wght\" 1.1" but got "\"wght\" 1.1, \"wdth\" 1"
-FAIL font-variation-settings uses discrete animation when animating between ""wdth" 1, "wght" 1.1" and ""wdth" 5" with keyframe easing assert_equals: The value should be "wdth" 1, "wght" 1.1 at 0ms expected "\"wdth\" 1, \"wght\" 1.1" but got "\"wght\" 1.1, \"wdth\" 1"
+PASS font-variation-settings uses discrete animation when animating between ""wdth" 1, "wght" 1.1" and ""wdth" 5" with linear easing
+PASS font-variation-settings uses discrete animation when animating between ""wdth" 1, "wght" 1.1" and ""wdth" 5" with effect easing
+PASS font-variation-settings uses discrete animation when animating between ""wdth" 1, "wght" 1.1" and ""wdth" 5" with keyframe easing
 PASS font-variation-settings uses discrete animation when animating between ""wdth" 5" and "normal" with linear easing
 PASS font-variation-settings uses discrete animation when animating between ""wdth" 5" and "normal" with effect easing
 PASS font-variation-settings uses discrete animation when animating between ""wdth" 5" and "normal" with keyframe easing

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -702,7 +702,7 @@ public:
     {
     }
 
-    virtual T value(const RenderStyle& style) const
+    T value(const RenderStyle& style) const
     {
         return (style.*m_getter)();
     }
@@ -1259,11 +1259,6 @@ private:
         if (&a == &b)
             return true;
         return value(a) == value(b);
-    }
-
-    FontVariationSettings value(const RenderStyle& style) const override
-    {
-        return PropertyWrapper::value(style).deduplicated();
     }
 
     bool canInterpolate(const RenderStyle& from, const RenderStyle& to, CompositeOperation) const final

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -3207,7 +3207,7 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
     }
 #if ENABLE(VARIATION_FONTS)
     case CSSPropertyFontVariationSettings: {
-        auto variationSettings = style.fontVariationSettings().deduplicated();
+        auto& variationSettings = style.fontDescription().variationSettings();
         if (variationSettings.isEmpty())
             return CSSPrimitiveValue::create(CSSValueNormal);
         auto list = CSSValueList::createCommaSeparated();


### PR DESCRIPTION
#### 39681d9b2bda037dcbaf89aa6e7c3ece7436d449
<pre>
[css-fonts] font-feature-settings and font-variation-settings should sort their tags alphabetically
<a href="https://bugs.webkit.org/show_bug.cgi?id=252238">https://bugs.webkit.org/show_bug.cgi?id=252238</a>

Reviewed by Myles C. Maxfield.

We have some WPT test failures for font-variation-settings animation due to our sorting duplicate
tags differently than Chrome and Firefox (alphabetically by ascending order). While the css-fonts
spec does not specify any order for tags in the computed style, we adopt the same style as Chrome
and Firefox for font-variation-settings.

Since this applies not just to animated values but this issue wasn&apos;t caught by parsing test, we add
some new WPT tests to css/css-fonts/parsing/font-variation-settings-computed.html.

Finally, since font-feature-settings is a similar type of property, and we implement both with the
templatized FontTaggedSettings class, we apply the same rule for this CSS property as well. We also
update our copy of the css/css-fonts/parsing/font-variation-settings-computed.html WPT since it now
passes with our new rule.

Since we implement the deduplication and sorting directly in FontTaggedSettings&lt;T&gt;::insert, there is
no need for the FontTaggedSettings&lt;T&gt;::deduplicated method used in ComputedStyleExtractor and
CSSPropertyAnimation which was recently introduced in 260212@main, so we largely revert that patch
as far as those two classes are concerned.

A spec issue was filed to match this behavior: <a href="https://github.com/w3c/csswg-drafts/issues/8450.">https://github.com/w3c/csswg-drafts/issues/8450.</a>

* LayoutTests/animations/font-variations/font-variation-settings-order-expected.txt:
* LayoutTests/animations/font-variations/font-variation-settings-order.html:
* LayoutTests/fast/text/variations/getComputedStyle-expected.txt:
* LayoutTests/fast/text/variations/getComputedStyle.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/inheritance-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-feature-settings-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-feature-settings-computed.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-variation-settings-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-variation-settings-computed.html:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-001-expected.txt:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::PropertyWrapperGetter::value const):
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle):
* Source/WebCore/platform/graphics/FontTaggedSettings.h:
(WebCore::FontTaggedSettings&lt;T&gt;::insert):
(WebCore::FontTaggedSetting&lt;T&gt;::operator&lt; const): Deleted.
(WebCore::FontTaggedSettings&lt;T&gt;::deduplicated const): Deleted.

Canonical link: <a href="https://commits.webkit.org/260298@main">https://commits.webkit.org/260298@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e93d04e49568f86b75c003b13104cc73bbd061cd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107736 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16794 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40638 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116886 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116272 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111627 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18213 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8112 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99918 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113490 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13755 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96950 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41438 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95663 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28590 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9765 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29938 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10448 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6830 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15919 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49522 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12010 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3865 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->