### PR TITLE
Compute the correct overflow-x and overflow-y values for table elements

### DIFF
--- a/LayoutTests/fast/table/overflowScroll-display-block-expected.html
+++ b/LayoutTests/fast/table/overflowScroll-display-block-expected.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<style>
+div
+{
+    margin-bottom: 35px;
+    width: 100px;
+    height: 100px;
+    background-color: green;
+}
+</style>
+<div style="overflow: scroll;">
+</div>
+<div style="overflow: scroll;">
+</div>
+<div style="overflow: scroll;">
+</div>
+<p> crbug.com/368699: When table elements have display: block, they should be allowed to have overflow:scroll. The exception is the table element, which doesn't permit anything other than visible per http://dev.w3.org/csswg/css2/visufx.html#overflow.</p>

--- a/LayoutTests/fast/table/overflowScroll-display-block.html
+++ b/LayoutTests/fast/table/overflowScroll-display-block.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<style>
+.scrollingElement
+{
+    width: 100px;
+    height: 100px;
+    background-color: green;
+    overflow: scroll;
+    display: block;
+}
+table
+{
+    margin-bottom: 35px;
+}
+</style>
+<table class="scrollingElement" cellspacing=0>
+    <tbody>
+        <tr><td></td></tr>
+    </tbody>
+</table>
+<table cellspacing=0>
+    <tbody class="scrollingElement">
+        <tr><td></td></tr>
+    </tbody>
+</table>
+<table cellspacing=0>
+    <tbody>
+        <tr class="scrollingElement"><td></td></tr>
+    </tbody>
+</table>
+<p> crbug.com/368699: When table elements have display: block, they should be allowed to have overflow:scroll. The exception is the table element, which doesn't permit anything other than visible per http://dev.w3.org/csswg/css2/visufx.html#overflow.</p>

--- a/LayoutTests/fast/table/overflowScroll-expected.html
+++ b/LayoutTests/fast/table/overflowScroll-expected.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<style>
+.scrollingElement
+{
+    width: 100px;
+    height: 100px;
+    background-color: green;
+}
+table
+{
+    margin-bottom: 35px;
+}
+</style>
+<table class="scrollingElement" cellspacing=0>
+    <tbody>
+        <tr><td> text text text text</td></tr>
+    </tbody>
+</table>
+<table cellspacing=0>
+    <tbody class="scrollingElement">
+        <tr><td> text text text text</td></tr>
+    </tbody>
+</table>
+<table cellspacing=0>
+    <tbody>
+        <tr class="scrollingElement"><td>text text text text</td></tr>
+    </tbody>
+</table>
+<p> crbug.com/368699: Tables, table rows and table sections don't have scrollbars when they have overflow:scroll. </p>

--- a/LayoutTests/fast/table/overflowScroll.html
+++ b/LayoutTests/fast/table/overflowScroll.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<style>
+.scrollingElement
+{
+    width: 100px;
+    height: 100px;
+    background-color: green;
+    overflow: scroll;
+}
+table
+{
+    margin-bottom: 35px;
+}
+</style>
+<table class="scrollingElement" cellspacing=0>
+    <tbody>
+        <tr><td> text text text text</td></tr>
+    </tbody>
+</table>
+<table cellspacing=0>
+    <tbody class="scrollingElement">
+        <tr><td> text text text text</td></tr>
+    </tbody>
+</table>
+<table cellspacing=0>
+    <tbody>
+        <tr class="scrollingElement"><td>text text text text</td></tr>
+    </tbody>
+</table>
+<p> crbug.com/368699: Tables, table rows and table sections don't have scrollbars when they have overflow:scroll. </p>

--- a/LayoutTests/fast/table/table-different-overflow-values-2-expected.txt
+++ b/LayoutTests/fast/table/table-different-overflow-values-2-expected.txt
@@ -1,0 +1,22 @@
+This test checks for overflow equality. If overflow-x is visible then overflow-y should be visible as well.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS table1: overflow-x is either not visible or both overflow values are visible.
+PASS table2: overflow-x is either not visible or both overflow values are visible.
+PASS table3: overflow-x is either not visible or both overflow values are visible.
+PASS inline_table1: overflow-x is either not visible or both overflow values are visible.
+PASS inline_table2: overflow-x is either not visible or both overflow values are visible.
+PASS inline_table3: overflow-x is either not visible or both overflow values are visible.
+PASS tbody1: overflow-x is either not visible or both overflow values are visible.
+PASS tbody2: overflow-x is either not visible or both overflow values are visible.
+PASS tbody3: overflow-x is either not visible or both overflow values are visible.
+PASS tr1: overflow-x is either not visible or both overflow values are visible.
+PASS tr2: overflow-x is either not visible or both overflow values are visible.
+PASS tr3: overflow-x is either not visible or both overflow values are visible.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+

