### PR TITLE
[CoordinatedGraphics] Provide scheduled display-update events for better scrolling handling

### DIFF
--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreeNicosia.cpp
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreeNicosia.cpp
@@ -32,6 +32,7 @@
 
 #include "AsyncScrollingCoordinator.h"
 #include "NicosiaPlatformLayer.h"
+#include "ScrollingThread.h"
 #include "ScrollingTreeFixedNodeNicosia.h"
 #include "ScrollingTreeFrameHostingNode.h"
 #include "ScrollingTreeFrameScrollingNodeNicosia.h"
@@ -73,6 +74,19 @@ Ref<ScrollingTreeNode> ScrollingTreeNicosia::createScrollingTreeNode(ScrollingNo
     }
 
     RELEASE_ASSERT_NOT_REACHED();
+}
+
+void ScrollingTreeNicosia::applyLayerPositionsInternal()
+{
+    std::unique_ptr<Nicosia::SceneIntegration::UpdateScope> updateScope;
+    if (ScrollingThread::isCurrentThread()) {
+        if (auto* rootScrollingNode = rootNode()) {
+            auto rootContentsLayer = static_cast<ScrollingTreeFrameScrollingNodeNicosia*>(rootScrollingNode)->rootContentsLayer();
+            updateScope = rootContentsLayer->createUpdateScope();
+        }
+    }
+
+    ThreadedScrollingTree::applyLayerPositionsInternal();
 }
 
 using Nicosia::CompositionLayer;

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreeNicosia.h
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreeNicosia.h
@@ -42,6 +42,8 @@ private:
 
     Ref<ScrollingTreeNode> createScrollingTreeNode(ScrollingNodeType, ScrollingNodeID) override;
 
+    void applyLayerPositionsInternal() final;
+
     RefPtr<ScrollingTreeNode> scrollingNodeForPoint(FloatPoint) final;
 };
 

--- a/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp
+++ b/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp
@@ -45,6 +45,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+static constexpr unsigned c_defaultRefreshRate = 60000;
+
 Ref<ThreadedCompositor> ThreadedCompositor::create(Client& client, ThreadedDisplayRefreshMonitor::Client& displayRefreshMonitorClient, PlatformDisplayID displayID, const IntSize& viewportSize, float scaleFactor, TextureMapper::PaintFlags paintFlags)
 {
     return adoptRef(*new ThreadedCompositor(client, displayRefreshMonitorClient, displayID, viewportSize, scaleFactor, paintFlags));
@@ -64,7 +66,17 @@ ThreadedCompositor::ThreadedCompositor(Client& client, ThreadedDisplayRefreshMon
         m_attributes.needsResize = !viewportSize.isEmpty();
     }
 
+    m_display.displayID = displayID;
+    m_display.displayUpdate = { 0, c_defaultRefreshRate / 1000 };
+
     m_compositingRunLoop->performTaskSync([this, protectedThis = Ref { *this }] {
+        m_display.updateTimer = makeUnique<RunLoop::Timer>(RunLoop::current(), this, &ThreadedCompositor::displayUpdateFired);
+#if USE(GLIB_EVENT_LOOP)
+        m_display.updateTimer->setPriority(RunLoopSourcePriority::CompositingThreadUpdateTimer);
+        m_display.updateTimer->setName("[WebKit] ThreadedCompositor::DisplayUpdate");
+#endif
+        m_display.updateTimer->startOneShot(Seconds { 1.0 / m_display.displayUpdate.updatesPerSecond });
+
         m_scene = adoptRef(new CoordinatedGraphicsScene(this));
         m_nativeSurfaceHandle = m_client.nativeSurfaceHandleForCompositing();
 
@@ -113,6 +125,8 @@ void ThreadedCompositor::invalidate()
         m_context = nullptr;
         m_client.didDestroyGLContext();
         m_scene = nullptr;
+
+        m_display.updateTimer = nullptr;
     });
     m_compositingRunLoop = nullptr;
 }
@@ -183,6 +197,8 @@ void ThreadedCompositor::renderLayerTree()
     if (!m_context || !m_context->makeContextCurrent())
         return;
 
+    m_display.updateTimer->stop();
+
     // Retrieve the scene attributes in a thread-safe manner.
     WebCore::IntSize viewportSize;
     WebCore::IntPoint scrollPosition;
