### PR TITLE
[WebCore] Shrink MQ::MediaQuery

### DIFF
--- a/Source/WebCore/css/CSSImportRule.h
+++ b/Source/WebCore/css/CSSImportRule.h
@@ -29,7 +29,7 @@ class MediaList;
 class StyleRuleImport;
 
 namespace MQ {
-struct MediaQuery;
+class MediaQuery;
 using MediaQueryList = Vector<MediaQuery>;
 }
 

--- a/Source/WebCore/css/CSSMediaRule.h
+++ b/Source/WebCore/css/CSSMediaRule.h
@@ -30,7 +30,7 @@ class MediaList;
 class StyleRuleMedia;
 
 namespace MQ {
-struct MediaQuery;
+class MediaQuery;
 using MediaQueryList = Vector<MediaQuery>;
 }
 

--- a/Source/WebCore/css/MediaQueryMatcher.h
+++ b/Source/WebCore/css/MediaQueryMatcher.h
@@ -33,7 +33,7 @@ class RenderStyle;
 class WeakPtrImplWithEventTargetData;
 
 namespace MQ {
-struct MediaQuery;
+class MediaQuery;
 using MediaQueryList = Vector<MediaQuery>;
 }
 

--- a/Source/WebCore/css/query/GenericMediaQueryParser.h
+++ b/Source/WebCore/css/query/GenericMediaQueryParser.h
@@ -124,6 +124,7 @@ std::optional<Condition> GenericMediaQueryParser<ConcreteParser>::consumeConditi
         range.consumeWhitespace();
     }
 
+    condition.queries.shrinkToFit();
     return condition;
 }
 

