### PR TITLE
[css-contain-intrinsic-size] Resync css/css-sizing/contain-intrinsic-size from WPT

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-006.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-006.html
@@ -76,6 +76,7 @@ function cleanup() {
   parent.className = "";
   target.className = "";
   contents.className = "";
+  checkSize(0, 0, "Sizing after cleanup");
 }
 
 promise_test(async function() {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-010-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-010-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Last remembered size supports multiple fragments assert_equals: Using last remembered size - fragment #1 width expected 50 but got 1
-FAIL Last remembered size is updated when 2nd fragment changes size assert_equals: Using updated last remembered size - fragment #1 width expected 50 but got 1
+FAIL Last remembered size supports multiple fragments assert_equals: Using last remembered size - clientWidth expected 50 but got 1
+FAIL Last remembered size is updated when 2nd fragment changes size assert_equals: Using updated last remembered size - clientWidth expected 50 but got 1
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-010.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-010.html
@@ -60,6 +60,11 @@ function checkSizes(expectedSizes, msg) {
   }
 }
 
+function checkSize(expectedWidth, expectedHeight, msg) {
+  assert_equals(target.clientWidth, expectedWidth, msg + " - clientWidth");
+  assert_equals(target.clientHeight, expectedHeight, msg + " - clientHeight");
+}
+
 function nextRendering() {
   return new Promise(resolve => {
     requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
@@ -72,7 +77,7 @@ promise_test(async function() {
 
   await nextRendering();
   target.className = "cis-auto content-skip";
-  checkSizes([[50, 150]], "Using last remembered size");
+  checkSize(50, 150, "Using last remembered size");
 }, "Last remembered size supports multiple fragments");
 
 promise_test(async function() {
@@ -85,6 +90,6 @@ promise_test(async function() {
 
   await nextRendering();
   target.className = "cis-auto content-skip";
-  checkSizes([[50, 175]], "Using updated last remembered size");
+  checkSize(50, 175, "Using updated last remembered size");
 }, "Last remembered size is updated when 2nd fragment changes size");
 </script>


### PR DESCRIPTION
#### ca4f52f19e0a47baf6e8f7e92c8c57f8480a47a7
<pre>
[css-contain-intrinsic-size] Resync css/css-sizing/contain-intrinsic-size from WPT
<a href="https://bugs.webkit.org/show_bug.cgi?id=252314">https://bugs.webkit.org/show_bug.cgi?id=252314</a>

Reviewed by Oriol Brufau.

Resync the tests in css/css-sizing/contain-intrinsic-size to commit 023e9ff20ec7a97553.

* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-006.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-010-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-010.html:

Canonical link: <a href="https://commits.webkit.org/260366@main">https://commits.webkit.org/260366@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7b6ce159594b14b0af064a1aecd8f02879a6a2d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108117 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17188 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40985 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117242 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116563 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18543 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8483 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100321 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113885 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97209 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41915 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95892 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28847 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10069 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30195 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10790 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7097 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16217 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49786 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7174 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12371 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->