@@ -246,22 +262,18 @@ void ThreadedCompositor::sceneUpdateFinished()
     // The DisplayRefreshMonitor will be used to dispatch a callback on the client thread if:
     //  - clientRendersNextFrame is true (i.e. client has to be notified about the finished update), or
     //  - a DisplayRefreshMonitor callback was requested from the Web engine
-    bool shouldDispatchDisplayRefreshCallback { false };
+    bool shouldDispatchDisplayRefreshCallback = m_displayRefreshMonitor->requiresDisplayRefreshCallback(m_display.displayUpdate);
 
-    {
+    if (!shouldDispatchDisplayRefreshCallback) {
         Locker locker { m_attributes.lock };
-        shouldDispatchDisplayRefreshCallback = m_attributes.clientRendersNextFrame
-            || m_displayRefreshMonitor->requiresDisplayRefreshCallback();
+        shouldDispatchDisplayRefreshCallback |= m_attributes.clientRendersNextFrame;
     }
 
     Locker stateLocker { m_compositingRunLoop->stateLock() };
 
     // Schedule the DisplayRefreshMonitor callback, if necessary.
-    if (shouldDispatchDisplayRefreshCallback) {
+    if (shouldDispatchDisplayRefreshCallback)
         m_displayRefreshMonitor->dispatchDisplayRefreshCallback();
-        // Notify the ScrollingTree to make sure scrolling does not depend on the main thread.
-        m_client.displayDidRefresh(m_displayRefreshMonitor->displayID());
-    }
 
     // Mark the scene update as completed.
     m_compositingRunLoop->updateCompleted(stateLocker);
@@ -300,13 +312,28 @@ WebCore::DisplayRefreshMonitor& ThreadedCompositor::displayRefreshMonitor() cons
 void ThreadedCompositor::frameComplete()
 {
     ASSERT(m_compositingRunLoop->isCurrent());
+    displayUpdateFired();
     sceneUpdateFinished();
 }
 
 void ThreadedCompositor::targetRefreshRateDidChange(unsigned rate)
 {
     ASSERT(RunLoop::isMain());
-    m_displayRefreshMonitor->setTargetRefreshRate(rate);
+
+    if (!rate)
+        rate = c_defaultRefreshRate;
+    m_compositingRunLoop->performTaskSync([this, protectedThis = Ref { *this }, rate] {
+        m_display.displayUpdate = { 0, rate / 1000 };
+    });
+}
+
+void ThreadedCompositor::displayUpdateFired()
+{
+    m_display.displayUpdate = m_display.displayUpdate.nextUpdate();
+
+    m_client.displayDidRefresh(m_display.displayID);
+
+    m_display.updateTimer->startOneShot(Seconds { 1.0 / m_display.displayUpdate.updatesPerSecond });
 }
 
 }

--- a/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.h
+++ b/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.h
@@ -89,6 +89,8 @@ private:
 
     void createGLContext();
 
+    void displayUpdateFired();
+
     Client& m_client;
     RefPtr<CoordinatedGraphicsScene> m_scene;
     std::unique_ptr<WebCore::GLContext> m_context;
@@ -109,6 +111,12 @@ private:
 
         bool clientRendersNextFrame { false };
     } m_attributes;
+
+    struct {
+        WebCore::PlatformDisplayID displayID;
+        WebCore::DisplayUpdate displayUpdate;
+        std::unique_ptr<RunLoop::Timer> updateTimer;
+    } m_display;
 
     Ref<ThreadedDisplayRefreshMonitor> m_displayRefreshMonitor;
 };

