### PR TITLE
Optimize use of consumeHTMLEntity() in HTMLFastPathParser::scanHTMLCharacterReference()

### DIFF
--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
@@ -738,13 +738,9 @@ private:
             // This handles uncommon named references.
             String inputString { reference.data(), static_cast<unsigned>(reference.size()) };
             SegmentedString inputSegmented { inputString };
-            StringBuilder entity;
             bool notEnoughCharacters = false;
-            if (!consumeHTMLEntity(inputSegmented, entity, notEnoughCharacters) || notEnoughCharacters)
+            if (!consumeHTMLEntity(inputSegmented, out, notEnoughCharacters) || notEnoughCharacters)
                 return didFail(HTMLFastPathResult::FailedParsingCharacterReference);
-
-            for (unsigned i = 0; i < entity.length(); ++i)
-                out.append(entity[i]);
         }
     }
 

--- a/Source/WebCore/html/parser/HTMLEntityParser.h
+++ b/Source/WebCore/html/parser/HTMLEntityParser.h
@@ -31,6 +31,8 @@
 namespace WebCore {
 
 bool consumeHTMLEntity(SegmentedString&, StringBuilder& decodedEntity, bool& notEnoughCharacters, UChar additionalAllowedCharacter = '\0');
+bool consumeHTMLEntity(SegmentedString&, Vector<UChar>& decodedEntity, bool& notEnoughCharacters, UChar additionalAllowedCharacter = '\0');
+
 void appendLegalEntityFor(UChar32, Vector<UChar>&);
 
 // Used by the XML parser.  Not suitable for use in HTML parsing.  Use consumeHTMLEntity instead.

--- a/Source/WebCore/xml/parser/CharacterReferenceParserInlines.h
+++ b/Source/WebCore/xml/parser/CharacterReferenceParserInlines.h
@@ -35,12 +35,16 @@ inline void unconsumeCharacters(SegmentedString& source, StringBuilder& consumed
     source.pushBack(consumedCharacters.toString());
 }
 
-template <typename ParserFunctions>
-bool consumeCharacterReference(SegmentedString& source, StringBuilder& decodedCharacter, bool& notEnoughCharacters, UChar additionalAllowedCharacter)
+template<typename T> void appendCharacterTo(T& output, UChar32 c)
+{
+    output.appendCharacter(c);
+}
+
+template <typename ParserFunctions, typename DecodedIdentityType>
+bool consumeCharacterReference(SegmentedString& source, DecodedIdentityType& decodedCharacter, bool& notEnoughCharacters, UChar additionalAllowedCharacter)
 {
     ASSERT(!additionalAllowedCharacter || additionalAllowedCharacter == '"' || additionalAllowedCharacter == '\'' || additionalAllowedCharacter == '>');
     ASSERT(!notEnoughCharacters);
-    ASSERT(decodedCharacter.isEmpty());
     
     enum {
         Initial,
@@ -109,11 +113,11 @@ bool consumeCharacterReference(SegmentedString& source, StringBuilder& decodedCh
             }
             if (character == ';') {
                 source.advancePastNonNewline();
-                decodedCharacter.appendCharacter(ParserFunctions::legalEntityFor(result.hasOverflowed() ? 0 : result.value()));
+                appendCharacterTo(decodedCharacter, ParserFunctions::legalEntityFor(result.hasOverflowed() ? 0 : result.value()));
                 return true;
             }
             if (ParserFunctions::acceptMalformed()) {
-                decodedCharacter.appendCharacter(ParserFunctions::legalEntityFor(result.hasOverflowed() ? 0 : result.value()));
+                appendCharacterTo(decodedCharacter, ParserFunctions::legalEntityFor(result.hasOverflowed() ? 0 : result.value()));
                 return true;
             }
             unconsumeCharacters(source, consumedCharacters);
@@ -127,11 +131,11 @@ bool consumeCharacterReference(SegmentedString& source, StringBuilder& decodedCh
             }
             if (character == ';') {
                 source.advancePastNonNewline();
-                decodedCharacter.appendCharacter(ParserFunctions::legalEntityFor(result.hasOverflowed() ? 0 : result.value()));
+                appendCharacterTo(decodedCharacter, ParserFunctions::legalEntityFor(result.hasOverflowed() ? 0 : result.value()));
                 return true;
             }
             if (ParserFunctions::acceptMalformed()) {
-                decodedCharacter.appendCharacter(ParserFunctions::legalEntityFor(result.hasOverflowed() ? 0 : result.value()));
+                appendCharacterTo(decodedCharacter, ParserFunctions::legalEntityFor(result.hasOverflowed() ? 0 : result.value()));
                 return true;
             }
             unconsumeCharacters(source, consumedCharacters);


### PR DESCRIPTION
#### a525a1c4c0bbb664237176ee401ed046fb140677
<pre>
Optimize use of consumeHTMLEntity() in HTMLFastPathParser::scanHTMLCharacterReference()
<a href="https://bugs.webkit.org/show_bug.cgi?id=252451">https://bugs.webkit.org/show_bug.cgi?id=252451</a>

Reviewed by Ryosuke Niwa.

Optimize use of consumeHTMLEntity() in HTMLFastPathParser::scanHTMLCharacterReference()
so that it appends directly to its Vector&lt;UChar&gt; instead of going via a StringBuilder.

* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
(WebCore::HTMLFastPathParser::scanHTMLCharacterReference):
* Source/WebCore/html/parser/HTMLEntityParser.cpp:
(WebCore::appendCharacterTo):
(WebCore::HTMLEntityParser::consumeNamedEntity):
(WebCore::consumeHTMLEntity):
(WebCore::appendLegalEntityFor):
* Source/WebCore/html/parser/HTMLEntityParser.h:
* Source/WebCore/xml/parser/CharacterReferenceParserInlines.h:
(WebCore::appendCharacterTo):
(WebCore::consumeCharacterReference):

Canonical link: <a href="https://commits.webkit.org/260426@main">https://commits.webkit.org/260426@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca579dab7562da3302f9fb5583ddeb2562d78139

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108267 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17358 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41132 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117385 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112154 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/18898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8637 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100481 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114036 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/18898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97325 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/42039 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28968 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10200 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30313 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10938 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16349 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49909 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7212 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12525 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->