### PR TITLE
[WGSL] Add a tiny DSL for declaring built-in types

### DIFF
--- a/Source/WebGPU/WGSL/Overload.h
+++ b/Source/WebGPU/WGSL/Overload.h
@@ -52,7 +52,7 @@ struct TypeVariable {
     };
 
     unsigned id;
-    Constraint constraints;
+    Constraint constraints { None };
 };
 
 struct AbstractVector;

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -118,33 +118,8 @@ TypeChecker::TypeChecker(ShaderModule& shaderModule)
     introduceVariable(AST::Identifier::make("u32"_s), m_types.u32Type());
     introduceVariable(AST::Identifier::make("f32"_s), m_types.f32Type());
 
-    // FIXME: Add all other overloads
-    // FIXME: we should make this a lot more convenient
-    // operator + [T<:Number](T, T) -> T
-    OverloadCandidate plus1;
-    {
-        TypeVariable T { 0, TypeVariable::Number };
-        plus1.typeVariables.append(T);
-        plus1.parameters.append(T);
-        plus1.parameters.append(T);
-        plus1.result = T;
-    }
-    // operator + [T<:Number, N](vector<T, N>, T) -> vector<T, N>
-    OverloadCandidate plus2;
-    {
-        TypeVariable T { 0, TypeVariable::Number };
-        NumericVariable N { 0 };
-        plus2.typeVariables.append(T);
-        plus2.numericVariables.append(N);
-        plus2.parameters.append(AbstractVector { T, N });
-        plus2.parameters.append(T);
-        plus2.result = AbstractVector { T, N };
-    }
-
-    m_overloadedOperations.add("+"_s, WTF::Vector<OverloadCandidate> ({
-        WTFMove(plus1),
-        WTFMove(plus2),
-    }));
+    // This file contains the declarations generated from `TypeDeclarations.rb`
+#include "TypeDeclarations.h" // NOLINT
 }
 
 void TypeChecker::check()

--- a/Source/WebGPU/WGSL/TypeDeclarations.js
+++ b/Source/WebGPU/WGSL/TypeDeclarations.js
@@ -1,0 +1,6 @@
+// FIXME: add all the missing type declarations here
+type('+', [Number(T)], [T, T], T)
+type('+', [Number(T), N], [Vector(T, N), T], T)
+type('+', [Number(T), N], [T, Vector(T, N)], Vector(T, N))
+type('+', [Number(T), N], [Vector(T, N), Vector(T, N)], Vector(T, N))
+type('+', [Float(T), C, R], [Matrix(T, C, R), Matrix(T, C, R)], Matrix(T, C, R))

