### PR TITLE
[DOM] For range.extractContents(), abort early if there's a doctype in range

### DIFF
--- a/LayoutTests/fast/dom/Range/range-commonroot-notfound-expected.txt
+++ b/LayoutTests/fast/dom/Range/range-commonroot-notfound-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/dom/Range/range-commonroot-notfound.html
+++ b/LayoutTests/fast/dom/Range/range-commonroot-notfound.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/gc.js"></script>
+<script>
+function main() {
+    var x1 = document.getElementById("x1");
+    var x2 = document.getElementById("x2");
+    var x3 = document.getElementById("x3");
+    var x7 = document.getElementById("x7");
+
+    if (window.testRunner) {
+        testRunner.waitUntilDone();
+        window.testRunner.dumpAsText();
+    }
+
+    x7.addEventListener("DOMNodeInserted", function(){ });
+
+    var range1 = document.createRange();
+    range1.setEndAfter(x3);
+    try { var v1 = range1.extractContents(); } catch(e) {}
+    try { range1.setStartAfter(x1); } catch(e) {}
+    try { range1.setEndBefore(x2); } catch(e) {}
+
+    gc();
+
+    try {var v2 = range1.extractContents(); } catch(e) {}
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+</script>
+</head>
+<body onload="main()">
+    <div id="x7">
+        <div id="x1"></div>
+        <div></div>
+    </div>
+    <div>
+        <div id="x2"></div>
+        <div></div>
+    </div>
+    <div>
+        <div id="x3"></div>
+        <div></div>
+    </div>
+    <p>PASS if no crash.</p>
+</body>
+</html>

--- a/Source/WebCore/dom/Range.cpp
+++ b/Source/WebCore/dom/Range.cpp
@@ -30,6 +30,7 @@
 #include "DOMRect.h"
 #include "DOMRectList.h"
 #include "DocumentFragment.h"
+#include "DocumentType.h"
 #include "ElementInlines.h"
 #include "Event.h"
 #include "Frame.h"
@@ -311,6 +312,13 @@ ExceptionOr<RefPtr<DocumentFragment>> Range::processContents(ActionType action)
 
     RefPtr<Node> commonRoot = commonAncestorContainer();
     ASSERT(commonRoot);
+    
+    if (action == Extract) {
+        auto& commonRootDocument = commonRoot->document();
+        RefPtr doctype = commonRootDocument.doctype();
+        if (doctype && contains(makeSimpleRange(*this), { *doctype, 0 }))
+            return Exception { HierarchyRequestError };
+    }
 
     if (&startContainer() == &endContainer()) {
         auto result = processContentsBetweenOffsets(action, fragment, &startContainer(), m_start.offset(), m_end.offset());


### PR DESCRIPTION
#### c20d51c646be933823b7b50b3f9c1a4a36950fa7
<pre>
[DOM] For range.extractContents(), abort early if there&apos;s a doctype in range
<a href="https://bugs.webkit.org/show_bug.cgi?id=252805">https://bugs.webkit.org/show_bug.cgi?id=252805</a>
rdar://103178567

Reviewed by Ryosuke Niwa.

Check if doctype is contained in range before start extracting contents,
if contained, return HierarchyRequestError.

* LayoutTests/fast/dom/Range/range-commonroot-notfound-expected.txt: Added.
* LayoutTests/fast/dom/Range/range-commonroot-notfound.html: Added.
* Source/WebCore/dom/Range.cpp:
(WebCore::Range::processContents):

Canonical link: <a href="https://commits.webkit.org/261342@main">https://commits.webkit.org/261342@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6eca9dc2528e3fb2240a13cf033819d289c28d79

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111292 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20435 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43837 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2722 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120100 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115240 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21800 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11534 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/2400 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117057 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16183 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99369 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103929 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98141 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/31021 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44780 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12934 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32361 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86620 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13452 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9352 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18891 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51945 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15407 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4304 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->