### PR TITLE
[JSC] Reflect the latest update in Intl.Locale info proposal

### DIFF
--- a/JSTests/stress/intl-date-pattern-includes-literal-text.js
+++ b/JSTests/stress/intl-date-pattern-includes-literal-text.js
@@ -9,6 +9,6 @@ shouldBe(new Intl.DateTimeFormat("fr", {hour: "numeric", hour12: false}).format(
 shouldBe(new Intl.DateTimeFormat("fr", {hour: "numeric", hourCycle: 'h24'}).format(new Date(2021, 2, 3, 23)), '23 h');
 shouldBe(new Intl.DateTimeFormat("fr", {hour: "numeric", hourCycle: 'h23'}).format(new Date(2021, 2, 3, 23)), '23 h');
 
-shouldBe(JSON.stringify(new Intl.Locale("fr", {hourCycle: 'h24'}).hourCycles), `["h24"]`);
-shouldBe(JSON.stringify(new Intl.Locale("fr", {hourCycle: 'h23'}).hourCycles), `["h23"]`);
-shouldBe(JSON.stringify(new Intl.Locale("fr").hourCycles), `["h23"]`);
+shouldBe(JSON.stringify(new Intl.Locale("fr", {hourCycle: 'h24'}).getHourCycles()), `["h24"]`);
+shouldBe(JSON.stringify(new Intl.Locale("fr", {hourCycle: 'h23'}).getHourCycles()), `["h23"]`);
+shouldBe(JSON.stringify(new Intl.Locale("fr").getHourCycles()), `["h23"]`);

--- a/JSTests/stress/intl-locale-info.js
+++ b/JSTests/stress/intl-locale-info.js
@@ -10,117 +10,117 @@ function shouldBeOneOf(actual, expectedArray) {
 
 {
     let he = new Intl.Locale("he")
-    shouldBe(JSON.stringify(he.weekInfo), `{"firstDay":7,"weekend":[5,6],"minimalDays":1}`);
+    shouldBe(JSON.stringify(he.getWeekInfo()), `{"firstDay":7,"weekend":[5,6],"minimalDays":1}`);
     let af = new Intl.Locale("af")
-    shouldBe(JSON.stringify(af.weekInfo), `{"firstDay":7,"weekend":[6,7],"minimalDays":1}`);
+    shouldBe(JSON.stringify(af.getWeekInfo()), `{"firstDay":7,"weekend":[6,7],"minimalDays":1}`);
     let enGB = new Intl.Locale("en-GB")
-    shouldBe(JSON.stringify(enGB.weekInfo), `{"firstDay":1,"weekend":[6,7],"minimalDays":4}`);
+    shouldBe(JSON.stringify(enGB.getWeekInfo()), `{"firstDay":1,"weekend":[6,7],"minimalDays":4}`);
     let msBN = new Intl.Locale("ms-BN");
     // "weekend" should be [5,7]. But currently ICU/CLDR does not support representing non-contiguous weekend.
-    shouldBe(JSON.stringify(msBN.weekInfo), `{"firstDay":1,"weekend":[6,7],"minimalDays":1}`);
+    shouldBe(JSON.stringify(msBN.getWeekInfo()), `{"firstDay":1,"weekend":[6,7],"minimalDays":1}`);
 }
 {
     let l = new Intl.Locale("ar")
-    shouldBe(JSON.stringify(l.textInfo), `{"direction":"rtl"}`);
+    shouldBe(JSON.stringify(l.getTextInfo()), `{"direction":"rtl"}`);
 }
 {
     let locale = new Intl.Locale("ar")
-    shouldBe(JSON.stringify(locale.calendars), `["gregory","coptic","islamic","islamic-civil","islamic-tbla"]`);
-    shouldBe(JSON.stringify(locale.collations), `["compat","emoji","eor"]`);
+    shouldBe(JSON.stringify(locale.getCalendars()), `["gregory","coptic","islamic","islamic-civil","islamic-tbla"]`);
+    shouldBe(JSON.stringify(locale.getCollations()), `["compat","emoji","eor"]`);
     shouldBe(locale.hourCycle, undefined);
-    shouldBe(JSON.stringify(locale.hourCycles), `["h12"]`);
-    let ns = JSON.stringify(locale.numberingSystems);
+    shouldBe(JSON.stringify(locale.getHourCycles()), `["h12"]`);
+    let ns = JSON.stringify(locale.getNumberingSystems());
     shouldBe(ns === `["arab"]` || ns === `["latn"]`, true);
-    shouldBe(locale.timeZones, undefined);
+    shouldBe(locale.getTimeZones(), undefined);
 }
 {
     let locale = new Intl.Locale("ar-EG")
-    shouldBe(JSON.stringify(locale.calendars), `["gregory","coptic","islamic","islamic-civil","islamic-tbla"]`);
-    shouldBe(JSON.stringify(locale.collations), `["compat","emoji","eor"]`);
+    shouldBe(JSON.stringify(locale.getCalendars()), `["gregory","coptic","islamic","islamic-civil","islamic-tbla"]`);
+    shouldBe(JSON.stringify(locale.getCollations()), `["compat","emoji","eor"]`);
     shouldBe(locale.hourCycle, undefined);
-    shouldBe(JSON.stringify(locale.hourCycles), `["h12"]`);
-    shouldBe(JSON.stringify(locale.numberingSystems), `["arab"]`);
-    shouldBe(JSON.stringify(locale.timeZones), `["Africa/Cairo"]`);
+    shouldBe(JSON.stringify(locale.getHourCycles()), `["h12"]`);
+    shouldBe(JSON.stringify(locale.getNumberingSystems()), `["arab"]`);
+    shouldBe(JSON.stringify(locale.getTimeZones()), `["Africa/Cairo"]`);
 }
 {
     let locale = new Intl.Locale("ar-SA")
-    let calendars = JSON.stringify(locale.calendars);
+    let calendars = JSON.stringify(locale.getCalendars());
     shouldBe(calendars === `["islamic-umalqura","islamic-rgsa","islamic","gregory"]` || calendars === `["islamic-umalqura","gregory","islamic","islamic-rgsa"]`, true);
-    shouldBe(JSON.stringify(locale.collations), `["compat","emoji","eor"]`);
+    shouldBe(JSON.stringify(locale.getCollations()), `["compat","emoji","eor"]`);
     shouldBe(locale.hourCycle, undefined);
-    shouldBe(JSON.stringify(locale.hourCycles), `["h12"]`);
-    shouldBe(JSON.stringify(locale.numberingSystems), `["arab"]`);
-    shouldBe(JSON.stringify(locale.timeZones), `["Asia/Riyadh"]`);
+    shouldBe(JSON.stringify(locale.getHourCycles()), `["h12"]`);
+    shouldBe(JSON.stringify(locale.getNumberingSystems()), `["arab"]`);
+    shouldBe(JSON.stringify(locale.getTimeZones()), `["Asia/Riyadh"]`);
 }
 {
     let locale = new Intl.Locale("ja")
-    shouldBe(JSON.stringify(locale.calendars), `["gregory","japanese"]`);
-    shouldBe(JSON.stringify(locale.collations), `["unihan","emoji","eor"]`);
+    shouldBe(JSON.stringify(locale.getCalendars()), `["gregory","japanese"]`);
+    shouldBe(JSON.stringify(locale.getCollations()), `["unihan","emoji","eor"]`);
     shouldBe(locale.hourCycle, undefined);
-    shouldBe(JSON.stringify(locale.hourCycles), `["h23"]`);
-    shouldBe(JSON.stringify(locale.numberingSystems), `["latn"]`);
-    shouldBe(locale.timeZones, undefined);
+    shouldBe(JSON.stringify(locale.getHourCycles()), `["h23"]`);
+    shouldBe(JSON.stringify(locale.getNumberingSystems()), `["latn"]`);
+    shouldBe(locale.getTimeZones(), undefined);
 }
 {
     let locale = new Intl.Locale("ja-JP")
-    shouldBe(JSON.stringify(locale.calendars), `["gregory","japanese"]`);
-    shouldBe(JSON.stringify(locale.collations), `["unihan","emoji","eor"]`);
+    shouldBe(JSON.stringify(locale.getCalendars()), `["gregory","japanese"]`);
+    shouldBe(JSON.stringify(locale.getCollations()), `["unihan","emoji","eor"]`);
     shouldBe(locale.hourCycle, undefined);
-    shouldBe(JSON.stringify(locale.hourCycles), `["h23"]`);
-    shouldBe(JSON.stringify(locale.numberingSystems), `["latn"]`);
-    shouldBe(JSON.stringify(locale.timeZones), `["Asia/Tokyo"]`);
+    shouldBe(JSON.stringify(locale.getHourCycles()), `["h23"]`);
+    shouldBe(JSON.stringify(locale.getNumberingSystems()), `["latn"]`);
+    shouldBe(JSON.stringify(locale.getTimeZones()), `["Asia/Tokyo"]`);
 }
 {
     let locale = new Intl.Locale("en-US")
-    shouldBe(JSON.stringify(locale.calendars), `["gregory"]`);
-    shouldBe(JSON.stringify(locale.collations), `["emoji","eor"]`);
+    shouldBe(JSON.stringify(locale.getCalendars()), `["gregory"]`);
+    shouldBe(JSON.stringify(locale.getCollations()), `["emoji","eor"]`);
     shouldBe(locale.hourCycle, undefined);
-    shouldBe(JSON.stringify(locale.hourCycles), `["h12"]`);
-    shouldBe(JSON.stringify(locale.numberingSystems), `["latn"]`);
-    shouldBe(JSON.stringify(locale.timeZones), `["America/Adak","America/Anchorage","America/Boise","America/Chicago","America/Denver","America/Detroit","America/Indiana/Knox","America/Indiana/Marengo","America/Indiana/Petersburg","America/Indiana/Tell_City","America/Indiana/Vevay","America/Indiana/Vincennes","America/Indiana/Winamac","America/Indianapolis","America/Juneau","America/Kentucky/Monticello","America/Los_Angeles","America/Louisville","America/Menominee","America/Metlakatla","America/New_York","America/Nome","America/North_Dakota/Beulah","America/North_Dakota/Center","America/North_Dakota/New_Salem","America/Phoenix","America/Sitka","America/Yakutat","Pacific/Honolulu"]`);
+    shouldBe(JSON.stringify(locale.getHourCycles()), `["h12"]`);
+    shouldBe(JSON.stringify(locale.getNumberingSystems()), `["latn"]`);
+    shouldBe(JSON.stringify(locale.getTimeZones()), `["America/Adak","America/Anchorage","America/Boise","America/Chicago","America/Denver","America/Detroit","America/Indiana/Knox","America/Indiana/Marengo","America/Indiana/Petersburg","America/Indiana/Tell_City","America/Indiana/Vevay","America/Indiana/Vincennes","America/Indiana/Winamac","America/Indianapolis","America/Juneau","America/Kentucky/Monticello","America/Los_Angeles","America/Louisville","America/Menominee","America/Metlakatla","America/New_York","America/Nome","America/North_Dakota/Beulah","America/North_Dakota/Center","America/North_Dakota/New_Salem","America/Phoenix","America/Sitka","America/Yakutat","Pacific/Honolulu"]`);
 }
 {
     let locale = new Intl.Locale("en-NZ")
-    shouldBe(JSON.stringify(locale.calendars), `["gregory"]`);
-    shouldBe(JSON.stringify(locale.collations), `["emoji","eor"]`);
+    shouldBe(JSON.stringify(locale.getCalendars()), `["gregory"]`);
+    shouldBe(JSON.stringify(locale.getCollations()), `["emoji","eor"]`);
     shouldBe(locale.hourCycle, undefined);
-    shouldBe(JSON.stringify(locale.hourCycles), `["h12"]`);
-    shouldBe(JSON.stringify(locale.numberingSystems), `["latn"]`);
-    shouldBe(JSON.stringify(locale.timeZones), `["Pacific/Auckland","Pacific/Chatham"]`);
+    shouldBe(JSON.stringify(locale.getHourCycles()), `["h12"]`);
+    shouldBe(JSON.stringify(locale.getNumberingSystems()), `["latn"]`);
+    shouldBe(JSON.stringify(locale.getTimeZones()), `["Pacific/Auckland","Pacific/Chatham"]`);
 }
 {
     let locale = new Intl.Locale("zh")
-    shouldBe(JSON.stringify(locale.calendars), `["gregory","chinese"]`);
-    shouldBe(JSON.stringify(locale.collations), `["pinyin","big5han","gb2312","stroke","unihan","zhuyin","emoji","eor"]`);
+    shouldBe(JSON.stringify(locale.getCalendars()), `["gregory","chinese"]`);
+    shouldBe(JSON.stringify(locale.getCollations()), `["pinyin","big5han","gb2312","stroke","unihan","zhuyin","emoji","eor"]`);
     shouldBe(locale.hourCycle, undefined);
-    shouldBeOneOf(JSON.stringify(locale.hourCycles), [ `["h23"]`, `["h12"]` ]);
-    shouldBe(JSON.stringify(locale.numberingSystems), `["latn"]`);
-    shouldBe(locale.timeZones, undefined);
+    shouldBeOneOf(JSON.stringify(locale.getHourCycles()), [ `["h23"]`, `["h12"]` ]);
+    shouldBe(JSON.stringify(locale.getNumberingSystems()), `["latn"]`);
+    shouldBe(locale.getTimeZones(), undefined);
 }
 {
     let locale = new Intl.Locale("zh-TW")
-    shouldBe(JSON.stringify(locale.calendars), `["gregory","roc","chinese"]`);
-    shouldBe(JSON.stringify(locale.collations), `["stroke","big5han","gb2312","pinyin","unihan","zhuyin","emoji","eor"]`);
+    shouldBe(JSON.stringify(locale.getCalendars()), `["gregory","roc","chinese"]`);
+    shouldBe(JSON.stringify(locale.getCollations()), `["stroke","big5han","gb2312","pinyin","unihan","zhuyin","emoji","eor"]`);
     shouldBe(locale.hourCycle, undefined);
-    shouldBe(JSON.stringify(locale.hourCycles), `["h12"]`);
-    shouldBe(JSON.stringify(locale.numberingSystems), `["latn"]`);
-    shouldBe(JSON.stringify(locale.timeZones), `["Asia/Taipei"]`);
+    shouldBe(JSON.stringify(locale.getHourCycles()), `["h12"]`);
+    shouldBe(JSON.stringify(locale.getNumberingSystems()), `["latn"]`);
+    shouldBe(JSON.stringify(locale.getTimeZones()), `["Asia/Taipei"]`);
 }
 {
     let locale = new Intl.Locale("zh-HK")
-    shouldBe(JSON.stringify(locale.calendars), `["gregory","chinese"]`);
-    shouldBe(JSON.stringify(locale.collations), `["stroke","big5han","gb2312","pinyin","unihan","zhuyin","emoji","eor"]`);
+    shouldBe(JSON.stringify(locale.getCalendars()), `["gregory","chinese"]`);
+    shouldBe(JSON.stringify(locale.getCollations()), `["stroke","big5han","gb2312","pinyin","unihan","zhuyin","emoji","eor"]`);
     shouldBe(locale.hourCycle, undefined);
-    shouldBe(JSON.stringify(locale.hourCycles), `["h12"]`);
-    shouldBe(JSON.stringify(locale.numberingSystems), `["latn"]`);
-    shouldBe(JSON.stringify(locale.timeZones), `["Asia/Hong_Kong"]`);
+    shouldBe(JSON.stringify(locale.getHourCycles()), `["h12"]`);
+    shouldBe(JSON.stringify(locale.getNumberingSystems()), `["latn"]`);
+    shouldBe(JSON.stringify(locale.getTimeZones()), `["Asia/Hong_Kong"]`);
 }
 {
     let locale = new Intl.Locale("fa")
-    shouldBe(JSON.stringify(locale.calendars), `["persian","gregory","islamic","islamic-civil","islamic-tbla"]`);
-    shouldBe(JSON.stringify(locale.collations), `["emoji","eor"]`);
+    shouldBe(JSON.stringify(locale.getCalendars()), `["persian","gregory","islamic","islamic-civil","islamic-tbla"]`);
+    shouldBe(JSON.stringify(locale.getCollations()), `["emoji","eor"]`);
     shouldBe(locale.hourCycle, undefined);
-    shouldBe(JSON.stringify(locale.hourCycles), `["h23"]`);
-    shouldBe(JSON.stringify(locale.numberingSystems), `["arabext"]`);
-    shouldBe(locale.timeZones, undefined);
+    shouldBe(JSON.stringify(locale.getHourCycles()), `["h23"]`);
+    shouldBe(JSON.stringify(locale.getNumberingSystems()), `["arabext"]`);
+    shouldBe(locale.getTimeZones(), undefined);
 }

--- a/JSTests/stress/intl-locale-invalid-hourCycles.js
+++ b/JSTests/stress/intl-locale-invalid-hourCycles.js
@@ -1,6 +1,6 @@
 function main() {
     const v24 = new Intl.Locale("trimEnd", { 'numberingSystem': "foobar" });
-    let empty = v24.hourCycles;
+    let empty = v24.getHourCycles();
     print(empty);
 }
 

--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -17,6 +17,7 @@ skip:
     - decorators
     - Intl.DurationFormat
     - regexp-duplicate-named-groups
+    - Intl.Locale-info # Getters are replaced with methods.
   paths:
     - test/built-ins/Temporal/Calendar
     - test/built-ins/Temporal/Instant/prototype/toZonedDateTime

--- a/Source/JavaScriptCore/runtime/IntlLocalePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlLocalePrototype.cpp
@@ -35,23 +35,24 @@ namespace JSC {
 static JSC_DECLARE_HOST_FUNCTION(intlLocalePrototypeFuncMaximize);
 static JSC_DECLARE_HOST_FUNCTION(intlLocalePrototypeFuncMinimize);
 static JSC_DECLARE_HOST_FUNCTION(intlLocalePrototypeFuncToString);
+static JSC_DECLARE_HOST_FUNCTION(intlLocalePrototypeFuncGetCalendars);
+static JSC_DECLARE_HOST_FUNCTION(intlLocalePrototypeFuncGetCollations);
+static JSC_DECLARE_HOST_FUNCTION(intlLocalePrototypeFuncGetHourCycles);
+static JSC_DECLARE_HOST_FUNCTION(intlLocalePrototypeFuncGetNumberingSystems);
+static JSC_DECLARE_HOST_FUNCTION(intlLocalePrototypeFuncGetTimeZones);
+static JSC_DECLARE_HOST_FUNCTION(intlLocalePrototypeFuncGetTextInfo);
+static JSC_DECLARE_HOST_FUNCTION(intlLocalePrototypeFuncGetWeekInfo);
+
 static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterBaseName);
 static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterCalendar);
-static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterCalendars);
 static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterCaseFirst);
 static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterCollation);
