### PR TITLE
Implement EXT_disjoint_timer_query_webgl2

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1873,6 +1873,7 @@ if (ENABLE_WEBGL)
         html/canvas/EXTColorBufferFloat.cpp
         html/canvas/EXTColorBufferHalfFloat.cpp
         html/canvas/EXTDisjointTimerQuery.cpp
+        html/canvas/EXTDisjointTimerQueryWebGL2.cpp
         html/canvas/EXTFloatBlend.cpp
         html/canvas/EXTFragDepth.cpp
         html/canvas/EXTShaderTextureLOD.cpp
@@ -1942,6 +1943,7 @@ list(APPEND WebCore_IDL_FILES
     html/canvas/EXTColorBufferFloat.idl
     html/canvas/EXTColorBufferHalfFloat.idl
     html/canvas/EXTDisjointTimerQuery.idl
+    html/canvas/EXTDisjointTimerQueryWebGL2.idl
     html/canvas/EXTFloatBlend.idl
     html/canvas/EXTFragDepth.idl
     html/canvas/EXTShaderTextureLOD.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1362,6 +1362,7 @@ $(PROJECT_DIR)/html/canvas/EXTBlendMinMax.idl
 $(PROJECT_DIR)/html/canvas/EXTColorBufferFloat.idl
 $(PROJECT_DIR)/html/canvas/EXTColorBufferHalfFloat.idl
 $(PROJECT_DIR)/html/canvas/EXTDisjointTimerQuery.idl
+$(PROJECT_DIR)/html/canvas/EXTDisjointTimerQueryWebGL2.idl
 $(PROJECT_DIR)/html/canvas/EXTFloatBlend.idl
 $(PROJECT_DIR)/html/canvas/EXTFragDepth.idl
 $(PROJECT_DIR)/html/canvas/EXTShaderTextureLOD.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -821,6 +821,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSEXTColorBufferHalfFloat.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSEXTColorBufferHalfFloat.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSEXTDisjointTimerQuery.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSEXTDisjointTimerQuery.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSEXTDisjointTimerQueryWebGL2.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSEXTDisjointTimerQueryWebGL2.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSEXTFloatBlend.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSEXTFloatBlend.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSEXTFragDepth.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1202,6 +1202,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/html/canvas/EXTColorBufferFloat.idl \
     $(WebCore)/html/canvas/EXTColorBufferHalfFloat.idl \
     $(WebCore)/html/canvas/EXTDisjointTimerQuery.idl \
+    $(WebCore)/html/canvas/EXTDisjointTimerQueryWebGL2.idl \
     $(WebCore)/html/canvas/EXTFloatBlend.idl \
     $(WebCore)/html/canvas/EXTFragDepth.idl \
     $(WebCore)/html/canvas/EXTShaderTextureLOD.idl \

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1424,6 +1424,7 @@ html/canvas/EXTBlendMinMax.cpp
 html/canvas/EXTColorBufferFloat.cpp
 html/canvas/EXTColorBufferHalfFloat.cpp
 html/canvas/EXTDisjointTimerQuery.cpp
+html/canvas/EXTDisjointTimerQueryWebGL2.cpp
 html/canvas/EXTFloatBlend.cpp
 html/canvas/EXTFragDepth.cpp
 html/canvas/EXTShaderTextureLOD.cpp
@@ -3283,6 +3284,7 @@ JSEXTBlendMinMax.cpp
 JSEXTColorBufferFloat.cpp
 JSEXTColorBufferHalfFloat.cpp
 JSEXTDisjointTimerQuery.cpp
+JSEXTDisjointTimerQueryWebGL2.cpp
 JSEXTFloatBlend.cpp
 JSEXTFragDepth.cpp
 JSEXTShaderTextureLOD.cpp

--- a/Source/WebCore/bindings/js/JSDOMConvertWebGL.cpp
+++ b/Source/WebCore/bindings/js/JSDOMConvertWebGL.cpp
@@ -34,6 +34,7 @@
 #include "JSEXTColorBufferFloat.h"
 #include "JSEXTColorBufferHalfFloat.h"
 #include "JSEXTDisjointTimerQuery.h"
+#include "JSEXTDisjointTimerQueryWebGL2.h"
 #include "JSEXTFloatBlend.h"
 #include "JSEXTFragDepth.h"
 #include "JSEXTShaderTextureLOD.h"
@@ -72,6 +73,7 @@
 #include "JSWebGLMultiDrawInstancedBaseVertexBaseInstance.h"
 #include "JSWebGLProgram.h"
 #include "JSWebGLProvokingVertex.h"
+#include "JSWebGLQuery.h"
 #include "JSWebGLRenderbuffer.h"
 #include "JSWebGLSampler.h"
 #include "JSWebGLTexture.h"
@@ -155,6 +157,9 @@ JSValue convertToJSValue(JSGlobalObject& lexicalGlobalObject, JSDOMGlobalObject&
         [&] (const RefPtr<WebGLVertexArrayObjectOES>& array) {
             return toJS(&lexicalGlobalObject, &globalObject, array.get());
         },
+        [&] (const RefPtr<WebGLQuery>& query) {
+            return toJS(&lexicalGlobalObject, &globalObject, query.get());
+        },
         [&] (const RefPtr<WebGLSampler>& sampler) {
             return toJS(&lexicalGlobalObject, &globalObject, sampler.get());
         },
@@ -179,6 +184,7 @@ JSValue convertToJSValue(JSGlobalObject& lexicalGlobalObject, JSDOMGlobalObject&
         TO_JS(EXTColorBufferFloat)
         TO_JS(EXTColorBufferHalfFloat)
         TO_JS(EXTDisjointTimerQuery)
+        TO_JS(EXTDisjointTimerQueryWebGL2)
         TO_JS(EXTFloatBlend)
         TO_JS(EXTFragDepth)
         TO_JS(EXTShaderTextureLOD)

--- a/Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.cpp
+++ b/Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2023 The Chromium Authors. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if ENABLE(WEBGL)
+#include "EXTDisjointTimerQueryWebGL2.h"
+
+#include "EventLoop.h"
+#include "ScriptExecutionContext.h"
+
+#include <wtf/IsoMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(EXTDisjointTimerQueryWebGL2);
+
+EXTDisjointTimerQueryWebGL2::EXTDisjointTimerQueryWebGL2(WebGLRenderingContextBase& context)
+    : WebGLExtension(context)
+{
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_disjoint_timer_query"_s);
+}
+
+EXTDisjointTimerQueryWebGL2::~EXTDisjointTimerQueryWebGL2() = default;
+
+WebGLExtension::ExtensionName EXTDisjointTimerQueryWebGL2::getName() const
+{
+    return EXTDisjointTimerQueryWebGL2Name;
+}
+
+bool EXTDisjointTimerQueryWebGL2::supported(GraphicsContextGL& context)
+{
+    return context.supportsExtension("GL_EXT_disjoint_timer_query"_s);
+}
+
+void EXTDisjointTimerQueryWebGL2::queryCounterEXT(WebGLQuery& query, GCGLenum target)
+{
+    auto context = WebGLExtensionScopedContext(this);
+    if (context.isLost() || !context->scriptExecutionContext())
+        return;
+
+    if (!context->validateWebGLObject("queryCounterEXT", &query))
+        return;
+
+    if (target != GraphicsContextGL::TIMESTAMP_EXT) {
+        context->synthesizeGLError(GraphicsContextGL::INVALID_ENUM, "queryCounterEXT", "invalid target");
+        return;
+    }
+
+    if (query.target() && query.target() != target) {
+        context->synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, "queryCounterEXT", "query type does not match target");
+        return;
+    }
+
+    query.setTarget(target);
+
+    context->graphicsContextGL()->queryCounterEXT(query.object(), target);
+
+    // A query's result must not be made available until control has returned to the user agent's main loop.
+    context->scriptExecutionContext()->eventLoop().queueMicrotask([&] {
+        query.makeResultAvailable();
+    });
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WEBGL)

--- a/Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.h
+++ b/Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 The Chromium Authors. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "WebGLExtension.h"
+
+namespace WebCore {
+
+class EXTDisjointTimerQueryWebGL2 final : public WebGLExtension {
+    WTF_MAKE_ISO_ALLOCATED(EXTDisjointTimerQueryWebGL2);
+public:
+    explicit EXTDisjointTimerQueryWebGL2(WebGLRenderingContextBase&);
+    virtual ~EXTDisjointTimerQueryWebGL2();
+
+    ExtensionName getName() const override;
+
+    static bool supported(GraphicsContextGL&);
+
+    void queryCounterEXT(WebGLQuery&, GCGLenum target);
+};
+
+} // namespace WebCore

--- a/Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.idl
+++ b/Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.idl
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 The Chromium Authors. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    LegacyNoInterfaceObject,
+    Conditional=WEBGL,
+    GenerateIsReachable=ImplWebGLRenderingContext
+] interface EXTDisjointTimerQueryWebGL2 {
+  const unsigned long QUERY_COUNTER_BITS_EXT = 0x8864;
+  const unsigned long TIME_ELAPSED_EXT       = 0x88BF;
+  const unsigned long TIMESTAMP_EXT          = 0x8E28;
+  const unsigned long GPU_DISJOINT_EXT       = 0x8FBB;
+
+  undefined queryCounterEXT(WebGLQuery query, unsigned long target);
+};

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.h
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.h
@@ -203,7 +203,7 @@ public:
     GCGLboolean isQuery(WebGLQuery*);
     void beginQuery(GCGLenum target, WebGLQuery&);
     void endQuery(GCGLenum target);
-    RefPtr<WebGLQuery> getQuery(GCGLenum target, GCGLenum pname);
+    WebGLAny getQuery(GCGLenum target, GCGLenum pname);
     WebGLAny getQueryParameter(WebGLQuery&, GCGLenum pname);
     
     // Sampler objects
@@ -308,7 +308,7 @@ private:
     WebGLFramebuffer* getReadFramebufferBinding() final;
     void restoreCurrentFramebuffer() final;
     bool validateNonDefaultFramebufferAttachment(const char* functionName, GCGLenum attachment);
-    enum ActiveQueryKey { SamplesPassed = 0, PrimitivesWritten = 1, NumKeys = 2 };
+    enum ActiveQueryKey { SamplesPassed = 0, PrimitivesWritten = 1, TimeElapsed = 2, NumKeys = 3 };
     std::optional<ActiveQueryKey> validateQueryTarget(const char* functionName, GCGLenum target);
     void renderbufferStorageImpl(GCGLenum target, GCGLsizei samples, GCGLenum internalformat, GCGLsizei width, GCGLsizei height, const char* functionName) final;
     void renderbufferStorageHelper(GCGLenum target, GCGLsizei samples, GCGLenum internalformat, GCGLsizei width, GCGLsizei height);

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.idl
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.idl
@@ -420,7 +420,7 @@ typedef (ImageBitmap or ImageData or HTMLImageElement or HTMLCanvasElement
     GLboolean isQuery(WebGLQuery? query);
     undefined beginQuery(GLenum target, WebGLQuery query);
     undefined endQuery(GLenum target);
-    WebGLQuery? getQuery(GLenum target, GLenum pname);
+    [OverrideIDLType=IDLWebGLAny] any getQuery(GLenum target, GLenum pname);
     [OverrideIDLType=IDLWebGLAny] any getQueryParameter(WebGLQuery query, GLenum pname);
 
     // Sampler Objects.

--- a/Source/WebCore/html/canvas/WebGLAny.h
+++ b/Source/WebCore/html/canvas/WebGLAny.h
@@ -41,6 +41,7 @@ class JSDOMGlobalObject;
 class WebGLBuffer;
 class WebGLFramebuffer;
 class WebGLProgram;
+class WebGLQuery;
 class WebGLRenderbuffer;
 class WebGLSampler;
 class WebGLTexture;
@@ -68,6 +69,7 @@ using WebGLAny = std::variant<
     RefPtr<WebGLBuffer>,
     RefPtr<WebGLFramebuffer>,
     RefPtr<WebGLProgram>,
+    RefPtr<WebGLQuery>,
     RefPtr<WebGLRenderbuffer>,
     RefPtr<WebGLSampler>,
     RefPtr<WebGLTexture>,

--- a/Source/WebCore/html/canvas/WebGLExtension.h
+++ b/Source/WebCore/html/canvas/WebGLExtension.h
@@ -62,6 +62,7 @@ public:
         EXTColorBufferFloatName,
         EXTColorBufferHalfFloatName,
         EXTDisjointTimerQueryName,
+        EXTDisjointTimerQueryWebGL2Name,
         EXTFloatBlendName,
         EXTFragDepthName,
         EXTShaderTextureLODName,

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -39,6 +39,7 @@
 #include "EXTColorBufferFloat.h"
 #include "EXTColorBufferHalfFloat.h"
 #include "EXTDisjointTimerQuery.h"
+#include "EXTDisjointTimerQueryWebGL2.h"
 #include "EXTFloatBlend.h"
 #include "EXTFragDepth.h"
 #include "EXTShaderTextureLOD.h"
@@ -2442,12 +2443,12 @@ WebGLAny WebGLRenderingContextBase::getParameter(GCGLenum pname)
         return nullptr;
     case GraphicsContextGL::TIMESTAMP_EXT: // EXT_disjoint_timer_query
     case GraphicsContextGL::GPU_DISJOINT_EXT:
-        if (m_extDisjointTimerQuery) {
+        if (m_extDisjointTimerQuery || m_extDisjointTimerQueryWebGL2) {
             if (pname == GraphicsContextGL::GPU_DISJOINT_EXT)
                 return getBooleanParameter(pname);
             return getInt64Parameter(pname);
         }
-        synthesizeGLError(GraphicsContextGL::INVALID_ENUM, "getParameter", "invalid parameter name, EXT_disjoint_timer_query not enabled");
+        synthesizeGLError(GraphicsContextGL::INVALID_ENUM, "getParameter", "invalid parameter name, EXT_disjoint_timer_query or EXT_disjoint_timer_query_webgl2 not enabled");
         return nullptr;
     case GraphicsContextGL::MAX_COLOR_ATTACHMENTS_EXT: // EXT_draw_buffers BEGIN
         if (m_webglDrawBuffers || isWebGL2())
@@ -2991,6 +2992,7 @@ bool WebGLRenderingContextBase::extensionIsEnabled(const String& name)
     CHECK_EXTENSION(m_extColorBufferFloat, "EXT_color_buffer_float");
     CHECK_EXTENSION(m_extColorBufferHalfFloat, "EXT_color_buffer_half_float");
     CHECK_EXTENSION(m_extDisjointTimerQuery, "EXT_disjoint_timer_query");
+    CHECK_EXTENSION(m_extDisjointTimerQueryWebGL2, "EXT_disjoint_timer_query_webgl2");
     CHECK_EXTENSION(m_extFloatBlend, "EXT_float_blend");
     CHECK_EXTENSION(m_extFragDepth, "EXT_frag_depth");
     CHECK_EXTENSION(m_extShaderTextureLOD, "EXT_shader_texture_lod");
@@ -5805,6 +5807,7 @@ void WebGLRenderingContextBase::loseExtensions(LostContextMode mode)
     LOSE_EXTENSION(m_extColorBufferFloat);
     LOSE_EXTENSION(m_extColorBufferHalfFloat);
     LOSE_EXTENSION(m_extDisjointTimerQuery);
+    LOSE_EXTENSION(m_extDisjointTimerQueryWebGL2);
     LOSE_EXTENSION(m_extFloatBlend);
     LOSE_EXTENSION(m_extFragDepth);
     LOSE_EXTENSION(m_extShaderTextureLOD);

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -40,6 +40,7 @@
 #include "WebGLContextAttributes.h"
 #include "WebGLFramebuffer.h"
 #include "WebGLProgram.h"
+#include "WebGLQuery.h"
 #include "WebGLRenderbuffer.h"
 #include "WebGLSampler.h"
 #include "WebGLStateTracker.h"
@@ -77,6 +78,7 @@ class EXTBlendMinMax;
 class EXTColorBufferFloat;
 class EXTColorBufferHalfFloat;
 class EXTDisjointTimerQuery;
+class EXTDisjointTimerQueryWebGL2;
 class EXTFloatBlend;
 class EXTFragDepth;
 class EXTShaderTextureLOD;
@@ -483,6 +485,7 @@ protected:
     WebGLRenderingContextBase(CanvasBase&, Ref<GraphicsContextGL>&&, WebGLContextAttributes);
 
     friend class EXTDisjointTimerQuery;
+    friend class EXTDisjointTimerQueryWebGL2;
     friend class EXTTextureCompressionBPTC;
     friend class EXTTextureCompressionRGTC;
     friend class OESDrawBuffersIndexed;
@@ -733,6 +736,7 @@ protected:
     RefPtr<EXTColorBufferFloat> m_extColorBufferFloat;
     RefPtr<EXTColorBufferHalfFloat> m_extColorBufferHalfFloat;
     RefPtr<EXTDisjointTimerQuery> m_extDisjointTimerQuery;
+    RefPtr<EXTDisjointTimerQueryWebGL2> m_extDisjointTimerQueryWebGL2;
     RefPtr<EXTFloatBlend> m_extFloatBlend;
     RefPtr<EXTFragDepth> m_extFragDepth;
     RefPtr<EXTShaderTextureLOD> m_extShaderTextureLOD;

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -1407,7 +1407,7 @@ public:
     virtual GCGLboolean isQuery(PlatformGLObject query) = 0;
     virtual void beginQuery(GCGLenum target, PlatformGLObject query) = 0;
     virtual void endQuery(GCGLenum target) = 0;
-    virtual PlatformGLObject getQuery(GCGLenum target, GCGLenum pname) = 0;
+    virtual GCGLint getQuery(GCGLenum target, GCGLenum pname) = 0;
     // getQueryParameter
     virtual GCGLuint getQueryObjectui(PlatformGLObject query, GCGLenum pname) = 0;
 

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -2684,14 +2684,14 @@ GCGLboolean GraphicsContextGLANGLE::isQuery(PlatformGLObject query)
     return GL_IsQuery(query);
 }
 
-PlatformGLObject GraphicsContextGLANGLE::getQuery(GCGLenum target, GCGLenum pname)
+GCGLint GraphicsContextGLANGLE::getQuery(GCGLenum target, GCGLenum pname)
 {
     if (!makeContextCurrent())
         return 0;
 
-    GLint value;
+    GLint value = 0;
     GL_GetQueryiv(target, pname, &value);
-    return static_cast<PlatformGLObject>(value);
+    return value;
 }
 
 PlatformGLObject GraphicsContextGLANGLE::createSampler()

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
@@ -270,7 +270,7 @@ public:
     GCGLboolean isQuery(PlatformGLObject query) final;
     void beginQuery(GCGLenum target, PlatformGLObject query) final;
     void endQuery(GCGLenum target) final;
-    PlatformGLObject getQuery(GCGLenum target, GCGLenum pname) final;
+    GCGLint getQuery(GCGLenum target, GCGLenum pname) final;
     GCGLuint getQueryObjectui(PlatformGLObject query, GCGLenum pname) final;
     PlatformGLObject createSampler() final;
     void deleteSampler(PlatformGLObject sampler) final;

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
@@ -263,7 +263,7 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {
     void IsQuery(uint32_t query) -> (bool returnValue) Synchronous
     void BeginQuery(uint32_t target, uint32_t query)
     void EndQuery(uint32_t target)
-    void GetQuery(uint32_t target, uint32_t pname) -> (uint32_t returnValue) Synchronous
+    void GetQuery(uint32_t target, uint32_t pname) -> (int32_t returnValue) Synchronous
     void GetQueryObjectui(uint32_t query, uint32_t pname) -> (uint32_t returnValue) Synchronous
     void CreateSampler() -> (uint32_t returnValue) Synchronous
     void DeleteSampler(uint32_t sampler)

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
@@ -1122,9 +1122,9 @@
         assertIsCurrent(workQueue());
         m_context->endQuery(target);
     }
-    void getQuery(uint32_t target, uint32_t pname, CompletionHandler<void(uint32_t)>&& completionHandler)
+    void getQuery(uint32_t target, uint32_t pname, CompletionHandler<void(int32_t)>&& completionHandler)
     {
-        PlatformGLObject returnValue = { };
+        GCGLint returnValue = { };
         assertIsCurrent(workQueue());
         returnValue = m_context->getQuery(target, pname);
         completionHandler(returnValue);

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
@@ -302,7 +302,7 @@ public:
     GCGLboolean isQuery(PlatformGLObject query) final;
     void beginQuery(GCGLenum target, PlatformGLObject query) final;
     void endQuery(GCGLenum target) final;
-    PlatformGLObject getQuery(GCGLenum target, GCGLenum pname) final;
+    GCGLint getQuery(GCGLenum target, GCGLenum pname) final;
     GCGLuint getQueryObjectui(PlatformGLObject query, GCGLenum pname) final;
     PlatformGLObject createSampler() final;
     void deleteSampler(PlatformGLObject sampler) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
@@ -2328,7 +2328,7 @@ void RemoteGraphicsContextGLProxy::endQuery(GCGLenum target)
     }
 }
 
-PlatformGLObject RemoteGraphicsContextGLProxy::getQuery(GCGLenum target, GCGLenum pname)
+GCGLint RemoteGraphicsContextGLProxy::getQuery(GCGLenum target, GCGLenum pname)
 {
     if (isContextLost())
         return { };


### PR DESCRIPTION
#### b5fbb15b789487d236cc790fe86337f1b4991796
<pre>
Implement EXT_disjoint_timer_query_webgl2
<a href="https://bugs.webkit.org/show_bug.cgi?id=252388">https://bugs.webkit.org/show_bug.cgi?id=252388</a>

Reviewed by Kimmo Kinnunen.

Drive-by updates:
* The return type of WebGL2RenderingContext::getQuery
  has been changed to WebGLAny
* QUERY_RESULT of unavailable active queries has been
  changed from false to 0 to match the spec
* QUERY_RESULT_AVAILABLE now always returns a boolean
* The return types of GraphicsContextGL::getQuery and
  its overrides have been changed to GCGLint

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/JSDOMConvertWebGL.cpp:
(WebCore::convertToJSValue):
* Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.cpp: Added.
(WebCore::EXTDisjointTimerQueryWebGL2::EXTDisjointTimerQueryWebGL2):
(WebCore::EXTDisjointTimerQueryWebGL2::getName const):
(WebCore::EXTDisjointTimerQueryWebGL2::supported):
(WebCore::EXTDisjointTimerQueryWebGL2::queryCounterEXT):
* Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.h: Added.
* Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.idl: Added.
* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::validateQueryTarget):
(WebCore::WebGL2RenderingContext::getQuery):
(WebCore::WebGL2RenderingContext::getQueryParameter):
(WebCore::WebGL2RenderingContext::getExtension):
(WebCore::WebGL2RenderingContext::getSupportedExtensions):
* Source/WebCore/html/canvas/WebGL2RenderingContext.h:
* Source/WebCore/html/canvas/WebGL2RenderingContext.idl:
* Source/WebCore/html/canvas/WebGLAny.h:
* Source/WebCore/html/canvas/WebGLExtension.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::getParameter):
(WebCore::WebGLRenderingContextBase::extensionIsEnabled):
(WebCore::WebGLRenderingContextBase::loseExtensions):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
* Source/WebCore/platform/graphics/GraphicsContextGL.h:
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::getQuery):
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h:
(getQuery):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp:
(WebKit::RemoteGraphicsContextGLProxy::getQuery):

Canonical link: <a href="https://commits.webkit.org/260507@main">https://commits.webkit.org/260507@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92158958792bf37ba3680062d162bbaa6037443f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108289 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17381 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41154 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117406 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116800 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112176 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18913 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8660 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100505 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114058 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14188 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97344 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42060 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96166 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28988 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/83742 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10220 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30332 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10959 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7237 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16369 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49929 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7263 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12545 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->