### PR TITLE
[macOS] Colors that depend on the app accent color are not always resolved with the effective color scheme

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1731,6 +1731,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/PixelBufferFormat.h
     platform/graphics/PixelFormat.h
     platform/graphics/PlatformAudioTrackConfiguration.h
+    platform/graphics/PlatformColor.h
     platform/graphics/PlatformColorSpace.h
     platform/graphics/PlatformDisplay.h
     platform/graphics/PlatformGraphicsContext.h

--- a/Source/WebCore/platform/graphics/PlatformColor.h
+++ b/Source/WebCore/platform/graphics/PlatformColor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,53 +23,22 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#if USE(APPKIT)
+#pragma once
 
-#import <AppKit/NSColor.h>
+#include <wtf/RetainPtr.h>
 
-#if USE(APPLE_INTERNAL_SDK)
+#if PLATFORM(COCOA)
+#include "ColorCocoa.h"
+#endif
 
-#import <AppKit/NSColor_Private.h>
-#import <AppKit/NSColor_UserAccent.h>
+namespace WebCore {
 
-#else // USE(APPLE_INTERNAL_SDK)
-
-@interface NSColor ()
-+ (NSColor *)systemRedColor;
-+ (NSColor *)systemGreenColor;
-+ (NSColor *)systemBlueColor;
-+ (NSColor *)systemOrangeColor;
-+ (NSColor *)systemYellowColor;
-+ (NSColor *)systemBrownColor;
-+ (NSColor *)systemPinkColor;
-+ (NSColor *)systemPurpleColor;
-+ (NSColor *)systemGrayColor;
-+ (NSColor *)linkColor;
-+ (NSColor *)findHighlightColor;
-+ (NSColor *)placeholderTextColor;
-+ (NSColor *)containerBorderColor;
-@end
-
-@interface NSCatalogColor : NSColor
-@end
-
-@interface NSDynamicNamedColor : NSCatalogColor
-@end
-
-typedef NS_ENUM(NSInteger, NSUserAccentColor) {
-    NSUserAccentColorRed = 0,
-    NSUserAccentColorOrange,
-    NSUserAccentColorYellow,
-    NSUserAccentColorGreen,
-    NSUserAccentColorBlue,
-    NSUserAccentColorPurple,
-    NSUserAccentColorPink,
-
-    NSUserAccentColorNoColor = -1,
+struct PlatformColor {
+#if PLATFORM(COCOA)
+    RetainPtr<CocoaColor> platformColor;
+#else
+    Color platformColor;
+#endif
 };
 
-extern "C" NSUserAccentColor NSColorGetUserAccentColor(void);
-
-#endif // USE(APPLE_INTERNAL_SDK)
-
-#endif // USE(APPKIT)
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/mac/ColorMac.h
+++ b/Source/WebCore/platform/graphics/mac/ColorMac.h
@@ -36,6 +36,9 @@ namespace WebCore {
 
 Color semanticColorFromNSColor(NSColor *);
 
+WEBCORE_EXPORT std::pair<Color, Color> lightAndDarkColorsFromNSColor(NSColor *);
+WEBCORE_EXPORT RetainPtr<NSColor> dynamicNSColorFromLightAndDarkColors(const Color&, const Color&);
+
 WEBCORE_EXPORT bool usesTestModeFocusRingColor();
 WEBCORE_EXPORT void setUsesTestModeFocusRingColor(bool);
 

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
@@ -49,3 +49,15 @@ struct WebCore::MediaRecorderPrivateOptions {
     std::optional<unsigned> bitsPerSecond;
 };
 #endif // ENABLE(MEDIA_RECORDER)
+
+#if USE(APPKIT)
+header: <AppKit/NSColor.h>
+#endif
+
+#if PLATFORM(IOS_FAMILY)
+header: <UIKit/UIColor.h>
+#endif
+
+struct WebCore::PlatformColor {
+    RetainPtr<WebCore::CocoaColor> platformColor;
+};

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1313,6 +1313,12 @@ header: <WebCore/ResourceRequest.h>
 };
 #endif
 
+#if !PLATFORM(COCOA)
+struct WebCore::PlatformColor {
+    WebCore::Color platformColor;
+};
+#endif
+
 enum class WebCore::DiagnosticLoggingDomain : uint8_t {
     Media
 };

--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -48,6 +48,7 @@
 #include <WebCore/MediaProducer.h>
 #include <WebCore/PageIdentifier.h>
 #include <WebCore/Pagination.h>
+#include <WebCore/PlatformColor.h>
 #include <WebCore/ScrollTypes.h>
 #include <WebCore/ShouldRelaxThirdPartyCookieBlocking.h>
 #include <WebCore/UserInterfaceLayoutDirection.h>
@@ -192,7 +193,7 @@ struct WebPageCreationParameters {
     Vector<SandboxExtension::Handle> fontMachExtensionHandles;
 #endif
 #if HAVE(APP_ACCENT_COLORS)
-    WebCore::Color accentColor;
+    WebCore::PlatformColor accentColor;
 #endif
 #if USE(WPE_RENDERER)
     UnixFileDescriptor hostFileDescriptor;

--- a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
@@ -50,6 +50,7 @@
 #include <WebCore/EventNames.h>
 #include <WebCore/GtkUtilities.h>
 #include <WebCore/NotImplemented.h>
+#include <WebCore/PlatformColor.h>
 #include <WebCore/RefPtrCairo.h>
 #include <WebCore/ValidationBubble.h>
 #include <wtf/Compiler.h>
@@ -597,28 +598,28 @@ void PageClientImpl::makeViewBlank(bool makeBlank)
     webkitWebViewBaseMakeBlank(WEBKIT_WEB_VIEW_BASE(m_viewWidget), makeBlank);
 }
 
-WebCore::Color PageClientImpl::accentColor()
+WebCore::PlatformColor PageClientImpl::accentColor()
 {
     auto* context = gtk_widget_get_style_context(m_viewWidget);
     GdkRGBA accentColor;
 
     // libadwaita
     if (gtk_style_context_lookup_color(context, "accent_bg_color", &accentColor))
-        return WebCore::Color(accentColor);
+        return { WebCore::Color(accentColor) };
 
     // elementary OS 6.x
     if (gtk_style_context_lookup_color(context, "accent_color", &accentColor))
-        return WebCore::Color(accentColor);
+        return { WebCore::Color(accentColor) };
 
     // elementary OS 5.x
     if (gtk_style_context_lookup_color(context, "accentColor", &accentColor))
-        return WebCore::Color(accentColor);
+        return { WebCore::Color(accentColor) };
 
     // Legacy
     if (gtk_style_context_lookup_color(context, "theme_selected_bg_color", &accentColor))
-        return WebCore::Color(accentColor);
+        return { WebCore::Color(accentColor) };
 
-    return SRGBA<uint8_t> { 52, 132, 228 };
+    return { SRGBA<uint8_t> { 52, 132, 228 } };
 }
 
 WebKitWebResourceLoadManager* PageClientImpl::webResourceLoadManager()

--- a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.h
@@ -174,7 +174,7 @@ private:
 
     void makeViewBlank(bool) override;
 
-    WebCore::Color accentColor() override;
+    WebCore::PlatformColor accentColor() override;
 
     WebKitWebResourceLoadManager* webResourceLoadManager() override;
 

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -119,6 +119,7 @@ enum class ScrollIsAnimated : uint8_t;
 struct AppHighlight;
 struct DataDetectorElementInfo;
 struct DictionaryPopupInfo;
+struct PlatformColor;
 struct TextIndicatorData;
 struct ViewportAttributes;
 struct ShareDataWithParsedURL;
@@ -403,7 +404,7 @@ public:
 #endif
 
 #if HAVE(APP_ACCENT_COLORS)
-    virtual WebCore::Color accentColor() = 0;
+    virtual WebCore::PlatformColor accentColor() = 0;
 #endif
 
     virtual bool effectiveAppearanceIsDark() const { return false; }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -10678,6 +10678,16 @@ void WebPageProxy::effectiveAppearanceDidChange()
     send(Messages::WebPage::EffectiveAppearanceDidChange(useDarkAppearance(), useElevatedUserInterfaceLevel()));
 }
 
+#if HAVE(APP_ACCENT_COLORS)
+void WebPageProxy::accentColorDidChange()
+{
+    if (!hasRunningProcess())
+        return;
+
+    send(Messages::WebPage::SetAccentColor(pageClient().accentColor()));
+}
+#endif
+
 #if HAVE(TOUCH_BAR)
 void WebPageProxy::touchBarMenuDataChanged(const TouchBarMenuData& touchBarMenuData)
 {

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1045,10 +1045,6 @@ public:
 #if PLATFORM(GTK)
     PlatformViewWidget viewWidget();
     bool makeGLContextCurrent();
-
-#if HAVE(APP_ACCENT_COLORS)
-    void accentColorDidChange();
-#endif
 #endif
 
     const std::optional<WebCore::Color>& backgroundColor() const { return m_backgroundColor; }
@@ -1231,6 +1227,10 @@ public:
     void semanticContextDidChange();
 
     WebCore::DestinationColorSpace colorSpace();
+#endif
+
+#if HAVE(APP_ACCENT_COLORS)
+    void accentColorDidChange();
 #endif
 
     void effectiveAppearanceDidChange();

--- a/Source/WebKit/UIProcess/gtk/WebPageProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/WebPageProxyGtk.cpp
@@ -106,14 +106,4 @@ void WebPageProxy::sendMessageToWebView(UserMessage&& message)
     sendMessageToWebViewWithReply(WTFMove(message), [](UserMessage&&) { });
 }
 
-void WebPageProxy::accentColorDidChange()
-{
-    if (!hasRunningProcess())
-        return;
-
-    WebCore::Color accentColor = pageClient().accentColor();
-
-    send(Messages::WebPage::SetAccentColor(accentColor));
-}
-
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -292,7 +292,7 @@ private:
     void takeFocus(WebCore::FocusDirection) override;
 
 #if HAVE(APP_ACCENT_COLORS)
-    WebCore::Color accentColor() override;
+    WebCore::PlatformColor accentColor() override;
 #endif
 
 #if HAVE(TRANSLATION_UI_SERVICES) && ENABLE(CONTEXT_MENUS)

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -72,6 +72,7 @@
 #import <WebCore/Image.h>
 #import <WebCore/KeyboardEvent.h>
 #import <WebCore/NotImplemented.h>
+#import <WebCore/PlatformColor.h>
 #import <WebCore/PlatformScreen.h>
 #import <WebCore/PromisedAttachmentInfo.h>
 #import <WebCore/SharedBuffer.h>
@@ -1027,9 +1028,9 @@ void PageClientImpl::makeViewBlank(bool makeBlank)
 }
 
 #if HAVE(APP_ACCENT_COLORS)
