### PR TITLE
[GLib] Add more padding to more vtables

### DIFF
--- a/Source/JavaScriptCore/API/glib/JSCClass.h.in
+++ b/Source/JavaScriptCore/API/glib/JSCClass.h.in
@@ -74,6 +74,12 @@ typedef struct {
     void (*_jsc_reserved1) (void);
     void (*_jsc_reserved2) (void);
     void (*_jsc_reserved3) (void);
+#if ENABLE(2022_GLIB_API)
+    void (*_jsc_reserved4) (void);
+    void (*_jsc_reserved5) (void);
+    void (*_jsc_reserved6) (void);
+    void (*_jsc_reserved7) (void);
+#endif
 } JSCClassVTable;
 
 JSC_API const char *

--- a/Source/WebKit/UIProcess/API/glib/WebKitPolicyDecision.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitPolicyDecision.h.in
@@ -47,6 +47,12 @@ struct _WebKitPolicyDecisionClass {
     void (*_webkit_reserved1) (void);
     void (*_webkit_reserved2) (void);
     void (*_webkit_reserved3) (void);
+#if ENABLE(2022_GLIB_API)
+    void (*_webkit_reserved4) (void);
+    void (*_webkit_reserved5) (void);
+    void (*_webkit_reserved6) (void);
+    void (*_webkit_reserved7) (void);
+#endif
 };
 
 WEBKIT_API void

--- a/Tools/TestWebKitAPI/Tests/JavaScriptCore/glib/TestJSC.cpp
+++ b/Tools/TestWebKitAPI/Tests/JavaScriptCore/glib/TestJSC.cpp
@@ -631,6 +631,10 @@ static JSCClassVTable moduleVTable = {
     nullptr,
     // padding
     nullptr, nullptr, nullptr, nullptr
+#if ENABLE(2022_GLIB_API)
+    // more padding
+    , nullptr, nullptr, nullptr, nullptr
+#endif
 };
 
 static void testJSCEvaluateInObject()
@@ -1834,6 +1838,10 @@ static JSCClassVTable fooVTable = {
     },
     // padding
     nullptr, nullptr, nullptr, nullptr
+#if ENABLE(2022_GLIB_API)
+    // more padding
+    , nullptr, nullptr, nullptr, nullptr
+#endif
 };
 
 static GFile* createGFile(const char* path)
@@ -3368,6 +3376,10 @@ static JSCClassVTable barVTable = {
     },
     // padding
     nullptr, nullptr, nullptr, nullptr
+#if ENABLE(2022_GLIB_API)
+    // more padding
+    , nullptr, nullptr, nullptr, nullptr
+#endif
 };
 
 static void testJSCPrototypes()


### PR DESCRIPTION
#### 7ca0c691aba64dd3dfba3a207f0381e13873a5cf
<pre>
[GLib] Add more padding to more vtables
<a href="https://bugs.webkit.org/show_bug.cgi?id=252052">https://bugs.webkit.org/show_bug.cgi?id=252052</a>

Reviewed by Adrian Perez de Castro.

Let&apos;s add more padding to these vtables for future-proofing. I am only
adding a small amount of additional padding because we never used any of
the previous padding and most likely that will not change.

* Source/JavaScriptCore/API/glib/JSCClass.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitPolicyDecision.h.in:
* Tools/TestWebKitAPI/Tests/JavaScriptCore/glib/TestJSC.cpp:

Canonical link: <a href="https://commits.webkit.org/260396@main">https://commits.webkit.org/260396@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf2a81f21c687f0dd5566810a9964f7e50d637c4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108182 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17265 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41049 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117306 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112069 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/18657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8551 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100390 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113950 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14031 "Build was cancelled. Recent messages:Cleaned up git repository; Failed to find identifier") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97258 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/41973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95942 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28898 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/97400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10129 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30245 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/38/builds/96758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/8232 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10853 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/7149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/38/builds/96758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16277 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49837 "Passed tests") | [  ~~🛠 jsc-mips~~](https://ews-build.webkit.org/#/builders/37/builds/105785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7190 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12435 "Built successfully") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/37/builds/105785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | | | | 
<!--EWS-Status-Bubble-End-->