### PR TITLE
Don't call FontCache invalidation callbacks when clearing FontCaches in response to memory pressure

### DIFF
--- a/Source/WebCore/platform/ThreadGlobalData.cpp
+++ b/Source/WebCore/platform/ThreadGlobalData.cpp
@@ -52,7 +52,7 @@ ThreadGlobalData::~ThreadGlobalData() = default;
 void ThreadGlobalData::destroy()
 {
     if (m_fontCache)
-        m_fontCache->invalidate();
+        m_fontCache->invalidate(FontCache::ShouldRunInvalidationCallbacks::No);
     m_fontCache = nullptr;
     m_destroyed = true;
 }

--- a/Source/WebCore/platform/graphics/FontCache.h
+++ b/Source/WebCore/platform/graphics/FontCache.h
@@ -142,11 +142,11 @@ public:
     // On the other hand, if we're invalidating because the set of installed fonts changed,
     // or if some accessibility text settings were altered, we should run a style recalc
     // so the user can immediately see the effect of the new environment.
-    enum class ShouldRunInvalidationCallback : bool {
+    enum class ShouldRunInvalidationCallbacks : bool {
         No,
         Yes
     };
-    WEBCORE_EXPORT static void invalidateAllFontCaches(ShouldRunInvalidationCallback = ShouldRunInvalidationCallback::Yes);
+    WEBCORE_EXPORT static void invalidateAllFontCaches(ShouldRunInvalidationCallbacks);
 
     WEBCORE_EXPORT size_t fontCount();
     WEBCORE_EXPORT size_t inactiveFontCount();
@@ -195,7 +195,7 @@ public:
     static bool configurePatternForFontDescription(FcPattern*, const FontDescription&);
 #endif
 
-    void invalidate();
+    void invalidate(ShouldRunInvalidationCallbacks);
 
 private:
     void releaseNoncriticalMemory();

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -542,7 +542,7 @@ static void fontCacheRegisteredFontsChangedNotificationCallback(CFNotificationCe
     ASSERT_UNUSED(observer, isMainThread() && observer == &FontCache::forCurrentThread());
 
     ensureOnMainThread([] {
-        FontCache::invalidateAllFontCaches();
+        FontCache::invalidateAllFontCaches(FontCache::ShouldRunInvalidationCallbacks::Yes);
     });
 }
 
@@ -1352,13 +1352,7 @@ void FontCache::prewarmGlobally()
 
 void FontCache::platformReleaseNoncriticalMemory()
 {
-    // FIXME(https://bugs.webkit.org/show_bug.cgi?id=251560): We should be calling invalidate() on all platforms, but this causes a memory regression on iOS.
-#if PLATFORM(MAC)
-    invalidate();
-#else
-    m_systemFontDatabaseCoreText.clear();
-    m_fontFamilySpecificationCoreTextCache.clear();
-#endif
+    invalidate(ShouldRunInvalidationCallbacks::No);
 }
 
 }