-WebCore::Color PageClientImpl::accentColor()
+WebCore::PlatformColor PageClientImpl::accentColor()
 {
-    return WebCore::colorFromCocoaColor([NSApp _effectiveAccentColor]);
+    return { [NSApp _effectiveAccentColor] };
 }
 #endif
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -5456,6 +5456,7 @@ bool WebViewImpl::useSystemAppearance()
 
 void WebViewImpl::effectiveAppearanceDidChange()
 {
+    m_page->accentColorDidChange();
     m_page->effectiveAppearanceDidChange();
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -268,6 +268,7 @@ struct GlobalWindowIdentifier;
 struct InteractionRegion;
 struct KeypressCommand;
 struct MediaUsageInfo;
+struct PlatformColor;
 struct PromisedAttachmentInfo;
 struct RequestStorageAccessResult;
 struct RunJavaScriptParameters;
@@ -1877,7 +1878,7 @@ private:
 #endif
 
 #if HAVE(APP_ACCENT_COLORS)
-    void setAccentColor(WebCore::Color);
+    void setAccentColor(WebCore::PlatformColor);
 #endif
 
     void setMainFrameIsScrollable(bool);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -563,7 +563,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
     EffectiveAppearanceDidChange(bool useDarkAppearance, bool useElevatedUserInterfaceLevel)
 
 #if HAVE(APP_ACCENT_COLORS)
-    SetAccentColor(WebCore::Color color)
+    SetAccentColor(struct WebCore::PlatformColor color)
 #endif
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/WebPage/gtk/WebPageGtk.cpp
+++ b/Source/WebKit/WebProcess/WebPage/gtk/WebPageGtk.cpp
@@ -121,9 +121,9 @@ void WebPage::showEmojiPicker(Frame& frame)
     sendWithAsyncReply(Messages::WebPageProxy::ShowEmojiPicker(frame.view()->contentsToRootView(frame.selection().absoluteCaretBounds())), WTFMove(completionHandler));
 }
 
