### PR TITLE
[WGSL] Implement parsing of let statements

### DIFF
--- a/Source/WebGPU/WGSL/AST/AST.h
+++ b/Source/WebGPU/WGSL/AST/AST.h
@@ -80,6 +80,7 @@
 #include "ASTUnaryExpression.h"
 #include "ASTUnsigned32Literal.h"
 #include "ASTValue.h"
+#include "ASTValueStatement.h"
 #include "ASTVariable.h"
 #include "ASTVariableQualifier.h"
 #include "ASTVariableStatement.h"

--- a/Source/WebGPU/WGSL/AST/ASTForward.h
+++ b/Source/WebGPU/WGSL/AST/ASTForward.h
@@ -79,6 +79,7 @@ class PhonyAssignmentStatement;
 class ReturnStatement;
 class StaticAssertStatement;
 class SwitchStatement;
+class ValueStatement;
 class VariableStatement;
 class WhileStatement;
 

--- a/Source/WebGPU/WGSL/AST/ASTNode.h
+++ b/Source/WebGPU/WGSL/AST/ASTNode.h
@@ -94,6 +94,7 @@ enum class NodeKind : uint8_t {
     ReturnStatement,
     StaticAssertStatement,
     SwitchStatement,
+    ValueStatement,
     VariableStatement,
     WhileStatement,
 

--- a/Source/WebGPU/WGSL/AST/ASTStatement.h
+++ b/Source/WebGPU/WGSL/AST/ASTStatement.h
@@ -64,6 +64,7 @@ static bool isType(const WGSL::AST::Node& node)
     case WGSL::AST::NodeKind::ReturnStatement:
     case WGSL::AST::NodeKind::StaticAssertStatement:
     case WGSL::AST::NodeKind::SwitchStatement:
+    case WGSL::AST::NodeKind::ValueStatement:
     case WGSL::AST::NodeKind::VariableStatement:
     case WGSL::AST::NodeKind::WhileStatement:
         return true;

--- a/Source/WebGPU/WGSL/AST/ASTValueStatement.h
+++ b/Source/WebGPU/WGSL/AST/ASTValueStatement.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,33 +25,26 @@
 
 #pragma once
 
-#include "ASTNode.h"
+#include "ASTStatement.h"
+#include "ASTValue.h"
 
 namespace WGSL::AST {
 
-class Value : public Node {
+class ValueStatement final : public Statement {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    using Ref = UniqueRef<Value>;
-
-    Value(SourceSpan span)
-        : Node(span)
+    ValueStatement(SourceSpan span, Value::Ref&& value)
+        : Statement(span)
+        , m_value(WTFMove(value))
     { }
+
+    NodeKind kind() const override;
+    Value& value() { return m_value.get(); }
+
+private:
+    Value::Ref m_value;
 };
 
 } // namespace WGSL::AST
 
-SPECIALIZE_TYPE_TRAITS_BEGIN(WGSL::AST::Value)
-static bool isType(const WGSL::AST::Node& node)
-{
-    switch (node.kind()) {
-    case WGSL::AST::NodeKind::ConstantValue:
-    case WGSL::AST::NodeKind::OverrideValue:
-    case WGSL::AST::NodeKind::LetValue:
-    case WGSL::AST::NodeKind::ParameterValue:
-        return true;
-    default:
-        return false;
-    }
-}
-SPECIALIZE_TYPE_TRAITS_END()
+SPECIALIZE_TYPE_TRAITS_WGSL_AST(ValueStatement)

--- a/Source/WebGPU/WGSL/Lexer.cpp
+++ b/Source/WebGPU/WGSL/Lexer.cpp
@@ -291,6 +291,7 @@ Token Lexer<T>::lex()
                 { "i32", TokenType::KeywordI32 },
                 { "i64", TokenType::ReservedWord },
                 { "i8", TokenType::ReservedWord },
+                { "let", TokenType::KeywordLet },
                 { "mat", TokenType::ReservedWord },
                 { "premerge", TokenType::ReservedWord },
                 { "private", TokenType::KeywordPrivate },

--- a/Source/WebGPU/WGSL/ParserPrivate.h
+++ b/Source/WebGPU/WGSL/ParserPrivate.h
@@ -31,6 +31,7 @@
 #include "ASTStatement.h"
 #include "ASTStructure.h"
 #include "ASTTypeName.h"
+#include "ASTValue.h"
 #include "ASTVariable.h"
 #include "CompilationMessage.h"
 #include "Lexer.h"
@@ -88,6 +89,7 @@ public:
     Result<AST::Expression::Ref> parseLHSExpression();
     Result<AST::Expression::Ref> parseCoreLHSExpression();
     Result<AST::Expression::List> parseArgumentExpressionList();
+    Result<AST::Value::Ref> parseLetValue();
 
 private:
     Expected<Token, TokenType> consumeType(TokenType);

--- a/Source/WebGPU/WGSL/Token.cpp
+++ b/Source/WebGPU/WGSL/Token.cpp
@@ -57,6 +57,8 @@ String toString(TokenType type)
         return "fn"_s;
     case TokenType::KeywordFunction:
         return "function"_s;
+    case TokenType::KeywordLet:
+        return "let"_s;
     case TokenType::KeywordPrivate:
         return "private"_s;
     case TokenType::KeywordRead:

--- a/Source/WebGPU/WGSL/Token.h
+++ b/Source/WebGPU/WGSL/Token.h
@@ -52,6 +52,7 @@ enum class TokenType: uint32_t {
     KeywordArray,
     KeywordFn,
     KeywordFunction,
+    KeywordLet,
     KeywordPrivate,
     KeywordRead,
     KeywordReadWrite,

--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -107,6 +107,7 @@
 		3A1A1F0328FD35E800C5934A /* ASTLetValue.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A1A1EFF28FD35E800C5934A /* ASTLetValue.h */; };
 		3A1A1F0428FD35E800C5934A /* ASTConstantValue.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A1A1F0028FD35E800C5934A /* ASTConstantValue.h */; };
 		3A1A1F0528FD35E800C5934A /* ASTOverrideValue.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A1A1F0128FD35E800C5934A /* ASTOverrideValue.h */; };
