### PR TITLE
WebGeolocationManager should use WeakHashMap of WebPage instead of raw pointers

### DIFF
--- a/Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.cpp
+++ b/Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.cpp
@@ -74,7 +74,7 @@ void WebGeolocationManager::registerWebPage(WebPage& page, const String& authori
     pageSets.pageSet.add(page);
     if (needsHighAccuracy)
         pageSets.highAccuracyPageSet.add(page);
-    m_pageToRegistrableDomain.add(&page, registrableDomain);
+    m_pageToRegistrableDomain.add(page, registrableDomain);
 
     if (!wasUpdating) {
         m_process.parentProcessConnection()->send(Messages::WebGeolocationManagerProxy::StartUpdating(registrableDomain, page.webPageProxyIdentifier(), authorizationToken, needsHighAccuracy), 0);
@@ -88,7 +88,7 @@ void WebGeolocationManager::registerWebPage(WebPage& page, const String& authori
 
 void WebGeolocationManager::unregisterWebPage(WebPage& page)
 {
-    auto registrableDomain = m_pageToRegistrableDomain.take(&page);
+    auto registrableDomain = m_pageToRegistrableDomain.take(page);
     if (registrableDomain.string().isEmpty())
         return;
 
@@ -116,7 +116,7 @@ void WebGeolocationManager::unregisterWebPage(WebPage& page)
 
 void WebGeolocationManager::setEnableHighAccuracyForPage(WebPage& page, bool enabled)
 {
-    auto registrableDomain = m_pageToRegistrableDomain.get(&page);
+    auto registrableDomain = m_pageToRegistrableDomain.get(page);
     if (registrableDomain.string().isEmpty())
         return;
 

--- a/Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.h
+++ b/Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.h
@@ -31,6 +31,7 @@
 #include <WebCore/RegistrableDomain.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/WeakHashMap.h>
 #include <wtf/WeakHashSet.h>
 
 namespace WebCore {
@@ -75,7 +76,7 @@ private:
 
     WebProcess& m_process;
     HashMap<WebCore::RegistrableDomain, PageSets> m_pageSets;
-    HashMap<WebPage*, WebCore::RegistrableDomain> m_pageToRegistrableDomain;
+    WeakHashMap<WebPage, WebCore::RegistrableDomain> m_pageToRegistrableDomain;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### 544d14e5357117f044702793e3169ec97c6ef0a6
<pre>
WebGeolocationManager should use WeakHashMap of WebPage instead of raw pointers
<a href="https://bugs.webkit.org/show_bug.cgi?id=252343">https://bugs.webkit.org/show_bug.cgi?id=252343</a>

Reviewed by Chris Dumez.

Deployed WeakHashMap in place of HashMap of raw pointers.

* Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.cpp:
(WebKit::WebGeolocationManager::registerWebPage):
(WebKit::WebGeolocationManager::unregisterWebPage):
(WebKit::WebGeolocationManager::setEnableHighAccuracyForPage):
* Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.h:

Canonical link: <a href="https://commits.webkit.org/260333@main">https://commits.webkit.org/260333@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b962d1ac68d28a091d042806a9ba2d2bd1296d6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108015 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17075 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40894 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117147 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/18451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8389 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100213 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113781 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/18451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97139 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/41840 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/18451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28777 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9980 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30125 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10696 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/7029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/16131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49715 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12273 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3886 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->