--- a/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedDisplayRefreshMonitor.cpp
+++ b/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedDisplayRefreshMonitor.cpp
@@ -43,8 +43,6 @@ ThreadedDisplayRefreshMonitor::ThreadedDisplayRefreshMonitor(WebCore::PlatformDi
     : WebCore::DisplayRefreshMonitor(displayID)
     , m_displayRefreshTimer(RunLoop::main(), this, &ThreadedDisplayRefreshMonitor::displayRefreshCallback)
     , m_client(&client)
-    , m_targetRefreshRate(defaultRefreshRate)
-    , m_currentUpdate({ 0, m_targetRefreshRate / 1000 })
 {
 #if USE(GLIB_EVENT_LOOP)
     m_displayRefreshTimer.setPriority(RunLoopSourcePriority::DisplayRefreshMonitorTimer);
@@ -73,9 +71,10 @@ bool ThreadedDisplayRefreshMonitor::requestRefreshCallback()
     return true;
 }
 
-bool ThreadedDisplayRefreshMonitor::requiresDisplayRefreshCallback()
+bool ThreadedDisplayRefreshMonitor::requiresDisplayRefreshCallback(const WebCore::DisplayUpdate& displayUpdate)
 {
     Locker locker { lock() };
+    m_displayUpdate = displayUpdate;
     return isScheduled() && isPreviousFrameDone();
 }
 
@@ -95,8 +94,10 @@ void ThreadedDisplayRefreshMonitor::invalidate()
         wasScheduled = isScheduled();
     }
     if (wasScheduled) {
-        displayDidRefresh(m_currentUpdate);
-        m_currentUpdate = m_currentUpdate.nextUpdate();
+        // This is shutting down, so there's no up-to-date DisplayUpdate available.
+        // Instead, the current value is progressed and used for this dispatch.
+        m_displayUpdate = m_displayUpdate.nextUpdate();
+        displayDidRefresh(m_displayUpdate);
     }
     m_client = nullptr;
 }
