### PR TITLE
Integrate PGM for large heap allocations

### DIFF
--- a/Source/bmalloc/bmalloc.xcodeproj/project.pbxproj
+++ b/Source/bmalloc/bmalloc.xcodeproj/project.pbxproj
@@ -635,7 +635,7 @@
 		2CE2AE3327596DEB00D02BBC /* pas_segregated_deallocation_logging_mode.h in Headers */ = {isa = PBXBuildFile; fileRef = 2CE2AE2C27596DEB00D02BBC /* pas_segregated_deallocation_logging_mode.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2CE2AE5D2769928300D02BBC /* pas_compact_tagged_void_ptr.h in Headers */ = {isa = PBXBuildFile; fileRef = 2CE2AE512769928200D02BBC /* pas_compact_tagged_void_ptr.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2CE2AE632769928300D02BBC /* pas_probabilistic_guard_malloc_allocator.c in Sources */ = {isa = PBXBuildFile; fileRef = 2CE2AE572769928300D02BBC /* pas_probabilistic_guard_malloc_allocator.c */; };
-		2CE2AE642769928300D02BBC /* pas_probabilistic_guard_malloc_allocator.h in Headers */ = {isa = PBXBuildFile; fileRef = 2CE2AE582769928300D02BBC /* pas_probabilistic_guard_malloc_allocator.h */; };
+		2CE2AE642769928300D02BBC /* pas_probabilistic_guard_malloc_allocator.h in Headers */ = {isa = PBXBuildFile; fileRef = 2CE2AE582769928300D02BBC /* pas_probabilistic_guard_malloc_allocator.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		4426E2801C838EE0008EB042 /* Logging.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4426E27E1C838EE0008EB042 /* Logging.cpp */; };
 		4426E2811C838EE0008EB042 /* Logging.h in Headers */ = {isa = PBXBuildFile; fileRef = 4426E27F1C838EE0008EB042 /* Logging.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		52F47249210BA30200B730BB /* MemoryStatusSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 52F47248210BA2F500B730BB /* MemoryStatusSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };

--- a/Source/bmalloc/libpas/src/libpas/bmalloc_heap_config.h
+++ b/Source/bmalloc/libpas/src/libpas/bmalloc_heap_config.h
@@ -75,7 +75,7 @@ PAS_API void bmalloc_heap_config_activate(void);
     .use_marge_bitfit = true, \
     .marge_bitfit_min_align_shift = PAS_MIN_MARGE_ALIGN_SHIFT, \
     .marge_bitfit_page_size = PAS_MARGE_PAGE_DEFAULT_SIZE, \
-    .pgm_enabled = false)
+    .pgm_enabled = true)
 
 PAS_API extern const pas_heap_config bmalloc_heap_config;
 

--- a/Source/bmalloc/libpas/src/libpas/iso_heap_config.h
+++ b/Source/bmalloc/libpas/src/libpas/iso_heap_config.h
@@ -74,7 +74,7 @@ PAS_BEGIN_EXTERN_C;
     .use_marge_bitfit = true, \
     .marge_bitfit_min_align_shift = PAS_MIN_MARGE_ALIGN_SHIFT, \
     .marge_bitfit_page_size = PAS_MARGE_PAGE_DEFAULT_SIZE, \
-    .pgm_enabled = false)
+    .pgm_enabled = true)
 
 PAS_API extern const pas_heap_config iso_heap_config;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap.c
@@ -38,6 +38,7 @@
 #include "pas_log.h"
 #include "pas_monotonic_time.h"
 #include "pas_primitive_heap_ref.h"
+#include "pas_probabilistic_guard_malloc_allocator.h"
 #include "pas_segregated_size_directory.h"
 
 pas_heap* pas_heap_create(pas_heap_ref* heap_ref,
@@ -68,6 +69,10 @@ pas_heap* pas_heap_create(pas_heap_ref* heap_ref,
     heap->heap_ref = heap_ref;
     heap->heap_ref_kind = heap_ref_kind;
     heap->config_kind = config->kind;
+
+    // PGM being enabled in the config does not guarantee it will be called during runtime.
+    if (config->pgm_enabled)
+        pas_probabilistic_guard_malloc_initialize_pgm();
     
     pas_all_heaps_add_heap(heap);
     

--- a/Source/bmalloc/libpas/src/libpas/pas_heap_config_utils.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap_config_utils.h
@@ -344,7 +344,7 @@ typedef struct {
             pas_heap_config_utils_for_each_shared_page_directory_remote, \
         .dump_shared_page_directory_arg = pas_shared_page_directory_by_size_dump_directory_arg, \
         PAS_HEAP_CONFIG_SPECIALIZATIONS(name ## _heap_config), \
-        .pgm_enabled = false \
+        .pgm_enabled = true \
     })
 
 #define PAS_BASIC_HEAP_CONFIG_SEGREGATED_HEAP_DECLARATIONS(name, upcase_name) \

--- a/Source/bmalloc/libpas/src/libpas/pas_large_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_heap.c
@@ -213,8 +213,14 @@ bool pas_large_heap_try_deallocate(uintptr_t begin,
     
     map_entry = pas_large_map_take(begin);
     
-    if (pas_large_map_entry_is_empty(map_entry))
+    if (pas_large_map_entry_is_empty(map_entry)) {
+        if (heap_config->pgm_enabled && pas_probabilistic_guard_malloc_check_exists(begin)) {
+            pas_probabilistic_guard_malloc_deallocate((void *) begin);
+            return true;
+        }
+
         return false;
+    }
     
     PAS_ASSERT(pas_heap_config_kind_get_config(
                    pas_heap_for_large_heap(map_entry.heap)->config_kind)

--- a/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c
@@ -40,15 +40,23 @@
 #include "iso_heap_config.h"
 #include "pas_utility_heap.h"
 #include "pas_large_utility_free_heap.h"
+#include "pas_random.h"
+#include <stdint.h>
 
 static size_t free_wasted_mem  = PAS_PGM_MAX_WASTED_MEMORY;
 static size_t free_virtual_mem = PAS_PGM_MAX_VIRTUAL_MEMORY;
 
-bool pas_pgm_can_use = true;
+uint16_t pas_probabilistic_guard_malloc_random;
+uint16_t pas_probabilistic_guard_malloc_counter = 0;
 
-// the hash map is used to keep track of all pgm allocations
-// key   : user's starting memory address
-// value : metadata for tracking that allocation (pas_pgm_storage)
+bool pas_probabilistic_guard_malloc_can_use = true;
+bool pas_probabilistic_guard_malloc_is_initialized = false;
+
+/*
+ * the hash map is used to keep track of all pgm allocations
+ * key   : user's starting memory address
+ * value : metadata for tracking that allocation (pas_pgm_storage)
+ */
 pas_ptr_hash_map pas_pgm_hash_map = PAS_HASHTABLE_INITIALIZER;
 
 static void pas_probabilistic_guard_malloc_debug_info(const void* key, const pas_pgm_storage* value, const char* operation);
@@ -77,12 +85,13 @@ pas_allocation_result pas_probabilistic_guard_malloc_allocate(pas_large_heap* la
     size_t mem_to_waste = (page_size - (size % page_size)) % page_size;
     if (mem_to_waste > free_wasted_mem)
         return result;
-
-    // calculate virtual memory
-    //
-    // *------------------* *------------------* *------------------*
-    // | lower guard page | | user alloc pages | | upper guard page |
-    // *------------------* *------------------* *------------------*
+    /*
+     * calculate virtual memory
+     *
+     * *------------------* *------------------* *------------------*
+     * | lower guard page | | user alloc pages | | upper guard page |
+     * *------------------* *------------------* *------------------*
+     */
     size_t mem_to_alloc = (2 * page_size) + size + mem_to_waste;
     if (mem_to_alloc > free_virtual_mem)
         return result;
@@ -91,7 +100,7 @@ pas_allocation_result pas_probabilistic_guard_malloc_allocate(pas_large_heap* la
     if (!result.did_succeed)
         return result;
 
-    // protect guard pages from being accessed
+    /* protect guard pages from being accessed */
     uintptr_t lower_guard_page = result.begin;
     uintptr_t upper_guard_page = result.begin + (mem_to_alloc - page_size);
 
@@ -101,19 +110,23 @@ pas_allocation_result pas_probabilistic_guard_malloc_allocate(pas_large_heap* la
     mprotect_res = mprotect( (void *) upper_guard_page, page_size, PROT_NONE);
     PAS_ASSERT(!mprotect_res);
 
-    // ensure physical addresses are released
-    // TODO: investigate using MADV_FREE_REUSABLE instead
+    /*
+     * ensure physical addresses are released
+     * TODO: investigate using MADV_FREE_REUSABLE instead
+     */
     int madvise_res = madvise((void *) upper_guard_page, page_size, MADV_FREE);
     PAS_ASSERT(!madvise_res);
 
     madvise_res = madvise((void *) lower_guard_page, page_size, MADV_FREE);
     PAS_ASSERT(!madvise_res);
 
-    // the key is the location where the user's starting memory address is located.
-    // allocations are right aligned, so the end backs up to the upper guard page.
+    /*
+     * the key is the location where the user's starting memory address is located.
+     * allocations are right aligned, so the end backs up to the upper guard page.
+     */
     void * key = (void*) (result.begin + page_size + mem_to_waste);
 
-    // create struct to hold hash map value
+    /* create struct to hold hash map value */
     pas_pgm_storage *value = pas_utility_heap_try_allocate(sizeof(pas_pgm_storage), "pas_pgm_hash_map_VALUE");
     PAS_ASSERT(value);
 
@@ -124,8 +137,9 @@ pas_allocation_result pas_probabilistic_guard_malloc_allocate(pas_large_heap* la
     value->upper_guard_page          = upper_guard_page;
     value->start_of_data_pages       = result.begin + page_size;
     value->allocation_size_requested = size;
+    value->large_heap                = large_heap;
 
-    pas_ptr_hash_map_add_result add_result = pas_ptr_hash_map_add(&pas_pgm_hash_map, key, NULL,&pas_large_utility_free_heap_allocation_config);
+    pas_ptr_hash_map_add_result add_result = pas_ptr_hash_map_add(&pas_pgm_hash_map, key, NULL, &pas_large_utility_free_heap_allocation_config);
     PAS_ASSERT(add_result.is_new_entry);
 
     add_result.entry->key = key;
@@ -139,9 +153,9 @@ pas_allocation_result pas_probabilistic_guard_malloc_allocate(pas_large_heap* la
 
     result.begin = (uintptr_t)key;
 
-    // 3 pages are the minimum required for PGM
+    /* 3 pages are the minimum required for PGM */
     if (free_virtual_mem < 3 * page_size)
-        pas_pgm_can_use = false;
+        pas_probabilistic_guard_malloc_can_use = false;
 
     return result;
 }
@@ -178,7 +192,7 @@ void pas_probabilistic_guard_malloc_deallocate(void* mem)
     if (verbose)
         pas_probabilistic_guard_malloc_debug_info(key, value, "Deallocating Memory");
 
-    pas_pgm_can_use = true;
+    pas_probabilistic_guard_malloc_can_use = true;
 
     pas_utility_heap_deallocate(value);
 }
@@ -195,6 +209,26 @@ bool pas_probabilistic_guard_malloc_check_exists(uintptr_t mem)
     return (entry && entry->value);
 }
 
+pas_large_map_entry pas_probabilistic_guard_malloc_return_as_large_map_entry(uintptr_t mem)
+{
+    pas_heap_lock_assert_held();
+    static const bool verbose = false;
+
+    pas_large_map_entry ret = { };
+
+    if (verbose)
+        printf("Grabbing PGM allocated size\n");
+
+    pas_ptr_hash_map_entry * entry = pas_ptr_hash_map_find(&pas_pgm_hash_map, (void *) mem);
+    if (entry && entry->value) {
+        pas_pgm_storage *entry_val = (pas_pgm_storage *) entry->value;
+        ret.begin = mem;
+        ret.end = mem + entry_val->allocation_size_requested;
+        ret.heap = entry_val->large_heap;
+    }
+
+    return ret;
+}
 
 #if PAS_COMPILER(CLANG)
 #pragma mark -
@@ -211,6 +245,27 @@ size_t pas_probabilistic_guard_malloc_get_free_wasted_memory(void)
 {
     pas_heap_lock_assert_held();
     return free_wasted_mem;
+}
+
+/*
+ * During heap creation we want to check whether we should enable PGM.
+ * PGM being enabled in the heap config does not mean it will be enabled at runtime.
+ * This function will be run once for all heaps (ISO, bmalloc, JIT, etc...), but only those with
+ * pgm_enabled config will ultimately be called.
+ */
+void pas_probabilistic_guard_malloc_initialize_pgm(void)
+{
+    if (!pas_probabilistic_guard_malloc_is_initialized) {
+        pas_probabilistic_guard_malloc_is_initialized = true;
+
+        if (PAS_LIKELY(pas_get_fast_random(1000) >= 1)) {
+            pas_probabilistic_guard_malloc_can_use = false;
+            return;
+        }
+
+        /* PGM will be called between every 4,000 to 5,000 times an allocation is tried. */
+        pas_probabilistic_guard_malloc_random = pas_get_secure_random(1000) + 4000;
+    }
 }
 
 void pas_probabilistic_guard_malloc_debug_info(const void* key, const pas_pgm_storage* value, const char* operation)

--- a/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h
@@ -23,18 +23,20 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
-
 #ifndef PAS_PROBABILISTIC_GUARD_MALLOC_ALLOCATOR
 #define PAS_PROBABILISTIC_GUARD_MALLOC_ALLOCATOR
 
 #include "pas_utils.h"
 #include "pas_large_heap.h"
 #include <stdbool.h>
+#include <stdint.h>
 
 PAS_BEGIN_EXTERN_C;
 
-// structure for holding metadata of pgm allocations
-// FIXME : Reduce size of structure
+/*
+ * structure for holding metadata of pgm allocations
+ * FIXME : Reduce size of structure
+ */
 typedef struct pas_pgm_storage pas_pgm_storage;
 struct pas_pgm_storage {
     size_t allocation_size_requested;
@@ -44,22 +46,29 @@ struct pas_pgm_storage {
     uintptr_t start_of_data_pages;
     uintptr_t upper_guard_page;
     uintptr_t lower_guard_page;
+    pas_large_heap* large_heap;
 };
 
-// max amount of free memory that can be wasted (1MB)
+/* max amount of free memory that can be wasted (1MB) */
 #define PAS_PGM_MAX_WASTED_MEMORY (1024 * 1024)
 
-// max amount of virtual memory that can be used by PGM (1GB)
-// including guard pages and wasted memory
+/*
+ * max amount of virtual memory that can be used by PGM (1GB)
+ * including guard pages and wasted memory
+ */
 #define PAS_PGM_MAX_VIRTUAL_MEMORY (1024 * 1024 * 1024)
 
-// Probability that we should call PGM in percentage (0-100)
-#define PAS_PGM_PROBABILITY (1)
-
-/* We want a fast way to determine if we can call PGM or not.
+/*
+ * We want a fast way to determine if we can call PGM or not.
  * It would be really wasteful to recompute this answer each time we try to allocate,
- * so just update this variable each time we allocate or deallocate. */
-extern PAS_API bool pas_pgm_can_use;
+ * so just update this variable each time we allocate or deallocate.
+ */
+extern PAS_API bool pas_probabilistic_guard_malloc_can_use;
+
+extern PAS_API bool pas_probabilistic_guard_malloc_is_initialized;
+
+extern PAS_API uint16_t pas_probabilistic_guard_malloc_random;
+extern PAS_API uint16_t pas_probabilistic_guard_malloc_counter;
 
 pas_allocation_result pas_probabilistic_guard_malloc_allocate(pas_large_heap* large_heap, size_t size, const pas_heap_config* heap_config, pas_physical_memory_transaction* transaction);
 void pas_probabilistic_guard_malloc_deallocate(void* memory);
@@ -68,6 +77,23 @@ size_t pas_probabilistic_guard_malloc_get_free_virtual_memory(void);
 size_t pas_probabilistic_guard_malloc_get_free_wasted_memory(void);
 
 bool pas_probabilistic_guard_malloc_check_exists(uintptr_t mem);
+
+/*
+ * Determine whether PGM can be called at runtime.
+ * PGM will be called between every 4,000 to 5,000 times an allocation is tried.
+ */
+static PAS_ALWAYS_INLINE bool pas_probabilistic_guard_malloc_should_call_pgm(void)
+{
+    if (++pas_probabilistic_guard_malloc_counter == pas_probabilistic_guard_malloc_random) {
+        pas_probabilistic_guard_malloc_counter = 0;
+        return true;
+    }
+
+    return false;
+}
+
+extern PAS_API void pas_probabilistic_guard_malloc_initialize_pgm(void);
+pas_large_map_entry pas_probabilistic_guard_malloc_return_as_large_map_entry(uintptr_t mem);
 
 PAS_END_EXTERN_C;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h
@@ -331,13 +331,15 @@ pas_try_reallocate(void* old_ptr,
         pas_heap_lock_lock();
         
         entry = pas_large_map_find(begin);
-        
+
         if (pas_large_map_entry_is_empty(entry)) {
-            pas_reallocation_did_fail(
-                "Source object not allocated",
-                NULL, heap, old_ptr, 0, new_size);
+            // Check for PGM case
+            if (config.pgm_enabled && pas_probabilistic_guard_malloc_check_exists(begin))
+                entry = pas_probabilistic_guard_malloc_return_as_large_map_entry(begin);
+            else
+                pas_reallocation_did_fail("Source object not allocated", NULL, heap, old_ptr, 0, new_size);
         }
-        
+
         PAS_ASSERT(entry.begin == begin);
         PAS_ASSERT(entry.end > begin);
         PAS_ASSERT(entry.heap);

--- a/Source/bmalloc/libpas/src/test/PGMTests.cpp
+++ b/Source/bmalloc/libpas/src/test/PGMTests.cpp
@@ -27,6 +27,8 @@
 #include <stdlib.h>
 
 #include "TestHarness.h"
+
+#include "bmalloc_heap.h"
 #include "pas_probabilistic_guard_malloc_allocator.h"
 #include "pas_heap.h"
 #include "iso_heap.h"
@@ -37,6 +39,7 @@ using namespace std;
 
 namespace {
 
+/* Test single PGM Allocation to ensure basic functionality is working. */
 void testPGMSingleAlloc() {
     pas_heap_ref heapRef = ISO_HEAP_REF_INITIALIZER_WITH_ALIGNMENT(getpagesize() * 100, getpagesize());
     pas_heap* heap = iso_heap_ref_get_heap(&heapRef);
@@ -70,7 +73,7 @@ void testPGMSingleAlloc() {
     return;
 }
 
-
+/* Testing multiple allocations to ensure numerous allocations are correctly handled. */
 void testPGMMultipleAlloc() {
     pas_heap_ref heapRef = ISO_HEAP_REF_INITIALIZER_WITH_ALIGNMENT(getpagesize() * 100, getpagesize());
     pas_heap* heap = iso_heap_ref_get_heap(&heapRef);
@@ -105,6 +108,48 @@ void testPGMMultipleAlloc() {
     pas_heap_lock_unlock();
 }
 
+/* Ensure reallocating PGM allocations works correctly. */
+void testPGMRealloc()
+{
+
+    /* setup code */
+    pas_heap_ref heapRef = ISO_HEAP_REF_INITIALIZER_WITH_ALIGNMENT(getpagesize() * 100, getpagesize());
+    pas_heap* heap = iso_heap_ref_get_heap(&heapRef);
+    pas_physical_memory_transaction transaction;
+    pas_physical_memory_transaction_construct(&transaction);
+
+    PAS_UNUSED_PARAM(heap);
+
+    /* Realloc the same size */
+    pas_heap_lock_lock();
+    pas_allocation_result alloc_memory = pas_probabilistic_guard_malloc_allocate(&heap->large_heap, 10000000, &iso_heap_config, &transaction);
+    pas_heap_lock_unlock();
+
+    void* new_realloc_memory = bmalloc_try_reallocate((void *) alloc_memory.begin, 10000000, pas_reallocate_free_always);
+
+    /* Realloc bigger size */
+    pas_heap_lock_lock();
+    alloc_memory = pas_probabilistic_guard_malloc_allocate(&heap->large_heap, 10000000, &iso_heap_config, &transaction);
+    pas_heap_lock_unlock();
+
+    new_realloc_memory = bmalloc_try_reallocate((void *) alloc_memory.begin, 20000000, pas_reallocate_free_always);
+
+    /* Realloc smaller size */
+    pas_heap_lock_lock();
+    alloc_memory = pas_probabilistic_guard_malloc_allocate(&heap->large_heap, 10000000, &iso_heap_config, &transaction);
+    pas_heap_lock_unlock();
+
+    new_realloc_memory = bmalloc_try_reallocate((void *) alloc_memory.begin, 05000000, pas_reallocate_free_always);
+
+    /* Realloc size of 0 */
+    pas_heap_lock_lock();
+    alloc_memory = pas_probabilistic_guard_malloc_allocate(&heap->large_heap, 10000000, &iso_heap_config, &transaction);
+    pas_heap_lock_unlock();
+
+    new_realloc_memory = bmalloc_try_reallocate((void *) alloc_memory.begin, 0, pas_reallocate_free_always);
+}
+
+/* Ensure all PGM errors cases are handled. */
 void testPGMErrors() {
     pas_heap_ref heapRef = ISO_HEAP_REF_INITIALIZER_WITH_ALIGNMENT(getpagesize() * 100, getpagesize());
     pas_heap* heap = iso_heap_ref_get_heap(&heapRef);
@@ -116,26 +161,26 @@ void testPGMErrors() {
 
     pas_allocation_result result;
 
-    // Test invalid alloc size
+    /* Test invalid alloc size */
     result = pas_probabilistic_guard_malloc_allocate(&heap->large_heap, 0, &iso_heap_config, &transaction);
     CHECK(!result.begin);
     CHECK(!result.did_succeed);
 
-    // Test NULL heap
+    /* Test NULL heap */
     result = pas_probabilistic_guard_malloc_allocate(nullptr, 1024, &iso_heap_config, &transaction);
     CHECK(!result.begin);
     CHECK(!result.did_succeed);
 
-    // Test allocating more than virtual memory available
+    /* Test allocating more than virtual memory available */
     result = pas_probabilistic_guard_malloc_allocate(nullptr, 1024 * 1024 * 1024 + 1, &iso_heap_config, &transaction);
     CHECK(!result.begin);
     CHECK(!result.did_succeed);
 
-    // Test allocating when wasted memory is full
+    /* Test allocating when wasted memory is full */
     size_t num_allocations = 1000;
     pas_allocation_result mem_storage[num_allocations];
     for (size_t i = 0; i < num_allocations; i++ ) {
-        size_t alloc_size = 1; // A small alloc size wastes more memory
+        size_t alloc_size = 1; /* A small alloc size wastes more memory */
         mem_storage[i] = pas_probabilistic_guard_malloc_allocate(&heap->large_heap, alloc_size, &iso_heap_config, &transaction);
     }
 
@@ -147,12 +192,12 @@ void testPGMErrors() {
         pas_probabilistic_guard_malloc_deallocate(reinterpret_cast<void *>(mem_storage[i].begin));
     }
 
-    // Test deallocating invalid memory locations
+    /* Test deallocating invalid memory locations */
     pas_probabilistic_guard_malloc_deallocate(nullptr);
     pas_probabilistic_guard_malloc_deallocate((void *) -1);
     pas_probabilistic_guard_malloc_deallocate((void *) 0x42);
 
-    // Test deallocating same memory location multiple times
+    /* Test deallocating same memory location multiple times */
     result = pas_probabilistic_guard_malloc_allocate(&heap->large_heap, 1, &iso_heap_config, &transaction);
     CHECK(result.begin);
     CHECK(result.did_succeed);
@@ -168,5 +213,6 @@ void testPGMErrors() {
 void addPGMTests() {
     ADD_TEST(testPGMSingleAlloc());
     ADD_TEST(testPGMMultipleAlloc());
+    ADD_TEST(testPGMRealloc());
     ADD_TEST(testPGMErrors());
 }


### PR DESCRIPTION
#### bad2b1b9cb893c36c7d869820a8fae97ab36356e
<pre>
Integrate PGM for large heap allocations
<a href="https://bugs.webkit.org/show_bug.cgi?id=249371">https://bugs.webkit.org/show_bug.cgi?id=249371</a>

Reviewed by Yusuke Suzuki.

This patch turns on PGM allocations for large heaps.
PGM will be enabled 1 in 1000 times upon process launch, and a PGM allocation
will be performed every 4,000 to 5,000 times.

This patch also adds re-allocation support to PGM. PGM allocations can be re-allocated
to a non pgm allocation and vice versa.

Based on benchmarks there was no noticable memory or performance overhead observed when enabling
this feature.

* Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj:
* Source/bmalloc/libpas/src/libpas/bmalloc_heap_config.h:
* Source/bmalloc/libpas/src/libpas/iso_heap_config.h:
* Source/bmalloc/libpas/src/libpas/pas_heap.c:
(pas_heap_create):
* Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c:
(pas_probabilistic_guard_malloc_allocate):
(pas_probabilistic_guard_malloc_return_as_large_map_entry):
(pas_probabilistic_guard_malloc_should_call_pgm):
(pas_probabilistic_guard_malloc_initialize_pgm):
* Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h:
* Source/bmalloc/libpas/src/libpas/pas_try_allocate_common.h:
(pas_try_allocate_common_impl_slow):
* Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h:
(pas_try_reallocate):
* Source/bmalloc/libpas/src/test/PGMTests.cpp:
(std::testPGMRealloc):
(addPGMTests):

Canonical link: <a href="https://commits.webkit.org/260353@main">https://commits.webkit.org/260353@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee893e829a2895e31f003f5ea5c5816b1a0e6e48

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108088 "14 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17158 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40956 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117213 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18513 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8454 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100292 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113856 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97183 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/41897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/95867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28821 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/97311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10041 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/30169 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/38/builds/96681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/8137 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10763 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/7072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/38/builds/96681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/16189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49760 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/105695 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7163 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12344 "Built successfully") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/26169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | | | | 
<!--EWS-Status-Bubble-End-->