### PR TITLE
[GStreamer][MediaStream] AudioDestination buffers layout is incorrect

### DIFF
--- a/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceGStreamer.cpp
+++ b/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceGStreamer.cpp
@@ -29,25 +29,21 @@
 
 namespace WebCore {
 
-static Vector<size_t> copyBusData(AudioBus& bus, GstBuffer* buffer, bool isMuted)
+static void copyBusData(AudioBus& bus, GstBuffer* buffer, bool isMuted)
 {
-    Vector<size_t> offsets;
     GstMappedBuffer mappedBuffer(buffer, GST_MAP_WRITE);
     if (isMuted) {
         memset(mappedBuffer.data(), 0, mappedBuffer.size());
-        return offsets;
+        return;
     }
 
-    DisableMallocRestrictionsForCurrentThreadScope disableMallocRestrictions;
-    offsets.reserveInitialCapacity(sizeof(size_t) * bus.numberOfChannels());
-    size_t size = mappedBuffer.size() / bus.numberOfChannels();
+    size_t offset = 0;
     for (size_t channelIndex = 0; channelIndex < bus.numberOfChannels(); ++channelIndex) {
         const auto& channel = *bus.channel(channelIndex);
-        auto offset = channelIndex * size;
-        memcpy(mappedBuffer.data() + offset, channel.data(), sizeof(float) * channel.length());
-        offsets.uncheckedAppend(offset);
+        auto dataSize = sizeof(float) * channel.length();
+        memcpy(mappedBuffer.data() + offset, channel.data(), dataSize);
+        offset += dataSize;
     }
-    return offsets;
 }
 
 void MediaStreamAudioSource::consumeAudio(AudioBus& bus, size_t numberOfFrames)
@@ -67,8 +63,12 @@ void MediaStreamAudioSource::consumeAudio(AudioBus& bus, size_t numberOfFrames)
 
     auto caps = adoptGRef(gst_audio_info_to_caps(&info));
     auto buffer = adoptGRef(gst_buffer_new_allocate(nullptr, size, nullptr));
-    auto offsets = copyBusData(bus, buffer.get(), muted());
-    gst_buffer_add_audio_meta(buffer.get(), &info, numberOfFrames, offsets.data());
+
+    GST_BUFFER_PTS(buffer.get()) = toGstClockTime(mediaTime);
+    GST_BUFFER_FLAG_SET(buffer.get(), GST_BUFFER_FLAG_LIVE);
+
+    copyBusData(bus, buffer.get(), muted());
+    gst_buffer_add_audio_meta(buffer.get(), &info, numberOfFrames, nullptr);
     auto sample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), nullptr, nullptr));
     GStreamerAudioData audioBuffer(WTFMove(sample), info);
     GStreamerAudioStreamDescription description(&info);


### PR DESCRIPTION
#### b2fe9a2501d1b73c500755ab1c90f6c34ba1eb86
<pre>
[GStreamer][MediaStream] AudioDestination buffers layout is incorrect
<a href="https://bugs.webkit.org/show_bug.cgi?id=252319">https://bugs.webkit.org/show_bug.cgi?id=252319</a>

Reviewed by Xabier Rodriguez-Calvar.

Copy the bus data to a tightly packed GstBuffer memory, as mandated by the audio layout advertised
by the caps. Also drive-by, set the PTS on the new buffer.

* Source/WebCore/Modules/webaudio/MediaStreamAudioSourceGStreamer.cpp:
(WebCore::copyBusData):
(WebCore::MediaStreamAudioSource::consumeAudio):

Canonical link: <a href="https://commits.webkit.org/260361@main">https://commits.webkit.org/260361@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ed0b931af7d294f1b94bff328c28bb08e9dd678

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107944 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17003 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40827 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117079 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116426 "Hash 7ed0b931 for PR 10150 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111831 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18390 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8321 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100134 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113707 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13878 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97098 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41701 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95790 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28735 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/83453 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9925 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30083 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10633 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6977 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16077 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49672 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7170 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12205 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->