-static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterCollations);
 static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterHourCycle);
-static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterHourCycles);
 static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterNumeric);
 static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterNumberingSystem);
-static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterNumberingSystems);
 static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterLanguage);
 static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterScript);
 static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterRegion);
-static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterTimeZones);
-static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterTextInfo);
-static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterWeekInfo);
 
 }
 
@@ -63,26 +64,26 @@ const ClassInfo IntlLocalePrototype::s_info = { "Intl.Locale"_s, &Base::s_info, 
 
 /* Source for IntlLocalePrototype.lut.h
 @begin localePrototypeTable
-  maximize         intlLocalePrototypeFuncMaximize           DontEnum|Function 0
-  minimize         intlLocalePrototypeFuncMinimize           DontEnum|Function 0
-  toString         intlLocalePrototypeFuncToString           DontEnum|Function 0
-  baseName         intlLocalePrototypeGetterBaseName         DontEnum|ReadOnly|CustomAccessor
-  calendar         intlLocalePrototypeGetterCalendar         DontEnum|ReadOnly|CustomAccessor
-  calendars        intlLocalePrototypeGetterCalendars        DontEnum|ReadOnly|CustomAccessor
-  caseFirst        intlLocalePrototypeGetterCaseFirst        DontEnum|ReadOnly|CustomAccessor
-  collation        intlLocalePrototypeGetterCollation        DontEnum|ReadOnly|CustomAccessor
-  collations       intlLocalePrototypeGetterCollations       DontEnum|ReadOnly|CustomAccessor
-  hourCycle        intlLocalePrototypeGetterHourCycle        DontEnum|ReadOnly|CustomAccessor
-  hourCycles       intlLocalePrototypeGetterHourCycles       DontEnum|ReadOnly|CustomAccessor
-  numeric          intlLocalePrototypeGetterNumeric          DontEnum|ReadOnly|CustomAccessor
-  numberingSystem  intlLocalePrototypeGetterNumberingSystem  DontEnum|ReadOnly|CustomAccessor
-  numberingSystems intlLocalePrototypeGetterNumberingSystems DontEnum|ReadOnly|CustomAccessor
-  language         intlLocalePrototypeGetterLanguage         DontEnum|ReadOnly|CustomAccessor
-  script           intlLocalePrototypeGetterScript           DontEnum|ReadOnly|CustomAccessor
-  region           intlLocalePrototypeGetterRegion           DontEnum|ReadOnly|CustomAccessor
-  timeZones        intlLocalePrototypeGetterTimeZones        DontEnum|ReadOnly|CustomAccessor
-  textInfo         intlLocalePrototypeGetterTextInfo         DontEnum|ReadOnly|CustomAccessor
-  weekInfo         intlLocalePrototypeGetterWeekInfo         DontEnum|ReadOnly|CustomAccessor
+  maximize            intlLocalePrototypeFuncMaximize            DontEnum|Function 0
+  minimize            intlLocalePrototypeFuncMinimize            DontEnum|Function 0
+  toString            intlLocalePrototypeFuncToString            DontEnum|Function 0
+  getCalendars        intlLocalePrototypeFuncGetCalendars        DontEnum|Function 0
+  getCollations       intlLocalePrototypeFuncGetCollations       DontEnum|Function 0
+  getHourCycles       intlLocalePrototypeFuncGetHourCycles       DontEnum|Function 0
+  getNumberingSystems intlLocalePrototypeFuncGetNumberingSystems DontEnum|Function 0
+  getTimeZones        intlLocalePrototypeFuncGetTimeZones        DontEnum|Function 0
+  getTextInfo         intlLocalePrototypeFuncGetTextInfo         DontEnum|Function 0
+  getWeekInfo         intlLocalePrototypeFuncGetWeekInfo         DontEnum|Function 0
+  baseName            intlLocalePrototypeGetterBaseName          DontEnum|ReadOnly|CustomAccessor
+  calendar            intlLocalePrototypeGetterCalendar          DontEnum|ReadOnly|CustomAccessor
+  caseFirst           intlLocalePrototypeGetterCaseFirst         DontEnum|ReadOnly|CustomAccessor
+  collation           intlLocalePrototypeGetterCollation         DontEnum|ReadOnly|CustomAccessor
+  hourCycle           intlLocalePrototypeGetterHourCycle         DontEnum|ReadOnly|CustomAccessor
+  numeric             intlLocalePrototypeGetterNumeric           DontEnum|ReadOnly|CustomAccessor
+  numberingSystem     intlLocalePrototypeGetterNumberingSystem   DontEnum|ReadOnly|CustomAccessor
+  language            intlLocalePrototypeGetterLanguage          DontEnum|ReadOnly|CustomAccessor
+  script              intlLocalePrototypeGetterScript            DontEnum|ReadOnly|CustomAccessor
+  region              intlLocalePrototypeGetterRegion            DontEnum|ReadOnly|CustomAccessor
 @end
 */
 
@@ -184,15 +185,15 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterCalendar, (JSGlobalObject* glo
     RELEASE_AND_RETURN(scope, JSValue::encode(calendar.isNull() ? jsUndefined() : jsString(vm, calendar)));
 }
 
-// https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.calendars
-JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterCalendars, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
+// https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.getCalendars
+JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncGetCalendars, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
+    auto* locale = jsDynamicCast<IntlLocale*>(callFrame->thisValue());
     if (!locale)
-        return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.calendars called on value that's not a Locale"_s);
+        return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.getCalendars called on value that's not a Locale"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(locale->calendars(globalObject)));
 }
