### PR TITLE
css/css-transitions/non-rendered-element-004.tentative.html is a unique failure

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6006,7 +6006,6 @@ imported/w3c/web-platform-tests/css/css-fonts/test_datafont_same_origin.html [ S
 imported/w3c/web-platform-tests/css/css-scroll-anchoring/anchor-inside-iframe.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-scroll-anchoring/reading-scroll-forces-anchoring.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-scroll-snap/input/keyboard.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-transitions/non-rendered-element-004.tentative.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-values/dynamic-viewport-units-rule-cache.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-variables/variable-reference-refresh.html [ Skip ]
 imported/w3c/web-platform-tests/css/cssom/caretPositionFromPoint-with-transformation.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/non-rendered-element-004.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/non-rendered-element-004.tentative-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Transitions on ::marker pseudo-elements are canceled when the parent display type is no longer list-item Test timed out
+PASS Transitions on ::marker pseudo-elements are canceled when the parent display type is no longer list-item
 

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -37,9 +37,11 @@
 #include "PseudoElement.h"
 #include "RenderDescendantIterator.h"
 #include "RenderInline.h"
+#include "RenderListItem.h"
 #include "RenderMultiColumnFlow.h"
 #include "RenderMultiColumnSet.h"
 #include "RenderSVGResource.h"
+#include "RenderStyleConstants.h"
 #include "RenderTreeUpdaterGeneratedContent.h"
 #include "RenderView.h"
 #include "SVGElement.h"
@@ -609,6 +611,16 @@ void RenderTreeUpdater::tearDownRenderers(Element& root, TeardownType teardownTy
 
             GeneratedContent::removeBeforePseudoElement(element, builder);
             GeneratedContent::removeAfterPseudoElement(element, builder);
+
+            if (!is<PseudoElement>(element)) {
+                // ::before and ::after cannot have a ::marker pseudo-element addressable via
+                // CSS selectors, and as such cannot possibly have animations on them. Additionally,
+                // we cannot create a Styleable with a PseudoElement.
+                if (auto* renderListItem = dynamicDowncast<RenderListItem>(element.renderer())) {
+                    if (renderListItem->markerRenderer())
+                        Styleable(element, PseudoId::Marker).cancelDeclarativeAnimations();
+                }
+            }
 
             if (auto* renderer = element.renderer()) {
                 builder.destroyAndCleanUpAnonymousWrappers(*renderer);


### PR DESCRIPTION
#### e48050be43a572745d972e1aff015538f469b9d4
<pre>
css/css-transitions/non-rendered-element-004.tentative.html is a unique failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=235137">https://bugs.webkit.org/show_bug.cgi?id=235137</a>
rdar://87785165

Reviewed by Antti Koivisto.

While we correctly call Styleable::cancelDeclarativeAnimations() during renderer teardown
in RenderTreeUpdater::tearDownRenderers(), only the provided element and its descendants
would be considered, but we did no work for anonymous renderers such as ::marker renderers.

We now also call Styleable::cancelDeclarativeAnimations() if we&apos;re dealing with an element
with a RenderListMarker renderer.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/non-rendered-element-004.tentative-expected.txt:
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::RenderTreeUpdater::tearDownRenderers):

Canonical link: <a href="https://commits.webkit.org/260352@main">https://commits.webkit.org/260352@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/237eea45645f7fbea19aeaa0633970a624cd47ef

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107936 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16993 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40820 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117069 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116416 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111823 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18380 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8311 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100124 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113699 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13874 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97092 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41693 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95786 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28729 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9917 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30077 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10624 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6973 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16068 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49666 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12196 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3894 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->