--- a/Source/WebGPU/WGSL/generator/main.js
+++ b/Source/WebGPU/WGSL/generator/main.js
@@ -1,0 +1,181 @@
+const Constraints  = {
+    Number: 'Number',
+    Float: 'Float',
+}
+
+class ConstrainedVariable {
+    constructor(variable, constraint) {
+        this.variable = variable
+        this.constraint = constraint
+    }
+
+    toString() {
+        return `${this.variable} <: ${this.constraint}`
+    }
+
+    dump(out, counter) {
+        out.line(`TypeVariable ${this.variable.name} { ${counter.typeId()}, TypeVariable::${this.constraint} };`)
+    }
+}
+
+class TypeVariable {
+    constructor(name, constraint) {
+        this.name = name;
+    }
+
+    toString() {
+        return this.name
+    }
+
+    dump(out, counter) {
+        out.line(`TypeVariable ${this.name} { ${counter.typeId()} };`)
+    }
+
+    toCpp() {
+        return this.name
+    }
+}
+
+class NumericVariable {
+    constructor(name) {
+        this.name = name
+    }
+
+    toString() {
+        return this.name
+    }
+
+    dump(out, counter) {
+        out.line(`NumericVariable ${this.name} { ${counter.numericId()} };`)
+    }
+
+    toCpp() {
+        return this.name
+    }
+}
+
+class AbstractType {
+    constructor(name, ...args) {
+        this.name = name
+        this.arguments = args
+    }
+
+    toString() {
+        return `${this.name}<${this.arguments.join(', ')}>`
+    }
+
+    toCpp() {
+        return `Abstract${this.name} { ${this.arguments.join(', ')} }`
+    }
+}
+
+class FunctionType {
+    constructor(variables, parameters, result) {
+        this.variables = variables
+        this.parameters = parameters
+        this.result = result
+    }
+
+    toString() {
+        return `${this.name} :: <${this.variables.join(', ')}>(${this.parameters.join(', ')}) -> ${this.result}`
+    }
+
+    dump(out) {
+        const counter = (() => {
+            let type = 0;
+            let numeric = 0;
+            return { typeId: () => type++, numericId: () => numeric++ }
+        })();
+
+        out.line('([&]() -> OverloadCandidate {')
+        out.indent(() => {
+            out.line(`// #{name} :: ${this.toString()}`)
+            out.line('OverloadCandidate candidate;')
+            this.variables.forEach(v => v.dump(out, counter))
+            this.parameters.forEach(p => {
+                out.line(`candidate.parameters.append(${p.toCpp()});`)
+            })
+            out.line(`candidate.result = ${this.result.toCpp()};`)
+            out.line('return candidate;')
+        })
+        out.line('}()),')
+    }
+}
+
+
+class Output {
+    out = []
+    indentation = 0
+    indentationSize = 4
+
+    indent(callback) {
+        this.indentation++
+        callback()
+        this.indentation--
+    }
+
+    line(...args) {
+        this.out.push(Array(this.indentation * this.indentationSize).fill(' ').join(''), ...args, '\n')
+    }
+
+    toString() {
+        return this.out.join('')
+    }
+}
+
+class DSL {
+    static context = {}
+    static declarations = {}
+
+    static prologue() {
+        // constraints
+        this.context.Number = variable => new ConstrainedVariable(variable, 'Number')
+        this.context.Float = variable => new ConstrainedVariable(variable, 'Float')
+
+        // types
+        this.context.Vector = (type, size) => new AbstractType('Vector', type, size)
+        this.context.Matrix = (type, columns, rows) => new AbstractType('Matrix', type, columns, rows)
+
+        // variables
+        this.context.T = new TypeVariable('T')
+        this.context.N = new NumericVariable('N')
+        this.context.C = new NumericVariable('C')
+        this.context.R = new NumericVariable('R')
+
+        // helpers
+        this.context.type = (name, variables, parameters, result) => {
+            const type = new FunctionType(variables, parameters, result)
+            let declarations = this.declarations[name]
+            if (!declarations)
+                declarations = this.declarations[name] = []
+            declarations.push(type)
+        }
+    }
+
+    static run(input) {
+        (new Function( `with(this) { ${read(input)} }`)).call(this.context)
+    }
+
+    static dump() {
+        const out = new Output();
+        for (const [name, overloads] of Object.entries(this.declarations)) {
+            out.line(`m_overloadedOperations.add("${name}"_s, Vector<OverloadCandidate>({`)
+            out.indent(() => {
+                overloads.forEach(overload => {
+                    overload.dump(out)
+                })
+            })
+            out.line('}));')
+        }
+        print(out.toString())
+    }
+}
+
+if (typeof arguments === 'undefined' || arguments.length !== 1)
+    throw new Error('usage: WGSL/generator/main.js <definition-file>')
+
+const input = arguments[0]
+
+DSL.prologue()
+DSL.run(input)
+DSL.dump()

--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -122,6 +122,7 @@
 		3AE27DB528C1BA480043A8E0 /* ASTVariableStatement.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AE27DB428C1BA480043A8E0 /* ASTVariableStatement.h */; };
 		664C92FD286A66090008D143 /* IOSurface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 664C92FC286A66090008D143 /* IOSurface.framework */; };
 		66DC575528627E0B0014CABD /* ParserPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 66DC575428627E0B0014CABD /* ParserPrivate.h */; };
+		97296769299D3401001C8BD4 /* TypeDeclarations.js in Sources */ = {isa = PBXBuildFile; fileRef = 97296768299D33C3001C8BD4 /* TypeDeclarations.js */; };
 		9776BE732992A236002D6D93 /* Overload.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9776BE712992A236002D6D93 /* Overload.cpp */; };
 		9776BE742992A236002D6D93 /* Overload.h in Headers */ = {isa = PBXBuildFile; fileRef = 9776BE722992A236002D6D93 /* Overload.h */; };
 		9776BE7629957E12002D6D93 /* WGSLShaderModule.h in Headers */ = {isa = PBXBuildFile; fileRef = 9776BE7529957E12002D6D93 /* WGSLShaderModule.h */; };
