### PR TITLE
Support the foreground color attribute in marked text

### DIFF
--- a/LayoutTests/editing/input/composition-highlights-expected.html
+++ b/LayoutTests/editing/input/composition-highlights-expected.html
@@ -54,7 +54,7 @@ div[contenteditable] {
 </style>
 </head>
 <body>
-<div contenteditable>Test&nbsp;<span class="container"><span id="red"></span>one</span><span class="container"><span id="green"></span>two</span><span class="container"><span id="blue"></span>three</span></div>
+<div contenteditable>Test&nbsp;<span class="container"><span id="red"></span>one</span><span class="container"><span id="green"></span>two</span><span class="container" style="color: #FF0000FF;"><span id="blue"></span>three</span></div>
 <p class="description">This test verifies that highlights can be specified when setting marked text.</p>
 <div id="overlay">Test&nbsp;<span class="container"><span class="box"></span>one</span><span class="container"><span class="box"></span>two</span><span class="container"><span class="box"></span>three</span></div>
 </body>

--- a/LayoutTests/editing/input/composition-highlights.html
+++ b/LayoutTests/editing/input/composition-highlights.html
@@ -53,7 +53,7 @@ if (window.textInputController) {
     textInputController.setMarkedText("onetwothree", 11, 11, true, [
         { from: 0, length: 3, color: "#FF000033" },
         { from: 3, length: 3, color: "#00FF0033" },
-        { from: 6, length: 5, color: "#0000FF33" }
+        { from: 6, length: 5, color: "#0000FF33", foregroundColor: "#FF0000FF" }
     ]);
 }
 </script>

--- a/Source/WebCore/editing/CompositionHighlight.h
+++ b/Source/WebCore/editing/CompositionHighlight.h
@@ -31,10 +31,11 @@ namespace WebCore {
 
 struct CompositionHighlight {
     CompositionHighlight() = default;
-    CompositionHighlight(unsigned startOffset, unsigned endOffset, const Color& c)
+    CompositionHighlight(unsigned startOffset, unsigned endOffset, const std::optional<Color>& backgroundColor, const std::optional<Color>& foregroundColor)
         : startOffset(startOffset)
         , endOffset(endOffset)
-        , color(c)
+        , backgroundColor(backgroundColor)
+        , foregroundColor(foregroundColor)
     {
     }
 
@@ -46,7 +47,8 @@ struct CompositionHighlight {
 
     unsigned startOffset { 0 };
     unsigned endOffset { 0 };
-    Color color { defaultCompositionFillColor };
+    std::optional<Color> backgroundColor;
+    std::optional<Color> foregroundColor;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/TextBoxPainter.h
+++ b/Source/WebCore/rendering/TextBoxPainter.h
@@ -63,6 +63,7 @@ protected:
     void paintForegroundAndDecorations();
     void paintCompositionBackground();
     void paintCompositionUnderlines();
+    void paintCompositionForeground();
     void paintPlatformDocumentMarkers();
 
     enum class BackgroundStyle { Normal, Rounded };

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3020,7 +3020,8 @@ struct WebCore::FontShadow {
 struct WebCore::CompositionHighlight {
     unsigned startOffset;
     unsigned endOffset;
-    WebCore::Color color;
+    std::optional<WebCore::Color> backgroundColor;
+    std::optional<WebCore::Color> foregroundColor;
 };
 
 header: <WebCore/FontAttributeChanges.h>

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -5646,10 +5646,15 @@ static Vector<WebCore::CompositionHighlight> compositionHighlights(NSAttributedS
         if (!attributes[NSMarkedClauseSegmentAttributeName])
             return;
 
-        WebCore::Color highlightColor { WebCore::CompositionHighlight::defaultCompositionFillColor };
-        if (UIColor *uiColor = attributes[NSBackgroundColorAttributeName])
-            highlightColor = WebCore::colorFromCocoaColor(uiColor);
-        highlights.append({ static_cast<unsigned>(range.location), static_cast<unsigned>(NSMaxRange(range)), highlightColor });
+        WebCore::Color backgroundHighlightColor { WebCore::CompositionHighlight::defaultCompositionFillColor };
+        if (UIColor *backgroundColor = attributes[NSBackgroundColorAttributeName])
+            backgroundHighlightColor = WebCore::colorFromCocoaColor(backgroundColor);
+
+        std::optional<WebCore::Color> foregroundHighlightColor;
+        if (UIColor *foregroundColor = attributes[NSForegroundColorAttributeName])
+            foregroundHighlightColor = WebCore::colorFromCocoaColor(foregroundColor);
+
+        highlights.append({ static_cast<unsigned>(range.location), static_cast<unsigned>(NSMaxRange(range)), backgroundHighlightColor, foregroundHighlightColor });
     }];
 
     std::sort(highlights.begin(), highlights.end(), [](auto& a, auto& b) {
@@ -5663,7 +5668,7 @@ static Vector<WebCore::CompositionHighlight> compositionHighlights(NSAttributedS
     Vector<WebCore::CompositionHighlight> mergedHighlights;
     mergedHighlights.reserveInitialCapacity(highlights.size());
     for (auto& highlight : highlights) {
-        if (mergedHighlights.isEmpty() || mergedHighlights.last().color != highlight.color)
+        if (mergedHighlights.isEmpty() || mergedHighlights.last().backgroundColor != highlight.backgroundColor || mergedHighlights.last().foregroundColor != highlight.foregroundColor)
             mergedHighlights.append(highlight);
         else
             mergedHighlights.last().endOffset = highlight.endOffset;

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -4624,6 +4624,8 @@ NSArray *WebViewImpl::validAttributesForMarkedText()
         NSMarkedClauseSegmentAttributeName,
         NSTextAlternativesAttributeName,
         NSTextInsertionUndoableAttributeName,
+        NSBackgroundColorAttributeName,
+        NSForegroundColorAttributeName,
     ];
     // NSText also supports the following attributes, but it's
     // hard to tell which are really required for text input to

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
@@ -617,10 +617,21 @@ void WKBundlePageSetComposition(WKBundlePageRef pageRef, WKStringRef text, int f
         highlights.reserveInitialCapacity(highlightDataArray->size());
         for (auto dictionary : highlightDataArray->elementsOfType<API::Dictionary>()) {
             auto startOffset = static_cast<API::UInt64*>(dictionary->get("from"_s))->value();
+
+            std::optional<WebCore::Color> backgroundHighlightColor;
+            std::optional<WebCore::Color> foregroundHighlightColor;
+
+            if (auto backgroundColor = dictionary->get("color"_s))
+                backgroundHighlightColor = WebCore::CSSParser::parseColorWithoutContext(static_cast<API::String*>(backgroundColor)->string());
+
+            if (auto foregroundColor = dictionary->get("foregroundColor"_s))
+                foregroundHighlightColor = WebCore::CSSParser::parseColorWithoutContext(static_cast<API::String*>(foregroundColor)->string());
+
             highlights.uncheckedAppend({
                 static_cast<unsigned>(startOffset),
                 static_cast<unsigned>(startOffset + static_cast<API::UInt64*>(dictionary->get("length"_s))->value()),
-                WebCore::CSSParser::parseColorWithoutContext(static_cast<API::String*>(dictionary->get("color"_s))->string())
+                backgroundHighlightColor,
+                foregroundHighlightColor
             });
         }
     }

--- a/Tools/WebKitTestRunner/InjectedBundle/TextInputController.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TextInputController.cpp
@@ -67,7 +67,13 @@ static WKArrayRef createCompositionHighlightData(JSContextRef context, JSValueRe
         auto dictionary = adoptWK(WKMutableDictionaryCreate());
         setValue(dictionary, "from", static_cast<uint64_t>(numericProperty(context, object, "from")));
         setValue(dictionary, "length", static_cast<uint64_t>(numericProperty(context, object, "length")));
-        setValue(dictionary, "color", toWK(stringProperty(context, object, "color")));
+
+        if (!JSValueIsUndefined(context, property(context, object, "color")))
+            setValue(dictionary, "color", toWK(stringProperty(context, object, "color")));
+
+        if (!JSValueIsUndefined(context, property(context, object, "foregroundColor")))
+            setValue(dictionary, "foregroundColor", toWK(stringProperty(context, object, "foregroundColor")));
+
         WKArrayAppendItem(result, dictionary.get());
     }
     return result;


### PR DESCRIPTION
#### e42cb64adc1b11a2f44bb54f8e4d4ee62e9c249f
<pre>
Support the foreground color attribute in marked text
<a href="https://bugs.webkit.org/show_bug.cgi?id=252366">https://bugs.webkit.org/show_bug.cgi?id=252366</a>
rdar://105182036

Reviewed by Alan Baradlay.

Add support for the foreground color attribute for marked text.

* Source/WebCore/editing/CompositionHighlight.h:
(WebCore::CompositionHighlight::CompositionHighlight):
* Source/WebCore/rendering/TextBoxPainter.cpp:
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::paintCompositionForeground):
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::paintForegroundAndDecorations):
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::paintCompositionBackground):
* Source/WebCore/rendering/TextBoxPainter.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::validAttributesForMarkedText):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp:
(WKBundlePageSetComposition):

Canonical link: <a href="https://commits.webkit.org/260549@main">https://commits.webkit.org/260549@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1739b5ca95ab5cf90a148e56175c7d11fd0442ae

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108524 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17621 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41374 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117630 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/117828 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112410 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19072 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8899 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100752 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114291 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14293 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97521 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42256 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96271 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29161 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/83971 "Found 2 new API test failures: /TestWebKit:WebKit.OnDeviceChangeCrash, /TestWebKit:WebKit.PrivateBrowsingPushStateNoHistoryCallback (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10431 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30510 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11188 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7421 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16578 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50106 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7292 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12776 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->