### PR TITLE
VectorBitwiseSelect should not create tricky IR to colour

### DIFF
--- a/JSTests/wasm/stress/simd-regalloc-stress.js
+++ b/JSTests/wasm/stress/simd-regalloc-stress.js
@@ -1,0 +1,78 @@
+//@ requireOptions("--useWebAssemblySIMD=1", "--thresholdForOMGOptimizeSoon=1", "--thresholdForOMGOptimizeAfterWarmUp=1")
+//@ skip if !$isSIMDPlatform
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+/*
+This test stresses the UD register on Arm64 for bitselect.
+
+Air     MoveVector (%tmp0), %ftmp12
+Air     MoveVector 16(%tmp0), %ftmp13
+Air     MoveVector 32(%tmp0), %ftmp11
+Air     MoveVector %ftmp11, %ftmp10
+Air     VectorBitwiseSelect %ftmp12, %ftmp13, %ftmp10
+Air     MoveVector %ftmp10, %*ftmp8*
+(ftmp11, ftmp10 are unspillable here because it is Use'd right after being Def'd, and the range is size 1)
+...
+Air     Patch &CCall1, %tmp1, %x0, %x1, %q0, %x0, %x1
+Air     MoveDoubleConditionallyTest32 NonZero, %tmp4, %tmp4, %*ftmp8*, %ftmp9, %ftmp6
+
+Then, after this iteration, we coalesce ftmp11 -> ftmp10 -> ftmp8:
+
+Air     MoveVector 32(%x23), %ftmp11
+Air     VectorBitwiseSelect %ftmp12, %ftmp13, %ftmp11
+
+But ftmp11 is still unspillable, and now the graph is uncolourable.
+
+Instead, we should emit this:
+
+Air     MoveVector %ftmp8, %ftmp6
+Air     VectorBitwiseSelect %ftmp9, %ftmp10, %ftmp6
+...
+Air     MoveDoubleConditionallyTest32 NonZero, %x21, %x21, %ftmp6, %ftmp7, %ftmp4
+
+Here, the register allocator can see the lifetime of ftmp6 right away, so we always consider spilling it.
+*/
+
+let wat = `
+(module
+    (memory 1566 2420)
+    (func $test_v (export "test_v") (result v128)
+        (v128.bitselect
+            (v128.const i32x4 0xc5390eea 0x380f028d 0x0783e59c 0x42450ed6)
+            (v128.const i32x4 0x06af5fea 0x88b2a9c9 0x464d61fd 0xa45d8e65)
+            (v128.const i32x4 0xaf7bd660 0xadc482ad 0x950b56f5 0x6eca2081))
+    
+        (v128.const i32x4 0xc4b8b1c4 0x61f689d9 0xd0aa3e6b 0x9664e1e7)
+        (memory.size)
+        (ref.func $test_v)
+        (drop)
+        (select)
+    
+        (v128.const i32x4 0xa87ec07f 0x862e0e2c 0xe8540566 0x681d8726)    
+        (v128.const i32x4 0x2f0f7b81 0xdf627e48 0x9df8369b 0xe6126ff6)
+        (v128.bitselect)
+        (v128.const i32x4 0xd5dfc95a 0x718c317c 0xec507a32 0x8acdd83f)
+        (ref.func $test_v)
+        (drop)
+        (v128.const i32x4 0x2f0f7b81 0xdf627e48 0x9df8369b 0xe6126ff6)
+        (v128.bitselect)
+    )
+
+    (func $test (export "test")
+        (call $test_v)
+        (drop)
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { simd: true })
+    const { test, test2 } = instance.exports
+
+    for (let i = 0; i < 10000; ++i) {
+        assert.eq(test(), undefined)
+    }
+}
+
+assert.asyncTest(test())

--- a/Source/JavaScriptCore/b3/B3LowerToAir.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir.cpp
@@ -4142,10 +4142,9 @@ private:
             return;
         case B3::VectorBitwiseSelect: {
             SIMDValue* value = m_value->as<SIMDValue>();
-            auto resultTmp = m_code.newTmp(FP);
+            auto resultTmp = tmp(value);
             append(MoveVector, tmp(value->child(2)), resultTmp);
             append(Air::VectorBitwiseSelect, tmp(value->child(0)), tmp(value->child(1)), resultTmp);
-            append(MoveVector, resultTmp, tmp(value));
             return;
         }
         case B3::VectorExtaddPairwise:

--- a/Source/JavaScriptCore/b3/air/AirInst.cpp
+++ b/Source/JavaScriptCore/b3/air/AirInst.cpp
@@ -89,11 +89,6 @@ unsigned Inst::jsHash() const
 void Inst::dump(PrintStream& out) const
 {
     out.print(kind, " ", listDump(args));
-    if (origin) {
-        if (args.size())
-            out.print(", ");
-        out.print(*origin);
-    }
 }
 
 } } } // namespace JSC::B3::Air


### PR DESCRIPTION
#### 6f477c95e4740dcab092e7320f8d0fbd681bad82
<pre>
VectorBitwiseSelect should not create tricky IR to colour
<a href="https://bugs.webkit.org/show_bug.cgi?id=252424">https://bugs.webkit.org/show_bug.cgi?id=252424</a>
rdar://105390761

Reviewed by Yusuke Suzuki.

This test stresses the UD register on Arm64 for bitselect.

Air     MoveVector (%tmp0), %ftmp12
Air     MoveVector 16(%tmp0), %ftmp13
Air     MoveVector 32(%tmp0), %ftmp11
Air     MoveVector %ftmp11, %ftmp10
Air     VectorBitwiseSelect %ftmp12, %ftmp13, %ftmp10
Air     MoveVector %ftmp10, %*ftmp8*
(ftmp11, ftmp10 are unspillable here because it is Use&apos;d right after
being Def&apos;d, and the range is size 1)
...
Air     Patch &amp;CCall1, %tmp1, %x0, %x1, %q0, %x0, %x1
Air     MoveDoubleConditionallyTest32 NonZero, %tmp4, %tmp4, %*ftmp8*, %ftmp9, %ftmp6

Then, after this iteration, we coalesce ftmp11 -&gt; ftmp10 -&gt; ftmp8:

Air     MoveVector 32(%x23), %ftmp11
Air     VectorBitwiseSelect %ftmp12, %ftmp13, %ftmp11

But ftmp11 is still unspillable, and now the graph is uncolourable.

Instead, we should emit this:

Air     MoveVector %ftmp8, %ftmp6
Air     VectorBitwiseSelect %ftmp9, %ftmp10, %ftmp6
...
Air     MoveDoubleConditionallyTest32 NonZero, %x21, %x21, %ftmp6, %ftmp7, %ftmp4

Here, the register allocator can see the lifetime of ftmp6 right away, so
we always consider spilling it.

In general, should the register allocator handle this case gracefully?
Probably. We should either:
1) Not coalesce unspillable registers until we know the graph is colourable
2) Remove registers from unspillableTmps when we increase their live range

There is a decent chance that these changes could break things, or be
subtly wrong in a different case. Let&apos;s just emit code that is easy to
colour.

* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/air/AirAllocateRegistersByGraphColoring.cpp:
* Source/JavaScriptCore/b3/air/AirInst.cpp:
(JSC::B3::Air::Inst::dump const):

Canonical link: <a href="https://commits.webkit.org/260449@main">https://commits.webkit.org/260449@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1fddb829e041331bbca1a2ffaa721238d7816fe4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108195 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17278 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41062 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117319 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116633 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18665 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8564 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100403 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113963 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14083 "Found 6 new test failures: editing/deleting/smart-delete-003.html, editing/pasteboard/smart-paste-003-trailing-whitespace.html, editing/pasteboard/smart-paste-005.html, editing/pasteboard/smart-paste-paragraph-004.html, editing/selection/doubleclick-whitespace-img-crash.html, editing/selection/ios/selection-handles-in-iframe.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97268 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41979 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95992 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28908 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/83661 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/97410 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10141 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30255 "Found 1 new test failure: media/video-playback-quality.html (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/96767 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/8244 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10866 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7161 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30929 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16290 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49847 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/105795 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7229 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12448 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26190 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->