### PR TITLE
[WebCore] Shrink Layout::InlineItem

### DIFF
--- a/Source/WebCore/layout/formattingContexts/inline/InlineItem.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineItem.cpp
@@ -33,14 +33,15 @@ namespace Layout {
 
 struct SameSizeAsInlineItem {
     void* layoutBox;
-    uint8_t enum1;
-    uint8_t enum2;
-    bool widthBool;
-    bool softHyphenBool;
-    bool isWordSeparator;
-    InlineLayoutUnit width;
-    unsigned start;
+    float width;
     unsigned length;
+    unsigned start;
+    uint8_t bidiLevel;
+    uint8_t type : 3;
+    uint8_t textItemType : 2;
+    bool widthBool : 1;
+    bool softHyphenBool : 1;
+    bool isWordSeparator : 1;
 };
 
 static_assert(sizeof(InlineItem) == sizeof(SameSizeAsInlineItem));

--- a/Source/WebCore/layout/formattingContexts/inline/InlineItem.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineItem.h
@@ -72,27 +72,32 @@ private:
     void setWidth(InlineLayoutUnit);
 
     const Box* m_layoutBox { nullptr };
-    Type m_type { };
-    UBiDiLevel m_bidiLevel { UBIDI_DEFAULT_LTR };
 
 protected:
-    // For InlineTextItem
-    enum class TextItemType  : uint8_t { Undefined, Whitespace, NonWhitespace };
-    TextItemType m_textItemType { TextItemType::Undefined };
-    bool m_hasWidth { false };
-    bool m_hasTrailingSoftHyphen { false };
-    bool m_isWordSeparator { false };
     InlineLayoutUnit m_width { };
     unsigned m_length { 0 };
 
     // For InlineTextItem and InlineSoftLineBreakItem
     unsigned m_startOrPosition { 0 };
+private:
+    UBiDiLevel m_bidiLevel { UBIDI_DEFAULT_LTR };
+
+    Type m_type : 3 { };
+
+protected:
+    // For InlineTextItem
+    enum class TextItemType  : uint8_t { Undefined, Whitespace, NonWhitespace };
+
+    TextItemType m_textItemType : 2 { TextItemType::Undefined };
+    bool m_hasWidth : 1 { false };
+    bool m_hasTrailingSoftHyphen : 1 { false };
+    bool m_isWordSeparator : 1 { false };
 };
 
 inline InlineItem::InlineItem(const Box& layoutBox, Type type, UBiDiLevel bidiLevel)
     : m_layoutBox(&layoutBox)
-    , m_type(type)
     , m_bidiLevel(bidiLevel)
+    , m_type(type)
 {
 }
 


### PR DESCRIPTION
#### c00bcc0d5aeddec6568a5dbbf2882c8619882aa9
<pre>
[WebCore] Shrink Layout::InlineItem
<a href="https://bugs.webkit.org/show_bug.cgi?id=252390">https://bugs.webkit.org/show_bug.cgi?id=252390</a>
rdar://105544210

Reviewed by Antti Koivisto.

Reduce the size of the class from 32 to 24 bytes by reordering and converting
a couple members to bit fields.

* Source/WebCore/layout/formattingContexts/inline/InlineItem.cpp:
* Source/WebCore/layout/formattingContexts/inline/InlineItem.h:
(WebCore::Layout::InlineItem::InlineItem):

Canonical link: <a href="https://commits.webkit.org/260446@main">https://commits.webkit.org/260446@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a97576c4a9957541eb1b7da21b0b97f4a26e50cf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108309 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17401 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41174 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117426 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116810 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112196 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/18928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8680 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100527 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114078 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/18928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97355 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42079 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96095 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28999 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10240 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30343 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10979 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7251 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16389 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49940 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7228 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12565 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->