### PR TITLE
Revert [260217@main] Only use EXCEPTION_IDENTITY_PROTECTED in thread_set_exception_ports

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -3869,7 +3869,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5D247B7014689C4700E78B76 /* DebugRelease.xcconfig */;
 			buildSettings = {
-				OTHER_MIGFLAGS = "-DMACH_EXC_SERVER_TASKIDTOKEN";
 			};
 			name = Debug;
 		};
@@ -3877,7 +3876,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5D247B7014689C4700E78B76 /* DebugRelease.xcconfig */;
 			buildSettings = {
-				OTHER_MIGFLAGS = "-DMACH_EXC_SERVER_TASKIDTOKEN";
 			};
 			name = Release;
 		};
@@ -3899,7 +3897,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5D247B6E14689C4700E78B76 /* Base.xcconfig */;
 			buildSettings = {
-				OTHER_MIGFLAGS = "-DMACH_EXC_SERVER_TASKIDTOKEN";
 			};
 			name = Production;
 		};

--- a/Source/WTF/wtf/PlatformJSCOnly.cmake
+++ b/Source/WTF/wtf/PlatformJSCOnly.cmake
@@ -82,7 +82,7 @@ elseif (APPLE)
             ${WTF_DERIVED_SOURCES_DIR}/mach_excUser.c
         MAIN_DEPENDENCY mac/MachExceptions.defs
         WORKING_DIRECTORY ${WTF_DERIVED_SOURCES_DIR}
