### PR TITLE
[WK2] Use size_t for container size values in RemoteGraphicsContextGL IPC messages

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
@@ -119,13 +119,13 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {
     void GetAttribLocation(uint32_t arg0, String name) -> (int32_t returnValue) Synchronous
     void GetBufferParameteri(uint32_t target, uint32_t pname) -> (int32_t returnValue) Synchronous
     void GetString(uint32_t name) -> (String returnValue) Synchronous
-    void GetFloatv(uint32_t pname, uint64_t valueSize) -> (IPC::ArrayReference<float> value) Synchronous
-    void GetIntegerv(uint32_t pname, uint64_t valueSize) -> (IPC::ArrayReference<int32_t> value) Synchronous
+    void GetFloatv(uint32_t pname, size_t valueSize) -> (IPC::ArrayReference<float> value) Synchronous
+    void GetIntegerv(uint32_t pname, size_t valueSize) -> (IPC::ArrayReference<int32_t> value) Synchronous
     void GetIntegeri_v(uint32_t pname, uint32_t index) -> (IPC::ArrayReference<int32_t, 4> value) Synchronous
     void GetInteger64(uint32_t pname) -> (int64_t returnValue) Synchronous
     void GetInteger64i(uint32_t pname, uint32_t index) -> (int64_t returnValue) Synchronous
     void GetProgrami(uint32_t program, uint32_t pname) -> (int32_t returnValue) Synchronous
-    void GetBooleanv(uint32_t pname, uint64_t valueSize) -> (IPC::ArrayReference<bool> value) Synchronous
+    void GetBooleanv(uint32_t pname, size_t valueSize) -> (IPC::ArrayReference<bool> value) Synchronous
     void GetFramebufferAttachmentParameteri(uint32_t target, uint32_t attachment, uint32_t pname) -> (int32_t returnValue) Synchronous
     void GetProgramInfoLog(uint32_t arg0) -> (String returnValue) Synchronous
     void GetRenderbufferParameteri(uint32_t target, uint32_t pname) -> (int32_t returnValue) Synchronous
@@ -135,9 +135,9 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {
     void GetShaderSource(uint32_t arg0) -> (String returnValue) Synchronous
     void GetTexParameterf(uint32_t target, uint32_t pname) -> (float returnValue) Synchronous
     void GetTexParameteri(uint32_t target, uint32_t pname) -> (int32_t returnValue) Synchronous
-    void GetUniformfv(uint32_t program, int32_t location, uint64_t valueSize) -> (IPC::ArrayReference<float> value) Synchronous
-    void GetUniformiv(uint32_t program, int32_t location, uint64_t valueSize) -> (IPC::ArrayReference<int32_t> value) Synchronous
-    void GetUniformuiv(uint32_t program, int32_t location, uint64_t valueSize) -> (IPC::ArrayReference<uint32_t> value) Synchronous
+    void GetUniformfv(uint32_t program, int32_t location, size_t valueSize) -> (IPC::ArrayReference<float> value) Synchronous
+    void GetUniformiv(uint32_t program, int32_t location, size_t valueSize) -> (IPC::ArrayReference<int32_t> value) Synchronous
+    void GetUniformuiv(uint32_t program, int32_t location, size_t valueSize) -> (IPC::ArrayReference<uint32_t> value) Synchronous
     void GetUniformLocation(uint32_t arg0, String name) -> (int32_t returnValue) Synchronous
     void GetVertexAttribOffset(uint32_t index, uint32_t pname) -> (uint64_t returnValue) Synchronous
     void Hint(uint32_t target, uint32_t mode)
@@ -214,7 +214,7 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {
     void IsVertexArray(uint32_t arg0) -> (bool returnValue) Synchronous
     void BindVertexArray(uint32_t arg0)
     void CopyBufferSubData(uint32_t readTarget, uint32_t writeTarget, uint64_t readOffset, uint64_t writeOffset, uint64_t arg4)
-    void GetBufferSubData(uint32_t target, uint64_t offset, uint64_t dataSize) -> (IPC::ArrayReference<uint8_t> data) Synchronous
+    void GetBufferSubData(uint32_t target, uint64_t offset, size_t dataSize) -> (IPC::ArrayReference<uint8_t> data) Synchronous
     void BlitFramebuffer(int32_t srcX0, int32_t srcY0, int32_t srcX1, int32_t srcY1, int32_t dstX0, int32_t dstY0, int32_t dstX1, int32_t dstY1, uint32_t mask, uint32_t filter)
     void FramebufferTextureLayer(uint32_t target, uint32_t attachment, uint32_t texture, int32_t level, int32_t layer)
     void InvalidateFramebuffer(uint32_t target, IPC::ArrayReference<uint32_t> attachments)
@@ -296,7 +296,7 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {
     void GetUniformBlockIndex(uint32_t program, String uniformBlockName) -> (uint32_t returnValue) Synchronous
     void GetActiveUniformBlockName(uint32_t program, uint32_t uniformBlockIndex) -> (String returnValue) Synchronous
     void UniformBlockBinding(uint32_t program, uint32_t uniformBlockIndex, uint32_t uniformBlockBinding)
-    void GetActiveUniformBlockiv(uint32_t program, uint32_t uniformBlockIndex, uint32_t pname, uint64_t paramsSize) -> (IPC::ArrayReference<int32_t> params) Synchronous
+    void GetActiveUniformBlockiv(uint32_t program, uint32_t uniformBlockIndex, uint32_t pname, size_t paramsSize) -> (IPC::ArrayReference<int32_t> params) Synchronous
     void GetTranslatedShaderSourceANGLE(uint32_t arg0) -> (String returnValue) Synchronous
     void DrawBuffersEXT(IPC::ArrayReference<uint32_t> bufs)
     void CreateQueryEXT() -> (uint32_t returnValue) Synchronous
@@ -319,7 +319,7 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {
     void DrawArraysInstancedBaseInstanceANGLE(uint32_t mode, int32_t first, int32_t count, int32_t instanceCount, uint32_t baseInstance)
     void DrawElementsInstancedBaseVertexBaseInstanceANGLE(uint32_t mode, int32_t count, uint32_t type, uint64_t offset, int32_t instanceCount, int32_t baseVertex, uint32_t baseInstance)
     void ProvokingVertexANGLE(uint32_t provokeMode)
-    void GetInternalformativ(uint32_t target, uint32_t internalformat, uint32_t pname, uint64_t paramsSize) -> (IPC::ArrayReference<int32_t> params) Synchronous
+    void GetInternalformativ(uint32_t target, uint32_t internalformat, uint32_t pname, size_t paramsSize) -> (IPC::ArrayReference<int32_t> params) Synchronous
     void SetDrawingBufferColorSpace(WebCore::DestinationColorSpace arg0)
     void PaintRenderingResultsToPixelBuffer() -> (RefPtr<WebCore::PixelBuffer> returnValue) Synchronous
 }

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
@@ -333,16 +333,16 @@
         returnValue = m_context->getString(name);
         completionHandler(WTFMove(returnValue));
     }
-    void getFloatv(uint32_t pname, uint64_t valueSize, CompletionHandler<void(IPC::ArrayReference<float>)>&& completionHandler)
+    void getFloatv(uint32_t pname, size_t valueSize, CompletionHandler<void(IPC::ArrayReference<float>)>&& completionHandler)
     {
-        Vector<GCGLfloat, 16> value(static_cast<size_t>(valueSize), 0);
+        Vector<GCGLfloat, 16> value(valueSize, 0);
         assertIsCurrent(workQueue());
         m_context->getFloatv(pname, value);
         completionHandler(IPC::ArrayReference<float>(reinterpret_cast<float*>(value.data()), value.size()));
     }
-    void getIntegerv(uint32_t pname, uint64_t valueSize, CompletionHandler<void(IPC::ArrayReference<int32_t>)>&& completionHandler)
+    void getIntegerv(uint32_t pname, size_t valueSize, CompletionHandler<void(IPC::ArrayReference<int32_t>)>&& completionHandler)
     {
-        Vector<GCGLint, 4> value(static_cast<size_t>(valueSize), 0);
+        Vector<GCGLint, 4> value(valueSize, 0);
         assertIsCurrent(workQueue());
         m_context->getIntegerv(pname, value);
         completionHandler(IPC::ArrayReference<int32_t>(reinterpret_cast<int32_t*>(value.data()), value.size()));
@@ -375,9 +375,9 @@
         returnValue = m_context->getProgrami(program, pname);
         completionHandler(returnValue);
     }
-    void getBooleanv(uint32_t pname, uint64_t valueSize, CompletionHandler<void(IPC::ArrayReference<bool>)>&& completionHandler)
+    void getBooleanv(uint32_t pname, size_t valueSize, CompletionHandler<void(IPC::ArrayReference<bool>)>&& completionHandler)
     {
-        Vector<GCGLboolean, 4> value(static_cast<size_t>(valueSize), 0);
+        Vector<GCGLboolean, 4> value(valueSize, 0);
         assertIsCurrent(workQueue());
         m_context->getBooleanv(pname, value);
         completionHandler(IPC::ArrayReference<bool>(reinterpret_cast<bool*>(value.data()), value.size()));
@@ -446,23 +446,23 @@
         returnValue = m_context->getTexParameteri(target, pname);
         completionHandler(returnValue);
     }
-    void getUniformfv(uint32_t program, int32_t location, uint64_t valueSize, CompletionHandler<void(IPC::ArrayReference<float>)>&& completionHandler)
+    void getUniformfv(uint32_t program, int32_t location, size_t valueSize, CompletionHandler<void(IPC::ArrayReference<float>)>&& completionHandler)
     {
-        Vector<GCGLfloat, 16> value(static_cast<size_t>(valueSize), 0);
+        Vector<GCGLfloat, 16> value(valueSize, 0);
         assertIsCurrent(workQueue());
         m_context->getUniformfv(program, location, value);
         completionHandler(IPC::ArrayReference<float>(reinterpret_cast<float*>(value.data()), value.size()));
     }
-    void getUniformiv(uint32_t program, int32_t location, uint64_t valueSize, CompletionHandler<void(IPC::ArrayReference<int32_t>)>&& completionHandler)
+    void getUniformiv(uint32_t program, int32_t location, size_t valueSize, CompletionHandler<void(IPC::ArrayReference<int32_t>)>&& completionHandler)
     {
-        Vector<GCGLint, 4> value(static_cast<size_t>(valueSize), 0);
+        Vector<GCGLint, 4> value(valueSize, 0);
         assertIsCurrent(workQueue());
         m_context->getUniformiv(program, location, value);
         completionHandler(IPC::ArrayReference<int32_t>(reinterpret_cast<int32_t*>(value.data()), value.size()));
     }
-    void getUniformuiv(uint32_t program, int32_t location, uint64_t valueSize, CompletionHandler<void(IPC::ArrayReference<uint32_t>)>&& completionHandler)
+    void getUniformuiv(uint32_t program, int32_t location, size_t valueSize, CompletionHandler<void(IPC::ArrayReference<uint32_t>)>&& completionHandler)
     {
-        Vector<GCGLuint, 4> value(static_cast<size_t>(valueSize), 0);
+        Vector<GCGLuint, 4> value(valueSize, 0);
         assertIsCurrent(workQueue());
         m_context->getUniformuiv(program, location, value);
         completionHandler(IPC::ArrayReference<uint32_t>(reinterpret_cast<uint32_t*>(value.data()), value.size()));
@@ -869,9 +869,9 @@
         assertIsCurrent(workQueue());
         m_context->copyBufferSubData(readTarget, writeTarget, static_cast<GCGLintptr>(readOffset), static_cast<GCGLintptr>(writeOffset), static_cast<GCGLsizeiptr>(arg4));
     }
-    void getBufferSubData(uint32_t target, uint64_t offset, uint64_t dataSize, CompletionHandler<void(IPC::ArrayReference<uint8_t>)>&& completionHandler)
+    void getBufferSubData(uint32_t target, uint64_t offset, size_t dataSize, CompletionHandler<void(IPC::ArrayReference<uint8_t>)>&& completionHandler)
     {
-        Vector<GCGLchar, 4> data(static_cast<size_t>(dataSize), 0);
+        Vector<GCGLchar, 4> data(dataSize, 0);
         assertIsCurrent(workQueue());
         m_context->getBufferSubData(target, static_cast<GCGLintptr>(offset), data);
         completionHandler(IPC::ArrayReference<uint8_t>(reinterpret_cast<uint8_t*>(data.data()), data.size()));
@@ -1321,9 +1321,9 @@
         assertIsCurrent(workQueue());
         m_context->uniformBlockBinding(program, uniformBlockIndex, uniformBlockBinding);
     }
-    void getActiveUniformBlockiv(uint32_t program, uint32_t uniformBlockIndex, uint32_t pname, uint64_t paramsSize, CompletionHandler<void(IPC::ArrayReference<int32_t>)>&& completionHandler)
+    void getActiveUniformBlockiv(uint32_t program, uint32_t uniformBlockIndex, uint32_t pname, size_t paramsSize, CompletionHandler<void(IPC::ArrayReference<int32_t>)>&& completionHandler)
     {
-        Vector<GCGLint, 4> params(static_cast<size_t>(paramsSize), 0);
+        Vector<GCGLint, 4> params(paramsSize, 0);
         assertIsCurrent(workQueue());
         m_context->getActiveUniformBlockiv(program, uniformBlockIndex, pname, params);
         completionHandler(IPC::ArrayReference<int32_t>(reinterpret_cast<int32_t*>(params.data()), params.size()));
@@ -1452,9 +1452,9 @@
         assertIsCurrent(workQueue());
         m_context->provokingVertexANGLE(provokeMode);
     }
-    void getInternalformativ(uint32_t target, uint32_t internalformat, uint32_t pname, uint64_t paramsSize, CompletionHandler<void(IPC::ArrayReference<int32_t>)>&& completionHandler)
+    void getInternalformativ(uint32_t target, uint32_t internalformat, uint32_t pname, size_t paramsSize, CompletionHandler<void(IPC::ArrayReference<int32_t>)>&& completionHandler)
     {
-        Vector<GCGLint, 4> params(static_cast<size_t>(paramsSize), 0);
+        Vector<GCGLint, 4> params(paramsSize, 0);
         assertIsCurrent(workQueue());
         m_context->getInternalformativ(target, internalformat, pname, params);
         completionHandler(IPC::ArrayReference<int32_t>(reinterpret_cast<int32_t*>(params.data()), params.size()));

--- a/Tools/Scripts/generate-gpup-webgl
+++ b/Tools/Scripts/generate-gpup-webgl
@@ -569,7 +569,7 @@ class webkit_ipc_msg(object):
         for a in out_args:
             ipc_out_args += [cpp_arg(webkit_ipc_types[a.type], a.name)]
             if a.type.is_dynamic_span():
-                ipc_in_args += [cpp_arg(get_cpp_type("uint64_t"), f"{a.name}Size")]
+                ipc_in_args += [cpp_arg(get_cpp_type("size_t"), f"{a.name}Size")]
         self.in_args = cpp_arg_list(ipc_in_args)
         self.out_args = cpp_arg_list(ipc_out_args)
 
@@ -814,10 +814,10 @@ class webkit_ipc_cpp_impl(object):
             self.out_exprs += [webkit_ipc_convert_expr(e, webkit_ipc_value_type)]
         elif a.type.is_dynamic_span():
             assert(isinstance(a.type, cpp_type_container))
-            size_arg = cpp_arg(get_cpp_type("uint64_t"), f"{a.name}Size")
+            size_arg = cpp_arg(get_cpp_type("size_t"), f"{a.name}Size")
             self.args.args += [size_arg]
             store_arg = cpp_arg(webkit_ipc_get_span_store_type(a.type), a.name)
-            self.pre_call_stmts += [f"{str(store_arg.type)} {str(store_arg.name)}(static_cast<size_t>({a.name}Size), 0);"]
+            self.pre_call_stmts += [f"{str(store_arg.type)} {str(store_arg.name)}({a.name}Size, 0);"]
             self.in_exprs += [cpp_expr(store_arg.type, f"{store_arg.name}")]
             webkit_ipc_type = webkit_ipc_types[a.type]
             self.out_exprs += [webkit_ipc_convert_expr(cpp_expr(store_arg.type, store_arg.name), webkit_ipc_type)]


### PR DESCRIPTION
#### 48f4d779d4f39d0cf0e37f907a704238e2af1f72
<pre>
[WK2] Use size_t for container size values in RemoteGraphicsContextGL IPC messages
<a href="https://bugs.webkit.org/show_bug.cgi?id=252246">https://bugs.webkit.org/show_bug.cgi?id=252246</a>

Reviewed by Kimmo Kinnunen.

Adopt size_t for container (i.e. Vector) size values used in different
RemoteGraphicsContextGL messages, instead of converting those values to and from
uint64_t.

The generate-gpup-webgl script, where this code is originating from, is changed
accordingly. The affected script output is updated.

* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h:
(getFloatv):
(getIntegerv):
(getBooleanv):
(getUniformfv):
(getUniformiv):
(getUniformuiv):
(getBufferSubData):
(getActiveUniformBlockiv):
(getInternalformativ):
* Tools/Scripts/generate-gpup-webgl:

Canonical link: <a href="https://commits.webkit.org/260436@main">https://commits.webkit.org/260436@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53f6423bc86dea71464f396923dc3f9073739b50

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107733 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16786 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40635 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116883 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116269 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111623 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18210 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8109 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99915 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113487 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13751 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96948 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41451 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95659 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28588 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/83290 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9762 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29936 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10445 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6826 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15916 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49520 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7218 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12007 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->