### PR TITLE
[GStreamer][WebRTC] Fixes for disabled audio tracks

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1692,6 +1692,7 @@ webkit.org/b/219825 webrtc/sframe-keys.html [ Skip ]
 webkit.org/b/229055 http/wpt/webrtc/sframe-transform-error.html [ Skip ]
 
 # On-the-fly track switching not supported yet.
+webkit.org/b/235885 webrtc/audio-replace-track.html [ Skip ]
 webkit.org/b/235885 webrtc/video-replace-track-to-null.html [ Skip ]
 webkit.org/b/235885 webrtc/video-replace-track.html [ Skip ]
 webkit.org/b/235885 webrtc/video-replace-muted-track.html
@@ -1739,6 +1740,7 @@ webkit.org/b/235885 webrtc/video-mediastreamtrack-stats.html [ Failure ]
 webkit.org/b/235885 webrtc/video-stats.html [ Failure ]
 webkit.org/b/235885 webrtc/video.html [ Failure ]
 webkit.org/b/235885 webrtc/vp8-then-h264.html [ Failure ]
+webkit.org/b/235885 webrtc/peer-connection-remote-audio-mute.html [ Pass Timeout ]
 
 # In these tests only one canvas frame is pushed towards the sender webrtcbin,
 # this is not enough for the receiver webrtcbin to create its video source pad,

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
@@ -135,7 +135,6 @@ public:
     InternalSource(GstElement* parent, MediaStreamTrackPrivate& track, const String& padName)
         : m_parent(parent)
         , m_track(track)
-        , m_trackEnabled(track.enabled())
         , m_padName(padName)
     {
         static uint64_t audioCounter = 0;
@@ -243,12 +242,13 @@ public:
         });
     }
 
-    void pushSample(GstSample* sample)
+    void pushSample(GstSample* sample, const char* logMessage)
     {
         ASSERT(m_src);
         if (!m_src || !m_isObserving)
             return;
 
+        GST_TRACE_OBJECT(m_src.get(), "%s", logMessage);
         auto* parent = WEBKIT_MEDIA_STREAM_SRC(m_parent);
         webkitMediaStreamSrcEnsureStreamCollectionPosted(parent);
 
@@ -302,7 +302,6 @@ public:
 
     void trackEnabledChanged(MediaStreamTrackPrivate&) final
     {
-        m_trackEnabled.store(m_track.enabled());
         GST_INFO_OBJECT(m_src.get(), "Track enabled: %s", boolForPrinting(m_track.enabled()));
         if (m_track.isVideo()) {
             m_enoughData = false;
@@ -352,15 +351,10 @@ public:
         if (!m_configuredSize.isEmpty() && m_lastKnownSize != m_configuredSize) {
             GST_DEBUG_OBJECT(m_src.get(), "Video size changed from %dx%d to %dx%d", m_lastKnownSize.width(), m_lastKnownSize.height(), m_configuredSize.width(), m_configuredSize.height());
             m_lastKnownSize = m_configuredSize;
-            updateBlackFrame();
         }
 
-        if (!m_blackFrame)
-            updateBlackFrame();
-
-        if (m_trackEnabled.load()) {
-            GST_TRACE_OBJECT(m_src.get(), "Pushing video frame from enabled track");
-            pushSample(gstSample);
+        if (m_track.enabled()) {
+            pushSample(gstSample, "Pushing video frame from enabled track");
             return;
         }
 
@@ -374,26 +368,12 @@ public:
 
         const auto& data = static_cast<const GStreamerAudioData&>(audioData);
         auto sample = data.getSample();
-        if (m_trackEnabled.load()) {
-            GST_TRACE_OBJECT(m_src.get(), "Pushing audio sample from enabled track");
-            pushSample(sample.get());
+        if (m_track.enabled()) {
+            pushSample(sample.get(), "Pushing audio sample from enabled track");
             return;
         }
 
-        if (!m_silentSample) {
-            DisableMallocRestrictionsForCurrentThreadScope disableMallocRestrictions;
-            auto size = gst_buffer_get_size(gst_sample_get_buffer(sample.get()));
-            auto buffer = adoptGRef(gst_buffer_new_and_alloc(size));
-            GstMappedBuffer map(buffer.get(), GST_MAP_WRITE);
-            GstAudioInfo info;
-            gst_audio_info_set_format(&info, GST_AUDIO_FORMAT_F32LE, 44100, 1, nullptr);
-            webkitGstAudioFormatFillSilence(info.finfo, map.data(), map.size());
-            auto caps = adoptGRef(gst_audio_info_to_caps(&info));
-            m_silentSample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), nullptr, nullptr));
-        }
-
-        GST_TRACE_OBJECT(m_src.get(), "Pushing audio silence from disabled track");
-        pushSample(m_silentSample.get());
+        pushSilentSample();
     }
 
     Lock* eosLocker() { return &m_eosLock; }
@@ -428,17 +408,21 @@ private:
         gst_element_send_event(m_src.get(), gst_event_new_flush_stop(FALSE));
     }
 
