### PR TITLE
Preserve-3d isn't applied to pseudo elements.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/preserve3d-pseudo-element-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/preserve3d-pseudo-element-expected.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<title>CSS Test: preserve-3d on pseudo elements</title>
+<link rel="author" title="Matt Woodrow" href="mailto:mattwoodrow@apple.com">
+<style>
+div {
+  width: 200px;
+  height: 200px;
+  background-color: green;
+}
+</style>
+<div></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/preserve3d-pseudo-element-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/preserve3d-pseudo-element-ref.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<title>CSS Test: preserve-3d on pseudo elements</title>
+<link rel="author" title="Matt Woodrow" href="mailto:mattwoodrow@apple.com">
+<style>
+div {
+  width: 200px;
+  height: 200px;
+  background-color: green;
+}
+</style>
+<div></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/preserve3d-pseudo-element.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/preserve3d-pseudo-element.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<title>CSS Test: preserve-3d on pseudo elements</title>
+<link rel="author" title="Matt Woodrow" href="mailto:mattwoodrow@apple.com">
+<link rel="match" href="preserve3d-pseudo-element-ref.html">
+<style>
+div {
+  width: 200px;
+  height: 200px;
+  transform: rotateX(90deg);
+  transform-style: preserve-3d;
+}
+
+div::before {
+  display: inline-block;
+  width: 200px;
+  height: 200px;
+  transform: rotateX(90deg);
+  content: '';
+  background-color: green;
+}
+</style>
+<div></div>
+</div>

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -3994,9 +3994,9 @@ static bool parentLayerIsDOMParent(const RenderLayer& layer)
 {
     if (!layer.parent())
         return false;
-    if (!layer.renderer().element() || !layer.renderer().element()->parentElement())
+    if (!layer.renderer().element() || !layer.renderer().element()->parentElementInComposedTree())
         return false;
-    return layer.parent()->renderer().element() == layer.renderer().element()->parentElement();
+    return layer.parent()->renderer().element() == layer.renderer().element()->parentElementInComposedTree();
 }
 
 static bool isHitCandidateLegacy(const RenderLayer* hitLayer, bool canDepthSort, double* zOffset, const HitTestingTransformState* transformState)

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -2279,9 +2279,9 @@ static bool ancestorLayerIsDOMParent(RenderLayer& layer, const RenderLayer* comp
 {
     if (!compositingAncestor)
         return false;
-    if (!layer.renderer().element() || !layer.renderer().element()->parentElement())
+    if (!layer.renderer().element() || !layer.renderer().element()->parentElementInComposedTree())
         return false;
-    return compositingAncestor->renderer().element() == layer.renderer().element()->parentElement();
+    return compositingAncestor->renderer().element() == layer.renderer().element()->parentElementInComposedTree();
 }
 
 static bool ancestorLayerWillCombineTransform(const RenderLayer* compositingAncestor)


### PR DESCRIPTION
#### b88545397c4f76fd23906b8e81980423c62c5a13
<pre>
Preserve-3d isn&apos;t applied to pseudo elements.
<a href="https://bugs.webkit.org/show_bug.cgi?id=252277">https://bugs.webkit.org/show_bug.cgi?id=252277</a>
&lt;rdar://problem/105474987&gt;

Reviewed by Simon Fraser.

We need to check the parent element in the composed tree to determine if we should be applying preserve-3d.

* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/preserve3d-pseudo-element-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/preserve3d-pseudo-element-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/preserve3d-pseudo-element.html: Added.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::parentLayerIsDOMParent):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::ancestorLayerIsDOMParent):

Canonical link: <a href="https://commits.webkit.org/260324@main">https://commits.webkit.org/260324@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d3202cbb2f2dcd8be28d08260b065f7a43e1f8d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107833 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16887 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40719 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116971 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116342 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111723 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18289 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8202 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100008 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113590 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13804 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97012 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41506 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95711 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28653 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/83351 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9837 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30001 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10532 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6897 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15990 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49585 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7141 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12099 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->