### PR TITLE
[WGSL] Handle parsing of short-circuit expression.

### DIFF
--- a/Source/WebGPU/WGSL/Lexer.cpp
+++ b/Source/WebGPU/WGSL/Lexer.cpp
@@ -53,7 +53,13 @@ Token Lexer<T>::lex()
         return makeToken(TokenType::Modulo);
     case '&':
         shift();
-        return makeToken(TokenType::And);
+        switch (m_current) {
+        case '&':
+            shift();
+            return makeToken(TokenType::AndAnd);
+        default:
+            return makeToken(TokenType::And);
+        }
     case '(':
         shift();
         return makeToken(TokenType::ParenLeft);
@@ -161,7 +167,13 @@ Token Lexer<T>::lex()
         return makeToken(TokenType::Xor);
     case '|':
         shift();
-        return makeToken(TokenType::Or);
+        switch (m_current) {
+        case '|':
+            shift();
+            return makeToken(TokenType::OrOr);
+        default:
+            return makeToken(TokenType::Or);
+        }
     case '0': {
         shift();
         double literalValue = 0;

--- a/Source/WebGPU/WGSL/ParserPrivate.h
+++ b/Source/WebGPU/WGSL/ParserPrivate.h
@@ -72,7 +72,8 @@ public:
     Result<AST::Statement::Ref> parseStatement();
     Result<AST::CompoundStatement> parseCompoundStatement();
     Result<AST::ReturnStatement> parseReturnStatement();
-    Result<AST::Expression::Ref> parseShortCircuitOrExpression();
+    Result<AST::Expression::Ref> parseShortCircuitExpression(AST::Expression::Ref&&, TokenType, AST::BinaryOperation);
+    Result<AST::Expression::Ref> parseRelationalExpression();
     Result<AST::Expression::Ref> parseRelationalExpressionPostUnary(AST::Expression::Ref&& lhs);
     Result<AST::Expression::Ref> parseShiftExpression();
     Result<AST::Expression::Ref> parseShiftExpressionPostUnary(AST::Expression::Ref&& lhs);

--- a/Source/WebGPU/WGSL/Token.cpp
+++ b/Source/WebGPU/WGSL/Token.cpp
@@ -89,6 +89,8 @@ String toString(TokenType type)
         return "false"_s;
     case TokenType::And:
         return "&"_s;
+    case TokenType::AndAnd:
+        return "&&"_s;
     case TokenType::Arrow:
         return "->"_s;
     case TokenType::Attribute:
@@ -133,6 +135,8 @@ String toString(TokenType type)
         return "%"_s;
     case TokenType::Or:
         return "|"_s;
+    case TokenType::OrOr:
+        return "||"_s;
     case TokenType::Plus:
         return "+"_s;
     case TokenType::PlusPlus:

--- a/Source/WebGPU/WGSL/Token.h
+++ b/Source/WebGPU/WGSL/Token.h
@@ -71,6 +71,7 @@ enum class TokenType: uint32_t {
     // FIXME: add all the other keywords: see #keyword-summary in the WGSL spec
 
     And,
+    AndAnd,
     Arrow,
     Attribute,
     Bang,
@@ -93,6 +94,7 @@ enum class TokenType: uint32_t {
     MinusMinus,
     Modulo,
     Or,
+    OrOr,
     ParenLeft,
     ParenRight,
     Period,

--- a/Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp
@@ -166,7 +166,9 @@ TEST(WGSLLexerTests, SpecialTokens)
     checkSingleToken("/"_s, TokenType::Slash);
     checkSingleToken("*"_s, TokenType::Star);
     checkSingleToken("&"_s, TokenType::And);
+    checkSingleToken("&&"_s, TokenType::AndAnd);
     checkSingleToken("|"_s, TokenType::Or);
+    checkSingleToken("||"_s, TokenType::OrOr);
     checkSingleToken("^"_s, TokenType::Xor);
     checkSingleToken("~"_s, TokenType::Tilde);
 }

--- a/Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp
@@ -623,6 +623,24 @@ TEST(WGSLParserTests, RelationalExpression)
     testBinaryExpressionXY("x <= y"_s, WGSL::AST::BinaryOperation::LessEqual,    { "x"_s, "y"_s });
 }
 
+// FIXME: Test failing cases, such as, "x && y || z"
+TEST(WGSLParserTest, ShortCircuitAndExpression)
+{
+    testBinaryExpressionXY("x && y"_s, WGSL::AST::BinaryOperation::ShortCircuitAnd, { "x"_s, "y"_s });
+    testBinaryExpressionXYZ("x && y && z"_s,
+        { WGSL::AST::BinaryOperation::ShortCircuitAnd, WGSL::AST::BinaryOperation::ShortCircuitAnd },
+        { "x"_s, "y"_s, "z"_s });
+}
+
+// FIXME: Test failing cases, such as, "x || y && z"
+TEST(WGSLParserTest, ShortCircuitOrExpression)
+{
+    testBinaryExpressionXY("x || y"_s, WGSL::AST::BinaryOperation::ShortCircuitOr, { "x"_s, "y"_s });
+    testBinaryExpressionXYZ("x || y || z"_s,
+        { WGSL::AST::BinaryOperation::ShortCircuitOr, WGSL::AST::BinaryOperation::ShortCircuitOr },
+        { "x"_s, "y"_s, "z"_s });
+}
+
 #pragma mark -
 #pragma mark WebGPU Example Shaders
 


### PR DESCRIPTION
#### a359a25937a0810886dc077d334c17323d2e29c6
<pre>
[WGSL] Handle parsing of short-circuit expression.
<a href="https://bugs.webkit.org/show_bug.cgi?id=252274">https://bugs.webkit.org/show_bug.cgi?id=252274</a>
rdar://problem/105473640

Reviewed by Myles C. Maxfield.

Implement parsing of expressions involving &amp;&amp; and || according to the WGSL spec.

* Source/WebGPU/WGSL/Lexer.cpp:
(WGSL::Lexer&lt;T&gt;::lex):
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::canContinueShortCircuitAndExpression):
(WGSL::canContinueShortCircuitOrExpression):
(WGSL::toBinaryOperation):
(WGSL::Parser&lt;Lexer&gt;::parseShortCircuitExpression):
(WGSL::Parser&lt;Lexer&gt;::parseRelationalExpression):
(WGSL::Parser&lt;Lexer&gt;::parseExpression):
* Source/WebGPU/WGSL/ParserPrivate.h:
* Source/WebGPU/WGSL/Token.cpp:
(WGSL::toString):
* Source/WebGPU/WGSL/Token.h:
* Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp:
(TestWGSLAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/260293@main">https://commits.webkit.org/260293@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0149b0c1a1ef5cc36e0bb8b4ef833fd3877b2177

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107831 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16885 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40717 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116969 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111721 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18287 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8200 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100006 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113588 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97007 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41504 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95708 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28648 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9835 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29996 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10530 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/6894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15988 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49580 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7120 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12097 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->