### PR TITLE
[web-animations] WPT test css/css-animations/translation-animation-on-important-property.html is a failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/translation-animation-on-important-property-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/translation-animation-on-important-property-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<title>Translation animation on important property</title>
+<link rel="help" href="https://crbug.com/1324679">
+<style>
+#target {
+  width: 100px;
+  height: 100px;
+  background: green;
+  transform:  none !important;
+}
+</style>
+<div id="target"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/translation-animation-on-important-property.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/translation-animation-on-important-property.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<title>Translation animation on important property</title>
+<link rel="help" href="https://crbug.com/1324679">
+<link rel="match" href="translation-animation-on-important-property-ref.html">
+<style>
+@keyframes move {
+  0% {transform: translateX(0px);}
+  100% {transform: translateX(100px);}
+}
+#target {
+  width: 100px;
+  height: 100px;
+  background: green;
+  transform:  none !important;
+  animation: move 10000s cubic-bezier(0, 1, 1, 0) -5000s;
+}
+</style>
+<div id="target"></div>

--- a/LayoutTests/webanimations/combining-transform-animations-with-different-acceleration-capabilities-4-expected.txt
+++ b/LayoutTests/webanimations/combining-transform-animations-with-different-acceleration-capabilities-4-expected.txt
@@ -1,0 +1,7 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
+PASS internals.acceleratedAnimationsForElement(element).length became 1
+PASS internals.acceleratedAnimationsForElement(element).length became 0
+PASS internals.acceleratedAnimationsForElement(element).length became 1
+

--- a/LayoutTests/webanimations/combining-transform-animations-with-different-acceleration-capabilities-4.html
+++ b/LayoutTests/webanimations/combining-transform-animations-with-different-acceleration-capabilities-4.html
@@ -1,0 +1,33 @@
+<div id="target" style="width: 100px; height: 100px; background-color: black;"></div>
+<script src="../resources/js-test.js"></script>
+<script>
+
+const element = document.getElementById("target");
+const timing = { duration: 1000, iterations: Infinity };
+
+const shouldBecomeEqualAsync = async (actual, expected) => new Promise(resolve => shouldBecomeEqual(actual, expected, resolve));
+
+(async () => {
+    if (!window.testRunner || !window.internals) {
+        debug("This test should be run in a test runner.");
+        return;
+    }
+
+    testRunner.waitUntilDone();
+
+    // First, start a transform-related animation that can be accelerated.
+    element.animate({ scale: [1, 2] }, timing);
+    await shouldBecomeEqualAsync("internals.acceleratedAnimationsForElement(element).length", "1");
+
+    // Now, set an !important style for that same property, which should interrupt the accelerated animation.
+    element.style.setProperty("scale", "3", "important");
+    await shouldBecomeEqualAsync("internals.acceleratedAnimationsForElement(element).length", "0");
+
+    // Now, remove the !important style, this should resume the accelerated animation.
+    element.style.removeProperty("scale");
+    await shouldBecomeEqualAsync("internals.acceleratedAnimationsForElement(element).length", "1");
+
+    testRunner.notifyDone();
+})();
+    
+</script>

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1000,6 +1000,7 @@ void KeyframeEffect::setBlendingKeyframes(KeyframeList&& blendingKeyframes)
     computeHasImplicitKeyframeForAcceleratedProperty();
     computeHasKeyframeComposingAcceleratedProperty();
     computeHasExplicitlyInheritedKeyframeProperty();
+    computeHasAcceleratedPropertyOverriddenByCascadeProperty();
 
     checkForMatchingTransformFunctionLists();
 
@@ -1638,6 +1639,9 @@ bool KeyframeEffect::canBeAccelerated() const
         return false;
 
     if (m_hasKeyframeComposingAcceleratedProperty)
+        return false;
+
+    if (m_hasAcceleratedPropertyOverriddenByCascadeProperty)
         return false;
 
     return true;
@@ -2405,6 +2409,20 @@ void KeyframeEffect::computeHasExplicitlyInheritedKeyframeProperty()
     }
 }
 