@@ -225,15 +226,15 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterCollation, (JSGlobalObject* gl
     RELEASE_AND_RETURN(scope, JSValue::encode(collation.isNull() ? jsUndefined() : jsString(vm, collation)));
 }
 
-// https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.collations
-JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterCollations, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
+// https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.getCollations
+JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncGetCollations, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
+    auto* locale = jsDynamicCast<IntlLocale*>(callFrame->thisValue());
     if (!locale)
-        return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.collations called on value that's not a Locale"_s);
+        return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.getCollations called on value that's not a Locale"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(locale->collations(globalObject)));
 }
@@ -252,15 +253,15 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterHourCycle, (JSGlobalObject* gl
     RELEASE_AND_RETURN(scope, JSValue::encode(hourCycle.isNull() ? jsUndefined() : jsString(vm, hourCycle)));
 }
 
-// https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.hourcycles
-JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterHourCycles, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
+// https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.getHourCycles
+JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncGetHourCycles, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
+    auto* locale = jsDynamicCast<IntlLocale*>(callFrame->thisValue());
     if (!locale)
-        return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.hourCycles called on value that's not a Locale"_s);
+        return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.getHourCycles called on value that's not a Locale"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(locale->hourCycles(globalObject)));
 }
@@ -292,15 +293,15 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterNumberingSystem, (JSGlobalObje
     RELEASE_AND_RETURN(scope, JSValue::encode(numberingSystem.isNull() ? jsUndefined() : jsString(vm, numberingSystem)));
 }
 
