### PR TITLE
[WebCore] Shrink FontDescription

### DIFF
--- a/Source/WebCore/platform/graphics/FontCascadeDescription.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeDescription.cpp
@@ -47,7 +47,7 @@ struct SameSizeAsFontCascadeDescription {
     AtomString string2;
     int16_t fontSelectionRequest[3];
     float size;
-    std::optional<float> sizeAdjust;
+    Markable<float, FloatMarkableTraits> sizeAdjust;
     unsigned bitfields1;
     unsigned bitfields2 : 22;
     void* array;

--- a/Source/WebCore/platform/graphics/FontDescription.h
+++ b/Source/WebCore/platform/graphics/FontDescription.h
@@ -31,11 +31,24 @@
 #include "TextFlags.h"
 #include "WebKitFontFamilyNames.h"
 #include <unicode/uscript.h>
+#include <wtf/Markable.h>
 #include <wtf/MathExtras.h>
 
 namespace WebCore {
 
 using namespace WebKitFontFamilyNames;
+
+struct FloatMarkableTraits {
+    constexpr static bool isEmptyValue(float value)
+    {
+        return value != value;
+    }
+
+    constexpr static float emptyValue()
+    {
+        return NAN;
+    }
+};
 
 class FontDescription {
 public:
@@ -163,7 +176,7 @@ private:
     AtomString m_specifiedLocale;
 
     FontSelectionRequest m_fontSelectionRequest;
-    std::optional<float> m_sizeAdjust; // Size adjust for font-size-adjust
+    Markable<float, FloatMarkableTraits> m_sizeAdjust; // Size adjust for font-size-adjust
     float m_computedSize { 0 }; // Computed size adjusted for the minimum font size and the zoom factor.
     unsigned m_orientation : 1; // FontOrientation - Whether the font is rendering on a horizontal line or a vertical line.
     unsigned m_nonCJKGlyphOrientation : 1; // NonCJKGlyphOrientation - Only used by vertical text. Determines the default orientation for non-ideograph glyphs.


### PR DESCRIPTION
#### 26968a0b0a522e031d2d2e5887d1e16f089caecb
<pre>
[WebCore] Shrink FontDescription
<a href="https://bugs.webkit.org/show_bug.cgi?id=252478">https://bugs.webkit.org/show_bug.cgi?id=252478</a>
rdar://105594136

Reviewed by Simon Fraser.

Use `WTF::Marked` instead of `std::optional` in `FontDescription::sizeAdjust` to
reduce its size from 216 to 208 bytes. Consequently, this shrinks `StyleRareData`
from 320 to 304 bytes, which takes it from the 352b to the 304b size class.

* Source/WebCore/platform/graphics/FontCascadeDescription.cpp:
* Source/WebCore/platform/graphics/FontDescription.h:
(WebCore::FloatMarkableTraits::isEmptyValue):
(WebCore::FloatMarkableTraits::emptyValue):

Canonical link: <a href="https://commits.webkit.org/260564@main">https://commits.webkit.org/260564@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26997d769f04b96241105cee3c4096ad467dc8c7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108341 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17435 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41205 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117457 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116832 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112227 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18942 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8714 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100563 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114109 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14203 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97380 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42111 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96181 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29024 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/83791 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10269 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30368 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11011 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7275 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16419 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49965 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7304 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12597 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->