+		3A40FE00299C7C570049F303 /* ASTValueStatement.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A40FDFF299C7C570049F303 /* ASTValueStatement.h */; };
 		3A7E164C28C57BB8003F49C9 /* ASTIndexAccessExpression.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A7E164B28C57BB7003F49C9 /* ASTIndexAccessExpression.h */; };
 		3A9D02A0298390A000888A75 /* ASTPointerDereference.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A9D029F298390A000888A75 /* ASTPointerDereference.h */; };
 		3A9D02A4298390CF00888A75 /* ASTStringDumper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3A9D02A1298390CF00888A75 /* ASTStringDumper.cpp */; };
@@ -121,9 +122,9 @@
 		3AE27DB528C1BA480043A8E0 /* ASTVariableStatement.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AE27DB428C1BA480043A8E0 /* ASTVariableStatement.h */; };
 		664C92FD286A66090008D143 /* IOSurface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 664C92FC286A66090008D143 /* IOSurface.framework */; };
 		66DC575528627E0B0014CABD /* ParserPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 66DC575428627E0B0014CABD /* ParserPrivate.h */; };
-		9776BE7629957E12002D6D93 /* WGSLShaderModule.h in Headers */ = {isa = PBXBuildFile; fileRef = 9776BE7529957E12002D6D93 /* WGSLShaderModule.h */; };
 		9776BE732992A236002D6D93 /* Overload.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9776BE712992A236002D6D93 /* Overload.cpp */; };
 		9776BE742992A236002D6D93 /* Overload.h in Headers */ = {isa = PBXBuildFile; fileRef = 9776BE722992A236002D6D93 /* Overload.h */; };
