### PR TITLE
[WebCore] Shrink Layout::LineBox and Layout::InlineLevelBox

### DIFF
--- a/Source/WebCore/css/CSSLineBoxContainValue.h
+++ b/Source/WebCore/css/CSSLineBoxContainValue.h
@@ -33,7 +33,7 @@ namespace WebCore {
 
 class CSSPrimitiveValue;
 
-enum class LineBoxContain {
+enum class LineBoxContain : uint8_t {
     Block           = 1 << 0,
     Inline          = 1 << 1,
     Font            = 1 << 2,

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBox.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBox.h
@@ -114,11 +114,11 @@ private:
 
 private:
     size_t m_lineIndex { 0 };
-    bool m_hasContent { false };
     InlineRect m_logicalRect;
+    bool m_hasContent { false };
+    FontBaseline m_baselineType { AlphabeticBaseline };
     OptionSet<InlineLevelBox::Type> m_boxTypes;
 
-    FontBaseline m_baselineType { AlphabeticBaseline };
     InlineLevelBox m_rootInlineBox;
     InlineLevelBoxList m_nonRootInlineLevelBoxList;
 

--- a/Source/WebCore/platform/graphics/FontBaseline.h
+++ b/Source/WebCore/platform/graphics/FontBaseline.h
@@ -28,7 +28,7 @@
 
 namespace WebCore {
 
-enum FontBaseline { AlphabeticBaseline, IdeographicBaseline, CentralBaseline };
+enum FontBaseline : uint8_t { AlphabeticBaseline, IdeographicBaseline, CentralBaseline };
 
 enum BaselineSynthesisEdge { ContentBox, BorderBox, MarginBox };
 


### PR DESCRIPTION
#### bd8547f0a5ac8d825ced04b40a0018d0b98729bd
<pre>
[WebCore] Shrink Layout::LineBox and Layout::InlineLevelBox
<a href="https://bugs.webkit.org/show_bug.cgi?id=252395">https://bugs.webkit.org/show_bug.cgi?id=252395</a>
rdar://105546978

Reviewed by NOBODY (OOPS!).

Shrink `Layout::InlineLevelBox` from 112 to 80 bytes and, consequently, reduce
reduce `Layout::LineBox` from 176 to 136 bytes. Most of the reductions came from
removing (convenient) abstractions, such as optionals. The public interface of
the class remains unchanged, but all the optionals got their &quot;has_value&quot; flags
lifted into a bit field. Also removed a few struct fields to better reorder their
fields among the other fields of the class.

* Source/WebCore/css/CSSLineBoxContainValue.h:
* Source/WebCore/layout/formattingContexts/inline/InlineLevelBox.h:
(WebCore::Layout::InlineLevelBox::descent const):
(WebCore::Layout::InlineLevelBox::layoutBounds const):
(WebCore::Layout::InlineLevelBox::verticalAlign const):
(WebCore::Layout::InlineLevelBox::isPreferredLineHeightFontMetricsBased const):
(WebCore::Layout::InlineLevelBox::hasLineBoxContain const):
(WebCore::Layout::InlineLevelBox::primarymetricsOfPrimaryFont const):
(WebCore::Layout::InlineLevelBox::fontSize const):
(WebCore::Layout::InlineLevelBox::textEdge const):
(WebCore::Layout::InlineLevelBox::leadingTrim const):
(WebCore::Layout::InlineLevelBox::hasAnnotation const):
(WebCore::Layout::InlineLevelBox::annotationAbove const):
(WebCore::Layout::InlineLevelBox::annotationUnder const):
(WebCore::Layout::InlineLevelBox::setDescent):
(WebCore::Layout::InlineLevelBox::setLayoutBounds):
(WebCore::Layout::m_primaryFontSize):
(WebCore::Layout::InlineLevelBox::preferredLineHeight const):
(WebCore::Layout::InlineLevelBox::lineBoxContain const):
(WebCore::Layout::m_style): Deleted.
* Source/WebCore/layout/formattingContexts/inline/InlineLineBox.h:
* Source/WebCore/platform/graphics/FontBaseline.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd8547f0a5ac8d825ced04b40a0018d0b98729bd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108128 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17202 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40997 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117254 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116575 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112017 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18555 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8495 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100334 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113896 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/97219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/41930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/95903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/28857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10081 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/30205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10802 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/7107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16229 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/49796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12383 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->