### PR TITLE
Use more weak pointers for CachedResource / CachedResourceClient

### DIFF
--- a/Source/WTF/wtf/WeakListHashSet.h
+++ b/Source/WTF/wtf/WeakListHashSet.h
@@ -326,6 +326,26 @@ private:
     mutable unsigned m_operationCountSinceLastCleanup { 0 };
 };
 
+template<typename MapFunction, typename T, typename WeakMapImpl>
+struct Mapper<MapFunction, const WeakListHashSet<T, WeakMapImpl> &, void> {
+    using SourceItemType = T&;
+    using DestinationItemType = typename std::invoke_result<MapFunction, SourceItemType&>::type;
+
+    static Vector<DestinationItemType> map(const WeakListHashSet<T, WeakMapImpl>& source, const MapFunction& mapFunction)
+    {
+        Vector<DestinationItemType> result;
+        result.reserveInitialCapacity(source.computeSize());
+        for (auto& item : source)
+            result.uncheckedAppend(mapFunction(item));
+        return result;
+    }
+};
+
+template<typename T, typename WeakMapImpl>
+inline auto copyToVector(const WeakListHashSet<T, WeakMapImpl>& collection) -> Vector<WeakPtr<T, WeakMapImpl>> {
+    return WTF::map(collection, [](auto& v) -> WeakPtr<T, WeakMapImpl> { return WeakPtr<T, WeakMapImpl> { v }; });
+}
+
 }
 
 using WTF::WeakListHashSet;

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1769,6 +1769,7 @@ loader/cache/CachedFont.cpp
 loader/cache/CachedImage.cpp
 loader/cache/CachedRawResource.cpp
 loader/cache/CachedResource.cpp
+loader/cache/CachedResourceClient.cpp
 loader/cache/CachedResourceHandle.cpp
 loader/cache/CachedResourceLoader.cpp
 loader/cache/CachedResourceRequest.cpp

--- a/Source/WebCore/loader/cache/CachedImage.cpp
+++ b/Source/WebCore/loader/cache/CachedImage.cpp
@@ -119,7 +119,7 @@ void CachedImage::setBodyDataFrom(const CachedResource& resource)
     m_image = image.m_image;
     m_imageObserver = image.m_imageObserver;
     if (m_imageObserver)
-        m_imageObserver->cachedImages().add(this);
+        m_imageObserver->cachedImages().add(*this);
 
     if (m_image && is<SVGImage>(*m_image))
         m_svgImageCache = makeUnique<SVGImageCache>(&downcast<SVGImage>(*m_image));
@@ -147,7 +147,7 @@ void CachedImage::didRemoveClient(CachedResourceClient& client)
     ASSERT(client.resourceClientType() == CachedImageClient::expectedType());
 
     m_pendingContainerContextRequests.remove(&downcast<CachedImageClient>(client));
-    m_clientsWaitingForAsyncDecoding.remove(&downcast<CachedImageClient>(client));
+    m_clientsWaitingForAsyncDecoding.remove(downcast<CachedImageClient>(client));
 
     if (m_svgImageCache)
         m_svgImageCache->removeClientFromCache(&downcast<CachedImageClient>(client));
