### PR TITLE
[css-animations] expose CSSKeyframesRule.length

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/idlharness-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/idlharness-expected.txt
@@ -64,6 +64,7 @@ PASS CSSKeyframesRule interface: existence and properties of interface prototype
 PASS CSSKeyframesRule interface: existence and properties of interface prototype object's @@unscopables property
 PASS CSSKeyframesRule interface: attribute name
 PASS CSSKeyframesRule interface: attribute cssRules
+PASS CSSKeyframesRule interface: attribute length
 PASS CSSKeyframesRule interface: operation appendRule(CSSOMString)
 PASS CSSKeyframesRule interface: operation deleteRule(CSSOMString)
 PASS CSSKeyframesRule interface: operation findRule(CSSOMString)
@@ -71,6 +72,7 @@ PASS CSSKeyframesRule must be primary interface of keyframes
 PASS Stringification of keyframes
 PASS CSSKeyframesRule interface: keyframes must inherit property "name" with the proper type
 PASS CSSKeyframesRule interface: keyframes must inherit property "cssRules" with the proper type
+PASS CSSKeyframesRule interface: keyframes must inherit property "length" with the proper type
 PASS CSSKeyframesRule interface: keyframes must inherit property "appendRule(CSSOMString)" with the proper type
 PASS CSSKeyframesRule interface: calling appendRule(CSSOMString) on keyframes with too few arguments must throw TypeError
 PASS CSSKeyframesRule interface: keyframes must inherit property "deleteRule(CSSOMString)" with the proper type

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSKeyframesRule-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSKeyframesRule-expected.txt
@@ -1,4 +1,4 @@
 
 FAIL name, cssRules, appendRule, findRule, deleteRule assert_equals: CSSKeyframesRule cssText attribute with CSS-wide keyword name expected "@keyframes\"initial\"{}" but got "@keyframesinitial{}"
-FAIL indexed getter, length assert_equals: CSSKeyframesRule.length expected (number) 2 but got (undefined) undefined
+PASS indexed getter, length
 

--- a/LayoutTests/imported/w3c/web-platform-tests/interfaces/css-animations.idl
+++ b/LayoutTests/imported/w3c/web-platform-tests/interfaces/css-animations.idl
@@ -1,7 +1,7 @@
 // GENERATED CONTENT - DO NOT EDIT
 // Content was automatically extracted by Reffy into webref
 // (https://github.com/w3c/webref)
-// Source: CSS Animations Level 1 (https://drafts.csswg.org/css-animations/)
+// Source: CSS Animations Level 1 (https://drafts.csswg.org/css-animations-1/)
 
 [Exposed=Window]
 interface AnimationEvent : Event {
@@ -31,7 +31,9 @@ interface CSSKeyframeRule : CSSRule {
 interface CSSKeyframesRule : CSSRule {
            attribute CSSOMString name;
   readonly attribute CSSRuleList cssRules;
+  readonly attribute unsigned long length;
 
+  getter CSSKeyframeRule (unsigned long index);
   undefined        appendRule(CSSOMString rule);
   undefined        deleteRule(CSSOMString select);
   CSSKeyframeRule? findRule(CSSOMString select);

--- a/Source/WebCore/css/CSSKeyframesRule.idl
+++ b/Source/WebCore/css/CSSKeyframesRule.idl
@@ -31,7 +31,8 @@
 ] interface CSSKeyframesRule : CSSRule {
     attribute [AtomString] DOMString name;
     readonly attribute CSSRuleList cssRules;
-    
+    readonly attribute unsigned long length;
+
     undefined appendRule(DOMString rule);
     undefined deleteRule(DOMString key);
     CSSKeyframeRule? findRule(DOMString key);


### PR DESCRIPTION
#### e6fb2489c688f12f374f6605820f9927b422ddeb
<pre>
[css-animations] expose CSSKeyframesRule.length
<a href="https://bugs.webkit.org/show_bug.cgi?id=252402">https://bugs.webkit.org/show_bug.cgi?id=252402</a>

Reviewed by Dean Jackson.

* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/idlharness-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSKeyframesRule-expected.txt
* LayoutTests/imported/w3c/web-platform-tests/interfaces/css-animations.idl:
* Source/WebCore/css/CSSKeyframesRule.idl:

Canonical link: <a href="https://commits.webkit.org/260400@main">https://commits.webkit.org/260400@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f7e5fd1604b9657564c6ae85ca34478f30b8c11

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108163 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17242 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41030 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117287 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116605 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112049 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/18650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8531 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100370 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113930 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14017 "Build was cancelled. Recent messages:Encountered some issues during cleanup") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97246 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41960 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95927 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28884 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10111 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30232 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10834 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7135 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16260 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49823 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12416 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3911 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->