-// https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.numberingSystems
-JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterNumberingSystems, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
+// https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.getNumberingSystems
+JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncGetNumberingSystems, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
+    auto* locale = jsDynamicCast<IntlLocale*>(callFrame->thisValue());
     if (!locale)
-        return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.numberingSystems called on value that's not a Locale"_s);
+        return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.getNumberingSystems called on value that's not a Locale"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(locale->numberingSystems(globalObject)));
 }
@@ -347,41 +348,41 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterRegion, (JSGlobalObject* globa
     RELEASE_AND_RETURN(scope, JSValue::encode(region.isEmpty() ? jsUndefined() : jsString(vm, region)));
 }
 
-// https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.timezones
-JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterTimeZones, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
+// https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.getTimezones
+JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncGetTimeZones, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
+    auto* locale = jsDynamicCast<IntlLocale*>(callFrame->thisValue());
     if (!locale)
-        return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.timeZones called on value that's not a Locale"_s);
+        return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.getTimeZones called on value that's not a Locale"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(locale->timeZones(globalObject)));
 }
 
-// https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.textInfo
-JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterTextInfo, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
+// https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.getTextInfo
+JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncGetTextInfo, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
+    auto* locale = jsDynamicCast<IntlLocale*>(callFrame->thisValue());
     if (!locale)
