### PR TITLE
Check for fileSystemPath being non-null when adding to set

### DIFF
--- a/LayoutTests/fast/history/add-file-with-invalid-utf8-crash-expected.txt
+++ b/LayoutTests/fast/history/add-file-with-invalid-utf8-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/history/add-file-with-invalid-utf8-crash.html
+++ b/LayoutTests/fast/history/add-file-with-invalid-utf8-crash.html
@@ -1,0 +1,14 @@
+
+<script>
+function test() {
+    if (window.testRunner)
+        testRunner.dumpAsText();
+    document.body.innerHTML = 'PASS if no crash.'
+}
+</script>
+<html>
+<body onload="test()">
+<object data="A%AA">
+</object>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -1232,13 +1232,18 @@ auto WebProcessProxy::visiblePageToken() const -> VisibleWebPageToken
 void WebProcessProxy::addPreviouslyApprovedFileURL(const URL& url)
 {
     ASSERT(url.isLocalFile());
-    m_previouslyApprovedFilePaths.add(url.fileSystemPath());
+    auto fileSystemPath = url.fileSystemPath();
+    if (!fileSystemPath.isEmpty())
+        m_previouslyApprovedFilePaths.add(fileSystemPath);
 }
 
 bool WebProcessProxy::wasPreviouslyApprovedFileURL(const URL& url) const
 {
     ASSERT(url.isLocalFile());
-    return m_previouslyApprovedFilePaths.contains(url.fileSystemPath());
+    auto fileSystemPath = url.fileSystemPath();
+    if (fileSystemPath.isEmpty())
+        return false;
+    return m_previouslyApprovedFilePaths.contains(fileSystemPath);
 }
 
 RefPtr<API::UserInitiatedAction> WebProcessProxy::userInitiatedActivity(uint64_t identifier)


### PR DESCRIPTION
#### 9605dc730f989f14ed646967fd70ab807d54ab36
<pre>
Check for fileSystemPath being non-null when adding to set
<a href="https://bugs.webkit.org/show_bug.cgi?id=252341">https://bugs.webkit.org/show_bug.cgi?id=252341</a>
rdar://99575855

Reviewed by Chris Dumez.

This change fixes the crash in the UI process when the fileSystemPath is
not a valid UTF-8.

* LayoutTests/fast/history/add-file-with-invalid-utf8-crash-expected.txt: Added.
* LayoutTests/fast/history/add-file-with-invalid-utf8-crash.html: Added.
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::addPreviouslyApprovedFileURL):
(WebKit::WebProcessProxy::wasPreviouslyApprovedFileURL const):

Canonical link: <a href="https://commits.webkit.org/260351@main">https://commits.webkit.org/260351@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54d6994f12b646ed8d7f2880a3b7a8c41ac51c01

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108005 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17065 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40887 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117138 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116473 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18444 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8380 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100202 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113771 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97137 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41830 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95829 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28775 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9973 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30123 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10687 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7019 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16124 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49713 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7164 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12263 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->