### PR TITLE
PGM Enumeration

### DIFF
--- a/Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj
+++ b/Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj
@@ -552,6 +552,7 @@
 		2B2E2FD12949A41100F85C38 /* pas_malloc_stack_logging.c in Sources */ = {isa = PBXBuildFile; fileRef = 2B2E2FCF2949A41100F85C38 /* pas_malloc_stack_logging.c */; };
 		2B2E2FD22949A41100F85C38 /* pas_malloc_stack_logging.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B2E2FD02949A41100F85C38 /* pas_malloc_stack_logging.h */; };
 		2B6055E42805368B00C8BDAC /* BmallocTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B6055E32805368B00C8BDAC /* BmallocTests.cpp */; };
+		2BF3F5B529A0051F005361FD /* EnumerationTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2BF3F5B429A0051F005361FD /* EnumerationTests.cpp */; };
 		2C11E88E2728A783002162D0 /* bmalloc_type.h in Headers */ = {isa = PBXBuildFile; fileRef = 2C11E88C2728A783002162D0 /* bmalloc_type.h */; };
 		2C11E88F2728A783002162D0 /* pas_simple_type.c in Sources */ = {isa = PBXBuildFile; fileRef = 2C11E88D2728A783002162D0 /* pas_simple_type.c */; };
 		2C11E8912728A893002162D0 /* bmalloc_type.c in Sources */ = {isa = PBXBuildFile; fileRef = 2C11E8902728A893002162D0 /* bmalloc_type.c */; };
@@ -1256,6 +1257,7 @@
 		2B2E2FCF2949A41100F85C38 /* pas_malloc_stack_logging.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pas_malloc_stack_logging.c; sourceTree = "<group>"; };
 		2B2E2FD02949A41100F85C38 /* pas_malloc_stack_logging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_malloc_stack_logging.h; sourceTree = "<group>"; };
 		2B6055E32805368B00C8BDAC /* BmallocTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BmallocTests.cpp; sourceTree = "<group>"; };
+		2BF3F5B429A0051F005361FD /* EnumerationTests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = EnumerationTests.cpp; sourceTree = "<group>"; };
 		2C11E88C2728A783002162D0 /* bmalloc_type.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bmalloc_type.h; sourceTree = "<group>"; };
 		2C11E88D2728A783002162D0 /* pas_simple_type.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pas_simple_type.c; sourceTree = "<group>"; };
 		2C11E8902728A893002162D0 /* bmalloc_type.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = bmalloc_type.c; sourceTree = "<group>"; };
@@ -1394,6 +1396,7 @@
 				2B6055E32805368B00C8BDAC /* BmallocTests.cpp */,
 				0F31A66723E8B336002C0CA3 /* CartesianTreeTests.cpp */,
 				0FC682362129D4EB003C6A13 /* CoalignTests.cpp */,
+				2BF3F5B429A0051F005361FD /* EnumerationTests.cpp */,
 				2C48132C273F4159006CAB55 /* ExpendableMemoryTests.cpp */,
 				0FC6822F2129CB43003C6A13 /* ExtendedGCDTests.cpp */,
 				0FC6821321248A77003C6A13 /* HashtableTests.cpp */,
@@ -2656,6 +2659,7 @@
 				2B6055E42805368B00C8BDAC /* BmallocTests.cpp in Sources */,
 				0F31A66823E8B336002C0CA3 /* CartesianTreeTests.cpp in Sources */,
 				0FC682382129D4EE003C6A13 /* CoalignTests.cpp in Sources */,
+				2BF3F5B529A0051F005361FD /* EnumerationTests.cpp in Sources */,
 				2C48132D273F4159006CAB55 /* ExpendableMemoryTests.cpp in Sources */,
 				0FC682312129CB46003C6A13 /* ExtendedGCDTests.cpp in Sources */,
 				0FC6821521248A79003C6A13 /* HashtableTests.cpp in Sources */,

--- a/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c
@@ -58,6 +58,7 @@ bool pas_probabilistic_guard_malloc_is_initialized = false;
  * value : metadata for tracking that allocation (pas_pgm_storage)
  */
 pas_ptr_hash_map pas_pgm_hash_map = PAS_HASHTABLE_INITIALIZER;
