### PR TITLE
Make CSSValueList immutable

### DIFF
--- a/Source/JavaScriptCore/runtime/ConfigFile.cpp
+++ b/Source/JavaScriptCore/runtime/ConfigFile.cpp
@@ -499,10 +499,10 @@ void ConfigFile::canonicalizePaths()
     }
 #endif
 
-    char* lastPathSeperator = strrchr(m_filename, '/');
+    char* lastPathSeparator = strrchr(m_filename, '/');
 
-    if (lastPathSeperator) {
-        unsigned dirnameLength = lastPathSeperator - &m_filename[0];
+    if (lastPathSeparator) {
+        unsigned dirnameLength = lastPathSeparator - &m_filename[0];
         strncpy(m_configDirectory, m_filename, dirnameLength);
         m_configDirectory[dirnameLength] = '\0';
     } else {

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -1402,14 +1402,14 @@ void dumpCharacterClass(PrintStream& out, YarrPattern* pattern, CharacterClass* 
         }
     }
 
-    bool needMatchesRangesSeperator = false;
+    bool needMatchesRangesSeparator = false;
 
     auto dumpMatches = [&] (const char* prefix, Vector<UChar32> matches) {
         size_t matchesSize = matches.size();
         if (matchesSize) {
-            if (needMatchesRangesSeperator)
+            if (needMatchesRangesSeparator)
                 out.print(",");
-            needMatchesRangesSeperator = true;
+            needMatchesRangesSeparator = true;
 
             out.print(prefix, ":(");
             for (size_t i = 0; i < matchesSize; ++i) {
@@ -1424,9 +1424,9 @@ void dumpCharacterClass(PrintStream& out, YarrPattern* pattern, CharacterClass* 
     auto dumpRanges = [&] (const char* prefix, Vector<CharacterRange> ranges) {
         size_t rangeSize = ranges.size();
         if (rangeSize) {
-            if (needMatchesRangesSeperator)
+            if (needMatchesRangesSeparator)
                 out.print(",");
-            needMatchesRangesSeperator = true;
+            needMatchesRangesSeparator = true;
 
             out.print(prefix, " ranges:(");
             for (size_t i = 0; i < rangeSize; ++i) {

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/video_coding/h264_sprop_parameter_sets.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/video_coding/h264_sprop_parameter_sets.cc
@@ -33,7 +33,7 @@ bool H264SpropParameterSets::DecodeSprop(const std::string& sprop) {
   size_t separator_pos = sprop.find(',');
   RTC_LOG(LS_INFO) << "Parsing sprop \"" << sprop << "\"";
   if ((separator_pos <= 0) || (separator_pos >= sprop.length() - 1)) {
-    RTC_LOG(LS_WARNING) << "Invalid seperator position " << separator_pos
+    RTC_LOG(LS_WARNING) << "Invalid separator position " << separator_pos
                         << " *" << sprop << "*";
     return false;
   }

--- a/Source/WebCore/animation/CompositeOperation.cpp
+++ b/Source/WebCore/animation/CompositeOperation.cpp
@@ -37,7 +37,7 @@ std::optional<CompositeOperation> toCompositeOperation(const CSSValue& value)
     if (!is<CSSPrimitiveValue>(value))
         return std::nullopt;
 
-    switch (downcast<CSSPrimitiveValue>(value).valueID()) {
+    switch (value.valueID()) {
     case CSSValueAdd:
         return CompositeOperation::Add;
     case CSSValueAccumulate:

--- a/Source/WebCore/css/CSSBorderImage.cpp
+++ b/Source/WebCore/css/CSSBorderImage.cpp
@@ -26,27 +26,23 @@ namespace WebCore {
 
 Ref<CSSValueList> createBorderImageValue(RefPtr<CSSValue>&& image, RefPtr<CSSValue>&& imageSlice, RefPtr<CSSValue>&& borderSlice, RefPtr<CSSValue>&& outset, RefPtr<CSSValue>&& repeat)
 {
-    auto list = CSSValueList::createSpaceSeparated();
+    CSSValueListBuilder list;
     if (image)
-        list.get().append(*image);
-
+        list.append(*image);
     if (borderSlice || outset) {
-        auto listSlash = CSSValueList::createSlashSeparated();
+        CSSValueListBuilder listSlash;
         if (imageSlice)
-            listSlash.get().append(imageSlice.releaseNonNull());
-
+            listSlash.append(imageSlice.releaseNonNull());
         if (borderSlice)
-            listSlash.get().append(borderSlice.releaseNonNull());
-
+            listSlash.append(borderSlice.releaseNonNull());
         if (outset)
-            listSlash.get().append(outset.releaseNonNull());
-
-        list.get().append(WTFMove(listSlash));
+            listSlash.append(outset.releaseNonNull());
+        list.append(CSSValueList::createSlashSeparated(WTFMove(listSlash)));
     } else if (imageSlice)
-        list.get().append(imageSlice.releaseNonNull());
+        list.append(imageSlice.releaseNonNull());
     if (repeat)
-        list.get().append(repeat.releaseNonNull());
-    return list;
+        list.append(repeat.releaseNonNull());
+    return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSCounterStyleDescriptors.cpp
+++ b/Source/WebCore/css/CSSCounterStyleDescriptors.cpp
@@ -43,10 +43,10 @@ static CSSCounterStyleDescriptors::Ranges translateRangeFromStyleProperties(cons
     auto& list = downcast<CSSValueList>(*ranges);
     CSSCounterStyleDescriptors::Ranges result;
     for (auto& rangeValue : list) {
-        if (!rangeValue->isPair())
+        if (!rangeValue.isPair())
             return { };
-        auto& low = downcast<CSSPrimitiveValue>(rangeValue->first());
-        auto& high = downcast<CSSPrimitiveValue>(rangeValue->second());
+        auto& low = downcast<CSSPrimitiveValue>(rangeValue.first());
+        auto& high = downcast<CSSPrimitiveValue>(rangeValue.second());
         int convertedLow { std::numeric_limits<int>::min() };
         int convertedHigh { std::numeric_limits<int>::max() };
         if (low.isInteger())
@@ -112,7 +112,7 @@ static Vector<CSSCounterStyleDescriptors::Symbol> translateSymbolsFromStylePrope
     Vector<CSSCounterStyleDescriptors::Symbol> result;
     auto& list = downcast<CSSValueList>(*symbolsValues);
     for (auto& symbolValue : list) {
-        auto symbolString = symbolToString(&symbolValue.get());
+        auto symbolString = symbolToString(&symbolValue);
         if (!symbolString.isNull())
             result.append((symbolString));
     }

--- a/Source/WebCore/css/CSSFontFace.cpp
+++ b/Source/WebCore/css/CSSFontFace.cpp
@@ -63,14 +63,14 @@ void CSSFontFace::appendSources(CSSFontFace& fontFace, CSSValueList& srcList, Sc
     bool allowDownloading = context && (context->settingsValues().downloadableBinaryFontAllowedTypes != DownloadableBinaryFontAllowedTypes::None);
     for (auto& src : srcList) {
         // An item in the list either specifies a string (local font name) or a URL (remote font to download).
-        if (auto local = dynamicDowncast<CSSFontFaceSrcLocalValue>(src.get())) {
+        if (auto local = dynamicDowncast<CSSFontFaceSrcLocalValue>(src)) {
             if (!local->svgFontFaceElement())
                 fontFace.adoptSource(makeUnique<CSSFontFaceSource>(fontFace, local->fontFaceName()));
             else if (allowDownloading)
                 fontFace.adoptSource(makeUnique<CSSFontFaceSource>(fontFace, local->fontFaceName(), *local->svgFontFaceElement()));
         } else {
             if (allowDownloading) {
-                if (auto request = downcast<CSSFontFaceSrcResourceValue>(src.get()).fontLoadRequest(*context, isInitiatingElementInUserAgentShadowTree))
+                if (auto request = downcast<CSSFontFaceSrcResourceValue>(const_cast<CSSValue&>(src)).fontLoadRequest(*context, isInitiatingElementInUserAgentShadowTree))
                     fontFace.adoptSource(makeUnique<CSSFontFaceSource>(fontFace, *context->cssFontSelector(), makeUniqueRefFromNonNullUniquePtr(WTFMove(request))));
             }
         }
@@ -283,7 +283,7 @@ void CSSFontFace::setUnicodeRange(CSSValueList& list)
     ranges.reserveInitialCapacity(list.length());
 
     for (auto& rangeValue : list) {
-        auto& range = downcast<CSSUnicodeRangeValue>(rangeValue.get());
+        auto& range = downcast<CSSUnicodeRangeValue>(rangeValue);
         ranges.uncheckedAppend({ range.from(), range.to() });
     }
 
@@ -309,7 +309,7 @@ void CSSFontFace::setFeatureSettings(CSSValue& featureSettings)
     if (is<CSSValueList>(featureSettings)) {
         auto& list = downcast<CSSValueList>(featureSettings);
         for (auto& rangeValue : list) {
-            auto& feature = downcast<CSSFontFeatureValue>(rangeValue.get());
+            auto& feature = downcast<CSSFontFeatureValue>(rangeValue);
             settings.insert({ feature.tag(), feature.value() });
         }
     }

--- a/Source/WebCore/css/CSSFontFaceSet.cpp
+++ b/Source/WebCore/css/CSSFontFaceSet.cpp
@@ -127,9 +127,8 @@ void CSSFontFaceSet::ensureLocalFontFacesForFamilyRegistered(const AtomString& f
         auto face = CSSFontFace::create(*m_owningFontSelector, nullptr, nullptr, true);
         
         // FIXME: Don't use a list here. https://bugs.webkit.org/show_bug.cgi?id=196381
-        Ref<CSSValueList> familyList = CSSValueList::createCommaSeparated();
-        familyList->append(m_owningFontSelector->scriptExecutionContext()->cssValuePool().createFontFamilyValue(familyName));
-        face->setFamilies(familyList.get());
+        auto& pool = m_owningFontSelector->scriptExecutionContext()->cssValuePool();
+        face->setFamilies(CSSValueList::createCommaSeparated(pool.createFontFamilyValue(familyName)).get());
         face->setFontSelectionCapabilities(item);
         face->adoptSource(makeUnique<CSSFontFaceSource>(face.get(), familyName));
         ASSERT(!face->computeFailureState());
@@ -175,7 +174,7 @@ void CSSFontFaceSet::addToFacesLookupTable(CSSFontFace& face)
     }
 
     for (auto& item : *families) {
-        auto familyName = AtomString { CSSFontFaceSet::familyNameFromPrimitive(downcast<CSSPrimitiveValue>(item.get())) };
+        auto familyName = AtomString { CSSFontFaceSet::familyNameFromPrimitive(downcast<CSSPrimitiveValue>(item)) };
         if (familyName.isEmpty())
             continue;
 
@@ -223,7 +222,7 @@ void CSSFontFaceSet::add(CSSFontFace& face)
 void CSSFontFaceSet::removeFromFacesLookupTable(const CSSFontFace& face, const CSSValueList& familiesToSearchFor)
 {
     for (auto& item : familiesToSearchFor) {
-        String familyName = CSSFontFaceSet::familyNameFromPrimitive(downcast<CSSPrimitiveValue>(item.get()));
+        String familyName = CSSFontFaceSet::familyNameFromPrimitive(downcast<CSSPrimitiveValue>(item));
         if (familyName.isEmpty())
             continue;
 

--- a/Source/WebCore/css/CSSFunctionValue.cpp
+++ b/Source/WebCore/css/CSSFunctionValue.cpp
@@ -30,15 +30,70 @@
 
 namespace WebCore {
     
+CSSFunctionValue::CSSFunctionValue(CSSValueID name, CSSValueListBuilder arguments)
+    : CSSValueContainingVector(FunctionClass, CommaSeparator, WTFMove(arguments))
+    , m_name(name)
+{
+}
+
 CSSFunctionValue::CSSFunctionValue(CSSValueID name)
     : CSSValueContainingVector(FunctionClass, CommaSeparator)
     , m_name(name)
 {
 }
 
+CSSFunctionValue::CSSFunctionValue(CSSValueID name, Ref<CSSValue> argument)
+    : CSSValueContainingVector(FunctionClass, CommaSeparator, WTFMove(argument))
+    , m_name(name)
+{
+}
+
+CSSFunctionValue::CSSFunctionValue(CSSValueID name, Ref<CSSValue> argument1, Ref<CSSValue> argument2)
+    : CSSValueContainingVector(FunctionClass, CommaSeparator, WTFMove(argument1), WTFMove(argument2))
+    , m_name(name)
+{
+}
+
+CSSFunctionValue::CSSFunctionValue(CSSValueID name, Ref<CSSValue> argument1, Ref<CSSValue> argument2, Ref<CSSValue> argument3)
+    : CSSValueContainingVector(FunctionClass, CommaSeparator, WTFMove(argument1), WTFMove(argument2), WTFMove(argument3))
+    , m_name(name)
+{
+}
+
+CSSFunctionValue::CSSFunctionValue(CSSValueID name, Ref<CSSValue> argument1, Ref<CSSValue> argument2, Ref<CSSValue> argument3, Ref<CSSValue> argument4)
+    : CSSValueContainingVector(FunctionClass, CommaSeparator, WTFMove(argument1), WTFMove(argument2), WTFMove(argument3), WTFMove(argument4))
+    , m_name(name)
+{
+}
+
+Ref<CSSFunctionValue> CSSFunctionValue::create(CSSValueID name, CSSValueListBuilder arguments)
+{
+    return adoptRef(*new CSSFunctionValue(name, WTFMove(arguments)));
+}
+
 Ref<CSSFunctionValue> CSSFunctionValue::create(CSSValueID name)
 {
     return adoptRef(*new CSSFunctionValue(name));
+}
+
+Ref<CSSFunctionValue> CSSFunctionValue::create(CSSValueID name, Ref<CSSValue> argument)
+{
+    return adoptRef(*new CSSFunctionValue(name, WTFMove(argument)));
+}
+
+Ref<CSSFunctionValue> CSSFunctionValue::create(CSSValueID name, Ref<CSSValue> argument1, Ref<CSSValue> argument2)
+{
+    return adoptRef(*new CSSFunctionValue(name, WTFMove(argument1), WTFMove(argument2)));
+}
+
+Ref<CSSFunctionValue> CSSFunctionValue::create(CSSValueID name, Ref<CSSValue> argument1, Ref<CSSValue> argument2, Ref<CSSValue> argument3)
+{
+    return adoptRef(*new CSSFunctionValue(name, WTFMove(argument1), WTFMove(argument2), WTFMove(argument3)));
+}
+
+Ref<CSSFunctionValue> CSSFunctionValue::create(CSSValueID name, Ref<CSSValue> argument1, Ref<CSSValue> argument2, Ref<CSSValue> argument3, Ref<CSSValue> argument4)
+{
+    return adoptRef(*new CSSFunctionValue(name, WTFMove(argument1), WTFMove(argument2), WTFMove(argument3), WTFMove(argument4)));
 }
 
 String CSSFunctionValue::customCSSText() const

--- a/Source/WebCore/css/CSSFunctionValue.h
+++ b/Source/WebCore/css/CSSFunctionValue.h
@@ -33,15 +33,25 @@ enum CSSValueID : uint16_t;
 
 class CSSFunctionValue final : public CSSValueContainingVector {
 public:
+    static Ref<CSSFunctionValue> create(CSSValueID name, CSSValueListBuilder arguments);
     static Ref<CSSFunctionValue> create(CSSValueID name);
-    
+    static Ref<CSSFunctionValue> create(CSSValueID name, Ref<CSSValue> argument);
+    static Ref<CSSFunctionValue> create(CSSValueID name, Ref<CSSValue> firstArgument, Ref<CSSValue> secondArgument);
+    static Ref<CSSFunctionValue> create(CSSValueID name, Ref<CSSValue> firstArgument, Ref<CSSValue> secondArgument, Ref<CSSValue> thirdArgument);
+    static Ref<CSSFunctionValue> create(CSSValueID name, Ref<CSSValue> firstArgument, Ref<CSSValue> secondArgument, Ref<CSSValue> thirdArgument, Ref<CSSValue> fourthArgument);
+
     CSSValueID name() const { return m_name; }
 
     String customCSSText() const;
     bool equals(const CSSFunctionValue& other) const { return m_name == other.m_name && itemsEqual(other); }
 
 private:
+    CSSFunctionValue(CSSValueID name, CSSValueListBuilder);
     explicit CSSFunctionValue(CSSValueID name);
+    CSSFunctionValue(CSSValueID name, Ref<CSSValue>);
+    CSSFunctionValue(CSSValueID name, Ref<CSSValue>, Ref<CSSValue>);
+    CSSFunctionValue(CSSValueID name, Ref<CSSValue>, Ref<CSSValue>, Ref<CSSValue>);
+    CSSFunctionValue(CSSValueID name, Ref<CSSValue>, Ref<CSSValue>, Ref<CSSValue>, Ref<CSSValue>);
 
     CSSValueID m_name { };
 };

--- a/Source/WebCore/css/CSSGridAutoRepeatValue.cpp
+++ b/Source/WebCore/css/CSSGridAutoRepeatValue.cpp
@@ -35,16 +35,16 @@
 
 namespace WebCore {
 
-CSSGridAutoRepeatValue::CSSGridAutoRepeatValue(bool isAutoFit)
-    : CSSValueContainingVector(GridAutoRepeatClass, SpaceSeparator)
+CSSGridAutoRepeatValue::CSSGridAutoRepeatValue(bool isAutoFit, CSSValueListBuilder builder)
+    : CSSValueContainingVector(GridAutoRepeatClass, SpaceSeparator, WTFMove(builder))
     , m_isAutoFit(isAutoFit)
 {
 }
 
-Ref<CSSGridAutoRepeatValue> CSSGridAutoRepeatValue::create(CSSValueID id)
+Ref<CSSGridAutoRepeatValue> CSSGridAutoRepeatValue::create(CSSValueID id, CSSValueListBuilder builder)
 {
     ASSERT(id == CSSValueAutoFill || id == CSSValueAutoFit);
-    return adoptRef(*new CSSGridAutoRepeatValue(id == CSSValueAutoFit));
+    return adoptRef(*new CSSGridAutoRepeatValue(id == CSSValueAutoFit, WTFMove(builder)));
 }
 
 CSSValueID CSSGridAutoRepeatValue::autoRepeatID() const

--- a/Source/WebCore/css/CSSGridAutoRepeatValue.h
+++ b/Source/WebCore/css/CSSGridAutoRepeatValue.h
@@ -47,7 +47,7 @@ namespace WebCore {
 // allows us to keep the parsing algorithm almost intact.
 class CSSGridAutoRepeatValue final : public CSSValueContainingVector {
 public:
-    static Ref<CSSGridAutoRepeatValue> create(CSSValueID);
+    static Ref<CSSGridAutoRepeatValue> create(CSSValueID, CSSValueListBuilder);
 
     CSSValueID autoRepeatID() const;
 
@@ -55,7 +55,7 @@ public:
     bool equals(const CSSGridAutoRepeatValue&) const;
 
 private:
-    explicit CSSGridAutoRepeatValue(bool isAutoFit);
+    explicit CSSGridAutoRepeatValue(bool isAutoFit, CSSValueListBuilder);
 
     bool m_isAutoFit { false };
 };

--- a/Source/WebCore/css/CSSGridIntegerRepeatValue.cpp
+++ b/Source/WebCore/css/CSSGridIntegerRepeatValue.cpp
@@ -35,16 +35,16 @@
 
 namespace WebCore {
 
-CSSGridIntegerRepeatValue::CSSGridIntegerRepeatValue(size_t repetitions)
-    : CSSValueContainingVector(GridIntegerRepeatClass, SpaceSeparator)
+CSSGridIntegerRepeatValue::CSSGridIntegerRepeatValue(size_t repetitions, CSSValueListBuilder builder)
+    : CSSValueContainingVector(GridIntegerRepeatClass, SpaceSeparator, WTFMove(builder))
     , m_repetitions(repetitions)
 {
     ASSERT(repetitions);
 }
 
-Ref<CSSGridIntegerRepeatValue> CSSGridIntegerRepeatValue::create(size_t repetitions)
+Ref<CSSGridIntegerRepeatValue> CSSGridIntegerRepeatValue::create(size_t repetitions, CSSValueListBuilder builder)
 {
-    return adoptRef(*new CSSGridIntegerRepeatValue(repetitions));
+    return adoptRef(*new CSSGridIntegerRepeatValue(repetitions, WTFMove(builder)));
 }
 
 String CSSGridIntegerRepeatValue::customCSSText() const

--- a/Source/WebCore/css/CSSGridIntegerRepeatValue.h
+++ b/Source/WebCore/css/CSSGridIntegerRepeatValue.h
@@ -30,7 +30,6 @@
 
 #pragma once
 
-#include "CSSValueKeywords.h"
 #include "CSSValueList.h"
 
 namespace WebCore {
@@ -45,17 +44,17 @@ namespace WebCore {
 //                          [ <line-names>? <fixed-size> ]+ <line-names>? )
 class CSSGridIntegerRepeatValue final : public CSSValueContainingVector {
 public:
-    static Ref<CSSGridIntegerRepeatValue> create(size_t repetitions);
+    static Ref<CSSGridIntegerRepeatValue> create(size_t repetitions, CSSValueListBuilder);
+
+    size_t repetitions() const { return m_repetitions; }
 
     String customCSSText() const;
     bool equals(const CSSGridIntegerRepeatValue&) const;
 
-    size_t repetitions() const { return m_repetitions; }
-
 private:
-    explicit CSSGridIntegerRepeatValue(size_t repetitions);
+    CSSGridIntegerRepeatValue(size_t repetitions, CSSValueListBuilder);
 
-    const size_t m_repetitions;
+    size_t m_repetitions;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSGridLineNamesValue.cpp
+++ b/Source/WebCore/css/CSSGridLineNamesValue.cpp
@@ -31,6 +31,7 @@
 #include "config.h"
 #include "CSSGridLineNamesValue.h"
 
+#include "CSSMarkup.h"
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
@@ -39,19 +40,25 @@ String CSSGridLineNamesValue::customCSSText() const
 {
     StringBuilder result;
     result.append('[');
-    serializeItems(result);
+    bool first = true;
+    for (auto& name : m_names) {
+        if (!std::exchange(first, false))
+            result.append(' ');
+        serializeIdentifier(name, result);
+    }
     result.append(']');
     return result.toString();
 }
 
-CSSGridLineNamesValue::CSSGridLineNamesValue()
-    : CSSValueContainingVector(GridLineNamesClass, SpaceSeparator)
+CSSGridLineNamesValue::CSSGridLineNamesValue(Span<const String> names)
+    : CSSValue(GridLineNamesClass)
+    , m_names(names.begin(), names.end())
 {
 }
 
-Ref<CSSGridLineNamesValue> CSSGridLineNamesValue::create()
+Ref<CSSGridLineNamesValue> CSSGridLineNamesValue::create(Span<const String> names)
 {
-    return adoptRef(*new CSSGridLineNamesValue);
+    return adoptRef(*new CSSGridLineNamesValue(names));
 }
 
 }

--- a/Source/WebCore/css/CSSGridLineNamesValue.h
+++ b/Source/WebCore/css/CSSGridLineNamesValue.h
@@ -30,19 +30,25 @@
 
 #pragma once
 
-#include "CSSValueList.h"
+#include "CSSValue.h"
+#include <wtf/FixedVector.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
-class CSSGridLineNamesValue final : public CSSValueContainingVector {
+class CSSGridLineNamesValue final : public CSSValue {
 public:
-    static Ref<CSSGridLineNamesValue> create();
+    static Ref<CSSGridLineNamesValue> create(Span<const String>);
+
+    Span<const String> names() const { return m_names; }
 
     String customCSSText() const;
-    bool equals(const CSSGridLineNamesValue& other) const { return itemsEqual(other); }
+    bool equals(const CSSGridLineNamesValue& other) const { return m_names == other.m_names; }
 
 private:
-    CSSGridLineNamesValue();
+    explicit CSSGridLineNamesValue(Span<const String>);
+
+    FixedVector<String> m_names;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSImageSetValue.cpp
+++ b/Source/WebCore/css/CSSImageSetValue.cpp
@@ -34,13 +34,13 @@
 
 namespace WebCore {
 
-Ref<CSSImageSetValue> CSSImageSetValue::create()
+Ref<CSSImageSetValue> CSSImageSetValue::create(CSSValueListBuilder builder)
 {
-    return adoptRef(*new CSSImageSetValue);
+    return adoptRef(*new CSSImageSetValue(WTFMove(builder)));
 }
 
-CSSImageSetValue::CSSImageSetValue()
-    : CSSValueContainingVector(ImageSetClass, CommaSeparator)
+CSSImageSetValue::CSSImageSetValue(CSSValueListBuilder builder)
+    : CSSValueContainingVector(ImageSetClass, CommaSeparator, WTFMove(builder))
 {
 }
 

--- a/Source/WebCore/css/CSSImageSetValue.h
+++ b/Source/WebCore/css/CSSImageSetValue.h
@@ -37,7 +37,7 @@ class BuilderState;
 
 class CSSImageSetValue final : public CSSValueContainingVector {
 public:
-    static Ref<CSSImageSetValue> create();
+    static Ref<CSSImageSetValue> create(CSSValueListBuilder);
 
     String customCSSText() const;
     bool equals(const CSSImageSetValue& other) const { return itemsEqual(other); }
@@ -45,7 +45,7 @@ public:
     RefPtr<StyleImage> createStyleImage(Style::BuilderState&) const;
 
 private:
-    CSSImageSetValue();
+    explicit CSSImageSetValue(CSSValueListBuilder);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -54,7 +54,7 @@ namespace WebCore {
 
 template<typename TargetType> TargetType fromCSSValue(const CSSValue& value)
 {
-    return fromCSSValueID<TargetType>(downcast<CSSPrimitiveValue>(value).valueID());
+    return fromCSSValueID<TargetType>(value.valueID());
 }
 
 class TypeDeducingCSSValueMapper {

--- a/Source/WebCore/css/CSSProperty.cpp
+++ b/Source/WebCore/css/CSSProperty.cpp
@@ -44,27 +44,4 @@ CSSPropertyID StylePropertyMetadata::shorthandID() const
     return shorthands[m_indexInShorthandsVector].id();
 }
 
-void CSSProperty::wrapValueInCommaSeparatedList()
-{
-    auto list = CSSValueList::createCommaSeparated();
-    list.get().append(m_value.releaseNonNull());
-    m_value = WTFMove(list);
-}
-
-Ref<CSSValueList> CSSProperty::createListForProperty(CSSPropertyID propertyID)
-{
-    switch (listValuedPropertySeparator(propertyID)) {
-    case ' ':
-        return CSSValueList::createSpaceSeparated();
-    case ',':
-        return CSSValueList::createCommaSeparated();
-    case '/':
-        return CSSValueList::createSlashSeparated();
-    default:
-        break;
-    }
-    ASSERT_NOT_REACHED();
-    return CSSValueList::createCommaSeparated();
-}
-
 } // namespace WebCore

--- a/Source/WebCore/css/CSSProperty.h
+++ b/Source/WebCore/css/CSSProperty.h
@@ -78,8 +78,6 @@ public:
 
     CSSValue* value() const { return m_value.get(); }
 
-    void wrapValueInCommaSeparatedList();
-
     static CSSPropertyID resolveDirectionAwareProperty(CSSPropertyID, TextDirection, WritingMode);
     static CSSPropertyID unresolvePhysicalProperty(CSSPropertyID, TextDirection, WritingMode);
     static bool isInheritedProperty(CSSPropertyID);
@@ -91,7 +89,6 @@ public:
     static bool isColorProperty(CSSPropertyID);
     static UChar listValuedPropertySeparator(CSSPropertyID);
     static bool isListValuedProperty(CSSPropertyID propertyID) { return !!listValuedPropertySeparator(propertyID); }
-    static Ref<CSSValueList> createListForProperty(CSSPropertyID);
     static bool allowsNumberOrIntegerInput(CSSPropertyID);
 
     const StylePropertyMetadata& metadata() const { return m_metadata; }

--- a/Source/WebCore/css/CSSSubgridValue.cpp
+++ b/Source/WebCore/css/CSSSubgridValue.cpp
@@ -45,14 +45,14 @@ String CSSSubgridValue::customCSSText() const
     return result.toString();
 }
 
-CSSSubgridValue::CSSSubgridValue()
-    : CSSValueContainingVector(SubgridClass, SpaceSeparator)
+CSSSubgridValue::CSSSubgridValue(CSSValueListBuilder builder)
+    : CSSValueContainingVector(SubgridClass, SpaceSeparator, WTFMove(builder))
 {
 }
 
-Ref<CSSSubgridValue> CSSSubgridValue::create()
+Ref<CSSSubgridValue> CSSSubgridValue::create(CSSValueListBuilder builder)
 {
-    return adoptRef(*new CSSSubgridValue);
+    return adoptRef(*new CSSSubgridValue(WTFMove(builder)));
 }
 
 }

--- a/Source/WebCore/css/CSSSubgridValue.h
+++ b/Source/WebCore/css/CSSSubgridValue.h
@@ -36,13 +36,13 @@ namespace WebCore {
 
 class CSSSubgridValue final : public CSSValueContainingVector {
 public:
-    static Ref<CSSSubgridValue> create();
+    static Ref<CSSSubgridValue> create(CSSValueListBuilder);
 
     String customCSSText() const;
     bool equals(const CSSSubgridValue& other) const { return itemsEqual(other); }
 
 private:
-    CSSSubgridValue();
+    explicit CSSSubgridValue(CSSValueListBuilder);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSToStyleMap.cpp
+++ b/Source/WebCore/css/CSSToStyleMap.cpp
@@ -85,7 +85,7 @@ void CSSToStyleMap::mapFillAttachment(CSSPropertyID propertyID, FillLayer& layer
     if (!is<CSSPrimitiveValue>(value))
         return;
 
-    switch (downcast<CSSPrimitiveValue>(value).valueID()) {
+    switch (value.valueID()) {
     case CSSValueFixed:
         layer.setAttachment(FillAttachment::FixedBackground);
         break;
@@ -152,7 +152,7 @@ void CSSToStyleMap::mapFillOrigin(CSSPropertyID propertyID, FillLayer& layer, co
     layer.setOrigin(fromCSSValue<FillBox>(value));
 }
 
-void CSSToStyleMap::mapFillImage(CSSPropertyID propertyID, FillLayer& layer, CSSValue& value)
+void CSSToStyleMap::mapFillImage(CSSPropertyID propertyID, FillLayer& layer, const CSSValue& value)
 {
     if (treatAsInitialValue(value, propertyID)) {
         layer.setImage(FillLayer::initialFillImage(layer.type()));
@@ -261,7 +261,7 @@ void CSSToStyleMap::mapFillMaskMode(CSSPropertyID propertyID, FillLayer& layer, 
     if (!is<CSSPrimitiveValue>(value))
         return;
 
-    switch (downcast<CSSPrimitiveValue>(value).valueID()) {
+    switch (value.valueID()) {
     case CSSValueAlpha:
         maskMode = MaskMode::Alpha;
         break;
@@ -305,7 +305,7 @@ void CSSToStyleMap::mapAnimationDirection(Animation& layer, const CSSValue& valu
     if (!is<CSSPrimitiveValue>(value))
         return;
 
-    switch (downcast<CSSPrimitiveValue>(value).valueID()) {
+    switch (value.valueID()) {
     case CSSValueNormal:
         layer.setDirection(Animation::AnimationDirectionNormal);
         break;
@@ -347,7 +347,7 @@ void CSSToStyleMap::mapAnimationFillMode(Animation& layer, const CSSValue& value
     if (!is<CSSPrimitiveValue>(value))
         return;
 
-    switch (downcast<CSSPrimitiveValue>(value).valueID()) {
+    switch (value.valueID()) {
     case CSSValueNone:
         layer.setFillMode(AnimationFillMode::None);
         break;
@@ -409,7 +409,7 @@ void CSSToStyleMap::mapAnimationPlayState(Animation& layer, const CSSValue& valu
     if (!is<CSSPrimitiveValue>(value))
         return;
 
-    AnimationPlayState playState = (downcast<CSSPrimitiveValue>(value).valueID() == CSSValuePaused) ? AnimationPlayState::Paused : AnimationPlayState::Playing;
+    AnimationPlayState playState = (value.valueID() == CSSValuePaused) ? AnimationPlayState::Paused : AnimationPlayState::Playing;
     layer.setPlayState(playState);
 }
 
@@ -468,11 +468,11 @@ void CSSToStyleMap::mapNinePieceImage(const CSSValue* value, NinePieceImage& ima
     auto& borderImage = downcast<CSSValueList>(*value);
 
     for (auto& current : borderImage) {
-        if (current->isImage())
+        if (current.isImage())
             image.setImage(styleImage(current));
-        else if (auto* imageSlice = dynamicDowncast<CSSBorderImageSliceValue>(current.get()))
+        else if (auto* imageSlice = dynamicDowncast<CSSBorderImageSliceValue>(current))
             mapNinePieceImageSlice(*imageSlice, image);
-        else if (auto* slashList = dynamicDowncast<CSSValueList>(current.get())) {
+        else if (auto* slashList = dynamicDowncast<CSSValueList>(current)) {
             // Map in the image slices.
             if (auto* imageSlice = dynamicDowncast<CSSBorderImageSliceValue>(slashList->item(0)))
                 mapNinePieceImageSlice(*imageSlice, image);
@@ -484,7 +484,7 @@ void CSSToStyleMap::mapNinePieceImage(const CSSValue* value, NinePieceImage& ima
             // Map in the outset.
             if (slashList->item(2))
                 image.setOutset(mapNinePieceImageQuad(*slashList->item(2)));
-        } else if (current->isPair()) {
+        } else if (current.isPair()) {
             // Set the appropriate rules for stretch/round/repeat of the slices.
             mapNinePieceImageRepeat(current, image);
         }

--- a/Source/WebCore/css/CSSToStyleMap.h
+++ b/Source/WebCore/css/CSSToStyleMap.h
@@ -53,7 +53,7 @@ public:
     static void mapFillComposite(CSSPropertyID, FillLayer&, const CSSValue&);
     static void mapFillBlendMode(CSSPropertyID, FillLayer&, const CSSValue&);
     static void mapFillOrigin(CSSPropertyID, FillLayer&, const CSSValue&);
-    void mapFillImage(CSSPropertyID, FillLayer&, CSSValue&);
+    void mapFillImage(CSSPropertyID, FillLayer&, const CSSValue&);
     static void mapFillRepeat(CSSPropertyID, FillLayer&, const CSSValue&);
     void mapFillSize(CSSPropertyID, FillLayer&, const CSSValue&);
     void mapFillXPosition(CSSPropertyID, FillLayer&, const CSSValue&);

--- a/Source/WebCore/css/CSSTransformListValue.cpp
+++ b/Source/WebCore/css/CSSTransformListValue.cpp
@@ -33,14 +33,24 @@
 
 namespace WebCore {
 
-CSSTransformListValue::CSSTransformListValue()
-    : CSSValueContainingVector(TransformListClass, SpaceSeparator)
+CSSTransformListValue::CSSTransformListValue(CSSValueListBuilder builder)
+    : CSSValueContainingVector(TransformListClass, SpaceSeparator, WTFMove(builder))
 {
 }
 
-Ref<CSSTransformListValue> CSSTransformListValue::create()
+CSSTransformListValue::CSSTransformListValue(Ref<CSSValue> value)
+    : CSSValueContainingVector(TransformListClass, SpaceSeparator, WTFMove(value))
 {
-    return adoptRef(*new CSSTransformListValue);
+}
+
+Ref<CSSTransformListValue> CSSTransformListValue::create(CSSValueListBuilder builder)
+{
+    return adoptRef(*new CSSTransformListValue(WTFMove(builder)));
+}
+
+Ref<CSSTransformListValue> CSSTransformListValue::create(Ref<CSSValue> value)
+{
+    return adoptRef(*new CSSTransformListValue(WTFMove(value)));
 }
 
 }

--- a/Source/WebCore/css/CSSTransformListValue.h
+++ b/Source/WebCore/css/CSSTransformListValue.h
@@ -36,13 +36,15 @@ namespace WebCore {
 
 class CSSTransformListValue final : public CSSValueContainingVector {
 public:
-    static Ref<CSSTransformListValue> create();
+    static Ref<CSSTransformListValue> create(CSSValueListBuilder);
+    static Ref<CSSTransformListValue> create(Ref<CSSValue>);
 
     String customCSSText() const { return serializeItems(); }
     bool equals(const CSSTransformListValue& other) const { return itemsEqual(other); }
 
 private:
-    CSSTransformListValue();
+    explicit CSSTransformListValue(CSSValueListBuilder);
+    explicit CSSTransformListValue(Ref<CSSValue>);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSValue.cpp
+++ b/Source/WebCore/css/CSSValue.cpp
@@ -253,7 +253,7 @@ void CSSValue::collectComputedStyleDependencies(ComputedStyleDependencies& depen
     // FIXME: Consider a non-recursive algorithm for walking this tree of dependencies.
     if (auto* asList = dynamicDowncast<CSSValueContainingVector>(*this)) {
         for (auto& listValue : *asList)
-            listValue->collectComputedStyleDependencies(dependencies);
+            listValue.collectComputedStyleDependencies(dependencies);
         return;
     }
     if (auto* asPrimitiveValue = dynamicDowncast<CSSPrimitiveValue>(*this))

--- a/Source/WebCore/css/CSSValueList.h
+++ b/Source/WebCore/css/CSSValueList.h
@@ -21,9 +21,7 @@
 #pragma once
 
 #include "CSSValue.h"
-#include "CSSValueKeywords.h"
-#include <wtf/Function.h>
-#include <wtf/Vector.h>
+#include <unicode/umachine.h>
 
 namespace WebCore {
 
@@ -31,25 +29,28 @@ using CSSValueListBuilder = Vector<Ref<CSSValue>, 4>;
 
 class CSSValueContainingVector : public CSSValue {
 public:
-    // Remove these functions; use size() and operator[] instead.
-    size_t length() const { return m_values.size(); }
-    CSSValue* item(size_t index) { return index < m_values.size() ? m_values[index].ptr() : nullptr; }
-    const CSSValue* item(size_t index) const { return index < m_values.size() ? m_values[index].ptr() : nullptr; }
-    CSSValue* itemWithoutBoundsCheck(size_t index) { return m_values[index].ptr(); }
-    const CSSValue* itemWithoutBoundsCheck(size_t index) const { ASSERT(index < m_values.size()); return m_values[index].ptr(); }
+    unsigned size() const { return m_size; }
+    const CSSValue& operator[](unsigned index) const;
 
-    const CSSValue& operator[](size_t index) const { return m_values[index]; }
-    using const_iterator = CSSValueListBuilder::const_iterator;
-    using iterator = const_iterator;
-    iterator begin() const { return m_values.begin(); }
-    iterator end() const { return m_values.end(); }
-    size_t size() const { return m_values.size(); }
+    struct iterator {
+        using iterator_category = std::forward_iterator_tag;
+        using value_type = const CSSValue&;
+        using difference_type = ptrdiff_t;
+        using pointer = const CSSValue*;
+        using reference = const CSSValue&;
 
-    // FIXME: Remove these functions and instead always construct with a CSSValueListBuilder.
-    void append(Ref<CSSValue>&&);
-    void prepend(Ref<CSSValue>&&);
-    bool removeAll(CSSValue&);
-    bool removeAll(CSSValueID);
+        const CSSValue& operator*() const { return vector[index]; }
+        iterator& operator++() { ++index; return *this; }
+        constexpr bool operator==(const iterator& other) const { return index == other.index; }
+        constexpr bool operator!=(const iterator& other) const { return index != other.index; }
+
+        const CSSValueContainingVector& vector;
+        unsigned index { 0 };
+    };
+    using const_iterator = iterator;
+
+    iterator begin() const { return { *this, 0 }; }
+    iterator end() const { return { *this, size() }; }
 
     bool hasValue(CSSValue&) const;
     bool hasValue(CSSValueID) const;
@@ -65,26 +66,45 @@ public:
 
     bool customTraverseSubresources(const Function<bool(const CachedResource&)>&) const;
 
+    CSSValueListBuilder copyValues() const;
+
+    // Consider removing these functions and having callers use size() and operator[] instead.
+    unsigned length() const { return size(); }
+    const CSSValue* item(unsigned index) const { return index < size() ? &(*this)[index] : nullptr; }
+    const CSSValue* itemWithoutBoundsCheck(unsigned index) const { return &(*this)[index]; }
+
 protected:
     CSSValueContainingVector(ClassType, ValueSeparator);
     CSSValueContainingVector(ClassType, ValueSeparator, CSSValueListBuilder);
-
-    const CSSValueListBuilder& values() const { return m_values; }
+    CSSValueContainingVector(ClassType, ValueSeparator, Ref<CSSValue>);
+    CSSValueContainingVector(ClassType, ValueSeparator, Ref<CSSValue>, Ref<CSSValue>);
+    CSSValueContainingVector(ClassType, ValueSeparator, Ref<CSSValue>, Ref<CSSValue>, Ref<CSSValue>);
+    CSSValueContainingVector(ClassType, ValueSeparator, Ref<CSSValue>, Ref<CSSValue>, Ref<CSSValue>, Ref<CSSValue>);
+    ~CSSValueContainingVector();
 
 private:
-    CSSValueListBuilder m_values;
+    unsigned m_size { 0 };
+    std::array<const CSSValue*, 4> m_inlineStorage;
+    const CSSValue** m_additionalStorage;
 };
 
 class CSSValueList : public CSSValueContainingVector {
 public:
-    static Ref<CSSValueList> createCommaSeparated();
-    static Ref<CSSValueList> createSpaceSeparated();
-    static Ref<CSSValueList> createSlashSeparated();
-    static Ref<CSSValueList> createCommaSeparated(CSSValueListBuilder);
-    static Ref<CSSValueList> createSpaceSeparated(CSSValueListBuilder);
-    static Ref<CSSValueList> createSlashSeparated(CSSValueListBuilder);
+    static Ref<CSSValueList> create(UChar separator, CSSValueListBuilder);
 
-    Ref<CSSValueList> copy();
+    static Ref<CSSValueList> createCommaSeparated(CSSValueListBuilder);
+    static Ref<CSSValueList> createCommaSeparated(Ref<CSSValue>); // FIXME: Upgrade callers to not use a list at all.
+
+    static Ref<CSSValueList> createSpaceSeparated(CSSValueListBuilder);
+    static Ref<CSSValueList> createSpaceSeparated(); // FIXME: Get rid of the caller that needs to create an empty list.
+    static Ref<CSSValueList> createSpaceSeparated(Ref<CSSValue>); // FIXME: Upgrade callers to not use a list at all.
+    static Ref<CSSValueList> createSpaceSeparated(Ref<CSSValue>, Ref<CSSValue>);
+    static Ref<CSSValueList> createSpaceSeparated(Ref<CSSValue>, Ref<CSSValue>, Ref<CSSValue>);
+    static Ref<CSSValueList> createSpaceSeparated(Ref<CSSValue>, Ref<CSSValue>, Ref<CSSValue>, Ref<CSSValue>);
+
+    static Ref<CSSValueList> createSlashSeparated(CSSValueListBuilder);
+    static Ref<CSSValueList> createSlashSeparated(Ref<CSSValue>); // FIXME: Upgrade callers to not use a list at all.
+    static Ref<CSSValueList> createSlashSeparated(Ref<CSSValue>, Ref<CSSValue>);
 
     String customCSSText() const;
     bool equals(const CSSValueList&) const;
@@ -92,16 +112,27 @@ public:
 private:
     explicit CSSValueList(ValueSeparator);
     CSSValueList(ValueSeparator, CSSValueListBuilder);
+    CSSValueList(ValueSeparator, Ref<CSSValue>);
+    CSSValueList(ValueSeparator, Ref<CSSValue>, Ref<CSSValue>);
+    CSSValueList(ValueSeparator, Ref<CSSValue>, Ref<CSSValue>, Ref<CSSValue>);
+    CSSValueList(ValueSeparator, Ref<CSSValue>, Ref<CSSValue>, Ref<CSSValue>, Ref<CSSValue>);
 };
 
-inline void CSSValueContainingVector::append(Ref<CSSValue>&& value)
+inline CSSValueContainingVector::~CSSValueContainingVector()
 {
-    m_values.append(WTFMove(value));
+    for (auto& value : *this)
+        value.deref();
+    if (m_size > m_inlineStorage.size())
+        fastFree(m_additionalStorage);
 }
 
-inline void CSSValueContainingVector::prepend(Ref<CSSValue>&& value)
+inline const CSSValue& CSSValueContainingVector::operator[](unsigned index) const
 {
-    m_values.insert(0, WTFMove(value));
+    ASSERT(index < m_size);
+    unsigned maxInlineSize = m_inlineStorage.size();
+    if (index < maxInlineSize)
+        return *m_inlineStorage[index];
+    return *m_additionalStorage[index - maxInlineSize];
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -96,14 +96,14 @@ public:
     virtual ~OrderedNamedLinesCollector() = default;
 
     bool isEmpty() const { return m_orderedNamedGridLines.isEmpty() && m_orderedNamedAutoRepeatGridLines.isEmpty(); }
-    virtual void collectLineNamesForIndex(CSSGridLineNamesValue&, unsigned index) const = 0;
+    virtual void collectLineNamesForIndex(Vector<String>&, unsigned index) const = 0;
 
     virtual int namedGridLineCount() const { return m_orderedNamedGridLines.size(); }
 
 protected:
 
     enum NamedLinesType { NamedLines, AutoRepeatNamedLines };
-    void appendLines(CSSGridLineNamesValue&, unsigned index, NamedLinesType) const;
+    void appendLines(Vector<String>&, unsigned index, NamedLinesType) const;
 
     const OrderedNamedGridLinesMap& m_orderedNamedGridLines;
     const OrderedNamedGridLinesMap& m_orderedNamedAutoRepeatGridLines;
@@ -119,7 +119,7 @@ public:
     {
     }
 
-    void collectLineNamesForIndex(CSSGridLineNamesValue&, unsigned index) const override;
+    void collectLineNamesForIndex(Vector<String>&, unsigned index) const override;
 
 private:
     unsigned m_insertionPoint;
@@ -148,7 +148,7 @@ public:
         m_autoRepeatTotalLineSets *= m_autoRepeatLineSetListLength;
     }
 
-    void collectLineNamesForIndex(CSSGridLineNamesValue&, unsigned index) const override;
+    void collectLineNamesForIndex(Vector<String>&, unsigned index) const override;
 
     int namedGridLineCount() const override { return m_totalLines; }
 private:
@@ -158,7 +158,7 @@ private:
     unsigned m_totalLines;
 };
 
-void OrderedNamedLinesCollector::appendLines(CSSGridLineNamesValue& lineNamesValue, unsigned index, NamedLinesType type) const
+void OrderedNamedLinesCollector::appendLines(Vector<String>& lineNamesValue, unsigned index, NamedLinesType type) const
 {
     auto iter = type == NamedLines ? m_orderedNamedGridLines.find(index) : m_orderedNamedAutoRepeatGridLines.find(index);
     auto endIter = type == NamedLines ? m_orderedNamedGridLines.end() : m_orderedNamedAutoRepeatGridLines.end();
@@ -166,10 +166,10 @@ void OrderedNamedLinesCollector::appendLines(CSSGridLineNamesValue& lineNamesVal
         return;
 
     for (const auto& lineName : iter->value)
-        lineNamesValue.append(CSSPrimitiveValue::createCustomIdent(lineName));
+        lineNamesValue.append(lineName);
 }
 
-void OrderedNamedLinesCollectorInGridLayout::collectLineNamesForIndex(CSSGridLineNamesValue& lineNamesValue, unsigned i) const
+void OrderedNamedLinesCollectorInGridLayout::collectLineNamesForIndex(Vector<String>& lineNamesValue, unsigned i) const
 {
     ASSERT(!isEmpty());
     if (!m_autoRepeatTrackListLength || i < m_insertionPoint) {
@@ -202,7 +202,7 @@ void OrderedNamedLinesCollectorInGridLayout::collectLineNamesForIndex(CSSGridLin
     appendLines(lineNamesValue, autoRepeatIndexInFirstRepetition, AutoRepeatNamedLines);
 }
 
-void OrderedNamedLinesCollectorInSubgridLayout::collectLineNamesForIndex(CSSGridLineNamesValue& lineNamesValue, unsigned i) const
+void OrderedNamedLinesCollectorInSubgridLayout::collectLineNamesForIndex(Vector<String>& lineNamesValue, unsigned i) const
 {
     if (!m_autoRepeatLineSetListLength || i < m_insertionPoint) {
         appendLines(lineNamesValue, i, NamedLines);
@@ -414,18 +414,18 @@ static inline Ref<CSSValue> valueForReflection(const StyleReflection* reflection
 
 static Ref<CSSValueList> createPositionListForLayer(CSSPropertyID propertyID, const FillLayer& layer, const RenderStyle& style)
 {
-    auto list = CSSValueList::createSpaceSeparated();
+    CSSValueListBuilder list;
     if (layer.isBackgroundXOriginSet() && layer.backgroundXOrigin() != Edge::Left) {
         ASSERT_UNUSED(propertyID, propertyID == CSSPropertyBackgroundPosition || propertyID == CSSPropertyMaskPosition || propertyID == CSSPropertyWebkitMaskPosition);
-        list->append(createConvertingToCSSValueID(layer.backgroundXOrigin()));
+        list.append(createConvertingToCSSValueID(layer.backgroundXOrigin()));
     }
-    list->append(zoomAdjustedPixelValueForLength(layer.xPosition(), style));
+    list.append(zoomAdjustedPixelValueForLength(layer.xPosition(), style));
     if (layer.isBackgroundYOriginSet() && layer.backgroundYOrigin() != Edge::Top) {
         ASSERT(propertyID == CSSPropertyBackgroundPosition || propertyID == CSSPropertyMaskPosition || propertyID == CSSPropertyWebkitMaskPosition);
-        list->append(createConvertingToCSSValueID(layer.backgroundYOrigin()));
+        list.append(createConvertingToCSSValueID(layer.backgroundYOrigin()));
     }
-    list->append(zoomAdjustedPixelValueForLength(layer.yPosition(), style));
-    return list;
+    list.append(zoomAdjustedPixelValueForLength(layer.yPosition(), style));
+    return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
 static Ref<CSSValue> createSingleAxisPositionValueForLayer(CSSPropertyID propertyID, const FillLayer& layer, const RenderStyle& style)
@@ -433,20 +433,13 @@ static Ref<CSSValue> createSingleAxisPositionValueForLayer(CSSPropertyID propert
     if (propertyID == CSSPropertyBackgroundPositionX || propertyID == CSSPropertyWebkitMaskPositionX) {
         if (!layer.isBackgroundXOriginSet() || layer.backgroundXOrigin() == Edge::Left)
             return zoomAdjustedPixelValueForLength(layer.xPosition(), style);
-
-        auto list = CSSValueList::createSpaceSeparated();
-        list->append(createConvertingToCSSValueID(layer.backgroundXOrigin()));
-        list->append(zoomAdjustedPixelValueForLength(layer.xPosition(), style));
-        return list;
+        return CSSValueList::createSpaceSeparated(createConvertingToCSSValueID(layer.backgroundXOrigin()),
+            zoomAdjustedPixelValueForLength(layer.xPosition(), style));
     }
-
     if (!layer.isBackgroundYOriginSet() || layer.backgroundYOrigin() == Edge::Top)
         return zoomAdjustedPixelValueForLength(layer.yPosition(), style);
-
-    auto list = CSSValueList::createSpaceSeparated();
-    list->append(createConvertingToCSSValueID(layer.backgroundYOrigin()));
-    list->append(zoomAdjustedPixelValueForLength(layer.yPosition(), style));
-    return list;
+    return CSSValueList::createSpaceSeparated(createConvertingToCSSValueID(layer.backgroundYOrigin()),
+        zoomAdjustedPixelValueForLength(layer.yPosition(), style));
 }
 
 static Length getOffsetComputedLength(const RenderStyle& style, CSSPropertyID propertyID)
@@ -609,12 +602,12 @@ static Ref<CSSValue> valueForQuotes(const QuotesData* quotes)
     unsigned size = quotes->size();
     if (!size)
         return CSSPrimitiveValue::create(CSSValueNone);
-    auto list = CSSValueList::createSpaceSeparated();
+    CSSValueListBuilder list;
     for (unsigned i = 0; i < size; ++i) {
-        list->append(CSSPrimitiveValue::create(quotes->openQuote(i)));
-        list->append(CSSPrimitiveValue::create(quotes->closeQuote(i)));
+        list.append(CSSPrimitiveValue::create(quotes->openQuote(i)));
+        list.append(CSSPrimitiveValue::create(quotes->closeQuote(i)));
     }
-    return list;
+    return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
 static std::pair<Ref<CSSPrimitiveValue>, Ref<CSSPrimitiveValue>> borderRadiusCornerValues(const LengthSize& radius, const RenderStyle& style)
@@ -628,6 +621,18 @@ static Ref<CSSValue> borderRadiusCornerValue(const LengthSize& radius, const Ren
 {
     auto [x, y] = borderRadiusCornerValues(radius, style);
     return CSSValuePair::create(WTFMove(x), WTFMove(y));
+}
+
+static bool itemsEqual(const CSSValueListBuilder& a, const CSSValueListBuilder& b)
+{
+    auto size = a.size();
+    if (size != b.size())
+        return false;
+    for (unsigned i = 0; i < size; ++i) {
+        if (!a[i]->equals(b[i]))
+            return false;
+    }
+    return true;
 }
 
 static Ref<CSSValueList> borderRadiusShorthandValue(const RenderStyle& style, CSSPropertyID propertyID)
@@ -645,35 +650,34 @@ static Ref<CSSValueList> borderRadiusShorthandValue(const RenderStyle& style, CS
     auto [bottomRightRadiusX, bottomRightRadiusY] = borderRadiusCornerValues(style.borderBottomRightRadius(), style);
     auto [bottomLeftRadiusX, bottomLeftRadiusY] = borderRadiusCornerValues(style.borderBottomLeftRadius(), style);
 
-    auto horizontalRadii = CSSValueList::createSpaceSeparated();
-    horizontalRadii->append(WTFMove(topLeftRadiusX));
+    CSSValueListBuilder horizontalRadii;
+    horizontalRadii.append(WTFMove(topLeftRadiusX));
     if (showHorizontalTopRight)
-        horizontalRadii->append(WTFMove(topRightRadiusX));
+        horizontalRadii.append(WTFMove(topRightRadiusX));
     if (showHorizontalBottomRight)
-        horizontalRadii->append(WTFMove(bottomRightRadiusX));
+        horizontalRadii.append(WTFMove(bottomRightRadiusX));
     if (showHorizontalBottomLeft)
-        horizontalRadii->append(WTFMove(bottomLeftRadiusX));
+        horizontalRadii.append(WTFMove(bottomLeftRadiusX));
 
-    auto verticalRadii = CSSValueList::createSpaceSeparated();
-    verticalRadii->append(WTFMove(topLeftRadiusY));
+    CSSValueListBuilder verticalRadii;
+    verticalRadii.append(WTFMove(topLeftRadiusY));
     if (showVerticalTopRight)
-        verticalRadii->append(WTFMove(topRightRadiusY));
+        verticalRadii.append(WTFMove(topRightRadiusY));
     if (showVerticalBottomRight)
-        verticalRadii->append(WTFMove(bottomRightRadiusY));
+        verticalRadii.append(WTFMove(bottomRightRadiusY));
     if (showVerticalBottomLeft)
-        verticalRadii->append(WTFMove(bottomLeftRadiusY));
+        verticalRadii.append(WTFMove(bottomLeftRadiusY));
 
     bool includeVertical = false;
-    if (!verticalRadii->equals(horizontalRadii))
+    if (!itemsEqual(horizontalRadii, verticalRadii))
         includeVertical = true;
     else if (propertyID == CSSPropertyWebkitBorderRadius && showHorizontalTopRight && !showHorizontalBottomRight)
-        horizontalRadii->append(WTFMove(bottomRightRadiusX));
+        horizontalRadii.append(WTFMove(bottomRightRadiusX));
 
-    auto list = CSSValueList::createSlashSeparated();
-    list->append(WTFMove(horizontalRadii));
-    if (includeVertical)
-        list->append(WTFMove(verticalRadii));
-    return list;
+    if (!includeVertical)
+        return CSSValueList::createSlashSeparated(CSSValueList::createSpaceSeparated(WTFMove(horizontalRadii)));
+    return CSSValueList::createSlashSeparated(CSSValueList::createSpaceSeparated(WTFMove(horizontalRadii)),
+        CSSValueList::createSpaceSeparated(WTFMove(verticalRadii)));
 }
 
 static LayoutRect sizingBox(RenderObject& renderer)
@@ -687,42 +691,25 @@ static LayoutRect sizingBox(RenderObject& renderer)
 
 static Ref<CSSFunctionValue> matrixTransformValue(const TransformationMatrix& transform, const RenderStyle& style)
 {
-    RefPtr<CSSFunctionValue> transformValue;
     auto zoom = style.effectiveZoom();
     if (transform.isAffine()) {
-        transformValue = CSSFunctionValue::create(CSSValueMatrix);
-
-        transformValue->append(CSSPrimitiveValue::create(transform.a()));
-        transformValue->append(CSSPrimitiveValue::create(transform.b()));
-        transformValue->append(CSSPrimitiveValue::create(transform.c()));
-        transformValue->append(CSSPrimitiveValue::create(transform.d()));
-        transformValue->append(CSSPrimitiveValue::create(transform.e() / zoom));
-        transformValue->append(CSSPrimitiveValue::create(transform.f() / zoom));
-    } else {
-        transformValue = CSSFunctionValue::create(CSSValueMatrix3d);
-
-        transformValue->append(CSSPrimitiveValue::create(transform.m11()));
-        transformValue->append(CSSPrimitiveValue::create(transform.m12()));
-        transformValue->append(CSSPrimitiveValue::create(transform.m13()));
-        transformValue->append(CSSPrimitiveValue::create(transform.m14() * zoom));
-
-        transformValue->append(CSSPrimitiveValue::create(transform.m21()));
-        transformValue->append(CSSPrimitiveValue::create(transform.m22()));
-        transformValue->append(CSSPrimitiveValue::create(transform.m23()));
-        transformValue->append(CSSPrimitiveValue::create(transform.m24() * zoom));
-
-        transformValue->append(CSSPrimitiveValue::create(transform.m31()));
-        transformValue->append(CSSPrimitiveValue::create(transform.m32()));
-        transformValue->append(CSSPrimitiveValue::create(transform.m33()));
-        transformValue->append(CSSPrimitiveValue::create(transform.m34() * zoom));
-
-        transformValue->append(CSSPrimitiveValue::create(transform.m41() / zoom));
-        transformValue->append(CSSPrimitiveValue::create(transform.m42() / zoom));
-        transformValue->append(CSSPrimitiveValue::create(transform.m43() / zoom));
-        transformValue->append(CSSPrimitiveValue::create(transform.m44()));
+        double values[] = { transform.a(), transform.b(), transform.c(), transform.d(), transform.e() / zoom, transform.f() / zoom };
+        CSSValueListBuilder arguments;
+        for (auto value : values)
+            arguments.append(CSSPrimitiveValue::create(value));
+        return CSSFunctionValue::create(CSSValueMatrix, WTFMove(arguments));
     }
 
-    return transformValue.releaseNonNull();
+    double values[] = {
+        transform.m11(), transform.m12(), transform.m13(), transform.m14() * zoom,
+        transform.m21(), transform.m22(), transform.m23(), transform.m24() * zoom,
+        transform.m31(), transform.m32(), transform.m33(), transform.m34() * zoom,
+        transform.m41() / zoom, transform.m42() / zoom, transform.m43() / zoom, transform.m44()
+    };
+    CSSValueListBuilder arguments;
+    for (auto value : values)
+        arguments.append(CSSPrimitiveValue::create(value));
+    return CSSFunctionValue::create(CSSValueMatrix3d, WTFMove(arguments));
 }
 
 RefPtr<CSSFunctionValue> transformOperationAsCSSValue(const TransformOperation& operation, const RenderStyle& style)
@@ -739,120 +726,77 @@ RefPtr<CSSFunctionValue> transformOperationAsCSSValue(const TransformOperation& 
 
     switch (operation.type()) {
     // translate
-    case TransformOperation::Type::TranslateX: {
-        auto functionValue = CSSFunctionValue::create(CSSValueTranslateX);
-        functionValue->append(translateLengthAsCSSValue(downcast<TranslateTransformOperation>(operation).x()));
-        return functionValue;
-    }
-    case TransformOperation::Type::TranslateY: {
-        auto functionValue = CSSFunctionValue::create(CSSValueTranslateY);
-        functionValue->append(translateLengthAsCSSValue(downcast<TranslateTransformOperation>(operation).y()));
-        return functionValue;
-    }
-    case TransformOperation::Type::TranslateZ: {
-        auto functionValue = CSSFunctionValue::create(CSSValueTranslateZ);
-        functionValue->append(translateLengthAsCSSValue(downcast<TranslateTransformOperation>(operation).z()));
-        return functionValue;
-    }
+    case TransformOperation::Type::TranslateX:
+        return CSSFunctionValue::create(CSSValueTranslateX, translateLengthAsCSSValue(downcast<TranslateTransformOperation>(operation).x()));
+    case TransformOperation::Type::TranslateY:
+        return CSSFunctionValue::create(CSSValueTranslateY, translateLengthAsCSSValue(downcast<TranslateTransformOperation>(operation).y()));
+    case TransformOperation::Type::TranslateZ:
+        return CSSFunctionValue::create(CSSValueTranslateZ, translateLengthAsCSSValue(downcast<TranslateTransformOperation>(operation).z()));
     case TransformOperation::Type::Translate:
     case TransformOperation::Type::Translate3D: {
         auto& translate = downcast<TranslateTransformOperation>(operation);
-        auto is3D = translate.is3DOperation();
-        auto functionValue = CSSFunctionValue::create(is3D ? CSSValueTranslate3d : CSSValueTranslate);
-        functionValue->append(translateLengthAsCSSValue(translate.x()));
-        if (is3D || includeLength(translate.y()))
-            functionValue->append(translateLengthAsCSSValue(translate.y()));
-        if (is3D)
-            functionValue->append(translateLengthAsCSSValue(translate.z()));
-        return functionValue;
+        if (!translate.is3DOperation()) {
+            if (!includeLength(translate.y()))
+                return CSSFunctionValue::create(CSSValueTranslate, translateLengthAsCSSValue(translate.x()));
+            return CSSFunctionValue::create(CSSValueTranslate, translateLengthAsCSSValue(translate.x()),
+                translateLengthAsCSSValue(translate.y()));
+        }
+        return CSSFunctionValue::create(CSSValueTranslate3d,
+            translateLengthAsCSSValue(translate.x()),
+            translateLengthAsCSSValue(translate.y()),
+            translateLengthAsCSSValue(translate.z()));
     }
     // scale
-    case TransformOperation::Type::ScaleX: {
-        auto functionValue = CSSFunctionValue::create(CSSValueScaleX);
-        functionValue->append(CSSPrimitiveValue::create(downcast<ScaleTransformOperation>(operation).x()));
-        return functionValue;
-    }
-    case TransformOperation::Type::ScaleY: {
-        auto functionValue = CSSFunctionValue::create(CSSValueScaleY);
-        functionValue->append(CSSPrimitiveValue::create(downcast<ScaleTransformOperation>(operation).y()));
-        return functionValue;
-    }
-    case TransformOperation::Type::ScaleZ: {
-        auto functionValue = CSSFunctionValue::create(CSSValueScaleZ);
-        functionValue->append(CSSPrimitiveValue::create(downcast<ScaleTransformOperation>(operation).z()));
-        return functionValue;
-    }
+    case TransformOperation::Type::ScaleX:
+        return CSSFunctionValue::create(CSSValueScaleX, CSSPrimitiveValue::create(downcast<ScaleTransformOperation>(operation).x()));
+    case TransformOperation::Type::ScaleY:
+        return CSSFunctionValue::create(CSSValueScaleY, CSSPrimitiveValue::create(downcast<ScaleTransformOperation>(operation).y()));
+    case TransformOperation::Type::ScaleZ:
+        return CSSFunctionValue::create(CSSValueScaleZ, CSSPrimitiveValue::create(downcast<ScaleTransformOperation>(operation).z()));
     case TransformOperation::Type::Scale:
     case TransformOperation::Type::Scale3D: {
         auto& scale = downcast<ScaleTransformOperation>(operation);
-        auto is3D = scale.is3DOperation();
-        auto functionValue = CSSFunctionValue::create(is3D ? CSSValueScale3d : CSSValueScale);
-        functionValue->append(CSSPrimitiveValue::create(scale.x()));
-        if (is3D || scale.x() != scale.y())
-            functionValue->append(CSSPrimitiveValue::create(scale.y()));
-        if (is3D)
-            functionValue->append(CSSPrimitiveValue::create(scale.z()));
-        return functionValue;
+        if (!scale.is3DOperation()) {
+            if (scale.x() == scale.y())
+                return CSSFunctionValue::create(CSSValueScale, CSSPrimitiveValue::create(scale.x()));
+            return CSSFunctionValue::create(CSSValueScale, CSSPrimitiveValue::create(scale.x()),
+                CSSPrimitiveValue::create(scale.y()));
+        }
+        return CSSFunctionValue::create(CSSValueScale3d,
+            CSSPrimitiveValue::create(scale.x()),
+            CSSPrimitiveValue::create(scale.y()),
+            CSSPrimitiveValue::create(scale.z()));
     }
     // rotate
-    case TransformOperation::Type::RotateX: {
-        auto functionValue = CSSFunctionValue::create(CSSValueRotateX);
-        functionValue->append(CSSPrimitiveValue::create(downcast<RotateTransformOperation>(operation).angle(), CSSUnitType::CSS_DEG));
-        return functionValue;
-    }
-    case TransformOperation::Type::RotateY: {
-        auto functionValue = CSSFunctionValue::create(CSSValueRotateX);
-        functionValue->append(CSSPrimitiveValue::create(downcast<RotateTransformOperation>(operation).angle(), CSSUnitType::CSS_DEG));
-        return functionValue;
-    }
-    case TransformOperation::Type::RotateZ: {
-        auto functionValue = CSSFunctionValue::create(CSSValueRotateZ);
-        functionValue->append(CSSPrimitiveValue::create(downcast<RotateTransformOperation>(operation).angle(), CSSUnitType::CSS_DEG));
-        return functionValue;
-    }
-    case TransformOperation::Type::Rotate: {
-        auto& rotate = downcast<RotateTransformOperation>(operation);
-        auto functionValue = CSSFunctionValue::create(CSSValueRotate);
-        functionValue->append(CSSPrimitiveValue::create(rotate.angle(), CSSUnitType::CSS_DEG));
-        return functionValue;
-    }
+    case TransformOperation::Type::RotateX:
+        return CSSFunctionValue::create(CSSValueRotateX, CSSPrimitiveValue::create(downcast<RotateTransformOperation>(operation).angle(), CSSUnitType::CSS_DEG));
+    case TransformOperation::Type::RotateY:
+        return CSSFunctionValue::create(CSSValueRotateX, CSSPrimitiveValue::create(downcast<RotateTransformOperation>(operation).angle(), CSSUnitType::CSS_DEG));
+    case TransformOperation::Type::RotateZ:
+        return CSSFunctionValue::create(CSSValueRotateZ, CSSPrimitiveValue::create(downcast<RotateTransformOperation>(operation).angle(), CSSUnitType::CSS_DEG));
+    case TransformOperation::Type::Rotate:
+        return CSSFunctionValue::create(CSSValueRotate, CSSPrimitiveValue::create(downcast<RotateTransformOperation>(operation).angle(), CSSUnitType::CSS_DEG));
     case TransformOperation::Type::Rotate3D: {
         auto& rotate = downcast<RotateTransformOperation>(operation);
-        auto functionValue = CSSFunctionValue::create(CSSValueRotate3d);
-        functionValue->append(CSSPrimitiveValue::create(rotate.x()));
-        functionValue->append(CSSPrimitiveValue::create(rotate.y()));
-        functionValue->append(CSSPrimitiveValue::create(rotate.z()));
-        functionValue->append(CSSPrimitiveValue::create(rotate.angle(), CSSUnitType::CSS_DEG));
-        return functionValue;
+        return CSSFunctionValue::create(CSSValueRotate3d, CSSPrimitiveValue::create(rotate.x()), CSSPrimitiveValue::create(rotate.y()), CSSPrimitiveValue::create(rotate.z()), CSSPrimitiveValue::create(rotate.angle(), CSSUnitType::CSS_DEG));
     }
     // skew
-    case TransformOperation::Type::SkewX: {
-        auto functionValue = CSSFunctionValue::create(CSSValueSkewX);
-        functionValue->append(CSSPrimitiveValue::create(downcast<SkewTransformOperation>(operation).angleX(), CSSUnitType::CSS_DEG));
-        return functionValue;
-    }
-    case TransformOperation::Type::SkewY: {
-        auto functionValue = CSSFunctionValue::create(CSSValueSkewY);
-        functionValue->append(CSSPrimitiveValue::create(downcast<SkewTransformOperation>(operation).angleY(), CSSUnitType::CSS_DEG));
-        return functionValue;
-    }
+    case TransformOperation::Type::SkewX:
+        return CSSFunctionValue::create(CSSValueSkewX, CSSPrimitiveValue::create(downcast<SkewTransformOperation>(operation).angleX(), CSSUnitType::CSS_DEG));
+    case TransformOperation::Type::SkewY:
+        return CSSFunctionValue::create(CSSValueSkewY, CSSPrimitiveValue::create(downcast<SkewTransformOperation>(operation).angleY(), CSSUnitType::CSS_DEG));
     case TransformOperation::Type::Skew: {
         auto& skew = downcast<SkewTransformOperation>(operation);
-        auto functionValue = CSSFunctionValue::create(CSSValueSkew);
-        functionValue->append(CSSPrimitiveValue::create(skew.angleX(), CSSUnitType::CSS_DEG));
-        if (skew.angleY())
-            functionValue->append(CSSPrimitiveValue::create(skew.angleY(), CSSUnitType::CSS_DEG));
-        return functionValue;
+        if (!skew.angleY())
+            return CSSFunctionValue::create(CSSValueSkew, CSSPrimitiveValue::create(skew.angleX(), CSSUnitType::CSS_DEG));
+        return CSSFunctionValue::create(CSSValueSkew, CSSPrimitiveValue::create(skew.angleX(), CSSUnitType::CSS_DEG),
+            CSSPrimitiveValue::create(skew.angleY(), CSSUnitType::CSS_DEG));
     }
     // perspective
-    case TransformOperation::Type::Perspective: {
-        auto functionValue = CSSFunctionValue::create(CSSValuePerspective);
+    case TransformOperation::Type::Perspective:
         if (auto perspective = downcast<PerspectiveTransformOperation>(operation).perspective())
-            functionValue->append(zoomAdjustedPixelValueForLength(*perspective, style));
-        else
-            functionValue->append(CSSPrimitiveValue::create(CSSValueNone));
-        return functionValue;
-    }
+            return CSSFunctionValue::create(CSSValuePerspective, zoomAdjustedPixelValueForLength(*perspective, style));
+        return CSSFunctionValue::create(CSSValuePerspective, CSSPrimitiveValue::create(CSSValueNone));
     // matrix
     case TransformOperation::Type::Matrix:
     case TransformOperation::Type::Matrix3D: {
@@ -877,9 +821,7 @@ static Ref<CSSValue> computedTransform(RenderElement* renderer, const RenderStyl
     if (renderer) {
         TransformationMatrix transform;
         style.applyTransform(transform, renderer->transformReferenceBoxRect(style), { });
-        auto list = CSSTransformListValue::create();
-        list->append(matrixTransformValue(transform, style));
-        return list;
+        return CSSTransformListValue::create(matrixTransformValue(transform, style));
     }
 
     // https://w3c.github.io/csswg-drafts/css-transforms-1/#serialization-of-the-computed-value
@@ -888,17 +830,13 @@ static Ref<CSSValue> computedTransform(RenderElement* renderer, const RenderStyl
     if (valueType == ComputedStyleExtractor::PropertyValueType::Resolved)
         return CSSPrimitiveValue::create(CSSValueNone);
 
-    auto list = CSSTransformListValue::create();
-
+    CSSValueListBuilder list;
     for (auto& operation : style.transform().operations()) {
-        auto functionValue = transformOperationAsCSSValue(*operation, style);
-        if (!functionValue)
-            continue;
-        list->append(functionValue.releaseNonNull());
+        if (auto functionValue = transformOperationAsCSSValue(*operation, style))
+            list.append(functionValue.releaseNonNull());
     }
-
-    if (list->length())
-        return list;
+    if (!list.isEmpty())
+        return CSSTransformListValue::create(WTFMove(list));
 
     return CSSPrimitiveValue::create(CSSValueNone);
 }
@@ -911,20 +849,19 @@ static Ref<CSSValue> computedTranslate(RenderObject* renderer, const RenderStyle
     if (!translate || is<RenderInline>(renderer) || translate->isIdentity())
         return CSSPrimitiveValue::create(CSSValueNone);
 
-    auto list = CSSValueList::createSpaceSeparated();
-    list->append(zoomAdjustedPixelValueForLength(translate->x(), style));
-
-    auto includeLength = [](const Length& length) -> bool {
+    auto includeLength = [](const Length& length) {
         return !length.isZero() || length.isPercent();
     };
 
-    if (includeLength(translate->y()) || includeLength(translate->z()))
-        list->append(zoomAdjustedPixelValueForLength(translate->y(), style));
+    auto value = [&](const Length& length) {
+        return zoomAdjustedPixelValueForLength(length, style);
+    };
 
     if (includeLength(translate->z()))
-        list->append(zoomAdjustedPixelValueForLength(translate->z(), style));
-
-    return list;
+        return CSSValueList::createSpaceSeparated(value(translate->x()), value(translate->y()), value(translate->z()));
+    if (includeLength(translate->y()))
+        return CSSValueList::createSpaceSeparated(value(translate->x()), value(translate->y()));
+    return CSSValueList::createSpaceSeparated(value(translate->x()));
 }
 
 static Ref<CSSValue> computedScale(RenderObject* renderer, const RenderStyle& style)
@@ -933,14 +870,15 @@ static Ref<CSSValue> computedScale(RenderObject* renderer, const RenderStyle& st
     if (!scale || is<RenderInline>(renderer) || scale->isIdentity())
         return CSSPrimitiveValue::create(CSSValueNone);
 
-    auto list = CSSValueList::createSpaceSeparated();
-    list->append(CSSPrimitiveValue::create(scale->x()));
-    if (scale->z() != 1) {
-        list->append(CSSPrimitiveValue::create(scale->y()));
-        list->append(CSSPrimitiveValue::create(scale->z()));
-    } else if (scale->x() != scale->y())
-        list->append(CSSPrimitiveValue::create(scale->y()));
-    return list;
+    auto value = [](double number) {
+        return CSSPrimitiveValue::create(number);
+    };
+
+    if (scale->z() != 1)
+        return CSSValueList::createSpaceSeparated(value(scale->x()), value(scale->y()), value(scale->z()));
+    if (scale->x() != scale->y())
+        return CSSValueList::createSpaceSeparated(value(scale->x()), value(scale->y()));
+    return CSSValueList::createSpaceSeparated(value(scale->x()));
 }
 
 static Ref<CSSValue> computedRotate(RenderObject* renderer, const RenderStyle& style)
@@ -949,24 +887,15 @@ static Ref<CSSValue> computedRotate(RenderObject* renderer, const RenderStyle& s
     if (!rotate || is<RenderInline>(renderer) || rotate->isIdentity())
         return CSSPrimitiveValue::create(CSSValueNone);
 
+    auto angle = CSSPrimitiveValue::create(rotate->angle(), CSSUnitType::CSS_DEG);
     if (!rotate->is3DOperation() || (!rotate->x() && !rotate->y() && rotate->z()))
-        return CSSPrimitiveValue::create(rotate->angle(), CSSUnitType::CSS_DEG);
-
-    auto list = CSSValueList::createSpaceSeparated();
-
+        return angle;
     if (rotate->x() && !rotate->y() && !rotate->z())
-        list->append(CSSPrimitiveValue::create(CSSValueX));
-    else if (!rotate->x() && rotate->y() && !rotate->z())
-        list->append(CSSPrimitiveValue::create(CSSValueY));
-    else {
-        list->append(CSSPrimitiveValue::create(rotate->x()));
-        list->append(CSSPrimitiveValue::create(rotate->y()));
-        list->append(CSSPrimitiveValue::create(rotate->z()));
-    }
-
-    list->append(CSSPrimitiveValue::create(rotate->angle(), CSSUnitType::CSS_DEG));
-
-    return list;
+        return CSSValueList::createSpaceSeparated(CSSPrimitiveValue::create(CSSValueX), WTFMove(angle));
+    if (!rotate->x() && rotate->y() && !rotate->z())
+        return CSSValueList::createSpaceSeparated(CSSPrimitiveValue::create(CSSValueY), WTFMove(angle));
+    return CSSValueList::createSpaceSeparated(CSSPrimitiveValue::create(rotate->x()),
+        CSSPrimitiveValue::create(rotate->y()), CSSPrimitiveValue::create(rotate->z()), WTFMove(angle));
 }
 
 static inline Ref<CSSPrimitiveValue> adjustLengthForZoom(const Length& length, const RenderStyle& style, ComputedStyleExtractor::AdjustPixelValuesForComputedStyle adjust)
@@ -978,9 +907,8 @@ Ref<CSSValue> ComputedStyleExtractor::valueForShadow(const ShadowData* shadow, C
 {
     if (!shadow)
         return CSSPrimitiveValue::create(CSSValueNone);
-
     auto& cssValuePool = CSSValuePool::singleton();
-    auto list = CSSValueList::createCommaSeparated();
+    CSSValueListBuilder list;
     for (const ShadowData* currShadowData = shadow; currShadowData; currShadowData = currShadowData->next()) {
         auto x = adjustLengthForZoom(currShadowData->x(), style, adjust);
         auto y = adjustLengthForZoom(currShadowData->y(), style, adjust);
@@ -988,9 +916,10 @@ Ref<CSSValue> ComputedStyleExtractor::valueForShadow(const ShadowData* shadow, C
         auto spread = propertyID == CSSPropertyTextShadow ? RefPtr<CSSPrimitiveValue>() : adjustLengthForZoom(currShadowData->spread(), style, adjust);
         auto style = propertyID == CSSPropertyTextShadow || currShadowData->style() == ShadowStyle::Normal ? RefPtr<CSSPrimitiveValue>() : CSSPrimitiveValue::create(CSSValueInset);
         auto color = cssValuePool.createColorValue(currShadowData->color());
-        list->prepend(CSSShadowValue::create(WTFMove(x), WTFMove(y), WTFMove(blur), WTFMove(spread), WTFMove(style), WTFMove(color)));
+        list.append(CSSShadowValue::create(WTFMove(x), WTFMove(y), WTFMove(blur), WTFMove(spread), WTFMove(style), WTFMove(color)));
     }
-    return list;
+    list.reverse();
+    return CSSValueList::createCommaSeparated(WTFMove(list));
 }
 
 Ref<CSSValue> ComputedStyleExtractor::valueForFilter(const RenderStyle& style, const FilterOperations& filterOperations, AdjustPixelValuesForComputedStyle adjust)
@@ -998,73 +927,62 @@ Ref<CSSValue> ComputedStyleExtractor::valueForFilter(const RenderStyle& style, c
     if (filterOperations.operations().isEmpty())
         return CSSPrimitiveValue::create(CSSValueNone);
 
-    auto list = CSSValueList::createSpaceSeparated();
+    CSSValueListBuilder list;
 
-    Vector<RefPtr<FilterOperation>>::const_iterator end = filterOperations.operations().end();
-    for (Vector<RefPtr<FilterOperation>>::const_iterator it = filterOperations.operations().begin(); it != end; ++it) {
-        FilterOperation& filterOperation = **it;
+    for (auto& filterOperationPointer : filterOperations.operations()) {
+        auto& filterOperation = *filterOperationPointer;
 
         if (filterOperation.type() == FilterOperation::Type::Reference) {
             ReferenceFilterOperation& referenceOperation = downcast<ReferenceFilterOperation>(filterOperation);
-            list->append(CSSPrimitiveValue::createURI(referenceOperation.url()));
+            list.append(CSSPrimitiveValue::createURI(referenceOperation.url()));
         } else {
             RefPtr<CSSFunctionValue> filterValue;
             switch (filterOperation.type()) {
-            case FilterOperation::Type::Grayscale: {
-                filterValue = CSSFunctionValue::create(CSSValueGrayscale);
-                filterValue->append(CSSPrimitiveValue::create(downcast<BasicColorMatrixFilterOperation>(filterOperation).amount()));
+            case FilterOperation::Type::Grayscale:
+                filterValue = CSSFunctionValue::create(CSSValueGrayscale,
+                    CSSPrimitiveValue::create(downcast<BasicColorMatrixFilterOperation>(filterOperation).amount()));
                 break;
-            }
-            case FilterOperation::Type::Sepia: {
-                filterValue = CSSFunctionValue::create(CSSValueSepia);
-                filterValue->append(CSSPrimitiveValue::create(downcast<BasicColorMatrixFilterOperation>(filterOperation).amount()));
+            case FilterOperation::Type::Sepia:
+                filterValue = CSSFunctionValue::create(CSSValueSepia,
+                    CSSPrimitiveValue::create(downcast<BasicColorMatrixFilterOperation>(filterOperation).amount()));
                 break;
-            }
-            case FilterOperation::Type::Saturate: {
-                filterValue = CSSFunctionValue::create(CSSValueSaturate);
-                filterValue->append(CSSPrimitiveValue::create(downcast<BasicColorMatrixFilterOperation>(filterOperation).amount()));
+            case FilterOperation::Type::Saturate:
+                filterValue = CSSFunctionValue::create(CSSValueSaturate,
+                    CSSPrimitiveValue::create(downcast<BasicColorMatrixFilterOperation>(filterOperation).amount()));
                 break;
-            }
-            case FilterOperation::Type::HueRotate: {
-                filterValue = CSSFunctionValue::create(CSSValueHueRotate);
-                filterValue->append(CSSPrimitiveValue::create(downcast<BasicColorMatrixFilterOperation>(filterOperation).amount(), CSSUnitType::CSS_DEG));
+            case FilterOperation::Type::HueRotate:
+                filterValue = CSSFunctionValue::create(CSSValueHueRotate,
+                    CSSPrimitiveValue::create(downcast<BasicColorMatrixFilterOperation>(filterOperation).amount(), CSSUnitType::CSS_DEG));
                 break;
-            }
-            case FilterOperation::Type::Invert: {
-                filterValue = CSSFunctionValue::create(CSSValueInvert);
-                filterValue->append(CSSPrimitiveValue::create(downcast<BasicComponentTransferFilterOperation>(filterOperation).amount()));
+            case FilterOperation::Type::Invert:
+                filterValue = CSSFunctionValue::create(CSSValueInvert,
+                    CSSPrimitiveValue::create(downcast<BasicComponentTransferFilterOperation>(filterOperation).amount()));
                 break;
-            }
-            case FilterOperation::Type::AppleInvertLightness: {
+            case FilterOperation::Type::AppleInvertLightness:
                 filterValue = CSSFunctionValue::create(CSSValueAppleInvertLightness);
                 break;
-            }
-            case FilterOperation::Type::Opacity: {
-                filterValue = CSSFunctionValue::create(CSSValueOpacity);
-                filterValue->append(CSSPrimitiveValue::create(downcast<BasicComponentTransferFilterOperation>(filterOperation).amount()));
+            case FilterOperation::Type::Opacity:
+                filterValue = CSSFunctionValue::create(CSSValueOpacity,
+                    CSSPrimitiveValue::create(downcast<BasicComponentTransferFilterOperation>(filterOperation).amount()));
                 break;
-            }
-            case FilterOperation::Type::Brightness: {
-                filterValue = CSSFunctionValue::create(CSSValueBrightness);
-                filterValue->append(CSSPrimitiveValue::create(downcast<BasicComponentTransferFilterOperation>(filterOperation).amount()));
+            case FilterOperation::Type::Brightness:
+                filterValue = CSSFunctionValue::create(CSSValueBrightness,
+                    CSSPrimitiveValue::create(downcast<BasicComponentTransferFilterOperation>(filterOperation).amount()));
                 break;
-            }
-            case FilterOperation::Type::Contrast: {
-                filterValue = CSSFunctionValue::create(CSSValueContrast);
-                filterValue->append(CSSPrimitiveValue::create(downcast<BasicComponentTransferFilterOperation>(filterOperation).amount()));
+            case FilterOperation::Type::Contrast:
+                filterValue = CSSFunctionValue::create(CSSValueContrast,
+                    CSSPrimitiveValue::create(downcast<BasicComponentTransferFilterOperation>(filterOperation).amount()));
                 break;
-            }
-            case FilterOperation::Type::Blur: {
-                filterValue = CSSFunctionValue::create(CSSValueBlur);
-                filterValue->append(adjustLengthForZoom(downcast<BlurFilterOperation>(filterOperation).stdDeviation(), style, adjust));
+            case FilterOperation::Type::Blur:
+                filterValue = CSSFunctionValue::create(CSSValueBlur,
+                    adjustLengthForZoom(downcast<BlurFilterOperation>(filterOperation).stdDeviation(), style, adjust));
                 break;
-            }
             case FilterOperation::Type::DropShadow: {
-                DropShadowFilterOperation& dropShadowOperation = downcast<DropShadowFilterOperation>(filterOperation);
-                filterValue = CSSFunctionValue::create(CSSValueDropShadow);
                 // We want our computed style to look like that of a text shadow (has neither spread nor inset style).
-                ShadowData shadowData = ShadowData({ Length(dropShadowOperation.location().x(), LengthType::Fixed), Length(dropShadowOperation.location().y(), LengthType::Fixed) }, Length(dropShadowOperation.stdDeviation(), LengthType::Fixed), Length(0, LengthType::Fixed), ShadowStyle::Normal, false, dropShadowOperation.color());
-                filterValue->append(valueForShadow(&shadowData, CSSPropertyTextShadow, style, adjust));
+                auto& dropShadowOperation = downcast<DropShadowFilterOperation>(filterOperation);
+                ShadowData shadowData({ Length(dropShadowOperation.location().x(), LengthType::Fixed), Length(dropShadowOperation.location().y(), LengthType::Fixed) }, Length(dropShadowOperation.stdDeviation(), LengthType::Fixed), Length(0, LengthType::Fixed), ShadowStyle::Normal, false, dropShadowOperation.color());
+                filterValue = CSSFunctionValue::create(CSSValueDropShadow,
+                    valueForShadow(&shadowData, CSSPropertyTextShadow, style, adjust));
                 break;
             }
             default:
@@ -1072,10 +990,10 @@ Ref<CSSValue> ComputedStyleExtractor::valueForFilter(const RenderStyle& style, c
                 filterValue = CSSFunctionValue::create(CSSValueInvalid);
                 break;
             }
-            list->append(filterValue.releaseNonNull());
+            list.append(filterValue.releaseNonNull());
         }
     }
-    return list;
+    return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
 static Ref<CSSValue> specifiedValueForGridTrackBreadth(const GridLength& trackBreadth, const RenderStyle& style)
@@ -1094,46 +1012,40 @@ static Ref<CSSValue> specifiedValueForGridTrackSize(const GridTrackSize& trackSi
     switch (trackSize.type()) {
     case LengthTrackSizing:
         return specifiedValueForGridTrackBreadth(trackSize.minTrackBreadth(), style);
-    case FitContentTrackSizing: {
-        auto fitContentTrackSize = CSSFunctionValue::create(CSSValueFitContent);
-        fitContentTrackSize->append(zoomAdjustedPixelValueForLength(trackSize.fitContentTrackBreadth().length(), style));
-        return fitContentTrackSize;
-    }
+    case FitContentTrackSizing:
+        return CSSFunctionValue::create(CSSValueFitContent, zoomAdjustedPixelValueForLength(trackSize.fitContentTrackBreadth().length(), style));
     default:
         ASSERT(trackSize.type() == MinMaxTrackSizing);
         if (trackSize.minTrackBreadth().isAuto() && trackSize.maxTrackBreadth().isFlex())
             return CSSPrimitiveValue::create(trackSize.maxTrackBreadth().flex(), CSSUnitType::CSS_FR);
-
-        auto minMaxTrackBreadths = CSSFunctionValue::create(CSSValueMinmax);
-        minMaxTrackBreadths->append(specifiedValueForGridTrackBreadth(trackSize.minTrackBreadth(), style));
-        minMaxTrackBreadths->append(specifiedValueForGridTrackBreadth(trackSize.maxTrackBreadth(), style));
-        return minMaxTrackBreadths;
+        return CSSFunctionValue::create(CSSValueMinmax, specifiedValueForGridTrackBreadth(trackSize.minTrackBreadth(), style),
+            specifiedValueForGridTrackBreadth(trackSize.maxTrackBreadth(), style));
     }
 }
 
-static void addValuesForNamedGridLinesAtIndex(OrderedNamedLinesCollector& collector, unsigned i, CSSValueList& list, bool renderEmpty = false)
+static void addValuesForNamedGridLinesAtIndex(OrderedNamedLinesCollector& collector, unsigned i, CSSValueListBuilder& list, bool renderEmpty = false)
 {
     if (collector.isEmpty() && !renderEmpty)
         return;
 
-    auto lineNames = CSSGridLineNamesValue::create();
-    collector.collectLineNamesForIndex(lineNames.get(), i);
-    if (lineNames->length() || renderEmpty)
-        list.append(WTFMove(lineNames));
+    Vector<String> lineNames;
+    collector.collectLineNamesForIndex(lineNames, i);
+    if (!lineNames.isEmpty() || renderEmpty)
+        list.append(CSSGridLineNamesValue::create(lineNames));
 }
 
 static Ref<CSSValueList> valueForGridTrackSizeList(GridTrackSizingDirection direction, const RenderStyle& style)
 {
     auto& autoTrackSizes = direction == ForColumns ? style.gridAutoColumns() : style.gridAutoRows();
 
-    auto list = CSSValueList::createSpaceSeparated();
+    CSSValueListBuilder list;
     for (auto& trackSize : autoTrackSizes)
-        list->append(specifiedValueForGridTrackSize(trackSize, style));
-    return list;
+        list.append(specifiedValueForGridTrackSize(trackSize, style));
+    return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
 template <typename T, typename F>
-void populateGridTrackList(CSSValueList& list, OrderedNamedLinesCollector& collector, const Vector<T>& tracks, F getTrackSize, int offset = 0)
+void populateGridTrackList(CSSValueListBuilder& list, OrderedNamedLinesCollector& collector, const Vector<T>& tracks, F getTrackSize, int offset = 0)
 {
     int start = 0;
     int end = tracks.size();
@@ -1148,7 +1060,7 @@ void populateGridTrackList(CSSValueList& list, OrderedNamedLinesCollector& colle
         addValuesForNamedGridLinesAtIndex(collector, end + offset, list);
 }
 
-static void populateSubgridLineNameList(CSSValueList& list, OrderedNamedLinesCollector& collector)
+static void populateSubgridLineNameList(CSSValueListBuilder& list, OrderedNamedLinesCollector& collector)
 {
     for (int i = 0; i < collector.namedGridLineCount(); i++)
         addValuesForNamedGridLinesAtIndex(collector, i, list, true);
@@ -1176,7 +1088,7 @@ static Ref<CSSValue> valueForGridTrackList(GridTrackSizingDirection direction, R
     if (trackListIsEmpty && !isSubgrid)
         return isMasonry ? CSSPrimitiveValue::create(CSSValueMasonry) : CSSPrimitiveValue::create(CSSValueNone);
 
-    auto list = CSSValueList::createSpaceSeparated();
+    CSSValueListBuilder list;
 
     // If the element is a grid container, the resolved value is the used value,
     // specifying track sizes in pixels and expanding the repeat() notation.
@@ -1185,70 +1097,63 @@ static Ref<CSSValue> valueForGridTrackList(GridTrackSizingDirection direction, R
     if (isRenderGrid && (!isSubgrid || downcast<RenderGrid>(renderer)->isSubgrid(direction))) {
         auto* grid = downcast<RenderGrid>(renderer);
         if (isSubgrid) {
-            list->append(CSSPrimitiveValue::create(CSSValueSubgrid));
+            list.append(CSSPrimitiveValue::create(CSSValueSubgrid));
 
             OrderedNamedLinesCollectorInSubgridLayout collector(style, isRowAxis, grid->numTracks(direction));
-            populateSubgridLineNameList(list.get(), collector);
-            return list;
+            populateSubgridLineNameList(list, collector);
+            return CSSValueList::createSpaceSeparated(WTFMove(list));
         }
         OrderedNamedLinesCollectorInGridLayout collector(style, isRowAxis, grid->autoRepeatCountForDirection(direction), autoRepeatTrackSizes.size());
         // Named grid line indices are relative to the explicit grid, but we are including all tracks.
         // So we need to subtract the number of leading implicit tracks in order to get the proper line index.
         int offset = -grid->explicitGridStartForDirection(direction);
-        populateGridTrackList(list.get(), collector, grid->trackSizesForComputedStyle(direction), [&](const LayoutUnit& v) {
+        populateGridTrackList(list, collector, grid->trackSizesForComputedStyle(direction), [&](const LayoutUnit& v) {
             return zoomAdjustedPixelValue(v, style);
         }, offset);
-        return list;
+        return CSSValueList::createSpaceSeparated(WTFMove(list));
     }
 
     // Otherwise, the resolved value is the computed value, preserving repeat().
-    const GridTrackList& computedTracks = isRowAxis ? style.gridColumnList() : style.gridRowList();
+    auto& computedTracks = isRowAxis ? style.gridColumnList() : style.gridRowList();
 
-    auto repeatVisitor = [&](CSSValueContainingVector& vector, const RepeatEntry& entry) {
+    auto repeatVisitor = [&](CSSValueListBuilder& list, const RepeatEntry& entry) {
         if (std::holds_alternative<Vector<String>>(entry)) {
             const auto& names = std::get<Vector<String>>(entry);
             if (names.isEmpty() && !isSubgrid)
                 return;
-            auto lineNamesValue = CSSGridLineNamesValue::create();
-            for (const auto& name : names)
-                lineNamesValue->append(CSSPrimitiveValue::createCustomIdent(name));
-            vector.append(lineNamesValue);
+            list.append(CSSGridLineNamesValue::create(names));
         } else
-            vector.append(specifiedValueForGridTrackSize(std::get<GridTrackSize>(entry), style));
+            list.append(specifiedValueForGridTrackSize(std::get<GridTrackSize>(entry), style));
     };
 
     auto trackEntryVisitor = WTF::makeVisitor([&](const GridTrackSize& size) {
-        list->append(specifiedValueForGridTrackSize(size, style));
+        list.append(specifiedValueForGridTrackSize(size, style));
     }, [&](const Vector<String>& names) {
         // Subgrids don't have track sizes specified, so empty line names sets
         // need to be serialized, as they are meaningful placeholders.
         if (names.isEmpty() && !isSubgrid)
             return;
-
-        auto lineNamesValue = CSSGridLineNamesValue::create();
-        for (const auto& name : names)
-            lineNamesValue->append(CSSPrimitiveValue::createCustomIdent(name));
-        list->append(lineNamesValue);
+        list.append(CSSGridLineNamesValue::create(names));
     }, [&](const GridTrackEntryRepeat& repeat) {
-        auto repeatedValues = CSSGridIntegerRepeatValue::create(repeat.repeats);
-        for (const auto& entry : repeat.list)
+        CSSValueListBuilder repeatedValues;
+        for (auto& entry : repeat.list)
             repeatVisitor(repeatedValues, entry);
-        list->append(repeatedValues);
+        list.append(CSSGridIntegerRepeatValue::create(repeat.repeats, WTFMove(repeatedValues)));
     }, [&](const GridTrackEntryAutoRepeat& repeat) {
-        auto repeatedValues = CSSGridAutoRepeatValue::create(repeat.type == AutoRepeatType::Fill ? CSSValueAutoFill : CSSValueAutoFit);
-        for (const auto& entry : repeat.list)
+        CSSValueListBuilder repeatedValues;
+        for (auto& entry : repeat.list)
             repeatVisitor(repeatedValues, entry);
-        list->append(repeatedValues);
+        list.append(CSSGridAutoRepeatValue::create(repeat.type == AutoRepeatType::Fill ? CSSValueAutoFill : CSSValueAutoFit, WTFMove(repeatedValues)));
     }, [&](const GridTrackEntrySubgrid&) {
-        list->append(CSSPrimitiveValue::create(CSSValueSubgrid));
-    }, [&](const GridTrackEntryMasonry) {
-        list->append(CSSPrimitiveValue::create(CSSValueMasonry));
+        list.append(CSSPrimitiveValue::create(CSSValueSubgrid));
+    }, [&](const GridTrackEntryMasonry&) {
+        list.append(CSSPrimitiveValue::create(CSSValueMasonry));
     });
 
-    for (const auto& entry : computedTracks)
+    for (auto& entry : computedTracks)
         std::visit(trackEntryVisitor, entry);
 
-    return list;
+    return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
 static Ref<CSSValue> valueForGridPosition(const GridPosition& position)
@@ -1260,17 +1165,17 @@ static Ref<CSSValue> valueForGridPosition(const GridPosition& position)
         return CSSPrimitiveValue::createCustomIdent(position.namedGridLine());
 
     bool hasNamedGridLine = !position.namedGridLine().isNull();
-    auto list = CSSValueList::createSpaceSeparated();
+    CSSValueListBuilder list;
     if (position.isSpan()) {
-        list->append(CSSPrimitiveValue::create(CSSValueSpan));
+        list.append(CSSPrimitiveValue::create(CSSValueSpan));
         if (!hasNamedGridLine || position.spanPosition() != 1)
-            list->append(CSSPrimitiveValue::createInteger(position.spanPosition()));
+            list.append(CSSPrimitiveValue::createInteger(position.spanPosition()));
     } else
-        list->append(CSSPrimitiveValue::createInteger(position.integerPosition()));
+        list.append(CSSPrimitiveValue::createInteger(position.integerPosition()));
 
     if (hasNamedGridLine)
-        list->append(CSSPrimitiveValue::createCustomIdent(position.namedGridLine()));
-    return list;
+        list.append(CSSPrimitiveValue::createCustomIdent(position.namedGridLine()));
+    return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
 static Ref<CSSValue> createTransitionPropertyValue(const Animation& animation)
@@ -1292,32 +1197,26 @@ static Ref<CSSValue> createTransitionPropertyValue(const Animation& animation)
 
 static Ref<CSSValueList> valueForScrollSnapType(const ScrollSnapType& type)
 {
-    auto value = CSSValueList::createSpaceSeparated();
     if (type.strictness == ScrollSnapStrictness::None)
-        value->append(CSSPrimitiveValue::create(CSSValueNone));
-    else {
-        value->append(createConvertingToCSSValueID(type.axis));
-        if (type.strictness != ScrollSnapStrictness::Proximity)
-            value->append(createConvertingToCSSValueID(type.strictness));
-    }
-    return value;
+        return CSSValueList::createSpaceSeparated(CSSPrimitiveValue::create(CSSValueNone));
+    if (type.strictness == ScrollSnapStrictness::Proximity)
+        return CSSValueList::createSpaceSeparated(createConvertingToCSSValueID(type.axis));
+    return CSSValueList::createSpaceSeparated(createConvertingToCSSValueID(type.axis),
+        createConvertingToCSSValueID(type.strictness));
 }
 
 static Ref<CSSValueList> valueForScrollSnapAlignment(const ScrollSnapAlign& alignment)
 {
-    auto value = CSSValueList::createSpaceSeparated();
-    value->append(createConvertingToCSSValueID(alignment.blockAlign));
-    if (alignment.inlineAlign != alignment.blockAlign)
-        value->append(createConvertingToCSSValueID(alignment.inlineAlign));
-    return value;
+    if (alignment.inlineAlign == alignment.blockAlign)
+        return CSSValueList::createSpaceSeparated(createConvertingToCSSValueID(alignment.blockAlign));
+    return CSSValueList::createSpaceSeparated(createConvertingToCSSValueID(alignment.blockAlign),
+        createConvertingToCSSValueID(alignment.inlineAlign));
 }
 
 static Ref<CSSValueList> valueForTextEdge(const TextEdge& textEdge)
 {
-    auto value = CSSValueList::createSpaceSeparated();
-    value->append(createConvertingToCSSValueID(textEdge.over));
-    value->append(createConvertingToCSSValueID(textEdge.under));
-    return value;
+    return CSSValueList::createSpaceSeparated(createConvertingToCSSValueID(textEdge.over),
+        createConvertingToCSSValueID(textEdge.under));
 }
 
 static Ref<CSSValue> willChangePropertyValue(const WillChangeData* willChangeData)
@@ -1325,29 +1224,28 @@ static Ref<CSSValue> willChangePropertyValue(const WillChangeData* willChangeDat
     if (!willChangeData || !willChangeData->numFeatures())
         return CSSPrimitiveValue::create(CSSValueAuto);
 
-    auto list = CSSValueList::createCommaSeparated();
+    CSSValueListBuilder list;
     for (size_t i = 0; i < willChangeData->numFeatures(); ++i) {
         WillChangeData::FeaturePropertyPair feature = willChangeData->featureAt(i);
         switch (feature.first) {
         case WillChangeData::ScrollPosition:
-            list->append(CSSPrimitiveValue::create(CSSValueScrollPosition));
+            list.append(CSSPrimitiveValue::create(CSSValueScrollPosition));
             break;
         case WillChangeData::Contents:
-            list->append(CSSPrimitiveValue::create(CSSValueContents));
+            list.append(CSSPrimitiveValue::create(CSSValueContents));
             break;
         case WillChangeData::Property:
-            list->append(CSSPrimitiveValue::create(feature.second));
+            list.append(CSSPrimitiveValue::create(feature.second));
             break;
         case WillChangeData::Invalid:
             ASSERT_NOT_REACHED();
             break;
         }
     }
-
-    return list;
+    return CSSValueList::createCommaSeparated(WTFMove(list));
 }
 
-static inline void appendLigaturesValue(CSSValueList& list, FontVariantLigatures value, CSSValueID yesValue, CSSValueID noValue)
+static inline void appendLigaturesValue(CSSValueListBuilder& list, FontVariantLigatures value, CSSValueID yesValue, CSSValueID noValue)
 {
     switch (value) {
     case FontVariantLigatures::Normal:
@@ -1369,12 +1267,12 @@ static Ref<CSSValue> fontVariantLigaturesPropertyValue(FontVariantLigatures comm
     if (common == FontVariantLigatures::Normal && discretionary == FontVariantLigatures::Normal && historical == FontVariantLigatures::Normal && contextualAlternates == FontVariantLigatures::Normal)
         return CSSPrimitiveValue::create(CSSValueNormal);
 
-    auto valueList = CSSValueList::createSpaceSeparated();
+    CSSValueListBuilder valueList;
     appendLigaturesValue(valueList, common, CSSValueCommonLigatures, CSSValueNoCommonLigatures);
     appendLigaturesValue(valueList, discretionary, CSSValueDiscretionaryLigatures, CSSValueNoDiscretionaryLigatures);
     appendLigaturesValue(valueList, historical, CSSValueHistoricalLigatures, CSSValueNoHistoricalLigatures);
     appendLigaturesValue(valueList, contextualAlternates, CSSValueContextual, CSSValueNoContextual);
-    return valueList;
+    return CSSValueList::createSpaceSeparated(WTFMove(valueList));
 }
 
 static Ref<CSSValue> fontVariantPositionPropertyValue(FontVariantPosition position)
@@ -1426,15 +1324,15 @@ static Ref<CSSValue> fontVariantNumericPropertyValue(FontVariantNumericFigure fi
     if (figure == FontVariantNumericFigure::Normal && spacing == FontVariantNumericSpacing::Normal && fraction == FontVariantNumericFraction::Normal && ordinal == FontVariantNumericOrdinal::Normal && slashedZero == FontVariantNumericSlashedZero::Normal)
         return CSSPrimitiveValue::create(CSSValueNormal);
 
-    auto valueList = CSSValueList::createSpaceSeparated();
+    CSSValueListBuilder valueList;
     switch (figure) {
     case FontVariantNumericFigure::Normal:
         break;
     case FontVariantNumericFigure::LiningNumbers:
-        valueList->append(CSSPrimitiveValue::create(CSSValueLiningNums));
+        valueList.append(CSSPrimitiveValue::create(CSSValueLiningNums));
         break;
     case FontVariantNumericFigure::OldStyleNumbers:
-        valueList->append(CSSPrimitiveValue::create(CSSValueOldstyleNums));
+        valueList.append(CSSPrimitiveValue::create(CSSValueOldstyleNums));
         break;
     }
 
@@ -1442,10 +1340,10 @@ static Ref<CSSValue> fontVariantNumericPropertyValue(FontVariantNumericFigure fi
     case FontVariantNumericSpacing::Normal:
         break;
     case FontVariantNumericSpacing::ProportionalNumbers:
-        valueList->append(CSSPrimitiveValue::create(CSSValueProportionalNums));
+        valueList.append(CSSPrimitiveValue::create(CSSValueProportionalNums));
         break;
     case FontVariantNumericSpacing::TabularNumbers:
-        valueList->append(CSSPrimitiveValue::create(CSSValueTabularNums));
+        valueList.append(CSSPrimitiveValue::create(CSSValueTabularNums));
         break;
     }
 
@@ -1453,19 +1351,19 @@ static Ref<CSSValue> fontVariantNumericPropertyValue(FontVariantNumericFigure fi
     case FontVariantNumericFraction::Normal:
         break;
     case FontVariantNumericFraction::DiagonalFractions:
-        valueList->append(CSSPrimitiveValue::create(CSSValueDiagonalFractions));
+        valueList.append(CSSPrimitiveValue::create(CSSValueDiagonalFractions));
         break;
     case FontVariantNumericFraction::StackedFractions:
-        valueList->append(CSSPrimitiveValue::create(CSSValueStackedFractions));
+        valueList.append(CSSPrimitiveValue::create(CSSValueStackedFractions));
         break;
     }
 
     if (ordinal == FontVariantNumericOrdinal::Yes)
-        valueList->append(CSSPrimitiveValue::create(CSSValueOrdinal));
+        valueList.append(CSSPrimitiveValue::create(CSSValueOrdinal));
     if (slashedZero == FontVariantNumericSlashedZero::Yes)
-        valueList->append(CSSPrimitiveValue::create(CSSValueSlashedZero));
+        valueList.append(CSSPrimitiveValue::create(CSSValueSlashedZero));
 
-    return valueList;
+    return CSSValueList::createSpaceSeparated(WTFMove(valueList));
 }
 
 static FontVariantAlternatesValues historicalFormsValues()
@@ -1490,27 +1388,27 @@ static Ref<CSSValue> fontVariantEastAsianPropertyValue(FontVariantEastAsianVaria
     if (variant == FontVariantEastAsianVariant::Normal && width == FontVariantEastAsianWidth::Normal && ruby == FontVariantEastAsianRuby::Normal)
         return CSSPrimitiveValue::create(CSSValueNormal);
 
-    auto valueList = CSSValueList::createSpaceSeparated();
+    CSSValueListBuilder valueList;
     switch (variant) {
     case FontVariantEastAsianVariant::Normal:
         break;
     case FontVariantEastAsianVariant::Jis78:
-        valueList->append(CSSPrimitiveValue::create(CSSValueJis78));
+        valueList.append(CSSPrimitiveValue::create(CSSValueJis78));
         break;
     case FontVariantEastAsianVariant::Jis83:
-        valueList->append(CSSPrimitiveValue::create(CSSValueJis83));
+        valueList.append(CSSPrimitiveValue::create(CSSValueJis83));
         break;
     case FontVariantEastAsianVariant::Jis90:
-        valueList->append(CSSPrimitiveValue::create(CSSValueJis90));
+        valueList.append(CSSPrimitiveValue::create(CSSValueJis90));
         break;
     case FontVariantEastAsianVariant::Jis04:
-        valueList->append(CSSPrimitiveValue::create(CSSValueJis04));
+        valueList.append(CSSPrimitiveValue::create(CSSValueJis04));
         break;
     case FontVariantEastAsianVariant::Simplified:
-        valueList->append(CSSPrimitiveValue::create(CSSValueSimplified));
+        valueList.append(CSSPrimitiveValue::create(CSSValueSimplified));
         break;
     case FontVariantEastAsianVariant::Traditional:
-        valueList->append(CSSPrimitiveValue::create(CSSValueTraditional));
+        valueList.append(CSSPrimitiveValue::create(CSSValueTraditional));
         break;
     }
 
@@ -1518,17 +1416,17 @@ static Ref<CSSValue> fontVariantEastAsianPropertyValue(FontVariantEastAsianVaria
     case FontVariantEastAsianWidth::Normal:
         break;
     case FontVariantEastAsianWidth::Full:
-        valueList->append(CSSPrimitiveValue::create(CSSValueFullWidth));
+        valueList.append(CSSPrimitiveValue::create(CSSValueFullWidth));
         break;
     case FontVariantEastAsianWidth::Proportional:
-        valueList->append(CSSPrimitiveValue::create(CSSValueProportionalWidth));
+        valueList.append(CSSPrimitiveValue::create(CSSValueProportionalWidth));
         break;
     }
 
     if (ruby == FontVariantEastAsianRuby::Yes)
-        valueList->append(CSSPrimitiveValue::create(CSSValueRuby));
+        valueList.append(CSSPrimitiveValue::create(CSSValueRuby));
 
-    return valueList;
+    return CSSValueList::createSpaceSeparated(WTFMove(valueList));
 }
 
 static Ref<CSSPrimitiveValue> valueForAnimationDuration(double duration)
@@ -1650,7 +1548,7 @@ static Ref<CSSValue> valueForAnimationTimingFunction(const TimingFunction& timin
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-void ComputedStyleExtractor::addValueForAnimationPropertyToList(CSSValueList& list, CSSPropertyID property, const Animation* animation)
+void ComputedStyleExtractor::addValueForAnimationPropertyToList(CSSValueListBuilder& list, CSSPropertyID property, const Animation* animation)
 {
     if (property == CSSPropertyAnimationDuration || property == CSSPropertyTransitionDuration) {
         if (!animation || !animation->isDurationFilled())
@@ -1693,33 +1591,30 @@ void ComputedStyleExtractor::addValueForAnimationPropertyToList(CSSValueList& li
 
 static Ref<CSSValueList> valueListForAnimationOrTransitionProperty(CSSPropertyID property, const AnimationList* animationList)
 {
-    auto list = CSSValueList::createCommaSeparated();
+    CSSValueListBuilder list;
     if (animationList) {
-        for (const auto& animation : *animationList)
-            ComputedStyleExtractor::addValueForAnimationPropertyToList(list.get(), property, animation.ptr());
+        for (auto& animation : *animationList)
+            ComputedStyleExtractor::addValueForAnimationPropertyToList(list, property, animation.ptr());
     } else
-        ComputedStyleExtractor::addValueForAnimationPropertyToList(list.get(), property, nullptr);
-    return list;
+        ComputedStyleExtractor::addValueForAnimationPropertyToList(list, property, nullptr);
+    return CSSValueList::createCommaSeparated(WTFMove(list));
 }
 
 static Ref<CSSValueList> animationShorthandValue(CSSPropertyID property, const AnimationList* animationList)
 {
-    auto parentList = CSSValueList::createCommaSeparated();
-
+    CSSValueListBuilder parentList;
     auto addAnimation = [&](Ref<Animation> animation) {
-        auto childList = CSSValueList::createSpaceSeparated();
+        CSSValueListBuilder childList;
         for (auto longhand : shorthandForProperty(property))
-            ComputedStyleExtractor::addValueForAnimationPropertyToList(childList.get(), longhand, animation.ptr());
-        parentList->append(childList);
+            ComputedStyleExtractor::addValueForAnimationPropertyToList(childList, longhand, animation.ptr());
+        parentList.append(CSSValueList::createSpaceSeparated(WTFMove(childList)));
     };
-
     if (animationList && !animationList->isEmpty()) {
-        for (const auto& animation : *animationList)
+        for (auto& animation : *animationList)
             addAnimation(animation);
     } else
         addAnimation(Animation::create());
-
-    return parentList;
+    return CSSValueList::createCommaSeparated(WTFMove(parentList));
 }
 
 static Ref<CSSValue> createLineBoxContainValue(OptionSet<LineBoxContain> lineBoxContain)
@@ -1740,10 +1635,8 @@ static Element* styleElementForNode(Node* node)
 
 static Ref<CSSValue> valueForPosition(const RenderStyle& style, const LengthPoint& position)
 {
-    auto list = CSSValueList::createSpaceSeparated();
-    list->append(zoomAdjustedPixelValueForLength(position.x(), style));
-    list->append(zoomAdjustedPixelValueForLength(position.y(), style));
-    return list;
+    return CSSValueList::createSpaceSeparated(zoomAdjustedPixelValueForLength(position.x(), style),
+        zoomAdjustedPixelValueForLength(position.y(), style));
 }
 
 static bool isAuto(const LengthPoint& position)
@@ -1788,15 +1681,11 @@ static Ref<CSSValue> valueForPathOperation(const RenderStyle& style, const PathO
         return CSSPrimitiveValue::createURI(downcast<ReferencePathOperation>(*operation).url());
 
     case PathOperation::Shape: {
-        auto list = CSSValueList::createSpaceSeparated();
-
         auto& shapeOperation = downcast<ShapePathOperation>(*operation);
-        list->append(valueForBasicShape(style, shapeOperation.basicShape(), conversion));
-
-        if (shapeOperation.referenceBox() != CSSBoxType::BoxMissing)
-            list->append(createConvertingToCSSValueID(shapeOperation.referenceBox()));
-
-        return list;
+        if (shapeOperation.referenceBox() == CSSBoxType::BoxMissing)
+            return CSSValueList::createSpaceSeparated(valueForBasicShape(style, shapeOperation.basicShape(), conversion));
+        return CSSValueList::createSpaceSeparated(valueForBasicShape(style, shapeOperation.basicShape(), conversion),
+            createConvertingToCSSValueID(shapeOperation.referenceBox()));
     }
 
     case PathOperation::Box:
@@ -1821,18 +1710,11 @@ static Ref<CSSValue> valueForContainIntrinsicSize(const RenderStyle& style, cons
     switch (type) {
     case ContainIntrinsicSizeType::None:
         return CSSPrimitiveValue::create(CSSValueNone);
-    case ContainIntrinsicSizeType::Length: {
-        ASSERT(containIntrinsicLength.has_value());
+    case ContainIntrinsicSizeType::Length:
         return zoomAdjustedPixelValueForLength(containIntrinsicLength.value(), style);
-    }
-    case ContainIntrinsicSizeType::AutoAndLength: {
-        auto autoValue = CSSPrimitiveValue::create(CSSValueAuto);
-        auto list = CSSValueList::createSpaceSeparated();
-        list->append(autoValue);
-        ASSERT(containIntrinsicLength.has_value());
-        list->append(zoomAdjustedPixelValueForLength(containIntrinsicLength.value(), style));
-        return list;
-    }
+    case ContainIntrinsicSizeType::AutoAndLength:
+        return CSSValueList::createSpaceSeparated(CSSPrimitiveValue::create(CSSValueAuto),
+            zoomAdjustedPixelValueForLength(containIntrinsicLength.value(), style));
     }
     RELEASE_ASSERT_NOT_REACHED();
     return CSSPrimitiveValue::create(CSSValueNone);
@@ -1923,33 +1805,31 @@ static Ref<CSSValue> touchActionFlagsToCSSValue(OptionSet<TouchAction> touchActi
     if (touchActions & TouchAction::Manipulation)
         return CSSPrimitiveValue::create(CSSValueManipulation);
 
-    auto list = CSSValueList::createSpaceSeparated();
+    CSSValueListBuilder list;
     if (touchActions & TouchAction::PanX)
-        list->append(CSSPrimitiveValue::create(CSSValuePanX));
+        list.append(CSSPrimitiveValue::create(CSSValuePanX));
     if (touchActions & TouchAction::PanY)
-        list->append(CSSPrimitiveValue::create(CSSValuePanY));
+        list.append(CSSPrimitiveValue::create(CSSValuePanY));
     if (touchActions & TouchAction::PinchZoom)
-        list->append(CSSPrimitiveValue::create(CSSValuePinchZoom));
-
-    if (!list->length())
+        list.append(CSSPrimitiveValue::create(CSSValuePinchZoom));
+    if (list.isEmpty())
         return CSSPrimitiveValue::create(CSSValueAuto);
-    return list;
+    return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
 static Ref<CSSValue> renderTextDecorationLineFlagsToCSSValue(OptionSet<TextDecorationLine> textDecorationLine)
 {
     // Blink value is ignored.
-    auto list = CSSValueList::createSpaceSeparated();
+    CSSValueListBuilder list;
     if (textDecorationLine & TextDecorationLine::Underline)
-        list->append(CSSPrimitiveValue::create(CSSValueUnderline));
+        list.append(CSSPrimitiveValue::create(CSSValueUnderline));
     if (textDecorationLine & TextDecorationLine::Overline)
-        list->append(CSSPrimitiveValue::create(CSSValueOverline));
+        list.append(CSSPrimitiveValue::create(CSSValueOverline));
     if (textDecorationLine & TextDecorationLine::LineThrough)
-        list->append(CSSPrimitiveValue::create(CSSValueLineThrough));
-
-    if (!list->length())
+        list.append(CSSPrimitiveValue::create(CSSValueLineThrough));
+    if (list.isEmpty())
         return CSSPrimitiveValue::create(CSSValueNone);
-    return list;
+    return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
 static Ref<CSSValue> renderTextDecorationStyleFlagsToCSSValue(TextDecorationStyle textDecorationStyle)
@@ -2010,14 +1890,14 @@ static Ref<CSSValue> renderEmphasisPositionFlagsToCSSValue(OptionSet<TextEmphasi
     ASSERT(!((textEmphasisPosition & TextEmphasisPosition::Left) && (textEmphasisPosition & TextEmphasisPosition::Right)));
     ASSERT((textEmphasisPosition & TextEmphasisPosition::Over) || (textEmphasisPosition & TextEmphasisPosition::Under));
 
-    auto list = CSSValueList::createSpaceSeparated();
+    CSSValueListBuilder list;
     if (textEmphasisPosition & TextEmphasisPosition::Over)
-        list->append(CSSPrimitiveValue::create(CSSValueOver));
+        list.append(CSSPrimitiveValue::create(CSSValueOver));
     if (textEmphasisPosition & TextEmphasisPosition::Under)
-        list->append(CSSPrimitiveValue::create(CSSValueUnder));
+        list.append(CSSPrimitiveValue::create(CSSValueUnder));
     if (textEmphasisPosition & TextEmphasisPosition::Left)
-        list->append(CSSPrimitiveValue::create(CSSValueLeft));
-    return list;
+        list.append(CSSPrimitiveValue::create(CSSValueLeft));
+    return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
 static Ref<CSSValue> valueForTextEmphasisStyle(const RenderStyle& style)
@@ -2037,45 +1917,44 @@ static Ref<CSSValue> valueForTextEmphasisStyle(const RenderStyle& style)
     case TextEmphasisMark::DoubleCircle:
     case TextEmphasisMark::Triangle:
     case TextEmphasisMark::Sesame:
-        auto list = CSSValueList::createSpaceSeparated();
-        if (style.textEmphasisFill() != TextEmphasisFill::Filled)
-            list->append(createConvertingToCSSValueID(style.textEmphasisFill()));
-        list->append(createConvertingToCSSValueID(style.textEmphasisMark()));
-        return list;
+        if (style.textEmphasisFill() == TextEmphasisFill::Filled)
+            return CSSValueList::createSpaceSeparated(createConvertingToCSSValueID(style.textEmphasisMark()));
+        return CSSValueList::createSpaceSeparated(createConvertingToCSSValueID(style.textEmphasisFill()),
+            createConvertingToCSSValueID(style.textEmphasisMark()));
     }
     RELEASE_ASSERT_NOT_REACHED();
 }
 
 static Ref<CSSValue> speakAsToCSSValue(OptionSet<SpeakAs> speakAs)
 {
-    auto list = CSSValueList::createSpaceSeparated();
+    CSSValueListBuilder list;
     if (speakAs & SpeakAs::SpellOut)
-        list->append(CSSPrimitiveValue::create(CSSValueSpellOut));
+        list.append(CSSPrimitiveValue::create(CSSValueSpellOut));
     if (speakAs & SpeakAs::Digits)
-        list->append(CSSPrimitiveValue::create(CSSValueDigits));
+        list.append(CSSPrimitiveValue::create(CSSValueDigits));
     if (speakAs & SpeakAs::LiteralPunctuation)
-        list->append(CSSPrimitiveValue::create(CSSValueLiteralPunctuation));
+        list.append(CSSPrimitiveValue::create(CSSValueLiteralPunctuation));
     if (speakAs & SpeakAs::NoPunctuation)
-        list->append(CSSPrimitiveValue::create(CSSValueNoPunctuation));
-    if (!list->length())
+        list.append(CSSPrimitiveValue::create(CSSValueNoPunctuation));
+    if (list.isEmpty())
         return CSSPrimitiveValue::create(CSSValueNormal);
-    return list;
+    return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
 static Ref<CSSValue> hangingPunctuationToCSSValue(OptionSet<HangingPunctuation> hangingPunctuation)
 {
-    auto list = CSSValueList::createSpaceSeparated();
+    CSSValueListBuilder list;
     if (hangingPunctuation & HangingPunctuation::First)
-        list->append(CSSPrimitiveValue::create(CSSValueFirst));
+        list.append(CSSPrimitiveValue::create(CSSValueFirst));
     if (hangingPunctuation & HangingPunctuation::AllowEnd)
-        list->append(CSSPrimitiveValue::create(CSSValueAllowEnd));
+        list.append(CSSPrimitiveValue::create(CSSValueAllowEnd));
     if (hangingPunctuation & HangingPunctuation::ForceEnd)
-        list->append(CSSPrimitiveValue::create(CSSValueForceEnd));
+        list.append(CSSPrimitiveValue::create(CSSValueForceEnd));
     if (hangingPunctuation & HangingPunctuation::Last)
-        list->append(CSSPrimitiveValue::create(CSSValueLast));
-    if (!list->length())
+        list.append(CSSPrimitiveValue::create(CSSValueLast));
+    if (list.isEmpty())
         return CSSPrimitiveValue::create(CSSValueNone);
-    return list;
+    return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
 static Ref<CSSValue> fillRepeatToCSSValue(FillRepeatXY repeat)
@@ -2091,10 +1970,8 @@ static Ref<CSSValue> fillRepeatToCSSValue(FillRepeatXY repeat)
     if (repeat.x == FillRepeat::NoRepeat && repeat.y == FillRepeat::Repeat)
         return CSSPrimitiveValue::create(CSSValueRepeatY);
 
-    auto list = CSSValueList::createSpaceSeparated();
-    list->append(createConvertingToCSSValueID(repeat.x));
-    list->append(createConvertingToCSSValueID(repeat.y));
-    return list;
+    return CSSValueList::createSpaceSeparated(createConvertingToCSSValueID(repeat.x),
+        createConvertingToCSSValueID(repeat.y));
 }
 
 static Ref<CSSValue> maskSourceTypeToCSSValue(MaskMode type)
@@ -2138,10 +2015,8 @@ static Ref<CSSValue> fillSizeToCSSValue(CSSPropertyID propertyID, const FillSize
     if (fillSize.size.height.isAuto() && (propertyID == CSSPropertyMaskSize || fillSize.size.width.isAuto()))
         return zoomAdjustedPixelValueForLength(fillSize.size.width, style);
 
-    auto list = CSSValueList::createSpaceSeparated();
-    list->append(zoomAdjustedPixelValueForLength(fillSize.size.width, style));
-    list->append(zoomAdjustedPixelValueForLength(fillSize.size.height, style));
-    return list;
+    return CSSValueList::createSpaceSeparated(zoomAdjustedPixelValueForLength(fillSize.size.width, style),
+        zoomAdjustedPixelValueForLength(fillSize.size.height, style));
 }
 
 static Ref<CSSValue> altTextToCSSValue(const RenderStyle& style)
@@ -2151,18 +2026,18 @@ static Ref<CSSValue> altTextToCSSValue(const RenderStyle& style)
 
 static Ref<CSSValueList> contentToCSSValue(const RenderStyle& style)
 {
-    auto list = CSSValueList::createSpaceSeparated();
+    CSSValueListBuilder list;
     for (auto* contentData = style.contentData(); contentData; contentData = contentData->next()) {
         if (is<CounterContentData>(*contentData))
-            list->append(CSSPrimitiveValue::createCounterName(downcast<CounterContentData>(*contentData).counter().identifier()));
+            list.append(CSSPrimitiveValue::createCounterName(downcast<CounterContentData>(*contentData).counter().identifier()));
         else if (is<ImageContentData>(*contentData))
-            list->append(downcast<ImageContentData>(*contentData).image().computedStyleValue(style));
+            list.append(downcast<ImageContentData>(*contentData).image().computedStyleValue(style));
         else if (is<TextContentData>(*contentData))
-            list->append(CSSPrimitiveValue::create(downcast<TextContentData>(*contentData).text()));
+            list.append(CSSPrimitiveValue::create(downcast<TextContentData>(*contentData).text()));
     }
-    if (!list->length())
-        list->append(CSSPrimitiveValue::create(style.hasEffectiveContentNone() ? CSSValueNone : CSSValueNormal));
-    return list;
+    if (list.isEmpty())
+        list.append(CSSPrimitiveValue::create(style.hasEffectiveContentNone() ? CSSValueNone : CSSValueNormal));
+    return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
 static Ref<CSSValue> counterToCSSValue(const RenderStyle& style, CSSPropertyID propertyID)
@@ -2171,26 +2046,24 @@ static Ref<CSSValue> counterToCSSValue(const RenderStyle& style, CSSPropertyID p
     if (!map)
         return CSSPrimitiveValue::create(CSSValueNone);
 
-    auto list = CSSValueList::createSpaceSeparated();
+    CSSValueListBuilder list;
     for (auto& keyValue : *map) {
         if (auto number = (propertyID == CSSPropertyCounterIncrement ? keyValue.value.incrementValue : keyValue.value.resetValue)) {
-            list->append(CSSPrimitiveValue::createCustomIdent(keyValue.key));
-            list->append(CSSPrimitiveValue::createInteger(*number));
+            list.append(CSSPrimitiveValue::createCustomIdent(keyValue.key));
+            list.append(CSSPrimitiveValue::createInteger(*number));
         }
     }
-
-    if (list->length())
-        return list;
-
+    if (!list.isEmpty())
+        return CSSValueList::createSpaceSeparated(WTFMove(list));
     return CSSPrimitiveValue::create(CSSValueNone);
 }
 
 static Ref<CSSValueList> fontFamilyList(const RenderStyle& style)
 {
-    auto list = CSSValueList::createCommaSeparated();
+    CSSValueListBuilder list;
     for (unsigned i = 0; i < style.fontCascade().familyCount(); ++i)
-        list->append(valueForFamily(style.fontCascade().familyAt(i)));
-    return list;
+        list.append(valueForFamily(style.fontCascade().familyAt(i)));
+    return CSSValueList::createCommaSeparated(WTFMove(list));
 }
 
 static Ref<CSSValue> fontFamily(const RenderStyle& style)
@@ -2284,30 +2157,30 @@ static Ref<CSSValue> fontStyle(const RenderStyle& style)
 
 Ref<CSSValue> ComputedStyleExtractor::fontVariantShorthandValue()
 {
-    auto list = CSSValueList::createSpaceSeparated();
+    CSSValueListBuilder list;
     for (auto longhand : fontVariantShorthand()) {
         auto value = propertyValue(longhand, UpdateLayout::No);
         if (isValueID(value, CSSValueNormal))
             continue;
-        list->append(value.releaseNonNull());
+        list.append(value.releaseNonNull());
     }
-    if (!list->length())
+    if (list.isEmpty())
         return CSSPrimitiveValue::create(CSSValueNormal);
-    return list;
+    return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
 static Ref<CSSValue> fontSynthesis(const RenderStyle& style)
 {
-    auto list = CSSValueList::createSpaceSeparated();
+    CSSValueListBuilder list;
     if (style.fontDescription().hasAutoFontSynthesisWeight())
-        list->append(CSSPrimitiveValue::create(CSSValueWeight));
+        list.append(CSSPrimitiveValue::create(CSSValueWeight));
     if (style.fontDescription().hasAutoFontSynthesisStyle())
-        list->append(CSSPrimitiveValue::create(CSSValueStyle));
+        list.append(CSSPrimitiveValue::create(CSSValueStyle));
     if (style.fontDescription().hasAutoFontSynthesisSmallCaps())
-        list->append(CSSPrimitiveValue::create(CSSValueSmallCaps));
-    if (!list->length())
+        list.append(CSSPrimitiveValue::create(CSSValueSmallCaps));
+    if (list.isEmpty())
         return CSSPrimitiveValue::create(CSSValueNone);
-    return list;
+    return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
 static Ref<CSSValue> fontSynthesisLonghandToCSSValue(FontSynthesisLonghandValue value)
@@ -2562,74 +2435,70 @@ static Ref<CSSValue> shapePropertyValue(const RenderStyle& style, const ShapeVal
 
     ASSERT(shapeValue->type() == ShapeValue::Type::Shape);
 
-    auto list = CSSValueList::createSpaceSeparated();
-    list->append(valueForBasicShape(style, *shapeValue->shape()));
-    if (shapeValue->cssBox() != CSSBoxType::BoxMissing)
-        list->append(createConvertingToCSSValueID(shapeValue->cssBox()));
-    return list;
+    if (shapeValue->cssBox() == CSSBoxType::BoxMissing)
+        return CSSValueList::createSpaceSeparated(valueForBasicShape(style, *shapeValue->shape()));
+    return CSSValueList::createSpaceSeparated(valueForBasicShape(style, *shapeValue->shape()),
+        createConvertingToCSSValueID(shapeValue->cssBox()));
 }
 
 static Ref<CSSValueList> valueForItemPositionWithOverflowAlignment(const StyleSelfAlignmentData& data)
 {
-    auto result = CSSValueList::createSpaceSeparated();
+    CSSValueListBuilder list;
     if (data.positionType() == ItemPositionType::Legacy)
-        result->append(CSSPrimitiveValue::create(CSSValueLegacy));
+        list.append(CSSPrimitiveValue::create(CSSValueLegacy));
     if (data.position() == ItemPosition::Baseline)
-        result->append(CSSPrimitiveValue::create(CSSValueBaseline));
+        list.append(CSSPrimitiveValue::create(CSSValueBaseline));
     else if (data.position() == ItemPosition::LastBaseline) {
-        result->append(CSSPrimitiveValue::create(CSSValueLast));
-        result->append(CSSPrimitiveValue::create(CSSValueBaseline));
+        list.append(CSSPrimitiveValue::create(CSSValueLast));
+        list.append(CSSPrimitiveValue::create(CSSValueBaseline));
     } else {
         if (data.position() >= ItemPosition::Center && data.overflow() != OverflowAlignment::Default)
-            result->append(createConvertingToCSSValueID(data.overflow()));
+            list.append(createConvertingToCSSValueID(data.overflow()));
         if (data.position() == ItemPosition::Legacy)
-            result->append(CSSPrimitiveValue::create(CSSValueNormal));
+            list.append(CSSPrimitiveValue::create(CSSValueNormal));
         else
-            result->append(createConvertingToCSSValueID(data.position()));
+            list.append(createConvertingToCSSValueID(data.position()));
     }
-    ASSERT(result->length() <= 2);
-    return result;
+    return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
 static Ref<CSSValueList> valueForContentPositionAndDistributionWithOverflowAlignment(const StyleContentAlignmentData& data)
 {
-    auto result = CSSValueList::createSpaceSeparated();
+    CSSValueListBuilder list;
+
     // Handle content-distribution values
     if (data.distribution() != ContentDistribution::Default)
-        result->append(createConvertingToCSSValueID(data.distribution()));
+        list.append(createConvertingToCSSValueID(data.distribution()));
 
     // Handle content-position values (either as fallback or actual value)
     switch (data.position()) {
     case ContentPosition::Normal:
         // Handle 'normal' value, not valid as content-distribution fallback.
         if (data.distribution() == ContentDistribution::Default)
-            result->append(CSSPrimitiveValue::create(CSSValueNormal));
+            list.append(CSSPrimitiveValue::create(CSSValueNormal));
         break;
     case ContentPosition::LastBaseline:
-        result->append(CSSPrimitiveValue::create(CSSValueLast));
-        result->append(CSSPrimitiveValue::create(CSSValueBaseline));
+        list.append(CSSPrimitiveValue::create(CSSValueLast));
+        list.append(CSSPrimitiveValue::create(CSSValueBaseline));
         break;
     default:
         // Handle overflow-alignment (only allowed for content-position values)
         if ((data.position() >= ContentPosition::Center || data.distribution() != ContentDistribution::Default) && data.overflow() != OverflowAlignment::Default)
-            result->append(createConvertingToCSSValueID(data.overflow()));
-        result->append(createConvertingToCSSValueID(data.position()));
+            list.append(createConvertingToCSSValueID(data.overflow()));
+        list.append(createConvertingToCSSValueID(data.position()));
     }
 
-    ASSERT(result->length() > 0);
-    ASSERT(result->length() <= 3);
-    return result;
+    ASSERT(list.size() > 0);
+    ASSERT(list.size() <= 3);
+    return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
 static Ref<CSSValueList> valueForOffsetRotate(const OffsetRotation& rotation)
 {
-    auto result = CSSValueList::createSpaceSeparated();
-
+    auto angle = CSSPrimitiveValue::create(rotation.angle(), CSSUnitType::CSS_DEG);
     if (rotation.hasAuto())
-        result->append(CSSPrimitiveValue::create(CSSValueAuto));
-    result->append(CSSPrimitiveValue::create(rotation.angle(), CSSUnitType::CSS_DEG));
-
-    return result;
+        return CSSValueList::createSpaceSeparated(CSSPrimitiveValue::create(CSSValueAuto), WTFMove(angle));
+    return CSSValueList::createSpaceSeparated(WTFMove(angle));
 }
 
 static Ref<CSSValue> valueForOffsetShorthand(const RenderStyle& style)
@@ -2639,33 +2508,30 @@ static Ref<CSSValue> valueForOffsetShorthand(const RenderStyle& style)
     // The first four elements are serialized in a space separated CSSValueList.
     // This is then combined with offset-anchor in a slash separated CSSValueList.
 
-    auto innerList = CSSValueList::createSpaceSeparated();
+    CSSValueListBuilder innerList;
 
     if (!isAuto(style.offsetPosition()))
-        innerList->append(valueForPositionOrAuto(style, style.offsetPosition()));
+        innerList.append(valueForPositionOrAuto(style, style.offsetPosition()));
 
     bool nonInitialDistance = !style.offsetDistance().isZero();
     bool nonInitialRotate = style.offsetRotate() != style.initialOffsetRotate();
 
     if (style.offsetPath() || nonInitialDistance || nonInitialRotate)
-        innerList->append(valueForPathOperation(style, style.offsetPath(), SVGPathConversion::ForceAbsolute));
+        innerList.append(valueForPathOperation(style, style.offsetPath(), SVGPathConversion::ForceAbsolute));
 
     if (nonInitialDistance)
-        innerList->append(CSSPrimitiveValue::create(style.offsetDistance(), style));
+        innerList.append(CSSPrimitiveValue::create(style.offsetDistance(), style));
     if (nonInitialRotate)
-        innerList->append(valueForOffsetRotate(style.offsetRotate()));
+        innerList.append(valueForOffsetRotate(style.offsetRotate()));
 
-    auto inner = innerList->length()
-        ? Ref<CSSValue> { WTFMove(innerList) }
-        : Ref<CSSValue> { CSSPrimitiveValue::create(CSSValueAuto) };
+    auto inner = innerList.isEmpty()
+        ? Ref<CSSValue> { CSSPrimitiveValue::create(CSSValueAuto) }
+        : Ref<CSSValue> { CSSValueList::createSpaceSeparated(WTFMove(innerList)) };
 
     if (isAuto(style.offsetAnchor()))
         return inner;
 
-    auto outerList = CSSValueList::createSlashSeparated();
-    outerList->append(WTFMove(inner));
-    outerList->append(valueForPosition(style, style.offsetAnchor()));
-    return outerList;
+    return CSSValueList::createSlashSeparated(WTFMove(inner), valueForPosition(style, style.offsetAnchor()));
 }
 
 static Ref<CSSValue> paintOrder(PaintOrder paintOrder)
@@ -2673,34 +2539,34 @@ static Ref<CSSValue> paintOrder(PaintOrder paintOrder)
     if (paintOrder == PaintOrder::Normal)
         return CSSPrimitiveValue::create(CSSValueNormal);
 
-    auto paintOrderList = CSSValueList::createSpaceSeparated();
+    CSSValueListBuilder paintOrderList;
     switch (paintOrder) {
     case PaintOrder::Normal:
         ASSERT_NOT_REACHED();
         break;
     case PaintOrder::Fill:
-        paintOrderList->append(CSSPrimitiveValue::create(CSSValueFill));
+        paintOrderList.append(CSSPrimitiveValue::create(CSSValueFill));
         break;
     case PaintOrder::FillMarkers:
-        paintOrderList->append(CSSPrimitiveValue::create(CSSValueFill));
-        paintOrderList->append(CSSPrimitiveValue::create(CSSValueMarkers));
+        paintOrderList.append(CSSPrimitiveValue::create(CSSValueFill));
+        paintOrderList.append(CSSPrimitiveValue::create(CSSValueMarkers));
         break;
     case PaintOrder::Stroke:
-        paintOrderList->append(CSSPrimitiveValue::create(CSSValueStroke));
+        paintOrderList.append(CSSPrimitiveValue::create(CSSValueStroke));
         break;
     case PaintOrder::StrokeMarkers:
-        paintOrderList->append(CSSPrimitiveValue::create(CSSValueStroke));
-        paintOrderList->append(CSSPrimitiveValue::create(CSSValueMarkers));
+        paintOrderList.append(CSSPrimitiveValue::create(CSSValueStroke));
+        paintOrderList.append(CSSPrimitiveValue::create(CSSValueMarkers));
         break;
     case PaintOrder::Markers:
-        paintOrderList->append(CSSPrimitiveValue::create(CSSValueMarkers));
+        paintOrderList.append(CSSPrimitiveValue::create(CSSValueMarkers));
         break;
     case PaintOrder::MarkersStroke:
-        paintOrderList->append(CSSPrimitiveValue::create(CSSValueMarkers));
-        paintOrderList->append(CSSPrimitiveValue::create(CSSValueStroke));
+        paintOrderList.append(CSSPrimitiveValue::create(CSSValueMarkers));
+        paintOrderList.append(CSSPrimitiveValue::create(CSSValueStroke));
         break;
     }
-    return paintOrderList;
+    return CSSValueList::createSpaceSeparated(WTFMove(paintOrderList));
 }
 
 static inline bool isFlexOrGridItem(RenderObject* renderer)
@@ -2851,13 +2717,10 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
     }
     case CSSPropertyAlignTracks:
     case CSSPropertyJustifyTracks: {
-        auto list = CSSValueList::createCommaSeparated();
-        auto alignments = (propertyID == CSSPropertyAlignTracks) ? style.alignTracks() : style.justifyTracks();
-
-        for (auto alignment : alignments)
-            list->append(valueForContentPositionAndDistributionWithOverflowAlignment(alignment));
-
-        return list;
+        CSSValueListBuilder list;
+        for (auto alignment : (propertyID == CSSPropertyAlignTracks) ? style.alignTracks() : style.justifyTracks())
+            list.append(valueForContentPositionAndDistributionWithOverflowAlignment(alignment));
+        return CSSValueList::createCommaSeparated(WTFMove(list));
     }
     case CSSPropertyBackgroundColor:
         return m_allowVisitedStyle ? cssValuePool.createColorValue(style.visitedDependentColor(CSSPropertyBackgroundColor)) : currentColorOrValidColor(style, style.backgroundColor());
@@ -2869,14 +2732,14 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
                 return layers.image()->computedStyleValue(style);
             return CSSPrimitiveValue::create(CSSValueNone);
         }
-        auto list = CSSValueList::createCommaSeparated();
+        CSSValueListBuilder list;
         for (auto* currLayer = &layers; currLayer; currLayer = currLayer->next()) {
             if (currLayer->image())
-                list->append(currLayer->image()->computedStyleValue(style));
+                list.append(currLayer->image()->computedStyleValue(style));
             else
-                list->append(CSSPrimitiveValue::create(CSSValueNone));
+                list.append(CSSPrimitiveValue::create(CSSValueNone));
         }
-        return list;
+        return CSSValueList::createCommaSeparated(WTFMove(list));
     }
     case CSSPropertyBackgroundSize:
     case CSSPropertyWebkitBackgroundSize:
@@ -2884,57 +2747,57 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
         auto& layers = propertyID == CSSPropertyMaskSize ? style.maskLayers() : style.backgroundLayers();
         if (!layers.next())
             return fillSizeToCSSValue(propertyID, layers.size(), style);
-        auto list = CSSValueList::createCommaSeparated();
+        CSSValueListBuilder list;
         for (auto* currLayer = &layers; currLayer; currLayer = currLayer->next())
-            list->append(fillSizeToCSSValue(propertyID, currLayer->size(), style));
-        return list;
+            list.append(fillSizeToCSSValue(propertyID, currLayer->size(), style));
+        return CSSValueList::createCommaSeparated(WTFMove(list));
     }
     case CSSPropertyBackgroundRepeat:
     case CSSPropertyMaskRepeat: {
         auto& layers = propertyID == CSSPropertyMaskRepeat ? style.maskLayers() : style.backgroundLayers();
         if (!layers.next())
             return fillRepeatToCSSValue(layers.repeat());
-        auto list = CSSValueList::createCommaSeparated();
+        CSSValueListBuilder list;
         for (auto* currLayer = &layers; currLayer; currLayer = currLayer->next())
-            list->append(fillRepeatToCSSValue(currLayer->repeat()));
-        return list;
+            list.append(fillRepeatToCSSValue(currLayer->repeat()));
+        return CSSValueList::createCommaSeparated(WTFMove(list));
     }
     case CSSPropertyWebkitMaskSourceType: {
         auto& layers = style.maskLayers();
         if (!layers.next())
             return maskSourceTypeToCSSValue(layers.maskMode());
-        auto list = CSSValueList::createCommaSeparated();
+        CSSValueListBuilder list;
         for (auto* currLayer = &layers; currLayer; currLayer = currLayer->next())
-            list->append(maskSourceTypeToCSSValue(currLayer->maskMode()));
-        return list;
+            list.append(maskSourceTypeToCSSValue(currLayer->maskMode()));
+        return CSSValueList::createCommaSeparated(WTFMove(list));
     }
     case CSSPropertyMaskMode: {
         auto& layers = style.maskLayers();
         if (!layers.next())
             return maskModeToCSSValue(layers.maskMode());
-        auto list = CSSValueList::createCommaSeparated();
+        CSSValueListBuilder list;
         for (auto* currLayer = &layers; currLayer; currLayer = currLayer->next())
-            list->append(maskModeToCSSValue(currLayer->maskMode()));
-        return list;
+            list.append(maskModeToCSSValue(currLayer->maskMode()));
+        return CSSValueList::createCommaSeparated(WTFMove(list));
     }
     case CSSPropertyWebkitMaskComposite:
     case CSSPropertyMaskComposite: {
         auto& layers = style.maskLayers();
         if (!layers.next())
             return CSSPrimitiveValue::create(toCSSValueID(layers.composite(), propertyID));
-        auto list = CSSValueList::createCommaSeparated();
+        CSSValueListBuilder list;
         for (auto* currLayer = &layers; currLayer; currLayer = currLayer->next())
-            list->append(CSSPrimitiveValue::create(toCSSValueID(currLayer->composite(), propertyID)));
-        return list;
+            list.append(CSSPrimitiveValue::create(toCSSValueID(currLayer->composite(), propertyID)));
+        return CSSValueList::createCommaSeparated(WTFMove(list));
     }
     case CSSPropertyBackgroundAttachment: {
         auto& layers = style.backgroundLayers();
         if (!layers.next())
             return createConvertingToCSSValueID(layers.attachment());
-        auto list = CSSValueList::createCommaSeparated();
+        CSSValueListBuilder list;
         for (auto* currLayer = &layers; currLayer; currLayer = currLayer->next())
-            list->append(createConvertingToCSSValueID(currLayer->attachment()));
-        return list;
+            list.append(createConvertingToCSSValueID(currLayer->attachment()));
+        return CSSValueList::createCommaSeparated(WTFMove(list));
     }
     case CSSPropertyBackgroundClip:
     case CSSPropertyBackgroundOrigin:
@@ -2947,10 +2810,10 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
         bool isClip = propertyID == CSSPropertyBackgroundClip || propertyID == CSSPropertyWebkitBackgroundClip || propertyID == CSSPropertyMaskClip || propertyID == CSSPropertyWebkitMaskClip;
         if (!layers.next())
             return createConvertingToCSSValueID(isClip ? layers.clip() : layers.origin());
-        auto list = CSSValueList::createCommaSeparated();
+        CSSValueListBuilder list;
         for (auto* currLayer = &layers; currLayer; currLayer = currLayer->next())
-            list->append(createConvertingToCSSValueID(isClip ? currLayer->clip() : currLayer->origin()));
-        return list;
+            list.append(createConvertingToCSSValueID(isClip ? currLayer->clip() : currLayer->origin()));
+        return CSSValueList::createCommaSeparated(WTFMove(list));
     }
     case CSSPropertyBackgroundPosition:
     case CSSPropertyWebkitMaskPosition:
@@ -2958,46 +2821,38 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
         auto& layers = propertyID == CSSPropertyBackgroundPosition ? style.backgroundLayers() : style.maskLayers();
         if (!layers.next())
             return createPositionListForLayer(propertyID, layers, style);
-
-        auto list = CSSValueList::createCommaSeparated();
+        CSSValueListBuilder list;
         for (auto* currLayer = &layers; currLayer; currLayer = currLayer->next())
-            list->append(createPositionListForLayer(propertyID, *currLayer, style));
-        return list;
+            list.append(createPositionListForLayer(propertyID, *currLayer, style));
+        return CSSValueList::createCommaSeparated(WTFMove(list));
     }
     case CSSPropertyBackgroundPositionX:
     case CSSPropertyWebkitMaskPositionX: {
         auto& layers = propertyID == CSSPropertyWebkitMaskPositionX ? style.maskLayers() : style.backgroundLayers();
         if (!layers.next())
             return createSingleAxisPositionValueForLayer(propertyID, layers, style);
-
-        auto list = CSSValueList::createCommaSeparated();
+        CSSValueListBuilder list;
         for (auto* currLayer = &layers; currLayer; currLayer = currLayer->next())
-            list->append(createSingleAxisPositionValueForLayer(propertyID, *currLayer, style));
-
-        return list;
+            list.append(createSingleAxisPositionValueForLayer(propertyID, *currLayer, style));
+        return CSSValueList::createCommaSeparated(WTFMove(list));
     }
     case CSSPropertyBackgroundPositionY:
     case CSSPropertyWebkitMaskPositionY: {
         auto& layers = propertyID == CSSPropertyWebkitMaskPositionY ? style.maskLayers() : style.backgroundLayers();
         if (!layers.next())
             return createSingleAxisPositionValueForLayer(propertyID, layers, style);
-
-        auto list = CSSValueList::createCommaSeparated();
+        CSSValueListBuilder list;
         for (auto* currLayer = &layers; currLayer; currLayer = currLayer->next())
-            list->append(createSingleAxisPositionValueForLayer(propertyID, *currLayer, style));
-
-        return list;
+            list.append(createSingleAxisPositionValueForLayer(propertyID, *currLayer, style));
+        return CSSValueList::createCommaSeparated(WTFMove(list));
     }
     case CSSPropertyBorderCollapse:
         if (style.borderCollapse() == BorderCollapse::Collapse)
             return CSSPrimitiveValue::create(CSSValueCollapse);
         return CSSPrimitiveValue::create(CSSValueSeparate);
-    case CSSPropertyBorderSpacing: {
-        auto list = CSSValueList::createSpaceSeparated();
-        list->append(zoomAdjustedPixelValue(style.horizontalBorderSpacing(), style));
-        list->append(zoomAdjustedPixelValue(style.verticalBorderSpacing(), style));
-        return list;
-    }
+    case CSSPropertyBorderSpacing:
+        return CSSValueList::createSpaceSeparated(zoomAdjustedPixelValue(style.horizontalBorderSpacing(), style),
+            zoomAdjustedPixelValue(style.verticalBorderSpacing(), style));
     case CSSPropertyWebkitBorderHorizontalSpacing:
         return zoomAdjustedPixelValue(style.horizontalBorderSpacing(), style);
     case CSSPropertyWebkitBorderVerticalSpacing:
@@ -3110,21 +2965,17 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
     case CSSPropertyTabSize:
         return CSSPrimitiveValue::create(style.tabSize().widthInPixels(1.0), style.tabSize().isSpaces() ? CSSUnitType::CSS_NUMBER : CSSUnitType::CSS_PX);
     case CSSPropertyCursor: {
-        RefPtr<CSSValueList> list;
-        auto* cursors = style.cursors();
-        if (cursors && cursors->size() > 0) {
-            list = CSSValueList::createCommaSeparated();
-            for (unsigned i = 0; i < cursors->size(); ++i) {
-                if (StyleImage* image = cursors->at(i).image())
-                    list->append(image->computedStyleValue(style));
-            }
-        }
         auto value = createConvertingToCSSValueID(style.cursor());
-        if (list) {
-            list->append(WTFMove(value));
-            return list;
+        auto* cursors = style.cursors();
+        if (!cursors || !cursors->size())
+            return value;
+        CSSValueListBuilder list;
+        for (unsigned i = 0; i < cursors->size(); ++i) {
+            if (auto* image = cursors->at(i).image())
+                list.append(image->computedStyleValue(style));
         }
-        return value;
+        list.append(WTFMove(value));
+        return CSSValueList::createCommaSeparated(WTFMove(list));
     }
 #if ENABLE(CURSOR_VISIBILITY)
     case CSSPropertyWebkitCursorVisibility:
@@ -3210,39 +3061,39 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
         const FontFeatureSettings& featureSettings = style.fontDescription().featureSettings();
         if (!featureSettings.size())
             return CSSPrimitiveValue::create(CSSValueNormal);
-        auto list = CSSValueList::createCommaSeparated();
+        CSSValueListBuilder list;
         for (auto& feature : featureSettings)
-            list->append(CSSFontFeatureValue::create(FontTag(feature.tag()), feature.value()));
-        return list;
+            list.append(CSSFontFeatureValue::create(FontTag(feature.tag()), feature.value()));
+        return CSSValueList::createCommaSeparated(WTFMove(list));
     }
 #if ENABLE(VARIATION_FONTS)
     case CSSPropertyFontVariationSettings: {
         auto& variationSettings = style.fontDescription().variationSettings();
         if (variationSettings.isEmpty())
             return CSSPrimitiveValue::create(CSSValueNormal);
-        auto list = CSSValueList::createCommaSeparated();
+        CSSValueListBuilder list;
         for (auto& feature : variationSettings)
-            list->append(CSSFontVariationValue::create(feature.tag(), feature.value()));
-        return list;
+            list.append(CSSFontVariationValue::create(feature.tag(), feature.value()));
+        return CSSValueList::createCommaSeparated(WTFMove(list));
     }
     case CSSPropertyFontOpticalSizing:
         return createConvertingToCSSValueID(style.fontDescription().opticalSizing());
 #endif
     case CSSPropertyGridAutoFlow: {
-        auto list = CSSValueList::createSpaceSeparated();
+        CSSValueListBuilder list;
         ASSERT(style.isGridAutoFlowDirectionRow() || style.isGridAutoFlowDirectionColumn());
         if (style.isGridAutoFlowDirectionColumn())
-            list->append(CSSPrimitiveValue::create(CSSValueColumn));
+            list.append(CSSPrimitiveValue::create(CSSValueColumn));
         else if (!style.isGridAutoFlowAlgorithmDense())
-            list->append(CSSPrimitiveValue::create(CSSValueRow));
+            list.append(CSSPrimitiveValue::create(CSSValueRow));
 
         if (style.isGridAutoFlowAlgorithmDense())
-            list->append(CSSPrimitiveValue::create(CSSValueDense));
+            list.append(CSSPrimitiveValue::create(CSSValueDense));
 
-        return list;
+        return CSSValueList::createSpaceSeparated(WTFMove(list));
     }
     case CSSPropertyMasonryAutoFlow: {
-        auto list = CSSValueList::createSpaceSeparated();
+        CSSValueListBuilder list;
         // MasonryAutoFlow information is stored in a struct that should always 
         // hold 2 pieces of information. It should contain both Pack/Next inside
         // the MasonryAutoFlowPlacementAlgorithm enum class and DefiniteFirst/Ordered
@@ -3250,15 +3101,15 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
         ASSERT((style.masonryAutoFlow().placementAlgorithm == MasonryAutoFlowPlacementAlgorithm::Pack || style.masonryAutoFlow().placementAlgorithm == MasonryAutoFlowPlacementAlgorithm::Next) && (style.masonryAutoFlow().placementOrder == MasonryAutoFlowPlacementOrder::DefiniteFirst || style.masonryAutoFlow().placementOrder == MasonryAutoFlowPlacementOrder::Ordered));
 
         if (style.masonryAutoFlow().placementAlgorithm == MasonryAutoFlowPlacementAlgorithm::Next)
-            list->append(CSSPrimitiveValue::create(CSSValueNext));
+            list.append(CSSPrimitiveValue::create(CSSValueNext));
         // Since we know that placementAlgorithm is not Next, it must be Packed. If the PlacementOrder
         // is DefiniteFirst, then the canonical form of the computed style is just Pack (DefiniteFirst is implicit)
         else if (style.masonryAutoFlow().placementOrder == MasonryAutoFlowPlacementOrder::DefiniteFirst)
-            list->append(CSSPrimitiveValue::create(CSSValuePack));
+            list.append(CSSPrimitiveValue::create(CSSValuePack));
 
         if (style.masonryAutoFlow().placementOrder == MasonryAutoFlowPlacementOrder::Ordered)
-            list->append(CSSPrimitiveValue::create(CSSValueOrdered));
-        return list;
+            list.append(CSSPrimitiveValue::create(CSSValueOrdered));
+        return CSSValueList::createSpaceSeparated(WTFMove(list));
     }
 
     // Specs mention that getComputedStyle() should return the used value of the property instead of the computed
@@ -3399,16 +3250,16 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
         if (marginTrim.containsAll({ MarginTrimType::InlineStart, MarginTrimType::InlineEnd }) && !marginTrim.containsAny({ MarginTrimType::BlockStart, MarginTrimType::BlockEnd }))
             return CSSPrimitiveValue::create(CSSValueInline);
 
-        auto list = CSSValueList::createSpaceSeparated();
+        CSSValueListBuilder list;
         if (marginTrim.contains(MarginTrimType::BlockStart))
-            list->append(CSSPrimitiveValue::create(CSSValueBlockStart));
+            list.append(CSSPrimitiveValue::create(CSSValueBlockStart));
         if (marginTrim.contains(MarginTrimType::InlineStart))
-            list->append(CSSPrimitiveValue::create(CSSValueInlineStart));
+            list.append(CSSPrimitiveValue::create(CSSValueInlineStart));
         if (marginTrim.contains(MarginTrimType::BlockEnd))
-            list->append(CSSPrimitiveValue::create(CSSValueBlockEnd));
+            list.append(CSSPrimitiveValue::create(CSSValueBlockEnd));
         if (marginTrim.contains(MarginTrimType::InlineEnd))
-            list->append(CSSPrimitiveValue::create(CSSValueInlineEnd));
-        return list;
+            list.append(CSSPrimitiveValue::create(CSSValueInlineEnd));
+        return CSSValueList::createSpaceSeparated(WTFMove(list));
     }
     case CSSPropertyWebkitUserModify:
         return createConvertingToCSSValueID(style.userModify());
@@ -3552,24 +3403,21 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
         return renderEmphasisPositionFlagsToCSSValue(style.textEmphasisPosition());
     case CSSPropertyTextEmphasisStyle:
         return valueForTextEmphasisStyle(style);
-    case CSSPropertyTextEmphasis: {
-        auto list = CSSValueList::createSpaceSeparated();
-        list->append(valueForTextEmphasisStyle(style));
-        list->append(currentColorOrValidColor(style, style.textEmphasisColor()));
-        return list;
-    }
+    case CSSPropertyTextEmphasis:
+        return CSSValueList::createSpaceSeparated(valueForTextEmphasisStyle(style),
+            currentColorOrValidColor(style, style.textEmphasisColor()));
     case CSSPropertyTextGroupAlign:
         return createConvertingToCSSValueID(style.textGroupAlign());
     case CSSPropertyTextIndent: {
         auto textIndent = zoomAdjustedPixelValueForLength(style.textIndent(), style);
         if (style.textIndentLine() == TextIndentLine::EachLine || style.textIndentType() == TextIndentType::Hanging) {
-            auto list = CSSValueList::createSpaceSeparated();
-            list->append(WTFMove(textIndent));
+            CSSValueListBuilder list;
+            list.append(WTFMove(textIndent));
             if (style.textIndentType() == TextIndentType::Hanging)
-                list->append(CSSPrimitiveValue::create(CSSValueHanging));
+                list.append(CSSPrimitiveValue::create(CSSValueHanging));
             if (style.textIndentLine() == TextIndentLine::EachLine)
-                list->append(CSSPrimitiveValue::create(CSSValueEachLine));
-            return list;
+                list.append(CSSPrimitiveValue::create(CSSValueEachLine));
+            return CSSValueList::createSpaceSeparated(WTFMove(list));
         }
         return textIndent;
     }
@@ -3710,17 +3558,12 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
             return CSSPrimitiveValue::create(CSSValueAuto);
         case AspectRatioType::AutoZero:
         case AspectRatioType::AutoAndRatio:
-        case AspectRatioType::Ratio: {
-            auto ratioList = CSSValueList::createSlashSeparated();
-            ratioList->append(CSSPrimitiveValue::create(style.aspectRatioWidth()));
-            ratioList->append(CSSPrimitiveValue::create(style.aspectRatioHeight()));
+        case AspectRatioType::Ratio:
+            auto ratioList = CSSValueList::createSlashSeparated(CSSPrimitiveValue::create(style.aspectRatioWidth()),
+                CSSPrimitiveValue::create(style.aspectRatioHeight()));
             if (style.aspectRatioType() != AspectRatioType::AutoAndRatio)
                 return ratioList;
-            auto list = CSSValueList::createSpaceSeparated();
-            list->append(CSSPrimitiveValue::create(CSSValueAuto));
-            list->append(ratioList);
-            return list;
-        }
+            return CSSValueList::createSpaceSeparated(CSSPrimitiveValue::create(CSSValueAuto), WTFMove(ratioList));
         }
         ASSERT_NOT_REACHED();
         return nullptr;
@@ -3732,38 +3575,39 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
             return CSSPrimitiveValue::create(CSSValueStrict);
         if (containment == RenderStyle::contentContainment())
             return CSSPrimitiveValue::create(CSSValueContent);
-        auto list = CSSValueList::createSpaceSeparated();
+        CSSValueListBuilder list;
         if (containment & Containment::Size)
-            list->append(CSSPrimitiveValue::create(CSSValueSize));
+            list.append(CSSPrimitiveValue::create(CSSValueSize));
         if (containment & Containment::InlineSize)
-            list->append(CSSPrimitiveValue::create(CSSValueInlineSize));
+            list.append(CSSPrimitiveValue::create(CSSValueInlineSize));
         if (containment & Containment::Layout)
-            list->append(CSSPrimitiveValue::create(CSSValueLayout));
+            list.append(CSSPrimitiveValue::create(CSSValueLayout));
         if (containment & Containment::Style)
-            list->append(CSSPrimitiveValue::create(CSSValueStyle));
+            list.append(CSSPrimitiveValue::create(CSSValueStyle));
         if (containment & Containment::Paint)
-            list->append(CSSPrimitiveValue::create(CSSValuePaint));
-        return list;
+            list.append(CSSPrimitiveValue::create(CSSValuePaint));
+        return CSSValueList::createSpaceSeparated(WTFMove(list));
     }
     case CSSPropertyContainer: {
-        auto list = CSSValueList::createSlashSeparated();
-        if (style.containerNames().isEmpty())
-            list->append(CSSPrimitiveValue::create(CSSValueNone));
-        else
-            list->append(propertyValue(CSSPropertyContainerName, UpdateLayout::No).releaseNonNull());
-        if (style.containerType() != ContainerType::Normal)
-            list->append(propertyValue(CSSPropertyContainerType, UpdateLayout::No).releaseNonNull());
-        return list;
+        auto name = [&]() -> Ref<CSSValue> {
+            if (style.containerNames().isEmpty())
+                return CSSPrimitiveValue::create(CSSValueNone);
+            return propertyValue(CSSPropertyContainerName, UpdateLayout::No).releaseNonNull();
+        }();
+        if (style.containerType() == ContainerType::Normal)
+            return CSSValueList::createSlashSeparated(WTFMove(name));
+        return CSSValueList::createSlashSeparated(WTFMove(name),
+            propertyValue(CSSPropertyContainerType, UpdateLayout::No).releaseNonNull());
     }
     case CSSPropertyContainerType:
         return createConvertingToCSSValueID(style.containerType());
     case CSSPropertyContainerName: {
         if (style.containerNames().isEmpty())
             return CSSPrimitiveValue::create(CSSValueNone);
-        auto list = CSSValueList::createSpaceSeparated();
+        CSSValueListBuilder list;
         for (auto& name : style.containerNames())
-            list->append(CSSPrimitiveValue::createCustomIdent(name));
-        return list;
+            list.append(CSSPrimitiveValue::createCustomIdent(name));
+        return CSSValueList::createSpaceSeparated(WTFMove(list));
     }
     case CSSPropertyContainIntrinsicSize:
         return getCSSPropertyValuesFor2SidesShorthand(containIntrinsicSizeShorthand());
@@ -3822,18 +3666,14 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
         if (!style.hasPerspective())
             return CSSPrimitiveValue::create(CSSValueNone);
         return zoomAdjustedPixelValue(style.perspective(), style);
-    case CSSPropertyPerspectiveOrigin: {
-        auto list = CSSValueList::createSpaceSeparated();
+    case CSSPropertyPerspectiveOrigin:
         if (renderer) {
             auto box = renderer->transformReferenceBoxRect(style);
-            list->append(zoomAdjustedPixelValue(minimumValueForLength(style.perspectiveOriginX(), box.width()), style));
-            list->append(zoomAdjustedPixelValue(minimumValueForLength(style.perspectiveOriginY(), box.height()), style));
-        } else {
-            list->append(zoomAdjustedPixelValueForLength(style.perspectiveOriginX(), style));
-            list->append(zoomAdjustedPixelValueForLength(style.perspectiveOriginY(), style));
+            return CSSValueList::createSpaceSeparated(zoomAdjustedPixelValue(minimumValueForLength(style.perspectiveOriginX(), box.width()), style),
+                zoomAdjustedPixelValue(minimumValueForLength(style.perspectiveOriginY(), box.height()), style));
         }
-        return list;
-    }
+        return CSSValueList::createSpaceSeparated(zoomAdjustedPixelValueForLength(style.perspectiveOriginX(), style),
+            zoomAdjustedPixelValueForLength(style.perspectiveOriginY(), style));
     case CSSPropertyWebkitRtlOrdering:
         return CSSPrimitiveValue::create(style.rtlOrdering() == Order::Visual ? CSSValueVisual : CSSValueLogical);
 #if ENABLE(TOUCH_EVENTS)
@@ -3877,20 +3717,20 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
     case CSSPropertyTransformBox:
         return createConvertingToCSSValueID(style.transformBox());
     case CSSPropertyTransformOrigin: {
-        auto list = CSSValueList::createSpaceSeparated();
+        CSSValueListBuilder list;
         if (renderer) {
             auto box = renderer->transformReferenceBoxRect(style);
-            list->append(zoomAdjustedPixelValue(minimumValueForLength(style.transformOriginX(), box.width()), style));
-            list->append(zoomAdjustedPixelValue(minimumValueForLength(style.transformOriginY(), box.height()), style));
+            list.append(zoomAdjustedPixelValue(minimumValueForLength(style.transformOriginX(), box.width()), style));
+            list.append(zoomAdjustedPixelValue(minimumValueForLength(style.transformOriginY(), box.height()), style));
             if (style.transformOriginZ())
-                list->append(zoomAdjustedPixelValue(style.transformOriginZ(), style));
+                list.append(zoomAdjustedPixelValue(style.transformOriginZ(), style));
         } else {
-            list->append(zoomAdjustedPixelValueForLength(style.transformOriginX(), style));
-            list->append(zoomAdjustedPixelValueForLength(style.transformOriginY(), style));
+            list.append(zoomAdjustedPixelValueForLength(style.transformOriginX(), style));
+            list.append(zoomAdjustedPixelValueForLength(style.transformOriginY(), style));
             if (style.transformOriginZ())
-                list->append(zoomAdjustedPixelValue(style.transformOriginZ(), style));
+                list.append(zoomAdjustedPixelValue(style.transformOriginZ(), style));
         }
-        return list;
+        return CSSValueList::createSpaceSeparated(WTFMove(list));
     }
     case CSSPropertyTransformStyle:
         switch (style.transformStyle3D()) {
@@ -3984,10 +3824,10 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
         auto& layers = style.backgroundLayers();
         if (!layers.next())
             return createConvertingToCSSValueID(layers.blendMode());
-        auto list = CSSValueList::createCommaSeparated();
+        CSSValueListBuilder list;
         for (auto* currLayer = &layers; currLayer; currLayer = currLayer->next())
-            list->append(createConvertingToCSSValueID(currLayer->blendMode()));
-        return list;
+            list.append(createConvertingToCSSValueID(currLayer->blendMode()));
+        return CSSValueList::createSpaceSeparated(WTFMove(list));
     }
     case CSSPropertyBackground:
         return getBackgroundShorthandValue();
@@ -4129,15 +3969,15 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
         if (colorScheme.isNormal())
             return CSSPrimitiveValue::create(CSSValueNormal);
 
-        auto list = CSSValueList::createSpaceSeparated();
+        CSSValueListBuilder list;
         if (colorScheme.contains(ColorScheme::Light))
-            list->append(CSSPrimitiveValue::create(CSSValueLight));
+            list.append(CSSPrimitiveValue::create(CSSValueLight));
         if (colorScheme.contains(ColorScheme::Dark))
-            list->append(CSSPrimitiveValue::create(CSSValueDark));
+            list.append(CSSPrimitiveValue::create(CSSValueDark));
         if (!colorScheme.allowsTransformations())
-            list->append(CSSPrimitiveValue::create(CSSValueOnly));
-        ASSERT(list->length());
-        return list;
+            list.append(CSSPrimitiveValue::create(CSSValueOnly));
+        ASSERT(!list.isEmpty());
+        return CSSValueList::createSpaceSeparated(WTFMove(list));
     }
 #endif
 
@@ -4347,16 +4187,14 @@ bool ComputedStyleExtractor::propertyMatches(CSSPropertyID propertyID, const CSS
 
 Ref<CSSValueList> ComputedStyleExtractor::getCSSPropertyValuesForShorthandProperties(const StylePropertyShorthand& shorthand)
 {
-    auto list = CSSValueList::createSpaceSeparated();
+    CSSValueListBuilder list;
     for (auto longhand : shorthand)
-        list->append(propertyValue(longhand, UpdateLayout::No).releaseNonNull());
-    return list;
+        list.append(propertyValue(longhand, UpdateLayout::No).releaseNonNull());
+    return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
 RefPtr<CSSValueList> ComputedStyleExtractor::getCSSPropertyValuesFor2SidesShorthand(const StylePropertyShorthand& shorthand)
 {
-    auto list = CSSValueList::createSpaceSeparated();
-
     // Assume the properties are in the usual order start, end.
     auto startValue = propertyValue(shorthand.properties()[0], UpdateLayout::No);
     auto endValue = propertyValue(shorthand.properties()[1], UpdateLayout::No);
@@ -4365,19 +4203,13 @@ RefPtr<CSSValueList> ComputedStyleExtractor::getCSSPropertyValuesFor2SidesShorth
     if (!startValue || !endValue)
         return nullptr;
 
-    bool showEnd = !compareCSSValuePtr(startValue, endValue);
-
-    list->append(startValue.releaseNonNull());
-    if (showEnd)
-        list->append(endValue.releaseNonNull());
-
-    return list;
+    if (compareCSSValuePtr(startValue, endValue))
+        return CSSValueList::createSpaceSeparated(startValue.releaseNonNull());
+    return CSSValueList::createSpaceSeparated(startValue.releaseNonNull(), endValue.releaseNonNull());
 }
 
 RefPtr<CSSValueList> ComputedStyleExtractor::getCSSPropertyValuesFor4SidesShorthand(const StylePropertyShorthand& shorthand)
 {
-    auto list = CSSValueList::createSpaceSeparated();
-
     // Assume the properties are in the usual order top, right, bottom, left.
     auto topValue = propertyValue(shorthand.properties()[0], UpdateLayout::No);
     auto rightValue = propertyValue(shorthand.properties()[1], UpdateLayout::No);
@@ -4392,23 +4224,23 @@ RefPtr<CSSValueList> ComputedStyleExtractor::getCSSPropertyValuesFor4SidesShorth
     bool showBottom = !compareCSSValuePtr(topValue, bottomValue) || showLeft;
     bool showRight = !compareCSSValuePtr(topValue, rightValue) || showBottom;
 
-    list->append(topValue.releaseNonNull());
+    CSSValueListBuilder list;
+    list.append(topValue.releaseNonNull());
     if (showRight)
-        list->append(rightValue.releaseNonNull());
+        list.append(rightValue.releaseNonNull());
     if (showBottom)
-        list->append(bottomValue.releaseNonNull());
+        list.append(bottomValue.releaseNonNull());
     if (showLeft)
-        list->append(leftValue.releaseNonNull());
-
-    return list;
+        list.append(leftValue.releaseNonNull());
+    return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
 Ref<CSSValueList> ComputedStyleExtractor::getCSSPropertyValuesForGridShorthand(const StylePropertyShorthand& shorthand)
 {
-    auto list = CSSValueList::createSlashSeparated();
+    CSSValueListBuilder builder;
     for (auto longhand : shorthand)
-        list->append(propertyValue(longhand, UpdateLayout::No).releaseNonNull());
-    return list;
+        builder.append(propertyValue(longhand, UpdateLayout::No).releaseNonNull());
+    return CSSValueList::createSlashSeparated(WTFMove(builder));
 }
 
 Ref<MutableStyleProperties> ComputedStyleExtractor::copyProperties(Span<const CSSPropertyID> properties)
@@ -4470,35 +4302,27 @@ Ref<CSSValue> ComputedStyleExtractor::getFillLayerPropertyShorthandValue(CSSProp
     // The computed properties are returned as lists of properties, with a list of layers in each.
     // We want to swap that around to have a list of layers, with a list of properties in each.
 
-    auto layers = CSSValueList::createCommaSeparated();
-
+    CSSValueListBuilder layers;
     for (size_t i = 0; i < layerCount; i++) {
-        auto list = CSSValueList::createSlashSeparated();
-        auto beforeList = CSSValueList::createSpaceSeparated();
-
+        CSSValueListBuilder beforeList;
         if (i == layerCount - 1 && lastValue)
-            beforeList->append(*lastValue);
-
+            beforeList.append(*lastValue);
         for (size_t j = 0; j < propertiesBeforeSlashSeparator.length(); j++) {
             auto& value = *before->item(j);
-            beforeList->append(layerCount == 1 ? value : *downcast<CSSValueList>(value).item(i));
+            beforeList.append(const_cast<CSSValue&>(layerCount == 1 ? value : *downcast<CSSValueList>(value).item(i)));
         }
-        list->append(beforeList);
-
-        auto afterList = CSSValueList::createSpaceSeparated();
+        CSSValueListBuilder afterList;
         for (size_t j = 0; j < propertiesAfterSlashSeparator.length(); j++) {
             auto& value = *after->item(j);
-            afterList->append(layerCount == 1 ? value : *downcast<CSSValueList>(value).item(i));
+            afterList.append(const_cast<CSSValue&>(layerCount == 1 ? value : *downcast<CSSValueList>(value).item(i)));
         }
-        list->append(afterList);
-
+        auto list = CSSValueList::createSlashSeparated(CSSValueList::createSpaceSeparated(WTFMove(beforeList)),
+            CSSValueList::createSpaceSeparated(WTFMove(afterList)));
         if (layerCount == 1)
             return list;
-
-        layers->append(list);
+        layers.append(WTFMove(list));
     }
-
-    return layers;
+    return CSSValueList::createCommaSeparated(WTFMove(layers));
 }
 
 
@@ -4512,10 +4336,10 @@ Ref<CSSValue> ComputedStyleExtractor::getBackgroundShorthandValue()
 
 Ref<CSSValue> ComputedStyleExtractor::getMaskShorthandValue()
 {
-    static const CSSPropertyID propertiesBeforeSlashSeperator[2] = { CSSPropertyMaskImage, CSSPropertyMaskPosition };
-    static const CSSPropertyID propertiesAfterSlashSeperator[6] = { CSSPropertyMaskSize, CSSPropertyMaskRepeat, CSSPropertyMaskOrigin, CSSPropertyMaskClip, CSSPropertyMaskComposite, CSSPropertyMaskMode };
+    static const CSSPropertyID propertiesBeforeSlashSeparator[2] = { CSSPropertyMaskImage, CSSPropertyMaskPosition };
+    static const CSSPropertyID propertiesAfterSlashSeparator[6] = { CSSPropertyMaskSize, CSSPropertyMaskRepeat, CSSPropertyMaskOrigin, CSSPropertyMaskClip, CSSPropertyMaskComposite, CSSPropertyMaskMode };
 
-    return getFillLayerPropertyShorthandValue(CSSPropertyMask, StylePropertyShorthand(CSSPropertyMask, propertiesBeforeSlashSeperator), StylePropertyShorthand(CSSPropertyMask, propertiesAfterSlashSeperator), CSSPropertyInvalid);
+    return getFillLayerPropertyShorthandValue(CSSPropertyMask, StylePropertyShorthand(CSSPropertyMask, propertiesBeforeSlashSeparator), StylePropertyShorthand(CSSPropertyMask, propertiesAfterSlashSeparator), CSSPropertyInvalid);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/ComputedStyleExtractor.h
+++ b/Source/WebCore/css/ComputedStyleExtractor.h
@@ -48,6 +48,8 @@ enum CSSValueID : uint16_t;
 enum class PseudoId : uint16_t;
 enum class SVGPaintType : uint8_t;
 
+using CSSValueListBuilder = Vector<Ref<CSSValue>, 4>;
+
 class ComputedStyleExtractor {
     WTF_MAKE_FAST_ALLOCATED;
 public:
@@ -77,7 +79,7 @@ public:
 
     static Ref<CSSPrimitiveValue> currentColorOrValidColor(const RenderStyle&, const StyleColor&);
 
-    static void addValueForAnimationPropertyToList(CSSValueList&, CSSPropertyID, const Animation*);
+    static void addValueForAnimationPropertyToList(CSSValueListBuilder&, CSSPropertyID, const Animation*);
 
     static bool updateStyleIfNeededForProperty(Element&, CSSPropertyID);
 

--- a/Source/WebCore/css/DOMMatrixReadOnly.cpp
+++ b/Source/WebCore/css/DOMMatrixReadOnly.cpp
@@ -234,7 +234,7 @@ ExceptionOr<DOMMatrixReadOnly::AbstractMatrix> DOMMatrixReadOnly::parseStringInt
     auto value = styleDeclaration->getPropertyCSSValue(CSSPropertyTransform);
 
     // Check for a "none" or empty transform. In these cases we can use the default identity matrix.
-    if (!value || (is<CSSPrimitiveValue>(*value) && downcast<CSSPrimitiveValue>(*value).valueID() == CSSValueNone))
+    if (!value || (is<CSSPrimitiveValue>(*value) && value->valueID() == CSSValueNone))
         return AbstractMatrix { };
 
     auto operations = transformsForValue(*value, { });

--- a/Source/WebCore/css/DeprecatedCSSOMValueList.h
+++ b/Source/WebCore/css/DeprecatedCSSOMValueList.h
@@ -45,7 +45,7 @@ public:
 private:
     DeprecatedCSSOMValueList(const CSSValueContainingVector& values, CSSStyleDeclaration& owner)
         : DeprecatedCSSOMValue(ClassType::List, owner)
-        , m_values(WTF::map(values, [&](auto& value) { return value->createDeprecatedCSSOMWrapper(owner); }))
+        , m_values(WTF::map(values, [&](auto& value) { return value.createDeprecatedCSSOMWrapper(owner); }))
     {
         m_valueSeparator = values.separator();
     }

--- a/Source/WebCore/css/FontFace.cpp
+++ b/Source/WebCore/css/FontFace.cpp
@@ -174,11 +174,8 @@ ExceptionOr<void> FontFace::setFamily(ScriptExecutionContext& context, const Str
 {
     if (family.isEmpty())
         return Exception { SyntaxError };
-
     // FIXME: Don't use a list here. https://bugs.webkit.org/show_bug.cgi?id=196381
-    auto list = CSSValueList::createCommaSeparated();
-    list->append(context.cssValuePool().createFontFamilyValue(AtomString { family }));
-    m_backing->setFamilies(list);
+    m_backing->setFamilies(CSSValueList::createCommaSeparated(context.cssValuePool().createFontFamilyValue(AtomString { family })));
     return { };
 }
 

--- a/Source/WebCore/css/FontVariantBuilder.cpp
+++ b/Source/WebCore/css/FontVariantBuilder.cpp
@@ -42,7 +42,7 @@ FontVariantLigaturesValues extractFontVariantLigatures(const CSSValue& value)
 
     if (is<CSSValueList>(value)) {
         for (auto& item : downcast<CSSValueList>(value)) {
-            switch (downcast<CSSPrimitiveValue>(item.get()).valueID()) {
+            switch (item.valueID()) {
             case CSSValueNoCommonLigatures:
                 common = FontVariantLigatures::No;
                 break;
@@ -73,7 +73,7 @@ FontVariantLigaturesValues extractFontVariantLigatures(const CSSValue& value)
             }
         }
     } else if (is<CSSPrimitiveValue>(value)) {
-        switch (downcast<CSSPrimitiveValue>(value).valueID()) {
+        switch (value.valueID()) {
         case CSSValueNormal:
             break;
         case CSSValueNone:
@@ -101,7 +101,7 @@ FontVariantNumericValues extractFontVariantNumeric(const CSSValue& value)
 
     if (is<CSSValueList>(value)) {
         for (auto& item : downcast<CSSValueList>(value)) {
-            switch (downcast<CSSPrimitiveValue>(item.get()).valueID()) {
+            switch (item.valueID()) {
             case CSSValueLiningNums:
                 figure = FontVariantNumericFigure::LiningNumbers;
                 break;
@@ -132,7 +132,7 @@ FontVariantNumericValues extractFontVariantNumeric(const CSSValue& value)
             }
         }
     } else if (is<CSSPrimitiveValue>(value))
-        ASSERT(downcast<CSSPrimitiveValue>(value).valueID() == CSSValueNormal);
+        ASSERT(value.valueID() == CSSValueNormal);
 
     return FontVariantNumericValues(figure, spacing, fraction, ordinal, slashedZero);
 }
@@ -145,7 +145,7 @@ FontVariantEastAsianValues extractFontVariantEastAsian(const CSSValue& value)
 
     if (is<CSSValueList>(value)) {
         for (auto& item : downcast<CSSValueList>(value)) {
-            switch (downcast<CSSPrimitiveValue>(item.get()).valueID()) {
+            switch (item.valueID()) {
             case CSSValueJis78:
                 variant = FontVariantEastAsianVariant::Jis78;
                 break;
@@ -179,7 +179,7 @@ FontVariantEastAsianValues extractFontVariantEastAsian(const CSSValue& value)
             }
         }
     } else if (is<CSSPrimitiveValue>(value))
-        ASSERT(downcast<CSSPrimitiveValue>(value).valueID() == CSSValueNormal);
+        ASSERT(value.valueID() == CSSValueNormal);
 
     return FontVariantEastAsianValues(variant, width, ruby);
 }

--- a/Source/WebCore/css/ShorthandSerializer.cpp
+++ b/Source/WebCore/css/ShorthandSerializer.cpp
@@ -474,7 +474,7 @@ public:
         ASSERT(m_shorthand.length() <= maxShorthandLength);
     }
 
-    void set(unsigned index, CSSValue* value, bool skipSerializing = false)
+    void set(unsigned index, const CSSValue* value, bool skipSerializing = false)
     {
         ASSERT(index < m_shorthand.length());
         m_skipSerializing[index] = skipSerializing
@@ -548,19 +548,19 @@ public:
 private:
     const StylePropertyShorthand& m_shorthand;
     bool m_skipSerializing[maxShorthandLength] { };
-    RefPtr<CSSValue> m_values[maxShorthandLength];
+    RefPtr<const CSSValue> m_values[maxShorthandLength];
 };
 
 String ShorthandSerializer::serializeLayered() const
 {
-    size_t numLayers = 1;
+    unsigned numLayers = 1;
     for (auto& value : longhandValues()) {
         if (is<CSSValueList>(value))
             numLayers = std::max(downcast<CSSValueList>(value).length(), numLayers);
     }
 
     StringBuilder result;
-    for (size_t i = 0; i < numLayers; i++) {
+    for (unsigned i = 0; i < numLayers; i++) {
         LayerValues layerValues { m_shorthand };
 
         for (unsigned j = 0; j < length(); j++) {
@@ -1088,12 +1088,12 @@ String ShorthandSerializer::serializeGridTemplate() const
     for (auto& currentValue : downcast<CSSValueList>(longhandValue(rowsIndex))) {
         if (!result.isEmpty())
             result.append(' ');
-        if (auto lineNames = dynamicDowncast<CSSGridLineNamesValue>(currentValue.get()))
+        if (auto lineNames = dynamicDowncast<CSSGridLineNamesValue>(currentValue))
             result.append(lineNames->customCSSText());
         else {
             result.append('"', areasValue->stringForRow(row), '"');
             if (!isValueID(currentValue, CSSValueAuto))
-                result.append(' ', currentValue->cssText());
+                result.append(' ', currentValue.cssText());
             row++;
         }
     }

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -816,7 +816,7 @@ RefPtr<StyleRuleFontPaletteValues> CSSParserImpl::consumeFontPaletteValuesRule(C
     if (auto overrideColorsValue = properties->getPropertyCSSValue(CSSPropertyOverrideColors)) {
         const auto& list = downcast<CSSValueList>(*overrideColorsValue);
         for (const auto& item : list) {
-            const auto& pair = downcast<CSSFontPaletteValuesOverrideColorsValue>(item.get());
+            const auto& pair = downcast<CSSFontPaletteValuesOverrideColorsValue>(item);
             if (!pair.key().isInteger())
                 continue;
             unsigned key = pair.key().value<unsigned>();
@@ -1015,7 +1015,7 @@ RefPtr<StyleRuleProperty> CSSParserImpl::consumePropertyRule(CSSParserTokenRange
             propertyDescriptor.syntax = downcast<CSSPrimitiveValue>(*property.value()).stringValue();
             continue;
         case CSSPropertyInherits:
-            propertyDescriptor.inherits = downcast<CSSPrimitiveValue>(*property.value()).valueID() == CSSValueTrue;
+            propertyDescriptor.inherits = property.value()->valueID() == CSSValueTrue;
             break;
         case CSSPropertyInitialValue:
             propertyDescriptor.initialValue = downcast<CSSCustomPropertyValue>(*property.value()).asVariableData();

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -394,13 +394,12 @@ std::pair<RefPtr<CSSValue>, CSSCustomPropertySyntax::Type> CSSPropertyParser::co
             });
         }
         case CSSCustomPropertySyntax::Multiplier::SpaceList: {
-            RefPtr<CSSValueList> valueList;
-            while (auto value = consumeSingleValue(range, component)) {
-                if (!valueList)
-                    valueList = CSSValueList::createSpaceSeparated();
-                valueList->append(value.releaseNonNull());
-            }
-            return valueList;
+            CSSValueListBuilder valueList;
+            while (auto value = consumeSingleValue(range, component))
+                valueList.append(value.releaseNonNull());
+            if (valueList.isEmpty())
+                return nullptr;
+            return CSSValueList::createSpaceSeparated(WTFMove(valueList));
         }
         }
         ASSERT_NOT_REACHED();
@@ -1649,14 +1648,12 @@ bool CSSPropertyParser::consumeLegacyTextOrientation(bool important)
     return true;
 }
 
-static bool isValidAnimationPropertyList(CSSPropertyID property, const CSSValueList& valueList)
+static bool isValidAnimationPropertyList(CSSPropertyID property, const CSSValueListBuilder& valueList)
 {
     // If there is more than one <single-transition> in the shorthand, and any of the transitions
     // has none as the <single-transition-property>, then the declaration is invalid.
-
-    if (property != CSSPropertyTransitionProperty || valueList.length() < 2)
+    if (property != CSSPropertyTransitionProperty || valueList.size() < 2)
         return true;
-
     for (auto& value : valueList) {
         if (isValueID(value, CSSValueNone))
             return false;
@@ -1699,10 +1696,8 @@ static RefPtr<CSSValue> consumeAnimationValueForShorthand(CSSPropertyID property
 bool CSSPropertyParser::consumeAnimationShorthand(const StylePropertyShorthand& shorthand, bool important)
 {
     const unsigned longhandCount = shorthand.length();
-    RefPtr<CSSValueList> longhands[8];
+    CSSValueListBuilder longhands[8];
     ASSERT(longhandCount <= 8);
-    for (size_t i = 0; i < longhandCount; ++i)
-        longhands[i] = CSSValueList::createCommaSeparated();
 
     do {
         bool parsedLonghand[8] = { false };
@@ -1715,7 +1710,7 @@ bool CSSPropertyParser::consumeAnimationShorthand(const StylePropertyShorthand& 
                 if (auto value = consumeAnimationValueForShorthand(shorthand.properties()[i], m_range, m_context)) {
                     parsedLonghand[i] = true;
                     foundProperty = true;
-                    longhands[i]->append(*value);
+                    longhands[i].append(*value);
                     break;
                 }
             }
@@ -1725,36 +1720,40 @@ bool CSSPropertyParser::consumeAnimationShorthand(const StylePropertyShorthand& 
 
         for (size_t i = 0; i < longhandCount; ++i) {
             if (!parsedLonghand[i])
-                longhands[i]->append(Ref { CSSPrimitiveValue::implicitInitialValue() });
+                longhands[i].append(Ref { CSSPrimitiveValue::implicitInitialValue() });
             parsedLonghand[i] = false;
         }
     } while (consumeCommaIncludingWhitespace(m_range));
 
     for (size_t i = 0; i < longhandCount; ++i) {
-        if (!isValidAnimationPropertyList(shorthand.properties()[i], *longhands[i]))
+        if (!isValidAnimationPropertyList(shorthand.properties()[i], longhands[i]))
             return false;
     }
 
     for (size_t i = 0; i < longhandCount; ++i)
-        addProperty(shorthand.properties()[i], shorthand.id(), WTFMove(longhands[i]), important);
+        addProperty(shorthand.properties()[i], shorthand.id(), CSSValueList::createCommaSeparated(WTFMove(longhands[i])), important);
 
     return m_range.atEnd();
 }
 
-static void addBackgroundValue(RefPtr<CSSValue>& list, Ref<CSSValue>&& value)
-{
-    assignOrDowngradeToListAndAppend(list, WTFMove(value));
-}
-
 static bool consumeBackgroundPosition(CSSParserTokenRange& range, const CSSParserContext& context, CSSPropertyID property, RefPtr<CSSValue>& resultX, RefPtr<CSSValue>& resultY)
 {
+    CSSValueListBuilder x;
+    CSSValueListBuilder y;
     do {
         auto position = consumePositionCoordinates(range, context.mode, UnitlessQuirk::Allow, property == CSSPropertyMaskPosition ? PositionSyntax::Position : PositionSyntax::BackgroundPosition, NegativePercentagePolicy::Allow);
         if (!position)
             return false;
-        addBackgroundValue(resultX, WTFMove(position->x));
-        addBackgroundValue(resultY, WTFMove(position->y));
+        x.append(WTFMove(position->x));
+        y.append(WTFMove(position->y));
     } while (consumeCommaIncludingWhitespace(range));
+    if (x.size() == 1) {
+        resultX = WTFMove(x[0]);
+        resultY = WTFMove(y[0]);
+    } else {
+        resultX = CSSValueList::createCommaSeparated(WTFMove(x));
+        resultY = CSSValueList::createCommaSeparated(WTFMove(y));
+    }
     return true;
 }
 
@@ -1829,7 +1828,7 @@ static RefPtr<CSSValue> consumeBackgroundComponent(CSSPropertyID property, CSSPa
 bool CSSPropertyParser::consumeBackgroundShorthand(const StylePropertyShorthand& shorthand, bool important)
 {
     const unsigned longhandCount = shorthand.length();
-    RefPtr<CSSValue> longhands[10];
+    CSSValueListBuilder longhands[10];
     ASSERT(longhandCount <= 10);
 
     do {
@@ -1879,11 +1878,11 @@ bool CSSPropertyParser::consumeBackgroundShorthand(const StylePropertyShorthand&
                         originValue = value;
                     parsedLonghand[i] = true;
                     foundProperty = true;
-                    addBackgroundValue(longhands[i], value.releaseNonNull());
+                    longhands[i].append(value.releaseNonNull());
                     lastParsedWasPosition = valueY;
                     if (valueY) {
                         parsedLonghand[i + 1] = true;
-                        addBackgroundValue(longhands[i + 1], valueY.releaseNonNull());
+                        longhands[i + 1].append(valueY.releaseNonNull());
                     }
                 }
             }
@@ -1899,11 +1898,11 @@ bool CSSPropertyParser::consumeBackgroundShorthand(const StylePropertyShorthand&
                 continue;
             }
             if ((property == CSSPropertyBackgroundClip || property == CSSPropertyMaskClip || property == CSSPropertyWebkitMaskClip) && !parsedLonghand[i] && originValue) {
-                addBackgroundValue(longhands[i], originValue.releaseNonNull());
+                longhands[i].append(originValue.releaseNonNull());
                 continue;
             }
             if (!parsedLonghand[i])
-                addBackgroundValue(longhands[i], Ref { CSSPrimitiveValue::implicitInitialValue() });
+                longhands[i].append(Ref { CSSPrimitiveValue::implicitInitialValue() });
         }
     } while (consumeCommaIncludingWhitespace(m_range));
     if (!m_range.atEnd())
@@ -1911,9 +1910,12 @@ bool CSSPropertyParser::consumeBackgroundShorthand(const StylePropertyShorthand&
 
     for (size_t i = 0; i < longhandCount; ++i) {
         CSSPropertyID property = shorthand.properties()[i];
-        if (property == CSSPropertyBackgroundSize && longhands[i] && m_context.useLegacyBackgroundSizeShorthandBehavior)
+        if (property == CSSPropertyBackgroundSize && !longhands[i].isEmpty() && m_context.useLegacyBackgroundSizeShorthandBehavior)
             continue;
-        addProperty(property, shorthand.id(), WTFMove(longhands[i]), important);
+        if (longhands[i].size() == 1)
+            addProperty(property, shorthand.id(), WTFMove(longhands[i][0]), important);
+        else
+            addProperty(property, shorthand.id(), CSSValueList::createCommaSeparated(WTFMove(longhands[i])), important);
     }
     return true;
 }
@@ -2019,7 +2021,7 @@ bool CSSPropertyParser::consumeGridTemplateRowsAndAreasAndColumns(CSSPropertyID 
     NamedGridAreaMap gridAreaMap;
     size_t rowCount = 0;
     size_t columnCount = 0;
-    RefPtr<CSSValueList> templateRows = CSSValueList::createSpaceSeparated();
+    CSSValueListBuilder templateRows;
 
     // Persists between loop iterations so we can use the same value for
     // consecutive <line-names> values
@@ -2027,10 +2029,17 @@ bool CSSPropertyParser::consumeGridTemplateRowsAndAreasAndColumns(CSSPropertyID 
 
     do {
         // Handle leading <custom-ident>*.
-        bool hasPreviousLineNames = lineNames;
-        lineNames = consumeGridLineNames(m_range, lineNames.get());
-        if (lineNames && !hasPreviousLineNames)
-            templateRows->append(lineNames.releaseNonNull());
+        auto previousLineNames = std::exchange(lineNames, consumeGridLineNames(m_range));
+        if (lineNames) {
+            if (!previousLineNames)
+                templateRows.append(lineNames.releaseNonNull());
+            else {
+                Vector<String> combinedLineNames;
+                combinedLineNames.append(previousLineNames->names());
+                combinedLineNames.append(lineNames->names());
+                templateRows.last() = CSSGridLineNamesValue::create(combinedLineNames);
+            }
+        }
 
         // Handle a template-area's row.
         if (m_range.peek().type() != StringToken || !parseGridTemplateAreasRow(m_range.consumeIncludingWhitespace().value(), gridAreaMap, rowCount, columnCount))
@@ -2038,15 +2047,15 @@ bool CSSPropertyParser::consumeGridTemplateRowsAndAreasAndColumns(CSSPropertyID 
         ++rowCount;
 
         // Handle template-rows's track-size.
-        RefPtr<CSSValue> value = consumeGridTrackSize(m_range, m_context.mode);
-        if (!value)
-            value = CSSPrimitiveValue::create(CSSValueAuto);
-        templateRows->append(*value);
+        if (auto value = consumeGridTrackSize(m_range, m_context.mode))
+            templateRows.append(value.releaseNonNull());
+        else
+            templateRows.append(CSSPrimitiveValue::create(CSSValueAuto));
 
         // This will handle the trailing/leading <custom-ident>* in the grammar.
         lineNames = consumeGridLineNames(m_range);
         if (lineNames)
-            templateRows->append(*lineNames);
+            templateRows.append(*lineNames);
     } while (!m_range.atEnd() && !(m_range.peek().type() == DelimiterToken && m_range.peek().delimiter() == '/'));
 
     RefPtr<CSSValue> columnsValue;
@@ -2059,7 +2068,7 @@ bool CSSPropertyParser::consumeGridTemplateRowsAndAreasAndColumns(CSSPropertyID 
     } else {
         columnsValue = CSSPrimitiveValue::create(CSSValueNone);
     }
-    addProperty(CSSPropertyGridTemplateRows, shorthandId, templateRows.releaseNonNull(), important);
+    addProperty(CSSPropertyGridTemplateRows, shorthandId, CSSValueList::createSpaceSeparated(WTFMove(templateRows)), important);
     addProperty(CSSPropertyGridTemplateColumns, shorthandId, columnsValue.releaseNonNull(), important);
     addProperty(CSSPropertyGridTemplateAreas, shorthandId, CSSGridTemplateAreasValue::create(gridAreaMap, rowCount, columnCount), important);
     return true;
@@ -2100,30 +2109,20 @@ bool CSSPropertyParser::consumeGridTemplateShorthand(CSSPropertyID shorthandId, 
     return consumeGridTemplateRowsAndAreasAndColumns(shorthandId, important);
 }
 
-static RefPtr<CSSValue> consumeImplicitGridAutoFlow(CSSParserTokenRange& range, Ref<CSSPrimitiveValue>&& flowDirection)
+static RefPtr<CSSValue> consumeImplicitGridAutoFlow(CSSParserTokenRange& range, CSSValueID flowDirection)
 {
     // [ auto-flow && dense? ]
-    if (range.atEnd())
+    bool autoFlow = consumeIdentRaw<CSSValueAutoFlow>(range).has_value();
+    bool dense = consumeIdentRaw<CSSValueDense>(range).has_value();
+    if (!autoFlow && (!dense || !consumeIdentRaw<CSSValueAutoFlow>(range)))
         return nullptr;
-    RefPtr<CSSValue> denseIdent;
-    if (range.peek().id() == CSSValueAutoFlow) {
-        range.consumeIncludingWhitespace();
-        denseIdent = consumeIdent<CSSValueDense>(range);
-    } else {
-        // Dense case
-        if (range.peek().id() != CSSValueDense)
-            return nullptr;
-        denseIdent = consumeIdent<CSSValueDense>(range);
-        if (!denseIdent || !consumeIdent<CSSValueAutoFlow>(range))
-            return nullptr;
-    }
-    auto list = CSSValueList::createSpaceSeparated();
-    if (flowDirection->valueID() == CSSValueColumn || !denseIdent)
-        list->append(WTFMove(flowDirection));
-    if (denseIdent)
-        list->append(denseIdent.releaseNonNull());
-    
-    return list;
+
+    if (!dense)
+        return CSSValueList::createSpaceSeparated(CSSPrimitiveValue::create(flowDirection));
+    if (flowDirection == CSSValueRow)
+        return CSSValueList::createSpaceSeparated(CSSPrimitiveValue::create(CSSValueDense));
+    return CSSValueList::createSpaceSeparated(CSSPrimitiveValue::create(flowDirection),
+        CSSPrimitiveValue::create(CSSValueDense));
 }
 
 bool CSSPropertyParser::consumeGridShorthand(bool important)
@@ -2153,7 +2152,7 @@ bool CSSPropertyParser::consumeGridShorthand(bool important)
     
     if (m_range.peek().id() == CSSValueAutoFlow || m_range.peek().id() == CSSValueDense) {
         // 2- [ auto-flow && dense? ] <grid-auto-rows>? / <grid-template-columns>
-        gridAutoFlow = consumeImplicitGridAutoFlow(m_range, CSSPrimitiveValue::create(CSSValueRow));
+        gridAutoFlow = consumeImplicitGridAutoFlow(m_range, CSSValueRow);
         if (!gridAutoFlow || m_range.atEnd())
             return false;
         if (consumeSlashIncludingWhitespace(m_range))
@@ -2179,7 +2178,7 @@ bool CSSPropertyParser::consumeGridShorthand(bool important)
             return false;
         if (!consumeSlashIncludingWhitespace(m_range) || m_range.atEnd())
             return false;
-        gridAutoFlow = consumeImplicitGridAutoFlow(m_range, CSSPrimitiveValue::create(CSSValueColumn));
+        gridAutoFlow = consumeImplicitGridAutoFlow(m_range, CSSValueColumn);
         if (!gridAutoFlow)
             return false;
         if (m_range.atEnd())

--- a/Source/WebCore/css/process-css-properties.py
+++ b/Source/WebCore/css/process-css-properties.py
@@ -3521,14 +3521,14 @@ class GenerateStyleBuilderGenerated:
                     return "fromCSSValueDeducingType(value)"
 
             if property in self.style_properties.all_by_name["font"].codegen_properties.longhands and "Initial" not in property.codegen_properties.custom and not property.codegen_properties.converter:
-                to.write(f"if (is<CSSPrimitiveValue>(value) && CSSPropertyParserHelpers::isSystemFontShorthand(downcast<CSSPrimitiveValue>(value).valueID())) {{")
+                to.write(f"if (CSSPropertyParserHelpers::isSystemFontShorthand(value.valueID())) {{")
                 with to.indent():
                     to.write(f"applyInitial{property.id_without_prefix}(builderState);")
                     to.write(f"return;")
                 to.write(f"}}")
 
             if property.codegen_properties.auto_functions:
-                to.write(f"if (downcast<CSSPrimitiveValue>(value).valueID() == CSSValueAuto) {{")
+                to.write(f"if (value.valueID() == CSSValueAuto) {{")
                 with to.indent():
                     to.write(f"builderState.style().setHasAuto{property.name_for_methods}();")
                     to.write(f"return;")

--- a/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
+++ b/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
@@ -140,7 +140,7 @@ ExceptionOr<Vector<Ref<CSSStyleValue>>> CSSStyleValueFactory::parseStyleValue(co
         if (CSSProperty::isListValuedProperty(propertyID)) {
             if (auto* values = dynamicDowncast<CSSValueContainingVector>(*cssValue)) {
                 for (auto& value : *values)
-                    cssValues.append(value);
+                    cssValues.append(Ref { const_cast<CSSValue&>(value) });
             }
         }
         if (cssValues.isEmpty())
@@ -176,10 +176,9 @@ static bool mayConvertCSSValueListToSingleValue(std::optional<CSSPropertyID> pro
         && *propertyID != CSSPropertyGridColumnEnd;
 }
 
-ExceptionOr<Ref<CSSStyleValue>> CSSStyleValueFactory::reifyValue(Ref<CSSValue> cssValue, std::optional<CSSPropertyID> propertyID, Document* document)
+ExceptionOr<Ref<CSSStyleValue>> CSSStyleValueFactory::reifyValue(const CSSValue& cssValue, std::optional<CSSPropertyID> propertyID, Document* document)
 {
-    if (is<CSSPrimitiveValue>(cssValue)) {
-        auto primitiveValue = downcast<CSSPrimitiveValue>(cssValue.ptr());
+    if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(cssValue)) {
         if (primitiveValue->isCalculated()) {
             auto* calcValue = primitiveValue->cssCalcValue();
             auto result = CSSNumericValue::reifyMathExpression(calcValue->expressionNode());
@@ -274,37 +273,37 @@ ExceptionOr<Ref<CSSStyleValue>> CSSStyleValueFactory::reifyValue(Ref<CSSValue> c
             break;
         }
     } else if (is<CSSImageValue>(cssValue))
-        return Ref<CSSStyleValue> { CSSStyleImageValue::create(downcast<CSSImageValue>(cssValue.get()), document) };
+        return Ref<CSSStyleValue> { CSSStyleImageValue::create(downcast<CSSImageValue>(const_cast<CSSValue&>(cssValue)), document) };
     else if (is<CSSVariableReferenceValue>(cssValue)) {
-        return Ref<CSSStyleValue> { CSSUnparsedValue::create(downcast<CSSVariableReferenceValue>(cssValue.get()).data().tokenRange()) };
+        return Ref<CSSStyleValue> { CSSUnparsedValue::create(downcast<CSSVariableReferenceValue>(cssValue).data().tokenRange()) };
     } else if (is<CSSPendingSubstitutionValue>(cssValue)) {
-        return Ref<CSSStyleValue> { CSSUnparsedValue::create(downcast<CSSPendingSubstitutionValue>(cssValue.get()).shorthandValue().data().tokenRange()) };
+        return Ref<CSSStyleValue> { CSSUnparsedValue::create(downcast<CSSPendingSubstitutionValue>(cssValue).shorthandValue().data().tokenRange()) };
     } else if (is<CSSCustomPropertyValue>(cssValue)) {
         // FIXME: remove CSSStyleValue::create(WTFMove(cssValue)), add reification control flow
-        return WTF::switchOn(downcast<CSSCustomPropertyValue>(cssValue.get()).value(), [&](const std::monostate&) {
-            return ExceptionOr<Ref<CSSStyleValue>> { CSSStyleValue::create(WTFMove(cssValue)) };
+        return WTF::switchOn(downcast<CSSCustomPropertyValue>(cssValue).value(), [&](const std::monostate&) {
+            return ExceptionOr<Ref<CSSStyleValue>> { CSSStyleValue::create(Ref(const_cast<CSSValue&>(cssValue))) };
         }, [&](const Ref<CSSVariableReferenceValue>& value) {
             return reifyValue(value, propertyID, document);
         }, [&](Ref<CSSVariableData>& value) {
             return reifyValue(CSSVariableReferenceValue::create(WTFMove(value)), propertyID);
         }, [&](const CSSValueID&) {
-            return ExceptionOr<Ref<CSSStyleValue>> { CSSStyleValue::create(WTFMove(cssValue)) };
+            return ExceptionOr<Ref<CSSStyleValue>> { CSSStyleValue::create(Ref(const_cast<CSSValue&>(cssValue))) };
         }, [&](const CSSCustomPropertyValue::SyntaxValue& syntaxValue) -> ExceptionOr<Ref<CSSStyleValue>> {
             if (auto styleValue = constructStyleValueForCustomPropertySyntaxValue(syntaxValue))
                 return { *styleValue };
-            CSSTokenizer tokenizer(downcast<CSSCustomPropertyValue>(cssValue.get()).customCSSText());
+            CSSTokenizer tokenizer(downcast<CSSCustomPropertyValue>(cssValue).customCSSText());
             return { CSSUnparsedValue::create(tokenizer.tokenRange()) };
         }, [&](const CSSCustomPropertyValue::SyntaxValueList& syntaxValueList) -> ExceptionOr<Ref<CSSStyleValue>> {
             if (auto styleValue = constructStyleValueForCustomPropertySyntaxValue(syntaxValueList.values[0]))
                 return { *styleValue };
-            CSSTokenizer tokenizer(downcast<CSSCustomPropertyValue>(cssValue.get()).customCSSText());
+            CSSTokenizer tokenizer(downcast<CSSCustomPropertyValue>(cssValue).customCSSText());
             return { CSSUnparsedValue::create(tokenizer.tokenRange()) };
         }, [&](auto&) {
-            CSSTokenizer tokenizer(downcast<CSSCustomPropertyValue>(cssValue.get()).customCSSText());
+            CSSTokenizer tokenizer(downcast<CSSCustomPropertyValue>(cssValue).customCSSText());
             return ExceptionOr<Ref<CSSStyleValue>> { CSSUnparsedValue::create(tokenizer.tokenRange()) };
         });
     } else if (is<CSSTransformListValue>(cssValue)) {
-        auto& transformList = downcast<CSSTransformListValue>(cssValue.get());
+        auto& transformList = downcast<CSSTransformListValue>(cssValue);
         auto transformValue = CSSTransformValue::create(transformList);
         if (transformValue.hasException())
             return transformValue.releaseException();
@@ -313,14 +312,14 @@ ExceptionOr<Ref<CSSStyleValue>> CSSStyleValueFactory::reifyValue(Ref<CSSValue> c
         // Reifying the first value in value list.
         // FIXME: Verify this is the expected behavior.
         // Refer to LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/get.html
-        auto valueList = downcast<CSSValueList>(cssValue.ptr());
-        if (!valueList->length())
+        auto& valueList = downcast<CSSValueList>(cssValue);
+        if (!valueList.length())
             return Exception { TypeError, "The CSSValueList should not be empty."_s };
-        if ((valueList->length() == 1 && mayConvertCSSValueListToSingleValue(propertyID)) || (propertyID && CSSProperty::isListValuedProperty(*propertyID)))
-            return reifyValue(*valueList->begin(), propertyID, document);
+        if ((valueList.length() == 1 && mayConvertCSSValueListToSingleValue(propertyID)) || (propertyID && CSSProperty::isListValuedProperty(*propertyID)))
+            return reifyValue(valueList[0], propertyID, document);
     }
     
-    return CSSStyleValue::create(WTFMove(cssValue));
+    return CSSStyleValue::create(Ref(const_cast<CSSValue&>(cssValue)));
 }
 
 RefPtr<CSSStyleValue> CSSStyleValueFactory::constructStyleValueForCustomPropertySyntaxValue(const CSSCustomPropertyValue::SyntaxValue& syntaxValue)

--- a/Source/WebCore/css/typedom/CSSStyleValueFactory.h
+++ b/Source/WebCore/css/typedom/CSSStyleValueFactory.h
@@ -44,7 +44,7 @@ class StylePropertyShorthand;
 
 class CSSStyleValueFactory {
 public:
-    static ExceptionOr<Ref<CSSStyleValue>> reifyValue(Ref<CSSValue>, std::optional<CSSPropertyID>, Document* = nullptr);
+    static ExceptionOr<Ref<CSSStyleValue>> reifyValue(const CSSValue&, std::optional<CSSPropertyID>, Document* = nullptr);
     static ExceptionOr<Vector<Ref<CSSStyleValue>>> parseStyleValue(const AtomString&, const String&, bool);
     static RefPtr<CSSStyleValue> constructStyleValueForShorthandSerialization(const String&);
     static ExceptionOr<Vector<Ref<CSSStyleValue>>> vectorFromStyleValuesOrStrings(const AtomString& property, FixedVector<std::variant<RefPtr<CSSStyleValue>, String>>&& values);

--- a/Source/WebCore/css/typedom/StylePropertyMap.cpp
+++ b/Source/WebCore/css/typedom/StylePropertyMap.cpp
@@ -50,12 +50,15 @@ static RefPtr<CSSValue> cssValueFromStyleValues(std::optional<CSSPropertyID> pro
     };
     if (values.size() == 1)
         return toCSSValue(values[0]);
-    auto list = propertyID ? CSSProperty::createListForProperty(*propertyID) : CSSValueList::createCommaSeparated();
+    CSSValueListBuilder list;
     for (auto&& value : WTFMove(values)) {
         if (auto cssValue = toCSSValue(value))
-            list->append(cssValue.releaseNonNull());
+            list.append(cssValue.releaseNonNull());
     }
-    return list;
+    auto separator = ',';
+    if (propertyID)
+        separator = CSSProperty::listValuedPropertySeparator(*propertyID);
+    return CSSValueList::create(separator, WTFMove(list));
 }
 
 // https://drafts.css-houdini.org/css-typed-om/#dom-stylepropertymap-set
@@ -142,12 +145,11 @@ ExceptionOr<void> StylePropertyMap::append(Document& document, const AtomString&
         return Exception { TypeError, makeString(property, " does not support multiple values"_s) };
 
     auto currentValue = propertyValue(propertyID);
-    RefPtr list = dynamicDowncast<CSSValueList>(currentValue.get());
-    if (!list) {
-        list = CSSProperty::createListForProperty(propertyID);
-        if (currentValue)
-            list->append(currentValue.releaseNonNull());
-    }
+    CSSValueListBuilder list;
+    if (auto* currentList = dynamicDowncast<CSSValueList>(currentValue.get()))
+        list = currentList->copyValues();
+    else if (currentValue)
+        list.append(currentValue.releaseNonNull());
 
     auto styleValuesOrException = CSSStyleValueFactory::vectorFromStyleValuesOrStrings(property, WTFMove(values));
     if (styleValuesOrException.hasException())
@@ -158,10 +160,10 @@ ExceptionOr<void> StylePropertyMap::append(Document& document, const AtomString&
         if (is<CSSUnparsedValue>(styleValue.get()))
             return Exception { TypeError, "Values cannot contain a CSSVariableReferenceValue or a CSSUnparsedValue"_s };
         if (auto cssValue = styleValue->toCSSValue())
-            list->append(cssValue.releaseNonNull());
+            list.append(cssValue.releaseNonNull());
     }
 
-    if (!setProperty(propertyID, list.releaseNonNull()))
+    if (!setProperty(propertyID, CSSValueList::create(CSSProperty::listValuedPropertySeparator(propertyID), WTFMove(list))))
         return Exception { TypeError, "Invalid values"_s };
 
     return { };

--- a/Source/WebCore/css/typedom/StylePropertyMapReadOnly.cpp
+++ b/Source/WebCore/css/typedom/StylePropertyMapReadOnly.cpp
@@ -79,8 +79,8 @@ Vector<RefPtr<CSSStyleValue>> StylePropertyMapReadOnly::reifyValueToVector(RefPt
     auto& valueList = downcast<CSSValueList>(*value);
     Vector<RefPtr<CSSStyleValue>> result;
     result.reserveInitialCapacity(valueList.length());
-    for (const auto& cssValue : valueList)
-        result.uncheckedAppend(StylePropertyMapReadOnly::reifyValue(cssValue.copyRef(), propertyID, document));
+    for (auto& item : valueList)
+        result.uncheckedAppend(StylePropertyMapReadOnly::reifyValue(Ref { const_cast<CSSValue&>(item) }, propertyID, document));
     return result;
 }
 

--- a/Source/WebCore/css/typedom/transform/CSSPerspective.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSPerspective.cpp
@@ -171,9 +171,7 @@ RefPtr<CSSValue> CSSPerspective::toCSSValue() const
     if (!length)
         return nullptr;
 
-    auto result = CSSFunctionValue::create(CSSValuePerspective);
-    result->append(length.releaseNonNull());
-    return result;
+    return CSSFunctionValue::create(CSSValuePerspective, length.releaseNonNull());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/transform/CSSRotate.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSRotate.cpp
@@ -76,7 +76,7 @@ ExceptionOr<Ref<CSSRotate>> CSSRotate::create(CSSFunctionValue& cssFunctionValue
 {
     auto makeRotate = [&](const Function<ExceptionOr<Ref<CSSRotate>>(Vector<RefPtr<CSSNumericValue>>&&)>& create, size_t expectedNumberOfComponents) -> ExceptionOr<Ref<CSSRotate>> {
         Vector<RefPtr<CSSNumericValue>> components;
-        for (auto componentCSSValue : cssFunctionValue) {
+        for (auto& componentCSSValue : cssFunctionValue) {
             auto valueOrException = CSSStyleValueFactory::reifyValue(componentCSSValue, std::nullopt);
             if (valueOrException.hasException())
                 return valueOrException.releaseException();
@@ -204,28 +204,24 @@ ExceptionOr<Ref<DOMMatrix>> CSSRotate::toMatrix()
 
 RefPtr<CSSValue> CSSRotate::toCSSValue() const
 {
-    auto result = CSSFunctionValue::create(is2D() ? CSSValueRotate : CSSValueRotate3d);
-    if (!is2D()) {
-        auto x = m_x->toCSSValue();
-        if (!x)
-            return nullptr;
-        auto y = m_y->toCSSValue();
-        if (!y)
-            return nullptr;
-        auto z = m_z->toCSSValue();
-        if (!z)
-            return nullptr;
-
-        result->append(x.releaseNonNull());
-        result->append(y.releaseNonNull());
-        result->append(z.releaseNonNull());
-    }
-
     auto angle = m_angle->toCSSValue();
     if (!angle)
         return nullptr;
-    result->append(angle.releaseNonNull());
-    return result;
+
+    if (is2D())
+        return CSSFunctionValue::create(CSSValueRotate, angle.releaseNonNull());
+
+    auto x = m_x->toCSSValue();
+    if (!x)
+        return nullptr;
+    auto y = m_y->toCSSValue();
+    if (!y)
+        return nullptr;
+    auto z = m_z->toCSSValue();
+    if (!z)
+        return nullptr;
+
+    return CSSFunctionValue::create(CSSValueRotate3d, x.releaseNonNull(), y.releaseNonNull(), z.releaseNonNull(), angle.releaseNonNull());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/transform/CSSScale.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSScale.cpp
@@ -74,7 +74,7 @@ ExceptionOr<Ref<CSSScale>> CSSScale::create(CSSFunctionValue& cssFunctionValue)
 {
     auto makeScale = [&](const Function<ExceptionOr<Ref<CSSScale>>(Vector<RefPtr<CSSNumericValue>>&&)>& create, size_t minNumberOfComponents, std::optional<size_t> maxNumberOfComponents = std::nullopt) -> ExceptionOr<Ref<CSSScale>> {
         Vector<RefPtr<CSSNumericValue>> components;
-        for (auto componentCSSValue : cssFunctionValue) {
+        for (auto& componentCSSValue : cssFunctionValue) {
             auto valueOrException = CSSStyleValueFactory::reifyValue(componentCSSValue, std::nullopt);
             if (valueOrException.hasException())
                 return valueOrException.releaseException();
@@ -182,16 +182,14 @@ RefPtr<CSSValue> CSSScale::toCSSValue() const
     if (!x || !y)
         return nullptr;
 
-    auto result = CSSFunctionValue::create(is2D() ? CSSValueScale : CSSValueScale3d);
-    result->append(x.releaseNonNull());
-    result->append(y.releaseNonNull());
-    if (!is2D()) {
-        auto z = m_z->toCSSValue();
-        if (!z)
-            return nullptr;
-        result->append(z.releaseNonNull());
-    }
-    return result;
+    if (is2D())
+        return CSSFunctionValue::create(CSSValueScale, x.releaseNonNull(), y.releaseNonNull());
+
+    auto z = m_z->toCSSValue();
+    if (!z)
+        return nullptr;
+
+    return CSSFunctionValue::create(CSSValueScale3d, x.releaseNonNull(), y.releaseNonNull(), z.releaseNonNull());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/transform/CSSSkew.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSSkew.cpp
@@ -59,7 +59,7 @@ ExceptionOr<Ref<CSSSkew>> CSSSkew::create(CSSFunctionValue& cssFunctionValue)
     }
 
     Vector<Ref<CSSNumericValue>> components;
-    for (auto componentCSSValue : cssFunctionValue) {
+    for (auto& componentCSSValue : cssFunctionValue) {
         auto valueOrException = CSSStyleValueFactory::reifyValue(componentCSSValue, std::nullopt);
         if (valueOrException.hasException())
             return valueOrException.releaseException();
@@ -139,12 +139,9 @@ RefPtr<CSSValue> CSSSkew::toCSSValue() const
     auto ay = m_ay->toCSSValue();
     if (!ax || !ay)
         return nullptr;
-
-    auto result = CSSFunctionValue::create(CSSValueSkew);
-    result->append(ax.releaseNonNull());
-    if (!is<CSSUnitValue>(m_ay.get()) || downcast<CSSUnitValue>(m_ay.get()).value())
-        result->append(ay.releaseNonNull());
-    return result;
+    if (is<CSSUnitValue>(m_ay.get()) && !downcast<CSSUnitValue>(m_ay.get()).value())
+        return CSSFunctionValue::create(CSSValueSkew, ax.releaseNonNull());
+    return CSSFunctionValue::create(CSSValueSkew, ax.releaseNonNull(), ay.releaseNonNull());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/transform/CSSSkewX.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSSkewX.cpp
@@ -112,9 +112,7 @@ RefPtr<CSSValue> CSSSkewX::toCSSValue() const
     auto ax = m_ax->toCSSValue();
     if (!ax)
         return nullptr;
-    auto result = CSSFunctionValue::create(CSSValueSkewX);
-    result->append(ax.releaseNonNull());
-    return result;
+    return CSSFunctionValue::create(CSSValueSkewX, ax.releaseNonNull());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/transform/CSSSkewY.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSSkewY.cpp
@@ -112,9 +112,9 @@ RefPtr<CSSValue> CSSSkewY::toCSSValue() const
     auto ay = m_ay->toCSSValue();
     if (!ay)
         return nullptr;
-    auto result = CSSFunctionValue::create(CSSValueSkewY);
-    result->append(ay.releaseNonNull());
-    return result;
+    CSSValueListBuilder arguments;
+    arguments.append(ay.releaseNonNull());
+    return CSSFunctionValue::create(CSSValueSkewY, WTFMove(arguments));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/transform/CSSTransformValue.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSTransformValue.cpp
@@ -94,17 +94,16 @@ static ExceptionOr<Ref<CSSTransformComponent>> createTransformComponent(CSSFunct
     }
 }
 
-ExceptionOr<Ref<CSSTransformValue>> CSSTransformValue::create(CSSTransformListValue& transformList)
+ExceptionOr<Ref<CSSTransformValue>> CSSTransformValue::create(const CSSTransformListValue& list)
 {
     Vector<RefPtr<CSSTransformComponent>> components;
-    for (auto transformFunction : transformList) {
-        if (!is<CSSFunctionValue>(transformFunction))
+    for (auto& value : list) {
+        if (!is<CSSFunctionValue>(value))
             return Exception { TypeError, "Expected only function values in a transform list."_s };
-        auto& functionValue = downcast<CSSFunctionValue>(transformFunction.get());
-        auto transformComponentOrException = createTransformComponent(functionValue);
-        if (transformComponentOrException.hasException())
-            return transformComponentOrException.releaseException();
-        components.append(transformComponentOrException.releaseReturnValue());
+        auto component = createTransformComponent(downcast<CSSFunctionValue>(const_cast<CSSValue&>(value)));
+        if (component.hasException())
+            return component.releaseException();
+        components.append(component.releaseReturnValue());
     }
     return adoptRef(*new CSSTransformValue(WTFMove(components)));
 }
@@ -181,12 +180,12 @@ void CSSTransformValue::serialize(StringBuilder& builder, OptionSet<Serializatio
 
 RefPtr<CSSValue> CSSTransformValue::toCSSValue() const
 {
-    auto cssValueList = CSSTransformListValue::create();
+    CSSValueListBuilder builder;
     for (auto& component : m_components) {
         if (auto cssComponent = component->toCSSValue())
-            cssValueList->append(cssComponent.releaseNonNull());
+            builder.append(cssComponent.releaseNonNull());
     }
-    return cssValueList;
+    return CSSTransformListValue::create(WTFMove(builder));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/transform/CSSTransformValue.h
+++ b/Source/WebCore/css/typedom/transform/CSSTransformValue.h
@@ -39,7 +39,7 @@ template<typename> class ExceptionOr;
 class CSSTransformValue final : public CSSStyleValue {
     WTF_MAKE_ISO_ALLOCATED(CSSTransformValue);
 public:
-    static ExceptionOr<Ref<CSSTransformValue>> create(CSSTransformListValue&);
+    static ExceptionOr<Ref<CSSTransformValue>> create(const CSSTransformListValue&);
     static ExceptionOr<Ref<CSSTransformValue>> create(Vector<RefPtr<CSSTransformComponent>>&&);
 
     size_t length() const { return m_components.size(); }

--- a/Source/WebCore/css/typedom/transform/CSSTranslate.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSTranslate.cpp
@@ -62,7 +62,7 @@ ExceptionOr<Ref<CSSTranslate>> CSSTranslate::create(CSSFunctionValue& cssFunctio
 {
     auto makeTranslate = [&](const Function<ExceptionOr<Ref<CSSTranslate>>(Vector<Ref<CSSNumericValue>>&&)>& create, size_t minNumberOfComponents, std::optional<size_t> maxNumberOfComponents = std::nullopt) -> ExceptionOr<Ref<CSSTranslate>> {
         Vector<Ref<CSSNumericValue>> components;
-        for (auto componentCSSValue : cssFunctionValue) {
+        for (auto& componentCSSValue : cssFunctionValue) {
             auto valueOrException = CSSStyleValueFactory::reifyValue(componentCSSValue, std::nullopt);
             if (valueOrException.hasException())
                 return valueOrException.releaseException();
@@ -180,16 +180,14 @@ RefPtr<CSSValue> CSSTranslate::toCSSValue() const
     if (!y)
         return nullptr;
 
-    auto result = CSSFunctionValue::create(is2D() ? CSSValueTranslate : CSSValueTranslate3d);
-    result->append(x.releaseNonNull());
-    result->append(y.releaseNonNull());
-    if (!is2D()) {
-        auto z = m_z->toCSSValue();
-        if (!z)
-            return nullptr;
-        result->append(z.releaseNonNull());
-    }
-    return result;
+    if (is2D())
+        return CSSFunctionValue::create(CSSValueTranslate, x.releaseNonNull(), y.releaseNonNull());
+
+    auto z = m_z->toCSSValue();
+    if (!z)
+        return nullptr;
+
+    return CSSFunctionValue::create(CSSValueTranslate3d, x.releaseNonNull(), y.releaseNonNull(), z.releaseNonNull());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/editing/ApplyStyleCommand.cpp
+++ b/Source/WebCore/editing/ApplyStyleCommand.cpp
@@ -59,11 +59,6 @@ namespace WebCore {
 
 using namespace HTMLNames;
 
-static int toIdentifier(RefPtr<CSSValue>&& value)
-{
-    return is<CSSPrimitiveValue>(value) ? downcast<CSSPrimitiveValue>(*value).valueID() : 0;
-}
-
 static String& styleSpanClassString()
 {
     static NeverDestroyed<String> styleSpanClassString = String::fromLatin1(AppleStyleSpanClass);
@@ -481,7 +476,7 @@ RefPtr<HTMLElement> ApplyStyleCommand::splitAncestorsWithUnicodeBidi(Node* node,
     RefPtr<Node> nextHighestAncestorWithUnicodeBidi;
     int highestAncestorUnicodeBidi = 0;
     for (auto ancestor = RefPtr { node->parentNode() }; ancestor != block; ancestor = ancestor->parentNode()) {
-        int unicodeBidi = toIdentifier(ComputedStyleExtractor(ancestor.get()).propertyValue(CSSPropertyUnicodeBidi));
+        int unicodeBidi = valueID(ComputedStyleExtractor(ancestor.get()).propertyValue(CSSPropertyUnicodeBidi).get());
         if (unicodeBidi && unicodeBidi != CSSValueNormal) {
             highestAncestorUnicodeBidi = unicodeBidi;
             nextHighestAncestorWithUnicodeBidi = highestAncestorWithUnicodeBidi;
@@ -531,7 +526,7 @@ void ApplyStyleCommand::removeEmbeddingUpToEnclosingBlock(Node* node, Node* unsp
             continue;
 
         StyledElement& element = downcast<StyledElement>(*ancestor);
-        int unicodeBidi = toIdentifier(ComputedStyleExtractor(&element).propertyValue(CSSPropertyUnicodeBidi));
+        int unicodeBidi = valueID(ComputedStyleExtractor(&element).propertyValue(CSSPropertyUnicodeBidi).get());
         if (!unicodeBidi || unicodeBidi == CSSValueNormal)
             continue;
 
@@ -557,7 +552,7 @@ void ApplyStyleCommand::removeEmbeddingUpToEnclosingBlock(Node* node, Node* unsp
 static RefPtr<Node> highestEmbeddingAncestor(Node* startNode, Node* enclosingNode)
 {
     for (RefPtr currentNode = startNode; currentNode && currentNode != enclosingNode; currentNode = currentNode->parentNode()) {
-        if (currentNode->isHTMLElement() && toIdentifier(ComputedStyleExtractor(currentNode.get()).propertyValue(CSSPropertyUnicodeBidi)) == CSSValueEmbed)
+        if (currentNode->isHTMLElement() && valueID(ComputedStyleExtractor(currentNode.get()).propertyValue(CSSPropertyUnicodeBidi).get()) == CSSValueEmbed)
             return currentNode;
     }
 

--- a/Source/WebCore/editing/DeleteSelectionCommand.cpp
+++ b/Source/WebCore/editing/DeleteSelectionCommand.cpp
@@ -258,7 +258,7 @@ void DeleteSelectionCommand::smartDeleteParagraphSpacers()
 {
     VisiblePosition visibleStart { m_upstreamStart };
     VisiblePosition visibleEnd { m_downstreamEnd };
-    bool selectionEndsInParagraphSeperator = isEndOfParagraph(visibleEnd);
+    bool selectionEndsInParagraphSeparator = isEndOfParagraph(visibleEnd);
     bool selectionEndIsEndOfContent = endOfEditableContent(visibleEnd) == visibleEnd;
     bool startAndEndInSameUnsplittableElement = unsplittableElementForPosition(visibleStart.deepEquivalent()) == unsplittableElementForPosition(visibleEnd.deepEquivalent());
     visibleStart = visibleStart.previous(CannotCrossEditingBoundary);
@@ -266,7 +266,7 @@ void DeleteSelectionCommand::smartDeleteParagraphSpacers()
     bool previousPositionIsStartOfContent = startOfEditableContent(visibleStart) == visibleStart;
     bool previousPositionIsBlankParagraph = isBlankParagraph(visibleStart);
     bool endPositionIsBlankParagraph = isBlankParagraph(visibleEnd);
-    bool hasBlankParagraphAfterEndOrIsEndOfContent = !selectionEndIsEndOfContent && (endPositionIsBlankParagraph || selectionEndsInParagraphSeperator);
+    bool hasBlankParagraphAfterEndOrIsEndOfContent = !selectionEndIsEndOfContent && (endPositionIsBlankParagraph || selectionEndsInParagraphSeparator);
     if (startAndEndInSameUnsplittableElement && previousPositionIsBlankParagraph && hasBlankParagraphAfterEndOrIsEndOfContent) {
         m_needPlaceholder = false;
         Position position;
@@ -279,7 +279,7 @@ void DeleteSelectionCommand::smartDeleteParagraphSpacers()
         m_trailingWhitespace = m_downstreamEnd.trailingWhitespacePosition(VisiblePosition::defaultAffinity);
         setStartingSelectionOnSmartDelete(m_upstreamStart, m_downstreamEnd);
     }
-    if (startAndEndInSameUnsplittableElement && selectionEndIsEndOfContent && previousPositionIsBlankParagraph && selectionEndsInParagraphSeperator) {
+    if (startAndEndInSameUnsplittableElement && selectionEndIsEndOfContent && previousPositionIsBlankParagraph && selectionEndsInParagraphSeparator) {
         m_needPlaceholder = false;
         VisiblePosition endOfParagraphBeforeStart;
         if (previousPositionIsStartOfContent)

--- a/Source/WebCore/editing/EditingStyle.cpp
+++ b/Source/WebCore/editing/EditingStyle.cpp
@@ -216,8 +216,7 @@ HTMLElementEquivalent::HTMLElementEquivalent(CSSPropertyID id, CSSValueID primit
 
 bool HTMLElementEquivalent::valueIsPresentInStyle(Element& element, const EditingStyle& style) const
 {
-    RefPtr<CSSValue> value = style.m_mutableStyle->getPropertyCSSValue(m_propertyID);
-    return matches(element) && is<CSSPrimitiveValue>(value) && downcast<CSSPrimitiveValue>(*value).valueID() == m_primitiveValue->valueID();
+    return matches(element) && style.m_mutableStyle->propertyAsValueID(m_propertyID) == m_primitiveValue->valueID();
 }
 
 void HTMLElementEquivalent::addToStyle(Element*, EditingStyle* style) const
@@ -389,6 +388,27 @@ RefPtr<CSSValue> HTMLFontSizeEquivalent::attributeValueAsCSSValue(Element* eleme
     if (!HTMLFontElement::cssValueFromFontSizeNumber(value, size))
         return nullptr;
     return CSSPrimitiveValue::create(size);
+}
+
+static bool removeAll(CSSValueListBuilder& list, CSSValueID valueID)
+{
+    return list.removeAllMatching([&](auto& item) {
+        return isValueID(item, valueID);
+    });
+}
+
+static bool removeAll(CSSValueListBuilder& list, const CSSValue& value)
+{
+    return list.removeAllMatching([&](auto& item) {
+        return value.equals(item);
+    });
+}
+
+static bool contains(const CSSValueListBuilder& list, CSSValueID valueID)
+{
+    return list.containsIf([&](auto& item) {
+        return isValueID(item, valueID);
+    });
 }
 
 float EditingStyle::NoFontDelta = 0.0f;
@@ -617,20 +637,17 @@ std::optional<WritingDirection> EditingStyle::textDirection() const
     if (!m_mutableStyle)
         return std::nullopt;
 
-    RefPtr<CSSValue> unicodeBidi = m_mutableStyle->getPropertyCSSValue(CSSPropertyUnicodeBidi);
-    if (!is<CSSPrimitiveValue>(unicodeBidi))
-        return std::nullopt;
+    auto unicodeBidi = m_mutableStyle->propertyAsValueID(CSSPropertyUnicodeBidi);
 
-    CSSValueID unicodeBidiValue = downcast<CSSPrimitiveValue>(*unicodeBidi).valueID();
-    if (unicodeBidiValue == CSSValueEmbed) {
-        RefPtr<CSSValue> direction = m_mutableStyle->getPropertyCSSValue(CSSPropertyDirection);
-        if (!is<CSSPrimitiveValue>(direction))
+    if (unicodeBidi == CSSValueEmbed) {
+        auto direction = m_mutableStyle->propertyAsValueID(CSSPropertyDirection);
+        if (!direction)
             return std::nullopt;
 
-        return downcast<CSSPrimitiveValue>(*direction).valueID() == CSSValueLtr ? WritingDirection::LeftToRight : WritingDirection::RightToLeft;
+        return direction == CSSValueLtr ? WritingDirection::LeftToRight : WritingDirection::RightToLeft;
     }
 
-    if (unicodeBidiValue == CSSValueNormal)
+    if (unicodeBidi == CSSValueNormal)
         return WritingDirection::Natural;
 
     return std::nullopt;
@@ -650,7 +667,7 @@ void EditingStyle::overrideWithStyle(const StyleProperties& style)
     return mergeStyle(&style, OverrideValues);
 }
 
-static void applyTextDecorationChangeToValueList(CSSValueList& valueList, TextDecorationChange change, Ref<CSSPrimitiveValue>&& value)
+static void applyTextDecorationChangeToValueList(CSSValueListBuilder& valueList, TextDecorationChange change, Ref<CSSPrimitiveValue>&& value)
 {
     switch (change) {
     case TextDecorationChange::None:
@@ -659,7 +676,7 @@ static void applyTextDecorationChangeToValueList(CSSValueList& valueList, TextDe
         valueList.append(WTFMove(value));
         break;
     case TextDecorationChange::Remove:
-        valueList.removeAll(value);
+        removeAll(valueList, value);
         break;
     }
 }
@@ -683,19 +700,18 @@ void EditingStyle::overrideTypingStyleAt(const EditingStyle& style, const Positi
     Ref<CSSPrimitiveValue> underline = CSSPrimitiveValue::create(CSSValueUnderline);
     Ref<CSSPrimitiveValue> lineThrough = CSSPrimitiveValue::create(CSSValueLineThrough);
     RefPtr<CSSValue> value = m_mutableStyle->getPropertyCSSValue(CSSPropertyWebkitTextDecorationsInEffect);
-    RefPtr<CSSValueList> valueList;
-    if (value && value->isValueList()) {
-        valueList = downcast<CSSValueList>(*value).copy();
-        applyTextDecorationChangeToValueList(*valueList, underlineChange, WTFMove(underline));
-        applyTextDecorationChangeToValueList(*valueList, strikeThroughChange, WTFMove(lineThrough));
+    CSSValueListBuilder valueList;
+    if (is<CSSValueList>(value)) {
+        valueList = downcast<CSSValueList>(*value).copyValues();
+        applyTextDecorationChangeToValueList(valueList, underlineChange, WTFMove(underline));
+        applyTextDecorationChangeToValueList(valueList, strikeThroughChange, WTFMove(lineThrough));
     } else {
-        valueList = CSSValueList::createSpaceSeparated();
         if (underlineChange == TextDecorationChange::Add)
-            valueList->append(WTFMove(underline));
+            valueList.append(WTFMove(underline));
         if (strikeThroughChange == TextDecorationChange::Add)
-            valueList->append(WTFMove(lineThrough));
+            valueList.append(WTFMove(lineThrough));
     }
-    m_mutableStyle->setProperty(CSSPropertyWebkitTextDecorationsInEffect, valueList.get());
+    m_mutableStyle->setProperty(CSSPropertyWebkitTextDecorationsInEffect, CSSValueList::createSpaceSeparated(WTFMove(valueList)));
 }
 
 void EditingStyle::clear()
@@ -882,10 +898,7 @@ TriState EditingStyle::triStateOfStyle(const VisibleSelection& selection) const
 
 static RefPtr<CSSValueList> textDecorationValueList(const StyleProperties& properties)
 {
-    RefPtr<CSSValue> value = properties.getPropertyCSSValue(CSSPropertyTextDecorationLine);
-    if (!is<CSSValueList>(value))
-        return nullptr;
-    return downcast<CSSValueList>(value.get());
+    return dynamicDowncast<CSSValueList>(properties.getPropertyCSSValue(CSSPropertyTextDecorationLine).get());
 }
 
 bool EditingStyle::conflictsWithInlineStyleOfElement(StyledElement& element, RefPtr<MutableStyleProperties>* newInlineStylePtr, EditingStyle* extractedStyle) const
@@ -903,34 +916,33 @@ bool EditingStyle::conflictsWithInlineStyleOfElement(StyledElement& element, Ref
     bool shouldRemoveUnderline = underlineChange() == TextDecorationChange::Remove;
     bool shouldRemoveStrikeThrough = strikeThroughChange() == TextDecorationChange::Remove;
     if (shouldRemoveUnderline || shouldRemoveStrikeThrough) {
-        if (RefPtr<CSSValueList> valueList = textDecorationValueList(*inlineStyle)) {
-            auto newValueList = valueList->copy();
-            auto extractedValueList = CSSValueList::createSpaceSeparated();
+        if (auto valueList = textDecorationValueList(*inlineStyle)) {
+            auto newValueList = valueList->copyValues();
+            CSSValueListBuilder extractedValueList;
 
             if (shouldRemoveUnderline && valueList->hasValue(CSSValueUnderline)) {
                 if (!newInlineStyle)
                     return true;
-                newValueList->removeAll(CSSValueUnderline);
-                extractedValueList->append(CSSPrimitiveValue::create(CSSValueUnderline));
+                removeAll(newValueList, CSSValueUnderline);
+                extractedValueList.append(CSSPrimitiveValue::create(CSSValueUnderline));
             }
 
             if (shouldRemoveStrikeThrough && valueList->hasValue(CSSValueLineThrough)) {
                 if (!newInlineStyle)
                     return true;
-                newValueList->removeAll(CSSValueLineThrough);
-                extractedValueList->append(CSSPrimitiveValue::create(CSSValueLineThrough));
+                removeAll(newValueList, CSSValueLineThrough);
+                extractedValueList.append(CSSPrimitiveValue::create(CSSValueLineThrough));
             }
 
-            if (extractedValueList->length()) {
+            if (!extractedValueList.isEmpty()) {
                 conflicts = true;
-                if (newValueList->length())
-                    newInlineStyle->setProperty(CSSPropertyTextDecorationLine, WTFMove(newValueList));
-                else
+                if (newValueList.isEmpty())
                     newInlineStyle->removeProperty(CSSPropertyTextDecorationLine);
-
+                else
+                    newInlineStyle->setProperty(CSSPropertyTextDecorationLine, CSSValueList::createSpaceSeparated(WTFMove(newValueList)));
                 if (extractedStyle) {
                     bool isImportant = inlineStyle->propertyIsImportant(CSSPropertyTextDecorationLine);
-                    extractedStyle->setProperty(CSSPropertyTextDecorationLine, extractedValueList->cssText(), isImportant);
+                    extractedStyle->setProperty(CSSPropertyTextDecorationLine, CSSValueList::createSpaceSeparated(extractedValueList)->cssText(), isImportant);
                 }
             }
         }
@@ -1148,11 +1160,11 @@ void EditingStyle::prepareToApplyAt(const Position& position, ShouldPreserveWrit
     auto editingStyleAtPosition = EditingStyle::create(position, EditingPropertiesInEffect);
     StyleProperties* styleAtPosition = editingStyleAtPosition->m_mutableStyle.get();
 
-    RefPtr<CSSValue> unicodeBidi;
-    RefPtr<CSSValue> direction;
+    std::optional<CSSValueID> unicodeBidi;
+    std::optional<CSSValueID> direction;
     if (shouldPreserveWritingDirection == PreserveWritingDirection) {
-        unicodeBidi = m_mutableStyle->getPropertyCSSValue(CSSPropertyUnicodeBidi);
-        direction = m_mutableStyle->getPropertyCSSValue(CSSPropertyDirection);
+        unicodeBidi = m_mutableStyle->propertyAsValueID(CSSPropertyUnicodeBidi);
+        direction = m_mutableStyle->propertyAsValueID(CSSPropertyDirection);
     }
 
     removeEquivalentProperties(*styleAtPosition);
@@ -1170,10 +1182,10 @@ void EditingStyle::prepareToApplyAt(const Position& position, ShouldPreserveWrit
         || cssValueToColor(m_mutableStyle->getPropertyCSSValue(CSSPropertyBackgroundColor).get()) == rgbaBackgroundColorInEffect(position.containerNode()))
         m_mutableStyle->removeProperty(CSSPropertyBackgroundColor);
 
-    if (is<CSSPrimitiveValue>(unicodeBidi)) {
-        m_mutableStyle->setProperty(CSSPropertyUnicodeBidi, static_cast<CSSValueID>(downcast<CSSPrimitiveValue>(*unicodeBidi).valueID()));
-        if (is<CSSPrimitiveValue>(direction))
-            m_mutableStyle->setProperty(CSSPropertyDirection, static_cast<CSSValueID>(downcast<CSSPrimitiveValue>(*direction).valueID()));
+    if (unicodeBidi) {
+        m_mutableStyle->setProperty(CSSPropertyUnicodeBidi, *unicodeBidi);
+        if (direction)
+            m_mutableStyle->setProperty(CSSPropertyDirection, *direction);
     }
 }
 
@@ -1282,12 +1294,12 @@ Ref<EditingStyle> EditingStyle::wrappingStyleForSerialization(Node& context, boo
 }
 
 
-static void mergeTextDecorationValues(CSSValueList& mergedValue, const CSSValueList& valueToMerge)
+static void mergeTextDecorationValues(CSSValueListBuilder& mergedValue, const CSSValueList& valueToMerge)
 {
-    if (valueToMerge.hasValue(CSSValueUnderline) && !mergedValue.hasValue(CSSValueUnderline))
+    if (valueToMerge.hasValue(CSSValueUnderline) && !contains(mergedValue, CSSValueUnderline))
         mergedValue.append(CSSPrimitiveValue::create(CSSValueUnderline));
 
-    if (valueToMerge.hasValue(CSSValueLineThrough) && !mergedValue.hasValue(CSSValueLineThrough))
+    if (valueToMerge.hasValue(CSSValueLineThrough) && !contains(mergedValue, CSSValueLineThrough))
         mergedValue.append(CSSPrimitiveValue::create(CSSValueLineThrough));
 }
 
@@ -1308,9 +1320,9 @@ void EditingStyle::mergeStyle(const StyleProperties* style, CSSPropertyOverrideM
         if ((property.id() == CSSPropertyTextDecorationLine || property.id() == CSSPropertyWebkitTextDecorationsInEffect)
             && is<CSSValueList>(*property.value()) && value) {
             if (is<CSSValueList>(*value)) {
-                auto newValue = downcast<CSSValueList>(*value).copy();
+                auto newValue = downcast<CSSValueList>(*value).copyValues();
                 mergeTextDecorationValues(newValue, downcast<CSSValueList>(*property.value()));
-                m_mutableStyle->setProperty(property.id(), WTFMove(newValue), property.isImportant());
+                m_mutableStyle->setProperty(property.id(), CSSValueList::createSpaceSeparated(WTFMove(newValue)), property.isImportant());
                 continue;
             }
             value = nullptr; // text-decoration: none is equivalent to not having the property.
@@ -1589,8 +1601,7 @@ WritingDirection EditingStyle::textDirectionForSelection(const VisibleSelection&
         for (auto& intersectingNode : intersectingNodes(*makeSimpleRange(position, end))) {
             if (!intersectingNode.isStyledElement())
                 continue;
-            auto valueObject = ComputedStyleExtractor(&intersectingNode).propertyValue(CSSPropertyUnicodeBidi);
-            auto value = is<CSSPrimitiveValue>(valueObject) ? downcast<CSSPrimitiveValue>(*valueObject).valueID() : CSSValueInvalid;
+            auto value = valueID(ComputedStyleExtractor(&intersectingNode).propertyValue(CSSPropertyUnicodeBidi).get());
             if (value == CSSValueEmbed || value == CSSValueBidiOverride)
                 return WritingDirection::Natural;
         }
@@ -1620,7 +1631,7 @@ WritingDirection EditingStyle::textDirectionForSelection(const VisibleSelection&
         if (!is<CSSPrimitiveValue>(unicodeBidi))
             continue;
 
-        CSSValueID unicodeBidiValue = downcast<CSSPrimitiveValue>(*unicodeBidi).valueID();
+        CSSValueID unicodeBidiValue = unicodeBidi->valueID();
         if (unicodeBidiValue == CSSValueNormal)
             continue;
 
@@ -1632,7 +1643,7 @@ WritingDirection EditingStyle::textDirectionForSelection(const VisibleSelection&
         if (!is<CSSPrimitiveValue>(direction))
             continue;
 
-        CSSValueID directionValue = downcast<CSSPrimitiveValue>(*direction).valueID();
+        CSSValueID directionValue = direction->valueID();
         if (directionValue != CSSValueLtr && directionValue != CSSValueRtl)
             continue;
 
@@ -1740,20 +1751,19 @@ StyleChange::StyleChange(EditingStyle* style, const Position& position)
         if (!is<CSSValueList>(value))
             value = computedStyle.propertyValue(CSSPropertyTextDecorationLine);
 
-        RefPtr<CSSValueList> valueList;
+        CSSValueListBuilder valueList;
         if (is<CSSValueList>(value))
-            valueList = downcast<CSSValueList>(value.get());
+            valueList = downcast<CSSValueList>(*value).copyValues();
 
-        bool hasUnderline = valueList && valueList->hasValue(CSSValueUnderline);
-        bool hasLineThrough = valueList && valueList->hasValue(CSSValueLineThrough);
+        bool hasUnderline = contains(valueList, CSSValueUnderline);
+        bool hasLineThrough = contains(valueList, CSSValueLineThrough);
 
         if (shouldStyleWithCSS) {
-            valueList = valueList ? valueList->copy() : CSSValueList::createSpaceSeparated();
             if (shouldAddUnderline && !hasUnderline)
-                valueList->append(CSSPrimitiveValue::create(CSSValueUnderline));
+                valueList.append(CSSPrimitiveValue::create(CSSValueUnderline));
             if (shouldAddStrikeThrough && !hasLineThrough)
-                valueList->append(CSSPrimitiveValue::create(CSSValueLineThrough));
-            mutableStyle->setProperty(CSSPropertyTextDecorationLine, valueList.get());
+                valueList.append(CSSPrimitiveValue::create(CSSValueLineThrough));
+            mutableStyle->setProperty(CSSPropertyTextDecorationLine, CSSValueList::createSpaceSeparated(WTFMove(valueList)));
         } else {
             m_applyUnderline = shouldAddUnderline && !hasUnderline;
             m_applyLineThrough = shouldAddStrikeThrough && !hasLineThrough;
@@ -1819,14 +1829,14 @@ void StyleChange::extractTextStyles(Document& document, MutableStyleProperties& 
     // Furthermore, text-decoration: none has been trimmed so that text-decoration property is always a CSSValueList.
     auto textDecoration = style.getPropertyCSSValue(CSSPropertyTextDecorationLine);
     if (is<CSSValueList>(textDecoration)) {
-        auto newTextDecoration = downcast<CSSValueList>(*textDecoration).copy();
-        if (newTextDecoration->removeAll(CSSValueUnderline))
+        auto newTextDecoration = downcast<CSSValueList>(*textDecoration).copyValues();
+        if (removeAll(newTextDecoration, CSSValueUnderline))
             m_applyUnderline = true;
-        if (newTextDecoration->removeAll(CSSValueLineThrough))
+        if (removeAll(newTextDecoration, CSSValueLineThrough))
             m_applyLineThrough = true;
 
         // If trimTextDecorations, delete underline and line-through
-        setTextDecorationProperty(style, newTextDecoration.get(), CSSPropertyTextDecorationLine);
+        setTextDecorationProperty(style, CSSValueList::createSpaceSeparated(WTFMove(newTextDecoration)), CSSPropertyTextDecorationLine);
     }
 
     int verticalAlign = identifierForStyleProperty(style, CSSPropertyVerticalAlign);
@@ -1864,18 +1874,15 @@ void StyleChange::extractTextStyles(Document& document, MutableStyleProperties& 
     }
 }
 
-static void diffTextDecorations(MutableStyleProperties& style, CSSPropertyID propertID, CSSValue* refTextDecoration)
+static void diffTextDecorations(MutableStyleProperties& style, CSSPropertyID propertyID, CSSValue* refTextDecoration)
 {
-    auto textDecoration = style.getPropertyCSSValue(propertID);
+    auto textDecoration = style.getPropertyCSSValue(propertyID);
     if (!is<CSSValueList>(textDecoration) || !is<CSSValueList>(refTextDecoration))
         return;
-
-    auto newTextDecoration = downcast<CSSValueList>(*textDecoration).copy();
-
-    for (auto& value :  downcast<CSSValueList>(*refTextDecoration))
-        newTextDecoration->removeAll(value);
-
-    setTextDecorationProperty(style, newTextDecoration.get(), propertID);
+    auto newTextDecoration = downcast<CSSValueList>(*textDecoration).copyValues();
+    for (auto& value : downcast<CSSValueList>(*refTextDecoration))
+        removeAll(newTextDecoration, value);
+    setTextDecorationProperty(style, CSSValueList::createSpaceSeparated(WTFMove(newTextDecoration)), propertyID);
 }
 
 template<typename T>

--- a/Source/WebCore/editing/FontAttributeChanges.cpp
+++ b/Source/WebCore/editing/FontAttributeChanges.cpp
@@ -94,13 +94,11 @@ static RefPtr<CSSValueList> cssValueListForShadow(const FontShadow& shadow)
     if (shadow.offset.isZero() && !shadow.blurRadius)
         return nullptr;
 
-    auto list = CSSValueList::createCommaSeparated();
     auto width = CSSPrimitiveValue::create(shadow.offset.width(), CSSUnitType::CSS_PX);
     auto height = CSSPrimitiveValue::create(shadow.offset.height(), CSSUnitType::CSS_PX);
     auto blurRadius = CSSPrimitiveValue::create(shadow.blurRadius, CSSUnitType::CSS_PX);
     auto color = CSSValuePool::singleton().createColorValue(shadow.color);
-    list->prepend(CSSShadowValue::create(WTFMove(width), WTFMove(height), WTFMove(blurRadius), { }, { }, WTFMove(color)));
-    return list.ptr();
+    return CSSValueList::createCommaSeparated(CSSShadowValue::create(WTFMove(width), WTFMove(height), WTFMove(blurRadius), { }, { }, WTFMove(color)));
 }
 
 FontAttributeChanges::FontAttributeChanges(std::optional<VerticalAlignChange>&& verticalAlign, std::optional<Color>&& backgroundColor, std::optional<Color>&& foregroundColor, std::optional<FontShadow>&& shadow, std::optional<bool>&& strikeThrough, std::optional<bool>&& underline, FontChanges&& fontChanges)

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -893,8 +893,7 @@ static bool propertyMissingOrEqualToNone(const StyleProperties* style, CSSProper
 {
     if (!style)
         return false;
-    auto value = style->getPropertyCSSValue(propertyID);
-    return !value || (is<CSSPrimitiveValue>(*value) && downcast<CSSPrimitiveValue>(*value).valueID() == CSSValueNone);
+    return style->propertyAsValueID(propertyID).value_or(CSSValueNone) == CSSValueNone;
 }
 
 static bool needInterchangeNewlineAfter(const VisiblePosition& v)

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -583,13 +583,8 @@ void HTMLElement::applyAspectRatioWithoutDimensionalRulesFromWidthAndHeightAttri
 
 void HTMLElement::addParsedWidthAndHeightToAspectRatioList(double width, double height, MutableStyleProperties& style)
 {
-    auto ratioList = CSSValueList::createSlashSeparated();
-    ratioList->append(CSSPrimitiveValue::create(width));
-    ratioList->append(CSSPrimitiveValue::create(height));
-    auto list = CSSValueList::createSpaceSeparated();
-    list->append(CSSPrimitiveValue::create(CSSValueAuto));
-    list->append(ratioList);
-    style.setProperty(CSSPropertyAspectRatio, WTFMove(list));
+    style.setProperty(CSSPropertyAspectRatio, CSSValueList::createSpaceSeparated(CSSPrimitiveValue::create(CSSValueAuto),
+        CSSValueList::createSlashSeparated(CSSPrimitiveValue::create(width), CSSPrimitiveValue::create(height))));
 }
 
 void HTMLElement::applyAlignmentAttributeToStyle(const AtomString& alignment, MutableStyleProperties& style)

--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -1426,7 +1426,7 @@ static Vector<String> authoredGridTrackSizes(Node* node, GridTrackSizingDirectio
         if (is<CSSGridAutoRepeatValue>(currentValue)) {
             // Auto-repeated values will be looped through until no more values were used in layout based on the expected track count.
             while (trackSizes.size() < expectedTrackCount) {
-                for (auto& autoRepeatValue : downcast<CSSValueList>(currentValue.get())) {
+                for (auto& autoRepeatValue : downcast<CSSValueList>(currentValue)) {
                     handleValueIgnoringLineNames(autoRepeatValue);
                     if (trackSizes.size() >= expectedTrackCount)
                         break;
@@ -1436,9 +1436,9 @@ static Vector<String> authoredGridTrackSizes(Node* node, GridTrackSizingDirectio
         }
 
         if (is<CSSGridIntegerRepeatValue>(currentValue)) {
-            size_t repetitions = downcast<CSSGridIntegerRepeatValue>(currentValue.get()).repetitions();
+            size_t repetitions = downcast<CSSGridIntegerRepeatValue>(currentValue).repetitions();
             for (size_t i = 0; i < repetitions; ++i) {
-                for (auto& integerRepeatValue : downcast<CSSValueList>(currentValue.get()))
+                for (auto& integerRepeatValue : downcast<CSSValueList>(currentValue))
                     handleValueIgnoringLineNames(integerRepeatValue);
             }
             continue;

--- a/Source/WebCore/platform/animation/TimingFunction.cpp
+++ b/Source/WebCore/platform/animation/TimingFunction.cpp
@@ -160,7 +160,7 @@ ExceptionOr<RefPtr<TimingFunction>> TimingFunction::createFromCSSText(const Stri
 RefPtr<TimingFunction> TimingFunction::createFromCSSValue(const CSSValue& value)
 {
     if (is<CSSPrimitiveValue>(value)) {
-        switch (downcast<CSSPrimitiveValue>(value).valueID()) {
+        switch (value.valueID()) {
         case CSSValueLinear:
             return LinearTimingFunction::create();
         case CSSValueEase:

--- a/Source/WebCore/rendering/style/StyleImageSet.cpp
+++ b/Source/WebCore/rendering/style/StyleImageSet.cpp
@@ -57,14 +57,12 @@ bool StyleImageSet::equals(const StyleImageSet& other) const
 
 Ref<CSSValue> StyleImageSet::computedStyleValue(const RenderStyle& style) const
 {
-    auto result = CSSImageSetValue::create();
-
+    CSSValueListBuilder builder;
     for (auto& image : m_images) {
-        result->append(image.image->computedStyleValue(style));
-        result->append(CSSPrimitiveValue::create(image.scaleFactor, CSSUnitType::CSS_DPPX));
+        builder.append(image.image->computedStyleValue(style));
+        builder.append(CSSPrimitiveValue::create(image.scaleFactor, CSSUnitType::CSS_DPPX));
     }
-
-    return result;
+    return CSSImageSetValue::create(WTFMove(builder));
 }
 
 ImageWithScale StyleImageSet::selectBestFitImage(const Document& document)

--- a/Source/WebCore/style/FilterOperationsBuilder.cpp
+++ b/Source/WebCore/style/FilterOperationsBuilder.cpp
@@ -87,7 +87,7 @@ std::optional<FilterOperations> createFilterOperations(const Document& document,
 
     for (auto& currentValue : downcast<CSSValueList>(inValue)) {
         if (is<CSSPrimitiveValue>(currentValue)) {
-            auto& primitiveValue = downcast<CSSPrimitiveValue>(currentValue.get());
+            auto& primitiveValue = downcast<CSSPrimitiveValue>(currentValue);
             if (!primitiveValue.isURI())
                 continue;
 
@@ -100,7 +100,7 @@ std::optional<FilterOperations> createFilterOperations(const Document& document,
         if (!is<CSSFunctionValue>(currentValue))
             continue;
 
-        auto& filterValue = downcast<CSSFunctionValue>(currentValue.get());
+        auto& filterValue = downcast<CSSFunctionValue>(currentValue);
         auto operationType = filterOperationForType(filterValue.name());
 
         // Check that all parameters are primitive values, with the

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -246,7 +246,7 @@ inline Length BuilderConverter::convertLengthAllowingNumber(const BuilderState& 
 
 inline Length BuilderConverter::convertLengthOrAuto(const BuilderState& builderState, const CSSValue& value)
 {
-    if (downcast<CSSPrimitiveValue>(value).valueID() == CSSValueAuto)
+    if (value.valueID() == CSSValueAuto)
         return Length(LengthType::Auto);
     return convertLength(builderState, value);
 }
@@ -284,7 +284,7 @@ inline Length BuilderConverter::convertLengthSizing(const BuilderState& builderS
 
 inline Length BuilderConverter::convertLengthMaxSizing(const BuilderState& builderState, const CSSValue& value)
 {
-    if (downcast<CSSPrimitiveValue>(value).valueID() == CSSValueNone)
+    if (value.valueID() == CSSValueNone)
         return Length(LengthType::Undefined);
     return convertLengthSizing(builderState, value);
 }
@@ -454,7 +454,7 @@ inline OptionSet<TextDecorationLine> BuilderConverter::convertTextDecorationLine
     auto result = RenderStyle::initialTextDecorationLine();
     if (is<CSSValueList>(value)) {
         for (auto& currentValue : downcast<CSSValueList>(value))
-            result.add(fromCSSValue<TextDecorationLine>(currentValue.get()));
+            result.add(fromCSSValue<TextDecorationLine>(currentValue));
     }
     return result;
 }
@@ -468,7 +468,7 @@ inline T BuilderConverter::convertNumber(BuilderState&, const CSSValue& value)
 template<typename T>
 inline T BuilderConverter::convertNumberOrAuto(BuilderState& builderState, const CSSValue& value)
 {
-    if (downcast<CSSPrimitiveValue>(value).valueID() == CSSValueAuto)
+    if (value.valueID() == CSSValueAuto)
         return -1;
     return convertNumber<T>(builderState, value);
 }
@@ -548,7 +548,7 @@ inline StyleColorScheme BuilderConverter::convertColorScheme(BuilderState&, cons
 
     if (is<CSSValueList>(value)) {
         for (auto& currentValue : downcast<CSSValueList>(value))
-            updateColorScheme(downcast<CSSPrimitiveValue>(currentValue.get()), colorScheme);
+            updateColorScheme(downcast<CSSPrimitiveValue>(currentValue), colorScheme);
     } else if (is<CSSPrimitiveValue>(value))
         updateColorScheme(downcast<CSSPrimitiveValue>(value), colorScheme);
 
@@ -567,14 +567,14 @@ inline String BuilderConverter::convertString(BuilderState&, const CSSValue& val
 
 inline String BuilderConverter::convertStringOrAuto(BuilderState& builderState, const CSSValue& value)
 {
-    if (downcast<CSSPrimitiveValue>(value).valueID() == CSSValueAuto)
+    if (value.valueID() == CSSValueAuto)
         return nullAtom();
     return convertString(builderState, value);
 }
 
 inline String BuilderConverter::convertStringOrNone(BuilderState& builderState, const CSSValue& value)
 {
-    if (downcast<CSSPrimitiveValue>(value).valueID() == CSSValueNone)
+    if (value.valueID() == CSSValueNone)
         return nullAtom();
     return convertString(builderState, value);
 }
@@ -607,7 +607,7 @@ inline OptionSet<TextEmphasisPosition> BuilderConverter::convertTextEmphasisPosi
 
     OptionSet<TextEmphasisPosition> position;
     for (auto& currentValue : downcast<CSSValueList>(value))
-        position.add(valueToEmphasisPosition(downcast<CSSPrimitiveValue>(currentValue.get())));
+        position.add(valueToEmphasisPosition(downcast<CSSPrimitiveValue>(currentValue)));
     return position;
 }
 
@@ -706,7 +706,7 @@ inline RefPtr<PathOperation> BuilderConverter::convertPathOperation(BuilderState
     auto referenceBox = CSSBoxType::BoxMissing;
     RefPtr<PathOperation> operation;
     for (auto& currentValue : downcast<CSSValueList>(value)) {
-        if (!currentValue->isValueID()) {
+        if (!currentValue.isValueID()) {
             operation = ShapePathOperation::create(basicShapeForValue(builderState.cssToLengthConversionData(),
                 currentValue, builderState.style().effectiveZoom()));
         } else
@@ -817,7 +817,7 @@ inline TextDecorationThickness BuilderConverter::convertTextDecorationThickness(
 inline RefPtr<StyleReflection> BuilderConverter::convertReflection(BuilderState& builderState, const CSSValue& value)
 {
     if (is<CSSPrimitiveValue>(value)) {
-        ASSERT(downcast<CSSPrimitiveValue>(value).valueID() == CSSValueNone);
+        ASSERT(value.valueID() == CSSValueNone);
         return nullptr;
     }
 
@@ -926,7 +926,7 @@ inline float BuilderConverter::convertTextStrokeWidth(BuilderState& builderState
 inline OptionSet<LineBoxContain> BuilderConverter::convertLineBoxContain(BuilderState&, const CSSValue& value)
 {
     if (is<CSSPrimitiveValue>(value)) {
-        ASSERT(downcast<CSSPrimitiveValue>(value).valueID() == CSSValueNone);
+        ASSERT(value.valueID() == CSSValueNone);
         return { };
     }
 
@@ -936,7 +936,7 @@ inline OptionSet<LineBoxContain> BuilderConverter::convertLineBoxContain(Builder
 inline RefPtr<ShapeValue> BuilderConverter::convertShapeValue(BuilderState& builderState, CSSValue& value)
 {
     if (is<CSSPrimitiveValue>(value)) {
-        ASSERT(downcast<CSSPrimitiveValue>(value).valueID() == CSSValueNone);
+        ASSERT(value.valueID() == CSSValueNone);
         return nullptr;
     }
 
@@ -946,7 +946,7 @@ inline RefPtr<ShapeValue> BuilderConverter::convertShapeValue(BuilderState& buil
     RefPtr<BasicShape> shape;
     CSSBoxType referenceBox = CSSBoxType::BoxMissing;
     for (auto& currentValue : downcast<CSSValueList>(value)) {
-        if (!currentValue->isValueID())
+        if (!currentValue.isValueID())
             shape = basicShapeForValue(builderState.cssToLengthConversionData(), currentValue);
         else
             referenceBox = fromCSSValue<CSSBoxType>(currentValue);
@@ -1031,20 +1031,14 @@ inline bool BuilderConverter::createGridTrackList(const CSSValue& value, GridTra
 {
     RefPtr<const CSSValueContainingVector> valueList;
 
-    // Handle 'none' or 'masonry'.
     bool isSubgrid = is<CSSSubgridValue>(value);
     if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
         if (primitiveValue->valueID() == CSSValueMasonry) {
             trackList.append(GridTrackEntryMasonry());
             return true;
         }
-        // Values coming from CSS Typed OM may not have been converted to a CSSValueList yet.
         if (primitiveValue->valueID() == CSSValueNone)
             return true;
-
-        auto newList = CSSValueList::createSpaceSeparated();
-        newList->append(const_cast<CSSValue&>(value));
-        valueList = WTFMove(newList);
     } else if (isSubgrid) {
         valueList = &downcast<CSSSubgridValue>(value);
         trackList.append(GridTrackEntrySubgrid());
@@ -1052,8 +1046,6 @@ inline bool BuilderConverter::createGridTrackList(const CSSValue& value, GridTra
         valueList = &downcast<CSSValueList>(value);
     else
         return false;
-
-    ASSERT(valueList);
 
     // https://drafts.csswg.org/css-grid-2/#computed-tracks
     // The computed track list of a non-subgrid axis is a list alternating between line name sets
@@ -1069,8 +1061,8 @@ inline bool BuilderConverter::createGridTrackList(const CSSValue& value, GridTra
         for (auto& currentValue : downcast<CSSValueContainingVector>(repeatValue)) {
             if (is<CSSGridLineNamesValue>(currentValue)) {
                 Vector<String> names;
-                for (auto& namedGridLineValue : downcast<CSSGridLineNamesValue>(currentValue.get()))
-                    names.append(downcast<CSSPrimitiveValue>(namedGridLineValue.get()).stringValue());
+                for (auto& namedGridLineValue : downcast<CSSGridLineNamesValue>(currentValue).names())
+                    names.append(namedGridLineValue);
                 repeatList.append(WTFMove(names));
             } else {
                 ensureLineNames(repeatList);
@@ -1082,19 +1074,19 @@ inline bool BuilderConverter::createGridTrackList(const CSSValue& value, GridTra
             ensureLineNames(repeatList);
     };
 
-    for (auto& currentValue : *valueList) {
+    auto addOne = [&](const CSSValue& currentValue) {
         if (is<CSSGridLineNamesValue>(currentValue)) {
             Vector<String> names;
-            for (auto& namedGridLineValue : downcast<CSSGridLineNamesValue>(currentValue.get()))
-                names.append(downcast<CSSPrimitiveValue>(namedGridLineValue.get()).stringValue());
+            for (auto& namedGridLineValue : downcast<CSSGridLineNamesValue>(currentValue).names())
+                names.append(namedGridLineValue);
             trackList.append(WTFMove(names));
-            continue;
+            return;
         }
 
         ensureLineNames(trackList);
 
         if (is<CSSGridAutoRepeatValue>(currentValue)) {
-            CSSValueID autoRepeatID = downcast<CSSGridAutoRepeatValue>(currentValue.get()).autoRepeatID();
+            CSSValueID autoRepeatID = downcast<CSSGridAutoRepeatValue>(currentValue).autoRepeatID();
             ASSERT(autoRepeatID == CSSValueAutoFill || autoRepeatID == CSSValueAutoFit);
 
             GridTrackEntryAutoRepeat repeat;
@@ -1104,13 +1096,20 @@ inline bool BuilderConverter::createGridTrackList(const CSSValue& value, GridTra
             trackList.append(WTFMove(repeat));
         } else if (is<CSSGridIntegerRepeatValue>(currentValue)) {
             GridTrackEntryRepeat repeat;
-            repeat.repeats = downcast<CSSGridIntegerRepeatValue>(currentValue.get()).repetitions();
+            repeat.repeats = downcast<CSSGridIntegerRepeatValue>(currentValue).repetitions();
 
             buildRepeatList(currentValue, repeat.list);
             trackList.append(WTFMove(repeat));
         } else {
             trackList.append(createGridTrackSize(currentValue, builderState));
         }
+    };
+
+    if (!valueList)
+        addOne(value);
+    else {
+        for (auto& value : *valueList)
+            addOne(value);
     }
 
     if (!trackList.isEmpty())
@@ -1138,19 +1137,19 @@ inline bool BuilderConverter::createGridPosition(const CSSValue& value, GridPosi
     ASSERT(values.length());
 
     auto it = values.begin();
-    const CSSPrimitiveValue* currentValue = &downcast<CSSPrimitiveValue>(it->get());
+    auto* currentValue = &downcast<CSSPrimitiveValue>(*it);
     bool isSpanPosition = false;
     if (currentValue->valueID() == CSSValueSpan) {
         isSpanPosition = true;
         ++it;
-        currentValue = it != values.end() ? &downcast<CSSPrimitiveValue>(it->get()) : nullptr;
+        currentValue = it != values.end() ? &downcast<CSSPrimitiveValue>(*it) : nullptr;
     }
 
     int gridLineNumber = 0;
     if (currentValue && currentValue->isInteger()) {
         gridLineNumber = currentValue->intValue();
         ++it;
-        currentValue = it != values.end() ? &downcast<CSSPrimitiveValue>(it->get()) : nullptr;
+        currentValue = it != values.end() ? &downcast<CSSPrimitiveValue>(*it) : nullptr;
     }
 
     String gridLineName;
@@ -1273,15 +1272,10 @@ inline GridAutoFlow BuilderConverter::convertGridAutoFlow(BuilderState&, const C
 inline Vector<StyleContentAlignmentData> BuilderConverter::convertContentAlignmentDataList(BuilderState& builder, const CSSValue& value)
 {
     auto& list = downcast<CSSValueList>(value);
-
     Vector<StyleContentAlignmentData> tracks;
     tracks.reserveInitialCapacity(list.length());
-
-    for (auto value : list) {
-        auto& contentDistributionValue = downcast<CSSContentDistributionValue>(value.get());
-        tracks.append(convertContentAlignmentData(builder, contentDistributionValue));
-    }
-
+    for (auto& value : list)
+        tracks.append(convertContentAlignmentData(builder, downcast<CSSContentDistributionValue>(value)));
     return tracks;
 }
 
@@ -1388,13 +1382,13 @@ inline std::optional<FilterOperations> BuilderConverter::convertFilterOperations
 inline FontFeatureSettings BuilderConverter::convertFontFeatureSettings(BuilderState&, const CSSValue& value)
 {
     if (is<CSSPrimitiveValue>(value)) {
-        ASSERT(downcast<CSSPrimitiveValue>(value).valueID() == CSSValueNormal || CSSPropertyParserHelpers::isSystemFontShorthand(downcast<CSSPrimitiveValue>(value).valueID()));
+        ASSERT(value.valueID() == CSSValueNormal || CSSPropertyParserHelpers::isSystemFontShorthand(value.valueID()));
         return { };
     }
 
     FontFeatureSettings settings;
     for (auto& item : downcast<CSSValueList>(value)) {
-        auto& feature = downcast<CSSFontFeatureValue>(item.get());
+        auto& feature = downcast<CSSFontFeatureValue>(item);
         settings.insert(FontFeature(feature.tag(), feature.value()));
     }
     return settings;
@@ -1447,7 +1441,7 @@ inline std::optional<FontSelectionValue> BuilderConverter::convertFontStyleFromV
     if (auto* fontStyleValue = dynamicDowncast<CSSFontStyleWithAngleValue>(value))
         return convertFontStyleAngle(fontStyleValue->obliqueAngle());
 
-    auto valueID = downcast<CSSPrimitiveValue>(value).valueID();
+    auto valueID = value.valueID();
     if (valueID == CSSValueNormal)
         return std::nullopt;
     ASSERT(valueID == CSSValueItalic || valueID == CSSValueOblique);
@@ -1477,13 +1471,13 @@ inline FontSelectionValue BuilderConverter::convertFontStretch(BuilderState&, co
 inline FontVariationSettings BuilderConverter::convertFontVariationSettings(BuilderState&, const CSSValue& value)
 {
     if (is<CSSPrimitiveValue>(value)) {
-        ASSERT(downcast<CSSPrimitiveValue>(value).valueID() == CSSValueNormal || CSSPropertyParserHelpers::isSystemFontShorthand(downcast<CSSPrimitiveValue>(value).valueID()));
+        ASSERT(value.valueID() == CSSValueNormal || CSSPropertyParserHelpers::isSystemFontShorthand(value.valueID()));
         return { };
     }
 
     FontVariationSettings settings;
     for (auto& item : downcast<CSSValueList>(value)) {
-        auto& feature = downcast<CSSFontVariationValue>(item.get());
+        auto& feature = downcast<CSSFontVariationValue>(item);
         settings.insert({ feature.tag(), feature.value() });
     }
     return settings;
@@ -1511,11 +1505,10 @@ inline OptionSet<TouchAction> BuilderConverter::convertTouchAction(BuilderState&
     if (is<CSSValueList>(value)) {
         OptionSet<TouchAction> touchActions;
         for (auto& currentValue : downcast<CSSValueList>(value)) {
-            auto& primitiveValue = downcast<CSSPrimitiveValue>(currentValue.get());
-            auto primitiveValueID = primitiveValue.valueID();
-            if (primitiveValueID != CSSValuePanX && primitiveValueID != CSSValuePanY && primitiveValueID != CSSValuePinchZoom)
+            auto valueID = currentValue.valueID();
+            if (valueID != CSSValuePanX && valueID != CSSValuePanY && valueID != CSSValuePinchZoom)
                 return RenderStyle::initialTouchActions();
-            touchActions.add(fromCSSValueID<TouchAction>(primitiveValueID));
+            touchActions.add(fromCSSValueID<TouchAction>(valueID));
         }
         return touchActions;
     }
@@ -1526,13 +1519,13 @@ inline OptionSet<TouchAction> BuilderConverter::convertTouchAction(BuilderState&
 #if ENABLE(OVERFLOW_SCROLLING_TOUCH)
 inline bool BuilderConverter::convertOverflowScrolling(BuilderState&, const CSSValue& value)
 {
-    return downcast<CSSPrimitiveValue>(value).valueID() == CSSValueTouch;
+    return value.valueID() == CSSValueTouch;
 }
 #endif
 
 inline bool BuilderConverter::convertSmoothScrolling(BuilderState&, const CSSValue& value)
 {
-    return downcast<CSSPrimitiveValue>(value).valueID() == CSSValueSmooth;
+    return value.valueID() == CSSValueSmooth;
 }
 
 inline SVGLengthValue BuilderConverter::convertSVGLengthValue(BuilderState& builderState, const CSSValue& value, ShouldConvertNumberToPxLength shouldConvertNumberToPxLength)
@@ -1568,18 +1561,18 @@ inline Vector<SVGLengthValue> BuilderConverter::convertStrokeDashArray(BuilderSt
 inline PaintOrder BuilderConverter::convertPaintOrder(BuilderState&, const CSSValue& value)
 {
     if (is<CSSPrimitiveValue>(value)) {
-        ASSERT(downcast<CSSPrimitiveValue>(value).valueID() == CSSValueNormal);
+        ASSERT(value.valueID() == CSSValueNormal);
         return PaintOrder::Normal;
     }
 
-    auto& orderTypeList = downcast<CSSValueList>(value);
-    switch (downcast<CSSPrimitiveValue>(*orderTypeList.itemWithoutBoundsCheck(0)).valueID()) {
+    auto& list = downcast<CSSValueList>(value);
+    switch (list[0].valueID()) {
     case CSSValueFill:
-        return orderTypeList.length() > 1 ? PaintOrder::FillMarkers : PaintOrder::Fill;
+        return list.length() > 1 ? PaintOrder::FillMarkers : PaintOrder::Fill;
     case CSSValueStroke:
-        return orderTypeList.length() > 1 ? PaintOrder::StrokeMarkers : PaintOrder::Stroke;
+        return list.length() > 1 ? PaintOrder::StrokeMarkers : PaintOrder::Stroke;
     case CSSValueMarkers:
-        return orderTypeList.length() > 1 ? PaintOrder::MarkersStroke : PaintOrder::Markers;
+        return list.length() > 1 ? PaintOrder::MarkersStroke : PaintOrder::Markers;
     default:
         ASSERT_NOT_REACHED();
         return PaintOrder::Normal;
@@ -1652,7 +1645,7 @@ inline GlyphOrientation BuilderConverter::convertGlyphOrientation(BuilderState&,
 
 inline GlyphOrientation BuilderConverter::convertGlyphOrientationOrAuto(BuilderState& builderState, const CSSValue& value)
 {
-    if (downcast<CSSPrimitiveValue>(value).valueID() == CSSValueAuto)
+    if (value.valueID() == CSSValueAuto)
         return GlyphOrientation::Auto;
     return convertGlyphOrientation(builderState, value);
 }
@@ -1719,7 +1712,7 @@ inline OptionSet<SpeakAs> BuilderConverter::convertSpeakAs(BuilderState&, const 
     if (is<CSSValueList>(value)) {
         for (auto& currentValue : downcast<CSSValueList>(value)) {
             if (!isValueID(currentValue, CSSValueNormal))
-                result.add(fromCSSValue<SpeakAs>(currentValue.get()));
+                result.add(fromCSSValue<SpeakAs>(currentValue));
         }
     }
     return result;
@@ -1730,14 +1723,14 @@ inline OptionSet<HangingPunctuation> BuilderConverter::convertHangingPunctuation
     auto result = RenderStyle::initialHangingPunctuation();
     if (is<CSSValueList>(value)) {
         for (auto& currentValue : downcast<CSSValueList>(value))
-            result.add(fromCSSValue<HangingPunctuation>(currentValue.get()));
+            result.add(fromCSSValue<HangingPunctuation>(currentValue));
     }
     return result;
 }
 
 inline GapLength BuilderConverter::convertGapLength(BuilderState& builderState, const CSSValue& value)
 {
-    return (downcast<CSSPrimitiveValue>(value).valueID() == CSSValueNormal) ? GapLength() : GapLength(convertLength(builderState, value));
+    return (value.valueID() == CSSValueNormal) ? GapLength() : GapLength(convertLength(builderState, value));
 }
 
 inline OffsetRotation BuilderConverter::convertOffsetRotate(BuilderState&, const CSSValue& value)
@@ -1782,14 +1775,14 @@ inline OffsetRotation BuilderConverter::convertOffsetRotate(BuilderState&, const
 inline Vector<AtomString> BuilderConverter::convertContainerName(BuilderState&, const CSSValue& value)
 {
     if (is<CSSPrimitiveValue>(value)) {
-        ASSERT(downcast<CSSPrimitiveValue>(value).valueID() == CSSValueNone);
+        ASSERT(value.valueID() == CSSValueNone);
         return { };
     }
     if (!is<CSSValueList>(value))
         return { };
 
     return WTF::map(downcast<CSSValueList>(value), [](auto& item) {
-        return AtomString { downcast<CSSPrimitiveValue>(item.get()).stringValue() };
+        return AtomString { downcast<CSSPrimitiveValue>(item).stringValue() };
     });
 }
 
@@ -1807,15 +1800,14 @@ inline OptionSet<MarginTrimType> BuilderConverter::convertMarginTrim(BuilderStat
         return RenderStyle::initialMarginTrim();
     OptionSet<MarginTrimType> marginTrim;
     ASSERT(list->size() <= 4);
-    for (auto item : *list) {
-        auto& primitiveValue = downcast<CSSPrimitiveValue>(item.get());
-        if (primitiveValue.valueID() == CSSValueBlockStart)
+    for (auto& item : *list) {
+        if (item.valueID() == CSSValueBlockStart)
             marginTrim.add(MarginTrimType::BlockStart);
-        if (primitiveValue.valueID() == CSSValueBlockEnd)
+        if (item.valueID() == CSSValueBlockEnd)
             marginTrim.add(MarginTrimType::BlockEnd);
-        if (primitiveValue.valueID() == CSSValueInlineStart)
+        if (item.valueID() == CSSValueInlineStart)
             marginTrim.add(MarginTrimType::InlineStart);
-        if (primitiveValue.valueID() == CSSValueInlineEnd)
+        if (item.valueID() == CSSValueInlineEnd)
             marginTrim.add(MarginTrimType::InlineEnd);
     }
     return marginTrim;

--- a/Source/WebCore/svg/SVGFontFaceElement.cpp
+++ b/Source/WebCore/svg/SVGFontFaceElement.cpp
@@ -273,9 +273,7 @@ void SVGFontFaceElement::rebuildFontFace()
 
     if (describesParentFont) {
         m_fontElement = downcast<SVGFontElement>(parentNode());
-
-        list = CSSValueList::createCommaSeparated();
-        list->append(CSSFontFaceSrcLocalValue::create(AtomString { fontFamily() }));
+        list = CSSValueList::createCommaSeparated(CSSFontFaceSrcLocalValue::create(AtomString { fontFamily() }));
     } else {
         m_fontElement = nullptr;
         if (srcElement)
@@ -292,7 +290,7 @@ void SVGFontFaceElement::rebuildFontFace()
         // Traverse parsed CSS values and associate CSSFontFaceSrcLocalValue elements with ourselves.
         if (auto* srcList = downcast<CSSValueList>(m_fontFaceRule->properties().getPropertyCSSValue(CSSPropertySrc).get())) {
             for (auto& item : *srcList)
-                downcast<CSSFontFaceSrcLocalValue>(item.get()).setSVGFontFaceElement(*this);
+                downcast<CSSFontFaceSrcLocalValue>(const_cast<CSSValue&>(item)).setSVGFontFaceElement(*this);
         }
     }
 

--- a/Source/WebKit/UIProcess/PDF/WKPDFHUDView.mm
+++ b/Source/WebKit/UIProcess/PDF/WKPDFHUDView.mm
@@ -51,10 +51,10 @@ static const CGFloat layerCornerRadius = 12;
 static const CGFloat layerGrayComponent = 0;
 static const CGFloat layerAlpha = 0.75;
 static const CGFloat layerImageScale = 1.5;
-static const CGFloat layerSeperatorControllerSize = 1.5;
+static const CGFloat layerSeparatorControllerSize = 1.5;
 static const CGFloat layerControllerHorizontalMargin = 10.0;
 static const CGFloat layerImageVerticalMargin = 12.0;
-static const CGFloat layerSeperatorVerticalMargin = 10.0;
+static const CGFloat layerSeparatorVerticalMargin = 10.0;
 static const CGFloat controlLayerNormalAlpha = 0.75;
 static const CGFloat controlLayerDownAlpha = 0.45;
 
@@ -62,7 +62,7 @@ static NSString * const PDFHUDZoomInControl = @"plus.magnifyingglass";
 static NSString * const PDFHUDZoomOutControl = @"minus.magnifyingglass";
 static NSString * const PDFHUDLaunchPreviewControl = @"preview";
 static NSString * const PDFHUDSavePDFControl = @"arrow.down.circle";
-static NSString * const PDFHUDSeperatorControl = @"PDFHUDSeperatorControl";
+static NSString * const PDFHUDSeparatorControl = @"PDFHUDSeparatorControl";
 
 static const CGFloat layerFadeInTimeInterval = 0.25;
 static const CGFloat layerFadeOutTimeInterval = 0.5;
@@ -73,7 +73,7 @@ static NSArray<NSString *> *controlArray()
     return @[
         PDFHUDZoomOutControl,
         PDFHUDZoomInControl,
-        PDFHUDSeperatorControl,
+        PDFHUDSeparatorControl,
         PDFHUDLaunchPreviewControl,
         PDFHUDSavePDFControl
     ];
@@ -179,7 +179,7 @@ static NSArray<NSString *> *controlArray()
 - (void)mouseDown:(NSEvent *)event
 {
     _activeControl = [self _controlForEvent:event];
-    if ([_activeControl isEqualToString:PDFHUDSeperatorControl])
+    if ([_activeControl isEqualToString:PDFHUDSeparatorControl])
         _activeControl = nil;
     if (_activeControl) {
         // Update rendering to highlight it..
@@ -284,10 +284,10 @@ static NSArray<NSString *> *controlArray()
         CGFloat controllerWidth = 0.0;
         CGFloat controllerHeight = 0.0;
 
-        if ([controlName isEqualToString:PDFHUDSeperatorControl]) {
-            dy = layerSeperatorVerticalMargin;
-            controllerWidth = layerSeperatorControllerSize;
-            controllerHeight = minIconImageHeight + (2.0 * layerImageVerticalMargin) - (2.0 * layerSeperatorVerticalMargin);
+        if ([controlName isEqualToString:PDFHUDSeparatorControl]) {
+            dy = layerSeparatorVerticalMargin;
+            controllerWidth = layerSeparatorControllerSize;
+            controllerHeight = minIconImageHeight + (2.0 * layerImageVerticalMargin) - (2.0 * layerSeparatorVerticalMargin);
             
             [controlLayer setBackgroundColor:[[NSColor lightGrayColor] CGColor]];
         } else {

--- a/Tools/TestWebKitAPI/Tests/WebCore/CSSParser.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CSSParser.cpp
@@ -34,14 +34,14 @@ namespace TestWebKitAPI {
 
 using namespace WebCore;
 
-static unsigned computeNumberOfTracks(CSSValueContainingVector& valueList)
+static unsigned computeNumberOfTracks(const CSSValueContainingVector& valueList)
 {
     unsigned numberOfTracks = 0;
-    for (const auto& value : valueList) {
-        if (value->isGridLineNamesValue())
+    for (auto& value : valueList) {
+        if (value.isGridLineNamesValue())
             continue;
         if (is<CSSGridIntegerRepeatValue>(value)) {
-            auto& repeatValue = downcast<CSSGridIntegerRepeatValue>(value.get());
+            auto& repeatValue = downcast<CSSGridIntegerRepeatValue>(value);
             numberOfTracks += repeatValue.repetitions() * computeNumberOfTracks(repeatValue);
             continue;
         }


### PR DESCRIPTION
#### bae83919e283152f248364fa56eb06b0ef9f89ab
<pre>
Make CSSValueList immutable
<a href="https://bugs.webkit.org/show_bug.cgi?id=252121">https://bugs.webkit.org/show_bug.cgi?id=252121</a>
rdar://problem/105342727

Reviewed by Antti Koivisto.

Removes the mutating functions from CSSValueContainingVector and implements
it slight more efficiently than the Vector-based implementation. We can do
further optimization in the future based on knowing the size at create time.

* Source/JavaScriptCore/runtime/ConfigFile.cpp:
(JSC::ConfigFile::canonicalizePaths): Fixed &quot;seperator&quot; spelling error.
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::dumpCharacterClass): Ditto.
* Source/ThirdParty/libwebrtc/Source/webrtc/modules/video_coding/h264_sprop_parameter_sets.cc:
Ditto.

* Source/WebCore/animation/CompositeOperation.cpp:
(WebCore::toCompositeOperation): Use CSSValue::valueID.

* Source/WebCore/css/CSSBorderImage.cpp:
(WebCore::createBorderImageValue): Use CSSValueListBuilder.

* Source/WebCore/css/CSSCounterStyleDescriptors.cpp:
(WebCore::translateRangeFromStyleProperties): Updated for change to CSSValueList
iteration.
(WebCore::translateSymbolsFromStyleProperties): Ditto.
* Source/WebCore/css/CSSFontFace.cpp:
(WebCore::CSSFontFace::appendSources): Ditto.
(WebCore::CSSFontFace::setUnicodeRange): Ditto.
(WebCore::CSSFontFace::setFeatureSettings): Ditto.

* Source/WebCore/css/CSSFontFaceSet.cpp:
(WebCore::CSSFontFaceSet::ensureLocalFontFacesForFamilyRegistered): Create the
families list without appending.
(WebCore::CSSFontFaceSet::addToFacesLookupTable): Updated for change to
CSSValueList iteration.
(WebCore::CSSFontFaceSet::removeFromFacesLookupTable): Ditto.

* Source/WebCore/css/CSSFunctionValue.cpp:
(WebCore::CSSFunctionValue::CSSFunctionValue): Added constructors that take
arguments so we don&apos;t have to append them later.
(WebCore::CSSFunctionValue::create): Ditto.
* Source/WebCore/css/CSSFunctionValue.h: Ditto.

* Source/WebCore/css/CSSGridAutoRepeatValue.cpp:
(WebCore::CSSGridAutoRepeatValue::CSSGridAutoRepeatValue): Added a
CSSValueListBuilder argument.
(WebCore::CSSGridAutoRepeatValue::create): Ditto.
* Source/WebCore/css/CSSGridAutoRepeatValue.h: Ditto.
* Source/WebCore/css/CSSGridIntegerRepeatValue.cpp:
(WebCore::CSSGridIntegerRepeatValue::CSSGridIntegerRepeatValue): Ditto.
(WebCore::CSSGridIntegerRepeatValue::create): Ditto.
* Source/WebCore/css/CSSGridIntegerRepeatValue.h: Ditto.

* Source/WebCore/css/CSSGridLineNamesValue.cpp:
(WebCore::CSSGridLineNamesValue::customCSSText const): Update to use
FixedVector&lt;String&gt; instead of a vector of CSSValue.
(WebCore::CSSGridLineNamesValue::CSSGridLineNamesValue): Ditto.
(WebCore::CSSGridLineNamesValue::create): Ditto.
* Source/WebCore/css/CSSGridLineNamesValue.h: Ditto.

* Source/WebCore/css/CSSImageSetValue.cpp:
(WebCore::CSSImageSetValue::create): Added a CSSValueListBuilder argument.
(WebCore::CSSImageSetValue::CSSImageSetValue): Ditto.
* Source/WebCore/css/CSSImageSetValue.h: Ditto.

* Source/WebCore/css/CSSPrimitiveValueMappings.h:
(WebCore::fromCSSValue): Use CSSValue::valueID.

* Source/WebCore/css/CSSProperty.cpp:
(WebCore::CSSProperty::wrapValueInCommaSeparatedList): Deleted.
(WebCore::CSSProperty::createListForProperty): Deleted.
* Source/WebCore/css/CSSProperty.h: Updated for above deletions.

* Source/WebCore/css/CSSSubgridValue.cpp:
(WebCore::CSSSubgridValue::CSSSubgridValue): Added a CSSValueListBuilder
argument.
(WebCore::CSSSubgridValue::create): Ditto.
* Source/WebCore/css/CSSSubgridValue.h: Ditto.

* Source/WebCore/css/CSSToStyleMap.cpp:
(WebCore::CSSToStyleMap::mapFillAttachment): Use CSSValue::valueID.
(WebCore::CSSToStyleMap::mapFillImage): Take a const CSSValue&amp; argument.
(WebCore::CSSToStyleMap::mapFillMaskMode): Use CSSValue::valueID.
(WebCore::CSSToStyleMap::mapAnimationDirection): Ditto.
(WebCore::CSSToStyleMap::mapAnimationFillMode): Ditto.
(WebCore::CSSToStyleMap::mapAnimationPlayState): Ditto.
(WebCore::CSSToStyleMap::mapNinePieceImage): Updated for change to
CSSValueList iteration.
* Source/WebCore/css/CSSToStyleMap.h: Updated for the above.

* Source/WebCore/css/CSSTransformListValue.cpp:
(WebCore::CSSTransformListValue::CSSTransformListValue): Added a
CSSValueListBuilder argument.
(WebCore::CSSTransformListValue::create): Ditto.
* Source/WebCore/css/CSSTransformListValue.h: Ditto.

* Source/WebCore/css/CSSValue.cpp:
(WebCore::CSSValue::collectComputedStyleDependencies const): Updated for
change to CSSValueList iteration.

* Source/WebCore/css/CSSValueList.cpp:
(WebCore::CSSValueContainingVector::CSSValueContainingVector): Updated
to initialize new data members m_size, m_inlineStorage, m_additionalStorage.
(WebCore::CSSValueList::CSSValueList): Added overloads with the builder and
with 1-4 values.
(WebCore::CSSValueList::createCommaSeparated): Ditto.
(WebCore::CSSValueList::createSlashSeparated): Ditto.
(WebCore::CSSValueList::createSpaceSeparated): Ditto.
(WebCore::CSSValueList::create): Added. Takes a separator character argument.
(WebCore::CSSValueContainingVector::removeAll): Deleted.
(WebCore::CSSValueContainingVector::hasValue const): Use iterator.
(WebCore::CSSValueContainingVector::copyValues const): Renamed from
CSSValueList::copy and implemented using iterator.
(WebCore::CSSValueContainingVector::serializeItems const): Use iterator.
(WebCore::CSSValueContainingVector::itemsEqual const): Use operator[].
(WebCore::CSSValueContainingVector::containsSingleEqualItem const): Use
size and operator[].
(WebCore::CSSValueContainingVector::customTraverseSubresources const):
Use iterator.

* Source/WebCore/css/CSSValueList.h: Removed unneeded includes.
Updated for the above. Added ~CSSValueContainingVector and operator[].

* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::OrderedNamedLinesCollector::appendLines const): Use Vector&lt;String&gt;.
(WebCore::OrderedNamedLinesCollectorInGridLayout::collectLineNamesForIndex const):
Ditto.
(WebCore::OrderedNamedLinesCollectorInSubgridLayout::collectLineNamesForIndex const):
Ditto.
(WebCore::createPositionListForLayer): Use CSSValueListBuilder.
(WebCore::createSingleAxisPositionValueForLayer): Use CSSValueList create
functions instead of append.
(WebCore::valueForQuotes): Use CSSValueListBuilder.
(WebCore::itemsEqual): Added.
(WebCore::borderRadiusShorthandValue): Use CSSValueListBuilder.
(WebCore::matrixTransformValue): Ditto.
(WebCore::transformOperationAsCSSValue): Use CSSValueList create functions
instead of append.
(WebCore::computedTransform): Use CSSValueListBuilder.
(WebCore::computedTranslate): Use CSSValueList create functions instead of
append.
(WebCore::computedScale): Ditto.
(WebCore::computedRotate): Ditto.
(WebCore::ComputedStyleExtractor::valueForShadow): Use CSSValueListBuilder,
and also use Vector::reverse instead of prepend.
(WebCore::ComputedStyleExtractor::valueForFilter): Use CSSValueListBuilder.
(WebCore::specifiedValueForGridTrackSize): Use CSSFunctionValue create
functions instead of append.
(WebCore::addValuesForNamedGridLinesAtIndex): Use Vector&lt;String&gt; and
CSSValueListBuilder.
(WebCore::valueForGridTrackSizeList): Use CSSValueListBuilder.
(WebCore::populateGridTrackList): Ditto.
(WebCore::populateSubgridLineNameList): Ditto.
(WebCore::valueForGridTrackList): Ditto.
(WebCore::valueForGridPosition): Ditto.
(WebCore::valueForScrollSnapType): Use CSSValueList create functions
instead of append.
(WebCore::valueForScrollSnapAlignment): Ditto.
(WebCore::valueForTextEdge): Ditto.
(WebCore::willChangePropertyValue): Use CSSValueListBuilder.
(WebCore::appendLigaturesValue): Ditto.
(WebCore::fontVariantLigaturesPropertyValue): Ditto.
(WebCore::fontVariantNumericPropertyValue): Ditto.
(WebCore::fontVariantEastAsianPropertyValue): Ditto.
(WebCore::ComputedStyleExtractor::addValueForAnimationPropertyToList):
Ditto.
(WebCore::valueListForAnimationOrTransitionProperty): Ditto.
(WebCore::animationShorthandValue): Ditto.
(WebCore::valueForPosition): Use CSSValueList create functions instead of
append.
(WebCore::valueForPathOperation): Ditto.
(WebCore::valueForContainIntrinsicSize): Ditto.
(WebCore::touchActionFlagsToCSSValue): Ditto.
(WebCore::renderTextDecorationLineFlagsToCSSValue): Ditto.
(WebCore::renderEmphasisPositionFlagsToCSSValue): Ditto.
(WebCore::valueForTextEmphasisStyle): Use CSSValueList create functions
instead of append.
(WebCore::speakAsToCSSValue): Use CSSValueListBuilder.
(WebCore::hangingPunctuationToCSSValue): Ditto.
(WebCore::fillRepeatToCSSValue): Use CSSValueList create functions instead of
append.
(WebCore::fillSizeToCSSValue): Ditto.
(WebCore::contentToCSSValue): Use CSSValueListBuilder.
(WebCore::counterToCSSValue): Ditto.
(WebCore::fontFamilyList): Ditto.
(WebCore::ComputedStyleExtractor::fontVariantShorthandValue): Ditto.
(WebCore::fontSynthesis): Ditto.
(WebCore::shapePropertyValue): Use CSSValueList create functions instead of
append.
(WebCore::valueForItemPositionWithOverflowAlignment): Use CSSValueListBuilder.
(WebCore::valueForContentPositionAndDistributionWithOverflowAlignment): Ditto.
(WebCore::valueForOffsetRotate): Use CSSValueList create functions instead of
append.
(WebCore::valueForOffsetShorthand): Use CSSValueListBuilder
(WebCore::paintOrder): Ditto.
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle): Ditto.
(WebCore::ComputedStyleExtractor::getCSSPropertyValuesForShorthandProperties):
Ditto.
(WebCore::ComputedStyleExtractor::getCSSPropertyValuesFor2SidesShorthand):
Ditto.
(WebCore::ComputedStyleExtractor::getCSSPropertyValuesFor4SidesShorthand):
Ditto.
(WebCore::ComputedStyleExtractor::getCSSPropertyValuesForGridShorthand): Ditto.
(WebCore::ComputedStyleExtractor::getFillLayerPropertyShorthandValue): Ditto.
(WebCore::ComputedStyleExtractor::getMaskShorthandValue): Ditto.
* Source/WebCore/css/ComputedStyleExtractor.h: Use CSSValueListBuilder.

* Source/WebCore/css/DOMMatrixReadOnly.cpp:
(WebCore::DOMMatrixReadOnly::parseStringIntoAbstractMatrix): Use CSSValue::valueID.

* Source/WebCore/css/DeprecatedCSSOMValueList.h:
(WebCore::DeprecatedCSSOMValueList::DeprecatedCSSOMValueList): Updated for
change to CSSValueList iteration.

* Source/WebCore/css/FontFace.cpp:
(WebCore::FontFace::setFamily): Use CSSValueList create functions instead of
append.

* Source/WebCore/css/FontVariantBuilder.cpp:
(WebCore::extractFontVariantLigatures): Use CSSValue::valueID.
(WebCore::extractFontVariantNumeric): Ditto.
(WebCore::extractFontVariantEastAsian): Ditto.

* Source/WebCore/css/ShorthandSerializer.cpp:
(WebCore::LayerValues::set): Use more const.
(WebCore::ShorthandSerializer::serializeLayered const): Use unsigned
for layer count instead of size_t.
(WebCore::ShorthandSerializer::serializeGridTemplate const): Updated for
change to CSSValueList iteration.

* Source/WebCore/css/TransformFunctions.cpp:
(WebCore::transformForValue): Use CSSValueList::operator[].
(WebCore::translateForValue): Ditto.
(WebCore::scaleForValue): Ditto.
(WebCore::rotateForValue): Ditto.

* Source/WebCore/css/parser/CSSParserFastPaths.cpp:
(WebCore::checkForValidDouble): Removed extraneous const.
(WebCore::parseDouble): Ditto.
(WebCore::parseColorIntOrPercentage): Ditto.
(WebCore::isTenthAlpha): Ditto.
(WebCore::parseAlphaValue): Ditto.
(WebCore::parseTransformTranslateArguments): Use CSSValueListBuilder.
(WebCore::parseTransformAngleArgument): Use a return value instead of
appending to a passed in CSSFunctionValue.
(WebCore::parseTransformNumberArguments): Use CSSValueListBuilder.
(WebCore::parseSimpleTransformValue): Ditto.
(WebCore::parseSimpleTransformList): Ditto.

* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumeFontPaletteValuesRule): Updated for
change to CSSValueList iteration.
(WebCore::CSSParserImpl::consumePropertyRule): Use CSSValue::valueID.

* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::CSSPropertyParser::consumeCustomPropertyValueWithSyntax):
Use CSSValueListBuilder.
(WebCore::isValidAnimationPropertyList): Ditto.
(WebCore::CSSPropertyParser::consumeAnimationShorthand): Ditto.
(WebCore::addBackgroundValue): Deleted.
(WebCore::consumeBackgroundPosition): Ditto.
(WebCore::CSSPropertyParser::consumeBackgroundShorthand): Ditto.
(WebCore::CSSPropertyParser::consumeGridTemplateRowsAndAreasAndColumns): Ditto.
(WebCore::consumeImplicitGridAutoFlow): Use CSSValueList create functions
instead of append. Also use CSSValueID.
(WebCore::CSSPropertyParser::consumeGridShorthand): Updated for change to
consumeImplicitGridAutoFlow.

* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeImageSet): Use CSSValueListBuilder.
(WebCore::CSSPropertyParserHelpers::consumeFilterFunction): Pass argument to
CSSFunctionValue::create.
(WebCore::CSSPropertyParserHelpers::consumeFilter): Use CSSValueListBuilder.
(WebCore::CSSPropertyParserHelpers::consumeAspectRatioValue): Use CSSValueList
create function instead of append.
(WebCore::CSSPropertyParserHelpers::consumeAspectRatio): Ditto.
(WebCore::CSSPropertyParserHelpers::consumeWillChange): Use CSSValueListBuilder.
(WebCore::CSSPropertyParserHelpers::consumeQuotes): Ditto.
(WebCore::CSSPropertyParserHelpers::consumeFontVariantEastAsian): Ditto.
(WebCore::CSSPropertyParserHelpers::consumeCounter): Ditto.
(WebCore::CSSPropertyParserHelpers::consumeSize): Use CSSValueList create
function instead of append.
(WebCore::CSSPropertyParserHelpers::consumeTextIndent): Ditto.
(WebCore::CSSPropertyParserHelpers::consumeMarginTrim): Use CSSValueListBuilder.
(WebCore::CSSPropertyParserHelpers::consumeTouchAction): Ditto.
(WebCore::CSSPropertyParserHelpers::consumeTextDecorationLine): Ditto.
(WebCore::CSSPropertyParserHelpers::consumeTextEmphasisStyle): Use CSSValueList
create function instead of append.
(WebCore::CSSPropertyParserHelpers::consumeTranslate3d): Use CSSValueListBuilder.
(WebCore::CSSPropertyParserHelpers::consumeNumbers): Ditto.
(WebCore::CSSPropertyParserHelpers::consumeNumbersOrPercents): Ditto.
(WebCore::CSSPropertyParserHelpers::consumePerspectiveFunctionArgument): Ditto.
(WebCore::CSSPropertyParserHelpers::consumeTransformFunction): Ditto.
(WebCore::CSSPropertyParserHelpers::consumeTransform): Ditto.
(WebCore::CSSPropertyParserHelpers::consumeTranslate): Use CSSValueList create
function instead of append.
(WebCore::CSSPropertyParserHelpers::consumeScale): Ditto.
(WebCore::CSSPropertyParserHelpers::consumeRotate): Ditto.
(WebCore::CSSPropertyParserHelpers::consumePaintStroke): Ditto.
(WebCore::CSSPropertyParserHelpers::consumePaintOrder): Use CSSValueListBuilder.
(WebCore::CSSPropertyParserHelpers::consumeStrokeDasharray): Ditto.
(WebCore::CSSPropertyParserHelpers::consumeCursor): Ditto.
(WebCore::CSSPropertyParserHelpers::consumeContent): Ditto.
(WebCore::CSSPropertyParserHelpers::consumeScrollSnapAlign): Use CSSValueList
create function instead of append.
(WebCore::CSSPropertyParserHelpers::consumeScrollSnapType): Ditto.
(WebCore::CSSPropertyParserHelpers::consumeTextEdge): Ditto.
(WebCore::CSSPropertyParserHelpers::consumeBasicShapeOrBox): Use
CSSValueListBuilder.
(WebCore::CSSPropertyParserHelpers::consumeShapeOutside): Ditto.
(WebCore::CSSPropertyParserHelpers::consumeAlignTracks): Ditto.
(WebCore::CSSPropertyParserHelpers::consumeJustifyTracks): Ditto.
(WebCore::CSSPropertyParserHelpers::consumeGridAutoFlow): Ditto.
(WebCore::CSSPropertyParserHelpers::consumeMasonryAutoFlow): Ditto.
(WebCore::CSSPropertyParserHelpers::consumeFitContent): Use CSSFunctionValue
create function instead of append.
(WebCore::CSSPropertyParserHelpers::consumeGridLine): Use CSSValueListBuilder.
(WebCore::CSSPropertyParserHelpers::consumeGridTrackSize): Use CSSFunctionValue
create function instead of append.
(WebCore::CSSPropertyParserHelpers::consumeGridLineNames): Use a vector of
strings instead of CSS values.
(WebCore::CSSPropertyParserHelpers::consumeGridTrackRepeatFunction): Use
CSSValueListBuilder.
(WebCore::CSSPropertyParserHelpers::consumeSubgridNameRepeatFunction): Ditto.
(WebCore::CSSPropertyParserHelpers::consumeGridTrackList): Ditto.
(WebCore::CSSPropertyParserHelpers::consumeContainerName): Ditto.
(WebCore::CSSPropertyParserHelpers::consumeSpeakAs): Ditto.
(WebCore::CSSPropertyParserHelpers::consumeHangingPunctuation): Ditto.
(WebCore::CSSPropertyParserHelpers::consumeContain): Ditto.
(WebCore::CSSPropertyParserHelpers::consumeContainIntrinsicSize): Use
CSSValueList create function instead of append.
(WebCore::CSSPropertyParserHelpers::consumeTextEmphasisPosition): Ditto.
(WebCore::CSSPropertyParserHelpers::consumeColorScheme): Use CSSValueListBuilder.
(WebCore::CSSPropertyParserHelpers::consumeFontFaceFontFamily): Use
CSSValueList create function instead of append.
(WebCore::CSSPropertyParserHelpers::consumeCounterStyleNegative): Ditto.
(WebCore::CSSPropertyParserHelpers::consumeCounterStylePad): Ditto.
(WebCore::CSSPropertyParserHelpers::consumeCounterStyleSymbols): Use
CSSValueListBuilder.
(WebCore::CSSPropertyParserHelpers::consumeCounterStyleAdditiveSymbols):
Use CSSValueList create function instead of append.

* Source/WebCore/css/parser/CSSPropertyParserHelpers.h: Removed declaration
of consumeAspectRatioValue. Updated for changes above.
(WebCore::CSSPropertyParserHelpers::assignOrDowngradeToListAndAppend): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeCommaSeparatedListWithSingleValueOptimization):
Use CSSValueListBuilder.
(WebCore::CSSPropertyParserHelpers::consumeCommaSeparatedListWithoutSingleValueOptimization):
Ditto.

* Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp:
(WebCore::CSSPropertyParserHelpersWorkerSafe::consumeFontFaceSrc): Use
CSSValueListBuilder.
(WebCore::CSSPropertyParserHelpersWorkerSafe::consumeFontStyleRange): Use
CSSValueList create functions instead of append.
(WebCore::CSSPropertyParserHelpersWorkerSafe::consumeFontWeightAbsoluteRange):
Ditto.
(WebCore::CSSPropertyParserHelpersWorkerSafe::fontStretchIsWithinRange): Deleted.
(WebCore::CSSPropertyParserHelpersWorkerSafe::consumeFontStretch): Removed unneeded
fontStretchIsWithinRange check.
(WebCore::CSSPropertyParserHelpersWorkerSafe::consumeFontStretchRange): Ditto.
Use CSSValueList create functions instead of append.
(WebCore::CSSPropertyParserHelpersWorkerSafe::consumeFontFaceUnicodeRange): Use
CSSValueListBuilder.

* Source/WebCore/css/process-css-properties.py: Use CSSValue::valueID.

* Source/WebCore/css/typedom/CSSStyleValueFactory.cpp:
(WebCore::CSSStyleValueFactory::parseStyleValue): Updated for change to
CSSValueList iteration.
(WebCore::CSSStyleValueFactory::reifyValue): Ditto.
* Source/WebCore/css/typedom/CSSStyleValueFactory.h: Updated for above.

* Source/WebCore/css/typedom/StylePropertyMap.cpp:
(WebCore::cssValueFromStyleValues): Use CSSValueListBuilder.
(WebCore::StylePropertyMap::append): Ditto.

* Source/WebCore/css/typedom/StylePropertyMapReadOnly.cpp:
(WebCore::StylePropertyMapReadOnly::reifyValueToVector): Updated for
change to CSSValueList iteration.

* Source/WebCore/css/typedom/transform/CSSMatrixComponent.cpp:
(WebCore::CSSMatrixComponent::create): Updated for change to CSSValueList
iteration.
(WebCore::CSSMatrixComponent::toCSSValue const): Use CSSValueListBuilder.

* Source/WebCore/css/typedom/transform/CSSPerspective.cpp:
(WebCore::CSSPerspective::toCSSValue const): Use CSSFunctionValue create
function instead of append.

* Source/WebCore/css/typedom/transform/CSSRotate.cpp:
(WebCore::CSSRotate::create): Updated for change to CSSValueList iteration.
(WebCore::CSSRotate::toCSSValue const): Use CSSFunctionValue create
function instead of append.

* Source/WebCore/css/typedom/transform/CSSScale.cpp:
(WebCore::CSSScale::create): Updated for change to CSSValueList iteration.
(WebCore::CSSScale::toCSSValue const): Use CSSFunctionValue create
function instead of append.

* Source/WebCore/css/typedom/transform/CSSSkew.cpp:
(WebCore::CSSSkew::create): Updated for change to CSSValueList iteration.
(WebCore::CSSSkew::toCSSValue const): Use CSSFunctionValue create
function instead of append.

* Source/WebCore/css/typedom/transform/CSSSkewX.cpp:
(WebCore::CSSSkewX::toCSSValue const): Use CSSFunctionValue create
function instead of append.

* Source/WebCore/css/typedom/transform/CSSSkewY.cpp:
(WebCore::CSSSkewY::toCSSValue const): Use CSSFunctionValue create
function instead of append.

* Source/WebCore/css/typedom/transform/CSSTransformValue.cpp:
(WebCore::CSSTransformValue::create): Updated for change to CSSValueList
iteration.
(WebCore::CSSTransformValue::toCSSValue const): Use CSSFunctionValue create
function instead of append.

* Source/WebCore/css/typedom/transform/CSSTransformValue.h: Take a
const&amp;.

* Source/WebCore/css/typedom/transform/CSSTranslate.cpp:
(WebCore::CSSTranslate::create): Updated for change to CSSValueList iteration.
(WebCore::CSSTranslate::toCSSValue const): Use CSSFunctionValue create
function instead of append.

* Source/WebCore/editing/ApplyStyleCommand.cpp:
(WebCore::toIdentifier): Deleted.
(WebCore::ApplyStyleCommand::splitAncestorsWithUnicodeBidi): Use valueID.
(WebCore::ApplyStyleCommand::removeEmbeddingUpToEnclosingBlock): Ditto.
(WebCore::highestEmbeddingAncestor): Ditto.

* Source/WebCore/editing/DeleteSelectionCommand.cpp:
(WebCore::DeleteSelectionCommand::smartDeleteParagraphSpacers):
Fixed &quot;seperator&quot; spelling error.

* Source/WebCore/editing/EditingStyle.cpp:
(WebCore::HTMLElementEquivalent::valueIsPresentInStyle const):
Use StyleProperties::propertyAsValueID.
(WebCore::removeAll): Added.
(WebCore::contains): Added.
(WebCore::EditingStyle::textDirection const): Use
StyleProperties::propertyAsValueID.
(WebCore::applyTextDecorationChangeToValueList): Use CSSValueListBuilder.
(WebCore::EditingStyle::overrideTypingStyleAt): Ditto.
(WebCore::textDecorationValueList): Use dynamicDowncast.
(WebCore::EditingStyle::conflictsWithInlineStyleOfElement const):
Use CSSValueListBuilder.
(WebCore::EditingStyle::prepareToApplyAt): Use CSSValue::valueID.
(WebCore::mergeTextDecorationValues): Use CSSValueListBuilder.
(WebCore::EditingStyle::mergeStyle): Use CSSValueList::copyValues.
(WebCore::EditingStyle::textDirectionForSelection): Use valueID.
(WebCore::StyleChange::StyleChange): Use CSSValueListBuilder.
(WebCore::StyleChange::extractTextStyles): Ditto.
(WebCore::diffTextDecorations): Ditto.

* Source/WebCore/editing/FontAttributeChanges.cpp:
(WebCore::cssValueListForShadow): Use CSSValueList create functions instead of
append.

* Source/WebCore/editing/markup.cpp:
(WebCore::propertyMissingOrEqualToNone): Use propertyAsValueID.

* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::addParsedWidthAndHeightToAspectRatioList): Use
CSSValueList create functions instead of append.

* Source/WebCore/inspector/InspectorOverlay.cpp:
(WebCore::authoredGridTrackSizes): Updated for change to CSSValueList
iteration.

* Source/WebCore/platform/animation/TimingFunction.cpp:
(WebCore::TimingFunction::createFromCSSValue): Use CSSValue::valueID.

* Source/WebCore/rendering/style/StyleImageSet.cpp:
(WebCore::StyleImageSet::computedStyleValue const): Use CSSValueListBuilder.

* Source/WebCore/style/FilterOperationsBuilder.cpp:
(WebCore::Style::createFilterOperations): Updated for change to CSSValueList
iteration.

* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertLengthOrAuto): Use CSSValue::valueID.
(WebCore::Style::BuilderConverter::convertLengthMaxSizing): Ditto.
(WebCore::Style::BuilderConverter::convertTextDecorationLine): Updated for
change to CSSValueList iteration.
(WebCore::Style::BuilderConverter::convertNumberOrAuto): Use CSSValue::valueID.
(WebCore::Style::BuilderConverter::convertColorScheme): Updated for change to
CSSValueList iteration.
(WebCore::Style::BuilderConverter::convertStringOrAuto): Use CSSValue::valueID.
(WebCore::Style::BuilderConverter::convertStringOrNone): Ditto.
(WebCore::Style::BuilderConverter::convertTextEmphasisPosition): Updated for
change to CSSValueList iteration.
(WebCore::Style::BuilderConverter::convertPathOperation): Use CSSValue::valueID.
(WebCore::Style::BuilderConverter::convertReflection): Ditto.
(WebCore::Style::BuilderConverter::convertLineBoxContain): Ditto.
(WebCore::Style::BuilderConverter::convertShapeValue): Ditto.
(WebCore::Style::BuilderConverter::createGridTrackList): Don&apos;t create a
CSSValueList just so we can iterate it later.
(WebCore::Style::BuilderConverter::createGridPosition): Updated for change to
CSSValueList iteration.
(WebCore::Style::BuilderConverter::convertContentAlignmentDataList): Ditto.
(WebCore::Style::BuilderConverter::convertFontFeatureSettings): Ditto.
(WebCore::Style::BuilderConverter::convertFontStyleFromValue): Use
CSSValue::valueID.
(WebCore::Style::BuilderConverter::convertFontVariationSettings): Updated for
change to CSSValueList iteration.
(WebCore::Style::BuilderConverter::convertTouchAction): Ditto.
(WebCore::Style::BuilderConverter::convertOverflowScrolling): Use
CSSValue::valueID.
(WebCore::Style::BuilderConverter::convertSmoothScrolling): Ditto.
(WebCore::Style::BuilderConverter::convertPaintOrder): Use CSSValue::valueID
and CSSValueList::operator[].
(WebCore::Style::BuilderConverter::convertGlyphOrientationOrAuto): Ditto.
(WebCore::Style::BuilderConverter::convertSpeakAs): Updated for change to
CSSValueList iteration.
(WebCore::Style::BuilderConverter::convertHangingPunctuation): Ditto.
(WebCore::Style::BuilderConverter::convertGapLength): Use CSSValue::valueID.
(WebCore::Style::BuilderConverter::convertContainerName): Updated for change to
CSSValueList iteration.
(WebCore::Style::BuilderConverter::convertMarginTrim): Ditto.

* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::getPageSizeFromName): Use const&amp;.
(WebCore::Style::BuilderCustom::applyValueSize): Use CSSValue::valueID and
updated for change to CSSValueList iteration.
(WebCore::Style::BuilderCustom::applyValueTextIndent): Ditto.
(WebCore::Style::BuilderCustom::applyValueLineHeight): Ditto.
(WebCore::Style::BuilderCustom::applyTextOrBoxShadowValue): Ditto.
(WebCore::Style::BuilderCustom::applyValueFontFamily): Ditto.
(WebCore::Style::BuilderCustom::applyValueAspectRatio): Ditto.
(WebCore::Style::BuilderCustom::applyValueContain): Ditto.
(WebCore::Style::BuilderCustom::applyValueTextEmphasisStyle): Ditto.
(WebCore::Style::BuilderCustom::applyValueCounter): Ditto.
(WebCore::Style::BuilderCustom::applyValueCursor): Ditto.
(WebCore::Style::BuilderCustom::applyValueContent): Ditto.
(WebCore::Style::BuilderCustom::applyValueFontVariantLigatures): Ditto.
(WebCore::Style::BuilderCustom::applyValueFontVariantNumeric): Ditto.
(WebCore::Style::BuilderCustom::applyValueFontVariantEastAsian): Ditto.
(WebCore::Style::BuilderCustom::applyValueGridTemplateAreas): Ditto.
(WebCore::Style::BuilderCustom::applyValueWillChange): Ditto.

* Source/WebCore/svg/SVGFontFaceElement.cpp:
(WebCore::SVGFontFaceElement::rebuildFontFace): Use CSSValueList create
functions instead of append. Updated for change to CSSValueList iteration.

* Source/WebKit/UIProcess/PDF/WKPDFHUDView.mm:
(-[WKPDFHUDView mouseDown:]): Fixed &quot;seperator&quot; spelling error.
(-[WKPDFHUDView _setupLayer:]): Ditto.

* Tools/TestWebKitAPI/Tests/WebCore/CSSParser.cpp:
(TestWebKitAPI::computeNumberOfTracks): Updated for change to CSSValueList
iteration.

Canonical link: <a href="https://commits.webkit.org/260566@main">https://commits.webkit.org/260566@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e13152ab478298c048fb3a89c34d4ecad000b02

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108492 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17588 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41341 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117597 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/117802 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112378 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19039 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8866 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100719 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114259 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14270 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97493 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42230 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96248 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29133 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/83932 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/97637 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10399 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30482 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/98532 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/8518 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11155 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7393 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30953 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16545 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50078 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/106061 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7305 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12743 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26271 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->