### PR TITLE
[UI-side compositing] History swipe on pages with horizontal scrollers doesn't work

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -91,8 +91,7 @@ public:
 
     void currentSnapPointIndicesDidChange(WebCore::ScrollingNodeID, std::optional<unsigned> horizontal, std::optional<unsigned> vertical);
 
-    // FIXME: expose the tree and pass this to that?
-    WebCore::WheelEventHandlingResult handleWheelEvent(const WebCore::PlatformWheelEvent&);
+    WebCore::WheelEventHandlingResult handleWheelEvent(const WebCore::PlatformWheelEvent&, WebCore::RectEdges<bool> rubberBandableEdges);
     void handleMouseEvent(const WebCore::PlatformMouseEvent&);
     
     virtual WebCore::PlatformWheelEvent filteredWheelEvent(const WebCore::PlatformWheelEvent& wheelEvent) { return wheelEvent; }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -3046,11 +3046,17 @@ void WebPageProxy::dispatchWheelEventWithoutScrolling(const WebWheelEvent& event
 void WebPageProxy::handleWheelEvent(const NativeWebWheelEvent& event)
 {
     WheelEventHandlingResult handlingResult;
+
+    auto rubberBandableEdges = rubberBandableEdgesRespectingHistorySwipe();
+
 #if ENABLE(ASYNC_SCROLLING) && PLATFORM(COCOA)
     if (m_scrollingCoordinatorProxy) {
-        handlingResult = m_scrollingCoordinatorProxy->handleWheelEvent(platform(event));
-        if (!handlingResult.needsMainThreadProcessing())
+        handlingResult = m_scrollingCoordinatorProxy->handleWheelEvent(platform(event), rubberBandableEdges);
+        if (!handlingResult.needsMainThreadProcessing()) {
+            if (!handlingResult.wasHandled)
+                wheelEventWasNotHandled(event);
             return;
+        }
     }
 #else
     handlingResult.steps = WheelEventProcessingSteps::MainThreadForScrolling;
@@ -3068,7 +3074,7 @@ void WebPageProxy::handleWheelEvent(const NativeWebWheelEvent& event)
 
     if (wheelEventCoalescer().shouldDispatchEvent(event, handlingResult.steps)) {
         auto eventAndSteps = wheelEventCoalescer().nextEventToDispatch();
-        sendWheelEvent(eventAndSteps->event, eventAndSteps->processingSteps);
+        sendWheelEvent(eventAndSteps->event, eventAndSteps->processingSteps, rubberBandableEdges);
     }
 }
 
@@ -3098,7 +3104,7 @@ void WebPageProxy::updateWheelEventActivityAfterProcessSwap()
 #endif
 }
 