--- a/LayoutTests/fast/table/table-different-overflow-values-2.html
+++ b/LayoutTests/fast/table/table-different-overflow-values-2.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<script src="../../resources/js-test.js"></script>
+<!-- For tables. -->
+<table id="table1" class="test" style="overflow-y: visible; overflow-x: auto"/>
+<table id="table2" class="test" style="overflow-y: visible; overflow-x: scroll"/>
+<table id="table3" class="test" style="overflow-y: visible; overflow-x: hidden"/>
+<!-- For inline tables. -->
+<table id="inline_table1" class="test" style="overflow-y: visible; overflow-x: auto; display: inline-table;"/>
+<table id="inline_table2" class="test" style="overflow-y: visible; overflow-x: scroll; display: inline-table;"/>
+<table id="inline_table3" class="test" style="overflow-y: visible; overflow-x: hidden; display: inline-table;"/>
+<!-- For table row groups. -->
+<table>
+    <tbody id="tbody1" class="test" style="overflow-y: visible; overflow-x: auto"/>
+    <tbody id="tbody2" class="test" style="overflow-y: visible; overflow-x: scroll"/>
+    <tbody id="tbody3" class="test" style="overflow-y: visible; overflow-x: hidden"/>
+</table>
+<!-- For table rows. -->
+<table>
+    <tr id="tr1" class="test" style="overflow-y: visible; overflow-x: auto"/>
+    <tr id="tr2" class="test" style="overflow-y: visible; overflow-x: scroll"/>
+    <tr id="tr3" class="test" style="overflow-y: visible; overflow-x: hidden"/>
+</table>
+<script>
+description("This test checks for overflow equality. If overflow-x is visible then overflow-y should be visible as well.");
+var elements = document.getElementsByClassName("test");
+for (i = 0; i < elements.length; ++i)
+{
+    computedStyle = getComputedStyle(elements[i]);
+    overflowX = computedStyle.getPropertyValue('overflow-x');
+    overflowY = computedStyle.getPropertyValue('overflow-y');
+    if (overflowX == "visible" && overflowX != overflowY)
+        testFailed(elements[i].id + ": overflow-y should be visible. Was " + overflowY + ".");
+    else
+        testPassed(elements[i].id + ": overflow-x is either not visible or both overflow values are visible.");
+}
+</script>

--- a/LayoutTests/fast/table/table-different-overflow-values-expected.txt
+++ b/LayoutTests/fast/table/table-different-overflow-values-expected.txt
@@ -1,0 +1,22 @@
+This test checks for overflow equality. If overflow-x is visible then overflow-y should be visible as well.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS table1: overflow-x is either not visible or both overflow values are visible.
+PASS table2: overflow-x is either not visible or both overflow values are visible.
+PASS table3: overflow-x is either not visible or both overflow values are visible.
+PASS inline_table1: overflow-x is either not visible or both overflow values are visible.
+PASS inline_table2: overflow-x is either not visible or both overflow values are visible.
+PASS inline_table3: overflow-x is either not visible or both overflow values are visible.
+PASS tbody1: overflow-x is either not visible or both overflow values are visible.
+PASS tbody2: overflow-x is either not visible or both overflow values are visible.
+PASS tbody3: overflow-x is either not visible or both overflow values are visible.
+PASS tr1: overflow-x is either not visible or both overflow values are visible.
+PASS tr2: overflow-x is either not visible or both overflow values are visible.
+PASS tr3: overflow-x is either not visible or both overflow values are visible.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+