-        return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.textInfo called on value that's not a Locale"_s);
+        return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.getTextInfo called on value that's not a Locale"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(locale->textInfo(globalObject)));
 }
 
-// https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.weekInfo
-JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterWeekInfo, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
+// https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.getWeekInfo
+JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncGetWeekInfo, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
+    auto* locale = jsDynamicCast<IntlLocale*>(callFrame->thisValue());
     if (!locale)
-        return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.weekInfo called on value that's not a Locale"_s);
+        return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.getWeekInfo called on value that's not a Locale"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(locale->weekInfo(globalObject)));
 }


### PR DESCRIPTION
#### 7e2deb203d53a225fa971d7fb8763dae3e493228
<pre>
[JSC] Reflect the latest update in Intl.Locale info proposal
<a href="https://bugs.webkit.org/show_bug.cgi?id=252444">https://bugs.webkit.org/show_bug.cgi?id=252444</a>
rdar://105570888

Reviewed by Mark Lam.

January TC39 meeting decided that Intl.Locale info getters should be replaced with getXXX methods[1].
This patch reflects this spec change to our implementation.

[1]: <a href="https://github.com/tc39/proposal-intl-locale-info/commit/c6daaee2c71bd932408469785d32a6e740e6ca07">https://github.com/tc39/proposal-intl-locale-info/commit/c6daaee2c71bd932408469785d32a6e740e6ca07</a>

* JSTests/stress/intl-date-pattern-includes-literal-text.js:
* JSTests/stress/intl-locale-info.js:
(throw.new.Error):
(shouldBe):
(let.l.new.Intl.Locale.shouldBe):
* JSTests/stress/intl-locale-invalid-hourCycles.js:
(main):
* JSTests/test262/config.yaml:
* Source/JavaScriptCore/runtime/IntlLocalePrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/260412@main">https://commits.webkit.org/260412@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85fc26fbf52a7597e2ebf4eb7f9f41db68d73b66

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108239 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17329 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41106 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117361 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/18882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8608 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100452 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114008 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/18882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/97302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/42015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28944 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/97442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/10177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/30289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/38/builds/96793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/8288 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10913 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/7195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/38/builds/96793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/16326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49885 "Passed tests") | [  ~~🛠 jsc-mips~~](https://ews-build.webkit.org/#/builders/37/builds/105829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12496 "Built successfully") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/37/builds/105829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3916 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->