### PR TITLE
REGRESSION (256782@main): Animating visibility with a display:contents child causes an element to disappear

### DIFF
--- a/LayoutTests/fast/animation/animation-display-contents-expected.html
+++ b/LayoutTests/fast/animation/animation-display-contents-expected.html
@@ -1,0 +1,13 @@
+<style>
+    li {
+        display: contents;
+    }
+    a {
+        color: green;
+    }
+</style>
+<ul>
+    <li>
+        <a id=a href="/">This should be green.</a>
+    </li>
+</ul>

--- a/LayoutTests/fast/animation/animation-display-contents.html
+++ b/LayoutTests/fast/animation/animation-display-contents.html
@@ -1,0 +1,42 @@
+<style>
+    @keyframes menu-opening {
+        100% {
+            visibility: visible;
+        }
+    }
+
+    ul {
+        animation: 0s menu-opening 0s 1 forwards;
+        visibility: hidden;
+    }
+
+    li {
+        display: contents;
+    }
+
+    a {
+        transition: color 10s steps(1, start);
+    }
+
+    a.transition {
+        color: green;
+    }
+</style>
+
+<ul>
+    <li>
+        <a id=a href="/">This should be green.</a>
+    </li>
+</ul>
+<script>
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+function transition() {
+    a.classList.add("transition");
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+requestAnimationFrame(transition);
+</script>

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2416,16 +2416,27 @@ bool Element::hasDisplayContents() const
     if (!hasRareData())
         return false;
 
-    const RenderStyle* style = elementRareData()->computedStyle();
-    return style && style->display() == DisplayType::Contents;
+    auto* style = elementRareData()->displayContentsStyle();
+    ASSERT(!style || style->display() == DisplayType::Contents);
+    return !!style;
 }
 
 void Element::storeDisplayContentsStyle(std::unique_ptr<RenderStyle> style)
 {
+    // This is used by RenderTreeBuilder to store the style for Elements with display:contents.
+    // Normally style is held in renderers but display:contents doesn't generate one.
+    // This is kept distinct from ElementRareData::computedStyle() which can update outside style resolution.
+    // This way renderOrDisplayContentsStyle() always returns consistent styles matching the rendering state.
     ASSERT(style && style->display() == DisplayType::Contents);
     ASSERT(!renderer() || isPseudoElement());
-    ensureElementRareData().setComputedStyle(WTFMove(style));
-    clearNodeFlag(NodeFlag::IsComputedStyleInvalidFlag);
+    ensureElementRareData().setDisplayContentsStyle(WTFMove(style));
+}
+
+void Element::clearDisplayContentsStyle()
+{
+    if (!hasRareData())
+        return;
+    elementRareData()->setDisplayContentsStyle(nullptr);
 }
 
 // Returns true is the given attribute is an event handler.
@@ -3862,7 +3873,7 @@ const RenderStyle* Element::existingComputedStyle() const
             return style;
     }
 
-    return renderStyle();
+    return renderOrDisplayContentsStyle();
 }
 
 const RenderStyle* Element::renderOrDisplayContentsStyle(PseudoId pseudoId) const
@@ -3871,24 +3882,21 @@ const RenderStyle* Element::renderOrDisplayContentsStyle(PseudoId pseudoId) cons
         if (auto* pseudoElement = beforeOrAfterPseudoElement(*this, pseudoId))
             return pseudoElement->renderOrDisplayContentsStyle();
 
-        if (auto* computedStyle = existingComputedStyle()) {
-            if (auto* cachedPseudoStyle = computedStyle->getCachedPseudoStyle(pseudoId))
+        if (auto* style = renderOrDisplayContentsStyle()) {
+            if (auto* cachedPseudoStyle = style->getCachedPseudoStyle(pseudoId))
                 return cachedPseudoStyle;
         }
-
         return nullptr;
     }
 
-    if (auto* style = renderStyle())
-        return style;
+    if (hasRareData()) {
+        if (auto* style = elementRareData()->displayContentsStyle()) {
+            ASSERT(style->display() == DisplayType::Contents);
+            return style;
+        }
+    }
 
-    if (!hasRareData())
-        return nullptr;
-    auto* style = elementRareData()->computedStyle();
-    if (style && style->display() == DisplayType::Contents)
-        return style;
-
-    return nullptr;
+    return renderStyle();
 }
 
 const RenderStyle* Element::resolveComputedStyle(ResolveComputedStyleMode mode)
