### PR TITLE
Reduce size of code emitted for stack loads/stores from Air on ARM

### DIFF
--- a/Source/JavaScriptCore/b3/air/opcode_generator.rb
+++ b/Source/JavaScriptCore/b3/air/opcode_generator.rb
@@ -952,7 +952,7 @@ writeH("OpcodeGenerated") {
                         outp.puts "OPGEN_RETURN(false);"
                     end
                 when "Index"
-                    outp.puts "if (!Arg::isValidIndexForm(args[#{index}].scale(), args[#{index}].offset(), #{arg.widthCode}))"
+                    outp.puts "if (!Arg::isValidIndexForm(this->kind.opcode, args[#{index}].scale(), args[#{index}].offset(), #{arg.widthCode}))"
                     outp.puts "OPGEN_RETURN(false);"
                 when "PreIndex"
                     outp.puts "if (!Arg::isValidIncrementIndexForm(args[#{index}].offset()))"


### PR DESCRIPTION
#### 6d88e2681672a4fac3e20dca5f30a253ea51f2af
<pre>
Reduce size of code emitted for stack loads/stores from Air on ARM
<a href="https://bugs.webkit.org/show_bug.cgi?id=252469">https://bugs.webkit.org/show_bug.cgi?id=252469</a>

Reviewed by Yusuke Suzuki.

This changes callFrameAddr (AirAllocateRegistersAndStackAndGenerateCode.cpp)
and its users to (which ever succeeds first)

 1. generate an address offset from GPRInfo::callFrameRegister
    (unchanged)
 2. generate an address offset from MacroAssembler::stackPointerRegister
 3. load the offset into extendedOffsetAddrRegister and generate
    a BaseIndex [GPRInfo::callFrameRegister, extendedOffsetAddrRegister]
 4. resort to computing the absolute address in extendedOffsetAddrRegister
    (this was the previous fallback after 1.)

For 3. to work reliably we need to change Air::Arg::isValidForm
to reject BaseIndex addressing when it is not supported on ARM.

The result of these changes is a significant reduction in code size
due to avoiding the fallback behavior in many cases (4).

Code generated for the JetStream2 WASM benchmarks is ~30% smaller on ARMv7
and ~40% smaller on ARM64.

* Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.cpp:
(JSC::B3::Air::callFrameAddr):
(JSC::B3::Air::GenerateAndAllocateRegisters::flush):
(JSC::B3::Air::GenerateAndAllocateRegisters::alloc):
* Source/JavaScriptCore/b3/air/AirArg.h:
(JSC::B3::Air::Arg::isValidAddrForm):
(JSC::B3::Air::Arg::isValidForm const):

Canonical link: <a href="https://commits.webkit.org/260680@main">https://commits.webkit.org/260680@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a55d140bc5d85390f6b79a6f8e8afe3bde9b010

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109036 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18115 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41857 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/569 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118304 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19573 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9417 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101273 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114795 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14672 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97910 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42803 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96644 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29557 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84551 "Found 2 new API test failures: /TestWebKit:WebKit.OnDeviceChangeCrash, /TestWebKit:WebKit.PrivateBrowsingPushStateNoHistoryCallback (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/98076 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10901 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30904 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/98868 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/8993 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11641 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7834 "Passed tests") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/31018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17017 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50502 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/106532 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13243 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26401 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4031 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->