-void WebPageProxy::sendWheelEvent(const WebWheelEvent& event, OptionSet<WebCore::WheelEventProcessingSteps> processingSteps)
+void WebPageProxy::sendWheelEvent(const WebWheelEvent& event, OptionSet<WebCore::WheelEventProcessingSteps> processingSteps, RectEdges<bool> rubberBandableEdges)
 {
 #if HAVE(CVDISPLAYLINK)
     m_wheelEventActivityHysteresis.impulse();
@@ -3107,12 +3113,6 @@ void WebPageProxy::sendWheelEvent(const WebWheelEvent& event, OptionSet<WebCore:
     auto* connection = messageSenderConnection();
     if (!connection)
         return;
-
-    auto rubberBandableEdges = this->rubberBandableEdges();
-    if (shouldUseImplicitRubberBandControl()) {
-        rubberBandableEdges.setLeft(!m_backForwardList->backItem());
-        rubberBandableEdges.setRight(!m_backForwardList->forwardItem());
-    }
 
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER)
     if (event.momentumPhase() == WebWheelEvent::PhaseBegan && m_scrollingAccelerationCurve != m_lastSentScrollingAccelerationCurve) {
@@ -3129,6 +3129,12 @@ void WebPageProxy::sendWheelEvent(const WebWheelEvent& event, OptionSet<WebCore:
     // Manually ping the web process to check for responsiveness since our wheel
     // event will dispatch to a non-main thread, which always responds.
     m_process->isResponsiveWithLazyStop();
+}
+
+void WebPageProxy::wheelEventWasNotHandled(const NativeWebWheelEvent& event)
+{
+    m_uiClient->didNotHandleWheelEvent(this, event);
+    pageClient().wheelEventWasNotHandledByWebCore(event);
 }
 
 WebWheelEventCoalescer& WebPageProxy::wheelEventCoalescer()
@@ -4324,6 +4330,17 @@ void WebPageProxy::setSuppressScrollbarAnimations(bool suppressAnimations)
         return;
 
     send(Messages::WebPage::SetSuppressScrollbarAnimations(suppressAnimations));
+}
+
+WebCore::RectEdges<bool> WebPageProxy::rubberBandableEdgesRespectingHistorySwipe() const
+{
+    auto rubberBandableEdges = this->rubberBandableEdges();
+    if (shouldUseImplicitRubberBandControl()) {
+        rubberBandableEdges.setLeft(!m_backForwardList->backItem());
+        rubberBandableEdges.setRight(!m_backForwardList->forwardItem());
+    }
+
+    return rubberBandableEdges;
 }
 
 void WebPageProxy::setRubberBandsAtLeft(bool rubberBandsAtLeft)
@@ -7881,13 +7898,11 @@ void WebPageProxy::didReceiveEvent(WebEventType eventType, bool handled)
         auto oldestProcessedEvent = wheelEventCoalescer().takeOldestEventBeingProcessed();
 
         // FIXME: Dispatch additional events to the didNotHandleWheelEvent client function.
-        if (!handled) {
-            m_uiClient->didNotHandleWheelEvent(this, oldestProcessedEvent);
-            pageClient().wheelEventWasNotHandledByWebCore(oldestProcessedEvent);
-        }
+        if (!handled)
+            wheelEventWasNotHandled(oldestProcessedEvent);
 
         if (auto eventToSend = wheelEventCoalescer().nextEventToDispatch())
-            sendWheelEvent(eventToSend->event, eventToSend->processingSteps);
+            sendWheelEvent(eventToSend->event, eventToSend->processingSteps, rubberBandableEdgesRespectingHistorySwipe());
         else if (auto* automationSession = process().processPool().automationSession())
             automationSession->wheelEventsFlushedForPage(*this);
         break;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1190,6 +1190,7 @@ public:
 
     WebCore::RectEdges<bool> pinnedState() const { return m_mainFramePinnedState; }
 
+    WebCore::RectEdges<bool> rubberBandableEdgesRespectingHistorySwipe() const;
     WebCore::RectEdges<bool> rubberBandableEdges() const { return m_rubberBandableEdges; }
     void setRubberBandableEdges(WebCore::RectEdges<bool> edges) { m_rubberBandableEdges = edges; }
     void setRubberBandsAtLeft(bool);
@@ -2597,7 +2598,8 @@ private:
 
     void setRenderTreeSize(uint64_t treeSize) { m_renderTreeSize = treeSize; }
 
-    void sendWheelEvent(const WebWheelEvent&, OptionSet<WebCore::WheelEventProcessingSteps>);
+    void sendWheelEvent(const WebWheelEvent&, OptionSet<WebCore::WheelEventProcessingSteps>, WebCore::RectEdges<bool> rubberBandableEdges);
+    void wheelEventWasNotHandled(const NativeWebWheelEvent&);
 
     WebWheelEventCoalescer& wheelEventCoalescer();
 


### PR DESCRIPTION
#### 72773d6ba85502c8ac50d778341baa8e8d1dcdae
<pre>
[UI-side compositing] History swipe on pages with horizontal scrollers doesn&apos;t work
<a href="https://bugs.webkit.org/show_bug.cgi?id=252446">https://bugs.webkit.org/show_bug.cgi?id=252446</a>
rdar://105525566

Reviewed by Tim Horton.

History swipes only happen if a gesture won&apos;t result in a scroll on the page, so on
pages that could potentially horizontally scroll, we need to tell the ViewGestureRecognizer
that the wheel event was never handled. For non-UI-side compositing, this happened via
`WebPageProxy::didReceiveEvent()`. For UI-side compositing, we need to run equivalent
code from WebPageProxy::handleWheelEvent() when the UI-side scrolling coordinator does
not handle the event.

We also need to push the &quot;rubberbandable edges&quot; state onto the ScrollingTree, just
like EventDispatcher does. These data reflect whether rubberbanding is allowed on an
edge, which is a combination of what the client wants (e.g. Safari&apos;s Continuous Reading List
can disable top and bottom rubberbanding), and whether there is a history item to swipe to.

Tested by swipe/pushstate-with-manual-scrollrestoration.html

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::handleWheelEvent):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::handleWheelEvent):
(WebKit::WebPageProxy::sendWheelEvent):
(WebKit::WebPageProxy::wheelEventWasNotHandled):
(WebKit::WebPageProxy::rubberBandableEdgesRespectingHistorySwipe const):
(WebKit::WebPageProxy::didReceiveEvent):
* Source/WebKit/UIProcess/WebPageProxy.h:

Canonical link: <a href="https://commits.webkit.org/260429@main">https://commits.webkit.org/260429@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32c7a4d88d5e28b1c6b371a7888a3b61579e6134

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108253 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17343 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41118 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117372 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/18888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8622 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100467 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114022 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/18888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97313 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42027 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28955 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10188 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30300 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10924 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7206 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16337 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49896 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7214 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12510 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->