@@ -4823,7 +4831,7 @@ void Element::resetComputedStyle()
     auto reset = [](Element& element) {
         if (element.hasCustomStyleResolveCallbacks())
             element.willResetComputedStyle();
-        element.elementRareData()->resetComputedStyle();
+        element.elementRareData()->setComputedStyle(nullptr);
     };
     reset(*this);
     for (auto& child : descendantsOfType<Element>(*this)) {

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -684,6 +684,7 @@ public:
 
     bool hasDisplayContents() const;
     void storeDisplayContentsStyle(std::unique_ptr<RenderStyle>);
+    void clearDisplayContentsStyle();
 
     using ContainerNode::setAttributeEventListener;
     void setAttributeEventListener(const AtomString& eventType, const QualifiedName& attributeName, const AtomString& value);

--- a/Source/WebCore/dom/ElementRareData.cpp
+++ b/Source/WebCore/dom/ElementRareData.cpp
@@ -36,7 +36,7 @@ namespace WebCore {
 struct SameSizeAsElementRareData : NodeRareData {
     IntPoint savedLayerScrollPosition;
     Vector<std::unique_ptr<ElementAnimationRareData>> animationRareData;
-    void* pointers[14];
+    void* pointers[15];
     void* intersectionObserverData;
     void* typedOMData[2];
     void* resizeObserverData;

--- a/Source/WebCore/dom/ElementRareData.h
+++ b/Source/WebCore/dom/ElementRareData.h
@@ -81,6 +81,9 @@ public:
     RenderStyle* computedStyle() const { return m_computedStyle.get(); }
     void setComputedStyle(std::unique_ptr<RenderStyle> computedStyle) { m_computedStyle = WTFMove(computedStyle); }
 
+    RenderStyle* displayContentsStyle() const { return m_displayContentsStyle.get(); }
+    void setDisplayContentsStyle(std::unique_ptr<RenderStyle> style) { m_displayContentsStyle = WTFMove(style); }
+
     const AtomString& effectiveLang() const { return m_effectiveLang; }
     void setEffectiveLang(const AtomString& lang) { m_effectiveLang = lang; }
 
@@ -131,6 +134,8 @@ public:
             result.add(UseType::ScrollingPosition);
         if (m_computedStyle)
             result.add(UseType::ComputedStyle);
+        if (m_displayContentsStyle)
+            result.add(UseType::DisplayContentsStyle);
         if (!m_effectiveLang.isEmpty())
             result.add(UseType::EffectiveLang);
         if (m_dataset)
@@ -174,6 +179,7 @@ public:
 private:
     IntPoint m_savedLayerScrollPosition;
     std::unique_ptr<RenderStyle> m_computedStyle;
+    std::unique_ptr<RenderStyle> m_displayContentsStyle;
 
     AtomString m_effectiveLang;
     std::unique_ptr<DatasetDOMStringMap> m_dataset;

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -144,6 +144,8 @@ static const char* stringForRareDataUseType(NodeRareData::UseType useType)
         return "ScrollingPosition";
     case NodeRareData::UseType::ComputedStyle:
         return "ComputedStyle";
+    case NodeRareData::UseType::DisplayContentsStyle:
+        return "DisplayContentsStyle";
     case NodeRareData::UseType::EffectiveLang:
         return "EffectiveLang";
     case NodeRareData::UseType::Dataset:

--- a/Source/WebCore/dom/NodeRareData.h
+++ b/Source/WebCore/dom/NodeRareData.h
@@ -274,6 +274,7 @@ public:
         PartNames = 1 << 22,
         Nonce = 1 << 23,
         ExplicitlySetAttrElementsMap = 1 << 24,
+        DisplayContentsStyle = 1 << 25,
     };
 #endif
 

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -343,7 +343,7 @@ void RenderTreeUpdater::updateElementRenderer(Element& element, const Style::Ele
     if (hasDisplayContents)
         element.storeDisplayContentsStyle(makeUnique<RenderStyle>(WTFMove(elementUpdateStyle)));
     else
-        element.resetComputedStyle();
+        element.clearDisplayContentsStyle();
 
     bool shouldCreateNewRenderer = !element.renderer() && !hasDisplayContents && !(element.isInTopLayer() && renderTreePosition().parent().style().effectiveSkipsContent());
     if (shouldCreateNewRenderer) {

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
@@ -154,7 +154,7 @@ void RenderTreeUpdater::GeneratedContent::updatePseudoElement(Element& current, 
         auto pseudoElementUpdateStyle = RenderStyle::cloneIncludingPseudoElements(*updateStyle);
         Style::ElementUpdate pseudoElementUpdate { makeUnique<RenderStyle>(WTFMove(pseudoElementUpdateStyle)), styleChange, elementUpdate.recompositeLayer };
         m_updater.updateElementRenderer(*pseudoElement, WTFMove(pseudoElementUpdate));
-        ASSERT(!pseudoElement->hasDisplayContents());
+        pseudoElement->clearDisplayContentsStyle();
     }
 
     auto* pseudoElementRenderer = pseudoElement->renderer();

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -858,8 +858,7 @@ void TreeResolver::resolveComposedTree()
 
         auto resolutionType = determineResolutionType(element, style, parent.descendantsToResolve, parent.change);
         if (resolutionType) {
-            if (!element.hasDisplayContents())
-                element.resetComputedStyle();
+            element.resetComputedStyle();
             element.resetStyleRelations();
 
             if (element.hasCustomStyleResolveCallbacks())


### PR DESCRIPTION
#### fb489a4674c82e7e1cc012123c851538c9f51cc4
<pre>
REGRESSION (256782@main): Animating visibility with a display:contents child causes an element to disappear
<a href="https://bugs.webkit.org/show_bug.cgi?id=251597">https://bugs.webkit.org/show_bug.cgi?id=251597</a>
rdar://105102892

Reviewed by NOBODY (OOPS!).

We currently use ElementRareData::computedStyle() to store styles for Elements that don&apos;t have renderers
because they have &quot;display:contents&quot;. This creates various problems because the computedStyle field can
update outside normal style resolution/render tree update (as a performance optimization). This can lead
to substly inconsistent state where display:contents style doesn&apos;t match the render tree style and
some assumptions break.

This patch gives display:contents style a separate field in element rare data that is only written to
by RenderTreeUpdater. This way it is always in sync with the render tree style.

* LayoutTests/fast/animation/animation-display-contents-expected.html: Added.
* LayoutTests/fast/animation/animation-display-contents.html: Added.
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::hasDisplayContents const):
(WebCore::Element::storeDisplayContentsStyle):
(WebCore::Element::clearDisplayContentsStyle):
(WebCore::Element::existingComputedStyle const):
(WebCore::Element::renderOrDisplayContentsStyle const):
(WebCore::Element::resolveComputedStyle):
(WebCore::Element::resetComputedStyle):
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/ElementRareData.cpp:
* Source/WebCore/dom/ElementRareData.h:
(WebCore::ElementRareData::displayContentsStyle const):
(WebCore::ElementRareData::setDisplayContentsStyle):
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::RenderTreeUpdater::updateElementRenderer):
* Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp:
(WebCore::RenderTreeUpdater::GeneratedContent::updatePseudoElement):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::affectsRenderedSubtree):
(WebCore::Style::TreeResolver::resolveComposedTree):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb489a4674c82e7e1cc012123c851538c9f51cc4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107738 "Failed to checkout and rebase branch from PR 10094") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16795 "Failed to checkout and rebase branch from PR 10094") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40639 "Failed to checkout and rebase branch from PR 10094") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116887 "Failed to checkout and rebase branch from PR 10094") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116273 "Failed to checkout and rebase branch from PR 10094") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111628 "Failed to checkout and rebase branch from PR 10094") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18214 "Failed to checkout and rebase branch from PR 10094") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8113 "Failed to checkout and rebase branch from PR 10094") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99919 "Failed to checkout and rebase branch from PR 10094") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113492 "Failed to checkout and rebase branch from PR 10094") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/76/builds/18214 "Failed to checkout and rebase branch from PR 10094") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/40639 "Failed to checkout and rebase branch from PR 10094") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/99919 "Failed to checkout and rebase branch from PR 10094") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/76/builds/18214 "Failed to checkout and rebase branch from PR 10094") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/40639 "Failed to checkout and rebase branch from PR 10094") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/99919 "Failed to checkout and rebase branch from PR 10094") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9766 "Failed to checkout and rebase branch from PR 10094") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/40639 "Failed to checkout and rebase branch from PR 10094") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10449 "Failed to checkout and rebase branch from PR 10094") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/85/builds/8113 "Failed to checkout and rebase branch from PR 10094") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15920 "Failed to checkout and rebase branch from PR 10094") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/40639 "Failed to checkout and rebase branch from PR 10094") | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12011 "Failed to checkout and rebase branch from PR 10094") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->