### PR TITLE
[css-transitions] the `all` value to `transition-property` should parse as a keyword and not a CSS property

### DIFF
--- a/LayoutTests/fast/css/transform-inline-style-expected.txt
+++ b/LayoutTests/fast/css/transform-inline-style-expected.txt
@@ -1,6 +1,6 @@
 Tests reading inline style of transition, and -webkit-transform-origin
 https://bugs.webkit.org/show_bug.cgi?id=22594
 
-style: all 1s, left 3s cubic-bezier(0.2, 0.3, 0.6, 0.8) 2s
+style: 1s, left 3s cubic-bezier(0.2, 0.3, 0.6, 0.8) 2s
 style: left 30%
 

--- a/LayoutTests/fast/css/transform-inline-style-remove-expected.txt
+++ b/LayoutTests/fast/css/transform-inline-style-remove-expected.txt
@@ -3,7 +3,7 @@ https://bugs.webkit.org/show_bug.cgi?id=22605
 
 All "after" results should be null/empty
 
-transition (before): all 1s, left 3s cubic-bezier(0.2, 0.3, 0.6, 0.8) 2s
+transition (before): 1s, left 3s cubic-bezier(0.2, 0.3, 0.6, 0.8) 2s
 transition property (before): all, left
 transition duration (before): 1s, 3s
 transition timing function (before): ease, cubic-bezier(0.2, 0.3, 0.6, 0.8)

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -1232,16 +1232,6 @@ static constexpr InitialValue initialValueForLonghand(CSSPropertyID longhand)
     }
 }
 
-// There are many non-animation values this would not correctly handle.
-static Ref<CSSValue> initialCSSValueForAnimationLonghand(CSSPropertyID longhand)
-{
-    return WTF::switchOn(initialValueForLonghand(longhand), [](CSSValueID value) -> Ref<CSSValue> {
-        return CSSPrimitiveValue::create(value);
-    }, [](InitialNumericValue value) -> Ref<CSSValue> {
-        return CSSPrimitiveValue::create(value.number, value.type);
-    });
-}
-
 static bool isValueIDPair(const CSSValue& value, CSSValueID valueID)
 {
     return value.isPair() && isValueID(value.first(), valueID) && isValueID(value.second(), valueID);
@@ -1735,7 +1725,7 @@ bool CSSPropertyParser::consumeAnimationShorthand(const StylePropertyShorthand& 
 
         for (size_t i = 0; i < longhandCount; ++i) {
             if (!parsedLonghand[i])
-                longhands[i]->append(initialCSSValueForAnimationLonghand(shorthand.properties()[i]));
+                longhands[i]->append(Ref { CSSPrimitiveValue::implicitInitialValue() });
             parsedLonghand[i] = false;
         }
     } while (consumeCommaIncludingWhitespace(m_range));

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -5687,6 +5687,8 @@ RefPtr<CSSValue> consumeKeyframesName(CSSParserTokenRange& range, const CSSParse
 
 static RefPtr<CSSValue> consumeSingleTransitionPropertyIdent(CSSParserTokenRange& range, const CSSParserToken& token)
 {
+    if (token.id() == CSSValueAll)
+        return consumeIdent(range);
     if (auto property = token.parseAsCSSPropertyID()) {
         range.consumeIncludingWhitespace();
         return CSSPrimitiveValue::create(property);


### PR DESCRIPTION
#### 47ace808375379d30d233bda3a5a7158d3babd88
<pre>
[css-transitions] the `all` value to `transition-property` should parse as a keyword and not a CSS property
<a href="https://bugs.webkit.org/show_bug.cgi?id=252393">https://bugs.webkit.org/show_bug.cgi?id=252393</a>

Reviewed by Darin Adler.

The `all` value for `transition-property` is a special keyword and not the CSS shorthand property of
the same name [1]. This is important because while the `all` keyword &quot;indicates that all properties
are to be transitioned&quot;, the `all` shorthand property &quot;resets all CSS properties&quot; but &quot;does not
reset custom properties&quot;. This is an important distinction working towards bug 252312 where we&apos;ll
allow registered custom properties to be transitioned when `all` is used.

The issue is that when we would parse `&lt;single-transition-property&gt;` we would fail to check for
CSSValueAll and match the spec definition `all | &lt;custom-ident&gt;` [2]. While this seems to be an
important mistake, this turned out not to be so bad because Styleable::updateCSSTransitions() expands
any shorthand property and thus CSSPropertyAll would expand to most every CSS property. Indeed, this
issue would only become apparent in the case where a custom property was expected to transition.

We now make CSSPropertyParserHelpers::consumeSingleTransitionPropertyIdent() account for CSSValueAll
which will yield the expected Animation::TransitionMode::All for the Animation object in RenderStyle.

This was a good opportunity to clean up and improve some of the longhand code for the `transition`
property where we now get rid of the initialCSSValueForAnimationLonghand() static method and instead
set CSSPrimitiveValue::implicitInitialValue() as the value for any implicit value in the shorthand.

This means that now isInitialValueForLonghand() will correctly recognize those values as implicit and
`all`, whether it was provided explicitly or implicitly, will no longer serialize for the `transition`
shorthand, in the spirit of the &quot;serialize a CSS value&quot; procedure [3] stating that &quot;if component values
can be omitted or replaced with a shorter representation without changing the meaning of the value,
omit/replace them.&quot;

As such we rebaseline a couple of tests which needlessly expected `all` to be serialized.

[0] <a href="https://drafts.csswg.org/css-transitions/#valdef-transition-property-all">https://drafts.csswg.org/css-transitions/#valdef-transition-property-all</a>
[1] <a href="https://w3c.github.io/csswg-drafts/css-cascade/#all-shorthand">https://w3c.github.io/csswg-drafts/css-cascade/#all-shorthand</a>
[2] <a href="https://drafts.csswg.org/css-transitions/#single-transition-property">https://drafts.csswg.org/css-transitions/#single-transition-property</a>
[3] <a href="https://www.w3.org/TR/cssom-1/#serialize-a-css-value">https://www.w3.org/TR/cssom-1/#serialize-a-css-value</a>

* LayoutTests/fast/css/transform-inline-style-expected.txt:
* LayoutTests/fast/css/transform-inline-style-remove-expected.txt:
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::CSSPropertyParser::consumeAnimationShorthand):
(WebCore::initialCSSValueForAnimationLonghand): Deleted.
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeSingleTransitionPropertyIdent):

Canonical link: <a href="https://commits.webkit.org/260383@main">https://commits.webkit.org/260383@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ee478713cc88f4b45d886f583381fe0232f3528

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108123 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17194 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40991 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117248 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116569 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112012 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18549 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8489 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100328 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113891 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97217 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41921 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95897 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28855 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10075 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30203 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10796 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7102 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16223 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49794 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12377 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3904 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->