+void KeyframeEffect::computeHasAcceleratedPropertyOverriddenByCascadeProperty()
+{
+    if (!m_inTargetEffectStack)
+        return;
+
+    ASSERT(m_target);
+    auto* effectStack = m_target->keyframeEffectStack(m_pseudoId);
+    if (!effectStack)
+        return;
+
+    auto relevantAcceleratedPropertiesOverriddenByCascade = effectStack->acceleratedPropertiesOverriddenByCascade().intersectionWith(animatedProperties());
+    m_hasAcceleratedPropertyOverriddenByCascadeProperty = !relevantAcceleratedPropertiesOverriddenByCascade.isEmpty();
+}
+
 void KeyframeEffect::effectStackNoLongerPreventsAcceleration()
 {
     if (m_runningAccelerated == RunningAccelerated::Failed)
@@ -2429,6 +2447,12 @@ void KeyframeEffect::abilityToBeAcceleratedDidChange()
     ASSERT(m_target);
     if (auto* effectStack = m_target->keyframeEffectStack(m_pseudoId))
         effectStack->effectAbilityToBeAcceleratedDidChange(*this);
+}
+
+void KeyframeEffect::acceleratedPropertiesOverriddenByCascadeDidChange()
+{
+    CanBeAcceleratedMutationScope mutationScope(this);
+    computeHasAcceleratedPropertyOverriddenByCascadeProperty();
 }
 
 KeyframeEffect::CanBeAcceleratedMutationScope::CanBeAcceleratedMutationScope(KeyframeEffect* effect)

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -175,6 +175,7 @@ public:
     void effectStackNoLongerAllowsAcceleration();
 
     void lastStyleChangeEventStyleDidChange(const RenderStyle* previousStyle, const RenderStyle* currentStyle);
+    void acceleratedPropertiesOverriddenByCascadeDidChange();
 
     static String CSSPropertyIDToIDLAttributeName(CSSPropertyID);
 
@@ -222,6 +223,7 @@ private:
     void computeHasImplicitKeyframeForAcceleratedProperty();
     void computeHasKeyframeComposingAcceleratedProperty();
     void computeHasExplicitlyInheritedKeyframeProperty();
+    void computeHasAcceleratedPropertyOverriddenByCascadeProperty();
     void abilityToBeAcceleratedDidChange();
     void updateAcceleratedAnimationIfNecessary();
 
@@ -261,6 +263,7 @@ private:
     bool m_hasImplicitKeyframeForAcceleratedProperty { false };
     bool m_hasKeyframeComposingAcceleratedProperty { false };
     bool m_hasExplicitlyInheritedKeyframeProperty { false };
+    bool m_hasAcceleratedPropertyOverriddenByCascadeProperty { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/animation/KeyframeEffectStack.cpp
+++ b/Source/WebCore/animation/KeyframeEffectStack.cpp
@@ -247,4 +247,26 @@ void KeyframeEffectStack::lastStyleChangeEventStyleDidChange(const RenderStyle* 
         effect->lastStyleChangeEventStyleDidChange(previousStyle, currentStyle);
 }
 
+void KeyframeEffectStack::didApplyCascade(const RenderStyle& styleBeforeCascade, const RenderStyle& styleAfterCascade, const HashSet<AnimatableProperty> animatedProperties, const Document& document)
+{
+    HashSet<AnimatableProperty> acceleratedPropertiesOverriddenByCascade;
+    if (styleBeforeCascade != styleAfterCascade) {
+        for (auto animatedProperty : animatedProperties) {
+            if (!CSSPropertyAnimation::animationOfPropertyIsAccelerated(animatedProperty))
+                continue;
+            if (!CSSPropertyAnimation::propertiesEqual(animatedProperty, styleBeforeCascade, styleAfterCascade, document))
+                acceleratedPropertiesOverriddenByCascade.add(animatedProperty);
+        }
+    }
+
+    if (acceleratedPropertiesOverriddenByCascade == m_acceleratedPropertiesOverriddenByCascade)
+        return;
+
+    m_acceleratedPropertiesOverriddenByCascade = WTFMove(acceleratedPropertiesOverriddenByCascade);
+
+    for (auto& effect : m_effects)
+        effect->acceleratedPropertiesOverriddenByCascadeDidChange();
+}
+
+
 } // namespace WebCore

--- a/Source/WebCore/animation/KeyframeEffectStack.h
+++ b/Source/WebCore/animation/KeyframeEffectStack.h
@@ -67,6 +67,9 @@ public:
     void addInvalidCSSAnimationName(const String&);
 
     void lastStyleChangeEventStyleDidChange(const RenderStyle* previousStyle, const RenderStyle* currentStyle);
