### PR TITLE
[CMake] Regenerate bindings only when IDL files change

### DIFF
--- a/Source/WebCore/WebCoreMacros.cmake
+++ b/Source/WebCore/WebCoreMacros.cmake
@@ -140,21 +140,25 @@ function(GENERATE_BINDINGS target)
         list(APPEND gen_sources ${arg_DESTINATION}/JS${_name}.cpp)
         list(APPEND gen_headers ${arg_DESTINATION}/JS${_name}.h)
     endforeach ()
+
     set(${arg_OUTPUT_SOURCE} ${${arg_OUTPUT_SOURCE}} ${gen_sources} PARENT_SCOPE)
+
     set(act_args)
     if (SHOW_BINDINGS_GENERATION_PROGRESS)
         list(APPEND args --showProgress)
-    endif ()
-    list(APPEND act_args BYPRODUCTS ${gen_sources} ${gen_headers})
-    if (SHOW_BINDINGS_GENERATION_PROGRESS)
         list(APPEND act_args USES_TERMINAL)
     endif ()
-    add_custom_target(${target}
+
+    add_custom_command(
+        OUTPUT ${gen_headers} ${gen_sources} ${arg_PP_EXTRA_OUTPUT}
         COMMAND ${PERL_EXECUTABLE} ${binding_generator} ${args}
-        DEPENDS ${arg_INPUT_FILES} ${arg_PP_INPUT_FILES}
+        DEPENDS ${arg_IDL_INCLUDES} ${arg_INPUT_FILES} ${arg_PP_INPUT_FILES} ${common_generator_dependencies}
         WORKING_DIRECTORY ${arg_BASE_DIR}
-        COMMENT "Generate bindings (${target})"
         VERBATIM ${act_args})
+
+    add_custom_target(${target}
+        DEPENDS ${gen_headers} ${gen_sources} ${arg_PP_EXTRA_OUTPUT}
+        COMMENT "Generate bindings (${target})")
 endfunction()
 
 


### PR DESCRIPTION
#### 9e585617f0ef26e62fd7d5872fbb1e55de9065bf
<pre>
[CMake] Regenerate bindings only when IDL files change
<a href="https://bugs.webkit.org/show_bug.cgi?id=252472">https://bugs.webkit.org/show_bug.cgi?id=252472</a>

Reviewed by NOBODY (OOPS!).

Currenlty, to genereate bingins `add_custom_target` is used.
Custom targets have no output and therefore are exectuted every time.
To prevent this we can use `add_custom_command` and specify IDL files
as input and generated .cpp and .h files as output.

* Source/WebCore/WebCoreMacros.cmake:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e585617f0ef26e62fd7d5872fbb1e55de9065bf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108348 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17442 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41212 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117464 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116839 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112234 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18949 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8721 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100570 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114116 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14207 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97384 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42113 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96185 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29028 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/83818 "Found 2 new API test failures: /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/cut-copy-paste/non-editable, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10276 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30372 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11018 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7282 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16426 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49969 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12604 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->