### PR TITLE
[JSC] Bound function should be unwrapped when calling it from C++

### DIFF
--- a/JSTests/microbenchmarks/call-from-cpp-bound-with-args.js
+++ b/JSTests/microbenchmarks/call-from-cpp-bound-with-args.js
@@ -1,0 +1,2 @@
+function test(a, b, c) { }
+$vm.callFromCPP(test.bind(null, 0, 1, 2), 4e6);

--- a/JSTests/microbenchmarks/call-from-cpp-bound.js
+++ b/JSTests/microbenchmarks/call-from-cpp-bound.js
@@ -1,0 +1,2 @@
+function test() { }
+$vm.callFromCPP(test.bind(null), 4e6);

--- a/Source/JavaScriptCore/API/JSCallbackConstructor.cpp
+++ b/Source/JavaScriptCore/API/JSCallbackConstructor.cpp
@@ -73,6 +73,7 @@ CallData JSCallbackConstructor::getConstructData(JSCell*)
     CallData constructData;
     constructData.type = CallData::Type::Native;
     constructData.native.function = constructJSCallbackConstructor;
+    constructData.native.isBoundFunction = false;
     return constructData;
 }
 

--- a/Source/JavaScriptCore/API/JSCallbackObjectFunctions.h
+++ b/Source/JavaScriptCore/API/JSCallbackObjectFunctions.h
@@ -459,6 +459,7 @@ CallData JSCallbackObject<Parent>::getConstructData(JSCell* cell)
         if (jsClass->callAsConstructor) {
             constructData.type = CallData::Type::Native;
             constructData.native.function = getConstructFunction();
+            constructData.native.isBoundFunction = false;
             break;
         }
     }
@@ -536,6 +537,7 @@ CallData JSCallbackObject<Parent>::getCallData(JSCell* cell)
         if (jsClass->callAsFunction) {
             callData.type = CallData::Type::Native;
             callData.native.function = getCallFunction();
+            callData.native.isBoundFunction = false;
             break;
         }
     }

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -1024,41 +1024,71 @@ failedJSONP:
     return JSValue::decode(vmEntryToJavaScript(jitCode->addressForCall(), &vm, &protoCallFrame));
 }
 
