### PR TITLE
[ews] Implement Login with GitHub on EWS

### DIFF
--- a/Tools/CISupport/ews-build/master.cfg
+++ b/Tools/CISupport/ews-build/master.cfg
@@ -60,16 +60,20 @@ if not is_test_mode_enabled:
         },
     )
 
-    credentials = load_password('EWS_CREDENTIALS')
-    if not credentials:
-        print('EWS credentials not found. Please ensure EWS_CREDENTIALS is configured either in env variables or in passwords.json')
+    GITHUB_CLIENT_ID = load_password('GITHUB_CLIENT_ID')
+    GITHUB_CLIENT_SECRET = load_password('GITHUB_CLIENT_SECRET')
+    if (not GITHUB_CLIENT_ID) or (not GITHUB_CLIENT_SECRET):
+        print('EWS credentials not found. Please ensure GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET are configured either in env variables or in passwords.json')
         sys.exit(1)
+
     # See https://docs.buildbot.net/current/manual/configuration/www.html#example-configs
     authz = util.Authz(
-        allowRules=[util.AnyControlEndpointMatcher(role="admin")],
-        roleMatchers=[util.RolesFromEmails(admin=list(credentials.keys()))]
+        allowRules=[util.AnyEndpointMatcher(role='Buildbot-Administrators', defaultDeny=False),
+                    util.RebuildBuildEndpointMatcher(role='Contributors'),
+                    util.AnyControlEndpointMatcher(role='Buildbot-Administrators')],
+        roleMatchers=[util.RolesFromGroups(groupPrefix='WebKit/')]
     )
-    auth = util.UserPasswordAuth(credentials)
+    auth = util.GitHubAuth(GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET, apiVersion=4, getTeamsMembership=True, debug=True)
     c['www']['auth'] = auth
     c['www']['authz'] = authz
 


### PR DESCRIPTION
#### a2a8bd0fd59f404abcc2442605c566c8f4542f52
<pre>
[ews] Implement Login with GitHub on EWS
<a href="https://bugs.webkit.org/show_bug.cgi?id=235829">https://bugs.webkit.org/show_bug.cgi?id=235829</a>
&lt;rdar://problem/88192177&gt;

Reviewed by Jonathan Bedard.

References:
<a href="https://docs.buildbot.net/latest/developer/auth.html">https://docs.buildbot.net/latest/developer/auth.html</a>
<a href="https://docs.buildbot.net/current/manual/configuration/www.html#authorization-rules">https://docs.buildbot.net/current/manual/configuration/www.html#authorization-rules</a>

* Tools/CISupport/ews-build/master.cfg:

Canonical link: <a href="https://commits.webkit.org/260531@main">https://commits.webkit.org/260531@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/190fd3cc28c69a8f0a22089f9dc42fc66dc41615

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108445 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17541 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41295 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117550 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116909 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112332 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18992 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8817 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100670 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114213 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14229 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97453 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42188 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96207 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29098 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/83887 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10358 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30442 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11110 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7352 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/107220 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16505 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50038 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12696 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3965 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->