### PR TITLE
Regression: "font-optical-sizing: auto" has no effect in Safari 16 on macOS Ventura & iOS 16

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -32,6 +32,8 @@
 #include "FontCreationContext.h"
 #include "FontDatabase.h"
 #include "FontFamilySpecificationCoreText.h"
+#include "FontInterrogation.h"
+#include "FontMetricsNormalization.h"
 #include "FontPaletteValues.h"
 #include "StyleFontSizeFunctions.h"
 #include "SystemFontDatabaseCoreText.h"
@@ -49,19 +51,6 @@
 #include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 
 namespace WebCore {
-
-static inline void appendOpenTypeFeature(CFMutableArrayRef features, const FontFeature& feature)
-{
-    auto featureKey = adoptCF(CFStringCreateWithBytes(kCFAllocatorDefault, reinterpret_cast<const UInt8*>(feature.tag().data()), feature.tag().size() * sizeof(FontTag::value_type), kCFStringEncodingASCII, false));
-    int rawFeatureValue = feature.value();
-    auto featureValue = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &rawFeatureValue));
-    CFTypeRef featureDictionaryKeys[] = { kCTFontOpenTypeFeatureTag, kCTFontOpenTypeFeatureValue };
-    CFTypeRef featureDictionaryValues[] = { featureKey.get(), featureValue.get() };
-    auto featureDictionary = adoptCF(CFDictionaryCreate(kCFAllocatorDefault, featureDictionaryKeys, featureDictionaryValues, std::size(featureDictionaryValues), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
-    CFArrayAppendValue(features, featureDictionary.get());
-}
-
-typedef HashMap<FontTag, float, FourCharacterTagHash, FourCharacterTagHashTraits> VariationsMap;
 
 static inline bool fontNameIsSystemFont(CFStringRef fontName)
 {
@@ -125,205 +114,6 @@ VariationDefaultsMap defaultVariationValues(CTFontRef font, ShouldLocalizeAxisNa
     return result;
 }
 
-// These values were calculated by performing a linear regression on the CSS weights/widths/slopes and Core Text weights/widths/slopes of San Francisco.
-// FIXME: <rdar://problem/31312602> Get the real values from Core Text.
-static inline float normalizeGXWeight(float value)
-{
-    return 523.7 * value - 109.3;
-}
-
-// These values were experimentally gathered from the various named weights of San Francisco.
-static struct {
-    float ctWeight;
-    float cssWeight;
-} keyframes[] = {
-    { -0.8, 30 },
-    { -0.4, 274 },
-    { 0, 400 },
-    { 0.23, 510 },
-    { 0.3, 590 },
-    { 0.4, 700 },
-    { 0.56, 860 },
-    { 0.62, 1000 },
-};
-static_assert(std::size(keyframes) > 0);
-
-float normalizeCTWeight(float value)
-{
-    if (value < keyframes[0].ctWeight)
-        return keyframes[0].cssWeight;
-    for (size_t i = 0; i < std::size(keyframes) - 1; ++i) {
-        auto& before = keyframes[i];
-        auto& after = keyframes[i + 1];
-        if (value >= before.ctWeight && value <= after.ctWeight) {
-            float ratio = (value - before.ctWeight) / (after.ctWeight - before.ctWeight);
-            return ratio * (after.cssWeight - before.cssWeight) + before.cssWeight;
-        }
-    }
-    return keyframes[std::size(keyframes) - 1].cssWeight;
-}
-
-static inline float normalizeSlope(float value)
-{
-    return value * 300;
-}
-
-static inline float denormalizeGXWeight(float value)
-{
-    return (value + 109.3) / 523.7;
-}
-
-float denormalizeCTWeight(float value)
-{
-    if (value < keyframes[0].cssWeight)
-        return keyframes[0].ctWeight;
-    for (size_t i = 0; i < std::size(keyframes) - 1; ++i) {
-        auto& before = keyframes[i];
-        auto& after = keyframes[i + 1];
-        if (value >= before.cssWeight && value <= after.cssWeight) {
-            float ratio = (value - before.cssWeight) / (after.cssWeight - before.cssWeight);
-            return ratio * (after.ctWeight - before.ctWeight) + before.ctWeight;
-        }
-    }
-    return keyframes[std::size(keyframes) - 1].ctWeight;
-}
-
-static inline float denormalizeSlope(float value)
-{
-    return value / 300;
-}
-
-static inline float denormalizeVariationWidth(float value)
-{
-    if (value <= 125)
-        return value / 100;
-    if (value <= 150)
-        return (value + 125) / 200;
-    return (value + 400) / 400;
-}
-
-static inline float normalizeVariationWidth(float value)
-{
-    if (value <= 1.25)
-        return value * 100;
-    if (value <= 1.375)
-        return value * 200 - 125;
-    return value * 400 - 400;
-}
-
-struct FontType {
-    FontType(CTFontRef font)
-    {
-        bool foundStat = false;
-        bool foundTrak = false;
-        auto tables = adoptCF(CTFontCopyAvailableTables(font, kCTFontTableOptionNoOptions));
-        if (!tables)
-            return;
-        auto size = CFArrayGetCount(tables.get());
-        for (CFIndex i = 0; i < size; ++i) {
-            auto tableTag = static_cast<CTFontTableTag>(reinterpret_cast<uintptr_t>(CFArrayGetValueAtIndex(tables.get(), i)));
-            switch (tableTag) {
-            case kCTFontTableFvar:
-                if (variationType == VariationType::NotVariable)
-                    variationType = VariationType::TrueTypeGX;
-                break;
-            case kCTFontTableSTAT:
-                foundStat = true;
-                variationType = VariationType::OpenType18;
-                break;
-            case kCTFontTableMorx:
-            case kCTFontTableMort:
-                aatShaping = true;
-                break;
-            case kCTFontTableGPOS:
-            case kCTFontTableGSUB:
-                openTypeShaping = true;
-                break;
-            case kCTFontTableTrak:
-                foundTrak = true;
-                break;
-            }
-        }
-        if (foundStat && foundTrak)
-            trackingType = TrackingType::Automatic;
-        else if (foundTrak)
-            trackingType = TrackingType::Manual;
-    }
-
-    enum class VariationType : uint8_t { NotVariable, TrueTypeGX, OpenType18, };
-    VariationType variationType { VariationType::NotVariable };
-    enum class TrackingType : uint8_t { None, Automatic, Manual, };
-    TrackingType trackingType { TrackingType::None };
-    bool openTypeShaping { false };
-    bool aatShaping { false };
-};
-
-static void addLightPalette(CFMutableDictionaryRef attributes)
-{
-    CFIndex light = kCTFontPaletteLight;
-    auto number = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberCFIndexType, &light));
-    CFDictionaryAddValue(attributes, kCTFontPaletteAttribute, number.get());
-}
-
-static void addDarkPalette(CFMutableDictionaryRef attributes)
-{
-    CFIndex dark = kCTFontPaletteDark;
-    auto number = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberCFIndexType, &dark));
-    CFDictionaryAddValue(attributes, kCTFontPaletteAttribute, number.get());
-}
-
-static void addAttributesForCustomFontPalettes(CFMutableDictionaryRef attributes, std::optional<FontPaletteIndex> basePalette, const Vector<FontPaletteValues::OverriddenColor>& overrideColors)
-{
-    if (basePalette) {
-        switch (basePalette->type) {
-        case FontPaletteIndex::Type::Light:
-            addLightPalette(attributes);
-            break;
-        case FontPaletteIndex::Type::Dark:
-            addDarkPalette(attributes);
-            break;
-        case FontPaletteIndex::Type::Integer: {
-            int64_t rawIndex = basePalette->integer; // There is no kCFNumberUIntType.
-            auto number = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt64Type, &rawIndex));
-            CFDictionaryAddValue(attributes, kCTFontPaletteAttribute, number.get());
-            break;
-        }
-        }
-    }
-
-    if (!overrideColors.isEmpty()) {
-        auto overrideDictionary = adoptCF(CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
-        for (const auto& pair : overrideColors) {
-            const auto& color = pair.second;
-            int64_t rawIndex = pair.first; // There is no kCFNumberUIntType.
-            auto number = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt64Type, &rawIndex));
-            auto colorObject = cachedCGColor(color);
-            CFDictionarySetValue(overrideDictionary.get(), number.get(), colorObject.get());
-        }
-        if (CFDictionaryGetCount(overrideDictionary.get()))
-            CFDictionaryAddValue(attributes, kCTFontPaletteColorsAttribute, overrideDictionary.get());
-    }
-}
-
-static void addAttributesForFontPalettes(CFMutableDictionaryRef attributes, const FontPalette& fontPalette, const FontPaletteValues* fontPaletteValues)
-{
-    switch (fontPalette.type) {
-    case FontPalette::Type::Normal:
-        break;
-    case FontPalette::Type::Light:
-        addLightPalette(attributes);
-        break;
-    case FontPalette::Type::Dark:
-        addDarkPalette(attributes);
-        break;
-    case FontPalette::Type::Custom: {
-        if (fontPaletteValues)
-            addAttributesForCustomFontPalettes(attributes, fontPaletteValues->basePalette(), fontPaletteValues->overrideColors());
-        break;
-    }
-    }
-}
-
 static std::optional<bool>& overrideEnhanceTextLegibility()
 {
     static NeverDestroyed<std::optional<bool>> overrideEnhanceTextLegibility;
@@ -346,160 +136,10 @@ static inline bool shouldEnhanceTextLegibility()
     return overrideEnhanceTextLegibility().value_or(platformShouldEnhanceTextLegibility());
 }
 