+    void didApplyCascade(const RenderStyle& styleBeforeCascade, const RenderStyle& styleAfterCascade, const HashSet<AnimatableProperty>, const Document&);
+
+    const HashSet<AnimatableProperty>& acceleratedPropertiesOverriddenByCascade() const { return m_acceleratedPropertiesOverriddenByCascade; }
 
 private:
     void ensureEffectsAreSorted();
@@ -76,6 +79,7 @@ private:
 
     Vector<WeakPtr<KeyframeEffect>> m_effects;
     HashSet<String> m_invalidCSSAnimationNames;
+    HashSet<AnimatableProperty> m_acceleratedPropertiesOverriddenByCascade;
     RefPtr<const AnimationList> m_cssAnimationList;
     bool m_isSorted { true };
 };

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -609,8 +609,11 @@ ElementUpdate TreeResolver::createAnimatedElementUpdate(ResolvedStyle&& resolved
             return { WTFMove(resolvedStyle.style), animationImpact };
 
         if (resolvedStyle.matchResult) {
+            auto animatedStyleBeforeCascadeApplication = RenderStyle::clonePtr(*animatedStyle);
             // The cascade may override animated properties and have dependencies to them.
             applyCascadeAfterAnimation(*animatedStyle, animatedProperties, *resolvedStyle.matchResult, element, resolutionContext);
+            ASSERT(styleable.keyframeEffectStack());
+            styleable.keyframeEffectStack()->didApplyCascade(*animatedStyleBeforeCascadeApplication, *animatedStyle, animatedProperties, document);
         }
 
         Adjuster adjuster(document, *resolutionContext.parentStyle, resolutionContext.parentBoxStyle, styleable.pseudoId == PseudoId::None ? &element : nullptr);


### PR DESCRIPTION
#### 50450e8c417a9b25ff80bc6e2bc76e9f238fe475
<pre>
[web-animations] WPT test css/css-animations/translation-animation-on-important-property.html is a failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=252481">https://bugs.webkit.org/show_bug.cgi?id=252481</a>

Reviewed by Antti Koivisto.

WPT.fyi reports we are failing the recently added css/css-animations/translation-animation-on-important-property.html.
This test fails because it is animating an accelerated property, in this case &quot;transform&quot;, but also setting an
!important style for it, checking that the !important value wins over the animated value. We fail to account for the
value set by the !important style when running accelerated animations.

To address this, we add a new method KeyframeEffectStack::acceleratedPropertiesOverriddenByCascade() called by
Style::TreeResolver::createAnimatedElementUpdate() with the animated style prior to further application of the
cascade and after the cascade has been fully applied. In this new method we see which accelerated properties have
a different value between the two styles which informs whether an !important style – or any style with higher
importance than animated style in the cascade - overrides the value set by animations.

We store this list of properties and inform all effects in the stack when this list changes. Then, an effect can determine
whether the presence of such a property prevents it from running accelerated and, using the existing system to interrupt
and resume accelerated animations based on whether other effects in the stack can or cannot be accelerated, will toggle
its accelerated running state.

Since the WPT test this patch fixes does not check whether animations can be interrupted and resumed dynamically
by the presence of an overriding static property, we add such a test.

* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/translation-animation-on-important-property-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/translation-animation-on-important-property.html: Added.
* LayoutTests/webanimations/combining-transform-animations-with-different-acceleration-capabilities-4-expected.txt: Added.
* LayoutTests/webanimations/combining-transform-animations-with-different-acceleration-capabilities-4.html: Added.
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::setBlendingKeyframes):
(WebCore::KeyframeEffect::canBeAccelerated const):
(WebCore::KeyframeEffect::computeHasAcceleratedPropertyOverriddenByCascadeProperty):
(WebCore::KeyframeEffect::acceleratedPropertiesOverriddenByCascadeDidChange):
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/animation/KeyframeEffectStack.cpp:
(WebCore::KeyframeEffectStack::didApplyCascade):
* Source/WebCore/animation/KeyframeEffectStack.h:
(WebCore::KeyframeEffectStack::acceleratedPropertiesOverriddenByCascade const):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::createAnimatedElementUpdate):

Canonical link: <a href="https://commits.webkit.org/260464@main">https://commits.webkit.org/260464@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04077f154061cb4ce81c68b9697f205ce7facad1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/108407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/17501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/41266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/117519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/112293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/8779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/100631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/114175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/41266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/100631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/41266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/100631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/10328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/41266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/11074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/8779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/16477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/41266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/12660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3932 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->