### PR TITLE
[WebCore] Shrink FontVariantAlternates

### DIFF
--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -5322,8 +5322,8 @@ RefPtr<CSSValue> consumeFontVariantAlternates(CSSParserTokenRange& range)
 
     auto parseSomethingWithoutError = [&range, &result]() {
         bool hasParsedSomething = false;
-        auto parseAndSetArgument = [&range, &hasParsedSomething] (std::optional<String>& value) {
-            if (value)
+        auto parseAndSetArgument = [&range, &hasParsedSomething] (String& value) {
+            if (!value.isNull())
                 return false;
 
             CSSParserTokenRange args = consumeFunction(range);

--- a/Source/WebCore/platform/text/TextFlags.cpp
+++ b/Source/WebCore/platform/text/TextFlags.cpp
@@ -85,20 +85,20 @@ WTF::TextStream& operator<<(TextStream& ts, FontVariantAlternates alternates)
             // Separate elements with a space.
             builder.append(builder.isEmpty() ? "": " ", std::forward<Ts>(args)...);
         };
-        if (values.stylistic)
-            append("stylistic(", *values.stylistic, ")");
+        if (!values.stylistic.isNull())
+            append("stylistic(", values.stylistic, ")");
         if (values.historicalForms)
             append("historical-forms"_s);
         if (!values.styleset.isEmpty())
             append("styleset(", makeStringByJoining(values.styleset, ", "_s), ")");
         if (!values.characterVariant.isEmpty())
             append("character-variant(", makeStringByJoining(values.characterVariant, ", "_s), ")");
-        if (values.swash)
-            append("swash(", *values.swash, ")");
-        if (values.ornaments)
-            append("ornaments(", *values.ornaments, ")");
-        if (values.annotation)
-            append("annotation(", *values.annotation, ")");
+        if (!values.swash.isNull())
+            append("swash(", values.swash, ")");
+        if (!values.ornaments.isNull())
+            append("ornaments(", values.ornaments, ")");
+        if (!values.annotation.isNull())
+            append("annotation(", values.annotation, ")");
         
         ts << builder.toString();
     }

--- a/Source/WebCore/platform/text/TextFlags.h
+++ b/Source/WebCore/platform/text/TextFlags.h
@@ -194,12 +194,12 @@ struct FontVariantAlternatesValues {
         return !(*this == other);
     }
 
-    std::optional<String> stylistic;
+    String stylistic;
     Vector<String> styleset;
     Vector<String> characterVariant;
-    std::optional<String> swash;
-    std::optional<String> ornaments;
-    std::optional<String> annotation;
+    String swash;
+    String ornaments;
+    String annotation;
     bool historicalForms = false;
 
     friend void add(Hasher&, const FontVariantAlternatesValues&);


### PR DESCRIPTION
#### 6418aea7fc71ec0fa418ba546de00c503cba4d18
<pre>
[WebCore] Shrink FontVariantAlternates
<a href="https://bugs.webkit.org/show_bug.cgi?id=252479">https://bugs.webkit.org/show_bug.cgi?id=252479</a>
rdar://105594318

Reviewed by Tim Nguyen.

Reduce the size of `FontVariantAlternates` from 120 to 80 bytes by replacing all
the instance of `std::optional&lt;String&gt;` in `FontVariantAlternatesValues` with
`String`. `String` can already distinguish between an empty string and a null
string, so it seems redundant to wrap it in an optinal. Combined with #10722,
this further reduces the size of `StyleInheritedData` to 264 bytes.

* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeFontVariantAlternates):
* Source/WebCore/platform/text/TextFlags.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/text/TextFlags.h:

Canonical link: <a href="https://commits.webkit.org/260465@main">https://commits.webkit.org/260465@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f8527b45ade3f7f367d662182d16e6bcd588af2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108343 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17437 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41207 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117459 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116834 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112229 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/18944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8716 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100565 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114111 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14139 "Build was cancelled. Recent messages:") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97379 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42108 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96118 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29023 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10271 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30367 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11013 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7276 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16421 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49964 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7237 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12599 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->