### PR TITLE
Move m_invisibleGamepadsForClient to being a WeakHashMap

### DIFF
--- a/Source/WebCore/platform/gamepad/GamepadProviderClient.h
+++ b/Source/WebCore/platform/gamepad/GamepadProviderClient.h
@@ -28,6 +28,7 @@
 #if ENABLE(GAMEPAD)
 
 #include <wtf/Forward.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
@@ -38,7 +39,7 @@ enum class EventMakesGamepadsVisible : bool {
     Yes,
 };
 
-class GamepadProviderClient {
+class GamepadProviderClient : public CanMakeWeakPtr<GamepadProviderClient> {
 public:
     virtual ~GamepadProviderClient() = default;
 

--- a/Source/WebCore/platform/gamepad/PlatformGamepad.h
+++ b/Source/WebCore/platform/gamepad/PlatformGamepad.h
@@ -32,13 +32,16 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
 #include <wtf/MonotonicTime.h>
+#include <wtf/WeakHashMap.h>
+#include <wtf/WeakHashSet.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
 struct GamepadEffectParameters;
 
-class PlatformGamepad {
+class PlatformGamepad : public CanMakeWeakPtr<PlatformGamepad> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     virtual ~PlatformGamepad() = default;

--- a/Source/WebCore/testing/MockGamepadProvider.h
+++ b/Source/WebCore/testing/MockGamepadProvider.h
@@ -61,9 +61,7 @@ private:
     void gamepadInputActivity();
 
     Vector<PlatformGamepad*> m_connectedGamepadVector;
-    // FIXME: Use HashMap<WeakPtr<GamepadProviderClient>, HashSet<WeakPtr<PlatformGamepad>>>
-    // after deriving GamepadProviderClient and PlatformGamepad from CanMakeWeakPtr
-    HashMap<GamepadProviderClient*, HashSet<PlatformGamepad*>>  m_invisibleGamepadsForClient;
+    WeakHashMap<GamepadProviderClient, WeakHashSet<PlatformGamepad>>  m_invisibleGamepadsForClient;
     Vector<std::unique_ptr<MockGamepad>> m_mockGamepadVector;
 
     bool m_shouldScheduleActivityCallback { true };


### PR DESCRIPTION
#### a36079d20158fc7cc3b0ee3b2ce63f7bd7fe2e61
<pre>
Move m_invisibleGamepadsForClient to being a WeakHashMap
<a href="https://bugs.webkit.org/show_bug.cgi?id=252439">https://bugs.webkit.org/show_bug.cgi?id=252439</a>
rdar://105567085

Reviewed by Ryosuke Niwa and David Kilzer.

Make GamepadProviderClient and PlatformGamepad support WeakPtr and use
them in m_invisibleGamepadsForClient.

* Source/WebCore/platform/gamepad/GamepadProviderClient.h:
* Source/WebCore/platform/gamepad/PlatformGamepad.h:
* Source/WebCore/testing/MockGamepadProvider.cpp:
(WebCore::MockGamepadProvider::startMonitoringGamepads):
(WebCore::MockGamepadProvider::stopMonitoringGamepads):
(WebCore::MockGamepadProvider::connectMockGamepad):
(WebCore::MockGamepadProvider::disconnectMockGamepad):
* Source/WebCore/testing/MockGamepadProvider.h:

Canonical link: <a href="https://commits.webkit.org/260411@main">https://commits.webkit.org/260411@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52941f6e93fc7ae53721bcb08a086e463036f067

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108221 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17306 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41088 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117344 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116670 "Failed to checkout and rebase branch from PR 10235") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112108 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18684 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8590 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100429 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113989 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97289 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/42001 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28931 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10160 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30276 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10892 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7181 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16309 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49871 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7201 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12474 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->