-    void updateBlackFrame()
+    void pushBlackFrame()
     {
-        GST_DEBUG_OBJECT(m_src.get(), "Updating black video frame");
         auto width = m_lastKnownSize.width() ? m_lastKnownSize.width() : 320;
         auto height = m_lastKnownSize.height() ? m_lastKnownSize.height() : 240;
-        auto caps = adoptGRef(gst_caps_new_simple("video/x-raw", "format", G_TYPE_STRING, "I420", "width", G_TYPE_INT, width, "height", G_TYPE_INT, height, nullptr));
+        if (!m_blackFrameCaps)
+            m_blackFrameCaps = adoptGRef(gst_caps_new_simple("video/x-raw", "format", G_TYPE_STRING, "I420", "width", G_TYPE_INT, width, "height", G_TYPE_INT, height, nullptr));
+        else
+            gst_caps_set_simple(m_blackFrameCaps.get(), "width", G_TYPE_INT, width, "height", G_TYPE_INT, height, nullptr);
 
         GstVideoInfo info;
-        gst_video_info_from_caps(&info, caps.get());
+        gst_video_info_from_caps(&info, m_blackFrameCaps.get());
 
-        auto buffer = adoptGRef(gst_buffer_new_allocate(nullptr, GST_VIDEO_INFO_SIZE(&info), nullptr));
+        VideoFrameTimeMetadata metadata;
+        metadata.captureTime = MonotonicTime::now().secondsSinceEpoch();
+        auto buffer = adoptGRef(webkitGstBufferSetVideoFrameTimeMetadata(gst_buffer_new_allocate(nullptr, GST_VIDEO_INFO_SIZE(&info), nullptr), metadata));
         {
             GstMappedBuffer data(buffer, GST_MAP_WRITE);
             auto yOffset = GST_VIDEO_INFO_PLANE_OFFSET(&info, 1);
@@ -446,25 +430,34 @@ private:
             memset(data.data() + yOffset, 128, data.size() - yOffset);
         }
         gst_buffer_add_video_meta_full(buffer.get(), GST_VIDEO_FRAME_FLAG_NONE, GST_VIDEO_FORMAT_I420, width, height, 3, info.offset, info.stride);
-        m_blackFrame = adoptGRef(gst_sample_new(buffer.get(), caps.get(), nullptr, nullptr));
+        GST_BUFFER_DTS(buffer.get()) = GST_BUFFER_PTS(buffer.get()) = gst_element_get_current_running_time(m_parent);
+        auto sample = adoptGRef(gst_sample_new(buffer.get(), m_blackFrameCaps.get(), nullptr, nullptr));
+        pushSample(sample.get(), "Pushing black video frame");
     }
 