-static RetainPtr<CTFontRef> preparePlatformFont(CTFontRef originalFont, const FontDescription& fontDescription, const FontCreationContext& fontCreationContext, FontTypeForPreparation fontTypeForPreparation, ApplyTraitsVariations applyTraitsVariations)
-{
-    if (!originalFont)
-        return originalFont;
-
-    FontType fontType { originalFont };
-
-    auto fontOpticalSizing = fontDescription.opticalSizing();
-
-    auto defaultValues = defaultVariationValues(originalFont, ShouldLocalizeAxisNames::No);
-
-    auto fontSelectionRequest = fontDescription.fontSelectionRequest();
-    auto fontStyleAxis = fontDescription.fontStyleAxis();
-
-    bool forceOpticalSizingOn = fontOpticalSizing == FontOpticalSizing::Enabled && fontType.variationType == FontType::VariationType::TrueTypeGX && defaultValues.contains({{'o', 'p', 's', 'z'}});
-    bool forceVariations = defaultValues.contains({{'w', 'g', 'h', 't'}}) || defaultValues.contains({{'w', 'd', 't', 'h'}}) || (fontStyleAxis == FontStyleAxis::ital && defaultValues.contains({{'i', 't', 'a', 'l'}})) || (fontStyleAxis == FontStyleAxis::slnt && defaultValues.contains({{'s', 'l', 'n', 't'}}));
-    const auto& variations = fontDescription.variationSettings();
-
-    const auto& features = fontDescription.featureSettings();
-    const auto& variantSettings = fontDescription.variantSettings();
-    auto textRenderingMode = fontDescription.textRenderingMode();
-    auto shouldDisableLigaturesForSpacing = fontDescription.shouldDisableLigaturesForSpacing();
-    bool dontNeedToApplyFontPalettes = fontDescription.fontPalette().type == FontPalette::Type::Normal;
-
-    // We might want to check fontType.trackingType == FontType::TrackingType::Manual here, but in order to maintain compatibility with the rest of the system, we don't.
-    bool noFontFeatureSettings = features.isEmpty();
-    bool noFontVariationSettings = !forceVariations && variations.isEmpty();
-    bool textRenderingModeIsAuto = textRenderingMode == TextRenderingMode::AutoTextRendering;
-    bool variantSettingsIsNormal = variantSettings.isAllNormal();
-    bool dontNeedToApplyOpticalSizing = fontOpticalSizing == FontOpticalSizing::Enabled && !forceOpticalSizingOn;
-    bool fontFaceDoesntSpecifyFeatures = !fontCreationContext.fontFaceFeatures() || fontCreationContext.fontFaceFeatures()->isEmpty();
-    if (noFontFeatureSettings && noFontVariationSettings && textRenderingModeIsAuto && variantSettingsIsNormal && dontNeedToApplyOpticalSizing && fontFaceDoesntSpecifyFeatures && !shouldDisableLigaturesForSpacing && dontNeedToApplyFontPalettes)
-        return originalFont;
-
-    // This algorithm is described at https://drafts.csswg.org/css-fonts-4/#feature-variation-precedence
-    FeaturesMap featuresToBeApplied;
-    VariationsMap variationsToBeApplied;
-
-    bool needsConversion = fontType.variationType == FontType::VariationType::TrueTypeGX;
-
-    // Step 1: CoreText handles default features (such as required ligatures).
-
-    // Step 2: font-weight, font-stretch, and font-style
-    // The system font is somewhat magical. Don't mess with its variations.
-    if (applyTraitsVariations == ApplyTraitsVariations::Yes
-#if USE(NON_VARIABLE_SYSTEM_FONT)
-        && fontTypeForPreparation == FontTypeForPreparation::NonSystemFont
-#endif
-    ) {
-        float weight = fontSelectionRequest.weight;
-        float width = fontSelectionRequest.width;
-        float slope = fontSelectionRequest.slope.value_or(normalItalicValue());
-        if (auto weightValue = fontCreationContext.fontFaceCapabilities().weight)
-            weight = std::max(std::min(weight, static_cast<float>(weightValue->maximum)), static_cast<float>(weightValue->minimum));
-        if (auto widthValue = fontCreationContext.fontFaceCapabilities().width)
-            width = std::max(std::min(width, static_cast<float>(widthValue->maximum)), static_cast<float>(widthValue->minimum));
-        if (auto slopeValue = fontCreationContext.fontFaceCapabilities().weight)
-            slope = std::max(std::min(slope, static_cast<float>(slopeValue->maximum)), static_cast<float>(slopeValue->minimum));
-        if (shouldEnhanceTextLegibility() && fontTypeForPreparation == FontTypeForPreparation::SystemFont) {
-            auto ctWeight = denormalizeCTWeight(weight);
-            ctWeight = CTFontGetAccessibilityBoldWeightOfWeight(ctWeight);
-            weight = normalizeCTWeight(ctWeight);
-        }
-        if (needsConversion) {
-            weight = denormalizeGXWeight(weight);
-            width = denormalizeVariationWidth(width);
-            slope = denormalizeSlope(slope);
-        }
-        variationsToBeApplied.set({ { 'w', 'g', 'h', 't' } }, weight);
-        variationsToBeApplied.set({ { 'w', 'd', 't', 'h' } }, width);
-        if (fontStyleAxis == FontStyleAxis::ital)
-            variationsToBeApplied.set({ { 'i', 't', 'a', 'l' } }, 1);
-        else
-            variationsToBeApplied.set({ { 's', 'l', 'n', 't' } }, slope);
-    }
-
-    // FIXME: Implement Step 5: font-named-instance
-
-    // FIXME: Implement Step 6: the font-variation-settings descriptor inside @font-face
-
-    // Step 7: Consult with font-feature-settings inside @font-face
-    if (fontCreationContext.fontFaceFeatures()) {
-        for (auto& fontFaceFeature : *fontCreationContext.fontFaceFeatures())
-            featuresToBeApplied.set(fontFaceFeature.tag(), fontFaceFeature.value());
-    }
-
-    // FIXME: Move font-optical-sizing handling here. It should be step 9.
-
-    // Step 10: Font-variant
-    for (auto& newFeature : computeFeatureSettingsFromVariants(variantSettings, fontCreationContext.fontFeatureValues()))
-        featuresToBeApplied.set(newFeature.key, newFeature.value);
-
-    // Step 11: Other properties
-    if (textRenderingMode == TextRenderingMode::OptimizeSpeed) {
-        featuresToBeApplied.set(fontFeatureTag("liga"), 0);
-        featuresToBeApplied.set(fontFeatureTag("clig"), 0);
-        featuresToBeApplied.set(fontFeatureTag("dlig"), 0);
-        featuresToBeApplied.set(fontFeatureTag("hlig"), 0);
-        featuresToBeApplied.set(fontFeatureTag("calt"), 0);
-    }
-    if (shouldDisableLigaturesForSpacing) {
-        featuresToBeApplied.set(fontFeatureTag("liga"), 0);
-        featuresToBeApplied.set(fontFeatureTag("clig"), 0);
-        featuresToBeApplied.set(fontFeatureTag("dlig"), 0);
-        featuresToBeApplied.set(fontFeatureTag("hlig"), 0);
-        // Core Text doesn't disable calt when letter-spacing is applied, so we won't either.
-    }
-
-    // Step 13: Font-feature-settings
-    for (auto& newFeature : features)
-        featuresToBeApplied.set(newFeature.tag(), newFeature.value());
-
-    // Step 12: font-variation-settings
-    for (auto& newVariation : variations)
-        variationsToBeApplied.set(newVariation.tag(), newVariation.value());
-
-    auto attributes = adoptCF(CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
-    if (!featuresToBeApplied.isEmpty()) {
-        auto featureArray = adoptCF(CFArrayCreateMutable(kCFAllocatorDefault, features.size(), &kCFTypeArrayCallBacks));
-        for (auto& p : featuresToBeApplied) {
-            auto feature = FontFeature(p.key, p.value);
-            appendOpenTypeFeature(featureArray.get(), feature);
-        }
-        CFDictionaryAddValue(attributes.get(), kCTFontFeatureSettingsAttribute, featureArray.get());
-    }
-    if (!variationsToBeApplied.isEmpty()) {
-        auto variationDictionary = adoptCF(CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
-        for (auto& p : variationsToBeApplied) {
-            long long bitwiseTag = p.key[0] << 24 | p.key[1] << 16 | p.key[2] << 8 | p.key[3];
-            auto tagNumber = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberLongLongType, &bitwiseTag));
-            auto valueNumber = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberFloatType, &p.value));
-            CFDictionarySetValue(variationDictionary.get(), tagNumber.get(), valueNumber.get());
-        }
-        CFDictionaryAddValue(attributes.get(), kCTFontVariationAttribute, variationDictionary.get());
-    }
-
-    // Step 9: font-optical-sizing
-    // FIXME: Apply this before font-variation-settings
-    if (forceOpticalSizingOn || textRenderingMode == TextRenderingMode::OptimizeLegibility)
-        CFDictionaryAddValue(attributes.get(), kCTFontOpticalSizeAttribute, CFSTR("auto"));
-    else if (fontOpticalSizing == FontOpticalSizing::Disabled)
-        CFDictionaryAddValue(attributes.get(), kCTFontOpticalSizeAttribute, CFSTR("none"));
-
-    addAttributesForFontPalettes(attributes.get(), fontDescription.fontPalette(), fontCreationContext.fontPaletteValues());
-
-    addAttributesForInstalledFonts(attributes.get(), fontDescription.shouldAllowUserInstalledFonts());
-
-    auto descriptor = adoptCF(CTFontDescriptorCreateWithAttributes(attributes.get()));
-    return adoptCF(CTFontCreateCopyWithAttributes(originalFont, CTFontGetSize(originalFont), nullptr, descriptor.get()));
-}
-
 RetainPtr<CTFontRef> preparePlatformFont(UnrealizedCoreTextFont&& originalFont, const FontDescription& fontDescription, const FontCreationContext& fontCreationContext, FontTypeForPreparation fontTypeForPreparation, ApplyTraitsVariations applyTraitsVariations)
 {
-    return preparePlatformFont(originalFont.realize().get(), fontDescription, fontCreationContext, fontTypeForPreparation, applyTraitsVariations);
+    originalFont.modifyFromContext(fontDescription, fontCreationContext, fontTypeForPreparation, applyTraitsVariations, shouldEnhanceTextLegibility());
+    return originalFont.realize();
 }
 
 RefPtr<Font> FontCache::similarFont(const FontDescription& description, const String& family)
