### PR TITLE
Avoid allocating a new DocumentFragment when tryFastParsingHTMLFragment() fails

### DIFF
--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
@@ -986,19 +986,19 @@ static bool canUseFastPath(Document& document, Element& contextElement, OptionSe
 }
 
 template<class Char>
-static bool tryFastParsingHTMLFragmentImpl(const Span<const Char>& source, Document& document, Ref<DocumentFragment>& fragment, Element& contextElement)
+static bool tryFastParsingHTMLFragmentImpl(const Span<const Char>& source, Document& document, DocumentFragment& fragment, Element& contextElement)
 {
     HTMLFastPathParser parser { source, document, fragment };
     bool success = parser.parse(contextElement);
     // The direction attribute may change as a result of parsing. Check again.
     if (document.isDirAttributeDirty() && document.settings().dirPseudoEnabled())
         success = false;
-    if (!success)
-        fragment = DocumentFragment::create(document);
+    if (!success && fragment.hasChildNodes())
+        fragment.removeChildren();
     return success;
 }
 
-bool tryFastParsingHTMLFragment(const String& source, Document& document, Ref<DocumentFragment>& fragment, Element& contextElement, OptionSet<ParserContentPolicy> policy)
+bool tryFastParsingHTMLFragment(const String& source, Document& document, DocumentFragment& fragment, Element& contextElement, OptionSet<ParserContentPolicy> policy)
 {
     if (!canUseFastPath(document, contextElement, policy))
         return false;

--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.h
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.h
@@ -41,7 +41,7 @@ class Element;
 
 enum class ParserContentPolicy : uint8_t;
 
-bool tryFastParsingHTMLFragment(const String& source, Document&, Ref<DocumentFragment>&, Element& contextElement, OptionSet<ParserContentPolicy>);
+bool tryFastParsingHTMLFragment(const String& source, Document&, DocumentFragment&, Element& contextElement, OptionSet<ParserContentPolicy>);
 
 } // namespace WebCore
 


### PR DESCRIPTION
#### 5824bab256ea74d26c8d4375ac7dbcabfc5c137d
<pre>
Avoid allocating a new DocumentFragment when tryFastParsingHTMLFragment() fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=252453">https://bugs.webkit.org/show_bug.cgi?id=252453</a>

Reviewed by Ryosuke Niwa.

We have an optimization in place in createFragmentForMarkup() to keep reusing
the same DocumentFragment (Document::documentFragmentForInnerOuterHTML())
whenever the innerHTML setter is called. documentFragmentForInnerOuterHTML()
calls removeChildren() on the DocumentFragment in between calls for reuse.

We recently added a new fast HTML parsing path for innerHTML. However, when
fast parsing fails, it may leave the DocumentFragment with children due to
partial parsing. To address this, we were re-constructing the
DocumentFragment before calling the full HTML parser (slow path).

In this patch, we now call removeChildren() on the DocumentFragment if the
fast path fails, instead of re-allocating a new DocumentFragment. This is
consistent with what documentFragmentForInnerOuterHTML() is doing and
maintains our optimization which avoids re-allocating new DocumentFragments
for each innerHTML assignment.

* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
(WebCore::tryFastParsingHTMLFragmentImpl):
(WebCore::tryFastParsingHTMLFragment):
* Source/WebCore/html/parser/HTMLDocumentParserFastPath.h:

Canonical link: <a href="https://commits.webkit.org/260424@main">https://commits.webkit.org/260424@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33ef7a4ffca926aca48fc348f41156d022c409b4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108269 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17360 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41134 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117387 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112156 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/18900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8639 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100483 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114038 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/18900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97326 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/42045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28969 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10202 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30314 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10940 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/7220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16351 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49910 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7211 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12527 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->