### PR TITLE
[Cocoa] Prevent active background page processes from suspending

### DIFF
--- a/Source/WebKit/UIProcess/ProcessThrottler.cpp
+++ b/Source/WebKit/UIProcess/ProcessThrottler.cpp
@@ -39,6 +39,7 @@
 namespace WebKit {
     
 static const Seconds processSuspensionTimeout { 20_s };
+static const Seconds removeAllAssertionsTimeout { 8_min };
 
 static uint64_t generatePrepareToSuspendRequestID()
 {
@@ -49,6 +50,7 @@ static uint64_t generatePrepareToSuspendRequestID()
 ProcessThrottler::ProcessThrottler(ProcessThrottlerClient& process, bool shouldTakeUIBackgroundAssertion)
     : m_process(process)
     , m_prepareToSuspendTimeoutTimer(RunLoop::main(), this, &ProcessThrottler::prepareToSuspendTimeoutTimerFired)
+    , m_removeAllAssertionsTimer(RunLoop::main(), this, &ProcessThrottler::removeAllAssertionsTimerFired)
     , m_shouldTakeUIBackgroundAssertion(shouldTakeUIBackgroundAssertion)
 {
 }
@@ -147,7 +149,7 @@ String ProcessThrottler::assertionName(ProcessAssertionType type) const
     return makeString(m_process.clientName(), " ", typeString, " Assertion");
 }
 
-std::optional<ProcessAssertionType> ProcessThrottler::assertionTypeForState(ProcessThrottleState state)
+ProcessAssertionType ProcessThrottler::assertionTypeForState(ProcessThrottleState state)
 {
     switch (state) {
     case ProcessThrottleState::Foreground:
@@ -155,7 +157,7 @@ std::optional<ProcessAssertionType> ProcessThrottler::assertionTypeForState(Proc
     case ProcessThrottleState::Background:
         return ProcessAssertionType::Background;
     case ProcessThrottleState::Suspended:
-        return m_shouldTakeSuspendedAssertion ? std::optional(ProcessAssertionType::Suspended) : std::nullopt;
+        return ProcessAssertionType::Suspended;
     }
 
     RELEASE_ASSERT_NOT_REACHED();
@@ -166,13 +168,7 @@ void ProcessThrottler::setThrottleState(ProcessThrottleState newState)
     m_state = newState;
     m_process.didChangeThrottleState(newState);
 
-    ProcessAssertionType newType;
-    if (auto assertionType = assertionTypeForState(newState))
-        newType = assertionType.value();
-    else {
-        m_assertion = nullptr;
-        return;
-    }
+    ProcessAssertionType newType = assertionTypeForState(newState);
 
     if (m_assertion && m_assertion->isValid() && m_assertion->type() == newType)
         return;
@@ -210,6 +206,7 @@ void ProcessThrottler::updateThrottleStateIfNeeded()
                 PROCESSTHROTTLER_RELEASE_LOG("updateThrottleStateIfNeeded: sending ProcessDidResume IPC because the WebProcess is still processing request to suspend=%" PRIu64, *m_pendingRequestToSuspendID);
             m_process.sendProcessDidResume(expectedThrottleState() == ProcessThrottleState::Foreground ? ProcessThrottlerClient::ResumeReason::ForegroundActivity : ProcessThrottlerClient::ResumeReason::BackgroundActivity);
             clearPendingRequestToSuspend();
+            m_removeAllAssertionsTimer.stop();
         }
     } else {
         // If the process is currently runnable but will be suspended then first give it a chance to complete what it was doing
@@ -217,6 +214,7 @@ void ProcessThrottler::updateThrottleStateIfNeeded()
         // in the background for too long.
         if (m_state != ProcessThrottleState::Suspended) {
             m_prepareToSuspendTimeoutTimer.startOneShot(processSuspensionTimeout);
+            m_removeAllAssertionsTimer.startOneShot(removeAllAssertionsTimeout);
             sendPrepareToSuspendIPC(IsSuspensionImminent::No);
             return;
         }
@@ -240,6 +238,14 @@ void ProcessThrottler::prepareToSuspendTimeoutTimerFired()
     PROCESSTHROTTLER_RELEASE_LOG("prepareToSuspendTimeoutTimerFired: Updating process assertion to allow suspension");
     RELEASE_ASSERT(m_pendingRequestToSuspendID);
     updateThrottleStateNow();
+}
+
+void ProcessThrottler::removeAllAssertionsTimerFired()
+{
+    PROCESSTHROTTLER_RELEASE_LOG("removeAllAssertionsTimerFired: Removing all process assertions");
+    RELEASE_ASSERT(m_assertion && m_assertion->type() == ProcessAssertionType::Suspended);
+    if (!m_shouldTakeSuspendedAssertion)
+        m_assertion = nullptr;
 }
     
 void ProcessThrottler::processReadyToSuspend()
@@ -320,10 +326,14 @@ void ProcessThrottler::setAllowsActivities(bool allow)
 
 void ProcessThrottler::setShouldTakeSuspendedAssertion(bool shouldTakeSuspendedAssertion)
 {
-    const bool shouldUpdateAssertion = m_shouldTakeSuspendedAssertion != shouldTakeSuspendedAssertion;
     m_shouldTakeSuspendedAssertion = shouldTakeSuspendedAssertion;
-    if (shouldUpdateAssertion && m_state == ProcessThrottleState::Suspended)
-        setThrottleState(ProcessThrottleState::Suspended);
+}
+
+void ProcessThrottler::delaySuspension()
+{
+    PROCESSTHROTTLER_RELEASE_LOG("delaySuspension");
+    if (m_removeAllAssertionsTimer.isActive())
+        m_removeAllAssertionsTimer.startOneShot(removeAllAssertionsTimeout);
 }
 
 ProcessThrottler::TimedActivity::TimedActivity(Seconds timeout, ProcessThrottler::ActivityVariant&& activity)

--- a/Source/WebKit/UIProcess/ProcessThrottler.h
+++ b/Source/WebKit/UIProcess/ProcessThrottler.h
@@ -142,6 +142,7 @@ public:
     bool shouldBeRunnable() const { return m_foregroundActivities.size() || m_backgroundActivities.size(); }
     void setAllowsActivities(bool);
     void setShouldTakeSuspendedAssertion(bool);
+    void delaySuspension();
 
 private:
     friend WTF::TextStream& operator<<(WTF::TextStream&, const ProcessThrottler&);
@@ -152,6 +153,7 @@ private:
     void setAssertionType(ProcessAssertionType);
     void setThrottleState(ProcessThrottleState);
     void prepareToSuspendTimeoutTimerFired();
+    void removeAllAssertionsTimerFired();
     void sendPrepareToSuspendIPC(IsSuspensionImminent);
     void processReadyToSuspend();
 
@@ -161,7 +163,7 @@ private:
     void removeActivity(BackgroundActivity&);
     void invalidateAllActivities();
     String assertionName(ProcessAssertionType) const;
-    std::optional<ProcessAssertionType> assertionTypeForState(ProcessThrottleState);
+    ProcessAssertionType assertionTypeForState(ProcessThrottleState);
 
     void uiAssertionWillExpireImminently();
     void assertionWasInvalidated();
@@ -172,6 +174,7 @@ private:
     ProcessID m_processIdentifier { 0 };
     RefPtr<ProcessAssertion> m_assertion;
     RunLoop::Timer m_prepareToSuspendTimeoutTimer;
+    RunLoop::Timer m_removeAllAssertionsTimer;
     HashSet<ForegroundActivity*> m_foregroundActivities;
     HashSet<BackgroundActivity*> m_backgroundActivities;
     std::optional<uint64_t> m_pendingRequestToSuspendID;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5550,6 +5550,8 @@ void WebPageProxy::didReceiveTitleForFrame(FrameIdentifier frameID, const String
     
     m_pageLoadState.commitChanges();
 
+    process().throttler().delaySuspension();
+
 #if ENABLE(REMOTE_INSPECTOR)
     if (frame->isMainFrame())
         remoteInspectorInformationDidChange();
@@ -9329,6 +9331,7 @@ void WebPageProxy::requestNotificationPermission(const String& originString, Com
 void WebPageProxy::showNotification(IPC::Connection& connection, const WebCore::NotificationData& notificationData, RefPtr<WebCore::NotificationResources>&& notificationResources)
 {
     m_process->processPool().supplement<WebNotificationManagerProxy>()->show(this, connection, notificationData, WTFMove(notificationResources));
+    m_process->throttler().delaySuspension();
 }
 
 void WebPageProxy::cancelNotification(const UUID& notificationID)


### PR DESCRIPTION
#### 06fe365b16021e6ae0c4a3b66e5e8351de765902
<pre>
[Cocoa] Prevent active background page processes from suspending
<a href="https://bugs.webkit.org/show_bug.cgi?id=252415">https://bugs.webkit.org/show_bug.cgi?id=252415</a>
rdar://105413250

Reviewed by Chris Dumez.

When a page is backgrounded we try to suspend its process if possible. When the
internal setting &quot;Take WebKit:Suspended assertion...&quot; is disabled, this will
cause the UI process to drop all of its process assertions on the web content
process, effectively making it un-schedulable. This means that pages which may
still be active will completely stop. This wasn&apos;t an issue before since the web
content process would still be schedulable because it was holding the
WebKit:Suspended assertion (this is very confusing since the WebKit:Suspended
process assertion actually _prevents_ suspension). Instead of dropping all
process assertions immediately upon being backgrounded, we should give the
page/process some time to be scheduled and if it performs any observable work
(e.g. changing document title text, sending a local notification, etc.) we
should delay suspending the process.

* Source/WebKit/UIProcess/ProcessThrottler.cpp:
(WebKit::ProcessThrottler::ProcessThrottler):
(WebKit::ProcessThrottler::assertionTypeForState):
(WebKit::ProcessThrottler::setThrottleState):
(WebKit::ProcessThrottler::updateThrottleStateIfNeeded):
(WebKit::ProcessThrottler::removeAllAssertionsTimerFired):
(WebKit::ProcessThrottler::setShouldTakeSuspendedAssertion):
(WebKit::ProcessThrottler::delaySuspension):
* Source/WebKit/UIProcess/ProcessThrottler.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didReceiveTitleForFrame):
(WebKit::WebPageProxy::showNotification):

Canonical link: <a href="https://commits.webkit.org/260482@main">https://commits.webkit.org/260482@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af493b3fe63d689da10d7f8a9e5a227051c44f20

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108411 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17505 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41270 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117523 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116886 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18959 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8783 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100635 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114179 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97440 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/42187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/29085 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10332 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30429 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11078 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/7328 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16481 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50025 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7252 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12664 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->