@@ -724,12 +364,12 @@ static VariationCapabilities variationCapabilitiesForFontDescriptor(CTFontDescri
     auto variationType = [&] {
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=247987 Stop creating a whole CTFont here. Ideally we'd be able to do all the inspection we need to do without one.
         auto font = adoptCF(CTFontCreateWithFontDescriptor(fontDescriptor, 0, nullptr));
-        return FontType(font.get()).variationType;
+        return FontInterrogation(font.get()).variationType;
     }();
 #else
-    auto variationType = FontType(font.get()).variationType;
+    auto variationType = FontInterrogation(font.get()).variationType;
 #endif
-    if (variationType == FontType::VariationType::TrueTypeGX && !optOutFromGXNormalization) {
+    if (variationType == FontInterrogation::VariationType::TrueTypeGX && !optOutFromGXNormalization) {
         if (result.weight)
             result.weight = { { normalizeGXWeight(result.weight.value().minimum), normalizeGXWeight(result.weight.value().maximum) } };
         if (result.width)

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.h
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.h
@@ -81,8 +81,6 @@ RetainPtr<CTFontRef> createFontForInstalledFonts(CTFontDescriptorRef, CGFloat si
 RetainPtr<CTFontRef> createFontForInstalledFonts(CTFontRef, AllowUserInstalledFonts);
 void addAttributesForWebFonts(CFMutableDictionaryRef attributes, AllowUserInstalledFonts);
 RetainPtr<CFSetRef> installedFontMandatoryAttributes(AllowUserInstalledFonts);
-float normalizeCTWeight(float);
-float denormalizeCTWeight(float);
 WEBCORE_EXPORT void setOverrideEnhanceTextLegibility(bool);
 
 CFStringRef getUIContentSizeCategoryDidChangeNotificationName();

--- a/Source/WebCore/platform/graphics/cocoa/FontFamilySpecificationCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontFamilySpecificationCoreText.cpp
@@ -50,7 +50,8 @@ FontRanges FontFamilySpecificationCoreText::fontRanges(const FontDescription& fo
 {
     auto size = fontDescription.computedSize();
     auto& originalPlatformData = FontFamilySpecificationCoreTextCache::forCurrentThread().ensure(FontFamilySpecificationKey(m_fontDescriptor.get(), fontDescription), [&]() {
-        UnrealizedCoreTextFont unrealizedFont = { RetainPtr { m_fontDescriptor } };
+        // FIXME: Stop creating this unnecessary CTFont once rdar://problem/105508842 is fixed.
+        UnrealizedCoreTextFont unrealizedFont = { adoptCF(CTFontCreateWithFontDescriptor(m_fontDescriptor.get(), size, nullptr)) };
         unrealizedFont.setSize(size);
 
         auto font = preparePlatformFont(WTFMove(unrealizedFont), fontDescription, { }, FontTypeForPreparation::SystemFont);

--- a/Source/WebCore/platform/graphics/cocoa/FontInterrogation.h
+++ b/Source/WebCore/platform/graphics/cocoa/FontInterrogation.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2017-2023 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * 3.  Neither the name of Apple Inc. ("Apple") nor the names of
+ *     its contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <CoreText/CoreText.h>
+
+namespace WebCore {
+
+struct FontInterrogation {
+    FontInterrogation(CTFontRef font)
+    {
+        bool foundStat = false;
+        bool foundTrak = false;
+        auto tables = adoptCF(CTFontCopyAvailableTables(font, kCTFontTableOptionNoOptions));
+        if (!tables)
+            return;
+        auto size = CFArrayGetCount(tables.get());
+        for (CFIndex i = 0; i < size; ++i) {
+            auto tableTag = static_cast<CTFontTableTag>(reinterpret_cast<uintptr_t>(CFArrayGetValueAtIndex(tables.get(), i)));
+            switch (tableTag) {
+            case kCTFontTableFvar:
+                if (variationType == VariationType::NotVariable)
+                    variationType = VariationType::TrueTypeGX;
+                break;
+            case kCTFontTableSTAT:
+                foundStat = true;
+                variationType = VariationType::OpenType18;
+                break;
+            case kCTFontTableMorx:
+            case kCTFontTableMort:
+                aatShaping = true;
+                break;
+            case kCTFontTableGPOS:
+            case kCTFontTableGSUB:
+                openTypeShaping = true;
+                break;
+            case kCTFontTableTrak:
+                foundTrak = true;
+                break;
+            }
+        }
+        if (foundStat && foundTrak)
+            trackingType = TrackingType::Automatic;
+        else if (foundTrak)
+            trackingType = TrackingType::Manual;
+    }
+
+    enum class VariationType : uint8_t { NotVariable, TrueTypeGX, OpenType18, };
+    VariationType variationType { VariationType::NotVariable };
+    enum class TrackingType : uint8_t { None, Automatic, Manual, };
+    TrackingType trackingType { TrackingType::None };
+    bool openTypeShaping { false };
+    bool aatShaping { false };
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/cocoa/FontMetricsNormalization.h
+++ b/Source/WebCore/platform/graphics/cocoa/FontMetricsNormalization.h
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2017-2023 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * 3.  Neither the name of Apple Inc. ("Apple") nor the names of
+ *     its contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+// These values were calculated by performing a linear regression on the CSS weights/widths/slopes and Core Text weights/widths/slopes of San Francisco.
+// FIXME: <rdar://problem/31312602> Get the real values from Core Text.
+inline float normalizeGXWeight(float value)
+{
+    return 523.7 * value - 109.3;
+}
+
+// These values were experimentally gathered from the various named weights of San Francisco.
+static struct {
+    float ctWeight;
+    float cssWeight;
+} keyframes[] = {
+    { -0.8, 30 },
+    { -0.4, 274 },
+    { 0, 400 },
+    { 0.23, 510 },
+    { 0.3, 590 },
+    { 0.4, 700 },
+    { 0.56, 860 },
+    { 0.62, 1000 },
+};
+static_assert(std::size(keyframes) > 0);
+
+inline float normalizeCTWeight(float value)
+{
+    if (value < keyframes[0].ctWeight)
+        return keyframes[0].cssWeight;
+    for (size_t i = 0; i < std::size(keyframes) - 1; ++i) {
+        auto& before = keyframes[i];
+        auto& after = keyframes[i + 1];
+        if (value >= before.ctWeight && value <= after.ctWeight) {
+            float ratio = (value - before.ctWeight) / (after.ctWeight - before.ctWeight);
+            return ratio * (after.cssWeight - before.cssWeight) + before.cssWeight;
+        }
+    }
+    return keyframes[std::size(keyframes) - 1].cssWeight;
+}
+
+inline float normalizeSlope(float value)
+{
+    return value * 300;
+}
+
+inline float denormalizeGXWeight(float value)
+{
+    return (value + 109.3) / 523.7;
+}
+
+inline float denormalizeCTWeight(float value)
+{
+    if (value < keyframes[0].cssWeight)
+        return keyframes[0].ctWeight;
+    for (size_t i = 0; i < std::size(keyframes) - 1; ++i) {
+        auto& before = keyframes[i];
+        auto& after = keyframes[i + 1];
+        if (value >= before.cssWeight && value <= after.cssWeight) {
+            float ratio = (value - before.cssWeight) / (after.cssWeight - before.cssWeight);
+            return ratio * (after.ctWeight - before.ctWeight) + before.ctWeight;
+        }
+    }
+    return keyframes[std::size(keyframes) - 1].ctWeight;
+}
+
+inline float denormalizeSlope(float value)
+{
+    return value / 300;
+}
+
+inline float denormalizeVariationWidth(float value)
+{
+    if (value <= 125)
+        return value / 100;
+    if (value <= 150)
+        return (value + 125) / 200;
+    return (value + 400) / 400;
+}
+
+inline float normalizeVariationWidth(float value)
+{
+    if (value <= 1.25)
+        return value * 100;
+    if (value <= 1.375)
+        return value * 200 - 125;
+    return value * 400 - 400;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/cocoa/SystemFontDatabaseCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/SystemFontDatabaseCoreText.cpp
@@ -29,6 +29,7 @@
 #include "FontCache.h"
 #include "FontCacheCoreText.h"
 #include "FontCascadeDescription.h"
+#include "FontMetricsNormalization.h"
 
 #include <wtf/cf/TypeCastsCF.h>
 

--- a/Source/WebCore/platform/graphics/cocoa/UnrealizedCoreTextFont.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/UnrealizedCoreTextFont.cpp
@@ -26,8 +26,11 @@
 #include "config.h"
 #include "UnrealizedCoreTextFont.h"
 
+#include "FontCacheCoreText.h"
 #include "FontCreationContext.h"
 #include "FontDescription.h"
+#include "FontInterrogation.h"
+#include "FontMetricsNormalization.h"
 
 #include <optional>
 
@@ -64,25 +67,6 @@ CGFloat UnrealizedCoreTextFont::getSize() const
     return 0;
 }
 
-RetainPtr<CTFontRef> UnrealizedCoreTextFont::realize() const
-{
-    return WTF::switchOn(m_baseFont, [this](const RetainPtr<CTFontRef>& font) -> RetainPtr<CTFontRef> {
-        if (!font)
-            return nullptr;
-        if (!CFDictionaryGetCount(m_attributes.get()))
-            return font;
-        auto modification = adoptCF(CTFontDescriptorCreateWithAttributes(m_attributes.get()));
-        return adoptCF(CTFontCreateCopyWithAttributes(font.get(), getSize(), nullptr, modification.get()));
-    }, [this](const RetainPtr<CTFontDescriptorRef>& fontDescriptor) -> RetainPtr<CTFontRef> {
-        if (!fontDescriptor)
-            return nullptr;
-        if (!CFDictionaryGetCount(m_attributes.get()))
-            return adoptCF(CTFontCreateWithFontDescriptor(fontDescriptor.get(), getSize(), nullptr));
-        auto updatedFontDescriptor = adoptCF(CTFontDescriptorCreateCopyWithAttributes(fontDescriptor.get(), m_attributes.get()));
-        return adoptCF(CTFontCreateWithFontDescriptor(updatedFontDescriptor.get(), getSize(), nullptr));
-    });
-}
-
 UnrealizedCoreTextFont::operator bool() const
 {
     return WTF::switchOn(m_baseFont, [](const RetainPtr<CTFontRef>& font) -> bool {
@@ -92,20 +76,307 @@ UnrealizedCoreTextFont::operator bool() const
     });
 }
 
-static void modifyFromContext(CFMutableDictionaryRef attributes, const FontDescription& fontDescription, const FontCreationContext& fontCreationContext, ApplyTraitsVariations applyTraitsVariations)
+static inline void appendOpenTypeFeature(CFMutableArrayRef features, const FontFeature& feature)
 {
-    // FIXME: Implement this
-    UNUSED_PARAM(attributes);
-    UNUSED_PARAM(fontDescription);
-    UNUSED_PARAM(fontCreationContext);
-    UNUSED_PARAM(applyTraitsVariations);
+    auto featureKey = adoptCF(CFStringCreateWithBytes(kCFAllocatorDefault, reinterpret_cast<const UInt8*>(feature.tag().data()), feature.tag().size() * sizeof(FontTag::value_type), kCFStringEncodingASCII, false));
+    int rawFeatureValue = feature.value();
+    auto featureValue = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &rawFeatureValue));
+    CFTypeRef featureDictionaryKeys[] = { kCTFontOpenTypeFeatureTag, kCTFontOpenTypeFeatureValue };
+    CFTypeRef featureDictionaryValues[] = { featureKey.get(), featureValue.get() };
+    auto featureDictionary = adoptCF(CFDictionaryCreate(kCFAllocatorDefault, featureDictionaryKeys, featureDictionaryValues, std::size(featureDictionaryValues), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+    CFArrayAppendValue(features, featureDictionary.get());
 }
 
-void UnrealizedCoreTextFont::modifyFromContext(const FontDescription& fontDescription, const FontCreationContext& fontCreationContext, ApplyTraitsVariations applyTraitsVariations)
+static void addLightPalette(CFMutableDictionaryRef attributes)
 {
+    CFIndex light = kCTFontPaletteLight;
+    auto number = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberCFIndexType, &light));
+    CFDictionarySetValue(attributes, kCTFontPaletteAttribute, number.get());
+}
+
+static void addDarkPalette(CFMutableDictionaryRef attributes)
+{
+    CFIndex dark = kCTFontPaletteDark;
+    auto number = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberCFIndexType, &dark));
+    CFDictionarySetValue(attributes, kCTFontPaletteAttribute, number.get());
+}
+
+static void addAttributesForCustomFontPalettes(CFMutableDictionaryRef attributes, std::optional<FontPaletteIndex> basePalette, const Vector<FontPaletteValues::OverriddenColor>& overrideColors)
+{
+    if (basePalette) {
+        switch (basePalette->type) {
+        case FontPaletteIndex::Type::Light:
+            addLightPalette(attributes);
+            break;
+        case FontPaletteIndex::Type::Dark:
+            addDarkPalette(attributes);
+            break;
+        case FontPaletteIndex::Type::Integer: {
+            int64_t rawIndex = basePalette->integer; // There is no kCFNumberUIntType.
+            auto number = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt64Type, &rawIndex));
+            CFDictionarySetValue(attributes, kCTFontPaletteAttribute, number.get());
+            break;
+        }
+        }
+    }
+
+    if (!overrideColors.isEmpty()) {
+        auto overrideDictionary = adoptCF(CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+        for (const auto& pair : overrideColors) {
+            const auto& color = pair.second;
+            int64_t rawIndex = pair.first; // There is no kCFNumberUIntType.
+            auto number = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt64Type, &rawIndex));
+            auto colorObject = cachedCGColor(color);
+            CFDictionarySetValue(overrideDictionary.get(), number.get(), colorObject.get());
+        }
+        if (CFDictionaryGetCount(overrideDictionary.get()))
+            CFDictionarySetValue(attributes, kCTFontPaletteColorsAttribute, overrideDictionary.get());
+    }
+}
+
+static void addAttributesForFontPalettes(CFMutableDictionaryRef attributes, const FontPalette& fontPalette, const FontPaletteValues* fontPaletteValues)
+{
+    switch (fontPalette.type) {
+    case FontPalette::Type::Normal:
+        break;
+    case FontPalette::Type::Light:
+        addLightPalette(attributes);
+        break;
+    case FontPalette::Type::Dark:
+        addDarkPalette(attributes);
+        break;
+    case FontPalette::Type::Custom: {
+        if (fontPaletteValues)
+            addAttributesForCustomFontPalettes(attributes, fontPaletteValues->basePalette(), fontPaletteValues->overrideColors());
+        break;
+    }
+    }
+}
+
+using VariationsMap = HashMap<FontTag, float, FourCharacterTagHash, FourCharacterTagHashTraits>;
+
+static void applyFeatures(CFMutableDictionaryRef attributes, const FeaturesMap& featuresToBeApplied)
+{
+    if (featuresToBeApplied.isEmpty())
+        return;
+
+    RetainPtr<CFMutableArrayRef> featureArray;
+    if (auto fontFeatureSettings = static_cast<CFArrayRef>(CFDictionaryGetValue(attributes, kCTFontFeatureSettingsAttribute)))
+        featureArray = adoptCF(CFArrayCreateMutableCopy(kCFAllocatorDefault, 0, fontFeatureSettings));
+    else
+        featureArray = adoptCF(CFArrayCreateMutable(kCFAllocatorDefault, 0, &kCFTypeArrayCallBacks));
+
+    for (auto& p : featuresToBeApplied) {
+        auto feature = FontFeature(p.key, p.value);
+        appendOpenTypeFeature(featureArray.get(), feature);
+    }
+
+    CFDictionarySetValue(attributes, kCTFontFeatureSettingsAttribute, featureArray.get());
+}
+
+static void applyVariations(CFMutableDictionaryRef attributes, const VariationsMap& variationsToBeApplied)
+{
+    if (variationsToBeApplied.isEmpty())
+        return;
+
+    RetainPtr<CFMutableDictionaryRef> variationDictionary;
+    if (auto fontVariations = static_cast<CFDictionaryRef>(CFDictionaryGetValue(attributes, kCTFontVariationAttribute)))
+        variationDictionary = adoptCF(CFDictionaryCreateMutableCopy(kCFAllocatorDefault, 0, fontVariations));
+    else
+        variationDictionary = adoptCF(CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+
+    for (auto& p : variationsToBeApplied) {
+        long long bitwiseTag = p.key[0] << 24 | p.key[1] << 16 | p.key[2] << 8 | p.key[3];
+        auto tagNumber = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberLongLongType, &bitwiseTag));
+        auto valueNumber = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberFloatType, &p.value));
+        CFDictionarySetValue(variationDictionary.get(), tagNumber.get(), valueNumber.get());
+    }
+
+    CFDictionarySetValue(attributes, kCTFontVariationAttribute, variationDictionary.get());
+}
+
+static void modifyFromContext(CFMutableDictionaryRef attributes, const FontDescription& fontDescription, const FontCreationContext& fontCreationContext, ApplyTraitsVariations applyTraitsVariations, float weight, float width, float slope)
+{
+    auto fontOpticalSizing = fontDescription.opticalSizing();
+    auto fontStyleAxis = fontDescription.fontStyleAxis();
+    const auto& variations = fontDescription.variationSettings();
+    const auto& features = fontDescription.featureSettings();
+    const auto& variantSettings = fontDescription.variantSettings();
+    auto textRenderingMode = fontDescription.textRenderingMode();
+    auto shouldDisableLigaturesForSpacing = fontDescription.shouldDisableLigaturesForSpacing();
+
+    // This algorithm is described at https://drafts.csswg.org/css-fonts-4/#feature-variation-precedence
+    FeaturesMap featuresToBeApplied;
+    VariationsMap variationsToBeApplied;
+
+    // Step 1: CoreText handles default features (such as required ligatures).
+
+    // Step 2: font-weight, font-stretch, and font-style
+    // The system font is somewhat magical. Don't mess with its variations.
+    if (applyTraitsVariations == ApplyTraitsVariations::Yes) {
+        variationsToBeApplied.set({ { 'w', 'g', 'h', 't' } }, weight);
+        variationsToBeApplied.set({ { 'w', 'd', 't', 'h' } }, width);
+        if (fontStyleAxis == FontStyleAxis::ital)
+            variationsToBeApplied.set({ { 'i', 't', 'a', 'l' } }, 1);
+        else
+            variationsToBeApplied.set({ { 's', 'l', 'n', 't' } }, slope);
+    }
+
+    // FIXME: Implement Step 5: font-named-instance
+
+    // FIXME: Implement Step 6: the font-variation-settings descriptor inside @font-face
+
+    // Step 7: Consult with font-feature-settings inside @font-face
+    if (fontCreationContext.fontFaceFeatures()) {
+        for (auto& fontFaceFeature : *fontCreationContext.fontFaceFeatures())
+            featuresToBeApplied.set(fontFaceFeature.tag(), fontFaceFeature.value());
+    }
+
+    // FIXME: Move font-optical-sizing handling here. It should be step 9.
+
+    // Step 10: Font-variant
+    for (auto& newFeature : computeFeatureSettingsFromVariants(variantSettings, fontCreationContext.fontFeatureValues()))
+        featuresToBeApplied.set(newFeature.key, newFeature.value);
+
+    // Step 11: Other properties
+    if (textRenderingMode == TextRenderingMode::OptimizeSpeed) {
+        featuresToBeApplied.set(fontFeatureTag("liga"), 0);
+        featuresToBeApplied.set(fontFeatureTag("clig"), 0);
+        featuresToBeApplied.set(fontFeatureTag("dlig"), 0);
+        featuresToBeApplied.set(fontFeatureTag("hlig"), 0);
+        featuresToBeApplied.set(fontFeatureTag("calt"), 0);
+    }
+    if (shouldDisableLigaturesForSpacing) {
+        featuresToBeApplied.set(fontFeatureTag("liga"), 0);
+        featuresToBeApplied.set(fontFeatureTag("clig"), 0);
+        featuresToBeApplied.set(fontFeatureTag("dlig"), 0);
+        featuresToBeApplied.set(fontFeatureTag("hlig"), 0);
+        // Core Text doesn't disable calt when letter-spacing is applied, so we won't either.
+    }
+
+    // Step 13: Font-feature-settings
+    for (auto& newFeature : features)
+        featuresToBeApplied.set(newFeature.tag(), newFeature.value());
+
+    // Step 12: font-variation-settings
+    for (auto& newVariation : variations)
+        variationsToBeApplied.set(newVariation.tag(), newVariation.value());
+
+    applyFeatures(attributes, featuresToBeApplied);
+    applyVariations(attributes, variationsToBeApplied);
+
+    // Step 9: font-optical-sizing
+    // FIXME: Apply this before font-variation-settings
+    if (textRenderingMode == TextRenderingMode::OptimizeLegibility)
+        CFDictionarySetValue(attributes, kCTFontOpticalSizeAttribute, CFSTR("auto"));
+    else if (fontOpticalSizing == FontOpticalSizing::Disabled)
+        CFDictionarySetValue(attributes, kCTFontOpticalSizeAttribute, CFSTR("none"));
+
+    addAttributesForFontPalettes(attributes, fontDescription.fontPalette(), fontCreationContext.fontPaletteValues());
+
+    addAttributesForInstalledFonts(attributes, fontDescription.shouldAllowUserInstalledFonts());
+}
+
+void UnrealizedCoreTextFont::modifyFromContext(const FontDescription& fontDescription, const FontCreationContext& fontCreationContext, FontTypeForPreparation fontTypeForPreparation, ApplyTraitsVariations applyTraitsVariations, bool shouldEnhanceTextLegibility)
+{
+    m_applyTraitsVariations = applyTraitsVariations;
+#if USE(NON_VARIABLE_SYSTEM_FONT)
+    if (fontTypeForPreparation == FontTypeForPreparation::SystemFont)
+        m_applyTraitsVariations = ApplyTraitsVariations::No;
+#endif
+
+    if (m_applyTraitsVariations == ApplyTraitsVariations::Yes) {
+        auto fontSelectionRequest = fontDescription.fontSelectionRequest();
+        m_weight = fontSelectionRequest.weight;
+        m_width = fontSelectionRequest.width;
+        m_slope = fontSelectionRequest.slope.value_or(normalItalicValue());
+        m_fontStyleAxis = fontDescription.fontStyleAxis();
+        if (auto weightValue = fontCreationContext.fontFaceCapabilities().weight)
+            m_weight = std::max(std::min(m_weight, static_cast<float>(weightValue->maximum)), static_cast<float>(weightValue->minimum));
+        if (auto widthValue = fontCreationContext.fontFaceCapabilities().width)
+            m_width = std::max(std::min(m_width, static_cast<float>(widthValue->maximum)), static_cast<float>(widthValue->minimum));
+        if (auto slopeValue = fontCreationContext.fontFaceCapabilities().weight)
+            m_slope = std::max(std::min(m_slope, static_cast<float>(slopeValue->maximum)), static_cast<float>(slopeValue->minimum));
+        if (shouldEnhanceTextLegibility && fontTypeForPreparation == FontTypeForPreparation::SystemFont) {
+            auto ctWeight = denormalizeCTWeight(m_weight);
+            ctWeight = CTFontGetAccessibilityBoldWeightOfWeight(ctWeight);
+            m_weight = normalizeCTWeight(ctWeight);
+        }
+    }
+
+    m_variationSettings = fontDescription.variationSettings();
+
     modify([&](CFMutableDictionaryRef attributes) {
-        WebCore::modifyFromContext(attributes, fontDescription, fontCreationContext, applyTraitsVariations);
+        WebCore::modifyFromContext(attributes, fontDescription, fontCreationContext, m_applyTraitsVariations, m_weight, m_width, m_slope);
     });
+}
+
+RetainPtr<CTFontRef> UnrealizedCoreTextFont::realize() const
+{
+    if (!static_cast<bool>(*this))
+        return nullptr;
+
+    auto size = getSize();
+
+    auto font = WTF::switchOn(m_baseFont, [this, size](const RetainPtr<CTFontRef>& font) -> RetainPtr<CTFontRef> {
+        if (!font)
+            return nullptr;
+        if (!CFDictionaryGetCount(m_attributes.get()))
+            return font;
+        auto modification = adoptCF(CTFontDescriptorCreateWithAttributes(m_attributes.get()));
+        return adoptCF(CTFontCreateCopyWithAttributes(font.get(), size, nullptr, modification.get()));
+    }, [this, size](const RetainPtr<CTFontDescriptorRef>& fontDescriptor) -> RetainPtr<CTFontRef> {
+        if (!fontDescriptor)
+            return nullptr;
+        if (!CFDictionaryGetCount(m_attributes.get()))
+            return adoptCF(CTFontCreateWithFontDescriptor(fontDescriptor.get(), size, nullptr));
+        auto updatedFontDescriptor = adoptCF(CTFontDescriptorCreateCopyWithAttributes(fontDescriptor.get(), m_attributes.get()));
+        return adoptCF(CTFontCreateWithFontDescriptor(updatedFontDescriptor.get(), size, nullptr));
+    });
+    ASSERT(font);
+
+    // Both OpenType 1.8 and TrueType GX support font variations, using the same named keys and values.
+    // However, the scale is different between the two: OpenType uses the CSS scale, whereas TrueType
+    // uses a 0-1-2 scale.
+    //
+    // However, we don't actually know whether the font is a TrueType GX font or not until we create a
+    // CTFont (which is done just above). The vast majority of fonts are OpenType fonts, so we
+    // opportunistically assume the font at hand is one of those and set the values accordingly. Now,
+    // after we've created the font, we can check to see whether or not our guess was correct. If it
+    // wasn't, we have to recreate the font with the normalized values.
+    //
+    // Once rdar://problem/105483251 is solved, we can delete this section.
+    if (m_applyTraitsVariations == ApplyTraitsVariations::Yes && FontInterrogation(font.get()).variationType == FontInterrogation::VariationType::TrueTypeGX) {
+        auto variationValues = defaultVariationValues(font.get(), ShouldLocalizeAxisNames::No);
+        if (variationValues.contains({ { 'w', 'g', 'h', 't' } })
+            || variationValues.contains({ { 'w', 'd', 't', 'h' } })
+            || variationValues.contains({ { 'i', 't', 'a', 'l' } })
+            || variationValues.contains({ { 's', 'l', 'n', 't' } })) {
+            VariationsMap variationsToBeApplied;
+
+            auto weight = denormalizeGXWeight(m_weight);
+            auto width = denormalizeVariationWidth(m_width);
+            auto slope = denormalizeSlope(m_slope);
+
+            variationsToBeApplied.set({ { 'w', 'g', 'h', 't' } }, weight);
+            variationsToBeApplied.set({ { 'w', 'd', 't', 'h' } }, width);
+            if (m_fontStyleAxis == FontStyleAxis::ital)
+                variationsToBeApplied.set({ { 'i', 't', 'a', 'l' } }, 1);
+            else
+                variationsToBeApplied.set({ { 's', 'l', 'n', 't' } }, slope);
+
+            for (auto& newVariation : m_variationSettings)
+                variationsToBeApplied.set(newVariation.tag(), newVariation.value());
+
+            auto attributes = adoptCF(CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+            applyVariations(attributes.get(), variationsToBeApplied);
+
+            auto modification = adoptCF(CTFontDescriptorCreateWithAttributes(attributes.get()));
+            return adoptCF(CTFontCreateCopyWithAttributes(font.get(), size, nullptr, modification.get()));
+        }
+    }
+
+    return font;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cocoa/UnrealizedCoreTextFont.h
+++ b/Source/WebCore/platform/graphics/cocoa/UnrealizedCoreTextFont.h
@@ -62,7 +62,8 @@ public:
 
     operator bool() const;
 
-    void modifyFromContext(const FontDescription&, const FontCreationContext&, ApplyTraitsVariations = ApplyTraitsVariations::Yes);
+    void modifyFromContext(const FontDescription&, const FontCreationContext&, FontTypeForPreparation = FontTypeForPreparation::NonSystemFont, ApplyTraitsVariations = ApplyTraitsVariations::Yes, bool shouldEnhanceTextLegibility = false);
+
     RetainPtr<CTFontRef> realize() const;
 
 private:
@@ -70,6 +71,13 @@ private:
 
     std::variant<RetainPtr<CTFontRef>, RetainPtr<CTFontDescriptorRef>> m_baseFont;
     RetainPtr<CFMutableDictionaryRef> m_attributes { adoptCF(CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks)) };
+
+    ApplyTraitsVariations m_applyTraitsVariations { ApplyTraitsVariations::Yes };
+    float m_weight { 0 };
+    float m_width { 0 };
+    float m_slope { 0 };
+    FontStyleAxis m_fontStyleAxis { FontStyleAxis::slnt };
+    FontVariationSettings m_variationSettings;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 78f657ca44f63973f129fab4e29cf8e5e36f128c
<pre>
Regression: &quot;font-optical-sizing: auto&quot; has no effect in Safari 16 on macOS Ventura &amp; iOS 16
<a href="https://bugs.webkit.org/show_bug.cgi?id=247987">https://bugs.webkit.org/show_bug.cgi?id=247987</a>
rdar://102432138

Reviewed by Alan Baradlay.

This patch hooks up the newly-created UnrealizedCoreTextFont to the logic that was formerly
in preparePlatformFont(). The purpose of UnrealizedCoreTextFont is so that we can make all
the font modifications we want without actually hitting Core Text; once we&apos;re done making
modifications there&apos;s a final &quot;commit&quot; step that finally ends up making a font.

Most of the reason for this is for preparePlatformFont(): its job used to be to take a font
as input, modify it, and produce a new font, but now with this patch its functionality is
represented as a set of modifications just on a dictionary of attributes inside the
UnrealizedCoreTextFont. This means we create no temporary fonts, and also means we are going
fast enough that we can enable optical sizing on every font - because doing so is just an
attribute in a dictionary, rather than creating a whole new CTFont. That is the fix for this
bug: enabling optical sizing on all fonts. All the previous patches in this series of
patches I&apos;ve been writing were just to set up UnrealizedCoreTextFont so that we could make
enabling optical sizing fast enough to do unconditionally, and to not create temporary font
objects when doing so.

There is one caveat to this: Without inspecting a CTFont, we can&apos;t know whether a font is
an OpenType or a TrueType font, and we need to know that in order to set the appropriate
values for the &apos;wght&apos;, &apos;wdth&apos;, &apos;slnt&apos;, and &apos;ital&apos; variation axes. This patch works around
that by exploiting the fact that the vast majority of fonts out there are A) not variable
fonts, and B) are OpenType fonts, so its actually beneficial to just assume the font is an
OpenType font and set it up accordingly, and then check after we&apos;ve created it whether our
guess was right. If our guess wasn&apos;t right, we can just fix up the font object we&apos;ve just
created, rather than creating a whole new one from scratch.

