### PR TITLE
[GTK] Criticals from webkitOptionMenuSetEvent when opening any combo box

### DIFF
--- a/Source/WebKit/Shared/API/glib/WebKitContextMenu.cpp
+++ b/Source/WebKit/Shared/API/glib/WebKitContextMenu.cpp
@@ -27,6 +27,11 @@
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/WTFGType.h>
 
+#if PLATFORM(GTK)
+#include <WebCore/GRefPtrGtk.h>
+#include <WebCore/GUniquePtrGtk.h>
+#endif
+
 using namespace WebKit;
 using namespace WebCore;
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitOptionMenu.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitOptionMenu.cpp
@@ -24,6 +24,11 @@
 #include "WebKitOptionMenuPrivate.h"
 #include <wtf/glib/WTFGType.h>
 
+#if PLATFORM(GTK)
+#include <WebCore/GRefPtrGtk.h>
+#include <WebCore/GUniquePtrGtk.h>
+#endif
+
 using namespace WebKit;
 
 /**

--- a/Source/WebKit/UIProcess/gtk/WebContextMenuProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/WebContextMenuProxyGtk.cpp
@@ -35,6 +35,7 @@
 #include "WebKitWebViewBasePrivate.h"
 #include "WebPageProxy.h"
 #include "WebProcessProxy.h"
+#include <WebCore/GUniquePtrGtk.h>
 #include <WebCore/GtkUtilities.h>
 #include <gio/gio.h>
 #include <gtk/gtk.h>


### PR DESCRIPTION
#### 587cb602ebdded6401ebc269b51028b6f414ca42
<pre>
[GTK] Criticals from webkitOptionMenuSetEvent when opening any combo box
<a href="https://bugs.webkit.org/show_bug.cgi?id=252264">https://bugs.webkit.org/show_bug.cgi?id=252264</a>

Reviewed by Adrian Perez de Castro.

WebKitOptionMenu.cpp does not #include &lt;WebCore/GRefPtrGtk.h&gt; and
therefore the template specialization for GdkEvent is missing, so the
GRefPtr treats it as a GObject even though it is not. This is really
dangerous and we need to find a better way to prevent it from happening,
but for now, add missing #includes here and in a couple other places
where it looks like they might be needed.

* Source/WebKit/Shared/API/glib/WebKitContextMenu.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitOptionMenu.cpp:
* Source/WebKit/UIProcess/gtk/WebContextMenuProxyGtk.cpp:

Canonical link: <a href="https://commits.webkit.org/260374@main">https://commits.webkit.org/260374@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65d2b94d2728ce8ca72f3a2d356f4724a62947a0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107952 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17013 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40838 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117087 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116432 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18399 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8330 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100144 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113715 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13882 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97106 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41707 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95794 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28743 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/83458 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9932 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30091 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10639 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6983 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16084 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49681 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7179 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12213 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->