### PR TITLE
hello-cube.html only draws to the upper left quarter of the screen

### DIFF
--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.cpp
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.cpp
@@ -62,8 +62,7 @@ static GPUPresentationContextDescriptor presentationContextDescriptor(GPUComposi
 static int getCanvasWidth(const GPUCanvasContext::CanvasType& canvas)
 {
     return WTF::switchOn(canvas, [](const RefPtr<HTMLCanvasElement>& htmlCanvas) -> int {
-        auto scaleFactor = htmlCanvas->document().deviceScaleFactor();
-        return scaleFactor * htmlCanvas->width();
+        return htmlCanvas->width();
     }
 #if ENABLE(OFFSCREEN_CANVAS)
     , [](const RefPtr<OffscreenCanvas>& offscreenCanvas) -> int {
@@ -76,8 +75,7 @@ static int getCanvasWidth(const GPUCanvasContext::CanvasType& canvas)
 static int getCanvasHeight(const GPUCanvasContext::CanvasType& canvas)
 {
     return WTF::switchOn(canvas, [](const RefPtr<HTMLCanvasElement>& htmlCanvas) -> int {
-        auto scaleFactor = htmlCanvas->document().deviceScaleFactor();
-        return scaleFactor * htmlCanvas->height();
+        return htmlCanvas->height();
     }
 #if ENABLE(OFFSCREEN_CANVAS)
     , [](const RefPtr<OffscreenCanvas>& offscreenCanvas) -> int {

--- a/Websites/webkit.org/demos/webgpu/hello-triangle-msaa.html
+++ b/Websites/webkit.org/demos/webgpu/hello-triangle-msaa.html
@@ -14,6 +14,8 @@ body {
 }
 canvas {
     margin: 0 auto;
+    max-width: 600px;
+    max-height: 600px;
 }
 </style>
 </head>

--- a/Websites/webkit.org/demos/webgpu/instanced-textured-cube.html
+++ b/Websites/webkit.org/demos/webgpu/instanced-textured-cube.html
@@ -14,6 +14,8 @@ body {
 }
 canvas {
     margin: 0 auto;
+    max-width: 600px;
+    max-height: 600px;
 }
 </style>
 </head>

--- a/Websites/webkit.org/demos/webgpu/scripts/hello-triangle-msaa.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/hello-triangle-msaa.js
@@ -5,15 +5,15 @@ async function helloTriangle() {
     }
 
     const canvas = document.querySelector("canvas");
-    canvas.width = 600;
-    canvas.height = 600;
+    const deviceScaleFactor = window.devicePixelRatio || 1;
+    canvas.width = 600 * deviceScaleFactor;
+    canvas.height = 600 * deviceScaleFactor;
 
     const adapter = await navigator.gpu.requestAdapter();
     const device = await adapter.requestDevice();
     
-    const deviceScaleFactor = window.devicePixelRatio || 1;
     const msaaRenderTarget = device.createTexture({
-        size: [ canvas.width * deviceScaleFactor, canvas.height * deviceScaleFactor ],
+        size: [ canvas.width, canvas.height ],
         sampleCount: 4,
         format: 'bgra8unorm',
         usage: GPUTextureUsage.RENDER_ATTACHMENT,

--- a/Websites/webkit.org/demos/webgpu/scripts/instanced-textured-cube.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/instanced-textured-cube.js
@@ -5,8 +5,9 @@ async function helloCube() {
     }
 
     const canvas = document.querySelector("canvas");
-    canvas.width = 600;
-    canvas.height = 600;
+    const deviceScaleFactor = window.devicePixelRatio || 1;
+    canvas.width = 600 * deviceScaleFactor;
+    canvas.height = 600 * deviceScaleFactor;
     
     const adapter = await navigator.gpu.requestAdapter();
     const device = await adapter.requestDevice();
@@ -213,16 +214,15 @@ async function helloCube() {
         multisample: { count: 4 }
     };
 
-    const deviceScaleFactor = window.devicePixelRatio || 1;
     const depthTexture = device.createTexture({
-        size: [ canvas.width * deviceScaleFactor, canvas.height * deviceScaleFactor ],
+        size: [ canvas.width, canvas.height ],
         format: 'depth24plus',
         usage: GPUTextureUsage.RENDER_ATTACHMENT,
         sampleCount: 4
     });
 
     const msaaRenderTarget = device.createTexture({
-        size: [ canvas.width * deviceScaleFactor, canvas.height * deviceScaleFactor ],
+        size: [ canvas.width, canvas.height ],
         sampleCount: 4,
         format: 'bgra8unorm',
         usage: GPUTextureUsage.RENDER_ATTACHMENT,


### PR DESCRIPTION
#### 3862c3abd921e36d305bb09d12ad0d1a1c840c15
<pre>
hello-cube.html only draws to the upper left quarter of the screen
<a href="https://bugs.webkit.org/show_bug.cgi?id=252333">https://bugs.webkit.org/show_bug.cgi?id=252333</a>
&lt;radar://105506949&gt;

Reviewed by Tadeu Zagallo.

Document.devicePixelRatio was being used incorrectly.

* Source/WebCore/html/canvas/GPUCanvasContextCocoa.cpp:
(WebCore::getCanvasWidth):
(WebCore::getCanvasHeight):
* Websites/webkit.org/demos/webgpu/scripts/hello-triangle-msaa.js:
(async helloTriangle):
* Websites/webkit.org/demos/webgpu/scripts/instanced-textured-cube.js:

* Websites/webkit.org/demos/webgpu/hello-triangle-msaa.html:
* Websites/webkit.org/demos/webgpu/instanced-textured-cube.html:
Limit width / height to 600

Canonical link: <a href="https://commits.webkit.org/260364@main">https://commits.webkit.org/260364@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eab6999c510ff380990815496979fba3670eca28

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108120 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17191 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40988 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117245 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116566 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112009 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18546 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8486 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100325 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113888 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97214 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41920 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95896 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28852 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10072 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30200 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10793 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7100 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16220 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49791 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7172 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12374 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->