### PR TITLE
Add block-step-size to CSS parser.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -33,6 +33,7 @@ PASS background-repeat
 PASS background-size
 PASS baseline-shift
 PASS block-size
+PASS block-step-size
 PASS border-block-end-color
 PASS border-block-end-style
 PASS border-block-end-width

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-size-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-size-computed-expected.txt
@@ -1,0 +1,8 @@
+
+PASS Property block-step-size value '0px'
+PASS Property block-step-size value 'none'
+PASS Property block-step-size value '100px'
+PASS Property block-step-size value '2em'
+PASS Property block-step-size value 'calc(10px + 0.5em)'
+PASS Property block-step-size value 'calc(10px - 0.5em)'
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-size-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-size-computed.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Rhythm: block-step-size computed values</title>
+<link rel="author" title="Sammy Gill" href="sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<meta name="assert" content="Checking computed values for block-step-size">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<style>
+    #target {
+      font-size: 40px;
+    }
+</style>
+</head>
+<body>
+<div id="target"></div>
+<script>
+    test_computed_value("block-step-size", "0px");
+    test_computed_value("block-step-size", "none");
+    test_computed_value("block-step-size", "100px");
+    test_computed_value("block-step-size", "2em", "80px");
+    test_computed_value("block-step-size", "calc(10px + 0.5em)", "30px");
+    test_computed_value("block-step-size", "calc(10px - 0.5em)", "0px");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-size-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-size-invalid-expected.txt
@@ -1,0 +1,7 @@
+
+PASS e.style['block-step-size'] = "auto" should not set the property value
+PASS e.style['block-step-size'] = "-1px" should not set the property value
+PASS e.style['block-step-size'] = "min-content" should not set the property value
+PASS e.style['block-step-size'] = "10%" should not set the property value
+PASS e.style['block-step-size'] = "20" should not set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-size-invalid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-size-invalid.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Rhythm: block-step-size invalid values</title>
+<link rel="author" title="Sammy Gill" href="sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<meta name="assert" content="Invalid values for block-step-size should not be parsed">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<style>
+    #target {
+      font-size: 40px;
+    }
+</style>
+</head>
+<body>
+<div id="target"></div>
+<script>
+    test_invalid_value("block-step-size", "auto");
+    test_invalid_value("block-step-size", "-1px");
+    test_invalid_value("block-step-size", "min-content");
+    test_invalid_value("block-step-size", "10%");
+    test_invalid_value("block-step-size", "20");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-size-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-size-valid-expected.txt
@@ -1,0 +1,8 @@
+
+PASS e.style['block-step-size'] = "1px" should set the property value
+PASS e.style['block-step-size'] = "2em" should set the property value
+PASS e.style['block-step-size'] = "0" should set the property value
+PASS e.style['block-step-size'] = "none" should set the property value
+PASS e.style['block-step-size'] = "calc(2em + 3ex)" should set the property value
+PASS e.style['block-step-size'] = "1.2em" should set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-size-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-size-valid.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Rhythm: block-step-size valid values</title>
+<link rel="author" title="Sammy Gill" href="sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<meta name="assert" content="Parsing valid values for block-step-size properties">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<style>
+    #target {
+      font-size: 40px;
+    }
+</style>
+</head>
+<body>
+<div id="target"></div>
+<script>
+    test_valid_value("block-step-size", "1px");
+    test_valid_value("block-step-size", "2em");
+    test_valid_value("block-step-size", "0", "0px");
+    test_valid_value("block-step-size", "none");
+    test_valid_value("block-step-size", "calc(2em + 3ex)");
+    test_valid_value("block-step-size", "1.2em");
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -33,6 +33,7 @@ PASS background-repeat
 PASS background-size
 PASS baseline-shift
 PASS block-size
+PASS block-step-size
 PASS border-block-end-color
 PASS border-block-end-style
 PASS border-block-end-width

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -33,6 +33,7 @@ PASS background-repeat
 PASS background-size
 PASS baseline-shift
 PASS block-size