--- a/Source/WebCore/css/query/GenericMediaQuerySerialization.cpp
+++ b/Source/WebCore/css/query/GenericMediaQuerySerialization.cpp
@@ -47,15 +47,20 @@ static void serialize(StringBuilder& builder, const QueryInParens& queryInParens
 
 void serialize(StringBuilder& builder, const Condition& condition)
 {
-    if (condition.queries.size() == 1 && condition.logicalOperator == LogicalOperator::Not) {
+    serialize(builder, condition.logicalOperator, condition.queries);
+}
+
+void serialize(StringBuilder& builder, LogicalOperator logicalOperator, const Vector<QueryInParens>& queries)
+{
+    if (queries.size() == 1 && logicalOperator == LogicalOperator::Not) {
         builder.append("not ");
-        serialize(builder, condition.queries.first());
+        serialize(builder, queries.first());
         return;
     }
 
-    for (auto& query : condition.queries) {
-        if (&query != &condition.queries.first())
-            builder.append(condition.logicalOperator == LogicalOperator::And ? " and " : " or ");
+    for (auto& query : queries) {
+        if (&query != &queries.first())
+            builder.append(logicalOperator == LogicalOperator::And ? " and " : " or ");
         serialize(builder, query);
     }
 }

--- a/Source/WebCore/css/query/GenericMediaQuerySerialization.h
+++ b/Source/WebCore/css/query/GenericMediaQuerySerialization.h
@@ -32,6 +32,7 @@ namespace MQ {
 
 void serialize(StringBuilder&, const Feature&);
 void serialize(StringBuilder&, const Condition&);
+void serialize(StringBuilder&, LogicalOperator, const Vector<QueryInParens>&);
 
 }
 }

--- a/Source/WebCore/css/query/MediaQueryEvaluator.cpp
+++ b/Source/WebCore/css/query/MediaQueryEvaluator.cpp
@@ -64,13 +64,13 @@ bool MediaQueryEvaluator::evaluate(const MediaQueryList& list) const
 
 bool MediaQueryEvaluator::evaluate(const MediaQuery& query) const
 {
-    bool isNegated = query.prefix && *query.prefix == Prefix::Not;
+    bool isNegated = query.prefix() && *query.prefix() == Prefix::Not;
 
     if (!evaluateMediaType(query))
         return isNegated;
 
     auto result = [&] {
-        if (!query.condition)
+        if (!query.hasCondition())
             return EvaluationResult::True;
 
         if (!m_document || !m_rootElementStyle)
@@ -88,7 +88,7 @@ bool MediaQueryEvaluator::evaluate(const MediaQuery& query) const
         defaultStyle.fontCascade().update();
 
         FeatureEvaluationContext context { *m_document, { *m_rootElementStyle, &defaultStyle, nullptr, m_document->renderView() }, nullptr };
-        return evaluateCondition(*query.condition, context);
+        return evaluateCondition(query.logicalOperator(), query.conditionQueries(), context);
     }();
 
     switch (result) {
@@ -106,11 +106,11 @@ bool MediaQueryEvaluator::evaluate(const MediaQuery& query) const
 
 bool MediaQueryEvaluator::evaluateMediaType(const MediaQuery& query) const
 {
-    if (query.mediaType.isEmpty())
+    if (query.mediaType().isEmpty())
         return true;
-    if (query.mediaType == allAtom())
+    if (query.mediaType() == allAtom())
         return true;
-    return query.mediaType == m_mediaType;
+    return query.mediaType() == m_mediaType;
 };
 
 OptionSet<MediaQueryDynamicDependency> MediaQueryEvaluator::collectDynamicDependencies(const MediaQueryList& queries) const


### PR DESCRIPTION
#### c9edb1a42359617a76cf9d43978733efc65474d0
<pre>
[WebCore] Shrink MQ::MediaQuery
<a href="https://bugs.webkit.org/show_bug.cgi?id=252391">https://bugs.webkit.org/show_bug.cgi?id=252391</a>
rdar://105544722

Reviewed by NOBODY (OOPS!).

Reduce the size of the data structure from 48 to 24 bytes. To reduce the size it
was necessary to store a `PackedRefPtr` to the `AtomStringImpl` instead of storing
the `AtomString` directly, as well as move the members of the `Condition` struct
directly into `MediaQuery` and converting some of the members to bit fields.

* Source/WebCore/css/CSSImportRule.h:
* Source/WebCore/css/CSSMediaRule.h:
* Source/WebCore/css/MediaQueryMatcher.h:
* Source/WebCore/css/query/GenericMediaQueryEvaluator.h:
(WebCore::MQ::GenericMediaQueryEvaluator&lt;ConcreteEvaluator&gt;::evaluateCondition const):
* Source/WebCore/css/query/GenericMediaQueryParser.h:
(WebCore::MQ::GenericMediaQueryParser&lt;ConcreteParser&gt;::consumeCondition):
* Source/WebCore/css/query/GenericMediaQuerySerialization.cpp:
(WebCore::MQ::serialize):
* Source/WebCore/css/query/GenericMediaQuerySerialization.h:
* Source/WebCore/css/query/MediaQuery.h:
(WebCore::MQ::MediaQuery::MediaQuery):
(WebCore::MQ::MediaQuery::mediaType const):
(WebCore::MQ::MediaQuery::hasCondition const):
(WebCore::MQ::MediaQuery::prefix const):
(WebCore::MQ::MediaQuery::conditionQueries const):
(WebCore::MQ::MediaQuery::logicalOperator const):
(WebCore::MQ::traverseFeatures):
(): Deleted.
* Source/WebCore/css/query/MediaQueryEvaluator.cpp:
(WebCore::MQ::MediaQueryEvaluator::evaluate const):
(WebCore::MQ::MediaQueryEvaluator::evaluateMediaType const):
* Source/WebCore/css/query/MediaQueryParser.cpp:
(WebCore::MQ::MediaQueryParser::parseCondition):
(WebCore::MQ::MediaQueryParser::consumeMediaQuery):
(WebCore::MQ::serialize):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9edb1a42359617a76cf9d43978733efc65474d0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108119 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17190 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40987 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117244 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116565 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112008 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18878 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8485 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100324 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113887 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14180 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97210 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41918 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96158 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28848 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/83590 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10071 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30196 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10792 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7099 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16219 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49787 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12373 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->