### PR TITLE
PlaybackSessionManager and VideoFullscreenManager should use WeakPtr and WeakHashMap

### DIFF
--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
@@ -30,7 +30,7 @@
 #include "MessageReceiver.h"
 #include "PlaybackSessionContextIdentifier.h"
 #include <WebCore/EventListener.h>
-#include <WebCore/HTMLMediaElementEnums.h>
+#include <WebCore/HTMLMediaElement.h>
 #include <WebCore/PlatformCALayer.h>
 #include <WebCore/PlatformMediaSession.h>
 #include <WebCore/PlaybackSessionModelMediaElement.h>
@@ -38,6 +38,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
+#include <wtf/WeakHashMap.h>
 
 namespace IPC {
 class Connection;
@@ -165,8 +166,8 @@ private:
     void setPlayingOnSecondScreen(PlaybackSessionContextIdentifier, bool value);
     void sendRemoteCommand(PlaybackSessionContextIdentifier, WebCore::PlatformMediaSession::RemoteControlCommandType, const WebCore::PlatformMediaSession::RemoteCommandArgument&);
 
-    WebPage* m_page;
-    HashMap<WebCore::HTMLMediaElement*, PlaybackSessionContextIdentifier> m_mediaElements;
+    WeakPtr<WebPage> m_page;
+    WeakHashMap<WebCore::HTMLMediaElement, PlaybackSessionContextIdentifier, WebCore::WeakPtrImplWithEventTargetData> m_mediaElements;
     HashMap<PlaybackSessionContextIdentifier, ModelInterfaceTuple> m_contextMap;
     PlaybackSessionContextIdentifier m_controlsManagerContextId;
     HashCountedSet<PlaybackSessionContextIdentifier> m_clientCounts;

--- a/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.h
+++ b/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.h
@@ -31,13 +31,14 @@
 #include "MessageReceiver.h"
 #include "PlaybackSessionContextIdentifier.h"
 #include <WebCore/EventListener.h>
-#include <WebCore/HTMLMediaElementEnums.h>
+#include <WebCore/HTMLVideoElement.h>
 #include <WebCore/PlatformCALayer.h>
 #include <WebCore/VideoFullscreenModelVideoElement.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/HashMap.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
+#include <wtf/WeakHashMap.h>
 
 namespace IPC {
 class Connection;
@@ -170,9 +171,9 @@ protected:
 
     void setCurrentlyInFullscreen(VideoFullscreenInterfaceContext&, bool);
 
-    WebPage* m_page;
+    WeakPtr<WebPage> m_page;
     Ref<PlaybackSessionManager> m_playbackSessionManager;
-    HashMap<WebCore::HTMLVideoElement*, PlaybackSessionContextIdentifier> m_videoElements;
+    WeakHashMap<WebCore::HTMLVideoElement, PlaybackSessionContextIdentifier, WebCore::WeakPtrImplWithEventTargetData> m_videoElements;
     HashMap<PlaybackSessionContextIdentifier, ModelInterfaceTuple> m_contextMap;
     PlaybackSessionContextIdentifier m_controlsManagerContextId;
     HashMap<PlaybackSessionContextIdentifier, int> m_clientCounts;

--- a/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm
@@ -195,10 +195,11 @@ void VideoFullscreenManager::removeContext(PlaybackSessionContextIdentifier cont
     m_playbackSessionManager->removeClientForContext(contextId);
 
     RefPtr<HTMLVideoElement> videoElement = model->videoElement();
+    RELEASE_ASSERT(videoElement);
     model->setVideoElement(nullptr);
     model->removeClient(*interface);
     interface->invalidate();
-    m_videoElements.remove(videoElement.get());
+    m_videoElements.remove(*videoElement);
     m_contextMap.remove(contextId);
 }
 
@@ -283,7 +284,7 @@ void VideoFullscreenManager::enterVideoFullscreenForVideoElement(HTMLVideoElemen
     LOG(Fullscreen, "VideoFullscreenManager::enterVideoFullscreenForVideoElement(%p)", this);
 
     auto contextId = m_playbackSessionManager->contextIdForMediaElement(videoElement);
-    auto addResult = m_videoElements.add(&videoElement, contextId);
+    auto addResult = m_videoElements.add(videoElement, contextId);
     UNUSED_PARAM(addResult);
     ASSERT(addResult.iterator->value == contextId);
 
@@ -348,9 +349,9 @@ void VideoFullscreenManager::exitVideoFullscreenForVideoElement(HTMLVideoElement
 {
     LOG(Fullscreen, "VideoFullscreenManager::exitVideoFullscreenForVideoElement(%p)", this);
     ASSERT(m_page);
-    ASSERT(m_videoElements.contains(&videoElement));
+    ASSERT(m_videoElements.contains(videoElement));
 
-    auto contextId = m_videoElements.get(&videoElement);
+    auto contextId = m_videoElements.get(videoElement);
     auto& interface = ensureInterface(contextId);
     if (interface.animationState() != VideoFullscreenInterfaceContext::AnimationType::None) {
         completionHandler(false);
@@ -378,12 +379,12 @@ void VideoFullscreenManager::exitVideoFullscreenToModeWithoutAnimation(HTMLVideo
     LOG(Fullscreen, "VideoFullscreenManager::exitVideoFullscreenToModeWithoutAnimation(%p)", this);
 
     ASSERT(m_page);
-    ASSERT(m_videoElements.contains(&videoElement));
+    ASSERT(m_videoElements.contains(videoElement));
 
     if (m_videoElementInPictureInPicture == &videoElement)
         m_videoElementInPictureInPicture = nullptr;
 
-    auto contextId = m_videoElements.get(&videoElement);
+    auto contextId = m_videoElements.get(videoElement);
     if (!contextId.isValid()) {
         // We have somehow managed to be asked to exit video fullscreen
         // for a video element which was either never in fullscreen or


### PR DESCRIPTION
#### b51fc8ba75c9d04015a051e0c4ab8dd854a49e9c
<pre>
PlaybackSessionManager and VideoFullscreenManager should use WeakPtr and WeakHashMap
<a href="https://bugs.webkit.org/show_bug.cgi?id=252348">https://bugs.webkit.org/show_bug.cgi?id=252348</a>

Reviewed by Chris Dumez.

Deployed WeakPtr and WeakHashMap in PlaybackSessionManager and VideoFullscreenManager.

* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h:
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm:
(WebKit::PlaybackSessionManager::PlaybackSessionManager):
(WebKit::PlaybackSessionManager::removeContext):
(WebKit::PlaybackSessionManager::setUpPlaybackControlsManager):
(WebKit::PlaybackSessionManager::contextIdForMediaElement):
* Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.h:
* Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm:
(WebKit::VideoFullscreenManager::removeContext):
(WebKit::VideoFullscreenManager::enterVideoFullscreenForVideoElement):
(WebKit::VideoFullscreenManager::exitVideoFullscreenForVideoElement):
(WebKit::VideoFullscreenManager::exitVideoFullscreenToModeWithoutAnimation):

Canonical link: <a href="https://commits.webkit.org/260382@main">https://commits.webkit.org/260382@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33a922ff2450f4ad9ec0e2c8f4f50e9dc76f2d86

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108029 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17089 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40906 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117159 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116491 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18463 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8401 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100227 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113795 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13930 "Found 7 new test failures: editing/deleting/smart-delete-002.html, editing/deleting/smart-delete-paragraph-002.html, editing/pasteboard/smart-paste-002.html, editing/pasteboard/smart-paste-006.html, editing/pasteboard/smart-paste-paragraph-003.html, editing/selection/doubleclick-whitespace-crash.html, editing/selection/ios/selection-handle-clamping-in-iframe.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97150 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41846 "Found 3 new test failures: fast/events/monotonic-event-time.html, imported/w3c/web-platform-tests/fetch/stale-while-revalidate/stale-css.html, imported/w3c/web-platform-tests/fetch/stale-while-revalidate/stale-image.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95839 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28788 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/83515 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9992 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30136 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10710 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7035 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16142 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49726 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12287 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3903 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->