-        COMMAND mig -DMACH_EXC_SERVER_TASKIDTOKEN -sheader MachExceptionsServer.h MachExceptions.defs
+        COMMAND mig -sheader MachExceptionsServer.h MachExceptions.defs
         VERBATIM)
     list(APPEND WTF_SOURCES
         cocoa/MemoryFootprintCocoa.cpp

--- a/Source/WTF/wtf/PlatformMac.cmake
+++ b/Source/WTF/wtf/PlatformMac.cmake
@@ -115,7 +115,7 @@ add_custom_command(
         ${WTF_DERIVED_SOURCES_DIR}/mach_excUser.c
     MAIN_DEPENDENCY mac/MachExceptions.defs
     WORKING_DIRECTORY ${WTF_DERIVED_SOURCES_DIR}
-    COMMAND mig -DMACH_EXC_SERVER_TASKIDTOKEN -sheader MachExceptionsServer.h MachExceptions2.defs
+    COMMAND mig -sheader MachExceptionsServer.h MachExceptions.defs
     VERBATIM)
 list(APPEND WTF_SOURCES
     ${WTF_DERIVED_SOURCES_DIR}/mach_excServer.c

--- a/Source/WTF/wtf/threads/Signals.cpp
+++ b/Source/WTF/wtf/threads/Signals.cpp
@@ -42,20 +42,17 @@ extern "C" {
 #include <dispatch/dispatch.h>
 #include <mach/mach.h>
 #include <mach/thread_act.h>
-#include <mach/thread_status.h>
 #endif
 
 #if OS(DARWIN)
 #include <mach/vm_param.h>
 #endif
 
-#include <unistd.h>
 #include <wtf/Atomics.h>
 #include <wtf/DataLog.h>
 #include <wtf/MathExtras.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/PlatformRegisters.h>
-#include <wtf/Scope.h>
 #include <wtf/ThreadGroup.h>
 #include <wtf/Threading.h>
 #include <wtf/WTFConfig.h>
@@ -206,168 +203,6 @@ kern_return_t catch_mach_exception_raise_state_identity(mach_port_t, mach_port_t
     return KERN_FAILURE;
 }
 
-static kern_return_t runSignalHandlers(Signal &signal, PlatformRegisters& registers, bool &didHandle, mach_msg_type_number_t dataCount, mach_exception_data_t exceptionData)
-{
-    SigInfo info;
-    SignalHandlers& handlers = g_wtfConfig.signalHandlers;
-    if (signal == Signal::AccessFault) {
-        ASSERT_UNUSED(dataCount, dataCount == 2);
-        info.faultingAddress = reinterpret_cast<void*>(exceptionData[1]);
-#if CPU(ADDRESS64)
-        // If the faulting address is out of the range of any valid memory, we would
-        // not have any reason to handle it. Just let the default handler take care of it.
-        static constexpr unsigned validAddressBits = OS_CONSTANT(EFFECTIVE_ADDRESS_WIDTH);
-        static constexpr uintptr_t invalidAddressMask = ~((1ull << validAddressBits) - 1);
-        if (bitwise_cast<uintptr_t>(info.faultingAddress) & invalidAddressMask)
-            return KERN_FAILURE;
-#endif
-    }
-
-    handlers.forEachHandler(signal, [&] (const SignalHandler& handler) {
-        SignalAction handlerResult = handler(signal, info, registers);
-        didHandle |= handlerResult == SignalAction::Handled;
-    });
-    return KERN_SUCCESS;
-}
-
-#ifdef EXCEPTION_IDENTITY_PROTECTED
-
-static thread_act_t threadIDGetThreadPort(uint64_t threadID)
-{
-    mach_msg_type_number_t threadCount;
-    thread_act_array_t threads;
-    struct thread_identifier_info threadIdentifierInfo;
-    unsigned infoCount = THREAD_IDENTIFIER_INFO_COUNT;
-    thread_act_t thread = THREAD_NULL;
-
-    task_threads(mach_task_self(), &threads, &threadCount);
-    for (mach_msg_type_number_t i = 0; i < threadCount; i++) {
-        if (thread != THREAD_NULL) {
-            // clean up all the unnecessary thread ports like a good citizen
-            ASSERT(thread != threads[i]);
-            mach_port_deallocate(mach_task_self(), threads[i]);
-            continue;
-        }
-
-        kern_return_t kr = thread_info(threads[i], THREAD_IDENTIFIER_INFO,
-            reinterpret_cast<thread_info_t>(&threadIdentifierInfo), &infoCount);
-
-        if (kr == MACH_SEND_INVALID_DEST) {
-            // ignore threads that have been destroyed
-            continue;
-        }
-
-        if (threadIdentifierInfo.thread_id == threadID) {
-            // we found the thread we are looking for
-            thread = threads[i];
-            continue;
-        }
-        mach_port_deallocate(mach_task_self(), threads[i]);
-    }
-    vm_deallocate(mach_task_self(), (vm_address_t)threads,
-        sizeof(threads[0]) * threadCount);
-    return thread;
-}
-
-kern_return_t catch_mach_exception_raise_state(
-    mach_port_t,
-    exception_type_t,
-    const mach_exception_data_t,
-    mach_msg_type_number_t,
-    int*,
-    const thread_state_t,
-    mach_msg_type_number_t,
-    thread_state_t,
-    mach_msg_type_number_t*)
-{
-    dataLogLn("We should not have called catch_mach_exception_raise_state, please file a bug at bugs.webkit.org");
-    return KERN_FAILURE;
-}
-
-kern_return_t catch_mach_exception_raise_identity_protected(
-    mach_port_t exceptionPort,
-    uint64_t threadID,
-    mach_port_t taskIDToken,
-    exception_type_t exceptionType,
-    mach_exception_data_t exceptionData,
-    mach_msg_type_number_t dataCount)
-{
-    UNUSED_PARAM(taskIDToken);
-
-    SignalHandlers& handlers = g_wtfConfig.signalHandlers;
-    RELEASE_ASSERT(exceptionPort == handlers.exceptionPort);
-    // If we wanted to distinguish between SIGBUS and SIGSEGV for EXC_BAD_ACCESS on Darwin we could do:
-    // if (exceptionData[0] == KERN_INVALID_ADDRESS)
-    //    signal = SIGSEGV;
-    // else
-    //    signal = SIGBUS;
-    Signal signal = fromMachException(exceptionType);
-    RELEASE_ASSERT(signal != Signal::Unknown);
-
-    thread_act_t thread = threadIDGetThreadPort(threadID);
-    auto clear = makeScopeExit([&] {
-        mach_port_deallocate(mach_task_self(), thread);
-    });
-
-
-    mach_msg_type_number_t stateCount = 0;
-
-#if CPU(X86_64) || CPU(X86)
-    x86_thread_state_t state;
-    int flavor = x86_THREAD_STATE;
-    stateCount = x86_THREAD_STATE_COUNT;
-#elif CPU(ARM64) || CPU(ARM)
-    arm_unified_thread_state state;
-    int flavor = ARM_THREAD_STATE;
-    stateCount = ARM_UNIFIED_THREAD_STATE_COUNT;
-#endif
-
-    kern_return_t kr = thread_get_state(thread, flavor, (thread_state_t)&state, &stateCount);
-    if (kr != KERN_SUCCESS) {
-        dataLogLn("thread_get_state failed due to ", mach_error_string(kr));
-        return kr;
-    }
-
-#if CPU(ARM64E) && OS(DARWIN)
-    ptrauth_generic_signature_t inStateHash = hashThreadState((thread_state_t)&state);
-#endif
-
-#if CPU(X86_64)
-    PlatformRegisters& registers = state.uts.ts64;
-    RELEASE_ASSERT(state.tsh.flavor == x86_THREAD_STATE64);
-#elif CPU(X86)
-    PlatformRegisters& registers = state.uts.ts32;
-    RELEASE_ASSERT(state.tsh.flavor == x86_THREAD_STATE32);
-#elif CPU(ARM64)
-    PlatformRegisters& registers = state.ts_64;
-    RELEASE_ASSERT(state.ash.flavor == ARM_THREAD_STATE64);
-#elif CPU(ARM)
-    PlatformRegisters& registers = state.ts_32;
-    RELEASE_ASSERT(state.ash.flavor == ARM_THREAD_STATE32);
-#endif
-
-    bool didHandle = false;
-    kr = runSignalHandlers(signal, registers, didHandle, dataCount, exceptionData);
-    if (kr != KERN_SUCCESS)
-        return kr;
-
-    if (didHandle) {
-#if CPU(ARM64E) && OS(DARWIN)
-        RELEASE_ASSERT(inStateHash == hashThreadState((thread_state_t)&state));
-#endif
-        kr = thread_set_state(thread, flavor, (thread_state_t)&state,
-            stateCount);
-
-        if (kr != KERN_SUCCESS)
-            dataLogLn("thread_set_state failed due to ", mach_error_string(kr));
-
-        return kr;
-    }
-    return KERN_FAILURE;
-}
-
-#else /* EXCEPTION_IDENTITY_PROTECTED */
-
 kern_return_t catch_mach_exception_raise_state(
     mach_port_t port,
     exception_type_t exceptionType,
@@ -409,10 +244,25 @@ kern_return_t catch_mach_exception_raise_state(
     PlatformRegisters& registers = reinterpret_cast<arm_unified_thread_state*>(outState)->ts_32;
 #endif
 
+    SigInfo info;
+    if (signal == Signal::AccessFault) {
+        ASSERT_UNUSED(dataCount, dataCount == 2);
+        info.faultingAddress = reinterpret_cast<void*>(exceptionData[1]);
+#if CPU(ADDRESS64)
+        // If the faulting address is out of the range of any valid memory, we would
+        // not have any reason to handle it. Just let the default handler take care of it.
+        static constexpr unsigned validAddressBits = OS_CONSTANT(EFFECTIVE_ADDRESS_WIDTH);
+        static constexpr uintptr_t invalidAddressMask = ~((1ull << validAddressBits) - 1);
+        if (bitwise_cast<uintptr_t>(info.faultingAddress) & invalidAddressMask)
+            return KERN_FAILURE;
+#endif
+    }
+
     bool didHandle = false;
-    kern_return_t kr = runSignalHandlers(signal, registers, didHandle, dataCount, exceptionData);
-    if (kr != KERN_SUCCESS)
-        return kr;
+    handlers.forEachHandler(signal, [&] (const SignalHandler& handler) {
+        SignalAction handlerResult = handler(signal, info, registers);
+        didHandle |= handlerResult == SignalAction::Handled;
+    });
 
     if (didHandle) {
 #if CPU(ARM64E) && OS(DARWIN)
@@ -424,7 +274,6 @@ kern_return_t catch_mach_exception_raise_state(
 
     return KERN_FAILURE;
 }
-#endif /* EXCEPTION_IDENTITY_PROTECTED */
 
 }; // extern "C"
 
@@ -439,14 +288,7 @@ inline void setExceptionPorts(const AbstractLocker& threadGroupLocker, Thread& t
 {
     UNUSED_PARAM(threadGroupLocker);
     SignalHandlers& handlers = g_wtfConfig.signalHandlers;
-
-#ifdef EXCEPTION_IDENTITY_PROTECTED
-    exception_behavior_t newBehavior = EXCEPTION_IDENTITY_PROTECTED | MACH_EXCEPTION_CODES;
-#else
-    exception_behavior_t newBehavior = EXCEPTION_STATE | MACH_EXCEPTION_CODES;
-#endif /* EXCEPTION_IDENTITY_PROTECTED */
-
-    kern_return_t result = thread_set_exception_ports(thread.machThread(), handlers.addedExceptions &activeExceptions, handlers.exceptionPort, newBehavior, MACHINE_THREAD_STATE);
+    kern_return_t result = thread_set_exception_ports(thread.machThread(), handlers.addedExceptions &activeExceptions, handlers.exceptionPort, EXCEPTION_STATE | MACH_EXCEPTION_CODES, MACHINE_THREAD_STATE);
     if (result != KERN_SUCCESS) {
         dataLogLn("thread set port failed due to ", mach_error_string(result));
         CRASH();


### PR DESCRIPTION
#### 621e4046a21a749699cc92064afe6f6f93d0fb7b
<pre>
Revert [260217@main] Only use EXCEPTION_IDENTITY_PROTECTED in thread_set_exception_ports
<a href="https://bugs.webkit.org/show_bug.cgi?id=252248">https://bugs.webkit.org/show_bug.cgi?id=252248</a>
rdar://105454615

Unreviewed.

Reverting because this change caused an issue with Rosetta.

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/PlatformJSCOnly.cmake:
* Source/WTF/wtf/PlatformMac.cmake:
* Source/WTF/wtf/threads/Signals.cpp:
(WTF::setExceptionPorts):

Canonical link: <a href="https://commits.webkit.org/260262@main">https://commits.webkit.org/260262@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47480022b4748932029b29bbdcb5517ec27eba73

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107739 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/16796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/40640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/116888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/18215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/8114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/99920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113493 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/18215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/40640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/99920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/18215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/40640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/99920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/97033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/9767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/40640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/38/builds/96427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/83/builds/7804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/10450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/8114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/38/builds/96427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/15921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/40640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-mips~~](https://ews-build.webkit.org/#/builders/37/builds/105401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/12012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/37/builds/105401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3847 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->