-void WebPage::setAccentColor(WebCore::Color color)
+void WebPage::setAccentColor(WebCore::PlatformColor color)
 {
-    static_cast<RenderThemeAdwaita&>(RenderTheme::singleton()).setAccentColor(color);
+    static_cast<RenderThemeAdwaita&>(RenderTheme::singleton()).setAccentColor(color.platformColor);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -82,6 +82,7 @@
 #import <WebCore/NodeRenderStyle.h>
 #import <WebCore/Page.h>
 #import <WebCore/PageOverlayController.h>
+#import <WebCore/PlatformColor.h>
 #import <WebCore/PlatformKeyboardEvent.h>
 #import <WebCore/PluginDocument.h>
 #import <WebCore/PointerCharacteristics.h>
@@ -1063,9 +1064,9 @@ bool WebPage::shouldAvoidComputingPostLayoutDataForEditorState() const
 
 #if HAVE(APP_ACCENT_COLORS)
 
-void WebPage::setAccentColor(WebCore::Color color)
+void WebPage::setAccentColor(WebCore::PlatformColor color)
 {
-    [NSApp _setAccentColor:cocoaColorOrNil(color).get()];
+    [NSApp _setAccentColor:color.platformColor.get()];
 }
 
 #endif // HAVE(APP_ACCENT_COLORS)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SystemColors.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SystemColors.mm
@@ -27,10 +27,19 @@
 
 #import "PlatformUtilities.h"
 #import "TestWKWebView.h"
+#import <WebCore/Color.h>
+#import <WebCore/ColorSerialization.h>
 #import <WebKit/WKWebViewPrivate.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/text/TextStream.h>
+
+#if PLATFORM(COCOA)
+#import <WebCore/ColorCocoa.h>
+#endif
 
 #if PLATFORM(MAC)
+#import <WebCore/ColorMac.h>
+#import <pal/spi/mac/NSApplicationSPI.h>
 #import <pal/spi/mac/NSColorSPI.h>
 #endif
 
@@ -40,6 +49,50 @@
 #endif
 
 namespace TestWebKitAPI {
+
+#if USE(APPKIT)
+
+static WebCore::Color getColorAtPointInWebView(TestWKWebView *webView, NSInteger x, NSInteger y)
+{
+    WebCore::Color color;
+
+    CGFloat viewWidth = CGRectGetWidth([webView frame]);
+    CGFloat viewHeight = CGRectGetHeight([webView frame]);
+    CGFloat backingScaleFactor = [[webView hostWindow] backingScaleFactor];
+
+    bool isDone = false;
+
+    RetainPtr<WKSnapshotConfiguration> snapshotConfiguration = adoptNS([[WKSnapshotConfiguration alloc] init]);
+    [webView takeSnapshotWithConfiguration:snapshotConfiguration.get() completionHandler:[&](NSImage *snapshotImage, NSError *error) {
+        EXPECT_NULL(error);
+
+        CGImageRef cgImage = [snapshotImage CGImageForProposedRect:nil context:nil hints:nil];
+        auto colorSpace = adoptCF(CGColorSpaceCreateDeviceRGB());
+
+        NSInteger viewWidthInPixels = viewWidth * backingScaleFactor;
+        NSInteger viewHeightInPixels = viewHeight * backingScaleFactor;
+
+        uint8_t *rgba = (unsigned char *)calloc(viewWidthInPixels * viewHeightInPixels * 4, sizeof(unsigned char));
+        auto context = adoptCF(CGBitmapContextCreate(rgba, viewWidthInPixels, viewHeightInPixels, 8, 4 * viewWidthInPixels, colorSpace.get(), static_cast<uint32_t>(kCGImageAlphaPremultipliedLast) | static_cast<uint32_t>(kCGBitmapByteOrder32Big)));
+        CGContextDrawImage(context.get(), CGRectMake(0, 0, viewWidthInPixels, viewHeightInPixels), cgImage);
+
+        NSInteger (^getPixelIndex)(NSInteger, NSInteger, NSInteger) = ^(NSInteger x, NSInteger y, NSInteger width) {
+            return (y * width + x) * 4;
+        };
+
+        NSInteger pixelIndex = getPixelIndex(x * backingScaleFactor, y * backingScaleFactor, viewWidthInPixels);
+        color = { WebCore::SRGBA<uint8_t> { rgba[pixelIndex], rgba[pixelIndex + 1], rgba[pixelIndex + 2], rgba[pixelIndex + 3] } };
+
+        free(rgba);
+
+        isDone = true;
+    }];
+    TestWebKitAPI::Util::run(&isDone);
+
+    return color;
+}
+
+#endif
 
 TEST(WebKit, LinkColor)
 {
@@ -69,6 +122,75 @@ TEST(WebKit, LinkColorWithSystemAppearance)
 
     NSString *cssLinkColor = [webView stringByEvaluatingJavaScript:@"getComputedStyle(document.links[0]).color"];
     EXPECT_WK_STREQ(expectedString.UTF8String, cssLinkColor);
+}
+
+TEST(WebKit, AppAccentColorToggleAppearance)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    [webView _setUseSystemAppearance:YES];
+
+    [webView synchronouslyLoadHTMLString:@"<body style='color: -apple-system-control-accent;'>Test</body>"];
+
+    NSColor *originalAccentColor = [NSApp _effectiveAccentColor];
+    NSColor *newAccentColor = [NSColor systemPurpleColor];
+
+    [NSApp _setAccentColor:newAccentColor];
+
+    auto [lightColor, darkColor] = WebCore::lightAndDarkColorsFromNSColor(newAccentColor);
+
+    NSAppearance *lightAppearance = [NSAppearance appearanceNamed:NSAppearanceNameAqua];
+    [webView setAppearance:lightAppearance];
+    NSString *lightCSSColor = [webView stringByEvaluatingJavaScript:@"getComputedStyle(document.body).color"];
+    EXPECT_WK_STREQ(WebCore::serializationForCSS(lightColor), lightCSSColor);
+
+    NSAppearance *darkAppearance = [NSAppearance appearanceNamed:NSAppearanceNameDarkAqua];
+    [webView setAppearance:darkAppearance];
+    NSString *darkCSSColor = [webView stringByEvaluatingJavaScript:@"getComputedStyle(document.body).color"];
+    EXPECT_WK_STREQ(WebCore::serializationForCSS(darkColor), darkCSSColor);
+
+    [NSApp _setAccentColor:originalAccentColor];
+}
+
+TEST(WebKit, AppAccentColorWithColorScheme)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    [[webView hostWindow] makeKeyAndOrderFront:nil];
+
+    [webView _setUseSystemAppearance:YES];
+    [webView synchronouslyLoadHTMLString:@"<body style='background: white'><div style='background: -apple-system-selected-text-background;'>________</div></body>"];
+
+    NSAppearance *originalAppearance = [webView appearance];
+    NSColor *originalAccentColor = [NSApp _effectiveAccentColor];
+    NSColor *newAccentColor = [NSColor systemPurpleColor];
+
+    [NSApp _setAccentColor:newAccentColor];
+
+    NSAppearance *lightAppearance = [NSAppearance appearanceNamed:NSAppearanceNameAqua];
+    [webView setAppearance:lightAppearance];
+    auto lightSelectionColor = getColorAtPointInWebView(webView.get(), 20, 20);
+
+    NSAppearance *darkAppearance = [NSAppearance appearanceNamed:NSAppearanceNameDarkAqua];
+    [webView setAppearance:darkAppearance];
+    auto darkSelectionColor = getColorAtPointInWebView(webView.get(), 20, 20);
+
+    [webView setAppearance:originalAppearance];
+    [webView _setUseSystemAppearance:NO];
+    [webView synchronouslyLoadHTMLString:@"<body contenteditable><div style='color-scheme: light;'>________</div><div style='color-scheme: dark;'>________</div></body>"];
+
+    [webView stringByEvaluatingJavaScript:@"document.body.focus(); window.getSelection().selectAllChildren(document.body);"];
+
+    auto lightSelectionColorObserved = getColorAtPointInWebView(webView.get(), 20, 20);
+    auto darkSelectionColorObserved = getColorAtPointInWebView(webView.get(), 20, 40);
+
+    ALWAYS_LOG_WITH_STREAM(stream << "<SYSTEM-COLOR-TEST>: lightSelectionColor: " << lightSelectionColor);
+    ALWAYS_LOG_WITH_STREAM(stream << "<SYSTEM-COLOR-TEST>: lightSelectionColorObserved: " << lightSelectionColorObserved);
+    ALWAYS_LOG_WITH_STREAM(stream << "<SYSTEM-COLOR-TEST>: darkSelectionColor: " << darkSelectionColor);
+    ALWAYS_LOG_WITH_STREAM(stream << "<SYSTEM-COLOR-TEST>: darkSelectionColorObserved: " << darkSelectionColorObserved);
+
+    EXPECT_EQ(lightSelectionColor, lightSelectionColorObserved);
+    EXPECT_EQ(darkSelectionColor, darkSelectionColorObserved);
+
+    [NSApp _setAccentColor:originalAccentColor];
 }
 #endif
 


