### PR TITLE
Implement EXT_disjoint_timer_query

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -6772,6 +6772,19 @@ WebGLEnabled:
     WebCore:
       default: false
 
+WebGLTimerQueriesEnabled:
+  type: bool
+  status: developer
+  humanReadableName: "WebGL Timer Queries"
+  humanReadableDescription: "Enable WebGL extensions that provide GPU timer queries"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 WebGLUsingMetal:
   type: bool
   status: testable

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1872,6 +1872,7 @@ if (ENABLE_WEBGL)
         html/canvas/EXTBlendMinMax.cpp
         html/canvas/EXTColorBufferFloat.cpp
         html/canvas/EXTColorBufferHalfFloat.cpp
+        html/canvas/EXTDisjointTimerQuery.cpp
         html/canvas/EXTFloatBlend.cpp
         html/canvas/EXTFragDepth.cpp
         html/canvas/EXTShaderTextureLOD.cpp
@@ -1926,6 +1927,7 @@ if (ENABLE_WEBGL)
         html/canvas/WebGLSharedObject.cpp
         html/canvas/WebGLSync.cpp
         html/canvas/WebGLTexture.cpp
+        html/canvas/WebGLTimerQueryEXT.cpp
         html/canvas/WebGLTransformFeedback.cpp
         html/canvas/WebGLUniformLocation.cpp
         html/canvas/WebGLVertexArrayObject.cpp