+PASS block-step-size
 PASS border-block-end-color
 PASS border-block-end-style
 PASS border-block-end-width

--- a/LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -33,6 +33,7 @@ PASS background-repeat
 PASS background-size
 PASS baseline-shift
 PASS block-size
+PASS block-step-size
 PASS border-block-end-color
 PASS border-block-end-style
 PASS border-block-end-width

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -33,6 +33,7 @@ PASS background-repeat
 PASS background-size
 PASS baseline-shift
 PASS block-size
+PASS block-step-size
 PASS border-block-end-color
 PASS border-block-end-style
 PASS border-block-end-width

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -33,6 +33,7 @@ PASS background-repeat
 PASS background-size
 PASS baseline-shift
 PASS block-size
+PASS block-step-size
 PASS border-block-end-color
 PASS border-block-end-style
 PASS border-block-end-width

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -3662,6 +3662,7 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         case CSSPropertyAnimationPlayState:
         case CSSPropertyAnimationTimingFunction:
         case CSSPropertyAppearance:
+        case CSSPropertyBlockStepSize:
         case CSSPropertyBorderBlock: // logical shorthand
         case CSSPropertyBorderBlockColor: // logical shorthand
         case CSSPropertyBorderBlockStyle: // logical shorthand

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -323,6 +323,17 @@
                 "url": "https://drafts.csswg.org/css-grid-3/#tracks-alignment"
             }
         },
