### PR TITLE
[popover] Implement beforetoggle event

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-animation-corner-cases.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-animation-corner-cases.tentative-expected.txt
@@ -1,10 +1,10 @@
 
 FAIL Descendent animations should keep the pop up visible until the animation ends assert_equals: There should be two animations running expected 2 but got 0
 PASS Pre-existing animations should *not* keep the pop up visible until the animation ends
-FAIL It should be possible to use the "beforetoggle" event handler to animate the hide assert_equals: the hide animation should now be running expected 1 but got 0
+FAIL It should be possible to use the "beforetoggle" event handler to animate the hide assert_true: The animation should keep the popover visible expected true got false
 FAIL It should be possible to use the "beforetoggle" event handler to animate the hide, even when the hide is due to dialog.showModal assert_equals: the hide animation should now be running expected 1 but got 0
 PASS toggle event cannot be cancelled
 FAIL Closing animations are triggered by changing the popover type assert_equals: There should be two animations running expected 2 but got 0
-FAIL animation finish/cancel events must be trusted in order to finish closing the popover. assert_equals: the hide animation should now be running expected 1 but got 0
+FAIL animation finish/cancel events must be trusted in order to finish closing the popover. assert_true: The popover should still be visible because the animation hasn't ended. expected true got false
 FAIL Capturing event listeners can't affect popover animations. assert_true: The popover should still be visible because the animation hasn't ended. expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic.tentative-expected.txt
@@ -1,7 +1,9 @@
+CONSOLE MESSAGE: Error: assert_true: The nested popover should be hidden first expected true got false
 Pop upPop upPop upPop upDifferent element typeDifferent element typeDifferent element typeDialog with popover attributeDialog with popover=manualInvalid popover value - defaults to popover=manualInvalid popover value - defaults to popover=manualInvalid popover value - defaults to popover=manual
 Not a popover
 Dialog without popover attribute
-Animated popover
+
+Harness Error (FAIL), message = Error: assert_true: The nested popover should be hidden first expected true got false
 
 FAIL The element <div popover="" id="boolean">Pop up</div> should behave as a popover. Element has unexpected visibility state
 FAIL The element <div popover="">Pop up</div> should behave as a popover. Element has unexpected visibility state
@@ -212,105 +214,4 @@ FAIL Removing a visible popover=manual element from the document should close th
 PASS A showing popover=manual does not match :modal
 FAIL Changing the popover type in a "beforetoggle" event handler should throw an exception (during showPopover()) assert_throws_dom: function "() => popover.showPopover()" did not throw
 FAIL Changing the popover type in a "beforetoggle" event handler should throw an exception (during hidePopover()) assert_throws_dom: function "() => popover.hidePopover()" did not throw