--- a/LayoutTests/fast/table/table-different-overflow-values.html
+++ b/LayoutTests/fast/table/table-different-overflow-values.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<script src="../../resources/js-test.js"></script>
+<!-- For tables. -->
+<table id="table1" class="test" style="overflow-x: visible; overflow-y: auto"/>
+<table id="table2" class="test" style="overflow-x: visible; overflow-y: scroll"/>
+<table id="table3" class="test" style="overflow-x: visible; overflow-y: hidden"/>
+<!-- For inline tables. -->
+<table id="inline_table1" class="test" style="overflow-x: visible; overflow-y: auto; display: inline-table;"/>
+<table id="inline_table2" class="test" style="overflow-x: visible; overflow-y: scroll; display: inline-table;"/>
+<table id="inline_table3" class="test" style="overflow-x: visible; overflow-y: hidden; display: inline-table;"/>
+<!-- For table row groups. -->
+<table>
+    <tbody id="tbody1" class="test" style="overflow-x: visible; overflow-y: auto"/>
+    <tbody id="tbody2" class="test" style="overflow-x: visible; overflow-y: scroll"/>
+    <tbody id="tbody3" class="test" style="overflow-x: visible; overflow-y: hidden"/>
+</table>
+<!-- For table rows. -->
+<table>
+    <tr id="tr1" class="test" style="overflow-x: visible; overflow-y: auto"/>
+    <tr id="tr2" class="test" style="overflow-x: visible; overflow-y: scroll"/>
+    <tr id="tr3" class="test" style="overflow-x: visible; overflow-y: hidden"/>
+</table>
+<script>
+description("This test checks for overflow equality. If overflow-x is visible then overflow-y should be visible as well.");
+var elements = document.getElementsByClassName("test");
+for (i = 0; i < elements.length; ++i)
+{
+    computedStyle = getComputedStyle(elements[i]);
+    overflowX = computedStyle.getPropertyValue('overflow-x');
+    overflowY = computedStyle.getPropertyValue('overflow-y');
+    if (overflowX == "visible" && overflowX != overflowY)
+        testFailed(elements[i].id + ": overflow-y should be visible. Was " + overflowY + ".");
+    else
+        testPassed(elements[i].id + ": overflow-x is either not visible or both overflow values are visible.");
+}
+</script>


### PR DESCRIPTION
<pre>
Compute the correct overflow-x and overflow-y values for table elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=252422">https://bugs.webkit.org/show_bug.cgi?id=252422</a>

Reviewed by NOBODY (OOPS!).

This patch is to align WebKit with Chromium / Blink and Firefox / Gecko.

Merge - <a href="https://src.chromium.org/viewvc/blink?view=revision&revision=199640">https://src.chromium.org/viewvc/blink?view=revision&revision=199640</a>

This patch is to align WebKit to respect web-specification[1] & [2], which tells us that
display:table must treat anything other than hidden as visible and if overflow-x and
overflow-y are different, how they must be resolved. This latter part is already taken care
of, we're just allowing it to be applied to tables and table parts now.

[1] <a href="https://drafts.csswg.org/css2/#overflow">https://drafts.csswg.org/css2/#overflow</a>
[2] <a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow-x">https://drafts.csswg.org/css-overflow-3/#propdef-overflow-x</a>

* Source/WebCore/style/StyleAdjuster.cpp:
(Adjuster::adjust): Update handling of "overflow-x" and "overflow-y" align with spec and
interop with other engines
* LayoutTests/fast/table/table-different-overflow-values.html: Add Test Case
* LayoutTests/fast/table/table-different-overflow-values-expected.txt: Add Test Case Expectation
* LayoutTests/fast/table/table-different-overflow-values-2.html: Add Test Case
* LayoutTests/fast/table/table-different-overflow-values-2-expected.txt: Add Test Case Expectation
* LayoutTests/fast/table/overflowScroll.html: Add Test Case
* LayoutTests/fast/table/overflowScroll-expected.html: Add Test Case Expectation
* LayoutTests/fast/table/overflowScroll-display-block.html: Add Test Case
* LayoutTests/fast/table/overflowScroll-display-block-expected.html: Add Test Case Expectation
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd1b94ad3565645f0dc2908a397ecaa191b31add

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108325 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17417 "Hash bd1b94ad for PR 10236 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41189 "Hash bd1b94ad for PR 10236 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117441 "Hash bd1b94ad for PR 10236 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116820 "Hash bd1b94ad for PR 10236 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112212 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18804 "Hash bd1b94ad for PR 10236 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8696 "Hash bd1b94ad for PR 10236 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100543 "Hash bd1b94ad for PR 10236 does not build (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114094 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/76/builds/18804 "Hash bd1b94ad for PR 10236 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/41189 "Hash bd1b94ad for PR 10236 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/100543 "Hash bd1b94ad for PR 10236 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/76/builds/18804 "Hash bd1b94ad for PR 10236 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/41189 "Hash bd1b94ad for PR 10236 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/100543 "Hash bd1b94ad for PR 10236 does not build (failure)") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10253 "Hash bd1b94ad for PR 10236 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/41189 "Hash bd1b94ad for PR 10236 does not build (failure)") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10993 "Hash bd1b94ad for PR 10236 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/85/builds/8696 "Hash bd1b94ad for PR 10236 does not build (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16403 "Hash bd1b94ad for PR 10236 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/41189 "Hash bd1b94ad for PR 10236 does not build (failure)") | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12579 "Hash bd1b94ad for PR 10236 does not build (failure)") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->