### PR TITLE
HTMLAttachmentElement action attribute in new horizontal layout

### DIFF
--- a/Source/WebCore/html/HTMLAttachmentElement.h
+++ b/Source/WebCore/html/HTMLAttachmentElement.h
@@ -69,6 +69,7 @@ public:
     RefPtr<HTMLImageElement> enclosingImageElement() const;
 
     WEBCORE_EXPORT String attachmentTitle() const;
+    const AtomString& attachmentActionForDisplay() const;
     String attachmentTitleForDisplay() const;
     String attachmentSubtitleForDisplay() const;
     WEBCORE_EXPORT String attachmentType() const;
@@ -118,6 +119,7 @@ private:
     FloatSize m_iconSize;
 
     RefPtr<HTMLAttachmentElement> m_innerLegacyAttachment;
+    RefPtr<HTMLElement> m_elementWithAction;
     RefPtr<HTMLElement> m_elementWithTitle;
     RefPtr<HTMLElement> m_elementWithSubtitle;
 

--- a/Source/WebCore/html/shadow/attachmentElementShadow.css
+++ b/Source/WebCore/html/shadow/attachmentElementShadow.css
@@ -43,6 +43,13 @@ attachment#attachment-preview {
     align-self: center;
 }
 
+div#attachment-action {
+    grid-row: 1;
+    grid-column: 2;
+    font-size: small;
+    color: rgb(82, 145, 214); /* FIXME: Use semantic colors, see rdar://105252500 */
+}
+
 div#attachment-title {
     grid-row: 2;
     grid-column: 2;

--- a/Source/WebCore/rendering/AttachmentLayout.mm
+++ b/Source/WebCore/rendering/AttachmentLayout.mm
@@ -275,7 +275,7 @@ AttachmentLayout::AttachmentLayout(const RenderAttachment& attachment, Attachmen
 
     hasProgress = getAttachmentProgress(attachment, progress);
     String title = attachment.attachmentElement().attachmentTitleForDisplay();
-    String action = attachment.attachmentElement().attributeWithoutSynchronization(HTMLNames::actionAttr);
+    String action = attachment.attachmentElement().attachmentActionForDisplay();
     String subtitle = attachment.attachmentElement().attachmentSubtitleForDisplay();
 
     CGFloat yOffset = 0;


### PR DESCRIPTION
#### e93a4bd9da8d93c8ea339bdfcd6c9a244f3b391d
<pre>
HTMLAttachmentElement action attribute in new horizontal layout
<a href="https://bugs.webkit.org/show_bug.cgi?id=252337">https://bugs.webkit.org/show_bug.cgi?id=252337</a>
rdar://105250367

Reviewed by Tim Nguyen, Aditya Keerthi and Wenson Hsieh.

* Source/WebCore/html/HTMLAttachmentElement.cpp:
(WebCore::HTMLAttachmentElement::ensureModernShadowTree):
* Source/WebCore/html/HTMLAttachmentElement.h:
* Source/WebCore/rendering/AttachmentLayout.mm:
(WebCore::AttachmentLayout::AttachmentLayout):

Canonical link: <a href="https://commits.webkit.org/260393@main">https://commits.webkit.org/260393@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/935c57b62d269bee97e0c10f189c6a2a6dd85400

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108013 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17073 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40892 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117145 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116478 "Hash 935c57b6 for PR 10164 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111901 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18449 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8387 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100211 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113779 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13924 "Too many flaky failures: editing/deleting/smart-delete-002.html, editing/deleting/smart-delete-004.html, editing/deleting/smart-delete-paragraph-002.html, editing/deleting/smart-editing-disabled-win.html, editing/pasteboard/smart-paste-002.html, editing/pasteboard/smart-paste-004.html, editing/pasteboard/smart-paste-006.html, editing/pasteboard/smart-paste-008.html, editing/pasteboard/smart-paste-paragraph-003.html, editing/selection/doubleclick-whitespace-crash.html, editing/selection/ios/select-text-under-hidden-subframe.html, editing/selection/ios/selection-handle-clamping-in-iframe.html, imported/w3c/web-platform-tests/html/semantics/popovers/popover-animated-hide-cleanup.tentative.html, platform/ipad/fast/viewport/empty-meta.html, platform/ipad/fast/viewport/meta-viewport-ignored.html, platform/ipad/fast/viewport/width-is-device-width.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97141 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41839 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95833 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28779 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/83508 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9978 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30127 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10694 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7026 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16129 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49717 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7192 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12271 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->