-    void pushBlackFrame()
+    void pushSilentSample()
     {
-        GST_TRACE_OBJECT(m_src.get(), "Pushing black video frame");
-        VideoFrameTimeMetadata metadata;
-        metadata.captureTime = MonotonicTime::now().secondsSinceEpoch();
-        auto* buffer = webkitGstBufferSetVideoFrameTimeMetadata(gst_sample_get_buffer(m_blackFrame.get()), metadata);
-        GST_BUFFER_DTS(buffer) = GST_BUFFER_PTS(buffer) = gst_element_get_current_running_time(m_parent);
-        // TODO: Use gst_sample_set_buffer() after bumping GStreamer dependency to 1.16.
-        auto* caps = gst_sample_get_caps(m_blackFrame.get());
-        m_blackFrame = adoptGRef(gst_sample_new(buffer, caps, nullptr, nullptr));
-        pushSample(m_blackFrame.get());
+        DisableMallocRestrictionsForCurrentThreadScope disableMallocRestrictions;
+        if (!m_silentSampleCaps) {
+            GstAudioInfo info;
+            gst_audio_info_set_format(&info, GST_AUDIO_FORMAT_F32LE, 44100, 1, nullptr);
+            m_silentSampleCaps = adoptGRef(gst_audio_info_to_caps(&info));
+        }
+
+        auto buffer = adoptGRef(gst_buffer_new_and_alloc(512));
+        GST_BUFFER_DTS(buffer.get()) = GST_BUFFER_PTS(buffer.get()) = gst_element_get_current_running_time(m_parent);
+        GstAudioInfo info;
+        gst_audio_info_from_caps(&info, m_silentSampleCaps.get());
+        {
+            GstMappedBuffer map(buffer.get(), GST_MAP_WRITE);
+            webkitGstAudioFormatFillSilence(info.finfo, map.data(), map.size());
+        }
+        auto sample = adoptGRef(gst_sample_new(buffer.get(), m_silentSampleCaps.get(), nullptr, nullptr));
+        pushSample(sample.get(), "Pushing audio silence from disabled track");
     }
 
     GstElement* m_parent { nullptr };
     MediaStreamTrackPrivate& m_track;
-    Atomic<bool> m_trackEnabled;
     GRefPtr<GstElement> m_src;
     GstClockTime m_firstBufferPts { GST_CLOCK_TIME_NONE };
     bool m_enoughData { false };
@@ -475,8 +468,8 @@ private:
     RefPtr<VideoTrackPrivateMediaStream> m_videoTrack;
     IntSize m_configuredSize;
     IntSize m_lastKnownSize;
