### PR TITLE
REGRESSION (259904@main): [ iOS ] Two editing/selection/iOS/ tests are a consistent timeout

### DIFF
--- a/LayoutTests/editing/selection/ios/change-selection-by-tapping-with-existing-selection.html
+++ b/LayoutTests/editing/selection/ios/change-selection-by-tapping-with-existing-selection.html
@@ -49,7 +49,7 @@ addEventListener("load", async () => {
     description("Verifies that tapping to change selection works when we already have a selection in the same editable root but do not currently have a focused node in the UIKit sense.");
 
     var target = document.getElementById("target");
-    window.getSelection().setBaseAndExtent(target, 0, target, 2);
+    window.getSelection().setBaseAndExtent(target, 0, target, 1);
 
     document.querySelector("#selection-before").textContent = selectionToString();
     await tapAndWaitForSelectionChange(5, 5);

--- a/LayoutTests/editing/selection/ios/persist-selection-after-tapping-on-element-with-mousedown-handler.html
+++ b/LayoutTests/editing/selection/ios/persist-selection-after-tapping-on-element-with-mousedown-handler.html
@@ -45,7 +45,7 @@
         });
 
         var target = document.getElementById("target");
-        window.getSelection().setBaseAndExtent(target, 0, target, 6);
+        window.getSelection().setBaseAndExtent(target, 0, target, 1);
 
         await UIHelper.activateElement(clickTarget);
     }

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3486,8 +3486,9 @@ webkit.org/b/229397 imported/w3c/web-platform-tests/css/css-writing-modes/clip-r
 webkit.org/b/229397 imported/w3c/web-platform-tests/css/css-writing-modes/clip-rect-vrl-008.xht [ ImageOnlyFailure ]
 
 # These three tests will be fixed by rdar://80384564.
+editing/selection/ios/change-selection-by-tapping-with-existing-selection.html  [ Pass Failure ]
 editing/selection/preserve-selection-when-clicking-button.html [ Failure ]
-
+editing/selection/ios/persist-selection-after-tapping-on-element-with-mousedown-handler.html [ Failure ]
 
 webkit.org/b/238211 fast/text/text-shadow-ink-overflow-missing.html [ Pass ImageOnlyFailure ]
 
@@ -4222,9 +4223,6 @@ webkit.org/b/251889 imported/w3c/web-platform-tests/content-security-policy/repo
 webkit.org/b/251875 fast/dynamic/create-renderer-for-whitespace-only-text.html [ Pass Failure ]
 
 webkit.org/b/252191 imported/w3c/web-platform-tests/editing/other/edit-in-textcontrol-immediately-after-hidden.tentative.html [ Skip ]
-
-webkit.org/b/252313 editing/selection/ios/change-selection-by-tapping-with-existing-selection.html [ Timeout ]
-webkit.org/b/252313 editing/selection/ios/persist-selection-after-tapping-on-element-with-mousedown-handler.html [ Timeout ]
 
 webkit.org/b/252317 imported/w3c/web-platform-tests/css/css-counter-styles/devanagari/css3-counter-styles-119.html [ ImageOnlyFailure ]
 webkit.org/b/252317 imported/w3c/web-platform-tests/css/css-counter-styles/devanagari/css3-counter-styles-120.html [ ImageOnlyFailure ]


### PR DESCRIPTION
#### 1fdbfd80de70e622ef15360b8cc069e72432c99e
<pre>
REGRESSION (259904@main): [ iOS ] Two editing/selection/iOS/ tests are a consistent timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=252313">https://bugs.webkit.org/show_bug.cgi?id=252313</a>

Reviewed by Wenson Hsieh.

The bug was caused by these tests using invalid offsets. Use valid offsets instead.

* LayoutTests/editing/selection/ios/change-selection-by-tapping-with-existing-selection.html:
* LayoutTests/editing/selection/ios/persist-selection-after-tapping-on-element-with-mousedown-handler.html:
* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/260354@main">https://commits.webkit.org/260354@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23a7aeb539d201903c4dd032de12ef9ad0122c6f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107982 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17044 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40868 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117117 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116459 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18427 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8359 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100176 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113746 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13912 "Found 7 new test failures: editing/deleting/smart-delete-002.html, editing/deleting/smart-delete-paragraph-002.html, editing/pasteboard/smart-paste-002.html, editing/pasteboard/smart-paste-006.html, editing/pasteboard/smart-paste-paragraph-003.html, editing/selection/doubleclick-whitespace-crash.html, editing/selection/ios/selection-handle-clamping-in-iframe.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97123 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41787 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95820 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28761 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9959 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30109 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10668 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7003 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16110 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49699 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12242 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3895 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->