### PR TITLE
[css-transitions] add WPT coverage for `transition: all` and `transition: initial`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-invalid-expected.txt
@@ -3,4 +3,5 @@ PASS e.style['transition'] = "1s 2s 3s" should not set the property value
 PASS e.style['transition'] = "-1s -2s" should not set the property value
 PASS e.style['transition'] = "steps(1) steps(2)" should not set the property value
 PASS e.style['transition'] = "none top" should not set the property value
+PASS e.style['transition'] = "initial 1s" should not set the property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-invalid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-invalid.html
@@ -19,6 +19,9 @@ test_invalid_value("transition", "-1s -2s");
 test_invalid_value("transition", "steps(1) steps(2)");
 
 test_invalid_value("transition", "none top");
+
+test_invalid_value("transition", "initial 1s");
+
 </script>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-valid-expected.txt
@@ -6,4 +6,7 @@ PASS e.style['transition'] = "none" should set the property value
 PASS e.style['transition'] = "top" should set the property value
 PASS e.style['transition'] = "1s -3s cubic-bezier(0, -2, 1, 3) top" should set the property value
 PASS e.style['transition'] = "1s -3s, cubic-bezier(0, -2, 1, 3) top" should set the property value
+PASS e.style['transition'] = "all" should set the property value
+PASS e.style['transition'] = "all 1s" should set the property value
+PASS e.style['transition'] = "initial" should set the property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-valid.html
@@ -22,6 +22,11 @@ test_valid_value("transition", "top", ["top", "top 0s ease 0s"]);
 test_valid_value("transition", "1s -3s cubic-bezier(0, -2, 1, 3) top", "top 1s cubic-bezier(0, -2, 1, 3) -3s");
 test_valid_value("transition", "1s -3s, cubic-bezier(0, -2, 1, 3) top", ["1s -3s, top cubic-bezier(0, -2, 1, 3)", "all 1s ease -3s, top 0s cubic-bezier(0, -2, 1, 3) 0s"]);
 
+test_valid_value("transition", "all", ["all", "all 0s ease 0s"]);
+test_valid_value("transition", "all 1s", ["1s", "all 1s ease 0s"]);
+
+test_valid_value("transition", "initial", "initial");
+
 // TODO: Add test with a single negative time.
 // TODO: Add test with a single timing-function keyword.
 </script>


### PR DESCRIPTION
#### 1d4fb4be3f92d5bd28ff74b286d2cce12c326ccb
<pre>
[css-transitions] add WPT coverage for `transition: all` and `transition: initial`
<a href="https://bugs.webkit.org/show_bug.cgi?id=252470">https://bugs.webkit.org/show_bug.cgi?id=252470</a>

Reviewed by Darin Adler.

Following the fixes made in bug 252393, we add WPT coverage for the `all` and `initial`
values for the `transition` shorthand property.

* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-invalid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-invalid.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-valid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-valid.html:

Canonical link: <a href="https://commits.webkit.org/260500@main">https://commits.webkit.org/260500@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bbf7423e2c924874dee2dbb706d7bf770ef3c12

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108413 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17507 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41272 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117525 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116888 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18970 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8785 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100637 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114181 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97436 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42166 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29081 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10334 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30425 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11080 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7330 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16483 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50021 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12666 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3953 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->