### PR TITLE
Rename deprecated NSView functions

### DIFF
--- a/Source/WebCore/PAL/pal/system/mac/PopupMenu.mm
+++ b/Source/WebCore/PAL/pal/system/mac/PopupMenu.mm
@@ -44,9 +44,7 @@ namespace PAL {
 void popUpMenu(NSMenu *menu, NSPoint location, float width, NSView *view, int selectedItem, NSFont *font, NSControlSize controlSize, bool usesCustomAppearance)
 {
     NSRect adjustedPopupBounds = [view.window convertRectToScreen:[view convertRect:view.bounds toView:nil]];
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    if (controlSize != NSMiniControlSize) {
-        ALLOW_DEPRECATED_DECLARATIONS_END
+    if (controlSize != NSControlSizeMini) {
         adjustedPopupBounds.origin.x -= 3;
         adjustedPopupBounds.origin.y -= 1;
         adjustedPopupBounds.size.width += 6;

--- a/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
+++ b/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
@@ -88,9 +88,7 @@ FloatRect AccessibilityObject::convertRectToPlatformSpace(const FloatRect& rect,
 
         NSRect nsRect = NSRectFromCGRect(cgRect);
         NSView *view = frameView->documentView();
-        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         nsRect = [[view window] convertRectToScreen:[view convertRect:nsRect toView:nil]];
-        ALLOW_DEPRECATED_DECLARATIONS_END
         return NSRectToCGRect(nsRect);
     }
 

--- a/Source/WebCore/page/mac/EventHandlerMac.mm
+++ b/Source/WebCore/page/mac/EventHandlerMac.mm
@@ -597,7 +597,7 @@ void EventHandler::sendFakeEventsAfterWidgetTracking(NSEvent *initiatingEvent)
     BEGIN_BLOCK_OBJC_EXCEPTIONS
 
     m_sendingEventToSubview = false;
-    int eventType = [initiatingEvent type];
+    NSEventType eventType = [initiatingEvent type];
     if (eventType == NSEventTypeLeftMouseDown || eventType == NSEventTypeKeyDown) {
         ASSERT([NSApp isRunning]);
         NSEvent *fakeEvent = nil;
@@ -632,9 +632,7 @@ void EventHandler::sendFakeEventsAfterWidgetTracking(NSEvent *initiatingEvent)
         // no up-to-date cache of them anywhere.
         fakeEvent = [NSEvent mouseEventWithType:NSEventTypeMouseMoved
                                        location:[[view->platformWidget() window]
-        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-                                  convertScreenToBase:[NSEvent mouseLocation]]
-        ALLOW_DEPRECATED_DECLARATIONS_END
+                                                    convertPointFromScreen:[NSEvent mouseLocation]]
                                   modifierFlags:[initiatingEvent modifierFlags]
                                       timestamp:[initiatingEvent timestamp]
                                    windowNumber:[initiatingEvent windowNumber]

--- a/Source/WebCore/platform/ios/ScrollViewIOS.mm
+++ b/Source/WebCore/platform/ios/ScrollViewIOS.mm
@@ -252,7 +252,7 @@ IntRect ScrollView::platformContentsToScreen(const IntRect& rect) const
     if (NSView* documentView = this->documentView()) {
         NSRect tempRect = rect;
         tempRect = [documentView convertRect:tempRect toView:nil];
-        tempRect.origin = [[documentView window] convertBaseToScreen:tempRect.origin];
+        tempRect = [[documentView window] convertRectToScreen:tempRect];
         return enclosingIntRect(tempRect);
     }
     END_BLOCK_OBJC_EXCEPTIONS
@@ -263,7 +263,7 @@ IntPoint ScrollView::platformScreenToContents(const IntPoint& point) const
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
     if (NSView* documentView = this->documentView()) {
-        NSPoint windowCoord = [[documentView window] convertScreenToBase: point];
+        NSPoint windowCoord = [[documentView window] convertPointFromScreen:point];
         return IntPoint([documentView convertPoint:windowCoord fromView:nil]);
     }
     END_BLOCK_OBJC_EXCEPTIONS

--- a/Source/WebCore/platform/ios/wak/WAKView.mm
+++ b/Source/WebCore/platform/ios/wak/WAKView.mm
@@ -377,7 +377,7 @@ static void _WAKCopyWrapper(const void *value, void *context)
     if (CGRectIsEmpty(rect))
         return;
 
-    CGRect baseRect = WKViewConvertRectToBase(viewRef, rect);
+    CGRect baseRect = WKViewConvertRectToBacking(viewRef, rect);
     [window setNeedsDisplayInRect:baseRect];
 }
 
@@ -564,17 +564,17 @@ static CGInterpolationQuality toCGInterpolationQuality(WebCore::InterpolationQua
 
 - (NSPoint)convertPoint:(NSPoint)aPoint toView:(WAKView *)aView 
 {
-    CGPoint p = WKViewConvertPointToBase (viewRef, aPoint);
+    CGPoint p = WKViewConvertPointToBacking(viewRef, aPoint);
     if (aView)
-        return WKViewConvertPointFromBase ([aView _viewRef], p);
+        return WKViewConvertPointFromBacking([aView _viewRef], p);
     return p;
 }
 
 - (NSPoint)convertPoint:(NSPoint)aPoint fromView:(WAKView *)aView
 {
     if (aView)
-        aPoint = WKViewConvertPointToBase ([aView _viewRef], aPoint);
-    return WKViewConvertPointFromBase (viewRef, aPoint);
+        aPoint = WKViewConvertPointToBacking([aView _viewRef], aPoint);
+    return WKViewConvertPointFromBacking(viewRef, aPoint);
 }
 
 - (NSSize)convertSize:(NSSize)size toView:(WAKView *)aView
@@ -585,15 +585,15 @@ static CGInterpolationQuality toCGInterpolationQuality(WebCore::InterpolationQua
 - (NSRect)convertRect:(NSRect)aRect fromView:(WAKView *)aView
 {
     if (aView)
-        aRect = WKViewConvertRectToBase ([aView _viewRef], aRect);
-    return WKViewConvertRectFromBase (viewRef, aRect);
+        aRect = WKViewConvertRectToBacking([aView _viewRef], aRect);
+    return WKViewConvertRectFromBacking(viewRef, aRect);
 }
 
 - (NSRect)convertRect:(NSRect)aRect toView:(WAKView *)aView
 {
-    CGRect r = WKViewConvertRectToBase (viewRef, aRect);
+    CGRect r = WKViewConvertRectToBacking(viewRef, aRect);
     if (aView)
-        return WKViewConvertRectFromBase ([aView _viewRef], r);
+        return WKViewConvertRectFromBacking([aView _viewRef], r);
     return r;
 }
 

--- a/Source/WebCore/platform/ios/wak/WAKWindow.h
+++ b/Source/WebCore/platform/ios/wak/WAKWindow.h
@@ -105,8 +105,8 @@ WEBCORE_EXPORT @interface WAKWindow : WAKResponder
 - (void)close;
 - (WAKView *)firstResponder;
 
-- (NSPoint)convertBaseToScreen:(NSPoint)point;
-- (NSPoint)convertScreenToBase:(NSPoint)point;
+- (NSPoint)convertPointToScreen:(NSPoint)point;
+- (NSPoint)convertPointFromScreen:(NSPoint)point;
 - (NSRect)convertRectToScreen:(NSRect)rect;
 - (NSRect)convertRectFromScreen:(NSRect)rect;
 - (BOOL)isKeyWindow;

--- a/Source/WebCore/platform/ios/wak/WAKWindow.mm
+++ b/Source/WebCore/platform/ios/wak/WAKWindow.mm
@@ -146,7 +146,7 @@ static RetainPtr<WebEvent>& currentEvent()
     return _nextResponder;
 }
 
-- (NSPoint)convertBaseToScreen:(NSPoint)aPoint
+- (NSPoint)convertPointToScreen:(NSPoint)aPoint
 {
     CALayer* rootLayer = _hostLayer;
     while (rootLayer.superlayer)
@@ -155,7 +155,7 @@ static RetainPtr<WebEvent>& currentEvent()
     return [_hostLayer convertPoint:aPoint toLayer:rootLayer];
 }
 
-- (NSPoint)convertScreenToBase:(NSPoint)aPoint
+- (NSPoint)convertPointFromScreen:(NSPoint)aPoint
 {
     CALayer* rootLayer = _hostLayer;
     while (rootLayer.superlayer)

--- a/Source/WebCore/platform/ios/wak/WKView.h
+++ b/Source/WebCore/platform/ios/wak/WKView.h
@@ -119,13 +119,13 @@ WEBCORE_EXPORT void WKViewRemoveFromSuperview (WKViewRef view);
 
 CGPoint WKViewConvertPointToSuperview (WKViewRef view, CGPoint aPoint);
 CGPoint WKViewConvertPointFromSuperview (WKViewRef view, CGPoint aPoint);
-CGPoint WKViewConvertPointToBase(WKViewRef view, CGPoint aPoint);
-CGPoint WKViewConvertPointFromBase(WKViewRef view, CGPoint aPoint);
+CGPoint WKViewConvertPointToBacking(WKViewRef, CGPoint);
+CGPoint WKViewConvertPointFromBacking(WKViewRef, CGPoint);
 
 CGRect WKViewConvertRectToSuperview (WKViewRef view, CGRect aRect);
 CGRect WKViewConvertRectFromSuperview (WKViewRef view, CGRect aRect);
-WEBCORE_EXPORT CGRect WKViewConvertRectToBase (WKViewRef view, CGRect r);
-WEBCORE_EXPORT CGRect WKViewConvertRectFromBase (WKViewRef view, CGRect aRect);
+WEBCORE_EXPORT CGRect WKViewConvertRectToBacking(WKViewRef, CGRect);
+WEBCORE_EXPORT CGRect WKViewConvertRectFromBacking(WKViewRef, CGRect);
 
 CGRect WKViewGetVisibleRect (WKViewRef view);
 

--- a/Source/WebCore/platform/ios/wak/WKView.mm
+++ b/Source/WebCore/platform/ios/wak/WKView.mm
@@ -554,8 +554,8 @@ CGRect WKViewGetVisibleRect(WKViewRef viewRef)
     }
     
     if (view != viewRef) {
-        rect = WKViewConvertRectToBase(view, rect);
-        rect = WKViewConvertRectFromBase(viewRef, rect);
+        rect = WKViewConvertRectToBacking(view, rect);
+        rect = WKViewConvertRectFromBacking(viewRef, rect);
     }
     
     return rect;
@@ -571,7 +571,7 @@ CGRect WKViewConvertRectToSuperview(WKViewRef view, CGRect r)
     return CGRectApplyAffineTransform(r, _WKViewGetTransform(view));
 }
 
-CGRect WKViewConvertRectToBase(WKViewRef view, CGRect r)
+CGRect WKViewConvertRectToBacking(WKViewRef view, CGRect r)
 {
     if (!view) {
         WKError ("invalid parameter");
@@ -609,7 +609,7 @@ CGPoint WKViewConvertPointFromSuperview(WKViewRef view, CGPoint p)
     return CGPointApplyAffineTransform(p, transform);
 }
 
-CGPoint WKViewConvertPointToBase(WKViewRef view, CGPoint p)
+CGPoint WKViewConvertPointToBacking(WKViewRef view, CGPoint p)
 {
     if (!view) {
         WKError ("invalid parameter");
@@ -646,7 +646,7 @@ static void _WKViewGetAncestorViewsIncludingView (WKViewRef view, WKViewRef *vie
     *viewCount = count;
 }
 
-CGPoint WKViewConvertPointFromBase(WKViewRef view, CGPoint p)
+CGPoint WKViewConvertPointFromBacking(WKViewRef view, CGPoint p)
 {
     if (!view) {
         WKError ("invalid parameter");
@@ -680,7 +680,7 @@ CGRect WKViewConvertRectFromSuperview(WKViewRef view, CGRect r)
     return CGRectApplyAffineTransform(r, transform);
 }
 
-CGRect WKViewConvertRectFromBase(WKViewRef view, CGRect r)
+CGRect WKViewConvertRectFromBacking(WKViewRef view, CGRect r)
 {
     if (!view) {
         WKError ("invalid parameter");

--- a/Source/WebCore/platform/mac/PlatformEventFactoryMac.mm
+++ b/Source/WebCore/platform/mac/PlatformEventFactoryMac.mm
@@ -45,9 +45,7 @@ namespace WebCore {
 
 NSPoint globalPoint(const NSPoint& windowPoint, NSWindow *window)
 {
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    return flipScreenPoint([window convertBaseToScreen:windowPoint], screen(window));
-    ALLOW_DEPRECATED_DECLARATIONS_END
+    return flipScreenPoint([window convertPointToScreen:windowPoint], screen(window));
 }
 
 static NSPoint globalPointForEvent(NSEvent *event)

--- a/Source/WebCore/platform/mac/ScrollViewMac.mm
+++ b/Source/WebCore/platform/mac/ScrollViewMac.mm
@@ -239,9 +239,7 @@ IntRect ScrollView::platformContentsToScreen(const IntRect& rect) const
     if (NSView* documentView = this->documentView()) {
         NSRect tempRect = rect;
         tempRect = [documentView convertRect:tempRect toView:nil];
-        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        tempRect.origin = [[documentView window] convertBaseToScreen:tempRect.origin];
-        ALLOW_DEPRECATED_DECLARATIONS_END
+        tempRect = [[documentView window] convertRectToScreen:tempRect];
         return enclosingIntRect(tempRect);
     }
     END_BLOCK_OBJC_EXCEPTIONS
@@ -252,9 +250,7 @@ IntPoint ScrollView::platformScreenToContents(const IntPoint& point) const
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
     if (NSView* documentView = this->documentView()) {
-        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        NSPoint windowCoord = [[documentView window] convertScreenToBase: point];
-        ALLOW_DEPRECATED_DECLARATIONS_END
+        NSPoint windowCoord = [[documentView window] convertPointFromScreen:point];
         return IntPoint([documentView convertPoint:windowCoord fromView:nil]);
     }
     END_BLOCK_OBJC_EXCEPTIONS

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -457,7 +457,7 @@ IntRect PageClientImpl::rootViewToScreen(const IntRect& rect)
 {
     NSRect tempRect = rect;
     tempRect = [m_view convertRect:tempRect toView:nil];
-    tempRect.origin = [m_view.window convertPointToScreen:tempRect.origin];
+    tempRect = [m_view.window convertRectToScreen:tempRect];
     return enclosingIntRect(tempRect);
 }
 

--- a/Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm
@@ -204,9 +204,7 @@ void WebPopupMenuProxyMac::showPopupMenu(const IntRect& rect, TextDirection text
     [NSApp postEvent:fakeEvent atStart:YES];
     fakeEvent = [NSEvent mouseEventWithType:NSEventTypeMouseMoved
                                    location:[[m_webView window]
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-                        convertScreenToBase:[NSEvent mouseLocation]]
-ALLOW_DEPRECATED_DECLARATIONS_END
+                                                convertPointFromScreen:[NSEvent mouseLocation]]
                               modifierFlags:[initiatingNSEvent modifierFlags]
                                   timestamp:[initiatingNSEvent timestamp]
                                windowNumber:[initiatingNSEvent windowNumber]

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -3844,9 +3844,7 @@ void WebViewImpl::draggedImage(NSImage *, CGPoint endPoint, NSDragOperation oper
 
 void WebViewImpl::sendDragEndToPage(CGPoint endPoint, NSDragOperation dragOperationMask)
 {
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    NSPoint windowImageLoc = [[m_view window] convertScreenToBase:NSPointFromCGPoint(endPoint)];
-    ALLOW_DEPRECATED_DECLARATIONS_END
+    NSPoint windowImageLoc = [[m_view window] convertPointFromScreen:NSPointFromCGPoint(endPoint)];
     NSPoint windowMouseLoc = windowImageLoc;
 
     // Prevent queued mouseDragged events from coming after the drag and fake mouseUp event.
@@ -4952,10 +4950,8 @@ void WebViewImpl::characterIndexForPoint(NSPoint point, void(^completionHandler)
 
     NSWindow *window = [m_view window];
 
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     if (window)
-        point = [window convertScreenToBase:point];
-    ALLOW_DEPRECATED_DECLARATIONS_END
+        point = [window convertPointFromScreen:point];
     point = [m_view convertPoint:point fromView:nil];  // the point is relative to the main frame
 
     m_page->characterIndexForPointAsync(WebCore::IntPoint(point), [completionHandler = makeBlockPtr(completionHandler)](uint64_t result) {

--- a/Source/WebKitLegacy/mac/WebInspector/WebNodeHighlight.mm
+++ b/Source/WebKitLegacy/mac/WebInspector/WebNodeHighlight.mm
@@ -266,11 +266,7 @@ using namespace WebCore;
     ASSERT([_targetView window]);
 
     NSRect highlightWindowFrame = [_targetView convertRect:[_targetView visibleRect] toView:nil];
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    highlightWindowFrame.origin = [[_targetView window] convertBaseToScreen:highlightWindowFrame.origin];
-    ALLOW_DEPRECATED_DECLARATIONS_END
-
-    return highlightWindowFrame;
+    return [[_targetView window] convertRectToScreen:highlightWindowFrame];
 }
 
 - (void)_repositionHighlightWindow

--- a/Source/WebKitLegacy/mac/WebView/WebFullScreenController.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFullScreenController.mm
@@ -493,10 +493,7 @@ static NSRect windowFrameFromApparentFrames(NSRect screenFrame, NSRect initialFr
     [_scaleAnimation.get() startAnimation];
     
     // setClipRectForWindow takes window coordinates, so convert from screen coordinates here:
-    NSRect finalBounds = _finalFrame;
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    finalBounds.origin = [[self window] convertScreenToBase:finalBounds.origin];
-    ALLOW_DEPRECATED_DECLARATIONS_END
+    NSRect finalBounds = [[self window] convertRectFromScreen:_finalFrame];
     setClipRectForWindow(self.window, finalBounds);
     
     [[self window] makeKeyAndOrderFront:self];
@@ -564,10 +561,7 @@ static NSRect windowFrameFromApparentFrames(NSRect screenFrame, NSRect initialFr
     [_backgroundWindow.get() orderWindow:NSWindowBelow relativeTo:[[self window] windowNumber]];
     
     // setClipRectForWindow takes window coordinates, so convert from screen coordinates here:
-    NSRect finalBounds = _finalFrame;
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    finalBounds.origin = [[self window] convertScreenToBase:finalBounds.origin];
-    ALLOW_DEPRECATED_DECLARATIONS_END
+    NSRect finalBounds = [[self window] convertRectFromScreen:_finalFrame];
     setClipRectForWindow(self.window, finalBounds);
     
     ALLOW_DEPRECATED_DECLARATIONS_BEGIN

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -1493,9 +1493,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 {
     NSEvent *fakeEvent = [NSEvent mouseEventWithType:NSEventTypeMouseMoved
         location:[[self window]
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        convertScreenToBase:[NSEvent mouseLocation]]
-ALLOW_DEPRECATED_DECLARATIONS_END
+        convertPointFromScreen:[NSEvent mouseLocation]]
         modifierFlags:[[NSApp currentEvent] modifierFlags]
         timestamp:[NSDate timeIntervalSinceReferenceDate]
         windowNumber:[[self window] windowNumber]
@@ -2074,9 +2072,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
     NSEvent *fakeEvent = [NSEvent mouseEventWithType:NSEventTypeLeftMouseDragged
         location:[[self window]
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        convertScreenToBase:[NSEvent mouseLocation]]
-ALLOW_DEPRECATED_DECLARATIONS_END
+        convertPointFromScreen:[NSEvent mouseLocation]]
         modifierFlags:[[NSApp currentEvent] modifierFlags]
         timestamp:[NSDate timeIntervalSinceReferenceDate]
         windowNumber:[[self window] windowNumber]
@@ -4305,8 +4301,8 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
     ASSERT(![self _webView] || [self _isTopHTMLView]);
-    
-    NSPoint windowImageLoc = [[self window] convertScreenToBase:aPoint];
+
+    NSPoint windowImageLoc = [[self window] convertPointFromScreen:aPoint];
     NSPoint windowMouseLoc = windowImageLoc;
     
     if (auto* page = core([self _webView])) {
@@ -5031,9 +5027,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 #if PLATFORM(IOS_FAMILY)
         return [accTree accessibilityHitTest:point];
 #else
-        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        NSPoint windowCoord = [[self window] convertScreenToBase:point];
-        ALLOW_DEPRECATED_DECLARATIONS_END
+        NSPoint windowCoord = [[self window] convertPointFromScreen:point];
         return [accTree accessibilityHitTest:[self convertPoint:windowCoord fromView:nil]];
 #endif
     }
@@ -6158,10 +6152,7 @@ static BOOL writingDirectionKeyBindingsEnabled()
         // If we are in a layer-backed view, we need to manually initialize the geometry for our layer.
         [viewLayer setBounds:NSRectToCGRect([_private->layerHostingView bounds])];
         [viewLayer setAnchorPoint:CGPointMake(0, [self isFlipped] ? 1 : 0)];
-        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        CGPoint layerPosition = NSPointToCGPoint([self convertPointToBase:[_private->layerHostingView frame].origin]);
-        ALLOW_DEPRECATED_DECLARATIONS_END
-        [viewLayer setPosition:layerPosition];
+        [viewLayer setPosition:NSPointToCGPoint([self convertPointToBacking:[_private->layerHostingView frame].origin])];
     }
     
     [_private->layerHostingView setLayer:viewLayer];

--- a/Source/WebKitLegacy/mac/WebView/WebTextCompletionController.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebTextCompletionController.mm
@@ -127,9 +127,7 @@ using namespace WebCore;
 
     NSRect windowFrame;
     NSPoint wordStart = topLeft;
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    windowFrame.origin = [[_view window] convertBaseToScreen:[_htmlView convertPoint:wordStart toView:nil]];
-    ALLOW_DEPRECATED_DECLARATIONS_END
+    windowFrame.origin = [[_view window] convertPointToScreen:[_htmlView convertPoint:wordStart toView:nil]];
     windowFrame.size.height = numberToShow * [_tableView rowHeight] + (numberToShow + 1) * [_tableView intercellSpacing].height;
     windowFrame.origin.y -= windowFrame.size.height;
     NSDictionary *attributes = @{ NSFontAttributeName: [NSFont systemFontOfSize:12.0f] };

--- a/Tools/DumpRenderTree/mac/DumpRenderTree.mm
+++ b/Tools/DumpRenderTree/mac/DumpRenderTree.mm
@@ -2094,7 +2094,7 @@ void displayAndTrackRepaintsWebView()
 
 + (NSPoint)mouseLocation
 {
-    return [[[mainFrame webView] window] convertBaseToScreen:lastMousePosition];
+    return [[[mainFrame webView] window] convertPointToScreen:lastMousePosition];
 }
 
 @end

--- a/Tools/DumpRenderTree/mac/TextInputControllerMac.m
+++ b/Tools/DumpRenderTree/mac/TextInputControllerMac.m
@@ -409,7 +409,7 @@
     if (textInput) {
         NSRect rect = [textInput firstRectForCharacterRange:NSMakeRange(from, length)];
         if (rect.origin.x || rect.origin.y || rect.size.width || rect.size.height) {
-            rect.origin = [[webView window] convertScreenToBase:rect.origin];
+            rect = [[webView window] convertRectFromScreen:rect];
             rect = [webView convertRect:rect fromView:nil];
         }
         return @[ @(rect.origin.x), @(rect.origin.y), @(rect.size.width), @(rect.size.height) ];
@@ -425,7 +425,7 @@
     if (textInput) {
         NSPoint point = NSMakePoint(x, y);
         point = [webView convertPoint:point toView:nil];
-        point = [[webView window] convertBaseToScreen:point];
+        point = [[webView window] convertPointToScreen:point];
         NSInteger index = [textInput characterIndexForPoint:point];
         if (index == NSNotFound)
             return -1;

--- a/Tools/WebKitTestRunner/mac/WebKitTestRunnerEvent.mm
+++ b/Tools/WebKitTestRunner/mac/WebKitTestRunnerEvent.mm
@@ -36,7 +36,7 @@
 + (NSPoint)mouseLocation
 {
     WKPoint location = WTR::TestController::singleton().eventSenderProxy()->position();
-    return [WTR::TestController::singleton().mainWebView()->platformWindow() convertBaseToScreen:NSMakePoint(location.x, location.y)];
+    return [WTR::TestController::singleton().mainWebView()->platformWindow() convertPointToScreen:NSMakePoint(location.x, location.y)];
 }
 
 @end


### PR DESCRIPTION
#### 03c19375fc641f545707a49f9693a1d5fc4d66b1
<pre>
Rename deprecated NSView functions
<a href="https://bugs.webkit.org/show_ddg.cgi?id=251865">https://bugs.webkit.org/show_ddg.cgi?id=251865</a>

Reviewed by NOBODY (OOPS!).

This changes the deprecated function calls to their non-deprecated equivalents.

In some cases, the point conversion of certain rectangle points is changed to
the conversion of the whole rectangle, as such an operation also allows us to
remove some manual work for said rectangles.

* Source/WebCore/PAL/pal/system/mac/PopupMenu.mm:(popUpMenu): Replace
  NSMiniControlSize with NSControlSizeMini.

* Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm:
  (AccessibilityObject): Remove unneeded ALLOW_DEPRECATED_DECLARATIONS
  macros, as convertRectToScreen is not deprecated.

* Source/WebCore/page/mac/EventHandlerMac.mm:
  (sendFakeEventsAfterWidgetTracking): Use NSEventType enum and replace
  convertScreenToBase with convertPointFromScreen.

* Source/WebCore/platform/ios/ScrollViewIOS.mm:
  (platformContentsToScreen): Replace convertBaseToScreen with
  convertRectToScreen.
  (platformScreenToContents): Replace convertScreenToBase with
  convertPointFromScreen.

* Source/WebCore/platform/ios/ScrollViewIOS.mm: Ditto.

* Source/WebCore/platform/ios/wak/WAKView.mm: Rename
  WKViewConvertRectToBase and WKViewConvertRectFromBase to
  WKViewConvertRectToBacking and WKViewConvertRectFromBacking
  respectively.

* Source/WebCore/platform/ios/wak/WAKWindow.h: Replace
  convertBaseToScreen and convertScreenToBase with convertPointToScreen
  and convertPointFromScreen respectively.

* Source/WebCore/platform/ios/wak/WAKWindow.mm: Ditto.

* Source/WebCore/platform/ios/wak/WKView.h: Rename
  WKViewConvertPointToBase and WKViewConvertPointFromBase to
  WKViewConvertPointToBacking and WKViewConvertPointFromBacking
  respectively.

* Source/WebCore/platform/ios/wak/WKView.mm: Ditto.

* Source/WebCore/platform/mac/PlatformEventFactoryMac.mm:(globalPoint):
  Replace convertBaseToScreen with convertPointToScreen.

* Source/WebCore/platform/mac/ScrollViewMac.mm: Ditto.

* Source/WebKit/UIProcess/mac/PageClientImplMac.mm: Ditto.

* Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm: Ditto.

* Source/WebKit/UIProcess/mac/WebViewImpl.mm: Ditto.

* Source/WebKitLegacy/mac/WebInspector/WebNodeHighlight.mm: Ditto.

* Source/WebKitLegacy/mac/WebView/WebFullScreenController.mm: Convert
  the whole rectangle instead of manually getting, converting, and
  setting the rectangle points.

* Source/WebKitLegacy/mac/WebView/WebHTMLView.mm: Replace
  convertScreenToBase with convertPointFromScreen.

* Source/WebKitLegacy/mac/WebView/WebTextCompletionController.mm: Ditto.

* Tools/DumpRenderTree/mac/DumpRenderTree.mm: Ditto.

* Tools/DumpRenderTree/mac/TextInputControllerMac.m: Convert whole
  rectangle instead of manually convertint the points.

* Tools/WebKitTestRunner/mac/WebKitTestRunnerEvent.mm:(mouseLocation):
  Replace convertBaseToScreen with convertPointToScreen.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03c19375fc641f545707a49f9693a1d5fc4d66b1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/113275 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/22408 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1947 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/5048 "Build is in progress. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121729 "Built successfully") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23776 "Built successfully") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/87/builds/5048 "Build is in progress. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/119062 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100933 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/106373 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1473 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46722 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 25 flakes 256 failures 1 missing results; Uploaded test results; 22 flakes 169 failures 1 missing results; Running compile-webkit-without-change") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14708 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1512 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/98976 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/15416 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20710 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53503 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/17271 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->