+		9776BE7629957E12002D6D93 /* WGSLShaderModule.h in Headers */ = {isa = PBXBuildFile; fileRef = 9776BE7529957E12002D6D93 /* WGSLShaderModule.h */; };
 		9789C31A297EA105009E9006 /* CallGraph.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9789C318297EA105009E9006 /* CallGraph.cpp */; };
 		978A9125298A4E8400B37E5E /* MangleNames.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 978A9123298A4E8400B37E5E /* MangleNames.cpp */; };
 		978A9126298A4E8400B37E5E /* MangleNames.h in Headers */ = {isa = PBXBuildFile; fileRef = 978A9124298A4E8400B37E5E /* MangleNames.h */; };
@@ -318,6 +319,7 @@
 		3A1A1EFF28FD35E800C5934A /* ASTLetValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTLetValue.h; sourceTree = "<group>"; };
 		3A1A1F0028FD35E800C5934A /* ASTConstantValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTConstantValue.h; sourceTree = "<group>"; };
 		3A1A1F0128FD35E800C5934A /* ASTOverrideValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTOverrideValue.h; sourceTree = "<group>"; };
+		3A40FDFF299C7C570049F303 /* ASTValueStatement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTValueStatement.h; sourceTree = "<group>"; };
 		3A7E164B28C57BB7003F49C9 /* ASTIndexAccessExpression.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTIndexAccessExpression.h; sourceTree = "<group>"; };
 		3A9D029F298390A000888A75 /* ASTPointerDereference.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTPointerDereference.h; sourceTree = "<group>"; };
 		3A9D02A1298390CF00888A75 /* ASTStringDumper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ASTStringDumper.cpp; sourceTree = "<group>"; };
@@ -332,9 +334,9 @@
 		3AE27DB428C1BA480043A8E0 /* ASTVariableStatement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTVariableStatement.h; sourceTree = "<group>"; };
 		664C92FC286A66090008D143 /* IOSurface.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOSurface.framework; path = System/Library/Frameworks/IOSurface.framework; sourceTree = SDKROOT; };
 		66DC575428627E0B0014CABD /* ParserPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ParserPrivate.h; sourceTree = "<group>"; };
-		9776BE7529957E12002D6D93 /* WGSLShaderModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WGSLShaderModule.h; sourceTree = "<group>"; };
 		9776BE712992A236002D6D93 /* Overload.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Overload.cpp; sourceTree = "<group>"; };
 		9776BE722992A236002D6D93 /* Overload.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Overload.h; sourceTree = "<group>"; };
+		9776BE7529957E12002D6D93 /* WGSLShaderModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WGSLShaderModule.h; sourceTree = "<group>"; };
 		9789C318297EA105009E9006 /* CallGraph.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CallGraph.cpp; sourceTree = "<group>"; };
 		9789C319297EA105009E9006 /* CallGraph.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CallGraph.h; sourceTree = "<group>"; };
 		978A9123298A4E8400B37E5E /* MangleNames.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MangleNames.cpp; sourceTree = "<group>"; };
@@ -606,6 +608,7 @@
 				3AAE4EB328C56E9A00DA484B /* ASTUnaryExpression.h */,
 				3A12AECA28FCFA9800C1B975 /* ASTUnsigned32Literal.h */,
 				3A12AE9128FCE94A00C1B975 /* ASTValue.h */,
+				3A40FDFF299C7C570049F303 /* ASTValueStatement.h */,
 				33EA186327BC1A1D00A1DD52 /* ASTVariable.h */,
 				33EA187127BC1FE100A1DD52 /* ASTVariableQualifier.h */,
 				3AE27DB428C1BA480043A8E0 /* ASTVariableStatement.h */,
@@ -704,6 +707,7 @@
 				3AAE4EB428C56E9A00DA484B /* ASTUnaryExpression.h in Headers */,
 				3A12AECC28FCFA9800C1B975 /* ASTUnsigned32Literal.h in Headers */,
 				3A12AEAB28FCE94C00C1B975 /* ASTValue.h in Headers */,
