### PR TITLE
ManagedMediaExtension missing SkipVTableValidation in IDL

### DIFF
--- a/LayoutTests/media/media-source/content/test-vorbis-manifest.json
+++ b/LayoutTests/media/media-source/content/test-vorbis-manifest.json
@@ -2,8 +2,8 @@
     "url": "content/test-vorbis.webm",
     "type": "audio/webm; codecs=\"vorbis\"",
     "init": { "offset": 0, "size": 3744 },
-    "duration": 1.33,
+    "duration": 1.325,
     "media": [
-        { "offset": 3744, "size": 10004, "timestamp": 0, "duration": 1.33 }
+        { "offset": 3744, "size": 10004, "timestamp": 0, "duration": 1.3392 }
     ]
 }

--- a/LayoutTests/media/media-source/content/test-xhe-aac-manifest.json
+++ b/LayoutTests/media/media-source/content/test-xhe-aac-manifest.json
@@ -2,8 +2,8 @@
     "url": "content/test-xhe-aac.m4a",
     "type": "audio/mp4; codecs=\"mp4a.40.42\"",
     "init": { "offset": 0, "size": 756 },
-    "duration": 33.968,
+    "duration": 33.9683,
     "media": [
-        { "offset": 756,   "size": 280130, "timestamp": 0, "duration": 33.968 }
+        { "offset": 756,   "size": 280130, "timestamp": 0, "duration": 33.9683 }
     ]
 }

--- a/LayoutTests/media/media-source/media-managedmse-expected.txt
+++ b/LayoutTests/media/media-source/media-managedmse-expected.txt
@@ -1,0 +1,17 @@
+
+RUN(video.src = URL.createObjectURL(source))
+EVENT(sourceopen)
+RUN(sourceBuffer = source.addSourceBuffer(loader.type()))
+RUN(sourceBuffer.appendBuffer(loader.initSegment()))
+EVENT(update)
+Append a media segment.
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0)))
+EVENT(update)
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+EXPECTED (sourceBuffer.buffered.end(0).toFixed(4) == loader.mediaSegmentEndTime(0) == 'true') OK
+Clean sourcebuffer of all content.
+RUN(sourceBuffer.remove(0, 100))
+EVENT(update)
+EXPECTED (sourceBuffer.buffered.length == '0') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-managedmse.html
+++ b/LayoutTests/media/media-source/media-managedmse.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ManagedMediaSourceEnabled=true MediaSourceEnabled=true ] -->
+<html>
+<head>
+    <title>managedmediasource</title>
+    <script src="../../media/media-source/media-source-loader.js"></script>
+    <script src="../../media/video-test.js"></script>
+    <script>
+    var loader;
+    var source;
+    var sourceBuffer;
+
+    function loaderPromise(loader) {
+        return new Promise((resolve, reject) => {
+            loader.onload = resolve;
+            loader.onerror = reject;
+        });
+    }
+
+    window.addEventListener('load', async event => {
+        try {
+            findMediaElement();
+
+            let manifests = [ 'content/test-opus-manifest.json', 'content/test-vorbis-manifest.json', 'content/test-48kHz-manifest.json', 'content/test-xhe-aac-manifest.json' ];
+            for (const manifest of manifests) {
+                loader = new MediaSourceLoader(manifest);
+                await loaderPromise(loader);
+                if (ManagedMediaSource.isTypeSupported(loader.type()))
+                    break;
+            }
+
+            source = new ManagedMediaSource();
+            run('video.src = URL.createObjectURL(source)');
+            await waitFor(source, 'sourceopen');
+            waitFor(video, 'error').then(failTest);
+
+            run('sourceBuffer = source.addSourceBuffer(loader.type())');
+            run('sourceBuffer.appendBuffer(loader.initSegment())');
+            await waitFor(sourceBuffer, 'update');
+
+            consoleWrite('Append a media segment.')
+            run('sourceBuffer.appendBuffer(loader.mediaSegment(0))');
+            await waitFor(sourceBuffer, 'update');
+            testExpected('sourceBuffer.buffered.length', '1');
+            testExpected('sourceBuffer.buffered.end(0).toFixed(4) == loader.mediaSegmentEndTime(0)', true);
+
+            consoleWrite('Clean sourcebuffer of all content.');
+            run('sourceBuffer.remove(0, 100)');
+            await waitFor(sourceBuffer, 'update');
+            testExpected('sourceBuffer.buffered.length', '0');
+
+            endTest();
+        } catch (e) {
+            failTest(`Caught exception: "${e}"`);
+        }
+    });
+    </script>
+</head>
+<body>
+    <video controls></video>
+</body>
+</html>

