### PR TITLE
[UI-side compositing] pointer-lock/mouse-event-delivery.html fails

### DIFF
--- a/LayoutTests/pointer-lock/mouse-event-delivery.html
+++ b/LayoutTests/pointer-lock/mouse-event-delivery.html
@@ -3,6 +3,7 @@
 <head>
 <script src="../http/tests/resources/js-test-pre.js"></script>
 <script src="../http/tests/resources/pointer-lock/pointer-lock-test-harness.js"></script>
+<script src="../resources/ui-helper.js"></script>
 </head>
 <body id="body">
 <div>
@@ -57,11 +58,14 @@
             targetdiv1.onwheel = eventExpectedThenNextStep;
             targetdiv2.onwheel = eventNotExpected;
             document.body.onwheel = eventExpected;
-            if (window.eventSender) {
-                window.eventSender.mouseMoveTo(20,20);
-                window.eventSender.leapForward(1000);
-                window.eventSender.mouseScrollBy(0,10);
-            }
+            setTimeout(async () => {
+                await UIHelper.ensurePresentationUpdate();
+                if (window.eventSender) {
+                    window.eventSender.mouseMoveTo(20,20);
+                    window.eventSender.leapForward(1000);
+                    window.eventSender.mouseScrollBy(0,10);
+                }
+            }, 0);
         },
         function () {
             debug("     With a lock in place move the mouse.")


### PR DESCRIPTION
#### fdf255ef8ca4a12536a0f21e3314e1edc7c9fcff
<pre>
[UI-side compositing] pointer-lock/mouse-event-delivery.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=252450">https://bugs.webkit.org/show_bug.cgi?id=252450</a>
rdar://105578477

Reviewed by Cameron McCormack.

The test needs to wait for the UI process to get an update before delivering wheel
events.

* LayoutTests/pointer-lock/mouse-event-delivery.html:

Canonical link: <a href="https://commits.webkit.org/260431@main">https://commits.webkit.org/260431@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f07c194e90a3c4e716529159ca53943e00eb6a50

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108264 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17354 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41128 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117383 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/18896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8633 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100479 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114033 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/18896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97327 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42037 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28970 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10198 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30315 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10935 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/7216 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16347 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49911 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7215 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12521 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->