### PR TITLE
[JSC][32bit] Fix JIT being disabled when compiling JSC on linux with clang

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirArg.h
+++ b/Source/JavaScriptCore/b3/air/AirArg.h
@@ -1340,7 +1340,7 @@ public:
         case MoveFloat:
             if (!std::is_signed<Int>::value)
                 return !((offset & 3) || (offset > (255 * 4)));
-            return !((offset & 3) || (offset > (255 * 4)) || (static_cast<std::make_signed<Int>::type>(offset) < -(255 * 4)));
+            return !((offset & 3) || (offset > (255 * 4)) || (static_cast<typename std::make_signed<Int>::type>(offset) < -(255 * 4)));
         default:
             return false;
         }

--- a/Source/JavaScriptCore/wasm/WasmOpcodeOrigin.h
+++ b/Source/JavaScriptCore/wasm/WasmOpcodeOrigin.h
@@ -38,8 +38,11 @@ class OpcodeOrigin {
     WTF_FORBID_HEAP_ALLOCATION;
 
     OpcodeOrigin() = default;
-#if USE(JSVALUE64)
+
 public:
+    void dump(PrintStream&) const;
+
+#if USE(JSVALUE64)
     OpcodeOrigin(OpType opcode, size_t offset)
     {
         ASSERT(static_cast<uint32_t>(offset) == offset);
@@ -50,8 +53,6 @@ public:
     {
     }
 
-    void dump(PrintStream&) const;
-
     OpType opcode() const { return static_cast<OpType>(packedData >> 32); }
     size_t location() const { return static_cast<uint32_t>(packedData); }
 
@@ -60,7 +61,7 @@ private:
     uint64_t packedData { 0 };
 
 #elif USE(JSVALUE32_64)
-    void dump(PrintStream&) const;
+    OpcodeOrigin(B3::Origin) { UNREACHABLE_FOR_PLATFORM(); }
 
     OpType opcode() const { UNREACHABLE_FOR_PLATFORM(); }
     size_t location() const { UNREACHABLE_FOR_PLATFORM(); }

--- a/Source/WTF/wtf/PlatformCPU.h
+++ b/Source/WTF/wtf/PlatformCPU.h
@@ -213,7 +213,9 @@
     || defined(__ARM_ARCH_7K__) \
     || defined(__ARM_ARCH_7M__) \
     || defined(__ARM_ARCH_7R__) \
-    || defined(__ARM_ARCH_7S__)
+    || defined(__ARM_ARCH_7S__) \
+    || defined(__ARM_ARCH_8__) \
+    || defined(__ARM_ARCH_8A__)
 #define WTF_THUMB_ARCH_VERSION 4
 
 /* RVCT sets __TARGET_ARCH_THUMB */

--- a/Source/bmalloc/bmalloc/BPlatform.h
+++ b/Source/bmalloc/bmalloc/BPlatform.h
@@ -227,7 +227,9 @@
 || defined(__ARM_ARCH_7K__) \
 || defined(__ARM_ARCH_7M__) \
 || defined(__ARM_ARCH_7R__) \
-|| defined(__ARM_ARCH_7S__)
+|| defined(__ARM_ARCH_7S__) \
+|| defined(__ARM_ARCH_8__) \
+|| defined(__ARM_ARCH_8A__)
 #define BTHUMB_ARCH_VERSION 4
 
 /* RVCT sets __TARGET_ARCH_THUMB */

--- a/Source/cmake/OptionsCommon.cmake
+++ b/Source/cmake/OptionsCommon.cmake
@@ -18,9 +18,20 @@ if (WTF_CPU_ARM)
     #error \"Thumb2 instruction set isn't available\"
     #endif
     int main() {}
-   ")
+    ")
 
+    if (COMPILER_IS_CLANG AND NOT (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin"))
+        set(CLANG_EXTRA_ARM_ARGS " -mthumb")
+    endif ()
+
+    set(CMAKE_REQUIRED_FLAGS "${CLANG_EXTRA_ARM_ARGS}")
     CHECK_CXX_SOURCE_COMPILES("${ARM_THUMB2_TEST_SOURCE}" ARM_THUMB2_DETECTED)
+    unset(CMAKE_REQUIRED_FLAGS)
+
+    if (ARM_THUMB2_DETECTED AND NOT (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin"))
+        string(APPEND CMAKE_C_FLAGS " ${CLANG_EXTRA_ARM_ARGS}")
+        string(APPEND CMAKE_CXX_FLAGS " ${CLANG_EXTRA_ARM_ARGS}")
+    endif ()
 endif ()
 
 # Use ld.lld when building with LTO, or for debug builds, if available.


### PR DESCRIPTION
#### 7dd18bda3626e7ca2f007d2ea8f7df7104bc95ab
<pre>
[JSC][32bit] Fix JIT being disabled when compiling JSC on linux with clang
<a href="https://bugs.webkit.org/show_bug.cgi?id=234034">https://bugs.webkit.org/show_bug.cgi?id=234034</a>

Reviewed by Justin Michaud.

JIT was always disabled when building JSC with clang on linux 32 bits
because CMake checked if the compiler defined __thumb2__ and while
gcc does define it by default, clang doesn&apos;t.

This patch adds extra compilation flags when compiling JSC with clang
for arm (except on Darwin), so the expected __thumb2__ define is defined
and JIT is enabled.

Also some minor changes:
(1) this patch also adds __ARM_ARCH_8__ and __ARM_ARCH_8A__
to the list that sets BTHUMB_ARCH_VERSION and WTF_THUMB_ARCH_VERSION to
4. These two seem to be used mostly for sanity check.
(2) a small fix in AirArg where clang complains about a missing
typename. gcc seems to accept either.

* Source/JavaScriptCore/b3/air/AirArg.h:
(JSC::B3::Air::Arg::isValidAddrForm):
* Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h:
(JSC::Wasm::parseAndCompileAirImpl):
* Source/WTF/wtf/PlatformCPU.h:
* Source/bmalloc/bmalloc/BPlatform.h:
* Source/cmake/OptionsCommon.cmake:

Canonical link: <a href="https://commits.webkit.org/260921@main">https://commits.webkit.org/260921@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad34acce2e6216c38a79e166f592e22d5bf95703

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108331 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17423 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41194 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117447 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116824 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18936 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8702 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100549 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114100 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14206 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97375 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42097 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96184 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29019 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/83777 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/97514 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10259 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30363 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/96858 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/8372 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10999 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7266 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30945 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16409 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49960 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/105926 "Built successfully") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7572 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12585 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26217 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->