### PR TITLE
[WGSL] Cache parameterized types

### DIFF
--- a/Source/WebGPU/WGSL/TypeStore.cpp
+++ b/Source/WebGPU/WGSL/TypeStore.cpp
@@ -34,6 +34,58 @@ namespace WGSL {
 
 using namespace Types;
 
+// These keys are used so that, for a given type T, we can have keys for all of
+// the following types:
+// vecN<T>, matCxR<T>, array<T, N?>
+//
+// To make sure they never collide, we encode them into a pair<Type*, uint64_t>
+// where the first element of the pair is always T and the second word is used
+// to disambiguate between all the possible types. That's possible because we
+// we only have 3 possibilities for Vector (2, 3, 4), 9 possibilities for Matrix
+// ((2, 3, 4) * (2, 3, 4)) and 2**32 for Array. To avoid collisions, the
+// data is encoded as follows:
+//
+// Vector: size in the least significant byte.
+// Matrix: rows in byte 1 and columns in byte 2
+// Array: 0 for dynamic array or 32-bit size in the upper 32-bits
+struct VectorKey {
+    Type* elementType;
+    uint8_t size;
+
+    uint64_t extra() const { return size; }
+};
+
+struct MatrixKey {
+    Type* elementType;
+    uint8_t columns;
+    uint8_t rows;
+
+    uint64_t extra() const { return (static_cast<uint64_t>(columns) << 8) | rows; }
+};
+
+struct ArrayKey {
+    Type* elementType;
+    std::optional<unsigned> size;
+
+    uint64_t extra() const { return size.has_value() ? static_cast<uint64_t>(*size) << 32 : 0; }
+};
+
+template<typename Key>
+Type* TypeStore::TypeCache::find(const Key& key) const
+{
+    auto it = m_storage.find(std::pair(key.elementType, key.extra()));
+    if (it != m_storage.end())
+        return it->value;
+    return nullptr;
+}
+
+template<typename Key>
+void TypeStore::TypeCache::insert(const Key& key, Type* type)
+{
+    auto it = m_storage.add(std::pair(key.elementType, key.extra()), type);
+    ASSERT_UNUSED(it, it.isNewEntry);
+}
+
 TypeStore::TypeStore()
     : m_typeConstrutors(AST::ParameterizedTypeName::NumberOfBaseTypes)
 {
@@ -67,27 +119,41 @@ Type* TypeStore::structType(const AST::Identifier& name)
 
 Type* TypeStore::constructType(AST::ParameterizedTypeName::Base base, Type* elementType)
 {
-    // FIXME: these should be cached
     auto& typeConstructor = m_typeConstrutors[WTF::enumToUnderlyingType(base)];
     return typeConstructor.construct(elementType);
 }
 
 Type* TypeStore::arrayType(Type* elementType, std::optional<unsigned> size)
 {
-    // FIXME: these should be cached
-    return allocateType<Array>(elementType, size);
+    ArrayKey key { elementType, size };
+    Type* type = m_cache.find(key);
+    if (type)
+        return type;
+    type = allocateType<Array>(elementType, size);
+    m_cache.insert(key, type);
+    return type;
 }
 
 Type* TypeStore::vectorType(Type* elementType, uint8_t size)
 {
-    // FIXME: these should be cached
-    return allocateType<Vector>(elementType, size);
+    VectorKey key { elementType, size };
+    Type* type = m_cache.find(key);
+    if (type)
+        return type;
+    type = allocateType<Vector>(elementType, size);
+    m_cache.insert(key, type);
+    return type;
 }
 
 Type* TypeStore::matrixType(Type* elementType, uint8_t columns, uint8_t rows)
 {
-    // FIXME: these should be cached
-    return allocateType<Matrix>(elementType, columns, rows);
+    MatrixKey key { elementType, columns, rows };
+    Type* type = m_cache.find(key);
+    if (type)
+        return type;
+    type = allocateType<Matrix>(elementType, columns, rows);
+    m_cache.insert(key, type);
+    return type;
 }
 
 template<typename TypeKind, typename... Arguments>
@@ -102,7 +168,6 @@ void TypeStore::allocateConstructor(TargetConstructor constructor, Base base, Ar
 {
     m_typeConstrutors[WTF::enumToUnderlyingType(base)] =
         TypeConstructor { [this, constructor, arguments...](Type* elementType) -> Type* {
-            // FIXME: this should be cached
             return (this->*constructor)(elementType, arguments...);
         } };
 }

--- a/Source/WebGPU/WGSL/TypeStore.h
+++ b/Source/WebGPU/WGSL/TypeStore.h
@@ -27,6 +27,7 @@
 
 #include "ASTTypeName.h"
 #include <wtf/FixedVector.h>
+#include <wtf/HashMap.h>
 #include <wtf/Vector.h>
 
 namespace WGSL {
@@ -60,6 +61,18 @@ public:
     Type* constructType(AST::ParameterizedTypeName::Base, Type*);
 
 private:
+    class TypeCache {
+    public:
+        template<typename Key>
+        Type* find(const Key&) const;
+
+        template<typename Key>
+        void insert(const Key&, Type*);
+
+    private:
+        HashMap<std::pair<Type*, uint64_t>, Type*> m_storage;
+    };
+
     template<typename TypeKind, typename... Arguments>
     Type* allocateType(Arguments&&...);
 
@@ -72,6 +85,7 @@ private:
 
     Vector<std::unique_ptr<Type>> m_types;
     FixedVector<TypeConstructor> m_typeConstrutors;
+    TypeCache m_cache;
 
     Type* m_bottom;
     Type* m_abstractInt;

--- a/Source/WebGPU/WGSL/Types.cpp
+++ b/Source/WebGPU/WGSL/Types.cpp
@@ -65,13 +65,9 @@ void Type::dump(PrintStream& out) const
             ASSERT_NOT_REACHED();
         },
         [&](const Bottom&) {
-#ifdef NDEBUG
-            RELEASE_ASSERT_NOT_REACHED();
-#else
             // Bottom is an implementation detail and should never leak, but we
             // keep the ability to print it in debug to help when dumping types
             out.print("⊥");
-#endif
         });
 }
 


### PR DESCRIPTION
#### 5ebfd986c0ce5db75eb4bed79902f577b3a4f3d7
<pre>
[WGSL] Cache parameterized types
<a href="https://bugs.webkit.org/show_bug.cgi?id=252326">https://bugs.webkit.org/show_bug.cgi?id=252326</a>
rdar://105503636

Reviewed by Myles C. Maxfield.

Hash cons parameterized types so they can be checked for equality
with pointer identity.

* Source/WebGPU/WGSL/TypeStore.cpp:
(WGSL::VectorKey::extra const):
(WGSL::MatrixKey::extra const):
(WGSL::ArrayKey::extra const):
(WGSL::TypeStore::TypeCache::find const):
(WGSL::TypeStore::TypeCache::insert):
(WGSL::TypeStore::constructType):
(WGSL::TypeStore::arrayType):
(WGSL::TypeStore::vectorType):
(WGSL::TypeStore::matrixType):
(WGSL::TypeStore::allocateConstructor):
* Source/WebGPU/WGSL/TypeStore.h:
* Source/WebGPU/WGSL/Types.cpp:
(WGSL::Type::dump const):

Canonical link: <a href="https://commits.webkit.org/260358@main">https://commits.webkit.org/260358@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/daabd2f87b6fcef209c4fd541308eccb7ffcfac3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108102 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17172 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40970 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117227 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18528 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8468 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100306 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113870 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97196 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/41901 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/95880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28834 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10054 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30182 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10776 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/7084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16202 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49773 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7167 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12357 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->