### PR TITLE
Drop _WKWebsiteDataTypeFileSystem

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.h
@@ -62,7 +62,7 @@ WK_EXTERN NSString * const WKWebsiteDataTypeServiceWorkerRegistrations WK_API_AV
 /*! @constant WKWebsiteDataTypeFileSystem File system storage. */
 WK_EXTERN NSString * const WKWebsiteDataTypeFileSystem WK_API_AVAILABLE(macos(13.0), ios(16.0));
 
-/*! @constant WKWebsiteDataTypeFileSystem Search field history. */
+/*! @constant WKWebsiteDataTypeSearchFieldRecentSearches Search field history. */
 WK_EXTERN NSString * const WKWebsiteDataTypeSearchFieldRecentSearches WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 /*! A WKWebsiteDataRecord represents website data, grouped by domain name using the public suffix list. */

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.mm
@@ -53,7 +53,6 @@ NSString * const _WKWebsiteDataTypeCredentials = @"_WKWebsiteDataTypeCredentials
 NSString * const _WKWebsiteDataTypeAdClickAttributions = @"_WKWebsiteDataTypeAdClickAttributions";
 NSString * const _WKWebsiteDataTypePrivateClickMeasurements = @"_WKWebsiteDataTypePrivateClickMeasurements";
 NSString * const _WKWebsiteDataTypeAlternativeServices = @"_WKWebsiteDataTypeAlternativeServices";
-NSString * const _WKWebsiteDataTypeFileSystem = WKWebsiteDataTypeFileSystem;
 
 #if PLATFORM(MAC)
 NSString * const _WKWebsiteDataTypePlugInData = @"_WKWebsiteDataTypePlugInData";
@@ -115,8 +114,6 @@ static NSString *dataTypesToString(NSSet *dataTypes)
         [array addObject:@"Private Click Measurements"];
     if ([dataTypes containsObject:_WKWebsiteDataTypeAlternativeServices])
         [array addObject:@"Alternative Services"];
-    if ([dataTypes containsObject:_WKWebsiteDataTypeFileSystem])
-        [array addObject:@"File System"];
 
     return [array componentsJoinedByString:@", "];
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecordPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecordPrivate.h
@@ -38,8 +38,6 @@ WK_EXTERN NSString * const _WKWebsiteDataTypeCredentials WK_API_AVAILABLE(macos(
 WK_EXTERN NSString * const _WKWebsiteDataTypeAdClickAttributions WK_API_AVAILABLE(macos(10.15), ios(13.0));
 WK_EXTERN NSString * const _WKWebsiteDataTypePrivateClickMeasurements WK_API_AVAILABLE(macos(12.0), ios(15.0));
 WK_EXTERN NSString * const _WKWebsiteDataTypeAlternativeServices WK_API_AVAILABLE(macos(11.0), ios(14.0));
-// _WKWebsiteDataTypeFileSystem will be deprecated; please use WKWebsiteDataTypeFileSystem.
-WK_EXTERN NSString * const _WKWebsiteDataTypeFileSystem WK_API_AVAILABLE(macos(13.0), ios(16.0));
 
 #if !TARGET_OS_IPHONE
 WK_EXTERN NSString * const _WKWebsiteDataTypePlugInData WK_API_AVAILABLE(macos(10.11));


### PR DESCRIPTION
#### 7c99453362807ed708bc1f4959fa985d9a20674f
<pre>
Drop _WKWebsiteDataTypeFileSystem
<a href="https://bugs.webkit.org/show_bug.cgi?id=252352">https://bugs.webkit.org/show_bug.cgi?id=252352</a>
rdar://105517561

Reviewed by Alex Christensen.

WKWebsiteDataTypeFileSystem is the replacement and existing client starts to use the new one.

* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.mm:
(dataTypesToString):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecordPrivate.h:

Canonical link: <a href="https://commits.webkit.org/260386@main">https://commits.webkit.org/260386@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71fad7506db68b326a6f411ecd70a731f9e0601d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108033 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17093 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40910 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117163 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116495 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18467 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8405 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100231 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113799 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13927 "Too many flaky failures: editing/deleting/smart-delete-002.html, editing/deleting/smart-delete-004.html, editing/deleting/smart-delete-paragraph-002.html, editing/deleting/smart-editing-disabled-win.html, editing/pasteboard/smart-paste-002.html, editing/pasteboard/smart-paste-004.html, editing/pasteboard/smart-paste-006.html, editing/pasteboard/smart-paste-008.html, editing/pasteboard/smart-paste-paragraph-003.html, editing/pasteboard/style-from-rules.html, editing/selection/doubleclick-whitespace-crash.html, editing/selection/ios/selection-handle-clamping-in-iframe.html, imported/w3c/web-platform-tests/html/semantics/popovers/popover-animated-hide-cleanup.tentative.html, platform/ipad/fast/viewport/empty-meta.html, platform/ipad/fast/viewport/meta-viewport-ignored.html, platform/ipad/fast/viewport/width-is-device-width.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97149 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41851 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95836 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28787 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/83520 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9996 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30135 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10714 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7036 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/update-not-allowed.https.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16146 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49725 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7187 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12291 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->