@@ -159,13 +159,13 @@ void CachedImage::didRemoveClient(CachedResourceClient& client)
 
 bool CachedImage::isClientWaitingForAsyncDecoding(const CachedImageClient& client) const
 {
-    return m_clientsWaitingForAsyncDecoding.contains(const_cast<CachedImageClient*>(&client));
+    return m_clientsWaitingForAsyncDecoding.contains(const_cast<CachedImageClient&>(client));
 }
 
 void CachedImage::addClientWaitingForAsyncDecoding(CachedImageClient& client)
 {
     ASSERT(client.resourceClientType() == CachedImageClient::expectedType());
-    if (m_clientsWaitingForAsyncDecoding.contains(&client))
+    if (m_clientsWaitingForAsyncDecoding.contains(client))
         return;
     if (!m_clients.contains(client)) {
         // If the <html> element does not have its own background specified, painting the root box
@@ -176,18 +176,18 @@ void CachedImage::addClientWaitingForAsyncDecoding(CachedImageClient& client)
         // all the m_clients to m_clientsWaitingForAsyncDecoding.
         CachedResourceClientWalker<CachedImageClient> walker(*this);
         while (auto* client = walker.next())
-            m_clientsWaitingForAsyncDecoding.add(client);
+            m_clientsWaitingForAsyncDecoding.add(*client);
     } else
-        m_clientsWaitingForAsyncDecoding.add(&client);
+        m_clientsWaitingForAsyncDecoding.add(client);
 }
     
 void CachedImage::removeAllClientsWaitingForAsyncDecoding()
 {
-    if (m_clientsWaitingForAsyncDecoding.isEmpty() || !hasImage() || !is<BitmapImage>(image()))
+    if (m_clientsWaitingForAsyncDecoding.isEmptyIgnoringNullReferences() || !hasImage() || !is<BitmapImage>(image()))
         return;
     downcast<BitmapImage>(image())->stopAsyncDecodingQueue();
-    for (auto* client : m_clientsWaitingForAsyncDecoding)
-        client->imageChanged(this);
+    for (auto& client : m_clientsWaitingForAsyncDecoding)
+        client.imageChanged(this);
     m_clientsWaitingForAsyncDecoding.clear();
 }
 
