### PR TITLE
Update parserSetAttributes() to take in a Span instead of a Vector

### DIFF
--- a/Source/WebCore/dom/DocumentSharedObjectPool.cpp
+++ b/Source/WebCore/dom/DocumentSharedObjectPool.cpp
@@ -59,16 +59,16 @@ ALWAYS_INLINE bool equalAttributes(const uint8_t* a, const uint8_t* b, unsigned 
 }
 #endif
 
-inline bool hasSameAttributes(const Vector<Attribute>& attributes, ShareableElementData& elementData)
+inline bool hasSameAttributes(Span<const Attribute> attributes, ShareableElementData& elementData)
 {
     if (attributes.size() != elementData.length())
         return false;
     return equalAttributes(reinterpret_cast<const uint8_t*>(attributes.data()), reinterpret_cast<const uint8_t*>(elementData.m_attributeArray), attributes.size() * sizeof(Attribute));
 }
 
-Ref<ShareableElementData> DocumentSharedObjectPool::cachedShareableElementDataWithAttributes(const Vector<Attribute>& attributes)
+Ref<ShareableElementData> DocumentSharedObjectPool::cachedShareableElementDataWithAttributes(Span<const Attribute> attributes)
 {
-    ASSERT(!attributes.isEmpty());
+    ASSERT(!attributes.empty());
 
     auto& cachedData = m_shareableElementDataCache.add(computeHash(attributes), nullptr).iterator->value;
 

--- a/Source/WebCore/dom/DocumentSharedObjectPool.h
+++ b/Source/WebCore/dom/DocumentSharedObjectPool.h
@@ -39,7 +39,7 @@ class ShareableElementData;
 class DocumentSharedObjectPool {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    Ref<ShareableElementData> cachedShareableElementDataWithAttributes(const Vector<Attribute>&);
+    Ref<ShareableElementData> cachedShareableElementDataWithAttributes(Span<const Attribute>);
 
 private:
     typedef HashMap<unsigned, RefPtr<ShareableElementData>, AlreadyHashed> ShareableElementDataCache;

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2464,24 +2464,24 @@ void Element::stripScriptingAttributes(Vector<Attribute>& attributeVector) const
     });
 }
 
-void Element::parserSetAttributes(const Vector<Attribute>& attributeVector)
+void Element::parserSetAttributes(Span<const Attribute> attributes)
 {
     ASSERT(!isConnected());
     ASSERT(!parentNode());
     ASSERT(!m_elementData);
 
-    if (!attributeVector.isEmpty()) {
+    if (attributes.size()) {
         if (document().sharedObjectPool())
-            m_elementData = document().sharedObjectPool()->cachedShareableElementDataWithAttributes(attributeVector);
+            m_elementData = document().sharedObjectPool()->cachedShareableElementDataWithAttributes(attributes);
         else
-            m_elementData = ShareableElementData::createWithAttributes(attributeVector);
+            m_elementData = ShareableElementData::createWithAttributes(attributes);
 
     }
 
     parserDidSetAttributes();
 
-    // Use attributeVector instead of m_elementData because attributeChanged might modify m_elementData.
-    for (const auto& attribute : attributeVector)
+    // Use attributes instead of m_elementData because attributeChanged might modify m_elementData.
+    for (const auto& attribute : attributes)
         attributeChanged(attribute.name(), nullAtom(), attribute.value(), ModifiedDirectly);
 }
 

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -310,7 +310,7 @@ public:
     virtual void parseAttribute(const QualifiedName&, const AtomString&) { }
 
     // Only called by the parser immediately after element construction.
-    void parserSetAttributes(const Vector<Attribute>&);
+    void parserSetAttributes(Span<const Attribute>);
 
     bool isEventHandlerAttribute(const Attribute&) const;
     virtual FormListedElement* asFormListedElement();

--- a/Source/WebCore/dom/ElementData.cpp
+++ b/Source/WebCore/dom/ElementData.cpp
@@ -70,7 +70,7 @@ static size_t sizeForShareableElementDataWithAttributeCount(unsigned count)
     return sizeof(ShareableElementData) + sizeof(Attribute) * count;
 }
 