@@ -1939,6 +1941,7 @@ list(APPEND WebCore_IDL_FILES
     html/canvas/EXTBlendMinMax.idl
     html/canvas/EXTColorBufferFloat.idl
     html/canvas/EXTColorBufferHalfFloat.idl
+    html/canvas/EXTDisjointTimerQuery.idl
     html/canvas/EXTFloatBlend.idl
     html/canvas/EXTFragDepth.idl
     html/canvas/EXTShaderTextureLOD.idl
@@ -1991,6 +1994,7 @@ list(APPEND WebCore_IDL_FILES
     html/canvas/WebGLShaderPrecisionFormat.idl
     html/canvas/WebGLSync.idl
     html/canvas/WebGLTexture.idl
+    html/canvas/WebGLTimerQueryEXT.idl
     html/canvas/WebGLTransformFeedback.idl
     html/canvas/WebGLUniformLocation.idl
     html/canvas/WebGLVertexArrayObject.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1361,6 +1361,7 @@ $(PROJECT_DIR)/html/canvas/CanvasUserInterface.idl
 $(PROJECT_DIR)/html/canvas/EXTBlendMinMax.idl
 $(PROJECT_DIR)/html/canvas/EXTColorBufferFloat.idl
 $(PROJECT_DIR)/html/canvas/EXTColorBufferHalfFloat.idl
+$(PROJECT_DIR)/html/canvas/EXTDisjointTimerQuery.idl
 $(PROJECT_DIR)/html/canvas/EXTFloatBlend.idl
 $(PROJECT_DIR)/html/canvas/EXTFragDepth.idl
 $(PROJECT_DIR)/html/canvas/EXTShaderTextureLOD.idl
@@ -1420,6 +1421,7 @@ $(PROJECT_DIR)/html/canvas/WebGLShader.idl
 $(PROJECT_DIR)/html/canvas/WebGLShaderPrecisionFormat.idl
 $(PROJECT_DIR)/html/canvas/WebGLSync.idl
 $(PROJECT_DIR)/html/canvas/WebGLTexture.idl
+$(PROJECT_DIR)/html/canvas/WebGLTimerQueryEXT.idl
 $(PROJECT_DIR)/html/canvas/WebGLTransformFeedback.idl
 $(PROJECT_DIR)/html/canvas/WebGLUniformLocation.idl
 $(PROJECT_DIR)/html/canvas/WebGLVertexArrayObject.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -819,6 +819,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSEXTColorBufferFloat.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSEXTColorBufferFloat.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSEXTColorBufferHalfFloat.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSEXTColorBufferHalfFloat.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSEXTDisjointTimerQuery.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSEXTDisjointTimerQuery.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSEXTFloatBlend.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSEXTFloatBlend.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSEXTFragDepth.cpp
@@ -2903,6 +2905,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebGLSync.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebGLSync.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebGLTexture.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebGLTexture.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebGLTimerQueryEXT.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebGLTimerQueryEXT.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebGLTransformFeedback.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebGLTransformFeedback.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebGLUniformLocation.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1201,6 +1201,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/html/canvas/EXTBlendMinMax.idl \
     $(WebCore)/html/canvas/EXTColorBufferFloat.idl \
     $(WebCore)/html/canvas/EXTColorBufferHalfFloat.idl \
+    $(WebCore)/html/canvas/EXTDisjointTimerQuery.idl \
     $(WebCore)/html/canvas/EXTFloatBlend.idl \
     $(WebCore)/html/canvas/EXTFragDepth.idl \
     $(WebCore)/html/canvas/EXTShaderTextureLOD.idl \
@@ -1260,6 +1261,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/html/canvas/WebGLShaderPrecisionFormat.idl \
     $(WebCore)/html/canvas/WebGLSync.idl \
     $(WebCore)/html/canvas/WebGLTexture.idl \
+    $(WebCore)/html/canvas/WebGLTimerQueryEXT.idl \
     $(WebCore)/html/canvas/WebGLTransformFeedback.idl \
     $(WebCore)/html/canvas/WebGLUniformLocation.idl \
     $(WebCore)/html/canvas/WebGLVertexArrayObject.idl \

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1423,6 +1423,7 @@ html/canvas/CanvasStyle.cpp
 html/canvas/EXTBlendMinMax.cpp
 html/canvas/EXTColorBufferFloat.cpp
 html/canvas/EXTColorBufferHalfFloat.cpp
+html/canvas/EXTDisjointTimerQuery.cpp
 html/canvas/EXTFloatBlend.cpp
 html/canvas/EXTFragDepth.cpp
 html/canvas/EXTShaderTextureLOD.cpp
@@ -1486,6 +1487,7 @@ html/canvas/WebGLSharedObject.cpp
 html/canvas/WebGLStateTracker.cpp
 html/canvas/WebGLSync.cpp
 html/canvas/WebGLTexture.cpp
+html/canvas/WebGLTimerQueryEXT.cpp
 html/canvas/WebGLTransformFeedback.cpp
 html/canvas/WebGLUniformLocation.cpp
 html/canvas/WebGLVertexArrayObject.cpp
@@ -3279,6 +3281,7 @@ JSDynamicsCompressorOptions.cpp
 JSEXTBlendMinMax.cpp
 JSEXTColorBufferFloat.cpp
 JSEXTColorBufferHalfFloat.cpp
+JSEXTDisjointTimerQuery.cpp
 JSEXTFloatBlend.cpp
 JSEXTFragDepth.cpp
 JSEXTShaderTextureLOD.cpp
@@ -4250,6 +4253,7 @@ JSWebGLShader.cpp
 JSWebGLShaderPrecisionFormat.cpp
 JSWebGLSync.cpp
 JSWebGLTexture.cpp
+JSWebGLTimerQueryEXT.cpp
 JSWebGLTransformFeedback.cpp
 JSWebGLUniformLocation.cpp
 JSWebGLVertexArrayObject.cpp

--- a/Source/WebCore/bindings/js/JSDOMConvertWebGL.cpp
+++ b/Source/WebCore/bindings/js/JSDOMConvertWebGL.cpp
@@ -33,6 +33,7 @@
 #include "JSEXTBlendMinMax.h"
 #include "JSEXTColorBufferFloat.h"
 #include "JSEXTColorBufferHalfFloat.h"
+#include "JSEXTDisjointTimerQuery.h"
 #include "JSEXTFloatBlend.h"
 #include "JSEXTFragDepth.h"
 #include "JSEXTShaderTextureLOD.h"
@@ -74,6 +75,7 @@
 #include "JSWebGLRenderbuffer.h"
 #include "JSWebGLSampler.h"
 #include "JSWebGLTexture.h"
+#include "JSWebGLTimerQueryEXT.h"
 #include "JSWebGLTransformFeedback.h"
 #include "JSWebGLVertexArrayObject.h"
 #include "JSWebGLVertexArrayObjectOES.h"
@@ -95,6 +97,8 @@ JSValue convertToJSValue(JSGlobalObject& lexicalGlobalObject, JSDOMGlobalObject&
         }, [] (unsigned value) -> JSValue {
             return jsNumber(value);
         }, [] (long long value) -> JSValue {
+            return jsNumber(value);
+        }, [] (unsigned long long value) -> JSValue {
             return jsNumber(value);
         }, [] (float value) -> JSValue {
             return jsNumber(purifyNaN(value));
@@ -145,6 +149,9 @@ JSValue convertToJSValue(JSGlobalObject& lexicalGlobalObject, JSDOMGlobalObject&
         [&] (const RefPtr<WebGLTexture>& texture) {
             return toJS(&lexicalGlobalObject, &globalObject, texture.get());
         },
+        [&] (const RefPtr<WebGLTimerQueryEXT>& query) {
+            return toJS(&lexicalGlobalObject, &globalObject, query.get());
+        },
         [&] (const RefPtr<WebGLVertexArrayObjectOES>& array) {
             return toJS(&lexicalGlobalObject, &globalObject, array.get());
         },
@@ -171,6 +178,7 @@ JSValue convertToJSValue(JSGlobalObject& lexicalGlobalObject, JSDOMGlobalObject&
         TO_JS(EXTBlendMinMax)
         TO_JS(EXTColorBufferFloat)
         TO_JS(EXTColorBufferHalfFloat)
+        TO_JS(EXTDisjointTimerQuery)
         TO_JS(EXTFloatBlend)
         TO_JS(EXTFragDepth)
         TO_JS(EXTShaderTextureLOD)

--- a/Source/WebCore/html/canvas/EXTDisjointTimerQuery.cpp
+++ b/Source/WebCore/html/canvas/EXTDisjointTimerQuery.cpp
@@ -1,0 +1,264 @@
+/*
+ * Copyright 2023 The Chromium Authors. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if ENABLE(WEBGL)
+#include "EXTDisjointTimerQuery.h"
+
+#include "EventLoop.h"
+#include "ScriptExecutionContext.h"
+#include "WebGLRenderingContext.h"
+
+#include <wtf/IsoMallocInlines.h>
+#include <wtf/Lock.h>
+#include <wtf/Locker.h>
+
+namespace WebCore {
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(EXTDisjointTimerQuery);
+
+EXTDisjointTimerQuery::EXTDisjointTimerQuery(WebGLRenderingContextBase& context)
+    : WebGLExtension(context)
+{
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_disjoint_timer_query"_s);
+}
+
+EXTDisjointTimerQuery::~EXTDisjointTimerQuery() = default;
+
+WebGLExtension::ExtensionName EXTDisjointTimerQuery::getName() const
+{
+    return EXTDisjointTimerQueryName;
+}
+
+bool EXTDisjointTimerQuery::supported(GraphicsContextGL& context)
+{
+    return context.supportsExtension("GL_EXT_disjoint_timer_query"_s);
+}
+
+RefPtr<WebGLTimerQueryEXT> EXTDisjointTimerQuery::createQueryEXT()
+{
+    auto context = WebGLExtensionScopedContext(this);
+    if (context.isLost())
+        return nullptr;
+
+    auto query = WebGLTimerQueryEXT::create(*context);
+    context->addContextObject(query.get());
+    return query;
+}
+
+void EXTDisjointTimerQuery::deleteQueryEXT(WebGLTimerQueryEXT* query)
+{
+    auto context = WebGLExtensionScopedContext(this);
+    if (context.isLost())
+        return;
+
+    Locker locker { context->objectGraphLock() };
+
+    if (!query)
+        return;
+
+    if (!query->validate(context->contextGroup(), *context)) {
+        context->synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, "delete", "object does not belong to this context");
+        return;
+    }
+
+    if (query->isDeleted())
+        return;
+
+    if (query == context.downcast<WebGLRenderingContext>()->m_activeQuery) {
+        context.downcast<WebGLRenderingContext>()->m_activeQuery = nullptr;
+        ASSERT(query->target() == GraphicsContextGL::TIME_ELAPSED_EXT);
+        context->graphicsContextGL()->endQueryEXT(GraphicsContextGL::TIME_ELAPSED_EXT);
+    }
+
+    query->deleteObject(locker, context->graphicsContextGL());
+}
+
+GCGLboolean EXTDisjointTimerQuery::isQueryEXT(WebGLTimerQueryEXT* query)
+{
+    auto context = WebGLExtensionScopedContext(this);
+    if (context.isLost())
+        return false;
+
+    if (!query || !query->validate(context->contextGroup(), *context))
+        return false;
+
+    if (query->isDeleted())
+        return false;
+
+    return context->graphicsContextGL()->isQueryEXT(query->object());
+}
+
+void EXTDisjointTimerQuery::beginQueryEXT(GCGLenum target, WebGLTimerQueryEXT& query)
+{
+    auto context = WebGLExtensionScopedContext(this);
+    if (context.isLost())
+        return;
+
+    Locker locker { context->objectGraphLock() };
+
+    if (!context->validateWebGLObject("beginQueryEXT", &query))
+        return;
+
+    // The WebGL extension requires ending time elapsed queries when they are deleted.
+    // Ending non-active queries is invalid so m_activeQuery is used to track them and
+    // to defer query results until control is returned to the user agent's main loop.
+
+    if (target != GraphicsContextGL::TIME_ELAPSED_EXT) {
+        context->synthesizeGLError(GraphicsContextGL::INVALID_ENUM, "beginQueryEXT", "invalid target");
+        return;
+    }
+
+    if (query.target() && query.target() != target) {
+        context->synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, "beginQueryEXT", "query type does not match target");
+        return;
+    }
+
+    if (context.downcast<WebGLRenderingContext>()->m_activeQuery) {
+        context->synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, "beginQueryEXT", "query object of target is already active");
+        return;
+    }
+
+    query.setTarget(target);
+    context.downcast<WebGLRenderingContext>()->m_activeQuery = &query;
+
+    context->graphicsContextGL()->beginQueryEXT(target, query.object());
+}
+
+void EXTDisjointTimerQuery::endQueryEXT(GCGLenum target)
+{
+    auto context = WebGLExtensionScopedContext(this);
+    if (context.isLost() || !context->scriptExecutionContext())
+        return;
+
+    Locker locker { context->objectGraphLock() };
+
+    if (target != GraphicsContextGL::TIME_ELAPSED_EXT) {
+        context->synthesizeGLError(GraphicsContextGL::INVALID_ENUM, "endQueryEXT", "invalid target");
+        return;
+    }
+
+    if (!context.downcast<WebGLRenderingContext>()->m_activeQuery) {
+        context->synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, "endQueryEXT", "query object of target is not active");
+        return;
+    }
+
+    context->graphicsContextGL()->endQueryEXT(target);
+
+    // A query's result must not be made available until control has returned to the user agent's main loop.
+    context->scriptExecutionContext()->eventLoop().queueMicrotask([query = WTFMove(context.downcast<WebGLRenderingContext>()->m_activeQuery)] {
+        query->makeResultAvailable();
+    });
+}
+
+void EXTDisjointTimerQuery::queryCounterEXT(WebGLTimerQueryEXT& query, GCGLenum target)
+{
+    auto context = WebGLExtensionScopedContext(this);
+    if (context.isLost() || !context->scriptExecutionContext())
+        return;
+
+    if (!context->validateWebGLObject("queryCounterEXT", &query))
+        return;
+
+    if (target != GraphicsContextGL::TIMESTAMP_EXT) {
+        context->synthesizeGLError(GraphicsContextGL::INVALID_ENUM, "queryCounterEXT", "invalid target");
+        return;
+    }
+
+    if (query.target() && query.target() != target) {
+        context->synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, "queryCounterEXT", "query type does not match target");
+        return;
+    }
+
+    query.setTarget(target);
+
+    context->graphicsContextGL()->queryCounterEXT(query.object(), target);
+
+    // A query's result must not be made available until control has returned to the user agent's main loop.
+    context->scriptExecutionContext()->eventLoop().queueMicrotask([&] {
+        query.makeResultAvailable();
+    });
+}
+
+WebGLAny EXTDisjointTimerQuery::getQueryEXT(GCGLenum target, GCGLenum pname)
+{
+    auto context = WebGLExtensionScopedContext(this);
+    if (context.isLost())
+        return nullptr;
+
+    if (target != GraphicsContextGL::TIME_ELAPSED_EXT && target != GraphicsContextGL::TIMESTAMP_EXT) {
+        context->synthesizeGLError(GraphicsContextGL::INVALID_ENUM, "getQueryEXT", "invalid target");
+        return nullptr;
+    }
+
+    switch (pname) {
+    case GraphicsContextGL::CURRENT_QUERY_EXT:
+        if (target == GraphicsContextGL::TIME_ELAPSED_EXT)
+            return context.downcast<WebGLRenderingContext>()->m_activeQuery;
+        return nullptr;
+    case GraphicsContextGL::QUERY_COUNTER_BITS_EXT:
+        return context->graphicsContextGL()->getQueryiEXT(target, pname);
+    }
+    context->synthesizeGLError(GraphicsContextGL::INVALID_ENUM, "getQueryEXT", "invalid parameter name");
+    return nullptr;
+}
+
+WebGLAny EXTDisjointTimerQuery::getQueryObjectEXT(WebGLTimerQueryEXT& query, GCGLenum pname)
+{
+    auto context = WebGLExtensionScopedContext(this);
+    if (context.isLost())
+        return nullptr;
+
+    if (!context->validateWebGLObject("getQueryObjectEXT", &query))
+        return nullptr;
+
+    if (!query.target()) {
+        context->synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, "getQueryObjectEXT", "query has not been used");
+        return nullptr;
+    }
+
+    if (&query == context.downcast<WebGLRenderingContext>()->m_activeQuery) {
+        context->synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, "getQueryObjectEXT", "query is currently active");
+        return nullptr;
+    }
+
+    switch (pname) {
+    case GraphicsContextGL::QUERY_RESULT_EXT:
+        if (!query.isResultAvailable())
+            return 0;
+        return context->graphicsContextGL()->getQueryObjectui64EXT(query.object(), pname);
+    case GraphicsContextGL::QUERY_RESULT_AVAILABLE_EXT:
+        if (!query.isResultAvailable())
+            return false;
+        return static_cast<bool>(context->graphicsContextGL()->getQueryObjectiEXT(query.object(), pname));
+    }
+    context->synthesizeGLError(GraphicsContextGL::INVALID_ENUM, "getQueryObjectEXT", "invalid parameter name");
+    return nullptr;
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WEBGL)

--- a/Source/WebCore/html/canvas/EXTDisjointTimerQuery.h
+++ b/Source/WebCore/html/canvas/EXTDisjointTimerQuery.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 The Chromium Authors. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "WebGLExtension.h"
+
+namespace WebCore {
+
+class EXTDisjointTimerQuery final : public WebGLExtension {
+    WTF_MAKE_ISO_ALLOCATED(EXTDisjointTimerQuery);
+public:
+    explicit EXTDisjointTimerQuery(WebGLRenderingContextBase&);
+    virtual ~EXTDisjointTimerQuery();
+
+    ExtensionName getName() const override;
+
+    static bool supported(GraphicsContextGL&);
+
+    RefPtr<WebGLTimerQueryEXT> createQueryEXT();
+    void deleteQueryEXT(WebGLTimerQueryEXT*);
+    GCGLboolean isQueryEXT(WebGLTimerQueryEXT*);
+    void beginQueryEXT(GCGLenum target, WebGLTimerQueryEXT&);
+    void endQueryEXT(GCGLenum target);
+    void queryCounterEXT(WebGLTimerQueryEXT&, GCGLenum target);
+    WebGLAny getQueryEXT(GCGLenum target, GCGLenum pname);
+    WebGLAny getQueryObjectEXT(WebGLTimerQueryEXT&, GCGLenum pname);
+};
+
+} // namespace WebCore

--- a/Source/WebCore/html/canvas/EXTDisjointTimerQuery.idl
+++ b/Source/WebCore/html/canvas/EXTDisjointTimerQuery.idl
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 The Chromium Authors. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    LegacyNoInterfaceObject,
+    Conditional=WEBGL,
+    GenerateIsReachable=ImplWebGLRenderingContext
+] interface EXTDisjointTimerQuery {
+  const unsigned long QUERY_COUNTER_BITS_EXT      = 0x8864;
+  const unsigned long CURRENT_QUERY_EXT           = 0x8865;
+  const unsigned long QUERY_RESULT_EXT            = 0x8866;
+  const unsigned long QUERY_RESULT_AVAILABLE_EXT  = 0x8867;
+  const unsigned long TIME_ELAPSED_EXT            = 0x88BF;
+  const unsigned long TIMESTAMP_EXT               = 0x8E28;
+  const unsigned long GPU_DISJOINT_EXT            = 0x8FBB;
+
+  WebGLTimerQueryEXT? createQueryEXT();
+  undefined deleteQueryEXT(WebGLTimerQueryEXT? query);
+  boolean isQueryEXT(WebGLTimerQueryEXT? query);
+  undefined beginQueryEXT(unsigned long target, WebGLTimerQueryEXT query);
+  undefined endQueryEXT(unsigned long target);
+  undefined queryCounterEXT(WebGLTimerQueryEXT query, unsigned long target);
+  [OverrideIDLType=IDLWebGLAny] any getQueryEXT(unsigned long target, unsigned long pname);
+  [OverrideIDLType=IDLWebGLAny] any getQueryObjectEXT(WebGLTimerQueryEXT query, unsigned long pname);
+};

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.h
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.h
@@ -288,7 +288,7 @@ private:
     RefPtr<ArrayBufferView> arrayBufferViewSliceFactory(const char* const functionName, const ArrayBufferView& data, unsigned startByte, unsigned bytelength);
     RefPtr<ArrayBufferView> sliceArrayBufferView(const char* const functionName, const ArrayBufferView& data, GCGLuint srcOffset, GCGLuint length);
 
-    long long getInt64Parameter(GCGLenum);
+    long long getInt64Parameter(GCGLenum) final;
     Vector<bool> getIndexedBooleanArrayParameter(GCGLenum pname, GCGLuint index);
 
     void initializeVertexArrayObjects() final;

--- a/Source/WebCore/html/canvas/WebGLAny.h
+++ b/Source/WebCore/html/canvas/WebGLAny.h
@@ -28,6 +28,7 @@
 #if ENABLE(WEBGL)
 
 #include <JavaScriptCore/Forward.h>
+#include <JavaScriptCore/TypedArrayInlines.h>
 
 namespace JSC {
 class CallFrame;
@@ -43,6 +44,7 @@ class WebGLProgram;
 class WebGLRenderbuffer;
 class WebGLSampler;
 class WebGLTexture;
+class WebGLTimerQueryEXT;
 class WebGLTransformFeedback;
 class WebGLVertexArrayObject;
 class WebGLVertexArrayObjectOES;
@@ -53,6 +55,7 @@ using WebGLAny = std::variant<
     int,
     unsigned,
     long long,
+    unsigned long long,
     float,
     String,
     Vector<bool>,
@@ -68,6 +71,7 @@ using WebGLAny = std::variant<
     RefPtr<WebGLRenderbuffer>,
     RefPtr<WebGLSampler>,
     RefPtr<WebGLTexture>,
+    RefPtr<WebGLTimerQueryEXT>,
     RefPtr<WebGLTransformFeedback>,
     RefPtr<WebGLVertexArrayObject>,
     RefPtr<WebGLVertexArrayObjectOES>

--- a/Source/WebCore/html/canvas/WebGLExtension.h
+++ b/Source/WebCore/html/canvas/WebGLExtension.h
@@ -61,6 +61,7 @@ public:
         EXTBlendMinMaxName,
         EXTColorBufferFloatName,
         EXTColorBufferHalfFloatName,
+        EXTDisjointTimerQueryName,
         EXTFloatBlendName,
         EXTFragDepthName,
         EXTShaderTextureLODName,

--- a/Source/WebCore/html/canvas/WebGLRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContext.cpp
@@ -32,6 +32,7 @@
 #include "CachedImage.h"
 #include "EXTBlendMinMax.h"
 #include "EXTColorBufferHalfFloat.h"
+#include "EXTDisjointTimerQuery.h"
 #include "EXTFloatBlend.h"
 #include "EXTFragDepth.h"
 #include "EXTShaderTextureLOD.h"
@@ -121,6 +122,11 @@ WebGLRenderingContext::WebGLRenderingContext(CanvasBase& canvas, Ref<GraphicsCon
         return;
 }
 
+WebGLRenderingContext::~WebGLRenderingContext()
+{
+    m_activeQuery = nullptr;
+}
+
 void WebGLRenderingContext::initializeVertexArrayObjects()
 {
     m_defaultVertexArrayObject = WebGLVertexArrayObjectOES::create(*this, WebGLVertexArrayObjectOES::Type::Default);
@@ -146,6 +152,7 @@ WebGLExtension* WebGLRenderingContext::getExtension(const String& name)
     ENABLE_IF_REQUESTED(ANGLEInstancedArrays, m_angleInstancedArrays, "ANGLE_instanced_arrays", ANGLEInstancedArrays::supported(*m_context));
     ENABLE_IF_REQUESTED(EXTBlendMinMax, m_extBlendMinMax, "EXT_blend_minmax", EXTBlendMinMax::supported(*m_context));
     ENABLE_IF_REQUESTED(EXTColorBufferHalfFloat, m_extColorBufferHalfFloat, "EXT_color_buffer_half_float", EXTColorBufferHalfFloat::supported(*m_context));
+    ENABLE_IF_REQUESTED(EXTDisjointTimerQuery, m_extDisjointTimerQuery, "EXT_disjoint_timer_query", EXTDisjointTimerQuery::supported(*m_context) && scriptExecutionContext()->settingsValues().webGLTimerQueriesEnabled);
     ENABLE_IF_REQUESTED(EXTFloatBlend, m_extFloatBlend, "EXT_float_blend", EXTFloatBlend::supported(*m_context));
     ENABLE_IF_REQUESTED(EXTFragDepth, m_extFragDepth, "EXT_frag_depth", EXTFragDepth::supported(*m_context));
     ENABLE_IF_REQUESTED(EXTShaderTextureLOD, m_extShaderTextureLOD, "EXT_shader_texture_lod", EXTShaderTextureLOD::supported(*m_context));
@@ -193,6 +200,7 @@ std::optional<Vector<String>> WebGLRenderingContext::getSupportedExtensions()
     APPEND_IF_SUPPORTED("ANGLE_instanced_arrays", ANGLEInstancedArrays::supported(*m_context))
     APPEND_IF_SUPPORTED("EXT_blend_minmax", EXTBlendMinMax::supported(*m_context))
     APPEND_IF_SUPPORTED("EXT_color_buffer_half_float", EXTColorBufferHalfFloat::supported(*m_context))
+    APPEND_IF_SUPPORTED("EXT_disjoint_timer_query", EXTDisjointTimerQuery::supported(*m_context) && scriptExecutionContext()->settingsValues().webGLTimerQueriesEnabled)
     APPEND_IF_SUPPORTED("EXT_float_blend", EXTFloatBlend::supported(*m_context))
     APPEND_IF_SUPPORTED("EXT_frag_depth", EXTFragDepth::supported(*m_context))
     APPEND_IF_SUPPORTED("EXT_shader_texture_lod", EXTShaderTextureLOD::supported(*m_context))
@@ -294,6 +302,11 @@ WebGLAny WebGLRenderingContext::getFramebufferAttachmentParameter(GCGLenum targe
     return nullptr;
 }
 
+long long WebGLRenderingContext::getInt64Parameter(GCGLenum pname)
+{
+    return m_context->getInteger64EXT(pname);
+}
+
 GCGLint WebGLRenderingContext::getMaxDrawBuffers()
 {
     if (!supportsDrawBuffers())
@@ -333,6 +346,14 @@ bool WebGLRenderingContext::validateBlendEquation(const char* functionName, GCGL
         synthesizeGLError(GraphicsContextGL::INVALID_ENUM, functionName, "invalid mode");
         return false;
     }
+}
+
+void WebGLRenderingContext::addMembersToOpaqueRoots(JSC::AbstractSlotVisitor& visitor)
+{
+    WebGLRenderingContextBase::addMembersToOpaqueRoots(visitor);
+
+    Locker locker { objectGraphLock() };
+    addWebCoreOpaqueRoot(visitor, m_activeQuery.get());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/WebGLRenderingContext.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContext.h
@@ -38,6 +38,8 @@ public:
     static std::unique_ptr<WebGLRenderingContext> create(CanvasBase&, GraphicsContextGLAttributes);
     static std::unique_ptr<WebGLRenderingContext> create(CanvasBase&, Ref<GraphicsContextGL>&&, GraphicsContextGLAttributes);
 
+    ~WebGLRenderingContext();
+
     bool isWebGL1() const final { return true; }
 
     WebGLExtension* getExtension(const String&) final;
@@ -45,10 +47,19 @@ public:
 
     WebGLAny getFramebufferAttachmentParameter(GCGLenum target, GCGLenum attachment, GCGLenum pname) final;
 
+    long long getInt64Parameter(GCGLenum) final;
+
     GCGLint getMaxDrawBuffers() final;
     GCGLint getMaxColorAttachments() final;
     void initializeVertexArrayObjects() final;
     bool validateBlendEquation(const char* functionName, GCGLenum mode) final;
+
+    void addMembersToOpaqueRoots(JSC::AbstractSlotVisitor&) final;
+
+protected:
+    friend class EXTDisjointTimerQuery;
+
+    RefPtr<WebGLTimerQueryEXT> m_activeQuery;
 
 private:
     WebGLRenderingContext(CanvasBase&, GraphicsContextGLAttributes);

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -38,6 +38,7 @@
 #include "EXTBlendMinMax.h"
 #include "EXTColorBufferFloat.h"
 #include "EXTColorBufferHalfFloat.h"
+#include "EXTDisjointTimerQuery.h"
 #include "EXTFloatBlend.h"
 #include "EXTFragDepth.h"
 #include "EXTShaderTextureLOD.h"
@@ -2439,6 +2440,15 @@ WebGLAny WebGLRenderingContextBase::getParameter(GCGLenum pname)
             return getUnsignedIntParameter(GraphicsContextGL::MAX_TEXTURE_MAX_ANISOTROPY_EXT);
         synthesizeGLError(GraphicsContextGL::INVALID_ENUM, "getParameter", "invalid parameter name, EXT_texture_filter_anisotropic not enabled");
         return nullptr;
+    case GraphicsContextGL::TIMESTAMP_EXT: // EXT_disjoint_timer_query
+    case GraphicsContextGL::GPU_DISJOINT_EXT:
+        if (m_extDisjointTimerQuery) {
+            if (pname == GraphicsContextGL::GPU_DISJOINT_EXT)
+                return getBooleanParameter(pname);
+            return getInt64Parameter(pname);
+        }
+        synthesizeGLError(GraphicsContextGL::INVALID_ENUM, "getParameter", "invalid parameter name, EXT_disjoint_timer_query not enabled");
+        return nullptr;
     case GraphicsContextGL::MAX_COLOR_ATTACHMENTS_EXT: // EXT_draw_buffers BEGIN
         if (m_webglDrawBuffers || isWebGL2())
             return getMaxColorAttachments();
@@ -2980,6 +2990,7 @@ bool WebGLRenderingContextBase::extensionIsEnabled(const String& name)
     CHECK_EXTENSION(m_extBlendMinMax, "EXT_blend_minmax");
     CHECK_EXTENSION(m_extColorBufferFloat, "EXT_color_buffer_float");
     CHECK_EXTENSION(m_extColorBufferHalfFloat, "EXT_color_buffer_half_float");
+    CHECK_EXTENSION(m_extDisjointTimerQuery, "EXT_disjoint_timer_query");
     CHECK_EXTENSION(m_extFloatBlend, "EXT_float_blend");
     CHECK_EXTENSION(m_extFragDepth, "EXT_frag_depth");
     CHECK_EXTENSION(m_extShaderTextureLOD, "EXT_shader_texture_lod");
@@ -5793,6 +5804,7 @@ void WebGLRenderingContextBase::loseExtensions(LostContextMode mode)
     LOSE_EXTENSION(m_extBlendMinMax);
     LOSE_EXTENSION(m_extColorBufferFloat);
     LOSE_EXTENSION(m_extColorBufferHalfFloat);
+    LOSE_EXTENSION(m_extDisjointTimerQuery);
     LOSE_EXTENSION(m_extFloatBlend);
     LOSE_EXTENSION(m_extFragDepth);
     LOSE_EXTENSION(m_extShaderTextureLOD);

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -44,6 +44,7 @@
 #include "WebGLSampler.h"
 #include "WebGLStateTracker.h"
 #include "WebGLTexture.h"
+#include "WebGLTimerQueryEXT.h"
 #include "WebGLTransformFeedback.h"
 #include "WebGLVertexArrayObject.h"
 #include "WebGLVertexArrayObjectOES.h"
@@ -75,6 +76,7 @@ class ANGLEInstancedArrays;
 class EXTBlendMinMax;
 class EXTColorBufferFloat;
 class EXTColorBufferHalfFloat;
+class EXTDisjointTimerQuery;
 class EXTFloatBlend;
 class EXTFragDepth;
 class EXTShaderTextureLOD;
@@ -480,6 +482,7 @@ protected:
     WebGLRenderingContextBase(CanvasBase&, WebGLContextAttributes);
     WebGLRenderingContextBase(CanvasBase&, Ref<GraphicsContextGL>&&, WebGLContextAttributes);
 
+    friend class EXTDisjointTimerQuery;
     friend class EXTTextureCompressionBPTC;
     friend class EXTTextureCompressionRGTC;
     friend class OESDrawBuffersIndexed;
@@ -729,6 +732,7 @@ protected:
     RefPtr<EXTBlendMinMax> m_extBlendMinMax;
     RefPtr<EXTColorBufferFloat> m_extColorBufferFloat;
     RefPtr<EXTColorBufferHalfFloat> m_extColorBufferHalfFloat;
+    RefPtr<EXTDisjointTimerQuery> m_extDisjointTimerQuery;
     RefPtr<EXTFloatBlend> m_extFloatBlend;
     RefPtr<EXTFragDepth> m_extFragDepth;
     RefPtr<EXTShaderTextureLOD> m_extShaderTextureLOD;
@@ -780,6 +784,7 @@ protected:
     float getFloatParameter(GCGLenum);
     int getIntParameter(GCGLenum);
     unsigned getUnsignedIntParameter(GCGLenum);
+    virtual long long getInt64Parameter(GCGLenum) = 0;
     RefPtr<Float32Array> getWebGLFloatArrayParameter(GCGLenum);
     RefPtr<Int32Array> getWebGLIntArrayParameter(GCGLenum);
 

--- a/Source/WebCore/html/canvas/WebGLTimerQueryEXT.cpp
+++ b/Source/WebCore/html/canvas/WebGLTimerQueryEXT.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 The Chromium Authors. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if ENABLE(WEBGL)
+#include "WebGLTimerQueryEXT.h"
+
+#include "WebGLRenderingContextBase.h"
+
+namespace WebCore {
+
+Ref<WebGLTimerQueryEXT> WebGLTimerQueryEXT::create(WebGLRenderingContextBase& context)
+{
+    return adoptRef(*new WebGLTimerQueryEXT(context));
+}
+
+WebGLTimerQueryEXT::~WebGLTimerQueryEXT()
+{
+    if (!context())
+        return;
+
+    runDestructor();
+}
+
+WebGLTimerQueryEXT::WebGLTimerQueryEXT(WebGLRenderingContextBase& context)
+    : WebGLContextObject(context)
+{
+    setObject(context.graphicsContextGL()->createQueryEXT());
+}
+
+void WebGLTimerQueryEXT::deleteObjectImpl(const AbstractLocker&, GraphicsContextGL* context3d, PlatformGLObject object)
+{
+    context3d->deleteQueryEXT(object);
+}
+
+}
+
+#endif // ENABLE(WEBGL)

--- a/Source/WebCore/html/canvas/WebGLTimerQueryEXT.h
+++ b/Source/WebCore/html/canvas/WebGLTimerQueryEXT.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023 The Chromium Authors. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEBGL)
+
+#include "WebGLContextObject.h"
+
+namespace WTF {
+class AbstractLocker;
+}
+
+namespace WebCore {
+
+class WebGLTimerQueryEXT final : public WebGLContextObject {
+public:
+    static Ref<WebGLTimerQueryEXT> create(WebGLRenderingContextBase&);
+    virtual ~WebGLTimerQueryEXT();
+
+    bool isResultAvailable() const { return m_isResultAvailable; }
+    void makeResultAvailable() { m_isResultAvailable = true; }
+
+    void setTarget(GCGLenum target) { m_target = target; }
+    GCGLenum target() const { return m_target; }
+
+private:
+    explicit WebGLTimerQueryEXT(WebGLRenderingContextBase&);
+    void deleteObjectImpl(const AbstractLocker&, GraphicsContextGL*, PlatformGLObject) override;
+
+    bool m_isResultAvailable { false };
+    GCGLenum m_target { 0 };
+};
+
+} // namespace WebCore
+
+#endif

--- a/Source/WebCore/html/canvas/WebGLTimerQueryEXT.idl
+++ b/Source/WebCore/html/canvas/WebGLTimerQueryEXT.idl
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 The Chromium Authors. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    LegacyNoInterfaceObject,
+    Conditional=WEBGL,
+    EnabledBySetting=WebGLEnabled,
+    GenerateIsReachable=Impl,
+    Exposed=(Window,Worker)
+] interface WebGLTimerQueryEXT {
+};

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -719,6 +719,15 @@ public:
     // EXT_color_buffer_half_float
     static constexpr GCGLenum FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE_EXT = 0x8211;
 
+    // GL_EXT_disjoint_timer_query
+    static constexpr GCGLenum QUERY_COUNTER_BITS_EXT = 0x8864;
+    static constexpr GCGLenum CURRENT_QUERY_EXT = 0x8865;
+    static constexpr GCGLenum QUERY_RESULT_EXT = 0x8866;
+    static constexpr GCGLenum QUERY_RESULT_AVAILABLE_EXT = 0x8867;
+    static constexpr GCGLenum TIME_ELAPSED_EXT = 0x88BF;
+    static constexpr GCGLenum TIMESTAMP_EXT = 0x8E28;
+    static constexpr GCGLenum GPU_DISJOINT_EXT = 0x8FBB;
+
     // EXT_blend_minmax enums
     static constexpr GCGLenum MIN_EXT = 0x8007;
     static constexpr GCGLenum MAX_EXT = 0x8008;
@@ -1467,6 +1476,18 @@ public:
 
     // GL_ARB_draw_buffers / GL_EXT_draw_buffers
     virtual void drawBuffersEXT(GCGLSpan<const GCGLenum> bufs) = 0;
+
+    // GL_EXT_disjoint_timer_query
+    virtual PlatformGLObject createQueryEXT() = 0;
+    virtual void deleteQueryEXT(PlatformGLObject query) = 0;
+    virtual GCGLboolean isQueryEXT(PlatformGLObject query) = 0;
+    virtual void beginQueryEXT(GCGLenum target, PlatformGLObject query) = 0;
+    virtual void endQueryEXT(GCGLenum target) = 0;
+    virtual void queryCounterEXT(PlatformGLObject query, GCGLenum target) = 0;
+    virtual GCGLint getQueryiEXT(GCGLenum target, GCGLenum pname) = 0;
+    virtual GCGLint getQueryObjectiEXT(PlatformGLObject query, GCGLenum pname) = 0;
+    virtual GCGLuint64 getQueryObjectui64EXT(PlatformGLObject query, GCGLenum pname) = 0;
+    virtual GCGLint64 getInteger64EXT(GCGLenum pname) = 0;
 
     // GL_OES_draw_buffers_indexed
     virtual void enableiOES(GCGLenum target, GCGLuint index) = 0;

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -2959,6 +2959,96 @@ void GraphicsContextGLANGLE::drawBuffersEXT(GCGLSpan<const GCGLenum> bufs)
     GL_DrawBuffersEXT(bufs.size(), bufs.data());
 }
 
+PlatformGLObject GraphicsContextGLANGLE::createQueryEXT()
+{
+    if (!makeContextCurrent())
+        return 0;
+
+    GLuint name = 0;
+    GL_GenQueriesEXT(1, &name);
+    return name;
+}
+
+void GraphicsContextGLANGLE::deleteQueryEXT(PlatformGLObject query)
+{
+    if (!makeContextCurrent())
+        return;
+
+    GL_DeleteQueriesEXT(1, &query);
+}
+
+GCGLboolean GraphicsContextGLANGLE::isQueryEXT(PlatformGLObject query)
+{
+    if (!makeContextCurrent())
+        return GL_FALSE;
+
+    return GL_IsQueryEXT(query);
+}
+
+void GraphicsContextGLANGLE::beginQueryEXT(GCGLenum target, PlatformGLObject query)
+{
+    if (!makeContextCurrent())
+        return;
+
+    GL_BeginQueryEXT(target, query);
+}
+
+void GraphicsContextGLANGLE::endQueryEXT(GCGLenum target)
+{
+    if (!makeContextCurrent())
+        return;
+
+    GL_EndQueryEXT(target);
+}
+
+void GraphicsContextGLANGLE::queryCounterEXT(PlatformGLObject query, GCGLenum target)
+{
+    if (!makeContextCurrent())
+        return;
+
+    GL_QueryCounterEXT(query, target);
+}
+
+GCGLint GraphicsContextGLANGLE::getQueryiEXT(GCGLenum target, GCGLenum pname)
+{
+    if (!makeContextCurrent())
+        return 0;
+
+    GLint value = 0;
+    GL_GetQueryivRobustANGLE(target, pname, 1, nullptr, &value);
+    return value;
+}
+
+GCGLint GraphicsContextGLANGLE::getQueryObjectiEXT(PlatformGLObject query, GCGLenum pname)
+{
+    if (!makeContextCurrent())
+        return 0;
+
+    GLint value = 0;
+    GL_GetQueryObjectivRobustANGLE(query, pname, 1, nullptr, &value);
+    return value;
+}
+
+GCGLuint64 GraphicsContextGLANGLE::getQueryObjectui64EXT(PlatformGLObject query, GCGLenum pname)
+{
+    if (!makeContextCurrent())
+        return 0;
+
+    GLuint64 value = 0;
+    GL_GetQueryObjectui64vRobustANGLE(query, pname, 1, nullptr, &value);
+    return value;
+}
+
+GCGLint64 GraphicsContextGLANGLE::getInteger64EXT(GCGLenum pname)
+{
+    if (!makeContextCurrent())
+        return 0;
+
+    GCGLint64 value = 0;
+    GL_GetInteger64vRobustANGLE(pname, 1, nullptr, &value);
+    return value;
+}
+
 void GraphicsContextGLANGLE::enableiOES(GCGLenum target, GCGLuint index)
 {
     if (!makeContextCurrent())

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
@@ -313,6 +313,16 @@ public:
     bool isExtensionEnabled(const String&) override;
     void drawBuffersEXT(GCGLSpan<const GCGLenum>) override;
     String getTranslatedShaderSourceANGLE(PlatformGLObject) override;
+    PlatformGLObject createQueryEXT() final;
+    void deleteQueryEXT(PlatformGLObject query) final;
+    GCGLboolean isQueryEXT(PlatformGLObject query) final;
+    void beginQueryEXT(GCGLenum target, PlatformGLObject query) final;
+    void endQueryEXT(GCGLenum target) final;
+    void queryCounterEXT(PlatformGLObject query, GCGLenum target) final;
+    GCGLint getQueryiEXT(GCGLenum target, GCGLenum pname) final;
+    GCGLint getQueryObjectiEXT(PlatformGLObject query, GCGLenum pname) final;
+    GCGLuint64 getQueryObjectui64EXT(PlatformGLObject query, GCGLenum pname) final;
+    GCGLint64 getInteger64EXT(GCGLenum pname) final;
     void enableiOES(GCGLenum target, GCGLuint index) final;
     void disableiOES(GCGLenum target, GCGLuint index) final;
     void blendEquationiOES(GCGLuint buf, GCGLenum mode) final;

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
@@ -299,6 +299,16 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {
     void GetActiveUniformBlockiv(uint32_t program, uint32_t uniformBlockIndex, uint32_t pname, uint64_t paramsSize) -> (IPC::ArrayReference<int32_t> params) Synchronous
     void GetTranslatedShaderSourceANGLE(uint32_t arg0) -> (String returnValue) Synchronous
     void DrawBuffersEXT(IPC::ArrayReference<uint32_t> bufs)
+    void CreateQueryEXT() -> (uint32_t returnValue) Synchronous
+    void DeleteQueryEXT(uint32_t query)
+    void IsQueryEXT(uint32_t query) -> (bool returnValue) Synchronous
+    void BeginQueryEXT(uint32_t target, uint32_t query)
+    void EndQueryEXT(uint32_t target)
+    void QueryCounterEXT(uint32_t query, uint32_t target)
+    void GetQueryiEXT(uint32_t target, uint32_t pname) -> (int32_t returnValue) Synchronous
+    void GetQueryObjectiEXT(uint32_t query, uint32_t pname) -> (int32_t returnValue) Synchronous
+    void GetQueryObjectui64EXT(uint32_t query, uint32_t pname) -> (uint64_t returnValue) Synchronous
+    void GetInteger64EXT(uint32_t pname) -> (int64_t returnValue) Synchronous
     void EnableiOES(uint32_t target, uint32_t index)
     void DisableiOES(uint32_t target, uint32_t index)
     void BlendEquationiOES(uint32_t buf, uint32_t mode)

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
@@ -1340,6 +1340,68 @@
         assertIsCurrent(workQueue());
         m_context->drawBuffersEXT(makeGCGLSpan(reinterpret_cast<const GCGLenum*>(bufs.data()), bufs.size()));
     }
+    void createQueryEXT(CompletionHandler<void(uint32_t)>&& completionHandler)
+    {
+        PlatformGLObject returnValue = { };
+        assertIsCurrent(workQueue());
+        returnValue = m_context->createQueryEXT();
+        completionHandler(returnValue);
+    }
+    void deleteQueryEXT(uint32_t query)
+    {
+        assertIsCurrent(workQueue());
+        m_context->deleteQueryEXT(query);
+    }
+    void isQueryEXT(uint32_t query, CompletionHandler<void(bool)>&& completionHandler)
+    {
+        GCGLboolean returnValue = { };
+        assertIsCurrent(workQueue());
+        returnValue = m_context->isQueryEXT(query);
+        completionHandler(static_cast<bool>(returnValue));
+    }
+    void beginQueryEXT(uint32_t target, uint32_t query)
+    {
+        assertIsCurrent(workQueue());
+        m_context->beginQueryEXT(target, query);
+    }
+    void endQueryEXT(uint32_t target)
+    {
+        assertIsCurrent(workQueue());
+        m_context->endQueryEXT(target);
+    }
+    void queryCounterEXT(uint32_t query, uint32_t target)
+    {
+        assertIsCurrent(workQueue());
+        m_context->queryCounterEXT(query, target);
+    }
+    void getQueryiEXT(uint32_t target, uint32_t pname, CompletionHandler<void(int32_t)>&& completionHandler)
+    {
+        GCGLint returnValue = { };
+        assertIsCurrent(workQueue());
+        returnValue = m_context->getQueryiEXT(target, pname);
+        completionHandler(returnValue);
+    }
+    void getQueryObjectiEXT(uint32_t query, uint32_t pname, CompletionHandler<void(int32_t)>&& completionHandler)
+    {
+        GCGLint returnValue = { };
+        assertIsCurrent(workQueue());
+        returnValue = m_context->getQueryObjectiEXT(query, pname);
+        completionHandler(returnValue);
+    }
+    void getQueryObjectui64EXT(uint32_t query, uint32_t pname, CompletionHandler<void(uint64_t)>&& completionHandler)
+    {
+        GCGLuint64 returnValue = { };
+        assertIsCurrent(workQueue());
+        returnValue = m_context->getQueryObjectui64EXT(query, pname);
+        completionHandler(static_cast<uint64_t>(returnValue));
+    }
+    void getInteger64EXT(uint32_t pname, CompletionHandler<void(int64_t)>&& completionHandler)
+    {
+        GCGLint64 returnValue = { };
+        assertIsCurrent(workQueue());
+        returnValue = m_context->getInteger64EXT(pname);
+        completionHandler(static_cast<int64_t>(returnValue));
+    }
     void enableiOES(uint32_t target, uint32_t index)
     {
         assertIsCurrent(workQueue());

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
@@ -338,6 +338,16 @@ public:
     void getActiveUniformBlockiv(GCGLuint program, GCGLuint uniformBlockIndex, GCGLenum pname, GCGLSpan<GCGLint> params) final;
     String getTranslatedShaderSourceANGLE(PlatformGLObject arg0) final;
     void drawBuffersEXT(GCGLSpan<const GCGLenum> bufs) final;
+    PlatformGLObject createQueryEXT() final;
+    void deleteQueryEXT(PlatformGLObject query) final;
+    GCGLboolean isQueryEXT(PlatformGLObject query) final;
+    void beginQueryEXT(GCGLenum target, PlatformGLObject query) final;
+    void endQueryEXT(GCGLenum target) final;
+    void queryCounterEXT(PlatformGLObject query, GCGLenum target) final;
+    GCGLint getQueryiEXT(GCGLenum target, GCGLenum pname) final;
+    GCGLint getQueryObjectiEXT(PlatformGLObject query, GCGLenum pname) final;
+    GCGLuint64 getQueryObjectui64EXT(PlatformGLObject query, GCGLenum pname) final;
+    GCGLint64 getInteger64EXT(GCGLenum pname) final;
     void enableiOES(GCGLenum target, GCGLuint index) final;
     void disableiOES(GCGLenum target, GCGLuint index) final;
     void blendEquationiOES(GCGLuint buf, GCGLenum mode) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
@@ -2762,6 +2762,128 @@ void RemoteGraphicsContextGLProxy::drawBuffersEXT(GCGLSpan<const GCGLenum> bufs)
     }
 }
 
+PlatformGLObject RemoteGraphicsContextGLProxy::createQueryEXT()
+{
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateQueryEXT());
+    if (!sendResult) {
+        markContextLost();
+        return { };
+    }
+    auto& [returnValue] = sendResult.reply();
+    return returnValue;
+}
+
+void RemoteGraphicsContextGLProxy::deleteQueryEXT(PlatformGLObject query)
+{
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteQueryEXT(query));
+    if (!sendResult) {
+        markContextLost();
+        return;
+    }
+}
+
+GCGLboolean RemoteGraphicsContextGLProxy::isQueryEXT(PlatformGLObject query)
+{
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsQueryEXT(query));
+    if (!sendResult) {
+        markContextLost();
+        return { };
+    }
+    auto& [returnValue] = sendResult.reply();
+    return static_cast<GCGLboolean>(returnValue);
+}
+
+void RemoteGraphicsContextGLProxy::beginQueryEXT(GCGLenum target, PlatformGLObject query)
+{
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::BeginQueryEXT(target, query));
+    if (!sendResult) {
+        markContextLost();
+        return;
+    }
+}
+
+void RemoteGraphicsContextGLProxy::endQueryEXT(GCGLenum target)
+{
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::EndQueryEXT(target));
+    if (!sendResult) {
+        markContextLost();
+        return;
+    }
+}
+
+void RemoteGraphicsContextGLProxy::queryCounterEXT(PlatformGLObject query, GCGLenum target)
+{
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::QueryCounterEXT(query, target));
+    if (!sendResult) {
+        markContextLost();
+        return;
+    }
+}
+
+GCGLint RemoteGraphicsContextGLProxy::getQueryiEXT(GCGLenum target, GCGLenum pname)
+{
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetQueryiEXT(target, pname));
+    if (!sendResult) {
+        markContextLost();
+        return { };
+    }
+    auto& [returnValue] = sendResult.reply();
+    return returnValue;
+}
+
+GCGLint RemoteGraphicsContextGLProxy::getQueryObjectiEXT(PlatformGLObject query, GCGLenum pname)
+{
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetQueryObjectiEXT(query, pname));
+    if (!sendResult) {
+        markContextLost();
+        return { };
+    }
+    auto& [returnValue] = sendResult.reply();
+    return returnValue;
+}
+
+GCGLuint64 RemoteGraphicsContextGLProxy::getQueryObjectui64EXT(PlatformGLObject query, GCGLenum pname)
+{
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetQueryObjectui64EXT(query, pname));
+    if (!sendResult) {
+        markContextLost();
+        return { };
+    }
+    auto& [returnValue] = sendResult.reply();
+    return static_cast<GCGLuint64>(returnValue);
+}
+
+GCGLint64 RemoteGraphicsContextGLProxy::getInteger64EXT(GCGLenum pname)
+{
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetInteger64EXT(pname));
+    if (!sendResult) {
+        markContextLost();
+        return { };
+    }
+    auto& [returnValue] = sendResult.reply();
+    return static_cast<GCGLint64>(returnValue);
+}
+
 void RemoteGraphicsContextGLProxy::enableiOES(GCGLenum target, GCGLuint index)
 {
     if (isContextLost())


### PR DESCRIPTION
#### dad993a38b597377683cd4cb437018e444819506
<pre>
Implement EXT_disjoint_timer_query
<a href="https://bugs.webkit.org/show_bug.cgi?id=129090">https://bugs.webkit.org/show_bug.cgi?id=129090</a>

Reviewed by Kimmo Kinnunen.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/JSDOMConvertWebGL.cpp:
(WebCore::convertToJSValue):
* Source/WebCore/html/canvas/EXTDisjointTimerQuery.cpp: Added.
(WebCore::EXTDisjointTimerQuery::EXTDisjointTimerQuery):
(WebCore::EXTDisjointTimerQuery::getName const):
(WebCore::EXTDisjointTimerQuery::supported):
(WebCore::EXTDisjointTimerQuery::createQueryEXT):
(WebCore::EXTDisjointTimerQuery::deleteQueryEXT):
(WebCore::EXTDisjointTimerQuery::isQueryEXT):
(WebCore::EXTDisjointTimerQuery::beginQueryEXT):
(WebCore::EXTDisjointTimerQuery::endQueryEXT):
(WebCore::EXTDisjointTimerQuery::queryCounterEXT):
(WebCore::EXTDisjointTimerQuery::getQueryEXT):
(WebCore::EXTDisjointTimerQuery::getQueryObjectEXT):
* Source/WebCore/html/canvas/EXTDisjointTimerQuery.h: Added.
* Source/WebCore/html/canvas/EXTDisjointTimerQuery.idl: Added.
* Source/WebCore/html/canvas/WebGL2RenderingContext.h:
* Source/WebCore/html/canvas/WebGLAny.h:
* Source/WebCore/html/canvas/WebGLExtension.h:
* Source/WebCore/html/canvas/WebGLRenderingContext.cpp:
(WebCore::WebGLRenderingContext::~WebGLRenderingContext):
(WebCore::WebGLRenderingContext::getExtension):
(WebCore::WebGLRenderingContext::getSupportedExtensions):
(WebCore::WebGLRenderingContext::getInt64Parameter):
(WebCore::WebGLRenderingContext::addMembersToOpaqueRoots):
* Source/WebCore/html/canvas/WebGLRenderingContext.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::getParameter):
(WebCore::WebGLRenderingContextBase::extensionIsEnabled):
(WebCore::WebGLRenderingContextBase::loseExtensions):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
* Source/WebCore/html/canvas/WebGLTimerQueryEXT.cpp: Added.
(WebCore::WebGLTimerQueryEXT::create):
(WebCore::WebGLTimerQueryEXT::~WebGLTimerQueryEXT):
(WebCore::WebGLTimerQueryEXT::WebGLTimerQueryEXT):
(WebCore::WebGLTimerQueryEXT::deleteObjectImpl):
* Source/WebCore/html/canvas/WebGLTimerQueryEXT.h: Added.
* Source/WebCore/html/canvas/WebGLTimerQueryEXT.idl: Added.
* Source/WebCore/platform/graphics/GraphicsContextGL.h:
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::createQueryEXT):
(WebCore::GraphicsContextGLANGLE::deleteQueryEXT):
(WebCore::GraphicsContextGLANGLE::isQueryEXT):
(WebCore::GraphicsContextGLANGLE::beginQueryEXT):
(WebCore::GraphicsContextGLANGLE::endQueryEXT):
(WebCore::GraphicsContextGLANGLE::queryCounterEXT):
(WebCore::GraphicsContextGLANGLE::getQueryiEXT):
(WebCore::GraphicsContextGLANGLE::getQueryObjectiEXT):
(WebCore::GraphicsContextGLANGLE::getQueryObjectui64EXT):
(WebCore::GraphicsContextGLANGLE::getInteger64EXT):
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h:
(createQueryEXT):
(deleteQueryEXT):
(isQueryEXT):
(beginQueryEXT):
(endQueryEXT):
(queryCounterEXT):
(getQueryiEXT):
(getQueryObjectiEXT):
(getQueryObjectui64EXT):
(getInteger64EXT):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp:
(WebKit::RemoteGraphicsContextGLProxy::createQueryEXT):
(WebKit::RemoteGraphicsContextGLProxy::deleteQueryEXT):
(WebKit::RemoteGraphicsContextGLProxy::isQueryEXT):
(WebKit::RemoteGraphicsContextGLProxy::beginQueryEXT):
(WebKit::RemoteGraphicsContextGLProxy::endQueryEXT):
(WebKit::RemoteGraphicsContextGLProxy::queryCounterEXT):
(WebKit::RemoteGraphicsContextGLProxy::getQueryiEXT):
(WebKit::RemoteGraphicsContextGLProxy::getQueryObjectiEXT):
(WebKit::RemoteGraphicsContextGLProxy::getQueryObjectui64EXT):
(WebKit::RemoteGraphicsContextGLProxy::getInteger64EXT):

Canonical link: <a href="https://commits.webkit.org/260367@main">https://commits.webkit.org/260367@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63a2827363044d04566d22dc1ba4cb934a40c285

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108114 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17185 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40982 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117239 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116560 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112003 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18540 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8480 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100318 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113882 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97207 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41912 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95890 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28845 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/97336 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10066 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30193 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/96700 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/8163 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10787 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7094 "Passed tests") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/30900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16214 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49784 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/105720 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7176 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12368 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26175 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->