@@ -401,33 +401,33 @@ inline void CachedImage::createImage()
 
 CachedImage::CachedImageObserver::CachedImageObserver(CachedImage& image)
 {
-    m_cachedImages.add(&image);
+    m_cachedImages.add(image);
 }
 
 void CachedImage::CachedImageObserver::encodedDataStatusChanged(const Image& image, EncodedDataStatus status)
 {
-    for (auto cachedImage : m_cachedImages)
-        cachedImage->encodedDataStatusChanged(image, status);
+    for (auto& cachedImage : m_cachedImages)
+        cachedImage.encodedDataStatusChanged(image, status);
 }
 
 void CachedImage::CachedImageObserver::decodedSizeChanged(const Image& image, long long delta)
 {
-    for (auto cachedImage : m_cachedImages)
-        cachedImage->decodedSizeChanged(image, delta);
+    for (auto& cachedImage : m_cachedImages)
+        cachedImage.decodedSizeChanged(image, delta);
 }
 
 void CachedImage::CachedImageObserver::didDraw(const Image& image)
 {
-    for (auto cachedImage : m_cachedImages)
-        cachedImage->didDraw(image);
+    for (auto& cachedImage : m_cachedImages)
+        cachedImage.didDraw(image);
 }
 
 bool CachedImage::CachedImageObserver::canDestroyDecodedData(const Image& image)
 {
-    for (auto cachedImage : m_cachedImages) {
-        if (&image != cachedImage->image())
+    for (auto& cachedImage : m_cachedImages) {
+        if (&image != cachedImage.image())
             continue;
-        if (!cachedImage->canDestroyDecodedData(image))
+        if (!cachedImage.canDestroyDecodedData(image))
             return false;
     }
     return true;
@@ -435,26 +435,26 @@ bool CachedImage::CachedImageObserver::canDestroyDecodedData(const Image& image)
 
 void CachedImage::CachedImageObserver::imageFrameAvailable(const Image& image, ImageAnimatingState animatingState, const IntRect* changeRect, DecodingStatus decodingStatus)
 {
-    for (auto cachedImage : m_cachedImages)
-        cachedImage->imageFrameAvailable(image, animatingState, changeRect, decodingStatus);
+    for (auto& cachedImage : m_cachedImages)
+        cachedImage.imageFrameAvailable(image, animatingState, changeRect, decodingStatus);
 }
 
 void CachedImage::CachedImageObserver::changedInRect(const Image& image, const IntRect* rect)
 {
-    for (auto cachedImage : m_cachedImages)
-        cachedImage->changedInRect(image, rect);
+    for (auto& cachedImage : m_cachedImages)
+        cachedImage.changedInRect(image, rect);
 }
 
 void CachedImage::CachedImageObserver::scheduleRenderingUpdate(const Image& image)
 {
-    for (auto cachedImage : m_cachedImages)
-        cachedImage->scheduleRenderingUpdate(image);
+    for (auto& cachedImage : m_cachedImages)
+        cachedImage.scheduleRenderingUpdate(image);
 }
 
 bool CachedImage::CachedImageObserver::allowsAnimation(const Image& image) const
 {
-    for (auto cachedImage : m_cachedImages) {
-        if (cachedImage->allowsAnimation(image))
+    for (auto& cachedImage : m_cachedImages) {
+        if (cachedImage.allowsAnimation(image))
             return true;
     }
     return false;
@@ -466,9 +466,9 @@ inline void CachedImage::clearImage()
         return;
 
     if (m_imageObserver) {
-        m_imageObserver->cachedImages().remove(this);
+        m_imageObserver->cachedImages().remove(*this);
 
-        if (m_imageObserver->cachedImages().isEmpty()) {
+        if (m_imageObserver->cachedImages().isEmptyIgnoringNullReferences()) {
             ASSERT(m_imageObserver->hasOneRef());
             m_image->setImageObserver(nullptr);
         }
@@ -683,7 +683,7 @@ void CachedImage::imageFrameAvailable(const Image& image, ImageAnimatingState an
 
     while (CachedImageClient* client = walker.next()) {
         // All the clients of animated images have to be notified. The new frame has to be drawn in all of them.
-        if (animatingState == ImageAnimatingState::No && !m_clientsWaitingForAsyncDecoding.contains(client))
+        if (animatingState == ImageAnimatingState::No && !m_clientsWaitingForAsyncDecoding.contains(*client))
             continue;
         if (client->imageFrameAvailable(*this, animatingState, changeRect) == VisibleInViewportState::Yes)
             visibleState = VisibleInViewportState::Yes;

--- a/Source/WebCore/loader/cache/CachedImage.h
+++ b/Source/WebCore/loader/cache/CachedImage.h
@@ -30,6 +30,7 @@
 #include "LayoutSize.h"
 #include "SVGImageCache.h"
 #include <wtf/HashMap.h>
+#include <wtf/HashSet.h>
 
 namespace WebCore {
 
@@ -142,16 +143,16 @@ private:
     class CachedImageObserver final : public RefCounted<CachedImageObserver>, public ImageObserver {
     public:
         static Ref<CachedImageObserver> create(CachedImage& image) { return adoptRef(*new CachedImageObserver(image)); }
-        HashSet<CachedImage*>& cachedImages() { return m_cachedImages; }
-        const HashSet<CachedImage*>& cachedImages() const { return m_cachedImages; }
+        WeakHashSet<CachedImage>& cachedImages() { return m_cachedImages; }
+        const WeakHashSet<CachedImage>& cachedImages() const { return m_cachedImages; }
 
     private:
         explicit CachedImageObserver(CachedImage&);
 
         // ImageObserver API
-        URL sourceUrl() const override { return !m_cachedImages.isEmpty() ? (*m_cachedImages.begin())->url() : URL(); }
-        String mimeType() const override { return !m_cachedImages.isEmpty() ? (*m_cachedImages.begin())->mimeType() : emptyString(); }
-        long long expectedContentLength() const override { return !m_cachedImages.isEmpty() ? (*m_cachedImages.begin())->expectedContentLength() : 0; }
+        URL sourceUrl() const override { return !m_cachedImages.isEmptyIgnoringNullReferences() ? (*m_cachedImages.begin()).url() : URL(); }
+        String mimeType() const override { return !m_cachedImages.isEmptyIgnoringNullReferences() ? (*m_cachedImages.begin()).mimeType() : emptyString(); }
+        long long expectedContentLength() const override { return !m_cachedImages.isEmptyIgnoringNullReferences() ? (*m_cachedImages.begin()).expectedContentLength() : 0; }
 
         void encodedDataStatusChanged(const Image&, EncodedDataStatus) final;
         void decodedSizeChanged(const Image&, long long delta) final;
@@ -163,9 +164,9 @@ private:
         void scheduleRenderingUpdate(const Image&) final;
 
         bool allowsAnimation(const Image&) const final;
-        bool layerBasedSVGEngineEnabled() const final { return !m_cachedImages.isEmpty() ? (*m_cachedImages.begin())->m_layerBasedSVGEngineEnabled : false; }
+        bool layerBasedSVGEngineEnabled() const final { return !m_cachedImages.isEmptyIgnoringNullReferences() ? (*m_cachedImages.begin()).m_layerBasedSVGEngineEnabled : false; }
 
-        HashSet<CachedImage*> m_cachedImages;
+        WeakHashSet<CachedImage> m_cachedImages;
     };
 
     void encodedDataStatusChanged(const Image&, EncodedDataStatus);
@@ -189,7 +190,7 @@ private:
     using ContainerContextRequests = HashMap<const CachedImageClient*, ContainerContext>;
     ContainerContextRequests m_pendingContainerContextRequests;
 
-    HashSet<CachedImageClient*> m_clientsWaitingForAsyncDecoding;
+    WeakHashSet<CachedImageClient> m_clientsWaitingForAsyncDecoding;
 
     RefPtr<CachedImageObserver> m_imageObserver;
     RefPtr<Image> m_image;

--- a/Source/WebCore/loader/cache/CachedResource.h
+++ b/Source/WebCore/loader/cache/CachedResource.h
@@ -62,7 +62,7 @@ enum class CachePolicy : uint8_t;
 // from CachedResourceClient, to get the function calls in case the requested data has arrived.
 // This class also does the actual communication with the loader to obtain the resource from the network.
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CachedResource);
-class CachedResource {
+class CachedResource : public CanMakeWeakPtr<CachedResource> {
     WTF_MAKE_NONCOPYABLE(CachedResource);
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(CachedResource);
     friend class MemoryCache;
@@ -258,7 +258,7 @@ public:
     bool isPreloaded() const { return m_preloadCount; }
     void increasePreloadCount() { ++m_preloadCount; }
     void decreasePreloadCount() { ASSERT(m_preloadCount); --m_preloadCount; }
-    bool isLinkPreload() { return m_isLinkPreload; }
+    bool isLinkPreload() const { return m_isLinkPreload; }
     void setLinkPreload() { m_isLinkPreload = true; }
     bool hasUnknownEncoding() { return m_hasUnknownEncoding; }
     void setHasUnknownEncoding(bool hasUnknownEncoding) { m_hasUnknownEncoding = hasUnknownEncoding; }

--- a/Source/WebCore/loader/cache/CachedResourceClient.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceClient.cpp
@@ -1,0 +1,74 @@
+/*
+    Copyright (C) 1998 Lars Knoll (knoll@mpi-hd.mpg.de)
+    Copyright (C) 2001 Dirk Mueller <mueller@kde.org>
+    Copyright (C) 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011 Apple Inc. All rights reserved.
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Library General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Library General Public License for more details.
+
+    You should have received a copy of the GNU Library General Public License
+    along with this library; see the file COPYING.LIB.  If not, write to
+    the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+    Boston, MA 02110-1301, USA.
+
+    This class provides all functionality needed for loading images, style sheets and html
+    pages from the web. It has a memory cache for these objects.
+*/
+
+#include "config.h"
+#include "CachedResourceClient.h"
+
+#include "CachedResource.h"
+
+namespace WebCore {
+
+CachedResourceClient::CachedResourceClient() = default;
+
+CachedResourceClient::~CachedResourceClient()
+{
+    ASSERT(m_associatedResources.isEmptyIgnoringNullReferences());
+}
+
+#if ASSERT_ENABLED
+void CachedResourceClient::addAssociatedResource(CachedResource& resource)
+{
+    m_associatedResources.add(resource);
+}
+
+void CachedResourceClient::removeAssociatedResource(CachedResource& resource)
+{
+    m_associatedResources.remove(resource);
+}
+#endif
+
+void CachedResourceClient::notifyFinished(CachedResource&, const NetworkLoadMetrics&)
+{
+}
+
+void CachedResourceClient::deprecatedDidReceiveCachedResource(CachedResource&)
+{
+}
+
+auto CachedResourceClient::expectedType() -> CachedResourceClientType
+{
+    return BaseResourceType;
+}
+
+auto CachedResourceClient::resourceClientType() const -> CachedResourceClientType
+{
+    return expectedType();
+}
+
+bool CachedResourceClient::shouldMarkAsReferenced() const
+{
+    return true;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/loader/cache/CachedResourceClient.h
+++ b/Source/WebCore/loader/cache/CachedResourceClient.h
@@ -24,8 +24,8 @@
 
 #pragma once
 
-#include <wtf/HashSet.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/WeakHashSet.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -33,7 +33,7 @@ namespace WebCore {
 class CachedResource;
 class NetworkLoadMetrics;
 
-class CachedResourceClient : public CanMakeWeakPtr<CachedResourceClient> {
+class WEBCORE_EXPORT CachedResourceClient : public CanMakeWeakPtr<CachedResourceClient> {
     WTF_MAKE_NONCOPYABLE(CachedResourceClient);
 public:
     enum CachedResourceClientType {
@@ -45,36 +45,26 @@ public:
         RawResourceType
     };
 
-    virtual ~CachedResourceClient()
-    {
-        ASSERT(m_associatedResources.isEmpty());
-    }
+    virtual ~CachedResourceClient();
 
-    virtual void notifyFinished(CachedResource&, const NetworkLoadMetrics&) { }
-    virtual void deprecatedDidReceiveCachedResource(CachedResource&) { }
+    virtual void notifyFinished(CachedResource&, const NetworkLoadMetrics&);
+    virtual void deprecatedDidReceiveCachedResource(CachedResource&);
 
-    static CachedResourceClientType expectedType() { return BaseResourceType; }
-    virtual CachedResourceClientType resourceClientType() const { return expectedType(); }
-    virtual bool shouldMarkAsReferenced() const { return true; }
+    static CachedResourceClientType expectedType();
+    virtual CachedResourceClientType resourceClientType() const;
+    virtual bool shouldMarkAsReferenced() const;
 
 #if ASSERT_ENABLED
-    void addAssociatedResource(CachedResource& resource)
-    {
-        m_associatedResources.add(&resource);
-    }
-
-    void removeAssociatedResource(CachedResource& resource)
-    {
-        m_associatedResources.remove(&resource);
-    }
+    void addAssociatedResource(CachedResource&);
+    void removeAssociatedResource(CachedResource&);
 #endif
 
 protected:
-    CachedResourceClient() = default;
+    CachedResourceClient();
 
 private:
 #if ASSERT_ENABLED
-    HashSet<CachedResource*> m_associatedResources;
+    WeakHashSet<CachedResource> m_associatedResources;
 #endif
 };
 

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -1211,7 +1211,7 @@ void CachedResourceLoader::documentDidFinishLoadEvent()
 
     // If m_preloads is not empty here, it's full of link preloads,
     // as speculative preloads were cleared at DCL.
-    if (m_preloads && m_preloads->size() && !m_unusedPreloadsTimer.isActive())
+    if (m_preloads && !m_preloads->isEmptyIgnoringNullReferences() && !m_unusedPreloadsTimer.isActive())
         m_unusedPreloadsTimer.startOneShot(unusedPreloadTimeout);
 }
 
@@ -1655,7 +1655,7 @@ ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::prel
         request.setCharset(m_document->charset());
 
     auto resource = requestResource(type, WTFMove(request), ForPreload::Yes);
-    if (resource && (!m_preloads || !m_preloads->contains(resource.value().get()))) {
+    if (resource && (!m_preloads || !m_preloads->contains(*resource.value().get()))) {
         auto resourceValue = resource.value();
         // Fonts need special treatment since just creating the resource doesn't trigger a load.
         if (type == CachedResource::Type::FontResource)
@@ -1663,8 +1663,8 @@ ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::prel
         resourceValue->increasePreloadCount();
 
         if (!m_preloads)
-            m_preloads = makeUnique<ListHashSet<CachedResource*>>();
-        m_preloads->add(resourceValue.get());
+            m_preloads = makeUnique<WeakListHashSet<CachedResource>>();
+        m_preloads->add(*resourceValue.get());
     }
     return resource;
 }
@@ -1674,9 +1674,9 @@ void CachedResourceLoader::warnUnusedPreloads()
     if (!m_preloads)
         return;
     for (const auto& resource : *m_preloads) {
-        if (resource && resource->isLinkPreload() && resource->preloadResult() == CachedResource::PreloadResult::PreloadNotReferenced && document()) {
+        if (resource.isLinkPreload() && resource.preloadResult() == CachedResource::PreloadResult::PreloadNotReferenced && document()) {
             document()->addConsoleMessage(MessageSource::Other, MessageLevel::Warning,
-                "The resource " + resource->url().string() +
+                "The resource " + resource.url().string() +
                 " was preloaded using link preload but not used within a few seconds from the window's load event. Please make sure it wasn't preloaded for nothing.");
         }
     }
@@ -1686,11 +1686,12 @@ bool CachedResourceLoader::isPreloaded(const String& urlString) const
 {
     const URL& url = m_document->completeURL(urlString);
 
-    if (m_preloads) {
-        for (auto& resource : *m_preloads) {
-            if (resource->url() == url)
-                return true;
-        }
+    if (!m_preloads)
+        return false;
+
+    for (auto& resource : *m_preloads) {
+        if (resource.url() == url)
+            return true;
     }
     return false;
 }
@@ -1700,19 +1701,18 @@ void CachedResourceLoader::clearPreloads(ClearPreloadsMode mode)
     if (!m_preloads)
         return;
 
-    std::unique_ptr<ListHashSet<CachedResource*>> remainingLinkPreloads;
-    for (auto* resource : *m_preloads) {
-        ASSERT(resource);
-        if (mode == ClearPreloadsMode::ClearSpeculativePreloads && resource->isLinkPreload()) {
+    std::unique_ptr<WeakListHashSet<CachedResource>> remainingLinkPreloads;
+    for (auto& resource : *m_preloads) {
+        if (mode == ClearPreloadsMode::ClearSpeculativePreloads && resource.isLinkPreload()) {
             if (!remainingLinkPreloads)
-                remainingLinkPreloads = makeUnique<ListHashSet<CachedResource*>>();
+                remainingLinkPreloads = makeUnique<WeakListHashSet<CachedResource>>();
             remainingLinkPreloads->add(resource);
             continue;
         }
-        resource->decreasePreloadCount();
-        bool deleted = resource->deleteIfPossible();
-        if (!deleted && resource->preloadResult() == CachedResource::PreloadResult::PreloadNotReferenced)
-            MemoryCache::singleton().remove(*resource);
+        resource.decreasePreloadCount();
+        bool deleted = resource.deleteIfPossible();
+        if (!deleted && resource.preloadResult() == CachedResource::PreloadResult::PreloadNotReferenced)
+            MemoryCache::singleton().remove(resource);
     }
     m_preloads = WTFMove(remainingLinkPreloads);
 }

--- a/Source/WebCore/loader/cache/CachedResourceLoader.h
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.h
@@ -35,8 +35,8 @@
 #include "Timer.h"
 #include <wtf/Expected.h>
 #include <wtf/HashMap.h>
-#include <wtf/ListHashSet.h>
 #include <wtf/RobinHoodHashSet.h>
+#include <wtf/WeakListHashSet.h>
 #include <wtf/text/StringHash.h>
 
 namespace WebCore {
@@ -211,7 +211,7 @@ private:
 
     int m_requestCount { 0 };
 
-    std::unique_ptr<ListHashSet<CachedResource*>> m_preloads;
+    std::unique_ptr<WeakListHashSet<CachedResource>> m_preloads;
     Timer m_unusedPreloadsTimer;
 
     Timer m_garbageCollectDocumentResourcesTimer;

--- a/Source/WebCore/loader/cache/MemoryCache.h
+++ b/Source/WebCore/loader/cache/MemoryCache.h
@@ -31,9 +31,9 @@
 #include <wtf/Function.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
-#include <wtf/ListHashSet.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakListHashSet.h>
 #include <wtf/text/StringHash.h>
 #include <wtf/text/WTFString.h>
 
@@ -149,7 +149,7 @@ public:
     WEBCORE_EXPORT Statistics getStatistics();
     
     void resourceAccessed(CachedResource&);
-    bool inLiveDecodedResourcesList(CachedResource& resource) const { return m_liveDecodedResources.contains(&resource); }
+    bool inLiveDecodedResourcesList(CachedResource&) const;
 
     typedef HashSet<RefPtr<SecurityOrigin>> SecurityOriginSet;
     WEBCORE_EXPORT void removeResourcesWithOrigin(const SecurityOrigin&);
@@ -168,8 +168,8 @@ public:
     WEBCORE_EXPORT void pruneLiveResourcesToSize(unsigned targetSize, bool shouldDestroyDecodedDataForAllLiveResources = false);
 
 private:
-    typedef HashMap<std::pair<URL, String /* partitionName */>, CachedResource*> CachedResourceMap;
-    typedef ListHashSet<CachedResource*> LRUList;
+    using CachedResourceMap = HashMap<std::pair<URL, String /* partitionName */>, CachedResource*>;
+    using LRUList = WeakListHashSet<CachedResource>;
 
     MemoryCache();
     ~MemoryCache(); // Not implemented to make sure nobody accidentally calls delete -- WebCore does not delete singletons.

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -110,18 +110,18 @@ RenderObject::SetLayoutNeededForbiddenScope::~SetLayoutNeededForbiddenScope()
 
 #endif
 
-struct SameSizeAsRenderObject {
+struct SameSizeAsRenderObject : CanMakeWeakPtr<SameSizeAsRenderObject> {
     virtual ~SameSizeAsRenderObject() = default; // Allocate vtable pointer.
 #if ASSERT_ENABLED
-    bool weakPtrFactorWasConstructedOnMainThread;
-    HashSet<void*> cachedResourceClientAssociatedResources;
+    WeakHashSet<void*> cachedResourceClientAssociatedResources;
 #endif
-    void* pointers[5];
+    WeakPtr<Node, WeakPtrImplWithEventTargetData> node;
+    void* pointers[3];
+    CheckedPtr<Layout::Box> layoutBox;
 #if ASSERT_ENABLED
     unsigned m_debugBitfields : 2;
 #endif
     unsigned m_bitfields;
-    WeakPtr<Node> m_node;
 };
 
 #if CPU(ADDRESS64)


### PR DESCRIPTION
#### f090c0624bfccef78c613b3403be4f0414668399
<pre>
Use more weak pointers for CachedResource / CachedResourceClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=252375">https://bugs.webkit.org/show_bug.cgi?id=252375</a>

Reviewed by Ryosuke Niwa.

* Source/WTF/wtf/WeakListHashSet.h:
(WTF::copyToVector):
* Source/WebCore/Sources.txt:
* Source/WebCore/loader/cache/CachedImage.cpp:
(WebCore::CachedImage::setBodyDataFrom):
(WebCore::CachedImage::didRemoveClient):
(WebCore::CachedImage::isClientWaitingForAsyncDecoding const):
(WebCore::CachedImage::addClientWaitingForAsyncDecoding):
(WebCore::CachedImage::removeAllClientsWaitingForAsyncDecoding):
(WebCore::CachedImage::CachedImageObserver::CachedImageObserver):
(WebCore::CachedImage::CachedImageObserver::encodedDataStatusChanged):
(WebCore::CachedImage::CachedImageObserver::decodedSizeChanged):
(WebCore::CachedImage::CachedImageObserver::didDraw):
(WebCore::CachedImage::CachedImageObserver::canDestroyDecodedData):
(WebCore::CachedImage::CachedImageObserver::imageFrameAvailable):
(WebCore::CachedImage::CachedImageObserver::changedInRect):
(WebCore::CachedImage::CachedImageObserver::scheduleRenderingUpdate):
(WebCore::CachedImage::CachedImageObserver::allowsAnimation const):
(WebCore::CachedImage::clearImage):
(WebCore::CachedImage::imageFrameAvailable):
* Source/WebCore/loader/cache/CachedImage.h:
* Source/WebCore/loader/cache/CachedResource.h:
(WebCore::CachedResource::isLinkPreload const):
(WebCore::CachedResource::isLinkPreload): Deleted.
* Source/WebCore/loader/cache/CachedResourceClient.cpp: Added.
(WebCore::CachedResourceClient::~CachedResourceClient):
(WebCore::CachedResourceClient::addAssociatedResource):
(WebCore::CachedResourceClient::removeAssociatedResource):
* Source/WebCore/loader/cache/CachedResourceClient.h:
(WebCore::CachedResourceClient::~CachedResourceClient): Deleted.
(WebCore::CachedResourceClient::addAssociatedResource): Deleted.
(WebCore::CachedResourceClient::removeAssociatedResource): Deleted.
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::documentDidFinishLoadEvent):
(WebCore::CachedResourceLoader::preload):
(WebCore::CachedResourceLoader::warnUnusedPreloads):
(WebCore::CachedResourceLoader::isPreloaded const):
(WebCore::CachedResourceLoader::clearPreloads):
* Source/WebCore/loader/cache/CachedResourceLoader.h:
* Source/WebCore/loader/cache/MemoryCache.cpp:
(WebCore::MemoryCache::pruneLiveResourcesToSize):
(WebCore::MemoryCache::pruneDeadResourcesToSize):
(WebCore::MemoryCache::removeFromLRUList):
(WebCore::MemoryCache::insertInLRUList):
(WebCore::MemoryCache::inLiveDecodedResourcesList const):
(WebCore::MemoryCache::removeFromLiveDecodedResourcesList):
(WebCore::MemoryCache::insertInLiveDecodedResourcesList):
(WebCore::MemoryCache::dumpLRULists const):
* Source/WebCore/loader/cache/MemoryCache.h:
(WebCore::MemoryCache::inLiveDecodedResourcesList const): Deleted.
* Source/WebCore/rendering/RenderObject.cpp:

Canonical link: <a href="https://commits.webkit.org/260388@main">https://commits.webkit.org/260388@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f51d40279a9134897657c448080d442f53c4240

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108092 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17162 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40960 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117217 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116541 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111981 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18517 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8458 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100296 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113860 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97185 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41891 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95870 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28823 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/97314 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10044 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30171 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/96683 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/8141 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10766 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7076 "Passed tests") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/30898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16192 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49762 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/105698 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7186 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12347 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26173 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->