### PR TITLE
Plumb the entire NetworkConnectionIntegrity option set into `enableNetworkConnectionIntegrity`

### DIFF
--- a/Source/WebCore/platform/network/NetworkConnectionIntegrity.h
+++ b/Source/WebCore/platform/network/NetworkConnectionIntegrity.h
@@ -35,6 +35,7 @@ enum class NetworkConnectionIntegrity : uint8_t {
     FailClosed = 1 << 4,
     WebSearchContent = 1 << 5,
     EnhancedTelemetry = 1 << 6,
+    RequestValidation = 1 << 7,
 };
 
 }
@@ -50,7 +51,8 @@ template<> struct EnumTraits<WebCore::NetworkConnectionIntegrity> {
         WebCore::NetworkConnectionIntegrity::HTTPSOnlyExplicitlyBypassedForDomain,
         WebCore::NetworkConnectionIntegrity::FailClosed,
         WebCore::NetworkConnectionIntegrity::WebSearchContent,
-        WebCore::NetworkConnectionIntegrity::EnhancedTelemetry
+        WebCore::NetworkConnectionIntegrity::EnhancedTelemetry,
+        WebCore::NetworkConnectionIntegrity::RequestValidation
     >;
 };
 

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h
@@ -39,6 +39,7 @@ OBJC_CLASS NSMutableURLRequest;
 namespace WebCore {
 class RegistrableDomain;
 class SharedBuffer;
+enum class NetworkConnectionIntegrity : uint8_t;
 }
 
 namespace WebKit {
@@ -131,6 +132,6 @@ private:
 WebCore::Credential serverTrustCredential(const WebCore::AuthenticationChallenge&);
 void setPCMDataCarriedOnRequest(WebCore::PrivateClickMeasurement::PcmDataCarried, NSMutableURLRequest *);
 
-void enableNetworkConnectionIntegrity(NSMutableURLRequest *, bool);
+void enableNetworkConnectionIntegrity(NSMutableURLRequest *, OptionSet<WebCore::NetworkConnectionIntegrity>);
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -62,7 +62,7 @@
 #import <WebKitAdditions/NetworkDataTaskCocoaAdditions.h>
 #else
 namespace WebKit {
-void enableNetworkConnectionIntegrity(NSMutableURLRequest *, bool) { }
+void enableNetworkConnectionIntegrity(NSMutableURLRequest *, OptionSet<WebCore::NetworkConnectionIntegrity>) { }
 }
 #endif
 
@@ -402,13 +402,12 @@ NetworkDataTaskCocoa::NetworkDataTaskCocoa(NetworkSession& session, NetworkDataT
 #endif
 
     auto networkConnectionIntegrityPolicy = parameters.networkConnectionIntegrityPolicy;
-    if (networkConnectionIntegrityPolicy.contains(WebCore::NetworkConnectionIntegrity::Enabled)) {
-        enableNetworkConnectionIntegrity(mutableRequest.get(), NetworkSession::needsAdditionalNetworkConnectionIntegritySettings(request));
 #if ENABLE(NETWORK_CONNECTION_INTEGRITY)
-        if (parameters.isMainFrameNavigation) 
-            configureForNetworkConnectionIntegrity(m_sessionWrapper->session.get());
+    if (networkConnectionIntegrityPolicy.contains(WebCore::NetworkConnectionIntegrity::Enabled) && parameters.isMainFrameNavigation)
+        configureForNetworkConnectionIntegrity(m_sessionWrapper->session.get());
+
+    enableNetworkConnectionIntegrity(mutableRequest.get(), networkConnectionIntegrityPolicy);
 #endif
-    }
 
 #if HAVE(PRIVACY_PROXY_FAIL_CLOSED_FOR_UNREACHABLE_HOSTS)
     if ([mutableRequest respondsToSelector:@selector(_setPrivacyProxyFailClosedForUnreachableHosts:)] && networkConnectionIntegrityPolicy.contains(WebCore::NetworkConnectionIntegrity::FailClosed))

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -1886,8 +1886,7 @@ std::unique_ptr<WebSocketTask> NetworkSessionCocoa::createWebSocketTask(WebPageP
             ensureMutableRequest()._privacyProxyFailClosedForUnreachableNonMainHosts = YES;
     }
 
-    if (networkConnectionIntegrityPolicy.contains(WebCore::NetworkConnectionIntegrity::Enabled))
-        enableNetworkConnectionIntegrity(ensureMutableRequest(), needsAdditionalNetworkConnectionIntegritySettings(request));
+    enableNetworkConnectionIntegrity(ensureMutableRequest(), networkConnectionIntegrityPolicy);
 
     auto& sessionSet = sessionSetForPage(webPageProxyID);
     RetainPtr task = [sessionSet.sessionWithCredentialStorage.session webSocketTaskWithRequest:nsRequest.get()];

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
@@ -602,13 +602,19 @@ static _WKWebsiteDeviceOrientationAndMotionAccessPolicy toWKWebsiteDeviceOrienta
 
 - (BOOL)_networkConnectionIntegrityEnabled
 {
-    return _websitePolicies->networkConnectionIntegrityPolicy().contains(WebCore::NetworkConnectionIntegrity::Enabled);
+    return _websitePolicies->networkConnectionIntegrityPolicy().containsAll({
+        WebCore::NetworkConnectionIntegrity::Enabled,
+        WebCore::NetworkConnectionIntegrity::EnhancedTelemetry,
+        WebCore::NetworkConnectionIntegrity::RequestValidation,
+    });
 }
 
 - (void)_setNetworkConnectionIntegrityEnabled:(BOOL)enabled
 {
     auto webCorePolicy = _websitePolicies->networkConnectionIntegrityPolicy();
     webCorePolicy.set(WebCore::NetworkConnectionIntegrity::Enabled, enabled);
+    webCorePolicy.set(WebCore::NetworkConnectionIntegrity::EnhancedTelemetry, enabled);
+    webCorePolicy.set(WebCore::NetworkConnectionIntegrity::RequestValidation, enabled);
     _websitePolicies->setNetworkConnectionIntegrityPolicy(webCorePolicy);
 }
 
@@ -638,6 +644,9 @@ static _WKWebsiteDeviceOrientationAndMotionAccessPolicy toWKWebsiteDeviceOrienta
     if (webCorePolicy.contains(WebCore::NetworkConnectionIntegrity::EnhancedTelemetry))
         policy |= _WKWebsiteNetworkConnectionIntegrityPolicyEnhancedTelemetry;
 
+    if (webCorePolicy.contains(WebCore::NetworkConnectionIntegrity::RequestValidation))
+        policy |= _WKWebsiteNetworkConnectionIntegrityPolicyRequestValidation;
+
     return policy;
 }
 
@@ -665,6 +674,9 @@ static _WKWebsiteDeviceOrientationAndMotionAccessPolicy toWKWebsiteDeviceOrienta
 
     if (networkConnectionIntegrityPolicy & _WKWebsiteNetworkConnectionIntegrityPolicyEnhancedTelemetry)
         webCorePolicy.add(WebCore::NetworkConnectionIntegrity::EnhancedTelemetry);
+
+    if (networkConnectionIntegrityPolicy & _WKWebsiteNetworkConnectionIntegrityPolicyRequestValidation)
+        webCorePolicy.add(WebCore::NetworkConnectionIntegrity::RequestValidation);
 
     _websitePolicies->setNetworkConnectionIntegrityPolicy(webCorePolicy);
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h
@@ -84,6 +84,7 @@ typedef NS_OPTIONS(NSUInteger, _WKWebsiteNetworkConnectionIntegrityPolicy) {
     _WKWebsiteNetworkConnectionIntegrityPolicyFailClosed = 1 << 4,
     _WKWebsiteNetworkConnectionIntegrityPolicyWebSearchContent = 1 << 5,
     _WKWebsiteNetworkConnectionIntegrityPolicyEnhancedTelemetry = 1 << 6,
+    _WKWebsiteNetworkConnectionIntegrityPolicyRequestValidation = 1 << 7,
 } WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 @class _WKCustomHeaderFields;


### PR DESCRIPTION
#### 353a1b7ca24dafae87a0111b8891a189880d8c78
<pre>
Plumb the entire NetworkConnectionIntegrity option set into `enableNetworkConnectionIntegrity`
<a href="https://bugs.webkit.org/show_bug.cgi?id=252294">https://bugs.webkit.org/show_bug.cgi?id=252294</a>
rdar://105412782

Reviewed by Aditya Keerthi.

Add a new NetworkConnectionIntegrity policy bit, and plumb it through the helper function
`enableNetworkConnectionIntegrity`.

* Source/WebCore/platform/network/NetworkConnectionIntegrity.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::enableNetworkConnectionIntegrity):
(WebKit::NetworkDataTaskCocoa::NetworkDataTaskCocoa):
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::NetworkSessionCocoa::createWebSocketTask):
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm:
(-[WKWebpagePreferences _networkConnectionIntegrityEnabled]):
(-[WKWebpagePreferences _setNetworkConnectionIntegrityEnabled:]):

Set three flags when the embedding client &quot;enables&quot; network connection integrity.

(-[WKWebpagePreferences _networkConnectionIntegrityPolicy]):
(-[WKWebpagePreferences _setNetworkConnectionIntegrityPolicy:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h:

Canonical link: <a href="https://commits.webkit.org/260308@main">https://commits.webkit.org/260308@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b720e95a0baa5fd1384ff10ee8a0427540ae315

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107875 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16930 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40760 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117013 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116365 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111764 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18325 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8246 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100055 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113635 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13833 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97043 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41537 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95741 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28681 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9862 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30029 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10568 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6925 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16014 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49617 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7132 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12139 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->