-JSValue Interpreter::executeCall(JSGlobalObject* lexicalGlobalObject, JSObject* function, const CallData& callData, JSValue thisValue, const ArgList& args)
+JSValue Interpreter::executeBoundCall(VM& vm, JSBoundFunction* function, const ArgList& args)
 {
-    VM& vm = lexicalGlobalObject->vm();
-    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    auto scope = DECLARE_THROW_SCOPE(vm);
 
+    ASSERT(function->boundArgs());
+
+    auto* boundArgs = function->boundArgs();
+    MarkedArgumentBuffer combinedArgs;
+    combinedArgs.ensureCapacity(boundArgs->length() + args.size());
+
+    for (unsigned i = 0; i < boundArgs->length(); ++i)
+        combinedArgs.append(boundArgs->get(i));
+    for (unsigned i = 0; i < args.size(); ++i)
+        combinedArgs.append(args.at(i));
+
+    if (UNLIKELY(combinedArgs.hasOverflowed()))
+        return throwStackOverflowError(function->globalObject(), scope);
+
+    JSObject* targetFunction = function->targetFunction();
+    JSValue boundThis = function->boundThis();
+    auto callData = JSC::getCallData(targetFunction);
+    ASSERT(callData.type != CallData::Type::None);
+
+    return executeCallImpl(vm, targetFunction, callData, boundThis, combinedArgs);
+}
+
+ALWAYS_INLINE JSValue Interpreter::executeCallImpl(VM& vm, JSObject* function, const CallData& callData, JSValue thisValue, const ArgList& args)
+{
     auto clobberizeValidator = makeScopeExit([&] {
         vm.didEnterVM = true;
     });
 
-    throwScope.assertNoException();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    scope.assertNoException();
+
     ASSERT(!vm.isCollectorBusyOnCurrentThread());
     if (vm.isCollectorBusyOnCurrentThread())
         return jsNull();
 
-    bool isJSCall = (callData.type == CallData::Type::JS);
-    JSScope* scope = nullptr;
-    size_t argsCount = 1 + args.size(); // implicit "this" parameter
-
-    JSGlobalObject* globalObject;
+    bool isJSCall = callData.type == CallData::Type::JS;
+    JSScope* functionScope = nullptr;
+    FunctionExecutable* functionExecutable = nullptr;
+    TaggedNativeFunction nativeFunction;
+    JSGlobalObject* globalObject = nullptr;
 
     if (isJSCall) {
-        scope = callData.js.scope;
-        globalObject = scope->globalObject();
+        functionScope = callData.js.scope;
+        functionExecutable = callData.js.functionExecutable;
+        globalObject = functionScope->globalObject();
     } else {
         ASSERT(callData.type == CallData::Type::Native);
+        nativeFunction = callData.native.function;
         globalObject = function->globalObject();
     }
 
+    size_t argsCount = 1 + args.size(); // implicit "this" parameter
+
     VMEntryScope entryScope(vm, globalObject);
     if (UNLIKELY(!vm.isSafeToRecurseSoft() || args.size() > maxArguments))
-        return throwStackOverflowError(globalObject, throwScope);
+        return throwStackOverflowError(globalObject, scope);
 
     if (UNLIKELY(vm.traps().needHandling(VMTraps::NonDebuggerAsyncEvents))) {
         if (vm.hasExceptionsAfterHandlingTraps())
-            return throwScope.exception();
+            return scope.exception();
     }
 
     RefPtr<JITCode> jitCode;
@@ -1069,8 +1099,8 @@ JSValue Interpreter::executeCall(JSGlobalObject* lexicalGlobalObject, JSObject* 
         CodeBlock* newCodeBlock = nullptr;
         if (isJSCall) {
             // Compile the callee:
-            callData.js.functionExecutable->prepareForExecution<FunctionExecutable>(vm, jsCast<JSFunction*>(function), scope, CodeForCall, newCodeBlock);
-            RETURN_IF_EXCEPTION(throwScope, throwScope.exception());
+            functionExecutable->prepareForExecution<FunctionExecutable>(vm, jsCast<JSFunction*>(function), functionScope, CodeForCall, newCodeBlock);
+            RETURN_IF_EXCEPTION(scope, scope.exception());
 
             ASSERT(newCodeBlock);
             newCodeBlock->m_shouldAlwaysBeInlined = false;
@@ -1079,18 +1109,38 @@ JSValue Interpreter::executeCall(JSGlobalObject* lexicalGlobalObject, JSObject* 
         {
             DisallowGC disallowGC; // Ensure no GC happens. GC can replace CodeBlock in Executable.
             if (isJSCall)
-                jitCode = callData.js.functionExecutable->generatedJITCodeForCall();
+                jitCode = functionExecutable->generatedJITCodeForCall();
             protoCallFrame.init(newCodeBlock, globalObject, function, thisValue, argsCount, args.data());
         }
     }
 
     // Execute the code:
-    throwScope.release();
+    scope.release();
     if (isJSCall) {
-        ASSERT(jitCode == callData.js.functionExecutable->generatedJITCodeForCall().ptr());
+        ASSERT(jitCode == functionExecutable->generatedJITCodeForCall().ptr());
         return JSValue::decode(vmEntryToJavaScript(jitCode->addressForCall(), &vm, &protoCallFrame));
     }
-    return JSValue::decode(vmEntryToNative(callData.native.function.taggedPtr(), &vm, &protoCallFrame));
+    return JSValue::decode(vmEntryToNative(nativeFunction.taggedPtr(), &vm, &protoCallFrame));
+}
+
+JSValue Interpreter::executeCall(JSGlobalObject* lexicalGlobalObject, JSObject* function, const CallData& callData, JSValue thisValue, const ArgList& args)
+{
+    VM& vm = lexicalGlobalObject->vm();
+    if (callData.type == CallData::Type::JS || !callData.native.isBoundFunction)
+        return executeCallImpl(vm, function, callData, thisValue, args);
+
+    // Only one-level unwrap is enough! We already made JSBoundFunction's nest smaller.
+    auto* boundFunction = jsCast<JSBoundFunction*>(function);
+    if (!boundFunction->boundArgs()) {
+        // This is the simplest path, just replacing |this|. We do not need to go to executeBoundCall.
+        // Let's just replace and get unwrapped functions again.
+        JSObject* targetFunction = boundFunction->targetFunction();
+        JSValue boundThis = boundFunction->boundThis();
+        auto targetFunctionCallData = JSC::getCallData(targetFunction);
+        ASSERT(targetFunctionCallData.type != CallData::Type::None);
+        return executeCallImpl(vm, targetFunction, targetFunctionCallData, boundThis, args);
+    }
+    return executeBoundCall(vm, boundFunction, args);
 }
 
 JSObject* Interpreter::executeConstruct(JSGlobalObject* lexicalGlobalObject, JSObject* constructor, const CallData& constructData, const ArgList& args, JSValue newTarget)

--- a/Source/JavaScriptCore/interpreter/Interpreter.h
+++ b/Source/JavaScriptCore/interpreter/Interpreter.h
@@ -31,6 +31,7 @@
 
 #include "JSCJSValue.h"
 #include "MacroAssemblerCodeRef.h"
+#include "NativeFunction.h"
 #include "Opcode.h"
 #include <variant>
 #include <wtf/HashMap.h>
@@ -63,6 +64,7 @@ using JSOrWasmInstruction = std::variant<const JSInstruction*, const WasmInstruc
     class Exception;
     class FunctionExecutable;
     class VM;
+    class JSBoundFunction;
     class JSFunction;
     class JSGlobalObject;
     class JSModuleEnvironment;
@@ -160,6 +162,8 @@ using JSOrWasmInstruction = std::variant<const JSInstruction*, const WasmInstruc
         CallFrameClosure prepareForRepeatCall(FunctionExecutable*, ProtoCallFrame*, JSFunction*, int argumentCountIncludingThis, JSScope*, const ArgList&);
 
         JSValue executeCachedCall(CallFrameClosure&);
+        JSValue executeBoundCall(VM&, JSBoundFunction*, const ArgList&);
+        JSValue executeCallImpl(VM&, JSObject*, const CallData&, JSValue, const ArgList&);
 
         inline VM& vm();
 #if ENABLE(C_LOOP)

--- a/Source/JavaScriptCore/runtime/CallData.h
+++ b/Source/JavaScriptCore/runtime/CallData.h
@@ -47,6 +47,7 @@ struct CallData {
     union {
         struct {
             TaggedNativeFunction function;
+            bool isBoundFunction;
         } native;
         struct {
             FunctionExecutable* functionExecutable;

--- a/Source/JavaScriptCore/runtime/InternalFunction.cpp
+++ b/Source/JavaScriptCore/runtime/InternalFunction.cpp
@@ -108,6 +108,7 @@ CallData InternalFunction::getCallData(JSCell* cell)
     CallData callData;
     callData.type = CallData::Type::Native;
     callData.native.function = function->m_functionForCall;
+    callData.native.isBoundFunction = false;
     return callData;
 }
 
@@ -119,6 +120,7 @@ CallData InternalFunction::getConstructData(JSCell* cell)
     if (function->m_functionForConstruct != callHostFunctionAsConstructor) {
         constructData.type = CallData::Type::Native;
         constructData.native.function = function->m_functionForConstruct;
+        constructData.native.isBoundFunction = false;
     }
     return constructData;
 }

--- a/Source/JavaScriptCore/runtime/JSBoundFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSBoundFunction.cpp
@@ -40,6 +40,7 @@ JSC_DEFINE_HOST_FUNCTION(boundThisNoArgsFunctionCall, (JSGlobalObject* globalObj
     JSImmutableButterfly* boundArgs = boundFunction->boundArgs();
 
     MarkedArgumentBuffer args;
+    args.ensureCapacity((boundArgs ? boundArgs->length() : 0) + callFrame->argumentCount());
     if (boundArgs) {
         for (unsigned i = 0; i < boundArgs->length(); ++i)
             args.append(boundArgs->get(i));
@@ -68,6 +69,7 @@ JSC_DEFINE_HOST_FUNCTION(boundFunctionCall, (JSGlobalObject* globalObject, CallF
     JSImmutableButterfly* boundArgs = boundFunction->boundArgs();
 
     MarkedArgumentBuffer args;
+    args.ensureCapacity((boundArgs ? boundArgs->length() : 0) + callFrame->argumentCount());
     if (boundArgs) {
         for (unsigned i = 0; i < boundArgs->length(); ++i)
             args.append(boundArgs->get(i));

--- a/Source/JavaScriptCore/runtime/JSFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSFunction.cpp
@@ -294,6 +294,7 @@ CallData JSFunction::getCallData(JSCell* cell)
     if (thisObject->isHostFunction()) {
         callData.type = CallData::Type::Native;
         callData.native.function = thisObject->nativeFunction();
+        callData.native.isBoundFunction = thisObject->inherits<JSBoundFunction>();
     } else {
         callData.type = CallData::Type::JS;
         callData.js.functionExecutable = thisObject->jsExecutable();
@@ -468,6 +469,7 @@ CallData JSFunction::getConstructData(JSCell* cell)
         if (thisObject->nativeConstructor() != callHostFunctionAsConstructor) {
             constructData.type = CallData::Type::Native;
             constructData.native.function = thisObject->nativeConstructor();
+            constructData.native.isBoundFunction = thisObject->inherits<JSBoundFunction>();
         }
     } else {
         FunctionExecutable* functionExecutable = thisObject->jsExecutable();

--- a/Source/JavaScriptCore/runtime/ProxyObject.cpp
+++ b/Source/JavaScriptCore/runtime/ProxyObject.cpp
@@ -537,6 +537,7 @@ CallData ProxyObject::getCallData(JSCell* cell)
     if (proxy->m_isCallable) {
         callData.type = CallData::Type::Native;
         callData.native.function = performProxyCall;
+        callData.native.isBoundFunction = false;
     }
     return callData;
 }
@@ -588,6 +589,7 @@ CallData ProxyObject::getConstructData(JSCell* cell)
     if (proxy->m_isConstructible) {
         constructData.type = CallData::Type::Native;
         constructData.native.function = performProxyConstruct;
+        constructData.native.isBoundFunction = false;
     }
     return constructData;
 }

--- a/Source/WebCore/bindings/js/JSHTMLAllCollectionCustom.cpp
+++ b/Source/WebCore/bindings/js/JSHTMLAllCollectionCustom.cpp
@@ -61,6 +61,7 @@ CallData JSHTMLAllCollection::getCallData(JSCell*)
     CallData callData;
     callData.type = CallData::Type::Native;
     callData.native.function = callJSHTMLAllCollection;
+    callData.native.isBoundFunction = false;
     return callData;
 }
 

--- a/Source/WebCore/bindings/js/JSPluginElementFunctions.cpp
+++ b/Source/WebCore/bindings/js/JSPluginElementFunctions.cpp
@@ -150,6 +150,7 @@ CallData pluginElementCustomGetCallData(JSHTMLElement* element)
     if (instance && instance->supportsInvokeDefaultMethod()) {
         callData.type = CallData::Type::Native;
         callData.native.function = callPlugin;
+        callData.native.isBoundFunction = false;
     }
 
     return callData;

--- a/Source/WebCore/bridge/objc/objc_runtime.mm
+++ b/Source/WebCore/bridge/objc/objc_runtime.mm
@@ -299,6 +299,7 @@ CallData ObjcFallbackObjectImp::getCallData(JSCell* cell)
     if ([targetObject respondsToSelector:@selector(invokeUndefinedMethodFromWebScript:withArguments:)]) {
         callData.type = CallData::Type::Native;
         callData.native.function = callObjCFallbackObject;
+        callData.native.isBoundFunction = false;
     }
 
     return callData;

--- a/Source/WebCore/bridge/runtime_object.cpp
+++ b/Source/WebCore/bridge/runtime_object.cpp
@@ -258,6 +258,7 @@ CallData RuntimeObject::getCallData(JSCell* cell)
     if (thisObject->m_instance && thisObject->m_instance->supportsInvokeDefaultMethod()) {
         callData.type = CallData::Type::Native;
         callData.native.function = callRuntimeObject;
+        callData.native.isBoundFunction = false;
     }
 
     return callData;
@@ -285,6 +286,7 @@ CallData RuntimeObject::getConstructData(JSCell* cell)
     if (thisObject->m_instance && thisObject->m_instance->supportsConstruct()) {
         constructData.type = CallData::Type::Native;
         constructData.native.function = callRuntimeConstructor;
+        constructData.native.isBoundFunction = false;
     }
 
     return constructData;


### PR DESCRIPTION
#### 1ef2618fca1d075259cb8c84e88299c1f34b2f41
<pre>
[JSC] Bound function should be unwrapped when calling it from C++
<a href="https://bugs.webkit.org/show_bug.cgi?id=252445">https://bugs.webkit.org/show_bug.cgi?id=252445</a>
rdar://105571741

Reviewed by Tadeu Zagallo.

We already unwrapped nested JSBoundFunctions in 260303@main. As a result, one-level unwrapping is enough to extract the target function in most cases.
This patch adds one-level unwrapping in executeCall so that we can skip JSBoundFunction indirection.

Before: CXX -&gt; vmEntryToNative -&gt; CXX JSBoundFunction implementation -&gt; vmEntryToJS -&gt; targetFunction
After: CXX -&gt; vmEntryToJS -&gt; targetFunction

We extract &quot;isBoundFunction&quot; information when calling getCallData / getConstructData. We use this to unwrap in executeCall.

We observed large improvement in microbenchmarks. And we observed 0.3% progression in Speedometer2.1

                                              ToT                     Patched

    call-from-cpp-bound                160.4848+-0.0830     ^     89.3845+-0.1212        ^ definitely 1.7954x faster
    call-from-cpp-bound-with-args      169.0045+-0.1030     ^    107.8479+-0.0877        ^ definitely 1.5671x faster

* JSTests/microbenchmarks/call-from-cpp-bound-with-args.js: Added.
(test):
* JSTests/microbenchmarks/call-from-cpp-bound.js: Added.
(test):
* Source/JavaScriptCore/API/JSCallbackConstructor.cpp:
(JSC::JSCallbackConstructor::getConstructData):
* Source/JavaScriptCore/API/JSCallbackObjectFunctions.h:
(JSC::JSCallbackObject&lt;Parent&gt;::getConstructData):
(JSC::JSCallbackObject&lt;Parent&gt;::getCallData):
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::Interpreter::executeBoundCall):
(JSC::Interpreter::executeCallImpl):
(JSC::Interpreter::executeCall):
* Source/JavaScriptCore/interpreter/Interpreter.h:
* Source/JavaScriptCore/runtime/CallData.h:
* Source/JavaScriptCore/runtime/InternalFunction.cpp:
(JSC::InternalFunction::getCallData):
(JSC::InternalFunction::getConstructData):
* Source/JavaScriptCore/runtime/JSBoundFunction.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSFunction.cpp:
(JSC::JSFunction::getCallData):
(JSC::JSFunction::getConstructData):
* Source/JavaScriptCore/runtime/ProxyObject.cpp:
(JSC::ProxyObject::getCallData):
(JSC::ProxyObject::getConstructData):
* Source/JavaScriptCore/tools/JSDollarVM.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::JSDollarVM::finishCreation):
* Source/WebCore/bindings/js/JSHTMLAllCollectionCustom.cpp:
(WebCore::JSHTMLAllCollection::getCallData):
* Source/WebCore/bindings/js/JSPluginElementFunctions.cpp:
(WebCore::pluginElementCustomGetCallData):
* Source/WebCore/bridge/objc/objc_runtime.mm:
(JSC::Bindings::ObjcFallbackObjectImp::getCallData):
* Source/WebCore/bridge/runtime_object.cpp:
(JSC::Bindings::RuntimeObject::getCallData):
(JSC::Bindings::RuntimeObject::getConstructData):

Canonical link: <a href="https://commits.webkit.org/260494@main">https://commits.webkit.org/260494@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b41f66f3a8fa547150b1cbcace02261774ea59f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108469 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17565 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41319 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117574 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/117787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112356 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19016 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8843 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100695 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114237 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97470 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42211 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/29113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/97622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10381 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30459 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/38/builds/98452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/8501 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11134 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/7375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/38/builds/98452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16528 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50055 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/106045 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12720 "Built successfully") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/26247 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3949 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->