### PR TITLE
[WGSL] Implement parsing of constant declarations and statements

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTValue.h
+++ b/Source/WebGPU/WGSL/AST/ASTValue.h
@@ -27,12 +27,15 @@
 
 #include "ASTNode.h"
 
+#include <wtf/UniqueRefVector.h>
+
 namespace WGSL::AST {
 
 class Value : public Node {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     using Ref = UniqueRef<Value>;
+    using List = UniqueRefVector<Value>;
 
     Value(SourceSpan span)
         : Node(span)

--- a/Source/WebGPU/WGSL/Lexer.cpp
+++ b/Source/WebGPU/WGSL/Lexer.cpp
@@ -277,7 +277,7 @@ Token Lexer<T>::lex()
                 { "asm", TokenType::ReservedWord },
                 { "bf16", TokenType::ReservedWord },
                 { "bool", TokenType::KeywordBool },
-                { "const", TokenType::ReservedWord },
+                { "const", TokenType::KeywordConst },
                 { "do", TokenType::ReservedWord },
                 { "enum", TokenType::ReservedWord },
                 { "f16", TokenType::ReservedWord },

--- a/Source/WebGPU/WGSL/ParserPrivate.h
+++ b/Source/WebGPU/WGSL/ParserPrivate.h
@@ -89,6 +89,7 @@ public:
     Result<AST::Expression::Ref> parseLHSExpression();
     Result<AST::Expression::Ref> parseCoreLHSExpression();
     Result<AST::Expression::List> parseArgumentExpressionList();
+    Result<AST::Value::Ref> parseConstantValue();
     Result<AST::Value::Ref> parseLetValue();
 
 private:

--- a/Source/WebGPU/WGSL/Token.cpp
+++ b/Source/WebGPU/WGSL/Token.cpp
@@ -51,6 +51,8 @@ String toString(TokenType type)
         return "ReservedWord"_s;
     case TokenType::KeywordArray:
         return "array"_s;
+    case TokenType::KeywordConst:
+        return "const"_s;
     case TokenType::KeywordStruct:
         return "struct"_s;
     case TokenType::KeywordFn:

--- a/Source/WebGPU/WGSL/Token.h
+++ b/Source/WebGPU/WGSL/Token.h
@@ -50,6 +50,7 @@ enum class TokenType: uint32_t {
 
     ReservedWord,
     KeywordArray,
+    KeywordConst,
     KeywordFn,
     KeywordFunction,
     KeywordLet,

--- a/Source/WebGPU/WGSL/WGSLShaderModule.h
+++ b/Source/WebGPU/WGSL/WGSLShaderModule.h
@@ -28,6 +28,7 @@
 #include "ASTDirective.h"
 #include "ASTFunction.h"
 #include "ASTStructure.h"
+#include "ASTValue.h"
 #include "ASTVariable.h"
 #include "WGSL.h"
 
@@ -53,6 +54,7 @@ public:
     AST::Directive::List& directives() { return m_directives; }
     AST::Function::List& functions() { return m_functions; }
     AST::Structure::List& structures() { return m_structures; }
+    AST::Value::List& values() { return m_values; }
     AST::Variable::List& variables() { return m_variables; }
 
 private:
@@ -61,6 +63,7 @@ private:
     AST::Directive::List m_directives;
     AST::Function::List m_functions;
     AST::Structure::List m_structures;
+    AST::Value::List m_values;
     AST::Variable::List m_variables;
 };
 

--- a/Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp
@@ -117,6 +117,7 @@ TEST(WGSLLexerTests, KeywordTokens)
 
     checkSingleToken("array"_s, TokenType::KeywordArray);
     checkSingleToken("bool"_s, TokenType::KeywordBool);
+    checkSingleToken("const"_s, TokenType::KeywordConst);
     checkSingleToken("f32"_s, TokenType::KeywordF32);
     checkSingleToken("fn"_s, TokenType::KeywordFn);
     checkSingleToken("function"_s, TokenType::KeywordFunction);


### PR DESCRIPTION
#### dfe14f41830df0fe73ba99c50f916305305b84e7
<pre>
[WGSL] Implement parsing of constant declarations and statements
<a href="https://bugs.webkit.org/show_bug.cgi?id=252288">https://bugs.webkit.org/show_bug.cgi?id=252288</a>
rdar://105480283

Reviewed by Tadeu Zagallo.

Implement parsing of constant declarations and statements according to WGSL spec.

* Source/WebGPU/WGSL/AST/ASTValue.h:
* Source/WebGPU/WGSL/Lexer.cpp:
(WGSL::Lexer&lt;T&gt;::lex):
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseGlobalDecl):
(WGSL::Parser&lt;Lexer&gt;::parseStatement):
(WGSL::Parser&lt;Lexer&gt;::parseConstantValue):
* Source/WebGPU/WGSL/ParserPrivate.h:
* Source/WebGPU/WGSL/Token.cpp:
(WGSL::toString):
* Source/WebGPU/WGSL/Token.h:
* Source/WebGPU/WGSL/WGSLShaderModule.h:
(WGSL::ShaderModule::values):
* Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp:
(TestWGSLAPI::TEST):
* Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp:
(TestWGSLAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/260342@main">https://commits.webkit.org/260342@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18a6ef2a53fce3c543b7f02a05cb63fae4625c88

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108074 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17144 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/40943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117198 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111962 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/18500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8440 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100276 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113842 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/18500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/40943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/41880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/18500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/40943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/10028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/40943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/10749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/7063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/16177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/40943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12330 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3891 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->