### PR TITLE
Uncaught Exception: 'Page.setShowRulers' was not found

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Base/Main.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Main.js
@@ -643,7 +643,10 @@ WI.initializeTarget = function(target)
 
         // COMPATIBILITY (iOS 13.4): Page.setShowRulers was removed.
         if (target.hasCommand("Page.setShowRulers") && WI.settings.showRulers.value)
-            target.PageAgent.setShowRulers(true);
+            target.PageAgent.setShowRulers(true).catch((error) => {
+                // FIXME <rdar://105244623> iOS platforms without a matching legacy protocol definition will fall back to the local macOS protocol definition.
+                console.error(error);
+            });
     }
 };
 

--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeContentView.js
@@ -719,7 +719,10 @@ WI.DOMTreeContentView = class DOMTreeContentView extends WI.ContentView
 
         for (let target of WI.targets) {
             if (target.hasCommand("Page.setShowRulers"))
-                target.PageAgent.setShowRulers(activated);
+                target.PageAgent.setShowRulers(activated).catch((error) => {
+                    // FIXME <rdar://105244623> iOS platforms without a matching legacy protocol definition will fall back to the local macOS protocol definition.
+                    console.error(error);
+                });
         }
     }
 


### PR DESCRIPTION
#### 3c2de1a4af3090aa7e2e9d2be17699131d45330b
<pre>
Uncaught Exception: &apos;Page.setShowRulers&apos; was not found
<a href="https://bugs.webkit.org/show_bug.cgi?id=252432">https://bugs.webkit.org/show_bug.cgi?id=252432</a>

Reviewed by Patrick Angle.

* Source/WebInspectorUI/UserInterface/Base/Main.js:
(WI.initializeTarget):
* Source/WebInspectorUI/UserInterface/Views/DOMTreeContentView.js:
(WI.DOMTreeContentView.prototype._showRulersChanged):

Canonical link: <a href="https://commits.webkit.org/260409@main">https://commits.webkit.org/260409@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86fcdecb5cb9309e7fd48c9d7ca4f7a5a0857651

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108232 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17323 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41099 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117354 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18711 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8601 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100445 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114001 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/97293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/42012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28935 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/10170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30280 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10906 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/7189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/16319 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49876 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7198 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12489 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->