### PR TITLE
[Wasm-GC] Initialize all ref-typed locals to JS null value

### DIFF
--- a/JSTests/wasm/gc/bug252299.js
+++ b/JSTests/wasm/gc/bug252299.js
@@ -1,0 +1,50 @@
+//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+
+import * as assert from "../assert.js";
+import { compile, instantiate } from "./wast-wrapper.js";
+
+function module(bytes, valid = true) {
+  let buffer = new ArrayBuffer(bytes.length);
+  let view = new Uint8Array(buffer);
+    for (let i = 0; i < bytes.length; ++i) {
+        print(bytes.charCodeAt(i));
+    view[i] = bytes.charCodeAt(i);
+  }
+  return new WebAssembly.Module(buffer);
+}
+
+function arrayGetUninitializedLocal() {
+    // Test that array.get/set, struct.get/set and i31.get_<sx> on an uninitialized local
+    // correctly trap null (i.e. that locals with reference types are initialized to
+    // null)
+    let m = instantiate(`(module
+      (type $a (array (mut i32)))
+      (type $s (struct (field $x (mut i32)) (field $y (mut i64))))
+      (func (export "arrayGetNull")
+        (local (ref null $a)) (drop (array.get $a (local.get 0) (i32.const 0)))
+      )
+      (func (export "arraySetNull")
+        (local (ref null $a)) (array.set $a (local.get 0) (i32.const 0) (i32.const 0))
+      )
+      (func (export "structGetNull")
+        (local (ref null $s)) (drop (struct.get $s $x (local.get 0)))
+      )
+      (func (export "structSetNull")
+        (local (ref null $s)) (struct.set $s $x (local.get 0) (i32.const 0))
+      )
+      (func (export "i31GetNull")
+        (local (ref null i31)) (drop (i31.get_s (local.get 0))))
+      )`);
+
+
+    for (var p of [["arrayGetNull", "array.get"],
+                   ["arraySetNull", "array.set"],
+                   ["structGetNull", "struct.get"],
+                   ["structSetNull", "struct.set"],
+                   ["i31GetNull", "i31.get_<sx>"]]) {
+        assert.throws(() => m.exports[p[0]](), WebAssembly.RuntimeError, p[1] + " to a null reference");
+    }
+}
+
+arrayGetUninitializedLocal();
+


### PR DESCRIPTION
#### 7ce4006e3d05bbd0d2215012b3887dba805e3e07
<pre>
[Wasm-GC] Initialize all ref-typed locals to JS null value
<a href="https://bugs.webkit.org/show_bug.cgi?id=252299">https://bugs.webkit.org/show_bug.cgi?id=252299</a>

Reviewed by Yusuke Suzuki and Tadeu Zagallo.

`LLIntGenerator::addLocal()` was only initializing uninitialized locals
to the JS null value if they were typed `Funcref` or `Externref`,
meaning that array- or struct-typed locals would be initialized to 0.
This caused a segfault if they were accessed with set/get operations.
Changed `addLocal()` to initialize all ref-typed locals to null.

* Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp:
(JSC::Wasm::LLIntGenerator::addLocal):

Canonical link: <a href="https://commits.webkit.org/260389@main">https://commits.webkit.org/260389@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed176652095c6af6b5a11c50d3940257e5b81d53

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107891 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16946 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40774 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117023 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116373 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18335 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8263 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100073 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113653 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13835 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97056 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95743 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28694 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/97147 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9871 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30042 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/96527 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/7945 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10578 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6936 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30870 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16023 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49631 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/105528 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7189 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12150 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26135 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->