I originally wrote 2 tests, and the he test font Newsreader was downloaded from
<a href="https://fonts.google.com/specimen/Newsreader/about?preview.size=35&amp">https://fonts.google.com/specimen/Newsreader/about?preview.size=35&amp</a>;preview.layout=row&amp;category=Serif&amp;vfonly=true
and is licensed with the Open Font License, which means we can use it in layout tests. We
have to keep it and all its files unmodified, which is why there are so many extra font
files - those just come with the one font file we actually want to test this. However,
because we have to check in the entire release unmodified, that would add megabytes to the
WebKit repo forever, we&apos;ve decided to check in this patch without a test and then I&apos;ll
asynchronously write a test that can use a smaller font.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp:
(WebCore::preparePlatformFont):
(WebCore::variationCapabilitiesForFontDescriptor):
(WebCore::appendOpenTypeFeature): Deleted.
(WebCore::normalizeGXWeight): Deleted.
(WebCore::normalizeCTWeight): Deleted.
(WebCore::normalizeSlope): Deleted.
(WebCore::denormalizeGXWeight): Deleted.
(WebCore::denormalizeCTWeight): Deleted.
(WebCore::denormalizeSlope): Deleted.
(WebCore::denormalizeVariationWidth): Deleted.
(WebCore::normalizeVariationWidth): Deleted.
(WebCore::FontType::FontType): Deleted.
(WebCore::addLightPalette): Deleted.
(WebCore::addDarkPalette): Deleted.
(WebCore::addAttributesForCustomFontPalettes): Deleted.
(WebCore::addAttributesForFontPalettes): Deleted.
* Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.h:
* Source/WebCore/platform/graphics/cocoa/FontInterrogation.h: Added.
(WebCore::FontInterrogation::FontInterrogation):
* Source/WebCore/platform/graphics/cocoa/FontMetricsNormalization.h: Added.
(WebCore::normalizeGXWeight):
(WebCore::normalizeCTWeight):
(WebCore::normalizeSlope):
(WebCore::denormalizeGXWeight):
(WebCore::denormalizeCTWeight):
(WebCore::denormalizeSlope):
(WebCore::denormalizeVariationWidth):
(WebCore::normalizeVariationWidth):
* Source/WebCore/platform/graphics/cocoa/SystemFontDatabaseCoreText.cpp:
* Source/WebCore/platform/graphics/cocoa/UnrealizedCoreTextFont.cpp:
(WebCore::appendOpenTypeFeature):
(WebCore::addLightPalette):
(WebCore::addDarkPalette):
(WebCore::addAttributesForCustomFontPalettes):
(WebCore::addAttributesForFontPalettes):
(WebCore::applyFeatures):
(WebCore::applyVariations):
(WebCore::modifyFromContext):
(WebCore::UnrealizedCoreTextFont::modifyFromContext):
(WebCore::UnrealizedCoreTextFont::realize const):
* Source/WebCore/platform/graphics/cocoa/UnrealizedCoreTextFont.h:

Canonical link: <a href="https://commits.webkit.org/260447@main">https://commits.webkit.org/260447@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8002949a713a37df8c9128232b8da6227eef8d34

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108346 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17440 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41210 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117462 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112232 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/18948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8719 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100568 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114114 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14140 "Build was cancelled. Recent messages:") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97386 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/42112 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/29030 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10274 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30374 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11016 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/7280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16424 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49971 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7227 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12602 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->