### PR TITLE
Allow iPad UserAgent header to be static

### DIFF
--- a/Source/WebCore/platform/ios/UserAgentIOS.mm
+++ b/Source/WebCore/platform/ios/UserAgentIOS.mm
@@ -61,6 +61,7 @@ ASCIILiteral osNameForUserAgent()
     return "iPhone OS"_s;
 }
 
+#if !USE(STATIC_IPAD_USER_AGENT_VALUE)
 static StringView deviceNameForUserAgent()
 {
     if (isClassic()) {
@@ -80,19 +81,27 @@ static StringView deviceNameForUserAgent()
     }();
     return name.get();
 }
+#endif
 
 String standardUserAgentWithApplicationName(const String& applicationName, const String& userAgentOSVersion, UserAgentType type)
 {
     auto separator = applicationName.isEmpty() ? "" : " ";
+
     if (type == UserAgentType::Desktop)
         return makeString("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko)", separator, applicationName);
 
+#if USE(STATIC_IPAD_USER_AGENT_VALUE)
+    UNUSED_PARAM(userAgentOSVersion);
+    UNUSED_PARAM(separator);
+    return makeString("Mozilla/5.0 (iPad; CPU OS 16_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.3 Mobile/15E148 Safari/604.1");
+#else
     // FIXME: We should deprecate and remove this override; see https://bugs.webkit.org/show_bug.cgi?id=217927 for details.
     if (auto override = dynamic_cf_cast<CFStringRef>(adoptCF(CFPreferencesCopyAppValue(CFSTR("UserAgent"), CFSTR("com.apple.WebFoundation")))))
         return override.get();
 
     auto osVersion = userAgentOSVersion.isEmpty() ? systemMarketingVersionForUserAgentString() : userAgentOSVersion;
     return makeString("Mozilla/5.0 (", deviceNameForUserAgent(), "; CPU ", osNameForUserAgent(), " ", osVersion, " like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko)", separator, applicationName);
+#endif
 }
 
 } // namespace WebCore.


### PR DESCRIPTION
#### fb48549c51eda1cc99d256d1cfbce7576883b9f5
<pre>
Allow iPad UserAgent header to be static
<a href="https://bugs.webkit.org/show_bug.cgi?id=252421">https://bugs.webkit.org/show_bug.cgi?id=252421</a>
rdar://105504510

Reviewed by Tim Horton.

There are cases where we want to provide a static UserAgent
header, similar to what we do for desktop-class browsing.
But unlike that, we still want to identify as a mobile
browser, so we need the &quot;iPad&quot; component.

This would be better exposed as a Setting, but this method
is called from WebKit without a Document, so it is a compile-
time guard for now.

* Source/WebCore/platform/ios/UserAgentIOS.mm:
(WebCore::standardUserAgentWithApplicationName):

Canonical link: <a href="https://commits.webkit.org/260450@main">https://commits.webkit.org/260450@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff5383b45e5a0562d079bab220a02dc278c36807

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108190 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17273 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41057 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117314 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116629 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112077 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18661 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8559 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100398 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113958 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14078 "Found 6 new test failures: editing/deleting/smart-delete-003.html, editing/pasteboard/smart-paste-003-trailing-whitespace.html, editing/pasteboard/smart-paste-005.html, editing/pasteboard/smart-paste-paragraph-004.html, editing/selection/doubleclick-whitespace-img-crash.html, editing/selection/ios/selection-handles-in-iframe.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97265 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41976 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95988 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28905 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/83648 "Found 1 new API test failure: /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/cut-copy-paste/non-editable (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10136 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30252 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10861 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7156 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16285 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49844 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/7230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12443 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3925 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->