### PR TITLE
[UI-side compositing] Have pinch zoom constrain zoom origin in commitTransientZoom

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTree.cpp
@@ -527,7 +527,7 @@ void ScrollingTree::clearLatchedNode()
 FloatPoint ScrollingTree::mainFrameScrollPosition() const
 {
     Locker locker { m_treeStateLock };
-    return m_treeState.mainFrameScrollPosition;
+    return m_rootNode->currentScrollPosition();
 }
 
 void ScrollingTree::setMainFrameScrollPosition(FloatPoint position)
@@ -546,6 +546,42 @@ OverscrollBehavior ScrollingTree::mainFrameVerticalOverscrollBehavior() const
 {
     Locker locker { m_treeLock };
     return m_rootNode ? m_rootNode->verticalOverscrollBehavior() : OverscrollBehavior::Auto;
+}
+
+IntPoint ScrollingTree::mainFrameScrollOrigin() const
+{
+    Locker locker { m_treeLock };
+    return m_rootNode ? m_rootNode->scrollOrigin() : IntPoint();
+}
+
+int ScrollingTree::mainFrameHeaderHeight() const
+{
+    Locker locker { m_treeLock };
+    return m_rootNode ? m_rootNode->headerHeight() : 0;
+}
+
+int ScrollingTree::mainFrameFooterHeight() const
+{
+    Locker locker { m_treeLock };
+    return m_rootNode ? m_rootNode->footerHeight() : 0;
+}
+
+float ScrollingTree::mainFrameScaleFactor() const
+{
+    Locker locker { m_treeLock };
+    return m_rootNode ? m_rootNode->frameScaleFactor() : 1;
+}
+
+FloatSize ScrollingTree::totalContentsSize() const
+{
+    Locker locker { m_treeLock };
+    return m_rootNode ? m_rootNode->totalContentsSize() : FloatSize();
+}
+
+FloatRect ScrollingTree::layoutViewport() const
+{
+    Locker locker { m_treeLock };
+    return m_rootNode ? m_rootNode->layoutViewport() : FloatRect();
 }
 
 void ScrollingTree::setGestureState(std::optional<WheelScrollGestureState> gestureState)

--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -227,6 +227,13 @@ public:
 
     WEBCORE_EXPORT OverscrollBehavior mainFrameHorizontalOverscrollBehavior() const;
     WEBCORE_EXPORT OverscrollBehavior mainFrameVerticalOverscrollBehavior() const;
+    
+    WEBCORE_EXPORT IntPoint mainFrameScrollOrigin() const;
+    WEBCORE_EXPORT int mainFrameHeaderHeight() const;
+    WEBCORE_EXPORT int mainFrameFooterHeight() const;
+    WEBCORE_EXPORT float mainFrameScaleFactor() const;
+    WEBCORE_EXPORT FloatSize totalContentsSize() const;
+    WEBCORE_EXPORT FloatRect layoutViewport() const;
 
 protected:
     WheelEventHandlingResult handleWheelEventWithNode(const PlatformWheelEvent&, OptionSet<WheelEventProcessingSteps>, ScrollingTreeNode*, EventTargeting = EventTargeting::Propagate);

--- a/Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.h
@@ -51,12 +51,12 @@ public:
     FloatRect layoutViewportRespectingRubberBanding() const;
 
     float frameScaleFactor() const { return m_frameScaleFactor; }
+    int headerHeight() const { return m_headerHeight; }
+    int footerHeight() const { return m_footerHeight; }
 
 protected:
     ScrollingTreeFrameScrollingNode(ScrollingTree&, ScrollingNodeType, ScrollingNodeID);
 
-    int headerHeight() const { return m_headerHeight; }
-    int footerHeight() const { return m_footerHeight; }
     float topContentInset() const { return m_topContentInset; }
 
     FloatPoint minLayoutViewportOrigin() const { return m_minLayoutViewportOrigin; }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -270,6 +270,45 @@ OverscrollBehavior RemoteScrollingCoordinatorProxy::mainFrameVerticalOverscrollB
     return m_scrollingTree->mainFrameVerticalOverscrollBehavior();
 }
 