@@ -105,19 +106,19 @@ void ThreadedDisplayRefreshMonitor::invalidate()
 void ThreadedDisplayRefreshMonitor::displayRefreshCallback()
 {
     bool shouldHandleDisplayRefreshNotification { false };
+    WebCore::DisplayUpdate displayUpdate;
     {
         Locker locker { lock() };
         shouldHandleDisplayRefreshNotification = isScheduled() && isPreviousFrameDone();
+        displayUpdate = m_displayUpdate;
         if (shouldHandleDisplayRefreshNotification) {
             setIsScheduled(false);
             setIsPreviousFrameDone(false);
         }
     }
 
-    if (shouldHandleDisplayRefreshNotification) {
-        displayDidRefresh(m_currentUpdate);
-        m_currentUpdate = m_currentUpdate.nextUpdate();
-    }
+    if (shouldHandleDisplayRefreshNotification)
+        displayDidRefresh(displayUpdate);
 
     // Retrieve the scheduled status for this DisplayRefreshMonitor.
     bool hasBeenRescheduled { false };
@@ -131,16 +132,6 @@ void ThreadedDisplayRefreshMonitor::displayRefreshCallback()
     // the notification handling.
     if (m_client)
         m_client->handleDisplayRefreshMonitorUpdate(hasBeenRescheduled);
-}
-
-void ThreadedDisplayRefreshMonitor::setTargetRefreshRate(unsigned rate)
-{
-    if (!rate)
-        rate = defaultRefreshRate;
-    if (m_targetRefreshRate != rate) {
-        m_targetRefreshRate = rate;
-        m_currentUpdate = { 0, m_targetRefreshRate / 1000 };
-    }
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedDisplayRefreshMonitor.h
+++ b/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedDisplayRefreshMonitor.h
@@ -50,11 +50,9 @@ public:
 
     bool requestRefreshCallback() override;
 
-    bool requiresDisplayRefreshCallback();
+    bool requiresDisplayRefreshCallback(const WebCore::DisplayUpdate&);
     void dispatchDisplayRefreshCallback();
     void invalidate();
-
-    void setTargetRefreshRate(unsigned);
 
 private:
     ThreadedDisplayRefreshMonitor(WebCore::PlatformDisplayID, Client&);
@@ -65,8 +63,7 @@ private:
     void displayRefreshCallback();
     RunLoop::Timer m_displayRefreshTimer;
     Client* m_client;
-    unsigned m_targetRefreshRate;
-    WebCore::DisplayUpdate m_currentUpdate;
+    WebCore::DisplayUpdate m_displayUpdate;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -34,6 +34,7 @@
 #include "DrawingArea.h"
 #include "WebPage.h"
 #include "WebPageProxyMessages.h"
+#include "WebProcess.h"
 #include <WebCore/AsyncScrollingCoordinator.h>
 #include <WebCore/Chrome.h>
 #include <WebCore/Frame.h>
@@ -427,14 +428,7 @@ void LayerTreeHost::didRenderFrame()
 
 void LayerTreeHost::displayDidRefresh(PlatformDisplayID displayID)
 {
-#if ENABLE(ASYNC_SCROLLING)
-    if (auto* scrollingCoordinator = m_webPage.scrollingCoordinator()) {
-        if (auto* scrollingTree = downcast<AsyncScrollingCoordinator>(*scrollingCoordinator).scrollingTree())
-            downcast<ThreadedScrollingTree>(*scrollingTree).displayDidRefresh(displayID);
-    }
-#else
-    UNUSED_PARAM(displayID);
-#endif
+    WebProcess::singleton().eventDispatcher().notifyScrollingTreesDisplayDidRefresh(displayID);
 }
 
 void LayerTreeHost::requestDisplayRefreshMonitorUpdate()


### PR DESCRIPTION
#### 06b9ec1834d27a4fb8a324e29908ed274305620a
<pre>
[CoordinatedGraphics] Provide scheduled display-update events for better scrolling handling
<a href="https://bugs.webkit.org/show_bug.cgi?id=252467">https://bugs.webkit.org/show_bug.cgi?id=252467</a>

Reviewed by Carlos Garcia Campos.

In ThreadedCompositor, a timer is established on the composition thread that is
used to mimic display updates at the desired update frequency. This is necessary
in order to provide opportunities for update producers like the scrolling thread
to actually enact the desired composition changes, like scrolling, independently
of the main thread.

The timer is put on the composition thread, matching the compositing-thread
update timer in priority. Its delay is based on the established frequency of the
display updates.

ThreadedCompositor::displayUpdateFired() method is added and is dispatched upon
every firing of the timer. It notifies the scrolling thread(s) for the given
display ID through the EventDispatcher instance on the WebProcess singleton,
and the next firing of the timer is then scheduled.

When ThreadedCompositor enters into the composition phase, the display update
timer is stopped, and the displayUpdateFired() dispatcher is invoked manually
when the frame-complete signal is returned from the embedder&apos;s environment. This
allows aligning the display update timer with the environment&apos;s vsync signals
without disturbing the composition itself.

The target update frequency logic is pulled from ThreadedDisplayRefreshMonitor
into ThreadedCompositor, with the desired DisplayUpdate object now also kept in
that class. In order for ThreadedDisplayRefreshMonitor to use a sensible
DisplayUpdate object for each of its own dispatches, the DisplayUpdate object
is passed through the requiresDisplayRefreshCallback() method to the monitor,
where it&apos;s then stored for next invocation on the main thread, if it occurs.

ScrollingTreeNicosia::applyLayerPositionsInternal() override is provided,
establishing an update scope when running on the scrolling thread. This will
cause the applied positions to actually go through composition whenever the
scrolling is being handled on the scrolling thread, meaning outside of the usual
update process.

* Source/WebCore/page/scrolling/nicosia/ScrollingTreeNicosia.cpp:
(WebCore::ScrollingTreeNicosia::applyLayerPositionsInternal):
* Source/WebCore/page/scrolling/nicosia/ScrollingTreeNicosia.h:
* Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp:
(WebKit::m_displayRefreshMonitor):
(WebKit::ThreadedCompositor::renderLayerTree):
(WebKit::ThreadedCompositor::sceneUpdateFinished):
(WebKit::ThreadedCompositor::frameComplete):
(WebKit::ThreadedCompositor::targetRefreshRateDidChange):
(WebKit::ThreadedCompositor::displayUpdateFired):
* Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.h:
* Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedDisplayRefreshMonitor.cpp:
(WebKit::ThreadedDisplayRefreshMonitor::ThreadedDisplayRefreshMonitor):
(WebKit::ThreadedDisplayRefreshMonitor::requiresDisplayRefreshCallback):
(WebKit::ThreadedDisplayRefreshMonitor::invalidate):
(WebKit::ThreadedDisplayRefreshMonitor::displayRefreshCallback):
(WebKit::ThreadedDisplayRefreshMonitor::setTargetRefreshRate): Deleted.
* Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedDisplayRefreshMonitor.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::displayDidRefresh):

Canonical link: <a href="https://commits.webkit.org/261124@main">https://commits.webkit.org/261124@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38175827b4dfcb2520afdede0e9a48fa35c9aa87

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110679 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19760 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/43243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/2029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/119515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114647 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21169 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10872 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/1540 "layout-tests (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116420 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/43243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102976 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/43243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44086 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/12396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/43243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/85982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12945 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18317 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/43243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7706 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/14883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->