### PR TITLE
[browserperfdash-benchmark] Add optional --timestamp parameter to send the data to the server with a custom date.

### DIFF
--- a/Tools/Scripts/webkitpy/browserperfdash/browserperfdash_runner.py
+++ b/Tools/Scripts/webkitpy/browserperfdash/browserperfdash_runner.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 Igalia S.L.
+# Copyright (C) 2018-2023 Igalia S.L.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -28,6 +28,7 @@ import logging
 import os
 import tempfile
 import urllib
+from datetime import datetime
 
 from webkitpy.benchmark_runner.benchmark_runner import BenchmarkRunner
 from webkitpy.benchmark_runner.browser_driver.browser_driver_factory import BrowserDriverFactory
@@ -50,6 +51,7 @@ def parse_args():
     parser.add_argument('--local-copy', dest='localCopy', help='Path to a local copy of the benchmark (e.g. PerformanceTests/SunSpider/).')
     parser.add_argument('--count', dest='countOverride', type=int, help='Number of times to run the benchmark (e.g. 5).')
     parser.add_argument('--timeout', dest='timeoutOverride', type=int, help='Number of seconds to wait for the benchmark to finish (e.g. 600).')
+    parser.add_argument('--timestamp', dest='timestamp', type=int, help='Date of when the benchmark was run that will be sent to the performance dashboard server. Format is Unix timestamp (second since epoch). Optional. The server will use as date "now" if not specified.')
     mutual_group = parser.add_mutually_exclusive_group(required=True)
     mutual_group.add_argument('--plan', dest='plan', help='Benchmark plan to run. e.g. speedometer, jetstream')
     mutual_group.add_argument('--allplans', action='store_true', help='Run all available benchmark plans sequentially')
@@ -78,6 +80,10 @@ class BrowserPerfDashRunner(object):
                              'test_id': None,
                              'test_version': None,
                              'test_data': None}
+        if args.timestamp:
+            self._result_data['timestamp'] = args.timestamp
+            date_str = datetime.fromtimestamp(self._result_data['timestamp']).isoformat()
+            _log.info('Will send the benchmark data as if it was generated on date: {date}'.format(date=date_str))
 
     def _parse_config_file(self, config_file):
         if not os.path.isfile(config_file):


### PR DESCRIPTION
#### dc0001d225dfccadb1bdd2587c39f64c078058fe
<pre>
[browserperfdash-benchmark] Add optional --timestamp parameter to send the data to the server with a custom date.
<a href="https://bugs.webkit.org/show_bug.cgi?id=252355">https://bugs.webkit.org/show_bug.cgi?id=252355</a>

Reviewed by Dewei Zhu.

Add an optional paramter &apos;--timestamp&apos; that allows to send the data
to the server marked with a specific date. So then the dashboard
will add the benchmark data as it was generated on the date specified.

This is useful for the following two use cases: 1) Several machines
downloading builds and doing performance tests in parallel are not
guaranteed to end the testing in the order they downloaded the
builds. So by passing a timestamp that can be obtained from the git
revision of the build (or even from the build executable timestamp)
the data gets sorted properly on the dashboard.
2) Some data for older versions is missed, this way it is possible
to tell the bot to run the benchmarks with an older version and then
have the data ordered properly on the dashboard.

* Tools/Scripts/webkitpy/browserperfdash/browserperfdash_runner.py:
(parse_args):
(BrowserPerfDashRunner.__init__):

Canonical link: <a href="https://commits.webkit.org/260345@main">https://commits.webkit.org/260345@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2702d8479f3a047a91243f43c1f0f61a77916ad0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108084 "Failed to checkout and rebase branch from PR 10180") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17154 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/40952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117209 "Failed to checkout and rebase branch from PR 10180") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111973 "Failed to checkout and rebase branch from PR 10180") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/18509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8450 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100288 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113852 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/18509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/40952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/41886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/5/builds/111615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/18509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/40952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/10037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/40952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10759 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/7068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/16185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/40952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12340 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3893 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->