--- a/LayoutTests/media/media-source/media-source-loader.js
+++ b/LayoutTests/media/media-source/media-source-loader.js
@@ -87,6 +87,14 @@ MediaSourceLoader.prototype = {
         return this._mediaData.slice(media.offset, media.offset + media.size);
     },
 
+    mediaSegmentEndTime: function(segmentNumber)
+    {
+        if (!this._manifest || !this._manifest.media || !this._mediaData || segmentNumber >= this._manifest.media.length)
+            return 0;
+        var media = this._manifest.media[segmentNumber];
+        return media.timestamp + media.duration;
+    },
+
     concatenateMediaSegments: function(segmentDataList)
     {
         var totalLength = 0;

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1017,6 +1017,8 @@ webkit.org/b/211995 fast/images/animated-image-mp4.html [ Failure Timeout ]
 
 webkit.org/b/214038 imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cues-cuechange.html [ Missing Failure ]
 
+webkit.org/b/252386 media/media-source/media-managedmse.html [ Failure ]
+
 # MSE failures
 webkit.org/b/167108 imported/w3c/web-platform-tests/media-source/URL-createObjectURL-revoke.html [ Failure ]
 

--- a/Source/WebCore/Modules/mediasource/MediaSource.idl
+++ b/Source/WebCore/Modules/mediasource/MediaSource.idl
@@ -40,6 +40,7 @@ enum ReadyState {
 };
 
 [
+    SkipVTableValidation,
     ActiveDOMObject,
     Conditional=MEDIA_SOURCE,
     EnabledBySetting=MediaSourceEnabled,

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.idl
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.idl
@@ -34,6 +34,7 @@
 };
 
 [
+    SkipVTableValidation,
     ActiveDOMObject,
     Conditional=MEDIA_SOURCE,
     EnabledBySetting=MediaSourceEnabled,


### PR DESCRIPTION
#### b4f656f61284ad79a2ea18d0227887eb112af8c0
<pre>
ManagedMediaExtension missing SkipVTableValidation in IDL
<a href="https://bugs.webkit.org/show_bug.cgi?id=252307">https://bugs.webkit.org/show_bug.cgi?id=252307</a>
rdar://105489108

Reviewed by Cameron McCormack.

ManagedMediaSource and ManagedSourceBuffer inherit from MediaSource
and SourceBuffer respectively.
As such, both MediaSource and SourceBuffer need SkipVTableValidation
keyword in their IDL definition to avoid
`RELEASE_ASSERT(actualVTablePointer == expectedVTablePointer);`

Added some minimal tests working on all platforms.

* LayoutTests/platform/glib/TestExpectations: Skip test for now (see bug 252386)
* LayoutTests/media/media-source/content/test-vorbis-manifest.json: Fix duration.
* LayoutTests/media/media-source/content/test-xhe-aac-manifest.json: Fix duration.
* LayoutTests/media/media-source/media-managedmse-expected.txt: Added.
* LayoutTests/media/media-source/media-managedmse.html: Added.
* LayoutTests/media/media-source/media-source-loader.js:
(MediaSourceLoader.prototype.mediaSegmentEndTime): Add method.
* Source/WebCore/Modules/mediasource/MediaSource.idl:
* Source/WebCore/Modules/mediasource/SourceBuffer.idl:

Canonical link: <a href="https://commits.webkit.org/260360@main">https://commits.webkit.org/260360@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5f2fbfa1606db7d77e567500cb2f8860ecf0a00

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108113 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17184 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40981 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117238 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116559 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112002 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18539 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8479 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100317 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113881 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97204 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41911 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95888 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28842 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10065 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30190 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10786 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7092 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16213 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49781 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7171 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12367 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->