### PR TITLE
[GPU Process][FormControls] Remove the flipping workaround for drawing a viewless NSCell

### DIFF
--- a/Source/WebCore/platform/cocoa/LocalCurrentGraphicsContext.h
+++ b/Source/WebCore/platform/cocoa/LocalCurrentGraphicsContext.h
@@ -35,7 +35,7 @@ namespace WebCore {
 class LocalCurrentGraphicsContext {
     WTF_MAKE_NONCOPYABLE(LocalCurrentGraphicsContext);
 public:
-    WEBCORE_EXPORT LocalCurrentGraphicsContext(GraphicsContext&);
+    WEBCORE_EXPORT LocalCurrentGraphicsContext(GraphicsContext&, bool isFlipped = true);
     WEBCORE_EXPORT ~LocalCurrentGraphicsContext();
     CGContextRef cgContext() { return m_savedGraphicsContext.platformContext(); }
 private:

--- a/Source/WebCore/platform/graphics/mac/controls/ControlMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlMac.h
@@ -71,7 +71,7 @@ protected:
 
 private:
     void drawCellInternal(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&, NSCell *);
-    void drawCellFocusRingInternal(const FloatRect&, float deviceScaleFactor, const ControlStyle&, NSCell *);
+    void drawCellFocusRingInternal(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&, NSCell *);
 
     void drawCellFocusRing(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&, NSCell *);
     void drawCellOrFocusRing(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&, NSCell *, bool drawCell = true);

--- a/Source/WebCore/platform/ios/LocalCurrentGraphicsContextIOS.mm
+++ b/Source/WebCore/platform/ios/LocalCurrentGraphicsContextIOS.mm
@@ -26,7 +26,7 @@
 
 namespace WebCore {
 
-LocalCurrentGraphicsContext::LocalCurrentGraphicsContext(GraphicsContext& graphicsContext)
+LocalCurrentGraphicsContext::LocalCurrentGraphicsContext(GraphicsContext& graphicsContext, bool)
     : m_savedGraphicsContext(graphicsContext)
 {
     m_savedGraphicsContext.save();

--- a/Source/WebCore/platform/mac/LocalCurrentGraphicsContextMac.mm
+++ b/Source/WebCore/platform/mac/LocalCurrentGraphicsContextMac.mm
@@ -26,7 +26,7 @@
 
 namespace WebCore {
 
-LocalCurrentGraphicsContext::LocalCurrentGraphicsContext(GraphicsContext& graphicsContext)
+LocalCurrentGraphicsContext::LocalCurrentGraphicsContext(GraphicsContext& graphicsContext, bool isFlipped)
     : m_savedGraphicsContext(graphicsContext)
 {
     m_savedGraphicsContext.save();
@@ -42,7 +42,7 @@ LocalCurrentGraphicsContext::LocalCurrentGraphicsContext(GraphicsContext& graphi
         return;
 
     m_savedNSGraphicsContext = [NSGraphicsContext currentContext];
-    NSGraphicsContext* newContext = [NSGraphicsContext graphicsContextWithCGContext:cgContext flipped:YES];
+    NSGraphicsContext* newContext = [NSGraphicsContext graphicsContextWithCGContext:cgContext flipped:isFlipped];
     [NSGraphicsContext setCurrentContext:newContext];
     m_didSetGraphicsContext = true;
 }


### PR DESCRIPTION
#### deb6370ae7025c39a7f2cc8263a04330872bd2e6
<pre>
[GPU Process][FormControls] Remove the flipping workaround for drawing a viewless NSCell
<a href="https://bugs.webkit.org/show_bug.cgi?id=252427">https://bugs.webkit.org/show_bug.cgi?id=252427</a>
rdar://105563614

Reviewed by Aditya Keerthi.

This patch will remove part of the workaround which was added in 260210@main.
But we still need to un-flip the flipped coordinates system before asking AppKit
to draw the NSCells. The only difference this patch makes is we will un-flip the
context unconditionally for all NSCell types.

* Source/WebCore/platform/cocoa/LocalCurrentGraphicsContext.h:
* Source/WebCore/platform/graphics/mac/controls/ControlMac.h:
* Source/WebCore/platform/graphics/mac/controls/ControlMac.mm:
(WebCore::drawSliderCell):
(WebCore::drawViewlessCell):
(WebCore::drawCellInView):
(WebCore::ControlMac::drawCellInternal):
(WebCore::ControlMac::drawCellFocusRingInternal):
(WebCore::ControlMac::drawCellFocusRing):
(WebCore::ControlMac::drawCellOrFocusRing):
(WebCore::shouldFlipContext): Deleted.
* Source/WebCore/platform/ios/LocalCurrentGraphicsContextIOS.mm:
(WebCore::LocalCurrentGraphicsContext::LocalCurrentGraphicsContext):
* Source/WebCore/platform/mac/LocalCurrentGraphicsContextMac.mm:
(WebCore::LocalCurrentGraphicsContext::LocalCurrentGraphicsContext):

Canonical link: <a href="https://commits.webkit.org/261085@main">https://commits.webkit.org/261085@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2571bad061c40c53a67a782609f457e14cc1de74

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110363 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19452 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42973 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1751 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119295 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114311 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20895 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10615 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102608 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116107 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15561 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98753 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43780 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97522 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30418 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85636 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12118 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31756 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12707 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8724 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18072 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51371 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7680 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14556 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->