### PR DESCRIPTION
#### 19560296912642889228fee249e644721e2ad9e6
<pre>
[macOS] Colors that depend on the app accent color are not always resolved with the effective color scheme
<a href="https://bugs.webkit.org/show_bug.cgi?id=252409">https://bugs.webkit.org/show_bug.cgi?id=252409</a>

Reviewed by NOBODY (OOPS!).

On macOS, applications can set an app-level accent color, which also affect the
values of some system colors.

Since the web process is responsible for resolving system colors, the app
accent color must be sent over from the UI process and set in the web process.
Encoding the accent color is currently lossy, as the `NSColor` is encoded as
a `WebCore::Color`, resolved with the user&apos;s current OS appearance. This means
that the app accent color set in the web process, does not respond to changes
in the user&apos;s OS appearance, or web content that has a different color scheme
than the user&apos;s default.

To fix, add support for encoding dynamic `NSColor`s and ensure the app accent
color is updated whenever the user&apos;s OS appearance changes.

* Source/WebCore/Headers.cmake:
* Source/WebCore/PAL/pal/spi/mac/NSColorSPI.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/PlatformColor.h: Added.

`PlatformColor` is a new abstraction that enables sending platform color types
over IPC. A struct is used as message parameters cannot currently include
Objective-C types.