+				3A40FE00299C7C570049F303 /* ASTValueStatement.h in Headers */,
 				33EA186427BC1A1D00A1DD52 /* ASTVariable.h in Headers */,
 				33EA187227BC1FE100A1DD52 /* ASTVariableQualifier.h in Headers */,
 				3AE27DB528C1BA480043A8E0 /* ASTVariableStatement.h in Headers */,

--- a/Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp
@@ -116,22 +116,23 @@ TEST(WGSLLexerTests, KeywordTokens)
     using WGSL::TokenType;
 
     checkSingleToken("array"_s, TokenType::KeywordArray);
+    checkSingleToken("bool"_s, TokenType::KeywordBool);
+    checkSingleToken("f32"_s, TokenType::KeywordF32);
     checkSingleToken("fn"_s, TokenType::KeywordFn);
     checkSingleToken("function"_s, TokenType::KeywordFunction);
+    checkSingleToken("i32"_s, TokenType::KeywordI32);
+    checkSingleToken("let"_s, TokenType::KeywordLet);
     checkSingleToken("private"_s, TokenType::KeywordPrivate);
     checkSingleToken("read"_s, TokenType::KeywordRead);
     checkSingleToken("read_write"_s, TokenType::KeywordReadWrite);
     checkSingleToken("return"_s, TokenType::KeywordReturn);
     checkSingleToken("storage"_s, TokenType::KeywordStorage);
     checkSingleToken("struct"_s, TokenType::KeywordStruct);
+    checkSingleToken("u32"_s, TokenType::KeywordU32);
     checkSingleToken("uniform"_s, TokenType::KeywordUniform);
     checkSingleToken("var"_s, TokenType::KeywordVar);
     checkSingleToken("workgroup"_s, TokenType::KeywordWorkgroup);
     checkSingleToken("write"_s, TokenType::KeywordWrite);
-    checkSingleToken("i32"_s, TokenType::KeywordI32);
-    checkSingleToken("u32"_s, TokenType::KeywordU32);
-    checkSingleToken("f32"_s, TokenType::KeywordF32);
-    checkSingleToken("bool"_s, TokenType::KeywordBool);
 }
 
 TEST(WGSLLexerTests, SpecialTokens)


### PR DESCRIPTION
#### 559f009359931aec78bad6adb3663dbf7a76a484
<pre>
[WGSL] Implement parsing of let statements
<a href="https://bugs.webkit.org/show_bug.cgi?id=252287">https://bugs.webkit.org/show_bug.cgi?id=252287</a>
rdar://105480246

Reviewed by Tadeu Zagallo.

Implement parsing of let statements local to functions according to WGSL spec.

* Source/WebGPU/WGSL/AST/AST.h:
* Source/WebGPU/WGSL/AST/ASTForward.h:
* Source/WebGPU/WGSL/AST/ASTNode.h:
* Source/WebGPU/WGSL/AST/ASTStatement.h:
(isType):
* Source/WebGPU/WGSL/AST/ASTValue.h:
* Source/WebGPU/WGSL/AST/ASTValueStatement.h: Copied from Source/WebGPU/WGSL/AST/ASTValue.h.
* Source/WebGPU/WGSL/Lexer.cpp:
(WGSL::Lexer&lt;T&gt;::lex):
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseStatement):
(WGSL::Parser&lt;Lexer&gt;::parseLetValue):
* Source/WebGPU/WGSL/ParserPrivate.h:
* Source/WebGPU/WGSL/Token.cpp:
(WGSL::toString):
* Source/WebGPU/WGSL/Token.h:
* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp:
(TestWGSLAPI::TEST):
* Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp:
(TestWGSLAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/260338@main">https://commits.webkit.org/260338@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4b7c0e514ee4ae5023c544c2d0eacd32c98869d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108071 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/17139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/40940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/117194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/111959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/18497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/8436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100272 "Built successfully") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113839 "Failed to checkout and rebase branch from PR 10122") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/18497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/40940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/41877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/18497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/40940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/10025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/40940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/10746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/8436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/16174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/40940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12327 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3889 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->