### PR TITLE
[Gardening]: [ iOS ] Five platform/ipad/fast/viewport/ tests are a consistent failure

### DIFF
--- a/LayoutTests/platform/ipad/fast/viewport/empty-meta-expected.txt
+++ b/LayoutTests/platform/ipad/fast/viewport/empty-meta-expected.txt
@@ -1,6 +1,6 @@
 Viewport:
 
-scale	0.78376
+scale	0.83673
 maxScale	5.00000
-minScale	0.78376
-visibleRect	{"left":"0.00000","top":"0.00000","width":"979.88843","height":"1281.00000"}
+minScale	0.83673
+visibleRect	{"left":"0.00000","top":"0.00000","width":"980.00000","height":"1381.56091"}

--- a/LayoutTests/platform/ipad/fast/viewport/percentage-inside-fixed-expected.txt
+++ b/LayoutTests/platform/ipad/fast/viewport/percentage-inside-fixed-expected.txt
@@ -1,0 +1,24 @@
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 2513.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 2513.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (position 0.00 213.00)
+          (preserves3D 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 440.00 340.00)
+              (contentsOpaque 1)
+              (drawsContent 1)
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/platform/ipad/fast/viewport/viewport-overriden-by-minimum-effective-width-if-ignore-meta-viewport-expected.txt
+++ b/LayoutTests/platform/ipad/fast/viewport/viewport-overriden-by-minimum-effective-width-if-ignore-meta-viewport-expected.txt
@@ -1,41 +1,41 @@
 setMinimumEffectiveWidth(640.00)
-window size: [768, 1004]
-square size: [77, 100]
+window size: [820, 1156]
+square size: [82, 116]
 zoom scale: 1.00
 
 setMinimumEffectiveWidth(768.00)
-window size: [768, 1004]
-square size: [77, 100]
+window size: [820, 1156]
+square size: [82, 116]
 zoom scale: 1.00
 
 setMinimumEffectiveWidth(834.00)
-window size: [834, 1090]
-square size: [83, 109]
-zoom scale: 0.92
+window size: [834, 1176]
+square size: [83, 118]
+zoom scale: 0.98
 
 setMinimumEffectiveWidth(980.00)
-window size: [980, 1281]
-square size: [98, 128]
-zoom scale: 0.78
+window size: [980, 1382]
+square size: [98, 138]
+zoom scale: 0.84
 
 setMinimumEffectiveWidth(1024.00)
-window size: [1024, 1339]
-square size: [102, 134]
-zoom scale: 0.75
+window size: [1024, 1444]
+square size: [102, 144]
+zoom scale: 0.80
 
 setMinimumEffectiveWidth(1112.00)
-window size: [1112, 1454]
-square size: [111, 145]
-zoom scale: 0.69
+window size: [1112, 1568]
+square size: [111, 157]
+zoom scale: 0.74
 
 setMinimumEffectiveWidth(1280.00)
-window size: [1280, 1673]
-square size: [128, 167]
-zoom scale: 0.60
+window size: [1280, 1804]
+square size: [128, 180]
+zoom scale: 0.64
 
 setMinimumEffectiveWidth(1336.00)
-window size: [1336, 1747]
-square size: [134, 175]
-zoom scale: 0.57
+window size: [1336, 1883]
+square size: [134, 188]
+zoom scale: 0.61
 
 

--- a/LayoutTests/platform/ipad/fast/viewport/viewport-unchanged-by-minimum-effective-width-if-not-ignore-meta-viewport-expected.txt
+++ b/LayoutTests/platform/ipad/fast/viewport/viewport-unchanged-by-minimum-effective-width-if-not-ignore-meta-viewport-expected.txt
@@ -1,41 +1,41 @@
 setMinimumEffectiveWidth(640.00)
-window size: [980, 1281]
-square size: [98, 128]
-zoom scale: 0.78
+window size: [980, 1382]
+square size: [98, 138]
+zoom scale: 0.84
 
 setMinimumEffectiveWidth(768.00)
-window size: [980, 1281]
-square size: [98, 128]
-zoom scale: 0.78
+window size: [980, 1382]
+square size: [98, 138]
+zoom scale: 0.84
 
 setMinimumEffectiveWidth(834.00)
-window size: [980, 1281]
-square size: [98, 128]
-zoom scale: 0.78
+window size: [980, 1382]
+square size: [98, 138]
+zoom scale: 0.84
 
 setMinimumEffectiveWidth(980.00)
-window size: [980, 1281]
-square size: [98, 128]
-zoom scale: 0.78
+window size: [980, 1382]
+square size: [98, 138]
+zoom scale: 0.84
 
 setMinimumEffectiveWidth(1024.00)
-window size: [980, 1281]
-square size: [98, 128]
-zoom scale: 0.78
+window size: [980, 1382]
+square size: [98, 138]
+zoom scale: 0.84
 
 setMinimumEffectiveWidth(1112.00)
-window size: [980, 1281]
-square size: [98, 128]
-zoom scale: 0.78
+window size: [980, 1382]
+square size: [98, 138]
+zoom scale: 0.84
 
 setMinimumEffectiveWidth(1280.00)
-window size: [980, 1281]
-square size: [98, 128]
-zoom scale: 0.78
+window size: [980, 1382]
+square size: [98, 138]
+zoom scale: 0.84
 
 setMinimumEffectiveWidth(1336.00)
-window size: [980, 1281]
-square size: [98, 128]
-zoom scale: 0.78
+window size: [980, 1382]
+square size: [98, 138]
+zoom scale: 0.84
 
 

--- a/LayoutTests/platform/ipad/fast/viewport/width-is-device-width-expected.txt
+++ b/LayoutTests/platform/ipad/fast/viewport/width-is-device-width-expected.txt
@@ -3,4 +3,4 @@ Viewport: width=device-width
 scale	1.00000
 maxScale	5.00000
 minScale	1.00000
-visibleRect	{"left":"0.00000","top":"0.00000","width":"768.00000","height":"1004.00000"}
+visibleRect	{"left":"0.00000","top":"0.00000","width":"820.00000","height":"1156.00000"}


### PR DESCRIPTION
#### 2ea7a9c7e04d1c0a37948983c061ef8dae3574c2
<pre>
[Gardening]: [ iOS ] Five platform/ipad/fast/viewport/ tests are a consistent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=252404">https://bugs.webkit.org/show_bug.cgi?id=252404</a>
rdar://105550616

Unreviewed test gardening.
Re-baseline.

* LayoutTests/platform/ipad/fast/viewport/empty-meta-expected.txt:
* LayoutTests/platform/ipad/fast/viewport/percentage-inside-fixed-expected.txt: Added.
* LayoutTests/platform/ipad/fast/viewport/viewport-overriden-by-minimum-effective-width-if-ignore-meta-viewport-expected.txt:
* LayoutTests/platform/ipad/fast/viewport/viewport-unchanged-by-minimum-effective-width-if-not-ignore-meta-viewport-expected.txt:
* LayoutTests/platform/ipad/fast/viewport/width-is-device-width-expected.txt:

Canonical link: <a href="https://commits.webkit.org/260376@main">https://commits.webkit.org/260376@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2a12aba4a915656b0cd15a36e104377ebbd9113

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108154 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/17232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/41022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/117280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/18582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/8522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100361 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113922 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/18582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/41022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/41945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/18582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/41022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/10104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/41022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/10827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/8522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/16253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/41022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/12408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3901 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->