* Source/WebCore/platform/graphics/mac/ColorMac.h:

Add helper methods to convert between `WebCore::Color`s and dynamic `NSColor`s.

* Source/WebCore/platform/graphics/mac/ColorMac.mm:
(WebCore::lightAndDarkColorsFromNSColor):
(WebCore::dynamicNSColorFromLightAndDarkColors):
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm:
(IPC::typeFromObject):
(IPC::encodeDynamicColorInternal):
(IPC::decodeDynamicColorInternal):
(IPC::encodeObject):
(IPC::decodeObject):
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebPageCreationParameters.h:
* Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp:
(WebKit::PageClientImpl::accentColor):
* Source/WebKit/UIProcess/API/gtk/PageClientImpl.h:
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::accentColorDidChange):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/gtk/WebPageProxyGtk.cpp:
(WebKit::WebPageProxy::accentColorDidChange): Deleted.
* Source/WebKit/UIProcess/mac/PageClientImplMac.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::accentColor):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::effectiveAppearanceDidChange):

Send over a new accent color whenever the effective appearance changes, since
any changes to app accent colors will automatically trigger an effective appearance
change. Additionally, light/dark variants are current the only things encoded in the
dynamic color representation, so a new color must be sent over when changing
accessibility preferences.

This change is only made inside `WebViewImpl`, since on other platforms, accent
colors changes are not related to appearance changes.

* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKit/WebProcess/WebPage/gtk/WebPageGtk.cpp:
(WebKit::WebPage::setAccentColor):
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::setAccentColor):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SystemColors.mm:
(TestWebKitAPI::getColorAtPointInWebView):
(TestWebKitAPI::TEST):

Add two tests to verify that dynamic app accent colors are reflected correctly.

1. A test that verifies that the system control accent color exposed via CSS
   accurately reflects the app accent color.

2. A test that has content with multiple color-schemes, ensuring both variants
   of accent color can be used at the same time. This test uses view snapshotting
   since the `_useSystemAppearance` SPI that makes it possible to read colors
   from CSS disables mixed color-schemes.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19560296912642889228fee249e644721e2ad9e6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109662 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18782 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42407 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1143 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118785 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113558 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20250 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9981 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101931 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115415 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15072 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98306 "2 api tests failed or timed out") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43291 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97046 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29958 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85074 "Found 1 new API test failure: /WebKitGTK/TestDownloads:/webkit/Downloads/local-file-error (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11513 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31300 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12169 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8236 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17535 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50909 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13913 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->