+        "block-step-size": {
+            "codegen-properties": {
+                "settings-flag": "cssRhythmicSizingEnabled",
+                "converter": "BlockStepSize",
+                "parser-grammar": "none | <length [0,inf]>"
+            },
+            "specification": {
+                "category": "css-rhythm",
+                "url": "https://drafts.csswg.org/css-rhythm/#block-step-size"
+            }
+        },
         "caret-color": {
             "inherited": true,
             "values": [

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -2846,6 +2846,12 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
             list.append(createSingleAxisPositionValueForLayer(propertyID, *currLayer, style));
         return CSSValueList::createCommaSeparated(WTFMove(list));
     }
+    case CSSPropertyBlockStepSize: {
+        auto blockStepSize = style.blockStepSize();
+        if (!blockStepSize)
+            return CSSPrimitiveValue::create(CSSValueNone);
+        return zoomAdjustedPixelValueForLength(*blockStepSize, style);
+    }
     case CSSPropertyBorderCollapse:
         if (style.borderCollapse() == BorderCollapse::Collapse)
             return CSSPrimitiveValue::create(CSSValueCollapse);

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -2052,6 +2052,10 @@ public:
     void setOverflowAnchor(OverflowAnchor a) { SET_NESTED_VAR(m_nonInheritedData, rareData, overflowAnchor, static_cast<unsigned>(a)); }
     static OverflowAnchor initialOverflowAnchor() { return OverflowAnchor::Auto; }
 
+    static std::optional<Length> initialBlockStepSize() { return { }; }
+    std::optional<Length> blockStepSize() const { return m_nonInheritedData->rareData->blockStepSize; } 
+    void setBlockStepSize(std::optional<Length> length) { SET_NESTED_VAR(m_nonInheritedData, rareData, blockStepSize, length); } 
+
 private:
     struct NonInheritedFlags {
         bool operator==(const NonInheritedFlags&) const;

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
@@ -85,6 +85,7 @@ StyleRareNonInheritedData::StyleRareNonInheritedData()
     // scrollSnapAlign
     // scrollSnapStop
     , zoom(RenderStyle::initialZoom())
+    , blockStepSize(RenderStyle::initialBlockStepSize())
     , overscrollBehaviorX(static_cast<unsigned>(RenderStyle::initialOverscrollBehaviorX()))
     , overscrollBehaviorY(static_cast<unsigned>(RenderStyle::initialOverscrollBehaviorY()))
     , pageSizeType(PAGE_SIZE_AUTO)
@@ -165,6 +166,7 @@ inline StyleRareNonInheritedData::StyleRareNonInheritedData(const StyleRareNonIn
     , scrollSnapAlign(o.scrollSnapAlign)
     , scrollSnapStop(o.scrollSnapStop)
     , zoom(o.zoom)
+    , blockStepSize(o.blockStepSize)
     , overscrollBehaviorX(o.overscrollBehaviorX)
     , overscrollBehaviorY(o.overscrollBehaviorY)
     , pageSizeType(o.pageSizeType)
@@ -252,6 +254,7 @@ bool StyleRareNonInheritedData::operator==(const StyleRareNonInheritedData& o) c
         && scrollSnapAlign == o.scrollSnapAlign
         && scrollSnapStop == o.scrollSnapStop
         && zoom == o.zoom
+        && blockStepSize == o.blockStepSize
         && overscrollBehaviorX == o.overscrollBehaviorX
         && overscrollBehaviorY == o.overscrollBehaviorY
         && pageSizeType == o.pageSizeType

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -173,6 +173,8 @@ public:
 
     float zoom;
 
+    std::optional<Length> blockStepSize;
+
     unsigned overscrollBehaviorX : 2; // OverscrollBehavior
     unsigned overscrollBehaviorY : 2; // OverscrollBehavior
 

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -191,6 +191,8 @@ public:
     static TextSpacingTrim convertTextSpacingTrim(BuilderState&, const CSSValue&);
     static TextAutospace convertTextAutospace(BuilderState&, const CSSValue&);
 
+    static std::optional<Length> convertBlockStepSize(BuilderState&, const CSSValue&);
+    
 private:
     friend class BuilderCustom;
 
@@ -1829,6 +1831,13 @@ inline TextAutospace BuilderConverter::convertTextAutospace(BuilderState&, const
             return { .m_autoSpace = TextAutospace::TextAutospaceType::Auto };
     }
     return { };
+}
+
+inline std::optional<Length> BuilderConverter::convertBlockStepSize(BuilderState& builderState, const CSSValue& value)
+{
+    if (downcast<CSSPrimitiveValue>(value).valueID() == CSSValueNone)
+        return { };
+    return convertLength(builderState, value);
 }
 
 } // namespace Style


### PR DESCRIPTION
#### 84095e2b636a19c1b36519d6869d0cd4e11f98df
<pre>
Add block-step-size to CSS parser.
<a href="https://bugs.webkit.org/show_bug.cgi?id=252205">https://bugs.webkit.org/show_bug.cgi?id=252205</a>
rdar://105421486

Reviewed by Tim Nguyen.

Grammar for property: none | &lt;length [0,∞]&gt;

We store the value within a std::optional&lt;Length&gt; within
StyleRareNonInheritedData. If we get an invalid value or &quot;none,&quot; this
field will not have a value inside of it. Otherwise, we will store the
specified length as the value.

It seems like it is currently an open discussion as to whether it should
be animatable, so we mark it as a property that cannot be animated. If
the spec changes, then we will need to make the proper changes.

* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-size-computed-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-size-computed.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-size-invalid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-size-invalid.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-size-valid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-size-valid.html: Added.
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle):
* Source/WebCore/rendering/style/RenderStyle.h:
(WebCore::RenderStyle::initialBlockStepSize):
(WebCore::RenderStyle::blockStepSize const):
(WebCore::RenderStyle::setBlockStepSize):
* Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp:
(WebCore::StyleRareNonInheritedData::StyleRareNonInheritedData):
(WebCore::StyleRareNonInheritedData::operator== const):
* Source/WebCore/rendering/style/StyleRareNonInheritedData.h:
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertBlockStepSize):

Canonical link: <a href="https://commits.webkit.org/260574@main">https://commits.webkit.org/260574@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca1c50b7633f0ab6fe4429208dee3d23d709565b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108695 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17797 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41553 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117805 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/118002 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112578 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19248 "Build is being retried. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9074 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100930 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114462 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14444 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97671 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42417 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96417 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29310 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/84178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10601 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30661 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11360 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7576 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16750 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50251 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7314 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12949 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->