### PR TITLE
[WGSL] Implement override declaration parsing

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTOverrideValue.h
+++ b/Source/WebGPU/WGSL/AST/ASTOverrideValue.h
@@ -36,7 +36,7 @@ namespace WGSL::AST {
 class OverrideValue : public Value {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    OverrideValue(SourceSpan span, Identifier&& name, TypeName::Ptr typeName, Expression::Ref&& initializer, Attribute::List&& attributes)
+    OverrideValue(SourceSpan span, Identifier&& name, TypeName::Ptr typeName, Expression::Ptr&& initializer, Attribute::List&& attributes)
         : Value(span)
         , m_name(WTFMove(name))
         , m_typeName(WTFMove(typeName))
@@ -48,12 +48,12 @@ public:
     Attribute::List& attributes() { return m_attributes; }
     Identifier& name() { return m_name; }
     TypeName* maybeTypeName() { return m_typeName.get(); }
-    Expression& initializer() { return m_initializer.get(); }
+    Expression* maybeInitializer() { return m_initializer.get(); }
 
 private:
     Identifier m_name;
     TypeName::Ptr m_typeName;
-    Expression::Ref m_initializer;
+    Expression::Ptr m_initializer;
     Attribute::List m_attributes;
 };
 

--- a/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
@@ -542,7 +542,7 @@ void Visitor::visit(AST::OverrideValue& overrideValue)
         checkErrorAndVisit(attribute);
     checkErrorAndVisit(overrideValue.name());
     maybeCheckErrorAndVisit(overrideValue.maybeTypeName());
-    checkErrorAndVisit(overrideValue.initializer());
+    maybeCheckErrorAndVisit(overrideValue.maybeInitializer());
 }
 
 void Visitor::visit(AST::LetValue& letValue)

--- a/Source/WebGPU/WGSL/Lexer.cpp
+++ b/Source/WebGPU/WGSL/Lexer.cpp
@@ -293,6 +293,7 @@ Token Lexer<T>::lex()
                 { "i8", TokenType::ReservedWord },
                 { "let", TokenType::KeywordLet },
                 { "mat", TokenType::ReservedWord },
+                { "override", TokenType::KeywordOverride },
                 { "premerge", TokenType::ReservedWord },
                 { "private", TokenType::KeywordPrivate },
                 { "read", TokenType::KeywordRead },

--- a/Source/WebGPU/WGSL/ParserPrivate.h
+++ b/Source/WebGPU/WGSL/ParserPrivate.h
@@ -91,6 +91,7 @@ public:
     Result<AST::Expression::List> parseArgumentExpressionList();
     Result<AST::Value::Ref> parseConstantValue();
     Result<AST::Value::Ref> parseLetValue();
+    Result<AST::Value::Ref> parseOverrideValueWithAttributes(AST::Attribute::List&&);
 
 private:
     Expected<Token, TokenType> consumeType(TokenType);

--- a/Source/WebGPU/WGSL/Token.cpp
+++ b/Source/WebGPU/WGSL/Token.cpp
@@ -61,6 +61,8 @@ String toString(TokenType type)
         return "function"_s;
     case TokenType::KeywordLet:
         return "let"_s;
+    case TokenType::KeywordOverride:
+        return "override"_s;
     case TokenType::KeywordPrivate:
         return "private"_s;
     case TokenType::KeywordRead:

--- a/Source/WebGPU/WGSL/Token.h
+++ b/Source/WebGPU/WGSL/Token.h
@@ -54,6 +54,7 @@ enum class TokenType: uint32_t {
     KeywordFn,
     KeywordFunction,
     KeywordLet,
+    KeywordOverride,
     KeywordPrivate,
     KeywordRead,
     KeywordReadWrite,

--- a/Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp
@@ -123,6 +123,7 @@ TEST(WGSLLexerTests, KeywordTokens)
     checkSingleToken("function"_s, TokenType::KeywordFunction);
     checkSingleToken("i32"_s, TokenType::KeywordI32);
     checkSingleToken("let"_s, TokenType::KeywordLet);
+    checkSingleToken("override"_s, TokenType::KeywordOverride);
     checkSingleToken("private"_s, TokenType::KeywordPrivate);
     checkSingleToken("read"_s, TokenType::KeywordRead);
     checkSingleToken("read_write"_s, TokenType::KeywordReadWrite);

--- a/Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp
@@ -454,6 +454,31 @@ TEST(WGSLParserTests, LocalLet)
     }
 }
 
+TEST(WGSLParserTests, GlobalOverride)
+{
+    auto shader = parse("override x: i32;\n"_s);
+
+    EXPECT_SHADER(shader);
+    EXPECT_TRUE(shader->directives().isEmpty());
+    EXPECT_TRUE(shader->structures().isEmpty());
+    EXPECT_EQ(shader->values().size(), 1u);
+    EXPECT_TRUE(shader->variables().isEmpty());
+    EXPECT_TRUE(shader->functions().isEmpty());
+
+    {
+        // override x: i32
+        EXPECT_TRUE(is<WGSL::AST::OverrideValue>(shader->values()[0]));
+        auto& override = downcast<WGSL::AST::OverrideValue>(shader->values()[0]);
+        EXPECT_TRUE(override.attributes().isEmpty());
+        EXPECT_EQ(override.name(), "x"_s);
+        EXPECT_TRUE(override.maybeTypeName());
+        EXPECT_TRUE(is<WGSL::AST::NamedTypeName>(*override.maybeTypeName()));
+        auto& typeName = downcast<WGSL::AST::NamedTypeName>(*override.maybeTypeName());
+        EXPECT_EQ(typeName.name().id(), "i32"_s);
+        EXPECT_EQ(override.maybeInitializer(), nullptr);
+    }
+}
+
 TEST(WGSLParserTests, LocalVariable)
 {
     auto shader = parse(


### PR DESCRIPTION
#### b591dc88c1634c6b585578a54d0734565cb1b601
<pre>
[WGSL] Implement override declaration parsing
<a href="https://bugs.webkit.org/show_bug.cgi?id=252289">https://bugs.webkit.org/show_bug.cgi?id=252289</a>
rdar://105480302

Reviewed by Tadeu Zagallo.

Implement parsing of override declarations according to WGSL spec.

* Source/WebGPU/WGSL/AST/ASTOverrideValue.h:
(WGSL::AST::OverrideValue::OverrideValue):
(WGSL::AST::OverrideValue::maybeInitializer):
(WGSL::AST::OverrideValue::initializer): Deleted.
* Source/WebGPU/WGSL/AST/ASTVisitor.cpp:
(WGSL::AST::Visitor::visit):
* Source/WebGPU/WGSL/Lexer.cpp:
(WGSL::Lexer&lt;T&gt;::lex):
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseGlobalDecl):
(WGSL::Parser&lt;Lexer&gt;::parseOverrideValueWithAttributes):
* Source/WebGPU/WGSL/ParserPrivate.h:
* Source/WebGPU/WGSL/Token.cpp:
(WGSL::toString):
* Source/WebGPU/WGSL/Token.h:
* Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp:
(TestWGSLAPI::TEST):
* Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp:
(TestWGSLAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/260344@main">https://commits.webkit.org/260344@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90c74bad0d599b0326d5034a64ae55e509158983

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/108077 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17146 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/40945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117201 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/111965 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/18502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/8442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100279 "Built successfully") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/113845 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/18502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/40945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/41879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/18502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/40945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/10030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/40945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/10751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/8442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/16179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/40945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/12332 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3892 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->