### PR TITLE
[GLib] WebKitPermissionRequest should use G_DECLARE_INTERFACE in 2022 API

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitDeviceInfoPermissionRequest.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitDeviceInfoPermissionRequest.cpp
@@ -27,6 +27,10 @@
 #include <glib/gi18n-lib.h>
 #include <wtf/glib/WTFGType.h>
 
+#if !ENABLE(2022_GLIB_API)
+typedef WebKitPermissionRequestIface WebKitPermissionRequestInterface;
+#endif
+
 using namespace WebKit;
 
 /**
@@ -45,7 +49,7 @@ using namespace WebKit;
  * Since: 2.24
  */
 
-static void webkit_permission_request_interface_init(WebKitPermissionRequestIface*);
+static void webkit_permission_request_interface_init(WebKitPermissionRequestInterface*);
 
 struct _WebKitDeviceInfoPermissionRequestPrivate {
     RefPtr<UserMediaPermissionCheckProxy> request;
@@ -95,7 +99,7 @@ static void webkitDeviceInfoPermissionRequestDeny(WebKitPermissionRequest* reque
     priv->request->setUserMediaAccessInfo(false);
 }
 
-static void webkit_permission_request_interface_init(WebKitPermissionRequestIface* iface)
+static void webkit_permission_request_interface_init(WebKitPermissionRequestInterface* iface)
 {
     iface->allow = webkitDeviceInfoPermissionRequestAllow;
     iface->deny = webkitDeviceInfoPermissionRequestDeny;

--- a/Source/WebKit/UIProcess/API/glib/WebKitGeolocationPermissionRequest.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitGeolocationPermissionRequest.cpp
@@ -25,6 +25,10 @@
 #include "WebKitPermissionRequest.h"
 #include <wtf/glib/WTFGType.h>
 
+#if !ENABLE(2022_GLIB_API)
+typedef WebKitPermissionRequestIface WebKitPermissionRequestInterface;
+#endif
+
 using namespace WebKit;
 
 /**
@@ -57,7 +61,7 @@ using namespace WebKit;
  * does not match the name of a valid `.desktop` file.
  */
 
-static void webkit_permission_request_interface_init(WebKitPermissionRequestIface*);
+static void webkit_permission_request_interface_init(WebKitPermissionRequestInterface*);
 
 struct _WebKitGeolocationPermissionRequestPrivate {
     RefPtr<GeolocationPermissionRequest> request;
@@ -96,7 +100,7 @@ static void webkitGeolocationPermissionRequestDeny(WebKitPermissionRequest* requ
     priv->madeDecision = true;
 }
 
-static void webkit_permission_request_interface_init(WebKitPermissionRequestIface* iface)
+static void webkit_permission_request_interface_init(WebKitPermissionRequestInterface* iface)
 {
     iface->allow = webkitGeolocationPermissionRequestAllow;
     iface->deny = webkitGeolocationPermissionRequestDeny;

--- a/Source/WebKit/UIProcess/API/glib/WebKitMediaKeySystemPermissionRequest.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitMediaKeySystemPermissionRequest.cpp
@@ -25,6 +25,10 @@
 #include "WebKitPermissionRequest.h"
 #include <wtf/glib/WTFGType.h>
 
+#if !ENABLE(2022_GLIB_API)
+typedef WebKitPermissionRequestIface WebKitPermissionRequestInterface;
+#endif
+
 using namespace WebKit;
 
 /**
@@ -44,7 +48,7 @@ using namespace WebKit;
  * requested CDM, unless it is already present on the host system.
  */
 
-static void webkit_permission_request_interface_init(WebKitPermissionRequestIface*);
+static void webkit_permission_request_interface_init(WebKitPermissionRequestInterface*);
 
 struct _WebKitMediaKeySystemPermissionRequestPrivate {
     RefPtr<MediaKeySystemPermissionRequest> request;
@@ -84,7 +88,7 @@ static void webkitMediaKeySystemPermissionRequestDeny(WebKitPermissionRequest* r
     priv->madeDecision = true;
 }
 
-static void webkit_permission_request_interface_init(WebKitPermissionRequestIface* iface)
+static void webkit_permission_request_interface_init(WebKitPermissionRequestInterface* iface)
 {
     iface->allow = webkitMediaKeySystemPermissionRequestAllow;
     iface->deny = webkitMediaKeySystemPermissionRequestDeny;

--- a/Source/WebKit/UIProcess/API/glib/WebKitNotificationPermissionRequest.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNotificationPermissionRequest.cpp
@@ -25,6 +25,10 @@
 #include "WebKitPermissionRequest.h"
 #include <wtf/glib/WTFGType.h>
 
+#if !ENABLE(2022_GLIB_API)
+typedef WebKitPermissionRequestIface WebKitPermissionRequestInterface;
+#endif
+
 using namespace WebKit;
 
 /**
@@ -43,7 +47,7 @@ using namespace WebKit;
  * Since: 2.8
  */
 
-static void webkit_permission_request_interface_init(WebKitPermissionRequestIface*);
+static void webkit_permission_request_interface_init(WebKitPermissionRequestInterface*);
 
 struct _WebKitNotificationPermissionRequestPrivate {
     RefPtr<NotificationPermissionRequest> request;
@@ -82,7 +86,7 @@ static void webkitNotificationPermissionRequestDeny(WebKitPermissionRequest* req
     priv->madeDecision = true;
 }
 
-static void webkit_permission_request_interface_init(WebKitPermissionRequestIface* iface)
+static void webkit_permission_request_interface_init(WebKitPermissionRequestInterface* iface)
 {
     iface->allow = webkitNotificationPermissionRequestAllow;
     iface->deny = webkitNotificationPermissionRequestDeny;

--- a/Source/WebKit/UIProcess/API/glib/WebKitPermissionRequest.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitPermissionRequest.cpp
@@ -20,6 +20,10 @@
 #include "config.h"
 #include "WebKitPermissionRequest.h"
 
+#if !ENABLE(2022_GLIB_API)
+typedef WebKitPermissionRequestIface WebKitPermissionRequestInterface;
+#endif
+
 /**
  * WebKitPermissionRequest:
  * @See_also: #WebKitWebView
@@ -34,10 +38,9 @@
  * #WebKitPermissionRequest object attached to it.
  */
 
-typedef WebKitPermissionRequestIface WebKitPermissionRequestInterface;
 G_DEFINE_INTERFACE(WebKitPermissionRequest, webkit_permission_request, G_TYPE_OBJECT)
 
-static void webkit_permission_request_default_init(WebKitPermissionRequestIface*)
+static void webkit_permission_request_default_init(WebKitPermissionRequestInterface*)
 {
 }
 
@@ -51,7 +54,7 @@ void webkit_permission_request_allow(WebKitPermissionRequest* request)
 {
     g_return_if_fail(WEBKIT_IS_PERMISSION_REQUEST(request));
 
-    WebKitPermissionRequestIface* iface = WEBKIT_PERMISSION_REQUEST_GET_IFACE(request);
+    WebKitPermissionRequestInterface* iface = WEBKIT_PERMISSION_REQUEST_GET_IFACE(request);
     if (iface->allow)
         iface->allow(request);
 }
@@ -66,7 +69,7 @@ void webkit_permission_request_deny(WebKitPermissionRequest* request)
 {
     g_return_if_fail(WEBKIT_IS_PERMISSION_REQUEST(request));
 
-    WebKitPermissionRequestIface* iface = WEBKIT_PERMISSION_REQUEST_GET_IFACE(request);
+    WebKitPermissionRequestInterface* iface = WEBKIT_PERMISSION_REQUEST_GET_IFACE(request);
     if (iface->deny)
         iface->deny(request);
 }

--- a/Source/WebKit/UIProcess/API/glib/WebKitPermissionRequest.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitPermissionRequest.h.in
@@ -28,6 +28,7 @@
 G_BEGIN_DECLS
 
 #define WEBKIT_TYPE_PERMISSION_REQUEST           (webkit_permission_request_get_type())
+#if !ENABLE(2022_GLIB_API)
 #define WEBKIT_PERMISSION_REQUEST(obj)           (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_PERMISSION_REQUEST, WebKitPermissionRequest))
 #define WEBKIT_IS_PERMISSION_REQUEST(obj)        (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_PERMISSION_REQUEST))
 #define WEBKIT_PERMISSION_REQUEST_GET_IFACE(obj) (G_TYPE_INSTANCE_GET_INTERFACE((obj), WEBKIT_TYPE_PERMISSION_REQUEST, WebKitPermissionRequestIface))
@@ -35,15 +36,22 @@ G_BEGIN_DECLS
 typedef struct _WebKitPermissionRequest WebKitPermissionRequest;
 typedef struct _WebKitPermissionRequestIface WebKitPermissionRequestIface;
 
+WEBKIT_API GType
+webkit_permission_request_get_type (void);
+#else
+WEBKIT_API G_DECLARE_INTERFACE (WebKitPermissionRequest, webkit_permission_request, WEBKIT, PERMISSION_REQUEST, GObject)
+#endif
+
+#if ENABLE(2022_GLIB_API)
+struct _WebKitPermissionRequestInterface {
+#else
 struct _WebKitPermissionRequestIface {
+#endif
     GTypeInterface parent_interface;
 
     void (* allow) (WebKitPermissionRequest *request);
     void (* deny)  (WebKitPermissionRequest *request);
 };
-
-WEBKIT_API GType
-webkit_permission_request_get_type (void);
 
 WEBKIT_API void
 webkit_permission_request_allow    (WebKitPermissionRequest *request);

--- a/Source/WebKit/UIProcess/API/glib/WebKitUserMediaPermissionRequest.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitUserMediaPermissionRequest.cpp
@@ -25,6 +25,10 @@
 #include <glib/gi18n-lib.h>
 #include <wtf/glib/WTFGType.h>
 
+#if !ENABLE(2022_GLIB_API)
+typedef WebKitPermissionRequestIface WebKitPermissionRequestInterface;
+#endif
+
 using namespace WebKit;
 
 /**
@@ -49,7 +53,7 @@ enum {
     PROP_IS_FOR_VIDEO_DEVICE
 };
 
-static void webkit_permission_request_interface_init(WebKitPermissionRequestIface*);
+static void webkit_permission_request_interface_init(WebKitPermissionRequestInterface*);
 
 struct _WebKitUserMediaPermissionRequestPrivate {
     RefPtr<UserMediaPermissionRequestProxy> request;
@@ -95,7 +99,7 @@ static void webkitUserMediaPermissionRequestDeny(WebKitPermissionRequest* reques
     priv->request->deny(UserMediaPermissionRequestProxy::UserMediaAccessDenialReason::PermissionDenied);
 }
 
-static void webkit_permission_request_interface_init(WebKitPermissionRequestIface* iface)
+static void webkit_permission_request_interface_init(WebKitPermissionRequestInterface* iface)
 {
     iface->allow = webkitUserMediaPermissionRequestAllow;
     iface->deny = webkitUserMediaPermissionRequestDeny;

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataAccessPermissionRequest.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataAccessPermissionRequest.cpp
@@ -24,6 +24,10 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/glib/WTFGType.h>
 
+#if !ENABLE(2022_GLIB_API)
+typedef WebKitPermissionRequestIface WebKitPermissionRequestInterface;
+#endif
+
 /**
  * WebKitWebsiteDataAccessPermissionRequest:
  * @See_also: #WebKitPermissionRequest, #WebKitWebView
@@ -39,7 +43,7 @@
  * Since: 2.30
  */
 
-static void webkit_permission_request_interface_init(WebKitPermissionRequestIface*);
+static void webkit_permission_request_interface_init(WebKitPermissionRequestInterface*);
 
 struct _WebKitWebsiteDataAccessPermissionRequestPrivate {
     CString requestingDomain;
@@ -69,7 +73,7 @@ static void webkitWebsiteDataAccessPermissionRequestDeny(WebKitPermissionRequest
         priv->completionHandler(false);
 }
 
-static void webkit_permission_request_interface_init(WebKitPermissionRequestIface* iface)
+static void webkit_permission_request_interface_init(WebKitPermissionRequestInterface* iface)
 {
     iface->allow = webkitWebsiteDataAccessPermissionRequestAllow;
     iface->deny = webkitWebsiteDataAccessPermissionRequestDeny;


### PR DESCRIPTION
#### 10d6f8608be482414bdde8ca71680efe694a116f
<pre>
[GLib] WebKitPermissionRequest should use G_DECLARE_INTERFACE in 2022 API
<a href="https://bugs.webkit.org/show_bug.cgi?id=252383">https://bugs.webkit.org/show_bug.cgi?id=252383</a>

Reviewed by Michael Catanzaro.

Use G_DECLARE_INTERFACE in the new API for the WebKitPermissionRequest
type. It is not worth it to add a new WEBKIT_DECLARE_INTERFACE macro
because it would basically forward the parameters to the GLib one.
This also fixes the autoptr cleanup not being defined in the new API
after 260190@main.

In the old API the interface type is named WebKitPermissionRequestIface,
whereas using the G_DECLARE_INTERFACE macro it is expected to be named
WebKitPermissionRequestInterface, and that needs choosing the name in
the header template. For the implementation files always use the new
name and typedef the old type name to the new to curb the difference.

* Source/WebKit/UIProcess/API/glib/WebKitPermissionRequest.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitDeviceInfoPermissionRequest.cpp:
(webkit_permission_request_interface_init):
* Source/WebKit/UIProcess/API/glib/WebKitGeolocationPermissionRequest.cpp:
(webkit_permission_request_interface_init):
* Source/WebKit/UIProcess/API/glib/WebKitMediaKeySystemPermissionRequest.cpp:
(webkit_permission_request_interface_init):
* Source/WebKit/UIProcess/API/glib/WebKitNotificationPermissionRequest.cpp:
(webkit_permission_request_interface_init):
* Source/WebKit/UIProcess/API/glib/WebKitPermissionRequest.cpp:
(webkit_permission_request_default_init):
(webkit_permission_request_allow):
(webkit_permission_request_deny):
* Source/WebKit/UIProcess/API/glib/WebKitPermissionRequest.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitUserMediaPermissionRequest.cpp:
(webkit_permission_request_interface_init):
* Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataAccessPermissionRequest.cpp:
(webkit_permission_request_interface_init):

Canonical link: <a href="https://commits.webkit.org/260403@main">https://commits.webkit.org/260403@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8bc4dfd35dc2538f263b4736364ff8f7ead4a4e2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108203 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17288 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41070 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117327 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116639 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18671 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8572 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100411 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113971 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97274 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/41987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/95995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28914 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10147 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/30261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10874 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/7168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16296 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49853 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7196 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12456 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->