--- a/Source/WebCore/testing/InternalSettings.cpp
+++ b/Source/WebCore/testing/InternalSettings.cpp
@@ -546,7 +546,7 @@ ExceptionOr<void> InternalSettings::setShouldMockBoldSystemFontForAccessibility(
 {
     if (!m_page)
         return Exception { InvalidAccessError };
-    FontCache::invalidateAllFontCaches();
+    FontCache::invalidateAllFontCaches(FontCache::ShouldRunInvalidationCallbacks::Yes);
 #if PLATFORM(COCOA)
     setOverrideEnhanceTextLegibility(should);
 #else

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1907,7 +1907,7 @@ ExceptionOr<void> Internals::setMarkedTextMatchesAreHighlighted(bool flag)
 
 void Internals::invalidateFontCache()
 {
-    FontCache::invalidateAllFontCaches();
+    FontCache::invalidateAllFontCaches(FontCache::ShouldRunInvalidationCallbacks::Yes);
 }
 
 ExceptionOr<void> Internals::setLowPowerModeEnabled(bool isEnabled)

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -4306,7 +4306,7 @@ void WebPage::drawToPDFiOS(WebCore::FrameIdentifier frameID, const PrintInfo& pr
 void WebPage::contentSizeCategoryDidChange(const String& contentSizeCategory)
 {
     setContentSizeCategory(contentSizeCategory);
-    FontCache::invalidateAllFontCaches();
+    FontCache::invalidateAllFontCaches(FontCache::ShouldRunInvalidationCallbacks::Yes);
 }
 
 String WebPage::platformUserAgent(const URL&) const

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -907,7 +907,7 @@ void WebProcess::terminate()
 #ifndef NDEBUG
     // These are done in an attempt to reduce LEAK output.
     GCController::singleton().garbageCollectNow();
-    FontCache::invalidateAllFontCaches();
+    FontCache::invalidateAllFontCaches(FontCache::ShouldRunInvalidationCallbacks::No);
     MemoryCache::singleton().setDisabled(true);
 #endif
 

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -1076,7 +1076,7 @@ void WebProcess::accessibilityPreferencesDidChange(const AccessibilityPreference
         _AXSInvertColorsSetEnabledApp(invertColorsEnabled, appID);
 #endif
     setOverrideEnhanceTextLegibility(preferences.enhanceTextLegibilityOverall);
-    FontCache::invalidateAllFontCaches();
+    FontCache::invalidateAllFontCaches(FontCache::ShouldRunInvalidationCallbacks::Yes);
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
     m_imageAnimationEnabled = preferences.imageAnimationEnabled;
     for (auto& page : m_pageMap.values())


### PR DESCRIPTION
#### 639f82dafd79e3bbcee84c1b0824ff17ee8f754c
<pre>
Don&apos;t call FontCache invalidation callbacks when clearing FontCaches in response to memory pressure
<a href="https://bugs.webkit.org/show_bug.cgi?id=251560">https://bugs.webkit.org/show_bug.cgi?id=251560</a>
&lt;rdar://problem/105197603&gt;

Reviewed by NOBODY (OOPS!).

As of <a href="https://bugs.webkit.org/show_bug.cgi?id=249561">https://bugs.webkit.org/show_bug.cgi?id=249561</a>, we call
FontCache::invalidate in response to memory pressure, in order to clear
some cache data. But we can end up calling FontCache invalidation
callbacks and FontSelector invalidation callbacks, both of which cause a
full style rebuild. This is not necessary when the FontCache is being
invalidated due to memory pressure.

We thread through the ShouldRunInvalidationCallbacks value through to
individual FontCache::invalidate calls so that we can skip informing the
FontSelectors about the invalidation.

The ShouldRunInvalidationCallbacks argument is made non-default, to
avoid future misuse.

* Source/WebCore/platform/ThreadGlobalData.cpp:
(WebCore::ThreadGlobalData::destroy):
* Source/WebCore/platform/graphics/FontCache.cpp:
(WebCore::FontCache::invalidate):
(WebCore::FontCache::invalidateAllFontCaches):
* Source/WebCore/platform/graphics/FontCache.h:
* Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp:
(WebCore::fontCacheRegisteredFontsChangedNotificationCallback):
(WebCore::FontCache::platformReleaseNoncriticalMemory):
* Source/WebCore/testing/InternalSettings.cpp:
(WebCore::InternalSettings::setShouldMockBoldSystemFontForAccessibility):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::invalidateFontCache):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::contentSizeCategoryDidChange):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::terminate):
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::accessibilityPreferencesDidChange):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/639f82dafd79e3bbcee84c1b0824ff17ee8f754c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107854 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16908 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40739 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116990 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116351 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111743 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18304 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8223 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100032 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113612 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13816 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97030 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41517 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95724 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28668 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/83363 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9847 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30016 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10551 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6907 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15999 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49604 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12118 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->