### PR TITLE
[css-fonts] font-feature-settings needs a test to check features are sorted alphabetically

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-feature-settings-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-feature-settings-computed.html
@@ -18,13 +18,11 @@ test_computed_value('font-feature-settings', '"dlig"');
 test_computed_value('font-feature-settings', '"smcp"');
 test_computed_value('font-feature-settings', '"c2sc"');
 test_computed_value('font-feature-settings', '"liga" 0');
-test_computed_value('font-feature-settings', '"tnum", "hist"',
-                    ['"tnum", "hist"', '"hist", "tnum"']);
+test_computed_value('font-feature-settings', '"tnum", "hist"', '"hist", "tnum"');
 
 test_computed_value('font-feature-settings', '"PKRN"');
 
-test_computed_value('font-feature-settings', '"dlig", "smcp", "dlig" 0',
-                    ['"smcp", "dlig" 0', '"dlig" 0, "smcp"']);
+test_computed_value('font-feature-settings', '"dlig", "smcp", "dlig" 0', '"dlig" 0, "smcp"');
 </script>
 </body>
 </html>


### PR DESCRIPTION
#### f0d659bc3e6678f0f8fb519152d14e28f5e0d44c
<pre>
[css-fonts] font-feature-settings needs a test to check features are sorted alphabetically
<a href="https://bugs.webkit.org/show_bug.cgi?id=252300">https://bugs.webkit.org/show_bug.cgi?id=252300</a>

Reviewed by Myles C. Maxfield.

We recently made a code change as part of bug 252238 to sort values in the `font-feature-settings`
computed style alphabetically and filed a spec issue (<a href="https://github.com/w3c/csswg-drafts/issues/8450)">https://github.com/w3c/csswg-drafts/issues/8450)</a>
such that the css-fonts spec would mandate the same thing. This has now been done so we can now make
the `font-feature-settings` computed style test more prescriptive in that regard.

* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-feature-settings-computed.html:

Canonical link: <a href="https://commits.webkit.org/260304@main">https://commits.webkit.org/260304@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4fe64e61867d249332092f7ed53e4b18964d42b4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107893 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16948 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40776 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117025 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116375 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18337 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8265 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100075 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113655 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97057 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41546 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95745 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28695 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9873 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30043 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10580 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/6937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16025 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49632 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12152 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3867 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->