### PR TITLE
Some of HTMLFastPathParser's member functions can be static

### DIFF
--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
@@ -142,14 +142,32 @@ static uint32_t tagNameHash(const String& s)
     return (s[0] + 17 * s[s.length() - 1]) & 63;
 }
 
-template<typename CharacterType> static bool isQuoteCharacter(CharacterType c)
+template<typename CharacterType> static inline bool isQuoteCharacter(CharacterType c)
 {
     return c == '"' || c == '\'';
 }
 
-template<typename CharacterType> bool isValidUnquotedAttributeValueChar(CharacterType c)
+template<typename CharacterType> static inline bool isValidUnquotedAttributeValueChar(CharacterType c)
 {
     return isASCIIAlphanumeric(c) || c == '_' || c == '-';
+}
+
+// https://html.spec.whatwg.org/#syntax-attribute-name
+template<typename CharacterType> static inline bool isValidAttributeNameChar(CharacterType c)
+{
+    if (c == '=') // Early return for the most common way to end an attribute.
+        return false;
+    return isASCIIAlphanumeric(c) || c == '-';
+}
+
+template<typename CharacterType> static inline bool isCharAfterTagNameOrAttribute(CharacterType c)
+{
+    return c == ' ' || c == '>' || isHTMLSpace(c) || c == '/';
+}
+
+template<typename CharacterType> static inline bool isCharAfterUnquotedAttribute(CharacterType c)
+{
+    return c == ' ' || c == '>' || isHTMLSpace(c);
 }
 
 #define FOR_EACH_SUPPORTED_TAG(APPLY) \
@@ -481,24 +499,6 @@ private:
         parseChildren<ParentTag>(m_fragment);
         if (m_parsingBuffer.hasCharactersRemaining())
             didFail(HTMLFastPathResult::FailedDidntReachEndOfInput);
-    }
-
-    // https://html.spec.whatwg.org/#syntax-attribute-name
-    bool isValidAttributeNameChar(Char c)
-    {
-        if (c == '=') // Early return for the most common way to end an attribute.
-            return false;
-        return isASCIIAlphanumeric(c) || c == '-';
-    }
-
-    bool isCharAfterTagNameOrAttribute(Char c)
-    {
-        return c == ' ' || c == '>' || isHTMLSpace(c) || c == '/';
-    }
-
-    bool isCharAfterUnquotedAttribute(Char c)
-    {
-        return c == ' ' || c == '>' || isHTMLSpace(c);
     }
 
     // We first try to scan text as an unmodified subsequence of the input.


### PR DESCRIPTION
#### ddd1481f565d39dbd15413c9d39512603676d742
<pre>
Some of HTMLFastPathParser&apos;s member functions can be static
<a href="https://bugs.webkit.org/show_bug.cgi?id=252455">https://bugs.webkit.org/show_bug.cgi?id=252455</a>

Reviewed by Yusuke Suzuki.

Some of HTMLFastPathParser&apos;s member functions can be static as they don&apos;t use
any of the data members.

* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
(WebCore::isQuoteCharacter):
(WebCore::isValidUnquotedAttributeValueChar):
(WebCore::isValidAttributeNameChar):
(WebCore::isCharAfterTagNameOrAttribute):
(WebCore::isCharAfterUnquotedAttribute):
(WebCore::HTMLFastPathParser::isValidAttributeNameChar): Deleted.
(WebCore::HTMLFastPathParser::isCharAfterTagNameOrAttribute): Deleted.
(WebCore::HTMLFastPathParser::isCharAfterUnquotedAttribute): Deleted.

Canonical link: <a href="https://commits.webkit.org/260427@main">https://commits.webkit.org/260427@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/385870bd70f9cc7fab6283ef57ccc0f83955d658

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108272 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17363 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41137 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117390 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112159 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/18902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8642 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100487 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114041 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/18902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97330 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/42051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28973 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10205 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30318 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10943 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/7223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16354 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49914 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7213 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12530 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->