-PASS Changing a popover from auto to auto (via attr), and then auto during 'beforetoggle' works
-PASS Changing a popover from auto to auto (via attr), and then manual during 'beforetoggle' works
-PASS Changing a popover from auto to auto (via attr), and then invalid during 'beforetoggle' works
-PASS Changing a popover from auto to auto (via attr), and then null during 'beforetoggle' works
-PASS Changing a popover from auto to auto (via attr), and then undefined during 'beforetoggle' works
-FAIL Changing a popover from auto to manual (via attr), and then auto during 'beforetoggle' works assert_equals: Content attribute expected "auto" but got "manual"
-PASS Changing a popover from auto to manual (via attr), and then manual during 'beforetoggle' works
-FAIL Changing a popover from auto to manual (via attr), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected "invalid" but got "manual"
-FAIL Changing a popover from auto to manual (via attr), and then null during 'beforetoggle' works assert_equals: Content attribute expected "null" but got "manual"
-FAIL Changing a popover from auto to manual (via attr), and then undefined during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" did not throw
-FAIL Changing a popover from auto to invalid (via attr), and then auto during 'beforetoggle' works assert_equals: Content attribute expected "auto" but got "invalid"
-FAIL Changing a popover from auto to invalid (via attr), and then manual during 'beforetoggle' works assert_equals: Content attribute expected "manual" but got "invalid"
-PASS Changing a popover from auto to invalid (via attr), and then invalid during 'beforetoggle' works
-FAIL Changing a popover from auto to invalid (via attr), and then null during 'beforetoggle' works assert_equals: Content attribute expected "null" but got "invalid"
-FAIL Changing a popover from auto to invalid (via attr), and then undefined during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" did not throw
-FAIL Changing a popover from auto to null (via attr), and then auto during 'beforetoggle' works assert_equals: Content attribute expected "auto" but got "null"
-FAIL Changing a popover from auto to null (via attr), and then manual during 'beforetoggle' works assert_equals: Content attribute expected "manual" but got "null"
-FAIL Changing a popover from auto to null (via attr), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected "invalid" but got "null"
-PASS Changing a popover from auto to null (via attr), and then null during 'beforetoggle' works
-FAIL Changing a popover from auto to null (via attr), and then undefined during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" did not throw
-FAIL Changing a popover from auto to undefined (via attr), and then auto during 'beforetoggle' works assert_equals: Content attribute expected (string) "auto" but got (object) null
-FAIL Changing a popover from auto to undefined (via attr), and then manual during 'beforetoggle' works assert_equals: Content attribute expected (string) "manual" but got (object) null
-FAIL Changing a popover from auto to undefined (via attr), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected (string) "invalid" but got (object) null
-FAIL Changing a popover from auto to undefined (via attr), and then null during 'beforetoggle' works assert_equals: Content attribute expected (string) "null" but got (object) null
-FAIL Changing a popover from auto to undefined (via attr), and then undefined during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL Changing a popover from manual to auto (via attr), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
-FAIL Changing a popover from manual to auto (via attr), and then manual during 'beforetoggle' works assert_equals: Content attribute expected "manual" but got "auto"
-FAIL Changing a popover from manual to auto (via attr), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected "invalid" but got "auto"
-FAIL Changing a popover from manual to auto (via attr), and then null during 'beforetoggle' works assert_equals: Content attribute expected "null" but got "auto"
-FAIL Changing a popover from manual to auto (via attr), and then undefined during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" did not throw
-PASS Changing a popover from manual to manual (via attr), and then auto during 'beforetoggle' works
-PASS Changing a popover from manual to manual (via attr), and then manual during 'beforetoggle' works
-PASS Changing a popover from manual to manual (via attr), and then invalid during 'beforetoggle' works
-PASS Changing a popover from manual to manual (via attr), and then null during 'beforetoggle' works
-PASS Changing a popover from manual to manual (via attr), and then undefined during 'beforetoggle' works
-PASS Changing a popover from manual to invalid (via attr), and then auto during 'beforetoggle' works
-PASS Changing a popover from manual to invalid (via attr), and then manual during 'beforetoggle' works
-PASS Changing a popover from manual to invalid (via attr), and then invalid during 'beforetoggle' works
-PASS Changing a popover from manual to invalid (via attr), and then null during 'beforetoggle' works
-PASS Changing a popover from manual to invalid (via attr), and then undefined during 'beforetoggle' works
-PASS Changing a popover from manual to null (via attr), and then auto during 'beforetoggle' works
-PASS Changing a popover from manual to null (via attr), and then manual during 'beforetoggle' works
-PASS Changing a popover from manual to null (via attr), and then invalid during 'beforetoggle' works
-PASS Changing a popover from manual to null (via attr), and then null during 'beforetoggle' works
-PASS Changing a popover from manual to null (via attr), and then undefined during 'beforetoggle' works
-FAIL Changing a popover from manual to undefined (via attr), and then auto during 'beforetoggle' works assert_equals: Content attribute expected (string) "auto" but got (object) null
-FAIL Changing a popover from manual to undefined (via attr), and then manual during 'beforetoggle' works assert_equals: Content attribute expected (string) "manual" but got (object) null
-FAIL Changing a popover from manual to undefined (via attr), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected (string) "invalid" but got (object) null
-FAIL Changing a popover from manual to undefined (via attr), and then null during 'beforetoggle' works assert_equals: Content attribute expected (string) "null" but got (object) null
-FAIL Changing a popover from manual to undefined (via attr), and then undefined during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-PASS Changing a popover from auto to auto (via idl), and then auto during 'beforetoggle' works
-PASS Changing a popover from auto to auto (via idl), and then manual during 'beforetoggle' works
-PASS Changing a popover from auto to auto (via idl), and then invalid during 'beforetoggle' works
-PASS Changing a popover from auto to auto (via idl), and then null during 'beforetoggle' works
-PASS Changing a popover from auto to auto (via idl), and then undefined during 'beforetoggle' works
-FAIL Changing a popover from auto to manual (via idl), and then auto during 'beforetoggle' works assert_equals: Content attribute expected "auto" but got "manual"
-PASS Changing a popover from auto to manual (via idl), and then manual during 'beforetoggle' works
-FAIL Changing a popover from auto to manual (via idl), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected "invalid" but got "manual"
-FAIL Changing a popover from auto to manual (via idl), and then null during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" did not throw
-FAIL Changing a popover from auto to manual (via idl), and then undefined during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" did not throw
-FAIL Changing a popover from auto to invalid (via idl), and then auto during 'beforetoggle' works assert_equals: Content attribute expected "auto" but got "invalid"
-FAIL Changing a popover from auto to invalid (via idl), and then manual during 'beforetoggle' works assert_equals: Content attribute expected "manual" but got "invalid"
-PASS Changing a popover from auto to invalid (via idl), and then invalid during 'beforetoggle' works
-FAIL Changing a popover from auto to invalid (via idl), and then null during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" did not throw
-FAIL Changing a popover from auto to invalid (via idl), and then undefined during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" did not throw
-FAIL Changing a popover from auto to null (via idl), and then auto during 'beforetoggle' works assert_equals: Content attribute expected (string) "auto" but got (object) null
-FAIL Changing a popover from auto to null (via idl), and then manual during 'beforetoggle' works assert_equals: Content attribute expected (string) "manual" but got (object) null
-FAIL Changing a popover from auto to null (via idl), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected (string) "invalid" but got (object) null
-FAIL Changing a popover from auto to null (via idl), and then null during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL Changing a popover from auto to null (via idl), and then undefined during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL Changing a popover from auto to undefined (via idl), and then auto during 'beforetoggle' works assert_equals: Content attribute expected (string) "auto" but got (object) null
-FAIL Changing a popover from auto to undefined (via idl), and then manual during 'beforetoggle' works assert_equals: Content attribute expected (string) "manual" but got (object) null
-FAIL Changing a popover from auto to undefined (via idl), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected (string) "invalid" but got (object) null
-FAIL Changing a popover from auto to undefined (via idl), and then null during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL Changing a popover from auto to undefined (via idl), and then undefined during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL Changing a popover from manual to auto (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
-FAIL Changing a popover from manual to auto (via idl), and then manual during 'beforetoggle' works assert_equals: Content attribute expected "manual" but got "auto"
-FAIL Changing a popover from manual to auto (via idl), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected "invalid" but got "auto"
-FAIL Changing a popover from manual to auto (via idl), and then null during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" did not throw
-FAIL Changing a popover from manual to auto (via idl), and then undefined during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" did not throw
-PASS Changing a popover from manual to manual (via idl), and then auto during 'beforetoggle' works
-PASS Changing a popover from manual to manual (via idl), and then manual during 'beforetoggle' works
-PASS Changing a popover from manual to manual (via idl), and then invalid during 'beforetoggle' works
-PASS Changing a popover from manual to manual (via idl), and then null during 'beforetoggle' works
-PASS Changing a popover from manual to manual (via idl), and then undefined during 'beforetoggle' works
-PASS Changing a popover from manual to invalid (via idl), and then auto during 'beforetoggle' works
-PASS Changing a popover from manual to invalid (via idl), and then manual during 'beforetoggle' works
-PASS Changing a popover from manual to invalid (via idl), and then invalid during 'beforetoggle' works
-PASS Changing a popover from manual to invalid (via idl), and then null during 'beforetoggle' works
-PASS Changing a popover from manual to invalid (via idl), and then undefined during 'beforetoggle' works
-FAIL Changing a popover from manual to null (via idl), and then auto during 'beforetoggle' works assert_equals: Content attribute expected (string) "auto" but got (object) null
-FAIL Changing a popover from manual to null (via idl), and then manual during 'beforetoggle' works assert_equals: Content attribute expected (string) "manual" but got (object) null
-FAIL Changing a popover from manual to null (via idl), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected (string) "invalid" but got (object) null
-FAIL Changing a popover from manual to null (via idl), and then null during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL Changing a popover from manual to null (via idl), and then undefined during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL Changing a popover from manual to undefined (via idl), and then auto during 'beforetoggle' works assert_equals: Content attribute expected (string) "auto" but got (object) null
-FAIL Changing a popover from manual to undefined (via idl), and then manual during 'beforetoggle' works assert_equals: Content attribute expected (string) "manual" but got (object) null
-FAIL Changing a popover from manual to undefined (via idl), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected (string) "invalid" but got (object) null
-FAIL Changing a popover from manual to undefined (via idl), and then null during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL Changing a popover from manual to undefined (via idl), and then undefined during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL Exceptions are thrown even when show/hide are animated assert_true: Animations should start on show expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-beforetoggle-opening-event.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-beforetoggle-opening-event.tentative-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Ensure the `beforetoggle` event can be used to populate content before the popover renders assert_equals: expected "Show Event Occurred" but got ""
+PASS Ensure the `beforetoggle` event can be used to populate content before the popover renders
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-events.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-events.tentative-expected.txt
@@ -1,6 +1,6 @@
 Popover
 
-FAIL The "beforetoggle" event (listener) get properly dispatched for popovers assert_equals: expected 0 but got 1
+FAIL The "beforetoggle" event (listener) get properly dispatched for popovers assert_equals: toggle show is fired asynchronously expected 0 but got 1
 FAIL The "beforetoggle" event (attribute) get properly dispatched for popovers assert_false: expected false got true
 FAIL The "beforetoggle" event is cancelable for the "opening" transition assert_false: expected false got true
 FAIL The "beforetoggle" event is not fired for element removal assert_false: expected false got true

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/toggleevent-interface.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/toggleevent-interface.tentative-expected.txt
@@ -1,43 +1,39 @@
 
-FAIL the event is an instance of ToggleEvent Can't find variable: ToggleEvent
-FAIL the event inherts from Event Can't find variable: ToggleEvent
-FAIL Missing type argument assert_throws_js: First argument (type) is required, so was expecting a TypeError. function "function () {
-    new ToggleEvent();
-  }" threw object "ReferenceError: Can't find variable: ToggleEvent" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL type argument is string Can't find variable: ToggleEvent
-FAIL type argument is null Can't find variable: ToggleEvent
-FAIL event type set to undefined Can't find variable: ToggleEvent
-FAIL oldState has default value of empty string Can't find variable: ToggleEvent
-FAIL oldState is readonly Can't find variable: ToggleEvent
-FAIL newState has default value of empty string Can't find variable: ToggleEvent
-FAIL newState is readonly Can't find variable: ToggleEvent
-FAIL ToggleEventInit argument is null Can't find variable: ToggleEvent
-FAIL ToggleEventInit argument is undefined Can't find variable: ToggleEvent
-FAIL ToggleEventInit argument is empty dictionary Can't find variable: ToggleEvent
-FAIL oldState set to 'sample' Can't find variable: ToggleEvent
-FAIL oldState set to undefined Can't find variable: ToggleEvent
-FAIL oldState set to null Can't find variable: ToggleEvent
-FAIL oldState set to false Can't find variable: ToggleEvent
-FAIL oldState set to true Can't find variable: ToggleEvent
-FAIL oldState set to a number Can't find variable: ToggleEvent
-FAIL oldState set to [] Can't find variable: ToggleEvent
-FAIL oldState set to [1, 2, 3] Can't find variable: ToggleEvent
-FAIL oldState set to an object Can't find variable: ToggleEvent
-FAIL oldState set to an object with a valueOf function Can't find variable: ToggleEvent
-FAIL ToggleEventInit properties set value Can't find variable: ToggleEvent
-FAIL ToggleEventInit properties set value 2 Can't find variable: ToggleEvent
-FAIL ToggleEventInit properties set value 3 Can't find variable: ToggleEvent
-FAIL ToggleEventInit properties set value 4 Can't find variable: ToggleEvent
-FAIL newState set to 'sample' Can't find variable: ToggleEvent
-FAIL newState set to undefined Can't find variable: ToggleEvent
-FAIL newState set to null Can't find variable: ToggleEvent
-FAIL newState set to false Can't find variable: ToggleEvent
-FAIL newState set to true Can't find variable: ToggleEvent
-FAIL newState set to a number Can't find variable: ToggleEvent
-FAIL newState set to [] Can't find variable: ToggleEvent
-FAIL newState set to [1, 2, 3] Can't find variable: ToggleEvent
-FAIL newState set to an object Can't find variable: ToggleEvent
-FAIL newState set to an object with a valueOf function Can't find variable: ToggleEvent
+PASS the event is an instance of ToggleEvent
+PASS the event inherts from Event
+PASS Missing type argument
+PASS type argument is string
+PASS type argument is null
+PASS event type set to undefined
+PASS oldState has default value of empty string
+PASS oldState is readonly
+PASS newState has default value of empty string
+PASS newState is readonly
+PASS ToggleEventInit argument is null
+PASS ToggleEventInit argument is undefined
+PASS ToggleEventInit argument is empty dictionary
+PASS oldState set to 'sample'
+PASS oldState set to undefined
+PASS oldState set to null
+PASS oldState set to false
+PASS oldState set to true
+PASS oldState set to a number
+PASS oldState set to []
+PASS oldState set to [1, 2, 3]
+PASS oldState set to an object
+PASS oldState set to an object with a valueOf function
+PASS ToggleEventInit properties set value
+PASS ToggleEventInit properties set value 2
+PASS ToggleEventInit properties set value 3
+PASS ToggleEventInit properties set value 4
+PASS newState set to 'sample'
+PASS newState set to undefined
+PASS newState set to null
+PASS newState set to false
+PASS newState set to true
+PASS newState set to a number
+PASS newState set to []
+PASS newState set to [1, 2, 3]
+PASS newState set to an object
+PASS newState set to an object with a valueOf function
 

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1049,6 +1049,7 @@ set(WebCore_NON_SVG_IDL_FILES
     dom/TextEncoderStream.idl
     dom/TextEncoderStreamEncoder.idl
     dom/TextEvent.idl
+    dom/ToggleEvent.idl
     dom/Touch.idl
     dom/TouchEvent.idl
     dom/TouchList.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1197,6 +1197,7 @@ $(PROJECT_DIR)/dom/TextEncoderStream.idl
 $(PROJECT_DIR)/dom/TextEncoderStream.js
 $(PROJECT_DIR)/dom/TextEncoderStreamEncoder.idl
 $(PROJECT_DIR)/dom/TextEvent.idl
+$(PROJECT_DIR)/dom/ToggleEvent.idl
 $(PROJECT_DIR)/dom/Touch.idl
 $(PROJECT_DIR)/dom/TouchEvent.idl
 $(PROJECT_DIR)/dom/TouchList.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -2709,6 +2709,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSTextTrackList.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSTextTrackList.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSTimeRanges.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSTimeRanges.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSToggleEvent.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSToggleEvent.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSTrackEvent.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSTrackEvent.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSTransferFunction.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1048,6 +1048,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/dom/TextEncoderStream.idl \
     $(WebCore)/dom/TextEncoderStreamEncoder.idl \
     $(WebCore)/dom/TextEvent.idl \
+    $(WebCore)/dom/ToggleEvent.idl \
     $(WebCore)/dom/TreeWalker.idl \
     $(WebCore)/dom/UIEvent.idl \
     $(WebCore)/dom/UIEventInit.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -823,6 +823,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/Text.h
     dom/TextEvent.h
     dom/TextEventInputType.h
+    dom/ToggleEvent.h
     dom/Touch.h
     dom/Traversal.h
     dom/TreeScope.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1127,6 +1127,7 @@ dom/TextEncoder.cpp
 dom/TextEncoderStreamEncoder.cpp
 dom/TextEvent.cpp
 dom/TextNodeTraversal.cpp
+dom/ToggleEvent.cpp
 dom/Touch.cpp @no-unify
 dom/TouchEvent.cpp @no-unify
 dom/TouchList.cpp @no-unify
@@ -4118,6 +4119,7 @@ JSTextTrackCueGeneric.cpp
 JSTextTrackCueList.cpp
 JSTextTrackList.cpp
 JSTimeRanges.cpp
+JSToggleEvent.cpp
 JSTrackEvent.cpp
 JSTransferFunction.cpp
 JSTransformStream.cpp

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -400,6 +400,7 @@ namespace WebCore {
     macro(TextEncoderStreamEncoder) \
     macro(TextTrackCue) \
     macro(TextTrackCueGeneric) \
+    macro(ToggleEvent) \
     macro(TransformStream) \
     macro(TransformStreamDefaultController) \
     macro(UndoItem) \

--- a/Source/WebCore/dom/Event.h
+++ b/Source/WebCore/dom/Event.h
@@ -71,7 +71,7 @@ public:
 
     const AtomString& type() const { return m_type; }
     void setType(const AtomString& type) { m_type = type; }
-    
+
     EventTarget* target() const { return m_target.get(); }
     void setTarget(RefPtr<EventTarget>&&);
 
@@ -114,6 +114,7 @@ public:
     virtual bool isMouseEvent() const { return false; }
     virtual bool isPointerEvent() const { return false; }
     virtual bool isTextEvent() const { return false; }
+    virtual bool isToggleEvent() const { return false; }
     virtual bool isTouchEvent() const { return false; }
     virtual bool isUIEvent() const { return false; }
     virtual bool isVersionChangeEvent() const { return false; }

--- a/Source/WebCore/dom/EventNames.h
+++ b/Source/WebCore/dom/EventNames.h
@@ -67,6 +67,7 @@ namespace WebCore {
     macro(beforeload) \
     macro(beforepaste) \
     macro(beforeprint) \
+    macro(beforetoggle) \
     macro(beforeunload) \
     macro(beginEvent) \
     macro(blocked) \

--- a/Source/WebCore/dom/EventNames.in
+++ b/Source/WebCore/dom/EventNames.in
@@ -40,6 +40,7 @@ PromiseRejectionEvent
 PushEvent conditional=SERVICE_WORKER
 PushSubscriptionChangeEvent conditional=SERVICE_WORKER
 SubmitEvent
+ToggleEvent
 TextEvent
 UIEvent
 UIEvents interfaceName=UIEvent

--- a/Source/WebCore/dom/ToggleEvent.cpp
+++ b/Source/WebCore/dom/ToggleEvent.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ToggleEvent.h"
+
+#include <wtf/IsoMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(ToggleEvent);
+
+ToggleEvent::ToggleEvent(const AtomString& type, const ToggleEvent::Init& initializer, Event::IsCancelable cancelable)
+    : Event(type, Event::CanBubble::Yes, cancelable, Event::IsComposed::No)
+    , m_oldState(initializer.oldState)
+    , m_newState(initializer.newState)
+{
+}
+
+ToggleEvent::ToggleEvent(const AtomString& type, const ToggleEvent::Init& initializer)
+    : Event(type, initializer, IsTrusted::No)
+    , m_oldState(initializer.oldState)
+    , m_newState(initializer.newState)
+{
+}
+
+Ref<ToggleEvent> ToggleEvent::create(const AtomString& eventType, const ToggleEvent::Init& init, Event::IsCancelable cancelable)
+{
+    return adoptRef(*new ToggleEvent(eventType, init, cancelable));
+}
+
+Ref<ToggleEvent> ToggleEvent::create(const AtomString& eventType, const ToggleEvent::Init& init)
+{
+    return adoptRef(*new ToggleEvent(eventType, init));
+}
+
+Ref<ToggleEvent> ToggleEvent::createForBindings()
+{
+    return adoptRef(*new ToggleEvent);
+}
+
+EventInterface ToggleEvent::eventInterface() const
+{
+    return ToggleEventInterfaceType;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/dom/ToggleEvent.h
+++ b/Source/WebCore/dom/ToggleEvent.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Event.h"
+#include "EventInit.h"
+
+namespace WebCore {
+
+class ToggleEvent final : public Event {
+    WTF_MAKE_ISO_ALLOCATED(ToggleEvent);
+public:
+    struct Init : EventInit {
+        String oldState;
+        String newState;
+    };
+
+    static Ref<ToggleEvent> create(const AtomString& type, const Init&, Event::IsCancelable);
+    static Ref<ToggleEvent> create(const AtomString& type, const Init&);
+    static Ref<ToggleEvent> createForBindings();
+
+    String oldState() const { return m_oldState; }
+    String newState() const { return m_newState; }
+
+private:
+    ToggleEvent() = default;
+    ToggleEvent(const AtomString&, const Init&, Event::IsCancelable);
+    ToggleEvent(const AtomString&, const Init&);
+
+    bool isToggleEvent() const final { return true; }
+
+    EventInterface eventInterface() const final;
+
+    String m_oldState;
+    String m_newState;
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENT(ToggleEvent)

--- a/Source/WebCore/dom/ToggleEvent.idl
+++ b/Source/WebCore/dom/ToggleEvent.idl
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[EnabledBySetting=PopoverAttributeEnabled, Exposed=Window]
+interface ToggleEvent : Event {
+    constructor([AtomString] DOMString type, optional ToggleEventInit eventInitDict = {});
+    readonly attribute DOMString oldState;
+    readonly attribute DOMString newState;
+};
+
+dictionary ToggleEventInit : EventInit {
+    DOMString oldState = "";
+    DOMString newState = "";
+};

--- a/Source/WebCore/html/HTMLElement.h
+++ b/Source/WebCore/html/HTMLElement.h
@@ -193,6 +193,10 @@ protected:
 private:
     String nodeName() const final;
 
+    enum class FocusPreviousElement : bool { No, Yes };
+    enum class FireEvents : bool { No, Yes };
+    ExceptionOr<void> hidePopoverInternal(FocusPreviousElement, FireEvents);
+
     void mapLanguageAttributeToLocale(const AtomString&, MutableStyleProperties&);
 
     void dirAttributeChanged(const AtomString&);


### PR DESCRIPTION
#### b975729cd495d6e06a8ce8ca0edbe8c44db97fd2
<pre>
[popover] Implement beforetoggle event
<a href="https://bugs.webkit.org/show_bug.cgi?id=252214">https://bugs.webkit.org/show_bug.cgi?id=252214</a>
rdar://105471198

Reviewed by Ryosuke Niwa.

- Add ToggleEvent interface used by beforetoggle &amp; toggle events.
- Fire beforetoggle events when appropriate

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-animation-corner-cases.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-beforetoggle-opening-event.tentative-expected.txt:
This test still fails because it needs special [popup=auto] behavior to be implemented.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-events.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/toggleevent-interface.tentative-expected.txt:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:
* Source/WebCore/dom/Event.h:
(WebCore::Event::isToggleEvent const):
* Source/WebCore/dom/EventNames.h:
* Source/WebCore/dom/EventNames.in:
* Source/WebCore/dom/ToggleEvent.cpp: Added.
(WebCore::ToggleEvent::ToggleEvent):
(WebCore::ToggleEvent::create):
(WebCore::ToggleEvent::createForBindings):
(WebCore::ToggleEvent::eventInterface const):
* Source/WebCore/dom/ToggleEvent.h: Added.
* Source/WebCore/dom/ToggleEvent.idl: Added.
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::showPopover):
(WebCore::HTMLElement::hidePopoverInternal):
(WebCore::HTMLElement::hidePopover):
(WebCore::HTMLElement::popoverAttributeChanged):
* Source/WebCore/html/HTMLElement.h:

Canonical link: <a href="https://commits.webkit.org/260329@main">https://commits.webkit.org/260329@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/044b98146943a713ee1aadbf21b8de5cc05c97f1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107997 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17057 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40879 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117130 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111885 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/18434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8372 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100193 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113762 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/18434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/97130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/41803 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/18434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/28768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/9966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/30116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10679 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/7015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/16117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/49706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12255 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3884 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->