### PR TITLE
[ews-build.webkit.org] Don't rely on hideStep in DetermineLandedIdentifier

### DIFF
--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -5744,24 +5744,8 @@ class TestDetermineLandedIdentifier(BuildStepMixinAdditions, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         timeout=300,
                         logEnviron=False,
-                        command=['git', 'log', '-1', '--no-decorate']) +
-                ExpectShell.log('stdio', stdout=''''commit 220797@main (14dbf1155cf56a1dd4d86a847e61af3c3e5d2ca5, r256729)
-Author: Aakash Jain <aakash_jain@apple.com>
-Date:   Mon Feb 17 15:09:42 2020 +0000
-
-    [ews] add SetBuildSummary step
-    https://bugs.webkit.org/show_bug.cgi?id=207556
-    
-    Reviewed by Jonathan Bedard.
-    
-    * BuildSlaveSupport/ews-build/factories.py:
-    (GTKBuildAndTestFactory.__init__):
-    * BuildSlaveSupport/ews-build/factories_unittest.py:
-    (TestBuildAndTestsFactory): Added unit-test.
-    
-    
-    Canonical link: https://commits.webkit.org/220797@main
-    git-svn-id: https://svn.webkit.org/repository/webkit/trunk@256729 268f45cc-cd09-0410-ab3c-d52691b4dbfc''') +
+                        command=['/bin/sh', '-c', "git log -1 --no-decorate | grep 'Canonical link: https://commits\\.webkit\\.org/'"]) +
+                ExpectShell.log('stdio', stdout='    Canonical link: https://commits.webkit.org/220797@main\n') +
                 0,
             )
             self.expectOutcome(result=SUCCESS, state_string='Identifier: 220797@main')
@@ -5782,22 +5766,8 @@ Date:   Mon Feb 17 15:09:42 2020 +0000
             ExpectShell(workdir='wkdir',
                         timeout=300,
                         logEnviron=False,
-                        command=['git', 'log', '-1', '--no-decorate']) +
-                ExpectShell.log('stdio', stdout=''''commit 5dc27962b4c5bdfd17d17faa785f70abbb0550ed
-Author: Matteo Flores <matteo_flores@apple.com>
-Date:   Fri Apr 22 21:24:12 2022 +0000
-
-    REBASLINE: [ Monterey ] fast/text/khmer-lao-font.html is a constant text failure
-    
-    https://bugs.webkit.org/show_bug.cgi?id=238917
-    
-    Unreviewed test gardening.
-    
-    * platform/mac-bigsur/fast/text/khmer-lao-font-expected.txt: Copied from LayoutTests/platform/mac/fast/text/khmer-lao-font-expected.txt.
-    * platform/mac/fast/text/khmer-lao-font-expected.txt:
-    
-    Canonical link: https://commits.webkit.org/249903@main
-    git-svn-id: https://svn.webkit.org/repository/webkit/trunk@293254 268f45cc-cd09-0410-ab3c-d52691b4dbfc''') +
+                        command=['/bin/sh', '-c', "git log -1 --no-decorate | grep 'Canonical link: https://commits\\.webkit\\.org/'"]) +
+                ExpectShell.log('stdio', stdout='    Canonical link: https://commits.webkit.org/249903@main\n') +
                 0,
             )
             self.expectOutcome(result=SUCCESS, state_string='Identifier: 249903@main')
@@ -5817,9 +5787,9 @@ Date:   Fri Apr 22 21:24:12 2022 +0000
             ExpectShell(workdir='wkdir',
                         timeout=300,
                         logEnviron=False,
-                        command=['git', 'log', '-1', '--no-decorate']) +
+                        command=['/bin/sh', '-c', "git log -1 --no-decorate | grep 'Canonical link: https://commits\\.webkit\\.org/'"]) +
                 ExpectShell.log('stdio', stdout='') +
-                0,
+                1,
             )
             self.expectOutcome(result=SUCCESS, state_string='Identifier: 220797@main')
             with current_hostname(EWS_BUILD_HOSTNAME):
@@ -5838,9 +5808,9 @@ Date:   Fri Apr 22 21:24:12 2022 +0000
             ExpectShell(workdir='wkdir',
                         timeout=300,
                         logEnviron=False,
-                        command=['git', 'log', '-1', '--no-decorate']) +
+                        command=['/bin/sh', '-c', "git log -1 --no-decorate | grep 'Canonical link: https://commits\\.webkit\\.org/'"]) +
                 ExpectShell.log('stdio', stdout='') +
-                0,
+                1,
             )
             self.expectOutcome(result=FAILURE, state_string='Failed to determine identifier')
             with current_hostname(EWS_BUILD_HOSTNAME):
@@ -5859,9 +5829,9 @@ Date:   Fri Apr 22 21:24:12 2022 +0000
             ExpectShell(workdir='wkdir',
                         timeout=300,
                         logEnviron=False,
-                        command=['git', 'log', '-1', '--no-decorate']) +
+                        command=['/bin/sh', '-c', "git log -1 --no-decorate | grep 'Canonical link: https://commits\\.webkit\\.org/'"]) +
                 ExpectShell.log('stdio', stdout='') +
-                0,
+                1,
             )
             self.expectOutcome(result=SUCCESS, state_string='Identifier: 220797@main')
             with current_hostname(EWS_BUILD_HOSTNAME):
@@ -5880,9 +5850,9 @@ Date:   Fri Apr 22 21:24:12 2022 +0000
             ExpectShell(workdir='wkdir',
                         timeout=300,
                         logEnviron=False,
-                        command=['git', 'log', '-1', '--no-decorate']) +
+                        command=['/bin/sh', '-c', "git log -1 --no-decorate | grep 'Canonical link: https://commits\\.webkit\\.org/'"]) +
                 ExpectShell.log('stdio', stdout='') +
-                0,
+                1,
             )
             self.expectOutcome(result=FAILURE, state_string='Failed to determine identifier')
             with current_hostname(EWS_BUILD_HOSTNAME):


### PR DESCRIPTION
#### b9f755449b9b44f6611d245bd57aba58748b0b03
<pre>
[ews-build.webkit.org] Don&apos;t rely on hideStep in DetermineLandedIdentifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=252242">https://bugs.webkit.org/show_bug.cgi?id=252242</a>
&lt;rdar://problem/105451038&gt;

Reviewed by Aakash Jain.

* Tools/CISupport/ews-build/steps.py:
(DetermineLandedIdentifier): Filter &apos;git log&apos; command to only include identifier.
(DetermineLandedIdentifier.run): Handle case where a line is empty or return code non-zero.
(DetermineLandedIdentifier.hideStepIf): Deleted.
* Tools/CISupport/ews-build/steps_unittest.py:

Canonical link: <a href="https://commits.webkit.org/260261@main">https://commits.webkit.org/260261@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96e2146b0b337104476a9f5a417e0f670ce91dca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/107730 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/16783 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/40626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/116877 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/111620 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/18207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/8102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/99906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/113484 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/18207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/40626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/99906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/18207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/40626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/99906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/9759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/40626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/10440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/8102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/20/builds/106554 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/15913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/40626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/12002 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3845 "Failed to close bug 252242") | | | | 
<!--EWS-Status-Bubble-End-->