### PR TITLE
[PlayStation] Fix build break after 260272@main

### DIFF
--- a/Source/WebCore/rendering/style/StyleMiscNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleMiscNonInheritedData.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "LengthPoint.h"
 #include "StyleContentAlignmentData.h"
 #include "StyleSelfAlignmentData.h"
 
@@ -33,6 +34,7 @@ namespace WebCore {
 class AnimationList;
 class ContentData;
 class FillLayer;
+class ShadowData;
 class StyleDeprecatedFlexibleBoxData;
 class StyleFilterData;
 class StyleFlexibleBoxData;

--- a/Source/WebCore/rendering/style/StyleVisitedLinkColorData.cpp
+++ b/Source/WebCore/rendering/style/StyleVisitedLinkColorData.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "StyleVisitedLinkColorData.h"
 
+#include "RenderStyle.h"
+
 namespace WebCore {
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleVisitedLinkColorData);


### PR DESCRIPTION
#### 49c105fabc6ceaa0cbd76068496385217e3a4d2e
<pre>
[PlayStation] Fix build break after 260272@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=252291">https://bugs.webkit.org/show_bug.cgi?id=252291</a>

Reviewed by Ross Kirsling.

Added missing header includes.

* Source/WebCore/rendering/style/StyleMiscNonInheritedData.h:
* Source/WebCore/rendering/style/StyleVisitedLinkColorData.cpp:

Canonical link: <a href="https://commits.webkit.org/260300@main">https://commits.webkit.org/260300@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/afc1a627ec9642efd1317831eda193a6a1b12b59

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107874 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16929 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40759 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117012 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111763 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18324 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8245 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100054 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113634 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97046 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/41535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/95738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28684 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/9861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30032 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10567 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/6923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/16013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49620 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7124 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12138 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->