### PR TITLE
Fix build failure with python 3.6

### DIFF
--- a/Source/WebKit/Scripts/glib/generate-api-header.py
+++ b/Source/WebKit/Scripts/glib/generate-api-header.py
@@ -100,7 +100,7 @@ def main(args):
                 input_data += expand_ifdefs(line)
 
     command = [unifdef, "-x1", "-o%s" % output] + unifdef_args + ["-"]
-    p = subprocess.Popen(command, stdin=subprocess.PIPE, text=True, encoding="utf-8")
+    p = subprocess.Popen(command, stdin=subprocess.PIPE, universal_newlines=True, encoding="utf-8")
     p.communicate(input_data)
 
     # unifdef returns 1 when no changes were made and output file is unmodified.


### PR DESCRIPTION
#### cccd00688012d25c2cac5d6aa11b86f937927770
<pre>
Fix build failure with python 3.6
<a href="https://bugs.webkit.org/show_bug.cgi?id=252265">https://bugs.webkit.org/show_bug.cgi?id=252265</a>

Reviewed by Michael Catanzaro.

For subprocess.popen, the text keyword was added in python 3.7 as an
easier-to-understand replacement for universal_newlines.

* Source/WebKit/Scripts/glib/generate-api-header.py: text -&gt; universal_newlines.

Canonical link: <a href="https://commits.webkit.org/260357@main">https://commits.webkit.org/260357@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a39f4473f48a08df6161b1d3fb0d21cd8948fdf6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108061 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17130 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40931 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117185 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116515 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18488 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8427 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100260 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113828 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97167 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41868 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/111589 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95849 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28805 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10016 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30153 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10737 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7055 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16166 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49744 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7166 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12318 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->