+WebCore::FloatRect RemoteScrollingCoordinatorProxy::computeVisibleContentRect()
+{
+    auto scrollPosition = currentMainFrameScrollPosition();
+    auto visibleContentRect = scrollingTree()->layoutViewport();
+    visibleContentRect.setX(scrollPosition.x());
+    visibleContentRect.setY(scrollPosition.y());
+    return visibleContentRect;
+}
+
+WebCore::FloatPoint RemoteScrollingCoordinatorProxy::currentMainFrameScrollPosition() const
+{
+    return m_scrollingTree->mainFrameScrollPosition();
+}
+
+IntPoint RemoteScrollingCoordinatorProxy::scrollOrigin() const
+{
+    return m_scrollingTree->mainFrameScrollOrigin();
+}
+
+int RemoteScrollingCoordinatorProxy::headerHeight() const
+{
+    return m_scrollingTree->mainFrameHeaderHeight();
+}
+
+int RemoteScrollingCoordinatorProxy::footerHeight() const
+{
+    return m_scrollingTree->mainFrameFooterHeight();
+}
+
+float RemoteScrollingCoordinatorProxy::mainFrameScaleFactor() const
+{
+    return m_scrollingTree->mainFrameScaleFactor();
+}
+
+FloatSize RemoteScrollingCoordinatorProxy::totalContentsSize() const
+{
+    return m_scrollingTree->totalContentsSize();
+}
+
 void RemoteScrollingCoordinatorProxy::displayDidRefresh(PlatformDisplayID displayID)
 {
     m_scrollingTree->displayDidRefresh(displayID);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -134,6 +134,14 @@ public:
     void removeWheelEventTestCompletionDeferralForReason(WebCore::ScrollingNodeID, WebCore::WheelEventTestMonitor::DeferReason);
 
     virtual void windowScreenDidChange(WebCore::PlatformDisplayID, std::optional<WebCore::FramesPerSecond>) { }
+    
+    WebCore::FloatPoint currentMainFrameScrollPosition() const;
+    WebCore::FloatRect computeVisibleContentRect();
+    WebCore::IntPoint scrollOrigin() const;
+    int headerHeight() const;
+    int footerHeight() const;
+    float mainFrameScaleFactor() const;
+    WebCore::FloatSize totalContentsSize() const;
 
 protected:
     RemoteScrollingTree* scrollingTree() const { return m_scrollingTree.get(); }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
@@ -38,6 +38,7 @@
 #import <WebCore/FloatPoint.h>
 #import <WebCore/ScrollView.h>
 #import <WebCore/ScrollingTreeFrameScrollingNode.h>
+#import <WebCore/ScrollingTreeScrollingNode.h>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
 #import <wtf/BlockObjCExceptions.h>
 
@@ -200,20 +201,38 @@ void RemoteLayerTreeDrawingAreaProxyMac::adjustTransientZoom(double scale, Float
 
 void RemoteLayerTreeDrawingAreaProxyMac::commitTransientZoom(double scale, FloatPoint origin)
 {
-    LOG_WITH_STREAM(ViewGestures, stream << "RemoteLayerTreeDrawingAreaProxyMac::commitTransientZoom - scale " << scale << " origin " << origin);
+    auto constrainedOrigin = origin;
 
+    auto visibleContentRect = m_webPageProxy.scrollingCoordinatorProxy()->computeVisibleContentRect();
+    
+    constrainedOrigin = visibleContentRect.location();
+    constrainedOrigin.moveBy(-origin);
+
+    IntSize scaledTotalContentsSize = roundedIntSize(m_webPageProxy.scrollingCoordinatorProxy()->totalContentsSize());
+    scaledTotalContentsSize.scale(scale / m_webPageProxy.scrollingCoordinatorProxy()->mainFrameScaleFactor());
+
+    LOG_WITH_STREAM(Scrolling, stream << "RemoteLayerTreeDrawingAreaProxyMac::commitTransientZoom constrainScrollPositionForOverhang - constrainedOrigin: " << constrainedOrigin << " visibleContentRect: " << visibleContentRect << " scaledTotalContentsSize: " << scaledTotalContentsSize << "scrollOrigin :"<<m_webPageProxy.scrollingCoordinatorProxy()->scrollOrigin() << "headerHeight :" << m_webPageProxy.scrollingCoordinatorProxy()->headerHeight() << " footerHeight : " << m_webPageProxy.scrollingCoordinatorProxy()->footerHeight());
+    
+    // Scaling may have exposed the overhang area, so we need to constrain the final
+    // layer position exactly like scrolling will once it's committed, to ensure that
+    // scrolling doesn't make the view jump.
+    constrainedOrigin = ScrollableArea::constrainScrollPositionForOverhang(roundedIntRect(visibleContentRect), scaledTotalContentsSize, roundedIntPoint(constrainedOrigin), m_webPageProxy.scrollingCoordinatorProxy()->scrollOrigin(), m_webPageProxy.scrollingCoordinatorProxy()->headerHeight(), m_webPageProxy.scrollingCoordinatorProxy()->footerHeight());
+    constrainedOrigin.moveBy(-visibleContentRect.location());
+    constrainedOrigin = -constrainedOrigin;
+    
+    LOG_WITH_STREAM(Scrolling, stream << "RemoteLayerTreeDrawingAreaProxyMac::commitTransientZoom - constrainedOrigin: " << constrainedOrigin << " origin: " << origin << " scale: " << scale);
+    
     auto transientZoomScale = std::exchange(m_transientZoomScale, { });
     auto transientZoomOrigin = std::exchange(m_transientZoomOrigin, { });
     
-    if (transientZoomScale == scale && roundedIntPoint(*transientZoomOrigin) == roundedIntPoint(origin)) {
+    if (transientZoomScale == scale && roundedIntPoint(*transientZoomOrigin) == roundedIntPoint(constrainedOrigin)) {
         // We're already at the right scale and position, so we don't need to animate.
         m_transactionIDAfterEndingTransientZoom = nextLayerTreeTransactionID();
         m_webPageProxy.send(Messages::DrawingArea::CommitTransientZoom(scale, origin), m_identifier);
         return;
     }
-    // TODO: Need to perform origin constraining here like in TiledCoreAnimationDrawingArea
     TransformationMatrix transform;
-    transform.translate(origin.x(), origin.y());
+    transform.translate(constrainedOrigin.x(), constrainedOrigin.y());
     transform.scale(scale);
     BEGIN_BLOCK_OBJC_EXCEPTIONS
 
@@ -223,17 +242,16 @@ void RemoteLayerTreeDrawingAreaProxyMac::commitTransientZoom(double scale, Float
     NSValue *transformValue = [NSValue valueWithCATransform3D:transform];
     [renderViewAnimationCA setToValue:transformValue];
     
-    [CATransaction setCompletionBlock:[layerForPageScale, this, scale, origin, transform] () {
+    [CATransaction setCompletionBlock:[layerForPageScale, this, scale, constrainedOrigin, transform] () {
         layerForPageScale.transform = transform;
         [layerForPageScale removeAnimationForKey:transientAnimationKey];
         [layerForPageScale removeAnimationForKey:@"transientZoomCommit"];
         m_transactionIDAfterEndingTransientZoom = nextLayerTreeTransactionID();
-        m_webPageProxy.send(Messages::DrawingArea::CommitTransientZoom(scale, origin), m_identifier);
+        m_webPageProxy.send(Messages::DrawingArea::CommitTransientZoom(scale, constrainedOrigin), m_identifier);
     }];
 
     [layerForPageScale addAnimation:renderViewAnimationCA.get() forKey:@"transientZoomCommit"];
     [CATransaction commit];
-    if (layerForPageScale && renderViewAnimationCA) { }
     END_BLOCK_OBJC_EXCEPTIONS
 }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
@@ -40,8 +40,6 @@ public:
     explicit RemoteScrollingCoordinatorProxyMac(WebPageProxy&);
     ~RemoteScrollingCoordinatorProxyMac();
 
-    WebCore::FloatPoint currentMainFrameScrollPosition() const;
-
 private:
     void handleWheelEvent(const NativeWebWheelEvent&, WebCore::RectEdges<bool> rubberBandableEdges) override;
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
@@ -61,11 +61,6 @@ RemoteScrollingCoordinatorProxyMac::~RemoteScrollingCoordinatorProxyMac()
 #endif
 }
 
-FloatPoint RemoteScrollingCoordinatorProxyMac::currentMainFrameScrollPosition() const
-{
-    return scrollingTree()->mainFrameScrollPosition();
-}
-
 void RemoteScrollingCoordinatorProxyMac::handleWheelEvent(const NativeWebWheelEvent& nativeWheelEvent, RectEdges<bool> rubberBandableEdges)
 {
 #if ENABLE(SCROLLING_THREAD)

--- a/Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm
@@ -96,7 +96,6 @@ void RemoteLayerTreeDrawingAreaMac::commitTransientZoom(double scale, WebCore::F
 
     scale *= m_webPage.viewScaleFactor();
     
-    // FIXME: Constrain scale and origin
     applyTransientZoomToPage(scale, origin);
 }
 

--- a/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
@@ -731,6 +731,8 @@ void TiledCoreAnimationDrawingArea::commitTransientZoom(double scale, FloatPoint
     IntSize scaledTotalContentsSize = frameView.totalContentsSize();
     scaledTotalContentsSize.scale(scale / m_webPage.totalScaleFactor());
 
+    LOG_WITH_STREAM(Scrolling, stream << "TiledCoreAnimationDrawingArea::commitTransientZoom constrainScrollPositionForOverhang - constrainedOrigin: " << constrainedOrigin << " visibleContentRect: " << visibleContentRect << " scaledTotalContentsSize: " << scaledTotalContentsSize << "scrollOrigin :"<<frameView.scrollOrigin() << "headerHeight :" << frameView.headerHeight() << " footerHeight : " << frameView.footerHeight());
+
     // Scaling may have exposed the overhang area, so we need to constrain the final
     // layer position exactly like scrolling will once it's committed, to ensure that
     // scrolling doesn't make the view jump.


### PR DESCRIPTION
#### d1ac2b0c842b877514d0109437565162ebf7272b
<pre>
[UI-side compositing] Have pinch zoom constrain zoom origin in commitTransientZoom
<a href="https://bugs.webkit.org/show_bug.cgi?id=252345">https://bugs.webkit.org/show_bug.cgi?id=252345</a>
rdar://105515035

Reviewed by Simon Fraser.

Mirror TiledCoreAnimationDrawingArea code by constraining the zoom origin to prevent
view jumping after commiting a zoom in certain scenarios. We do this by querying
the root frame scrolling node about certain state to pass to the ScrollableArea
static function constrainScrollPositionForOverhang(). We also pass this constrained
origin to the WebProcess. We also add several functions to ScrollingTree and
RemoteScrollingCoordinatorProxy to retreive root node state while holding the tree
lock. It was also necessary to change ScrollingTree::mainFrameScrollPosition to use
the root node&apos;s scroll position rather than mainFrameScrollPosition since that
member does not appear to be updated with UI-side compositing on.

* Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::commitTransientZoom):
* Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm:
(WebKit::RemoteLayerTreeDrawingAreaMac::commitTransientZoom):

Canonical link: <a href="https://commits.webkit.org/261226@main">https://commits.webkit.org/261226@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de931d21e5b7593bbd9baa9529ff164fa2b6c10d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110812 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19898 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43356 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2343 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119709 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114774 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21295 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10999 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/2025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116562 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15866 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99026 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103212 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97826 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30692 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44259 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12504 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32028 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86142 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13064 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9008 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18438 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15009 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4255 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->