### PR TITLE
Process swap on cross-site window.open behind a flag

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -5013,6 +5013,18 @@ ProcessSwapOnCrossSiteNavigationEnabled:
       "PLATFORM(PLAYSTATION)": false
       default: true
 
+ProcessSwapOnCrossSiteWindowOpenEnabled:
+   type: bool
+   status: unstable
+   category: networking
+   humanReadableName: "Swap Processes on Cross-Site Window Open"
+   humanReadableDescription: "Swap WebContent Processes on cross-site window.open"
+   webcoreBinding: none
+   exposed: [ WebKit ]
+   defaultValue:
+     WebKit:
+       default: false
+
 PunchOutWhiteBackgroundsInDarkMode:
   type: bool
   status: embedder

--- a/Source/WebCore/bindings/js/WindowProxy.cpp
+++ b/Source/WebCore/bindings/js/WindowProxy.cpp
@@ -86,6 +86,12 @@ void WindowProxy::detachFromFrame()
     }
 }
 
+void WindowProxy::replaceFrame(Frame& frame)
+{
+    m_frame = frame;
+    setDOMWindow(frame.window());
+}
+
 void WindowProxy::destroyJSWindowProxy(DOMWrapperWorld& world)
 {
     ASSERT(m_jsWindowProxies->contains(&world));

--- a/Source/WebCore/bindings/js/WindowProxy.h
+++ b/Source/WebCore/bindings/js/WindowProxy.h
@@ -52,6 +52,7 @@ public:
 
     WEBCORE_EXPORT Frame* frame() const;
     void detachFromFrame();
+    void replaceFrame(Frame&);
 
     void destroyJSWindowProxy(DOMWrapperWorld&);
 

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -83,6 +83,7 @@ bool Frame::isRootFrame() const
 
 void Frame::resetWindowProxy()
 {
+    ASSERT(m_windowProxy->frame() == this);
     m_windowProxy->detachFromFrame();
     m_windowProxy = WindowProxy::create(*this);
 }
@@ -102,6 +103,14 @@ void Frame::disconnectOwnerElement()
     // FIXME: This is a layering violation. Move this code so Frame doesn't do anything with its Document.
     if (auto* document = is<LocalFrame>(*this) ? downcast<LocalFrame>(*this).document() : nullptr)
         document->frameWasDisconnectedFromOwner();
+}
+
+void Frame::takeWindowProxy(Frame& frame)
+{
+    ASSERT(m_windowProxy->frame() == this);
+    m_windowProxy->detachFromFrame();
+    m_windowProxy = frame.windowProxy();
+    m_windowProxy->replaceFrame(*this);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -67,6 +67,7 @@ public:
     inline HTMLFrameOwnerElement* ownerElement() const; // Defined in HTMLFrameOwnerElement.h.
     WEBCORE_EXPORT void disconnectOwnerElement();
     NavigationScheduler& navigationScheduler() const { return m_navigationScheduler.get(); }
+    WEBCORE_EXPORT void takeWindowProxy(Frame&);
 
     virtual void frameDetached() = 0;
     virtual bool preventsParentFromBeingComplete() const = 0;

--- a/Source/WebKit/Shared/WebPageCreationParameters.cpp
+++ b/Source/WebKit/Shared/WebPageCreationParameters.cpp
@@ -202,6 +202,7 @@ void WebPageCreationParameters::encode(IPC::Encoder& encoder) const
 
     encoder << contentSecurityPolicyModeForExtension;
     encoder << subframeProcessFrameTreeCreationParameters;
+    encoder << openerFrameIdentifier;
 
 #if ENABLE(NETWORK_CONNECTION_INTEGRITY)
     encoder << lookalikeCharacterStrings;
@@ -650,6 +651,9 @@ std::optional<WebPageCreationParameters> WebPageCreationParameters::decode(IPC::
         return std::nullopt;
 
     if (!decoder.decode(parameters.subframeProcessFrameTreeCreationParameters))
+        return std::nullopt;
+
+    if (!decoder.decode(parameters.openerFrameIdentifier))
         return std::nullopt;
 
 #if ENABLE(NETWORK_CONNECTION_INTEGRITY)

--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -291,6 +291,7 @@ struct WebPageCreationParameters {
     WebCore::ContentSecurityPolicyModeForExtension contentSecurityPolicyModeForExtension { WebCore::ContentSecurityPolicyModeForExtension::None };
 
     std::optional<FrameTreeCreationParameters> subframeProcessFrameTreeCreationParameters;
+    std::optional<WebCore::FrameIdentifier> openerFrameIdentifier;
 
 #if ENABLE(NETWORK_CONNECTION_INTEGRITY)
     Vector<WebCore::LookalikeCharactersSanitizationData> lookalikeCharacterStrings;

--- a/Source/WebKit/UIProcess/FrameLoadState.cpp
+++ b/Source/WebKit/UIProcess/FrameLoadState.cpp
@@ -46,8 +46,6 @@ void FrameLoadState::removeObserver(Observer& observer)
 
 void FrameLoadState::didStartProvisionalLoad(const URL& url)
 {
-    ASSERT(m_provisionalURL.isEmpty());
-
     m_state = State::Provisional;
     m_provisionalURL = url;
 }

--- a/Source/WebKit/UIProcess/SubframePageProxy.cpp
+++ b/Source/WebKit/UIProcess/SubframePageProxy.cpp
@@ -38,7 +38,7 @@
 
 namespace WebKit {
 
-SubframePageProxy::SubframePageProxy(WebPageProxy& page, WebProcessProxy& process, bool isInSameProcessAsMainFrame)
+SubframePageProxy::SubframePageProxy(WebPageProxy& page, WebProcessProxy& process, bool isInSameProcessAsMainFrame, bool isOpener)
     : m_webPageID(page.webPageID())
     , m_process(process)
     , m_page(page)
@@ -53,8 +53,10 @@ SubframePageProxy::SubframePageProxy(WebPageProxy& page, WebProcessProxy& proces
     parameters.isProcessSwap = true; // FIXME: This should be a parameter to creationParameters rather than doctoring up the parameters afterwards.
     parameters.topContentInset = 0;
     m_process->send(Messages::WebProcess::CreateWebPage(m_webPageID, parameters), 0);
-    m_process->addVisitedLinkStoreUser(page.visitedLinkStore(), page.identifier());
-    drawingArea->attachToProvisionalFrameProcess(m_process);
+    if (!isOpener) {
+        m_process->addVisitedLinkStoreUser(page.visitedLinkStore(), page.identifier());
+        drawingArea->attachToProvisionalFrameProcess(m_process);
+    }
 }
 
 SubframePageProxy::~SubframePageProxy()

--- a/Source/WebKit/UIProcess/SubframePageProxy.h
+++ b/Source/WebKit/UIProcess/SubframePageProxy.h
@@ -62,7 +62,7 @@ struct FrameInfoData;
 class SubframePageProxy : public IPC::MessageReceiver, public IPC::MessageSender {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    SubframePageProxy(WebPageProxy&, WebProcessProxy&, bool isInSameProcessAsMainFrame);
+    SubframePageProxy(WebPageProxy&, WebProcessProxy&, bool isInSameProcessAsMainFrame, bool isOpener);
     ~SubframePageProxy();
 
     WebProcessProxy& process() { return m_process.get(); }
@@ -78,6 +78,7 @@ private:
     WebCore::PageIdentifier m_webPageID;
     Ref<WebProcessProxy> m_process;
     WeakPtr<WebPageProxy> m_page;
+    WeakPtr<WebFrameProxy> m_frame;
 
     // FIXME: We shouldn't make a SubframePageProxy for frames in the same process as the main frame.
     const bool m_isInSameProcessAsMainFrame { false };

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -515,6 +515,7 @@ public:
     PAL::SessionID sessionID() const;
 
     WebFrameProxy* mainFrame() const { return m_mainFrame.get(); }
+    WebFrameProxy* openerFrame() const { return m_openerFrame.get(); }
     WebFrameProxy* focusedFrame() const { return m_focusedFrame.get(); }
 
     DrawingAreaProxy* drawingArea() const { return m_drawingArea.get(); }
@@ -2399,6 +2400,8 @@ private:
     void didFinishLoadForResource(WebCore::ResourceLoaderIdentifier, WebCore::FrameIdentifier, WebCore::ResourceError&&);
 #endif
 
+    bool shouldClosePreviousPage(bool didSuspendPreviousPage);
+
 #if ENABLE(MEDIA_STREAM)
     UserMediaPermissionRequestManagerProxy& userMediaPermissionRequestManager();
 #endif
@@ -2740,6 +2743,8 @@ private:
 
     void didAttachToRunningProcess();
 
+    bool shouldClosePreviousPage();
+
 #if ENABLE(TRACKING_PREVENTION)
     void logFrameNavigation(const WebFrameProxy&, const URL& pageURL, const WebCore::ResourceRequest&, const URL& redirectURL, bool wasPotentiallyInitiatedByUser);
 #endif
@@ -2886,6 +2891,8 @@ private:
     Ref<WebsiteDataStore> m_websiteDataStore;
 
     RefPtr<WebFrameProxy> m_mainFrame;
+
+    RefPtr<WebFrameProxy> m_openerFrame;
 
     RefPtr<WebFrameProxy> m_focusedFrame;
 

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -76,6 +76,7 @@
 #include "WebKit2Initialize.h"
 #include "WebMemorySampler.h"
 #include "WebNotificationManagerProxy.h"
+#include "WebPageCreationParameters.h"
 #include "WebPageGroup.h"
 #include "WebPageProxy.h"
 #include "WebPreferences.h"
@@ -1152,6 +1153,8 @@ Ref<WebPageProxy> WebProcessPool::createWebPage(PageClient& pageClient, Ref<API:
     if (wasProcessSwappingOnNavigationEnabled != m_configuration->processSwapsOnNavigation())
         m_webProcessCache->updateCapacity(*this);
 
+    if (auto processSwapOnCrossSiteWindowOpenEnabled = page->preferences().processSwapOnCrossSiteWindowOpenEnabled())
+        m_configuration->setProcessSwapsOnWindowOpenWithOpener(processSwapOnCrossSiteWindowOpenEnabled);
 #if ENABLE(GPU_PROCESS)
     if (auto* gpuProcess = GPUProcessProxy::singletonIfCreated()) {
         gpuProcess->updatePreferences(*process);
@@ -1845,7 +1848,7 @@ void WebProcessPool::processForNavigation(WebPageProxy& page, WebFrameProxy& fra
     if (!frame.isMainFrame() && page.preferences().siteIsolationEnabled()) {
         RegistrableDomain navigationDomain(navigation.currentRequest().url());
         if (!navigationDomain.isEmpty() && navigationDomain != mainFrameDomain) {
-            auto subFramePageProxy = makeUniqueRef<SubframePageProxy>(page, process, frame.isMainFrame());
+            auto subFramePageProxy = makeUniqueRef<SubframePageProxy>(page, process, frame.isMainFrame(), false /* isOpener */);
             page.addSubframePageProxyForFrameID(frame.frameID(), navigationDomain, WTFMove(subFramePageProxy));
         }
     }

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -111,7 +111,7 @@ public:
     FormSubmitListenerIdentifier setUpWillSubmitFormListener(CompletionHandler<void()>&&);
     void continueWillSubmitForm(FormSubmitListenerIdentifier);
 
-    void didCommitLoadInAnotherProcess(WebCore::LayerHostingContextIdentifier, WebCore::ProcessIdentifier);
+    void didCommitLoadInAnotherProcess(std::optional<WebCore::LayerHostingContextIdentifier>, WebCore::ProcessIdentifier);
     void didFinishLoadInAnotherProcess();
 
     void startDownload(const WebCore::ResourceRequest&, const String& suggestedName = { });

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -603,7 +603,7 @@ public:
     void getFrameInfo(WebCore::FrameIdentifier, CompletionHandler<void(FrameInfoData&&)>&&);
     void getFrameTree(CompletionHandler<void(FrameTreeNodeData&&)>&&);
     void continueWillSubmitForm(WebCore::FrameIdentifier, WebKit::FormSubmitListenerIdentifier);
-    void didCommitLoadInAnotherProcess(WebCore::FrameIdentifier, WebCore::LayerHostingContextIdentifier, WebCore::ProcessIdentifier remoteProcessIdentifier);
+    void didCommitLoadInAnotherProcess(WebCore::FrameIdentifier, std::optional<WebCore::LayerHostingContextIdentifier>, WebCore::ProcessIdentifier remoteProcessIdentifier);
     void didFinishLoadInAnotherProcess(WebCore::FrameIdentifier);
 
     std::optional<WebCore::SimpleRange> currentSelectionAsRange();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -198,7 +198,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
     GetFrameInfo(WebCore::FrameIdentifier frameID) -> (struct WebKit::FrameInfoData data)
     GetFrameTree() -> (struct WebKit::FrameTreeNodeData data)
     ContinueWillSubmitForm(WebCore::FrameIdentifier frameID, WebKit::FormSubmitListenerIdentifier listenerID)
-    DidCommitLoadInAnotherProcess(WebCore::FrameIdentifier frameID, WebCore::LayerHostingContextIdentifier layerHostingContextIdentifier, WebCore::ProcessIdentifier remoteProcessIdentifier)
+    DidCommitLoadInAnotherProcess(WebCore::FrameIdentifier frameID, std::optional<WebCore::LayerHostingContextIdentifier>    layerHostingContextIdentifier, WebCore::ProcessIdentifier remoteProcessIdentifier)
     DidFinishLoadInAnotherProcess(WebCore::FrameIdentifier frameID)
 
     NavigateToPDFLinkWithSimulatedClick(String url, WebCore::IntPoint documentPoint, WebCore::IntPoint screenPoint)

--- a/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
@@ -365,8 +365,10 @@ void TiledCoreAnimationDrawingArea::updateRendering(UpdateRenderingType flushTyp
         }
 
         FloatRect visibleRect = [m_hostingLayer frame];
-        if (auto exposedRect = m_webPage.mainFrameView()->viewExposedRect())
-            visibleRect.intersect(*exposedRect);
+        if (auto mainFrameView = m_webPage.mainFrameView()) {
+            if (auto exposedRect = mainFrameView->viewExposedRect())
+                visibleRect.intersect(*exposedRect);
+        }
 
         // Because our view-relative overlay root layer is not attached to the main GraphicsLayer tree, we need to flush it manually.
         if (m_viewOverlayRootLayer)


### PR DESCRIPTION
#### f2c0fb94999f81c0383bbb80e186a983962e42c6
<pre>
Process swap on cross-site window.open behind a flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=252339">https://bugs.webkit.org/show_bug.cgi?id=252339</a>
rdar://problem/105511244

Reviewed by NOBODY (OOPS!).

This patch starts process swapping upon cross-site navigations in a window opened via
window.open with an opener relationship. In order to accomplish this, we pass along
the opener to the UI process when creating a page. Then, whenever a cross-site navigation
that causes a process swap occurs, the UI process notifies both the opener process and openee
process of their relationship.

This is accomplished by sending pages with remote main frames to each process and including
info about them whenever creating the process swapped page as well as the page with a remote
main frame in the opener&apos;s process.

The above functionality is guarded by the processSwapsOnWindowOpenWithOpener option on a WebProcessPool.
This is exposed as a feature flag, off by default, as &quot;Swap Processes on Cross-Site Window Open.&quot;

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/bindings/js/WindowProxy.cpp:
(WebCore::WindowProxy::replaceFrame):
* Source/WebCore/bindings/js/WindowProxy.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::fallbackBaseURL const):
(WebCore::Document::canNavigateInternal):
(WebCore::Document::initSecurityContext):
(WebCore::Document::initContentSecurityPolicy):
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::doCrossOriginOpenerHandlingOfResponse):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::detachFromAllOpenedFrames):
(WebCore::FrameLoader::opener):
(WebCore::FrameLoader::opener const):
(WebCore::FrameLoader::setOpener):
(WebCore::FrameLoader::setOriginalURLForDownloadRequest):
(WebCore::FrameLoader::updateRequestAndAddExtraFields):
(WebCore::FrameLoader::effectiveReferrerPolicy const):
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::resetWindowProxy):
(WebCore::Frame::takeWindowProxy):
* Source/WebCore/page/Frame.h:
* Source/WebCore/page/PageConfiguration.h:
* Source/WebKit/Platform/IPC/MessageReceiverMap.cpp:
* Source/WebKit/Shared/WebPageCreationParameters.cpp:
(WebKit::WebPageCreationParameters::encode const):
(WebKit::WebPageCreationParameters::decode):
(WebKit::WebPageCreationParameters::SubframeProcessFrameTreeInitializationParameters::decode):
* Source/WebKit/Shared/WebPageCreationParameters.h:
* Source/WebKit/Sources.txt:
* Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.h:
* Source/WebKit/UIProcess/OpenedPageProxy.cpp: Added.
(WebKit::OpenedPageProxy::OpenedPageProxy):
(WebKit::OpenedPageProxy::~OpenedPageProxy):
(WebKit::OpenedPageProxy::messageSenderConnection const):
(WebKit::OpenedPageProxy::messageSenderDestinationID const):
(WebKit::OpenedPageProxy::didReceiveMessage):
(WebKit::OpenedPageProxy::didReceiveSyncMessage):
* Source/WebKit/UIProcess/OpenedPageProxy.h: Added.
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::takeOpenedPage):
(WebKit::ProvisionalPageProxy::initializeWebPage):
(WebKit::ProvisionalPageProxy::didCreateMainFrame):
* Source/WebKit/UIProcess/ProvisionalPageProxy.h:
(WebKit::ProvisionalPageProxy::openedPage const):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::swapToProvisionalPage):
(WebKit::WebPageProxy::close):
(WebKit::WebPageProxy::createNewPage):
(WebKit::WebPageProxy::swapToProvisionalPage): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::createWebPage):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::scheduleLoadFromNetworkProcess):
* Source/WebKit/WebProcess/WebCoreSupport/WebResourceLoadObserver.cpp:
(WebKit::WebResourceLoadObserver::logUserInteractionWithReducedTimeResolution):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_appHighlightsVisible):
(WebKit::WebPage::constructFrameTree):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::createWebPage):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19fa706191569de19f3b2caf69d536244bb83c1f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6638 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6854 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7036 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8229 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6920 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6637 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8017 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6802 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9814 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6756 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7353 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6074 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8316 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/4809 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6004 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13840 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/5605 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6592 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6084 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8763 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/6226 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6572 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5385 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/6775 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5968 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1572 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10140 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/6958 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6341 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1701 "Passed tests") | 
<!--EWS-Status-Bubble-End-->