+pas_ptr_hash_map_in_flux_stash pas_pgm_hash_map_in_flux_stash;
 
 static void pas_probabilistic_guard_malloc_debug_info(const void* key, const pas_pgm_storage* value, const char* operation);
 
@@ -178,8 +179,10 @@ void pas_probabilistic_guard_malloc_deallocate(void* mem)
     int mprotect_res = mprotect( (void *) value->start_of_data_pages, value->size_of_data_pages, PROT_NONE);
     PAS_ASSERT(!mprotect_res);
 
-    // ensure physical addresses are released
-    // TODO: investigate using MADV_FREE_REUSABLE instead
+    /*
+     * ensure physical addresses are released
+     * TODO: investigate using MADV_FREE_REUSABLE instead
+     */
     int madvise_res = madvise((void *) value->start_of_data_pages, value->size_of_data_pages, MADV_FREE);
     PAS_ASSERT(!madvise_res);
 

--- a/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h
@@ -28,6 +28,7 @@
 
 #include "pas_utils.h"
 #include "pas_large_heap.h"
+#include "pas_ptr_hash_map.h"
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -57,6 +58,9 @@ struct pas_pgm_storage {
  * including guard pages and wasted memory
  */
 #define PAS_PGM_MAX_VIRTUAL_MEMORY (1024 * 1024 * 1024)
+
+extern PAS_API pas_ptr_hash_map pas_pgm_hash_map;
+extern PAS_API pas_ptr_hash_map_in_flux_stash pas_pgm_hash_map_in_flux_stash;
 
 /*
  * We want a fast way to determine if we can call PGM or not.

--- a/Source/bmalloc/libpas/src/libpas/pas_root.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_root.c
@@ -38,6 +38,7 @@
 #include "pas_large_map.h"
 #include "pas_large_sharing_pool.h"
 #include "pas_payload_reservation_page_list.h"
+#include "pas_probabilistic_guard_malloc_allocator.h"
 #include "pas_scavenger.h"
 #include "pas_thread_local_cache_layout.h"
 #include "pas_thread_local_cache_node.h"
@@ -125,6 +126,9 @@ void pas_root_construct(pas_root* root)
         &pas_tiny_large_map_hashtable_instance_in_flux_stash;
     root->tiny_large_map_second_level_hashtable_in_flux_stash_instance =
         &pas_tiny_large_map_second_level_hashtable_in_flux_stash_instance;
+
+    root->pas_pgm_hash_map_instance = &pas_pgm_hash_map;
+    root->pas_pgm_hash_map_instance_in_flux_stash = &pas_pgm_hash_map_in_flux_stash;
 
     root->heap_configs = pas_immortal_heap_allocate(
         sizeof(const pas_heap_config*) * pas_heap_config_kind_num_kinds,

--- a/Source/bmalloc/libpas/src/libpas/pas_root.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_root.h
@@ -50,6 +50,8 @@ struct pas_thread_local_cache_node;
 struct pas_tiny_large_map_hashtable;
 struct pas_tiny_large_map_hashtable_in_flux_stash;
 struct pas_tiny_large_map_second_level_hashtable_in_flux_stash;
+struct pas_ptr_hash_map;
+struct pas_ptr_hash_map_in_flux_stash;
 typedef struct pas_baseline_allocator pas_baseline_allocator;
 typedef struct pas_enumerable_range_list pas_enumerable_range_list;
 typedef struct pas_heap_config pas_heap_config;
@@ -65,6 +67,8 @@ typedef struct pas_thread_local_cache_layout_segment pas_thread_local_cache_layo
 typedef struct pas_tiny_large_map_hashtable pas_tiny_large_map_hashtable;
 typedef struct pas_tiny_large_map_hashtable_in_flux_stash pas_tiny_large_map_hashtable_in_flux_stash;
 typedef struct pas_tiny_large_map_second_level_hashtable_in_flux_stash pas_tiny_large_map_second_level_hashtable_in_flux_stash;
+typedef struct pas_ptr_hash_map pas_ptr_hash_map;
+typedef struct pas_ptr_hash_map_in_flux_stash pas_ptr_hash_map_in_flux_stash;
 
 struct pas_root {
     uintptr_t magic;
@@ -95,6 +99,8 @@ struct pas_root {
     size_t page_malloc_alignment;
     pas_baseline_allocator** baseline_allocator_table;
     size_t num_baseline_allocators;
+    pas_ptr_hash_map* pas_pgm_hash_map_instance;
+    pas_ptr_hash_map_in_flux_stash* pas_pgm_hash_map_instance_in_flux_stash;
 };
 
 #define PAS_ROOT_MAGIC 0xbeeeeeeeeflu

--- a/Source/bmalloc/libpas/src/test/EnumerationTests.cpp
+++ b/Source/bmalloc/libpas/src/test/EnumerationTests.cpp
@@ -1,0 +1,291 @@
+/*
+ * Copyright (c) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "TestHarness.h"
+#include "pas_root.h"
+#include "bmalloc_heap.h"
+#include "pas_probabilistic_guard_malloc_allocator.h"
+#include "pas_heap.h"
+#include "iso_heap.h"
+#include "iso_heap_config.h"
+#include "pas_heap_ref_kind.h"
+
+#include <map>
+#include <stdlib.h>
+#include <set>
+#include <sys/mman.h>
+
+using namespace std;
+
+namespace {
+
+const bool verbose = false;
+
+struct PageRange {
+    PageRange() = default;
+
+    PageRange(void* base, size_t size)
+        : base(base)
+        , size(size)
+    {
+        PAS_ASSERT(pas_is_aligned(reinterpret_cast<uintptr_t>(base), pas_page_malloc_alignment()));
+        PAS_ASSERT(pas_is_aligned(size, pas_page_malloc_alignment()));
+        PAS_ASSERT(!!base == !!size);
+    }
+
+    bool operator<(PageRange range) const
+    {
+        return base < range.base;
+    }
+
+    void* end() const
+    {
+        return reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(base) + size);
+    }
+
+    void* base { nullptr };
+    size_t size { 0 };
+};
+
+set<PageRange> pageRanges;
+
+struct RecordedRange {
+    RecordedRange() = default;
+
+    RecordedRange(void* base, size_t size)
+        : base(base)
+        , size(size)
+    {
+        PAS_ASSERT(base);
+    }
+
+    bool operator<(RecordedRange other) const
+    {
+        return base < other.base;
+    }
+
+    void* end() const
+    {
+        return reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(base) + size);
+    }
+
+    void* base { nullptr };
+    size_t size { 0 };
+};
+
+struct ReaderRange {
+    ReaderRange() = default;
+
+    ReaderRange(void* base, size_t size)
+        : base(base)
+        , size(size)
+    {
+        PAS_ASSERT(base);
+        PAS_ASSERT(size);
+    }
+
+    bool operator<(ReaderRange other) const
+    {
+        if (base != other.base)
+            return base < other.base;
+        return size < other.size;
+    }
+
+    void* base { nullptr };
+    size_t size { 0 };
+};
+
+map<pas_enumerator_record_kind, set<RecordedRange>> recordedRanges;
+map<ReaderRange, void*> readerCache;
+
+void* enumeratorReader(pas_enumerator* enumerator, void* address, size_t size, void* arg)
+{
+    CHECK(!arg);
+    CHECK(size);
+
+    ReaderRange range = ReaderRange(address, size);
+
+    auto readerCacheIter = readerCache.find(range);
+    if (readerCacheIter != readerCache.end())
+        return readerCacheIter->second;
+
+    void* result = pas_enumerator_allocate(enumerator, size);
+
+    void* pageAddress = reinterpret_cast<void*>(
+        pas_round_down_to_power_of_2(
+            reinterpret_cast<uintptr_t>(address),
+            pas_page_malloc_alignment()));
+    size_t pagesSize =
+        pas_round_up_to_power_of_2(
+            reinterpret_cast<uintptr_t>(address) + size,
+            pas_page_malloc_alignment())
+        - reinterpret_cast<uintptr_t>(pageAddress);
+    void* pageEndAddress = reinterpret_cast<void*>(
+        reinterpret_cast<uintptr_t>(pageAddress) + pagesSize);
+
+    bool areProtectedPages = false;
+    if (!pageRanges.empty()) {
+        auto pageRangeIter = pageRanges.upper_bound(PageRange(pageAddress, pagesSize));
+        if (pageRangeIter != pageRanges.begin()) {
+            --pageRangeIter;
+            areProtectedPages =
+                pageRangeIter->base <= pageAddress
+                && pageRangeIter->end() > pageAddress;
+        }
+    }
+
+    if (verbose) {
+        cout << "address = " << address << "..."
+             << reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(address) + size)
+             << ", pageAddress = " << pageAddress << "..." << pageEndAddress
+             << ", areProtectedPages = " << areProtectedPages << "\n";
+    }
+
+    if (areProtectedPages) {
+        int systemResult = mprotect(pageAddress, pagesSize, PROT_READ);
+        PAS_ASSERT(!systemResult);
+    }
+
+    memcpy(result, address, size);
+
+    if (areProtectedPages) {
+        int systemResult = mprotect(pageAddress, pagesSize, PROT_NONE);
+        PAS_ASSERT(!systemResult);
+    }
+
+    readerCache[range] = result;
+    return result;
+}
+
+void enumeratorRecorder(pas_enumerator* enumerator, void* address, size_t size, pas_enumerator_record_kind kind, void* arg)
+{
+    PAS_UNUSED_PARAM(enumerator);
+    CHECK(size);
+    CHECK(!arg);
+
+    if (verbose) {
+        cout << "Recording " << pas_enumerator_record_kind_get_string(kind) << ":" << address
+             << "..." << reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(address) + size) << "\n";
+    }
+
+    RecordedRange range = RecordedRange(address, size);
+
+    CHECK(!recordedRanges[kind].count(range));
+    recordedRanges[kind].insert(range);
+}
+
+
+void testBasicEnumeration() {
+
+    pas_heap_lock_lock();
+    pas_root* root = pas_root_create();
+    pas_heap_lock_unlock();
+
+    auto size = 25;
+    void* arr[size];
+    for (auto i = 0; i < size; i++) {
+        arr[i] = bmalloc_try_allocate(1000000);
+        PAS_ASSERT(arr[i]);
+    }
+
+    pas_enumerator* enumerator = pas_enumerator_create(root, enumeratorReader, nullptr, enumeratorRecorder, nullptr, pas_enumerator_record_meta_records, pas_enumerator_record_payload_records, pas_enumerator_record_object_records);
+    pas_enumerator_enumerate_all(enumerator);
+
+    pas_enumerator_destroy(enumerator);
+}
+
+void testPGMEnumerationBasic() {
+
+    pas_heap_lock_lock();
+    pas_root* root = pas_root_create();
+    pas_heap_lock_unlock();
+
+    pas_heap_ref heapRef = ISO_HEAP_REF_INITIALIZER_WITH_ALIGNMENT(getpagesize() * 100, getpagesize());
+    pas_heap* heap = iso_heap_ref_get_heap(&heapRef);
+    pas_physical_memory_transaction transaction;
+    pas_physical_memory_transaction_construct(&transaction);
+
+    pas_heap_lock_lock();
+
+    size_t alloc_size = 16384;
+    pas_allocation_result result = pas_probabilistic_guard_malloc_allocate(&heap->large_heap, alloc_size, &iso_heap_config, &transaction);
+    CHECK(result.begin);
+
+    result = pas_probabilistic_guard_malloc_allocate(&heap->large_heap, alloc_size, &iso_heap_config, &transaction);
+    CHECK(result.begin);
+
+    result = pas_probabilistic_guard_malloc_allocate(&heap->large_heap, alloc_size, &iso_heap_config, &transaction);
+    CHECK(result.begin);
+
+    pas_heap_lock_unlock();
+
+    pas_enumerator* enumerator = pas_enumerator_create(root, enumeratorReader, nullptr, enumeratorRecorder, nullptr, pas_enumerator_record_meta_records, pas_enumerator_record_payload_records, pas_enumerator_record_object_records);
+    pas_enumerator_enumerate_all(enumerator);
+
+    pas_enumerator_destroy(enumerator);
+}
+
+void testPGMEnumerationAddAndFree() {
+
+    pas_heap_lock_lock();
+    pas_root* root = pas_root_create();
+    pas_heap_lock_unlock();
+
+    pas_heap_ref heapRef = ISO_HEAP_REF_INITIALIZER_WITH_ALIGNMENT(getpagesize() * 100, getpagesize());
+    pas_heap* heap = iso_heap_ref_get_heap(&heapRef);
+    pas_physical_memory_transaction transaction;
+    pas_physical_memory_transaction_construct(&transaction);
+
+    pas_heap_lock_lock();
+
+    size_t alloc_size = 16384;
+    pas_allocation_result result = pas_probabilistic_guard_malloc_allocate(&heap->large_heap, alloc_size, &iso_heap_config, &transaction);
+    CHECK(result.begin);
+
+    result = pas_probabilistic_guard_malloc_allocate(&heap->large_heap, alloc_size, &iso_heap_config, &transaction);
+    CHECK(result.begin);
+
+    result = pas_probabilistic_guard_malloc_allocate(&heap->large_heap, alloc_size, &iso_heap_config, &transaction);
+    CHECK(result.begin);
+
+    pas_probabilistic_guard_malloc_deallocate((void*) result.begin);
+
+    pas_heap_lock_unlock();
+
+    pas_enumerator* enumerator = pas_enumerator_create(root, enumeratorReader, nullptr, enumeratorRecorder, nullptr, pas_enumerator_record_meta_records, pas_enumerator_record_payload_records, pas_enumerator_record_object_records);
+    pas_enumerator_enumerate_all(enumerator);
+
+    pas_enumerator_destroy(enumerator);
+
+}
+
+
+} // end namespace
+
+void addEnumerationTests() {
+    ADD_TEST(testBasicEnumeration());
+    ADD_TEST(testPGMEnumerationBasic());
+    ADD_TEST(testPGMEnumerationAddAndFree());
+}

--- a/Source/bmalloc/libpas/src/test/TestHarness.cpp
+++ b/Source/bmalloc/libpas/src/test/TestHarness.cpp
@@ -356,6 +356,7 @@ void addBitvectorTests();
 void addBmallocTests();
 void addCartesianTreeTests();
 void addCoalignTests();
+void addEnumerationTests();
 void addExpendableMemoryTests();
 void addExtendedGCDTests();
 void addHashtableTests();
@@ -725,6 +726,7 @@ int main(int argc, char** argv)
     ADD_SUITE(Bmalloc);
     ADD_SUITE(CartesianTree);
     ADD_SUITE(Coalign);
+    ADD_SUITE(Enumeration);
     ADD_SUITE(ExpendableMemory);
     ADD_SUITE(ExtendedGCD);
     ADD_SUITE(Hashtable);


### PR DESCRIPTION
#### e1dfe8ee432e1e56188157ffb1ce6f6afb7758ba
<pre>
PGM Enumeration
<a href="https://bugs.webkit.org/show_bug.cgi?id=252331">https://bugs.webkit.org/show_bug.cgi?id=252331</a>

Reviewed by Brent Fulgham.

Add enumeration support for PGM allocation. This will enumerate both the allocation and
surronding metadata regarding that allocation. Freed PGM allocations are not tracked.

* Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj:
* Source/bmalloc/libpas/src/libpas/pas_enumerate_large_heaps.c:
(pas_hash_map_entry_callback):
(enumerate_pgm_map):
(pas_enumerate_large_heaps):
* Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c:
(pas_probabilistic_guard_malloc_deallocate):
* Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h:
* Source/bmalloc/libpas/src/libpas/pas_root.c:
(pas_root_construct):
* Source/bmalloc/libpas/src/libpas/pas_root.h:
* Source/bmalloc/libpas/src/test/EnumerationTests.cpp: Added.
(std::PageRange::PageRange):
(std::PageRange::operator&lt; const):
(std::PageRange::end const):
(std::RecordedRange::RecordedRange):
(std::RecordedRange::operator&lt; const):
(std::RecordedRange::end const):
(std::ReaderRange::ReaderRange):
(std::ReaderRange::operator&lt; const):
(std::enumeratorReader):
(std::enumeratorRecorder):
(std::testBasicEnumeration):
(std::testPGMEnumerationBasic):
(std::testPGMEnumerationAddAndFree):
(addEnumerationTests):
* Source/bmalloc/libpas/src/test/TestHarness.cpp:
(main):

Canonical link: <a href="https://commits.webkit.org/260978@main">https://commits.webkit.org/260978@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01647f1fe6225bf97451bf198f74abbfac831810

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110137 "22 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19236 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42803 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1565 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/119142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20697 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10426 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102393 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115883 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/43631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/30279 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/85469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/98915 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11931 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/31616 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/99874 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/9972 "Built successfully and passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/12545 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31202 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/17910 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51232 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/107895 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7608 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14349 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26613 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->