-    GRefPtr<GstSample> m_blackFrame;
-    GRefPtr<GstSample> m_silentSample;
+    GRefPtr<GstCaps> m_blackFrameCaps;
+    GRefPtr<GstCaps> m_silentSampleCaps;
     VideoFrame::Rotation m_videoRotation { VideoFrame::Rotation::None };
     bool m_videoMirrored { false };
 

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp
@@ -115,7 +115,7 @@ bool RealtimeOutgoingAudioSourceGStreamer::setPayloadType(const GRefPtr<GstCaps>
 
     auto preEncoderSinkPad = adoptGRef(gst_element_get_static_pad(m_preEncoderQueue.get(), "sink"));
     if (!gst_pad_is_linked(preEncoderSinkPad.get()))
-        gst_element_link_many(m_outgoingSource.get(), m_valve.get(), m_audioconvert.get(), m_audioresample.get(), m_preEncoderQueue.get(), nullptr);
+        gst_element_link_many(m_outgoingSource.get(), m_audioconvert.get(), m_audioresample.get(), m_preEncoderQueue.get(), nullptr);
 
     gst_element_link_many(m_preEncoderQueue.get(), m_encoder.get(), m_payloader.get(), m_postEncoderQueue.get(), nullptr);
     gst_bin_sync_children_states(GST_BIN_CAST(m_bin.get()));

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.h
@@ -51,11 +51,13 @@ public:
     GRefPtr<GstElement> bin() const { return m_bin; }
 
     virtual bool setPayloadType(const GRefPtr<GstCaps>&) { return false; }
+    virtual void teardown() { }
 
 protected:
     explicit RealtimeOutgoingMediaSourceGStreamer(const String& mediaStreamId, MediaStreamTrack&);
 
     void initializeFromTrack();
+    virtual void sourceEnabledChanged();
 
     String m_mediaStreamId;
     String m_trackId;
@@ -80,7 +82,6 @@ protected:
 
 private:
     void sourceMutedChanged();
-    void sourceEnabledChanged();
 
     virtual RTCRtpCapabilities rtpCapabilities() const = 0;
     virtual void codecPreferencesChanged(const GRefPtr<GstCaps>&) { }

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.h
@@ -33,11 +33,14 @@ public:
     void setApplyRotation(bool shouldApplyRotation) { m_shouldApplyRotation = shouldApplyRotation; }
 
     bool setPayloadType(const GRefPtr<GstCaps>&) final;
+    void teardown() final;
 
     const GstStructure* stats() const { return m_stats.get(); }
 
 protected:
     explicit RealtimeOutgoingVideoSourceGStreamer(const String& mediaStreamId, MediaStreamTrack&);
+
+    void sourceEnabledChanged() final;
 
     bool m_shouldApplyRotation { false };
 
@@ -45,11 +48,16 @@ private:
     void codecPreferencesChanged(const GRefPtr<GstCaps>&) final;
     RTCRtpCapabilities rtpCapabilities() const final;
 
+    void startUpdatingStats();
+    void stopUpdatingStats();
+
     void updateStats(GstBuffer*);
 
     GRefPtr<GstElement> m_videoConvert;
     GRefPtr<GstElement> m_videoFlip;
     GUniquePtr<GstStructure> m_stats;
+
+    unsigned long m_statsPadProbeId { 0 };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 08a6948cfbbf41fa5168a7a53d1c7669ec5ec676
<pre>
[GStreamer][WebRTC] Fixes for disabled audio tracks
<a href="https://bugs.webkit.org/show_bug.cgi?id=252399">https://bugs.webkit.org/show_bug.cgi?id=252399</a>

Reviewed by Xabier Rodriguez-Calvar.

We should not interrupt the data flow when an outgoing media track has been disabled.
`MediaStreamTrack::enabled` is like muted, but it&apos;s a state that can be changed by the app, in
opposition with muted. So there&apos;s no need for a valve element in outgoing sources.

This patch also refactors silent/black samples pushing code in the mediastreamsrc element, some of
it was previously unsafe. And we make sure that outgoing buffers always have a valid PTS and DTS.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingAudioSourceGStreamer::setPayloadType):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingMediaSourceGStreamer::RealtimeOutgoingMediaSourceGStreamer):
(WebCore::RealtimeOutgoingMediaSourceGStreamer::~RealtimeOutgoingMediaSourceGStreamer):
(WebCore::RealtimeOutgoingMediaSourceGStreamer::start):
(WebCore::RealtimeOutgoingMediaSourceGStreamer::stop):
(WebCore::RealtimeOutgoingMediaSourceGStreamer::sourceMutedChanged):
(WebCore::RealtimeOutgoingMediaSourceGStreamer::sourceEnabledChanged):
(WebCore::RealtimeOutgoingMediaSourceGStreamer::initializeFromTrack):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.h:
(WebCore::RealtimeOutgoingMediaSourceGStreamer::teardown):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingVideoSourceGStreamer::RealtimeOutgoingVideoSourceGStreamer):
(WebCore::RealtimeOutgoingVideoSourceGStreamer::teardown):
(WebCore::RealtimeOutgoingVideoSourceGStreamer::setPayloadType):
(WebCore::RealtimeOutgoingVideoSourceGStreamer::startUpdatingStats):
(WebCore::RealtimeOutgoingVideoSourceGStreamer::stopUpdatingStats):
(WebCore::RealtimeOutgoingVideoSourceGStreamer::sourceEnabledChanged):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/260669@main">https://commits.webkit.org/260669@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eaaf3987ef7baa83078067bc20a6a1101e3ff38f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108305 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17397 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41170 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117422 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116808 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112192 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18926 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8676 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100523 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114074 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14200 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97354 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42077 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96178 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28998 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/83761 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10236 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30342 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10975 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7249 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16385 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49939 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7367 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12561 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->