### PR TITLE
css/css-transitions/changing-while-transition-004.html is a unique failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/changing-while-transition-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/changing-while-transition-004-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Unsettign transition should not affect in-flight transitions assert_equals: Even after unsetting transition, the transition should be 50% complete expected "50px" but got "100px"
+PASS Unsettign transition should not affect in-flight transitions
 

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -393,11 +393,6 @@ static bool propertyInStyleMatchesValueForTransitionInMap(AnimatableProperty pro
     return false;
 }
 
-static double transitionCombinedDuration(const Animation* transition)
-{
-    return std::max(0.0, transition->duration()) + transition->delay();
-}
-
 static bool transitionMatchesProperty(const Animation& transition, AnimatableProperty property, const RenderStyle& style)
 {
     if (transition.isPropertyFilled())
@@ -443,8 +438,11 @@ static void compileTransitionPropertiesInStyle(const RenderStyle& style, HashSet
         return;
 
     auto* transitions = style.transitions();
-    if (!transitions)
+    if (!transitions) {
+        // If we don't have any transitions in the map, this means that the initial value "all 0s" was set.
+        transitionPropertiesContainAll = true;
         return;
+    }
 
     for (const auto& transition : *transitions) {
         auto transitionProperty = transition->property();
@@ -488,12 +486,21 @@ static void updateCSSTransitionsForStyleableAndProperty(const Styleable& styleab
     if (animation && !isDeclarative)
         return;
 
+    auto hasMatchingTransitionProperty = false;
+    auto matchingTransitionDuration = 0.0;
     const Animation* matchingBackingAnimation = nullptr;
     if (auto* transitions = newStyle.transitions()) {
         for (auto& backingAnimation : *transitions) {
-            if (transitionMatchesProperty(backingAnimation.get(), property, newStyle))
+            if (transitionMatchesProperty(backingAnimation.get(), property, newStyle)) {
+                hasMatchingTransitionProperty = true;
                 matchingBackingAnimation = backingAnimation.ptr();
+                matchingTransitionDuration = std::max(0.0, matchingBackingAnimation->duration()) + matchingBackingAnimation->delay();
+            }
         }
+    } else {
+        // If we don't have any transitions in the map, this means that the initial value "all 0s" was set
+        // and thus all properties match.
+        hasMatchingTransitionProperty = true;
     }
 
     auto effectTargetsProperty = [property](KeyframeEffect& effect) {
@@ -545,7 +552,7 @@ static void updateCSSTransitionsForStyleableAndProperty(const Styleable& styleab
         && !CSSPropertyAnimation::propertiesEqual(property, beforeChangeStyle, afterChangeStyle, document)
         && CSSPropertyAnimation::canPropertyBeInterpolated(property, beforeChangeStyle, afterChangeStyle, document)
         && !propertyInStyleMatchesValueForTransitionInMap(property, afterChangeStyle, styleable.ensureCompletedTransitionsByProperty(), document)
-        && matchingBackingAnimation && transitionCombinedDuration(matchingBackingAnimation) > 0) {
+        && hasMatchingTransitionProperty && matchingTransitionDuration > 0) {
         // 1. If all of the following are true:
         //   - the element does not have a running transition for the property,
         //   - the before-change style is different from and can be interpolated with the after-change style for that property,
@@ -563,6 +570,7 @@ static void updateCSSTransitionsForStyleableAndProperty(const Styleable& styleab
         //   - end value is the value of the transitioning property in the after-change style,
         //   - reversing-adjusted start value is the same as the start value, and
         //   - reversing shortening factor is 1.
+        ASSERT(matchingBackingAnimation);
         auto delay = Seconds(matchingBackingAnimation->delay());
         auto duration = Seconds(matchingBackingAnimation->duration());
         auto& reversingAdjustedStartStyle = beforeChangeStyle;
@@ -575,7 +583,7 @@ static void updateCSSTransitionsForStyleableAndProperty(const Styleable& styleab
     }
 
     bool hasRunningTransition = styleable.hasRunningTransitionForProperty(property);
-    if ((hasRunningTransition || styleable.hasCompletedTransitionForProperty(property)) && !matchingBackingAnimation) {
+    if ((hasRunningTransition || styleable.hasCompletedTransitionForProperty(property)) && !hasMatchingTransitionProperty) {
         // 3. If the element has a running transition or completed transition for the property, and there is not a matching transition-property
         //    value, then implementations must cancel the running transition or remove the completed transition from the set of completed transitions.
         if (hasRunningTransition)
@@ -584,7 +592,7 @@ static void updateCSSTransitionsForStyleableAndProperty(const Styleable& styleab
             styleable.ensureCompletedTransitionsByProperty().remove(property);
     }
 
-    if (matchingBackingAnimation && styleable.hasRunningTransitionForProperty(property) && !propertyInStyleMatchesValueForTransitionInMap(property, afterChangeStyle, styleable.ensureRunningTransitionsByProperty(), document)) {
+    if (hasMatchingTransitionProperty && styleable.hasRunningTransitionForProperty(property) && !propertyInStyleMatchesValueForTransitionInMap(property, afterChangeStyle, styleable.ensureRunningTransitionsByProperty(), document)) {
         auto previouslyRunningTransition = styleable.ensureRunningTransitionsByProperty().take(property);
         auto& previouslyRunningTransitionCurrentStyle = previouslyRunningTransition->currentStyle();
         // 4. If the element has a running transition for the property, there is a matching transition-property value, and the end value of the running
@@ -593,7 +601,7 @@ static void updateCSSTransitionsForStyleableAndProperty(const Styleable& styleab
             // 1. If the current value of the property in the running transition is equal to the value of the property in the after-change style,
             //    or if these two values cannot be interpolated, then implementations must cancel the running transition.
             previouslyRunningTransition->cancelFromStyle();
-        } else if (transitionCombinedDuration(matchingBackingAnimation) <= 0.0 || !CSSPropertyAnimation::canPropertyBeInterpolated(property, previouslyRunningTransitionCurrentStyle, afterChangeStyle, document)) {
+        } else if (matchingTransitionDuration <= 0.0 || !CSSPropertyAnimation::canPropertyBeInterpolated(property, previouslyRunningTransitionCurrentStyle, afterChangeStyle, document)) {
             // 2. Otherwise, if the combined duration is less than or equal to 0s, or if the current value of the property in the running transition
             //    cannot be interpolated with the value of the property in the after-change style, then implementations must cancel the running transition.
             previouslyRunningTransition->cancelFromStyle();
@@ -611,6 +619,7 @@ static void updateCSSTransitionsForStyleableAndProperty(const Styleable& styleab
             //   - end time is the start time plus the product of the matching transition duration and the new transition’s reversing shortening factor,
             //   - start value is the current value of the property in the running transition,
             //   - end value is the value of the property in the after-change style
+            ASSERT(matchingBackingAnimation);
             auto& reversingAdjustedStartStyle = previouslyRunningTransition->targetStyle();
             double transformedProgress = 1;
             if (auto* effect = previouslyRunningTransition->effect()) {
@@ -631,6 +640,7 @@ static void updateCSSTransitionsForStyleableAndProperty(const Styleable& styleab
             //   - end value is the value of the property in the after-change style,
             //   - reversing-adjusted start value is the same as the start value, and
             //   - reversing shortening factor is 1.
+            ASSERT(matchingBackingAnimation);
             auto delay = Seconds(matchingBackingAnimation->delay());
             auto duration = Seconds(matchingBackingAnimation->duration());
             auto& reversingAdjustedStartStyle = currentStyle;


### PR DESCRIPTION
#### 72fbef8329886aa121db84301c056ce9fdc0609d
<pre>
css/css-transitions/changing-while-transition-004.html is a unique failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=235132">https://bugs.webkit.org/show_bug.cgi?id=235132</a>
rdar://87785199

Reviewed by Dean Jackson.

We used to assume that not finding an Animation object matching the CSS property being considered for transitions
meant that that property was not found in the transition-property value list. However, the initial value for
transition-property is `all` and means that any CSS property matches. So we must distinguish between
that and having a matching Animation object to correctly implement the &quot;starting a transition&quot; procedure.

* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/changing-while-transition-004-expected.txt:
* Source/WebCore/style/Styleable.cpp:
(WebCore::compileTransitionPropertiesInStyle):
(WebCore::updateCSSTransitionsForStyleableAndProperty):
(WebCore::transitionCombinedDuration): Deleted.

Canonical link: <a href="https://commits.webkit.org/260398@main">https://commits.webkit.org/260398@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1af72ee68ce39db28587c05bfa6bd90ef141d580

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108168 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17249 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41035 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117292 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116610 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112054 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/18653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8536 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100375 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113935 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14024 "Build was cancelled. Recent messages:Encountered some issues during cleanup") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97249 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41959 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95934 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28887 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10116 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30235 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10839 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7139 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16265 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49826 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12421 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3910 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->