### PR TITLE
Missing Interactions Regions occlusions in some cases

### DIFF
--- a/LayoutTests/interaction-region/full-page-overlay-expected.txt
+++ b/LayoutTests/interaction-region/full-page-overlay-expected.txt
@@ -1,0 +1,36 @@
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 1536.00 2008.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 1536.00 2008.00)
+      (contentsOpaque 1)
+      (drawsContent 1)
+      (backgroundColor #FFFFFF)
+      (event region
+        (rect (0,0) width=1536 height=2008)
+      )
+      (children 1
+        (GraphicsLayer
+          (preserves3D 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 1536.00 2008.00)
+              (contentsOpaque 1)
+              (event region
+                (rect (0,0) width=1536 height=2008)
+
+              (interaction regions [
+                (occlusion
+                    (rect (0,0) width=1536 height=2008)
+)
+                (borderRadius 0.00)])
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/interaction-region/full-page-overlay.html
+++ b/LayoutTests/interaction-region/full-page-overlay.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta name="viewport" content="initial-scale=0.5">
+    <style>
+        html, body {
+            width: 100%;
+            height: 100%;
+            margin: 0;
+        }
+
+        .overlay {
+            position: fixed;
+            top: 0;
+            left: 0;
+            z-index: 1;
+            width: 100%;
+            height: 100%;
+            background-color: purple;
+        }
+
+        .spacer {
+            height: 2000px;
+        }
+    </style>
+</head>
+<body>
+<div class="overlay"></div>
+<div class="spacer"></div>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.onload = async function () {
+    if (window.internals)
+       results.textContent = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+};
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -117,7 +117,8 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
 
     FloatSize frameViewSize = mainFrameView.size();
     // Adding some wiggle room, we use this to avoid extreme cases.
-    frameViewSize.scale(1.3, 1.3);
+    auto scale = 1 / mainFrameView.visibleContentScaleFactor() + 0.2;
+    frameViewSize.scale(scale, scale);
     auto frameViewArea = frameViewSize.area();
 
     auto checkedRegionArea = bounds.area<RecordOverflow>();
@@ -149,7 +150,7 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
     bool hasListener = renderer.style().eventListenerRegionTypes().contains(EventListenerRegionType::MouseClick);
     bool hasPointer = cursorTypeForElement(*element) == CursorType::Pointer || shouldAllowNonPointerCursorForElement(*element);
     if (!hasListener || !hasPointer) {
-        bool isOverlay = checkedRegionArea.value() <= frameViewArea && renderer.style().specifiedZIndex() > 0;
+        bool isOverlay = checkedRegionArea.value() <= frameViewArea && (renderer.style().specifiedZIndex() > 0 || renderer.isFixedPositioned());
         if (isOverlay) {
             Region boundsRegion;
             boundsRegion.unite(bounds);


### PR DESCRIPTION
#### 5b60400f474f318e45cd713638e365366b98dd87
<pre>
Missing Interactions Regions occlusions in some cases
<a href="https://bugs.webkit.org/show_bug.cgi?id=252396">https://bugs.webkit.org/show_bug.cgi?id=252396</a>
&lt;rdar://105470110&gt;

Reviewed by Tim Horton.

Take the content scale into account when checking interaction regions&apos;
area and use fixed position as a hint for occlusions.

* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::interactionRegionForRenderedRegion):
* LayoutTests/interaction-region/full-page-overlay-expected.txt: Added.
* LayoutTests/interaction-region/full-page-overlay.html: Added.
Add test case.

Canonical link: <a href="https://commits.webkit.org/260527@main">https://commits.webkit.org/260527@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/027abb080c955aa706f9a068d3b2913bcf060f99

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108308 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17400 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41173 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117425 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116809 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112195 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18927 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8679 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100526 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114077 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14192 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97363 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42078 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96170 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29007 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/83762 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10239 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30351 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10978 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7250 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16388 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49948 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7260 "etiennesegonzac does not have committer permissions") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12564 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3963 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->