-Ref<ShareableElementData> ShareableElementData::createWithAttributes(const Vector<Attribute>& attributes)
+Ref<ShareableElementData> ShareableElementData::createWithAttributes(Span<const Attribute> attributes)
 {
     void* slot = ShareableElementDataMalloc::malloc(sizeForShareableElementDataWithAttributeCount(attributes.size()));
     return adoptRef(*new (NotNull, slot) ShareableElementData(attributes));
@@ -81,7 +81,7 @@ Ref<UniqueElementData> UniqueElementData::create()
     return adoptRef(*new UniqueElementData);
 }
 
-ShareableElementData::ShareableElementData(const Vector<Attribute>& attributes)
+ShareableElementData::ShareableElementData(Span<const Attribute> attributes)
     : ElementData(attributes.size())
 {
     unsigned attributeArraySize = arraySize();

--- a/Source/WebCore/dom/ElementData.h
+++ b/Source/WebCore/dom/ElementData.h
@@ -189,9 +189,9 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(ShareableElementData);
 class ShareableElementData : public ElementData {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(ShareableElementData);
 public:
-    static Ref<ShareableElementData> createWithAttributes(const Vector<Attribute>&);
+    static Ref<ShareableElementData> createWithAttributes(Span<const Attribute>);
 
-    explicit ShareableElementData(const Vector<Attribute>&);
+    explicit ShareableElementData(Span<const Attribute>);
     explicit ShareableElementData(const UniqueElementData&);
     ~ShareableElementData();
 

--- a/Source/WebCore/html/parser/HTMLConstructionSite.cpp
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.cpp
@@ -68,7 +68,7 @@ static inline void setAttributes(Element& element, Vector<Attribute>& attributes
 {
     if (!scriptingContentIsAllowed(parserContentPolicy))
         element.stripScriptingAttributes(attributes);
-    element.parserSetAttributes(attributes);
+    element.parserSetAttributes(attributes.span());
     element.setHasDuplicateAttribute(hasDuplicateAttribute == HasDuplicateAttribute::Yes);
 }
 

--- a/Source/WebCore/html/shadow/TextControlInnerElements.cpp
+++ b/Source/WebCore/html/shadow/TextControlInnerElements.cpp
@@ -161,8 +161,8 @@ void TextControlInnerTextElement::updateInnerTextElementEditabilityImpl(bool isE
 {
     const auto& value = isEditable ? plaintextOnlyAtom() : falseAtom();
     if (initialization) {
-        Vector<Attribute> attributes { Attribute(contenteditableAttr, value) };
-        parserSetAttributes(attributes);
+        Attribute attribute(contenteditableAttr, value);
+        parserSetAttributes(Span { &attribute, 1 });
     } else
         setAttributeWithoutSynchronization(contenteditableAttr, value);
 }

--- a/Source/WebCore/xml/XMLErrors.cpp
+++ b/Source/WebCore/xml/XMLErrors.cpp
@@ -85,18 +85,16 @@ static inline Ref<Element> createXHTMLParserErrorHeader(Document& document, Stri
 {
     Ref<Element> reportElement = document.createElement(QualifiedName(nullAtom(), "parsererror"_s, xhtmlNamespaceURI), true);
 
-    Vector<Attribute> reportAttributes;
-    reportAttributes.append(Attribute(styleAttr, "display: block; white-space: pre; border: 2px solid #c77; padding: 0 1em 0 1em; margin: 1em; background-color: #fdd; color: black"_s));
-    reportElement->parserSetAttributes(reportAttributes);
+    Attribute reportAttribute(styleAttr, "display: block; white-space: pre; border: 2px solid #c77; padding: 0 1em 0 1em; margin: 1em; background-color: #fdd; color: black"_s);
+    reportElement->parserSetAttributes(Span { &reportAttribute, 1 });
 
     auto h3 = HTMLHeadingElement::create(h3Tag, document);
     reportElement->parserAppendChild(h3);
     h3->parserAppendChild(Text::create(document, "This page contains the following errors:"_s));
 
     auto fixed = HTMLDivElement::create(document);
-    Vector<Attribute> fixedAttributes;
-    fixedAttributes.append(Attribute(styleAttr, "font-family:monospace;font-size:12px"_s));
-    fixed->parserSetAttributes(fixedAttributes);
+    Attribute fixedAttribute(styleAttr, "font-family:monospace;font-size:12px"_s);
+    fixed->parserSetAttributes(Span { &fixedAttribute, 1 });
     reportElement->parserAppendChild(fixed);
 
     fixed->parserAppendChild(Text::create(document, WTFMove(errorMessages)));
@@ -146,10 +144,9 @@ void XMLErrors::insertErrorMessageBlock()
 
 #if ENABLE(XSLT)
     if (m_document.transformSourceDocument()) {
-        Vector<Attribute> attributes;
-        attributes.append(Attribute(styleAttr, "white-space: normal"_s));
+        Attribute attribute(styleAttr, "white-space: normal"_s);
         auto paragraph = HTMLParagraphElement::create(m_document);
-        paragraph->parserSetAttributes(attributes);
+        paragraph->parserSetAttributes(Span { &attribute, 1 });
         paragraph->parserAppendChild(m_document.createTextNode("This document was created as the result of an XSL transformation. The line and column numbers given are from the transformed result."_s));
         reportElement->parserAppendChild(paragraph);
     }

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -406,7 +406,7 @@ static inline void setAttributes(Element* element, Vector<Attribute>& attributeV
 {
     if (!scriptingContentIsAllowed(parserContentPolicy))
         element->stripScriptingAttributes(attributeVector);
-    element->parserSetAttributes(attributeVector);
+    element->parserSetAttributes(attributeVector.span());
 }
 
 static void switchToUTF16(xmlParserCtxtPtr ctxt)


### PR DESCRIPTION
#### 7ee416a7a42e06bc63dc488a43757ebc9f283bb7
<pre>
Update parserSetAttributes() to take in a Span instead of a Vector
<a href="https://bugs.webkit.org/show_bug.cgi?id=252361">https://bugs.webkit.org/show_bug.cgi?id=252361</a>

Reviewed by Ryosuke Niwa.

Update parserSetAttributes() to take in a Span instead of a Vector.
Its implementation doesn&apos;t require a Vector, a Span suffices. Using a Span has
a couple of benefits:
1. It allows some call sites to not create a Vector at all to set a single
   attribute.
2. It allows call sites to use Vectors that can have various inline capacities.

* Source/WebCore/dom/DocumentSharedObjectPool.cpp:
(WebCore::hasSameAttributes):
(WebCore::DocumentSharedObjectPool::cachedShareableElementDataWithAttributes):
* Source/WebCore/dom/DocumentSharedObjectPool.h:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::parserSetAttributes):
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/ElementData.cpp:
(WebCore::ShareableElementData::createWithAttributes):
(WebCore::ShareableElementData::ShareableElementData):
* Source/WebCore/dom/ElementData.h:
* Source/WebCore/html/parser/HTMLConstructionSite.cpp:
(WebCore::setAttributes):
* Source/WebCore/html/shadow/TextControlInnerElements.cpp:
(WebCore::TextControlInnerTextElement::updateInnerTextElementEditabilityImpl):
* Source/WebCore/xml/XMLErrors.cpp:
(WebCore::createXHTMLParserErrorHeader):
(WebCore::XMLErrors::insertErrorMessageBlock):
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::setAttributes):

Canonical link: <a href="https://commits.webkit.org/260349@main">https://commits.webkit.org/260349@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d26fa9776b3ccc29aa13e446867c9deb8eaf86c8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108051 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17117 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40925 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117178 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111939 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18482 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8420 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100249 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113817 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97163 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/41865 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/95853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28801 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10011 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30149 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10730 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/7049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16161 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49740 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7161 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12309 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->