### PR TITLE
Performance dashboard should support hiding tests.

### DIFF
--- a/Websites/perf.webkit.org/init-database.sql
+++ b/Websites/perf.webkit.org/init-database.sql
@@ -138,6 +138,7 @@ CREATE TABLE tests (
     test_name varchar(255) NOT NULL,
     test_parent integer REFERENCES tests ON DELETE CASCADE,
     test_url varchar(1024) DEFAULT NULL,
+    test_hidden boolean NOT NULL DEFAULT FALSE,
     CONSTRAINT parent_test_must_be_unique UNIQUE(test_parent, test_name));
 
 CREATE TABLE test_metrics (

--- a/Websites/perf.webkit.org/migrate-database.sql
+++ b/Websites/perf.webkit.org/migrate-database.sql
@@ -10,11 +10,12 @@ IF NOT EXISTS (SELECT NULL FROM pg_type WHERE typname = 'analysis_test_group_rep
 END IF;
 
 ALTER TABLE build_requests ADD COLUMN IF NOT EXISTS request_status_description varchar(1024) DEFAULT NULL;
-ALTER TABLE platforms ADD COLUMN  IF NOT EXISTS platform_group integer REFERENCES platform_groups DEFAULT NULL;
+ALTER TABLE platforms ADD COLUMN IF NOT EXISTS platform_group integer REFERENCES platform_groups DEFAULT NULL;
 ALTER TABLE commits ADD COLUMN IF NOT EXISTS commit_revision_identifier varchar(64) DEFAULT NULL;
 ALTER TABLE analysis_test_groups ADD COLUMN IF NOT EXISTS testgroup_repetition_type analysis_test_group_repetition_type NOT NULL DEFAULT 'alternating';
 ALTER TABLE commits DROP CONSTRAINT IF EXISTS commit_string_identifier_in_repository_must_be_unique;
 ALTER TABLE commits ADD CONSTRAINT commit_string_identifier_in_repository_must_be_unique UNIQUE(commit_repository, commit_revision_identifier);
+ALTER TABLE tests ADD COLUMN IF NOT EXISTS test_hidden boolean NOT NULL DEFAULT FALSE;
 
 IF EXISTS (SELECT NULL FROM information_schema.columns WHERE TABLE_NAME = 'commits' AND COLUMN_NAME = 'commit_order' AND DATA_TYPE = 'integer') THEN
     ALTER TABLE commits ALTER commit_order TYPE bigint;

--- a/Websites/perf.webkit.org/public/admin/tests.php
+++ b/Websites/perf.webkit.org/public/admin/tests.php
@@ -4,7 +4,7 @@ require_once('../include/admin-header.php');
 require_once('../include/test-name-resolver.php');
 
 if ($action == 'update') {
-    if (!update_field('tests', 'test', 'url'))
+    if (!update_field('tests', 'test', 'url') && !update_boolean_field('tests', 'test', 'hidden'))
         notice('Invalid parameters');
 } else if ($action == 'add') {
     if (array_key_exists('test_id', $_POST) && array_key_exists('metric_name', $_POST)) {
@@ -57,7 +57,7 @@ if ($db) {
 ?>
 <table>
 <thead>
-    <tr><td>Test ID</td><td>Full Name</td><td>Parent ID</td><td>URL</td><td>Triggerables</td>
+    <tr><td>Test ID</td><td>Full Name</td><td>Parent ID</td><td>Hidden</td><td>URL</td><td>Triggerables</td>
         <td>Metric ID</td><td>Metric Name</td><td>Aggregator</td>
 </thead>
 <tbody>
@@ -79,6 +79,7 @@ if ($db) {
             $odd = !$odd;
 
             $test_url = htmlspecialchars($test['test_url']);
+            $checkedness = Database::is_true($test['test_hidden']) ? ' checked' : '';
 
             $triggerable_platform_list = '';
 
@@ -103,6 +104,11 @@ if ($db) {
         <td rowspan="$row_count">$test_id</td>
         <td rowspan="$row_count">$linked_test_name</td>
         <td rowspan="$row_count">{$test['test_parent']}</td>
+        <td rowspan="$row_count">
+        <form method="POST"><input type="hidden" name="id" value="$test_id">
+        <input type="hidden" name="updated-column" value="hidden">
+        <input type="checkbox" name="hidden" $checkedness>
+        <button type="submit" name="action" value="update">Update</button></form></td>
         <td rowspan="$row_count">
         <form method="POST"><input type="hidden" name="id" value="$test_id">
         <input type="hidden" name="action" value="update">

--- a/Websites/perf.webkit.org/public/include/manifest-generator.php
+++ b/Websites/perf.webkit.org/public/include/manifest-generator.php
@@ -74,6 +74,7 @@ class ManifestGenerator {
                 'name' => $test_row['test_name'],
                 'url' => $test_row['test_url'],
                 'parentId' => $test_row['test_parent'],
+                'hidden' => Database::is_true($test_row['test_hidden']),
             );
         }
         return $tests;

--- a/Websites/perf.webkit.org/public/v3/components/pane-selector.js
+++ b/Websites/perf.webkit.org/public/v3/components/pane-selector.js
@@ -107,6 +107,7 @@ class PaneSelector extends ComponentBase {
             .map(function (metric) { return self._createListItem(metric, metric.label()); });
 
         var testItems = tests
+            .filter(test => !test.isHidden())
             .map(function (test) {
                 var data = test;
                 var label = test.label();

--- a/Websites/perf.webkit.org/public/v3/models/test.js
+++ b/Websites/perf.webkit.org/public/v3/models/test.js
@@ -8,6 +8,7 @@ class Test extends LabeledObject {
         this._parentId = object.parentId;
         this._childTests = [];
         this._metrics = [];
+        this._hidden = object.hidden;
         this._computePathLazily = new LazilyEvaluatedFunction(this._computePath.bind(this));
 
         if (!this._parentId)
@@ -87,6 +88,7 @@ class Test extends LabeledObject {
 
     addChildTest(test) { this._childTests.push(test); }
     addMetric(metric) { this._metrics.push(metric); }
+    isHidden() { return this._hidden; }
 }
 
 if (typeof module != 'undefined')

--- a/Websites/perf.webkit.org/public/v3/pages/charts-page.js
+++ b/Websites/perf.webkit.org/public/v3/pages/charts-page.js
@@ -258,7 +258,7 @@ class ChartsPage extends PageWithHeading {
     insertBreakdownPanesAfter(platform, metric, referencePane)
     {
         console.assert(referencePane);
-        var childMetrics = metric.childMetrics();
+        var childMetrics = metric.childMetrics().filter(metric => !metric.test().isHidden());
 
         var index = this._paneList.indexOf(referencePane);
         console.assert(index >= 0);
@@ -273,7 +273,7 @@ class ChartsPage extends PageWithHeading {
 
     canBreakdown(platform, metric)
     {
-        var childMetrics = metric.childMetrics();
+        var childMetrics = metric.childMetrics().filter(metric => !metric.test().isHidden());
         if (!childMetrics.length)
             return false;
 

--- a/Websites/perf.webkit.org/server-tests/api-manifest-tests.js
+++ b/Websites/perf.webkit.org/server-tests/api-manifest-tests.js
@@ -203,10 +203,10 @@ describe('/api/manifest', function () {
             return TestServer.remoteAPI().getJSON('/api/manifest');
         }).then((content) => {
             assert.deepStrictEqual(content.tests, {
-                "1": {"name": "SomeTest", "parentId": null, "url": null},
-                "2": {"name": "SomeOtherTest", "parentId": null, "url": null},
-                "3": {"name": "ChildTest", "parentId": "1", "url": null},
-                "4": {"name": "GrandChild", "parentId": "3", "url": null},
+                "1": {"name": "SomeTest", "parentId": null, "url": null, hidden: false},
+                "2": {"name": "SomeOtherTest", "parentId": null, "url": null, hidden: false},
+                "3": {"name": "ChildTest", "parentId": "1", "url": null, hidden: false},
+                "4": {"name": "GrandChild", "parentId": "3", "url": null, hidden: false},
             });
 
             assert.deepStrictEqual(content.metrics, {
@@ -324,13 +324,13 @@ describe('/api/manifest', function () {
         });
     });
 
-    it("should generate manifest with platforms hidden field", async () => {
+    it("should generate manifest with platforms and tests hidden field", async () => {
         let db = TestServer.database();
         await Promise.all([
-            db.insert('tests', {id: 1, name: 'SomeTest'}),
+            db.insert('tests', {id: 1, name: 'SomeTest', hidden: true}),
             db.insert('tests', {id: 2, name: 'SomeOtherTest'}),
-            db.insert('tests', {id: 3, name: 'ChildTest', parent: 1}),
-            db.insert('tests', {id: 4, name: 'GrandChild', parent: 3}),
+            db.insert('tests', {id: 3, name: 'ChildTest', parent: 1, hidden: true}),
+            db.insert('tests', {id: 4, name: 'GrandChild', parent: 3, hidden: true}),
             db.insert('aggregators', {id: 200, name: 'Total'}),
             db.insert('test_metrics', {id: 5, test: 1, name: 'Time'}),
             db.insert('test_metrics', {id: 6, test: 2, name: 'Time', aggregator: 200}),
@@ -357,6 +357,15 @@ describe('/api/manifest', function () {
         assert(mavericks);
         assert(ios9iphone5s.isHidden());
         assert(!mavericks.isHidden());
+
+        const someTest = Test.findById(1);
+        const someOtherTest = Test.findById(2);
+        const childTest = Test.findById(3);
+        const grandChildTest = Test.findById(4);
+        assert(someTest.isHidden());
+        assert(childTest.isHidden());
+        assert(grandChildTest.isHidden());
+        assert(!someOtherTest.isHidden());
     });
 
     it("should generate manifest with triggerables", () => {


### PR DESCRIPTION
#### 58309e2c8119abf8d172db3a92a24acb966052aa
<pre>
Performance dashboard should support hiding tests.
<a href="https://bugs.webkit.org/show_bug.cgi?id=252369">https://bugs.webkit.org/show_bug.cgi?id=252369</a>
rdar://100648198

Reviewed by Ryosuke Niwa.

Add support to hide tests on performance dashboard.

* Websites/perf.webkit.org/init-database.sql: Added &apos;test_hidden&apos; to &apos;tests&apos; table.
* Websites/perf.webkit.org/migrate-database.sql: Added &apos;test_hidden&apos; field for migration.
* Websites/perf.webkit.org/public/admin/tests.php: Added support to update &apos;test_hidden&apos;
field in this admin page.
* Websites/perf.webkit.org/public/include/manifest-generator.php: Expose test hidden field
in manifest.
* Websites/perf.webkit.org/public/v3/components/pane-selector.js: Filtered hidden tests
in pane selector.
(PaneSelector.prototype._buildTestList):
* Websites/perf.webkit.org/public/v3/models/test.js: Exposed test hidden field in &apos;Test&apos; model.
(Test):
(Test.prototype.isHidden):
* Websites/perf.webkit.org/public/v3/pages/charts-page.js: Filtered hidden tests in breakdown.
(ChartsPage.prototype.insertBreakdownPanesAfter):
(ChartsPage.prototype.canBreakdown):
* Websites/perf.webkit.org/server-tests/api-manifest-tests.js: Updated existing unit tests to
check test &apos;hidden&apos; field.

Canonical link: <a href="https://commits.webkit.org/260378@main">https://commits.webkit.org/260378@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f7e51a04ddfe89a127993a9e796b19ad9d4f7e8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108150 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17226 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41018 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117276 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116595 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18578 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8518 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100357 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113918 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/97237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/41942 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95917 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/28875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/10101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/30223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10823 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/7124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16250 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/49814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/7181 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12404 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3902 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->