### PR TITLE
Performance Dashboard should be able to gracefully handle hidden platforms.

### DIFF
--- a/Websites/perf.webkit.org/public/include/manifest-generator.php
+++ b/Websites/perf.webkit.org/public/include/manifest-generator.php
@@ -122,14 +122,13 @@ class ManifestGenerator {
         $platforms = array();
         if ($platform_table) {
             foreach ($platform_table as $platform_row) {
-                if (Database::is_true($platform_row['platform_hidden']))
-                    continue;
                 $id = $platform_row['platform_id'];
                 if (array_key_exists($id, $platform_metrics)) {
                     $platforms[$id] = array(
                         'name' => $platform_row['platform_name'],
                         'metrics' => $platform_metrics[$id]['metrics'],
                         'group' => $platform_row['platform_group'],
+                        'hidden' => Database::is_true($platform_row['platform_hidden']),
                         'lastModified' => $platform_metrics[$id]['last_modified']);
                 }
             }

--- a/Websites/perf.webkit.org/public/v3/components/pane-selector.js
+++ b/Websites/perf.webkit.org/public/v3/components/pane-selector.js
@@ -49,6 +49,8 @@ class PaneSelector extends ComponentBase {
 
             if (currentMetric) {
                 for (var platform of Platform.sortByName(Platform.all())) {
+                    if (platform.isHidden())
+                        continue;
                     if (platform.hasMetric(currentMetric))
                         this._platformItems.push(this._createListItem(platform, platform.label()));
                 }

--- a/Websites/perf.webkit.org/public/v3/models/platform.js
+++ b/Websites/perf.webkit.org/public/v3/models/platform.js
@@ -6,6 +6,7 @@ class Platform extends LabeledObject {
         super(id, object);
         this._metrics = object.metrics;
         this._lastModifiedByMetric = object.lastModifiedByMetric;
+        this._isHidden = object.hidden;
         this._containingTests = null;
 
         this.ensureNamedStaticMap('name')[object.name] = this;
@@ -52,6 +53,11 @@ class Platform extends LabeledObject {
     {
         console.assert(metric instanceof Metric);
         return this._lastModifiedByMetric[metric.id()];
+    }
+
+    isHidden()
+    {
+        return this._isHidden;
     }
 
     group() { return this._group; }

--- a/Websites/perf.webkit.org/public/v3/pages/charts-page.js
+++ b/Websites/perf.webkit.org/public/v3/pages/charts-page.js
@@ -251,7 +251,7 @@ class ChartsPage extends PageWithHeading {
         }
 
         return metric.platforms().filter(function (platform) {
-            return !existingPlatforms[platform.id()];
+            return !existingPlatforms[platform.id()] && !platform.isHidden();
         });
     }
 


### PR DESCRIPTION
#### e87820646ce924819148b2900a4458d63950672f
<pre>
Performance Dashboard should be able to gracefully handle hidden platforms.
<a href="https://bugs.webkit.org/show_bug.cgi?id=252290">https://bugs.webkit.org/show_bug.cgi?id=252290</a>
rdar://100648187

Reviewed by Ryosuke Niwa.

Fix a bug that analysis task page on performance dashboard does not load properly
when any platform in this task is hidden.

* Websites/perf.webkit.org/public/include/manifest-generator.php: Include &apos;platform_hidden&apos;
field in platform manifest and stop filtering out hidden platforms in manifest.
* Websites/perf.webkit.org/public/v3/components/pane-selector.js:
(PaneSelector.prototype._renderPlatformList): Add code to ensure hidden platform does not
show in pane.
* Websites/perf.webkit.org/public/v3/models/platform.js: Added &apos;hidden&apos; field and a &apos;isHidden&apos;
function to indicate if a platform is hidden.
(Platform):
(Platform.prototype.isHidden):
* Websites/perf.webkit.org/public/v3/pages/charts-page.js: Filter out hidden platforms from
&apos;ChartsPage.alternatePlatforms&apos;.
(ChartsPage):
(ChartsPage.prototype.alternatePlatforms):
* Websites/perf.webkit.org/server-tests/api-manifest-tests.js: Added unit test for
&apos;Platform.isHidden&apos;.

Canonical link: <a href="https://commits.webkit.org/260325@main">https://commits.webkit.org/260325@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9b80a3b6a49ca9469904c3b8c31a650e9425c76

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107961 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17022 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40847 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117096 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116440 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18408 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8339 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100154 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113724 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/97112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/41721 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/95801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28749 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9940 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30097 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10648 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/6992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/16092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49687 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7140 "Found 1 new test failure: media/video-playback-quality.html (failure)") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12222 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3881 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->