### PR TITLE
Optimize Reflect.get() leveraging the recently introduced GetByValWithThis IC

### DIFF
--- a/JSTests/microbenchmarks/reflect-get-with-receiver.js
+++ b/JSTests/microbenchmarks/reflect-get-with-receiver.js
@@ -1,0 +1,11 @@
+(function() {
+    var target = { get foo() { return this.bar; }, bar: 1 };
+    var receiver = { bar: 2 };
+
+    var bar;
+    for (var i = 0; i < 1e7; i++)
+        bar = Reflect.get(target, "foo", receiver);
+
+    if (bar !== 2)
+        throw new Error("Bad assertion!");
+})();

--- a/JSTests/microbenchmarks/reflect-get.js
+++ b/JSTests/microbenchmarks/reflect-get.js
@@ -1,0 +1,10 @@
+(function() {
+    var target = { foo: 1 };
+
+    var foo;
+    for (var i = 0; i < 1e7; i++)
+        foo = Reflect.get(target, "foo");
+
+    if (foo !== 1)
+        throw new Error("Bad assertion!");
+})();

--- a/Source/JavaScriptCore/builtins/BuiltinNames.h
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.h
@@ -89,7 +89,6 @@ namespace JSC {
     macro(starNamespace) \
     macro(keys) \
     macro(values) \
-    macro(get) \
     macro(set) \
     macro(clear) \
     macro(context) \

--- a/Source/JavaScriptCore/builtins/ReflectObject.js
+++ b/Source/JavaScriptCore/builtins/ReflectObject.js
@@ -49,6 +49,21 @@ function deleteProperty(target, propertyKey)
     return delete target[propertyKey];
 }
 
+// https://tc39.es/ecma262/#sec-reflect.get
+function get(target, propertyKey /*, receiver */)
+{
+    "use strict";
+
+    if (!@isObject(target))
+        @throwTypeError("Reflect.get requires the first argument be an object");
+
+    if (@argumentCount() < 3)
+        return target[propertyKey];
+
+    var receiver = @argument(2);
+    return @getByValWithThis(target, receiver, propertyKey);
+}
+
 // https://tc39.github.io/ecma262/#sec-reflect.has
 function has(target, propertyKey)
 {

--- a/Source/JavaScriptCore/runtime/ReflectObject.cpp
+++ b/Source/JavaScriptCore/runtime/ReflectObject.cpp
@@ -33,7 +33,6 @@ namespace JSC {
 
 static JSC_DECLARE_HOST_FUNCTION(reflectObjectConstruct);
 static JSC_DECLARE_HOST_FUNCTION(reflectObjectDefineProperty);
-static JSC_DECLARE_HOST_FUNCTION(reflectObjectGet);
 static JSC_DECLARE_HOST_FUNCTION(reflectObjectGetOwnPropertyDescriptor);
 static JSC_DECLARE_HOST_FUNCTION(reflectObjectGetPrototypeOf);
 static JSC_DECLARE_HOST_FUNCTION(reflectObjectIsExtensible);
@@ -58,7 +57,7 @@ const ClassInfo ReflectObject::s_info = { "Reflect"_s, &Base::s_info, &reflectOb
     construct                reflectObjectConstruct                DontEnum|Function 2
     defineProperty           reflectObjectDefineProperty           DontEnum|Function 3
     deleteProperty           JSBuiltin                             DontEnum|Function 2
-    get                      reflectObjectGet                      DontEnum|Function 2
+    get                      JSBuiltin                             DontEnum|Function 2
     getOwnPropertyDescriptor reflectObjectGetOwnPropertyDescriptor DontEnum|Function 2
     getPrototypeOf           reflectObjectGetPrototypeOf           DontEnum|Function 1 ReflectGetPrototypeOfIntrinsic
     has                      JSBuiltin                             DontEnum|Function 2
@@ -147,27 +146,6 @@ JSC_DEFINE_HOST_FUNCTION(reflectObjectDefineProperty, (JSGlobalObject* globalObj
     bool shouldThrow = false;
     JSObject* targetObject = asObject(target);
     RELEASE_AND_RETURN(scope, JSValue::encode(jsBoolean(targetObject->methodTable()->defineOwnProperty(targetObject, globalObject, propertyName, descriptor, shouldThrow))));
-}
-
-// https://tc39.github.io/ecma262/#sec-reflect.get
-JSC_DEFINE_HOST_FUNCTION(reflectObjectGet, (JSGlobalObject* globalObject, CallFrame* callFrame))
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    JSValue target = callFrame->argument(0);
-    if (!target.isObject())
-        return JSValue::encode(throwTypeError(globalObject, scope, "Reflect.get requires the first argument be an object"_s));
-
-    const Identifier propertyName = callFrame->argument(1).toPropertyKey(globalObject);
-    RETURN_IF_EXCEPTION(scope, encodedJSValue());
-
-    JSValue receiver = target;
-    if (callFrame->argumentCount() >= 3)
-        receiver = callFrame->argument(2);
-
-    PropertySlot slot(receiver, PropertySlot::InternalMethodType::Get);
-    RELEASE_AND_RETURN(scope, JSValue::encode(target.get(globalObject, propertyName, slot)));
 }
 
 // https://tc39.github.io/ecma262/#sec-reflect.getownpropertydescriptor


### PR DESCRIPTION
#### 0f0092e17fdbdd3127963eeb9eb45e8db4506726
<pre>
Optimize Reflect.get() leveraging the recently introduced GetByValWithThis IC
<a href="https://bugs.webkit.org/show_bug.cgi?id=252328">https://bugs.webkit.org/show_bug.cgi?id=252328</a>
&lt;rdar://problem/105504833&gt;

Reviewed by Yusuke Suzuki.

This change re-implements Reflect.get() as JSBuiltin to leverage GetByValWithThis IC,
speeding up microbenchmarks 8.5X times and JetStream3/proxy-vue by 1.5-2%.

                                      ToT                      patch

reflect-get-with-receiver      331.8347+-1.6323     ^     38.7435+-0.2977        ^ definitely 8.5649x faster
reflect-get                     91.5221+-0.3572     ^     10.7350+-0.0942        ^ definitely 8.5256x faster

* JSTests/microbenchmarks/reflect-get-with-receiver.js: Added.
* JSTests/microbenchmarks/reflect-get.js: Added.
* Source/JavaScriptCore/builtins/BuiltinNames.h:
* Source/JavaScriptCore/builtins/ReflectObject.js:
* Source/JavaScriptCore/runtime/ReflectObject.cpp:

Canonical link: <a href="https://commits.webkit.org/260327@main">https://commits.webkit.org/260327@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69b4375502cf7cff08892103bef45264c0272f88

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/108017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/17077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/40896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/117149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/18453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/8391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/100215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/113783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/18453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/40896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/100215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/18453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/40896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/100215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/97255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/9982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/40896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/38/builds/96625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/83/builds/8070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/10698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/8391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/38/builds/96625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/16133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/40896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-mips~~](https://ews-build.webkit.org/#/builders/37/builds/105638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/12275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/37/builds/105638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3883 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->