### PR TITLE
Rebaseline text-spacing-trim tests for WK1 after 260288@main

### DIFF
--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -316,8 +316,8 @@ PASS text-orientation
 PASS text-overflow
 PASS text-rendering
 PASS text-shadow
-PASS text-transform
 PASS text-spacing-trim
+PASS text-transform
 PASS text-underline-offset
 PASS text-underline-position
 PASS text-wrap

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
@@ -226,6 +226,9 @@ PASS text-rendering: "optimizeLegibility" onto "optimizeSpeed"
 PASS text-rendering: "optimizeSpeed" onto "optimizeLegibility"
 PASS text-shadow (type: textShadowList) has testAccumulation function
 PASS text-shadow: shadow
+PASS text-spacing-trim (type: discrete) has testAccumulation function
+PASS text-spacing-trim: "space-all" onto "auto"
+PASS text-spacing-trim: "auto" onto "space-all"
 PASS text-transform (type: discrete) has testAccumulation function
 PASS text-transform: "uppercase" onto "capitalize"
 PASS text-transform: "capitalize" onto "uppercase"

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
@@ -226,6 +226,9 @@ PASS text-rendering: "optimizeLegibility" onto "optimizeSpeed"
 PASS text-rendering: "optimizeSpeed" onto "optimizeLegibility"
 PASS text-shadow (type: textShadowList) has testAddition function
 PASS text-shadow: shadow
+PASS text-spacing-trim (type: discrete) has testAddition function
+PASS text-spacing-trim: "space-all" onto "auto"
+PASS text-spacing-trim: "auto" onto "space-all"
 PASS text-transform (type: discrete) has testAddition function
 PASS text-transform: "uppercase" onto "capitalize"
 PASS text-transform: "capitalize" onto "uppercase"

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
@@ -280,6 +280,10 @@ PASS text-shadow: shadow list
 PASS text-shadow: mismatched list length (from longer to shorter)
 PASS text-shadow: mismatched list length (from shorter to longer)
 PASS text-shadow: with currentcolor
+PASS text-spacing-trim (type: discrete) has testInterpolation function
+PASS text-spacing-trim uses discrete animation when animating between "auto" and "space-all" with linear easing
+PASS text-spacing-trim uses discrete animation when animating between "auto" and "space-all" with effect easing
+PASS text-spacing-trim uses discrete animation when animating between "auto" and "space-all" with keyframe easing
 PASS text-transform (type: discrete) has testInterpolation function
 PASS text-transform uses discrete animation when animating between "capitalize" and "uppercase" with linear easing
 PASS text-transform uses discrete animation when animating between "capitalize" and "uppercase" with effect easing


### PR DESCRIPTION
#### 2a90f74b4327a1641aea3371160780cf5c93781b
<pre>
Removing FontCascade::width overload which is never defined
<a href="https://bugs.webkit.org/show_bug.cgi?id=252577">https://bugs.webkit.org/show_bug.cgi?id=252577</a>
rdar://105683236

Reviewed by NOBODY (OOPS!).

* Source/WebCore/platform/graphics/FontCascade.h:
</pre>