@@ -149,6 +150,24 @@
 		97F547B9298055D90011D79A /* GlobalVariableRewriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 97F547B7298055D90011D79A /* GlobalVariableRewriter.h */; };
 		DD05A35C27BF09C60096EFAB /* libWTF.a in Product Dependencies */ = {isa = PBXBuildFile; fileRef = 1CEBD8292716CAE700A5254D /* libWTF.a */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXBuildRule section */
+		9729675F299BF1BE001C8BD4 /* PBXBuildRule */ = {
+			isa = PBXBuildRule;
+			compilerSpec = com.apple.compilers.proxy.script;
+			filePatterns = "*.js";
+			fileType = pattern.proxy;
+			inputFiles = (
+				"$(SRCROOT)/WGSL/generator/main.js",
+			);
+			isEditable = 1;
+			outputFiles = (
+				"$(BUILT_PRODUCTS_DIR)/DerivedSources/WGSL/TypeDeclarations.h",
+			);
+			runOncePerArchitecture = 0;
+			script = "/System/Library/Frameworks/JavaScriptCore.framework/Versions/Current/Helpers/jsc \"${SCRIPT_INPUT_FILE_0}\" -- \"${INPUT_FILE_PATH}\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+		};
+/* End PBXBuildRule section */
 
 /* Begin PBXContainerItemProxy section */
 		1CEBD8272716CACC00A5254D /* PBXContainerItemProxy */ = {
@@ -334,6 +353,8 @@
 		3AE27DB428C1BA480043A8E0 /* ASTVariableStatement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTVariableStatement.h; sourceTree = "<group>"; };
 		664C92FC286A66090008D143 /* IOSurface.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOSurface.framework; path = System/Library/Frameworks/IOSurface.framework; sourceTree = SDKROOT; };
 		66DC575428627E0B0014CABD /* ParserPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ParserPrivate.h; sourceTree = "<group>"; };
+		97296767299D33B9001C8BD4 /* main.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = main.js; sourceTree = "<group>"; };
+		97296768299D33C3001C8BD4 /* TypeDeclarations.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = TypeDeclarations.js; sourceTree = "<group>"; };
 		9776BE712992A236002D6D93 /* Overload.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Overload.cpp; sourceTree = "<group>"; };
 		9776BE722992A236002D6D93 /* Overload.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Overload.h; sourceTree = "<group>"; };
 		9776BE7529957E12002D6D93 /* WGSLShaderModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WGSLShaderModule.h; sourceTree = "<group>"; };
@@ -476,6 +497,7 @@
 			isa = PBXGroup;
 			children = (
 				33EA185C27BC193D00A1DD52 /* AST */,
+				97296763299BFB72001C8BD4 /* generator */,
 				979240B1297018290050EA2C /* Metal */,
 				3AD0D2362988D3F90080D728 /* API.h */,
 				9789C318297EA105009E9006 /* CallGraph.cpp */,
@@ -506,6 +528,7 @@
 				338BB2CD27B6B60200E066AB /* Token.h */,
 				978A912E298AD3DA00B37E5E /* TypeCheck.cpp */,
 				978A912D298AD3DA00B37E5E /* TypeCheck.h */,
+				97296768299D33C3001C8BD4 /* TypeDeclarations.js */,
 				978A9132298BBFD300B37E5E /* Types.cpp */,
 				978A9131298BBFD300B37E5E /* Types.h */,
 				978A9136298D40F100B37E5E /* TypeStore.cpp */,
@@ -618,6 +641,14 @@
 				3A12AE9828FCE94B00C1B975 /* ASTWorkgroupSizeAttribute.h */,
 			);
 			path = AST;
+			sourceTree = "<group>";
+		};
+		97296763299BFB72001C8BD4 /* generator */ = {
+			isa = PBXGroup;
+			children = (
+				97296767299D33B9001C8BD4 /* main.js */,
+			);
+			path = generator;
 			sourceTree = "<group>";
 		};
 		979240B1297018290050EA2C /* Metal */ = {
@@ -771,6 +802,7 @@
 				1CEBD7F02716B2CC00A5254D /* Frameworks */,
 			);
 			buildRules = (
+				9729675F299BF1BE001C8BD4 /* PBXBuildRule */,
 			);
 			dependencies = (
 			);
@@ -901,6 +933,7 @@
 				979240C4297558F10050EA2C /* ResolveTypeReferences.cpp in Sources */,
 				338BB2D027B6B61B00E066AB /* Token.cpp in Sources */,
 				978A9130298AD3DA00B37E5E /* TypeCheck.cpp in Sources */,
+				97296769299D3401001C8BD4 /* TypeDeclarations.js in Sources */,
 				978A9134298BBFD300B37E5E /* Types.cpp in Sources */,
 				978A9138298D40F100B37E5E /* TypeStore.cpp in Sources */,
 				1CEBD8032716BF8200A5254D /* WGSL.cpp in Sources */,


### PR DESCRIPTION
#### 8375c946e46d51914c60cf86e060b1d6e8765d65
<pre>
[WGSL] Add a tiny DSL for declaring built-in types
<a href="https://bugs.webkit.org/show_bug.cgi?id=252251">https://bugs.webkit.org/show_bug.cgi?id=252251</a>
rdar://105457268

Reviewed by Myles C. Maxfield.

Initializing all the built-in types in C++ is quite verbose, so this patch adds a tiny
embedded DSL in JavaScript for declaring such types.

* Source/WebGPU/WGSL/Overload.h:
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::TypeChecker):
* Source/WebGPU/WGSL/TypeDeclarations.rb: Added.
* Source/WebGPU/WGSL/generator/main.rb: Added.
* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/260433@main">https://commits.webkit.org/260433@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9cabde058244d1f16f92bccfac458a7a7ffc7b70

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108111 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17181 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40979 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117236 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116557 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18702 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8477 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100315 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113879 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97201 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41907 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96026 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28839 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/83580 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10063 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30187 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10784 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7089 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16211 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49778 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7217 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12365 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->