### PR TITLE
Add flag to dump-class-layout to skip nested classes

### DIFF
--- a/Tools/Scripts/dump-class-layout
+++ b/Tools/Scripts/dump-class-layout
@@ -65,6 +65,9 @@ def main():
     parser.add_argument('-t', '--target-path', dest='target_path', action='store',
         help='Path to the target')
 
+    parser.add_argument('-s', '--skip-nested', dest='skip_nested', default=False, action='store_true',
+        help='Do not traverse nested classes and structs')
+
     args = parser.parse_args()
     build_dir = webkit_build_dir()
 
@@ -80,7 +83,7 @@ def main():
         target_path = os.path.join(build_dir, args.config, args.framework + ".framework", args.framework);
     
     lldb_instance = LLDBDebuggerInstance(target_path, args.arch)
-    class_layout = lldb_instance.layout_for_classname(args.classname)
+    class_layout = lldb_instance.layout_for_classname(args.classname, args.skip_nested)
     class_layout.dump()
 
 


### PR DESCRIPTION
#### 696e225e79a2e81b02773273d57e3613c9fb0db2
<pre>
Add flag to dump-class-layout to skip nested classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=252477">https://bugs.webkit.org/show_bug.cgi?id=252477</a>
rdar://105593812

Reviewed by Simon Fraser.

Add a `-s` or `--skip-nested` flag that stops `dump-class-layout` from recursively
printing members that are classes/structs. This can be helpful to look at the padding
of the top-level class individually.

* Tools/Scripts/dump-class-layout:
* Tools/lldb/lldb_dump_class_layout.py:
(ClassLayout.__init__):
(ClassLayout._parse):
(LLDBDebuggerInstance.layout_for_classname):

Canonical link: <a href="https://commits.webkit.org/260558@main">https://commits.webkit.org/260558@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d17335c1513ede8ea6cbb6c2bc8592c97b3d2c7a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108334 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17426 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41197 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117450 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116827 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112221 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18939 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8705 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100552 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114103 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14204 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97374 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42101 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96182 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29018 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/83781 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10262 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30362 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11002 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7268 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16412 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49959 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7299 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12588 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->