### PR TITLE
Calculate auto margins on orthogonal tables correctly

### DIFF
--- a/LayoutTests/fast/css/vertical-lr-table-bfc-auto-margins-beside-float-expected.html
+++ b/LayoutTests/fast/css/vertical-lr-table-bfc-auto-margins-beside-float-expected.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<style>
+#container {
+    width: 200px; height: 50px;
+    background-color: orange;
+}
+
+#float {
+    float: left;
+    width: 50px; height: 50px; background: blue;
+}
+
+#vertical {
+    width: 50px; height: 50px;
+    overflow: hidden;
+    margin: 0 auto;
+    background: blue;
+}
+</style>
+<p>This tests that auto margins in an empty table orthogonal to its containing block are calculated correctly.</p>
+<p>The auto margins should horizontally center the blue square in the orange rectangle.</p>
+<div id="container">
+    <table id="vertical"></table>
+</div>

--- a/LayoutTests/fast/css/vertical-lr-table-bfc-auto-margins-beside-float.html
+++ b/LayoutTests/fast/css/vertical-lr-table-bfc-auto-margins-beside-float.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<style>
+#container {
+    width: 200px; height: 50px;
+    background-color: orange;
+}
+
+#float {
+    float: left;
+    width: 50px; height: 50px; background: blue;
+}
+
+#vertical {
+    width: 50px; height: 50px;
+    -webkit-writing-mode: vertical-rl;
+    overflow: hidden;
+    margin: 0 auto;
+    background: blue;
+}
+</style>
+<p>This tests that auto margins in an empty table orthogonal to its containing block are calculated correctly.</p>
+<p>The auto margins should horizontally center the blue square in the orange rectangle.</p>
+<div id="container">
+    <table id="vertical"></table>
+</div>

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -511,9 +511,6 @@ void RenderTable::layout()
 
         setLogicalHeight(logicalHeight() + borderAndPaddingBefore);
 
-        if (!isOutOfFlowPositioned())
-            updateLogicalHeight();
-
         LayoutUnit computedLogicalHeight;
     
         Length logicalHeightLength = style().logicalHeight();
@@ -571,8 +568,7 @@ void RenderTable::layout()
 
         layoutCaptions(BottomCaptionLayoutPhase::Yes);
 
-        if (isOutOfFlowPositioned())
-            updateLogicalHeight();
+        updateLogicalHeight();
 
         // table can be containing block of positioned elements.
         bool dimensionChanged = oldLogicalWidth != logicalWidth() || oldLogicalHeight != logicalHeight();


### PR DESCRIPTION
<pre>
Calculate auto margins on orthogonal tables correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=250206">https://bugs.webkit.org/show_bug.cgi?id=250206</a>
rdar://problem/104223475

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit to Blink / Chromium and Gecko / Firefox.

Partial Merge (only RenderTable.cpp) - <a href="https://chromium.googlesource.com/chromium/blink/+/977524d1fa2ea6e758b8e25a7a08473e1559f9b8">https://chromium.googlesource.com/chromium/blink/+/977524d1fa2ea6e758b8e25a7a08473e1559f9b8</a>

When a table is in an orthogonal flow to its containing block and
it has auto margins its important that we know the logical height
of the table if we are to get the margins right. So don't call
'updateLogicalHeight' in RenderTable::layout() until we've
computed the logical height of the table. (For normal flow
tables, updateLogicalHeight() is just a way of obtaining and
updating the margins.)

* Source/WebCore/rendering/RenderTable.cpp:
(RenderTable::layout): Just call "updateLogicalHeight" later without "if" condition
* LayoutTests/fast/css/vertical-lr-table-bfc-auto-margins-beside-float.html: Add Test Case
* LayoutTests/fast/css/vertical-lr-table-bfc-auto-margins-beside-float-expected.html: Add Test Case Expectation
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e3ef6386d919cc154b01210f411d667b7d7a3a2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108345 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17439 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41209 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117461 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116836 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112231 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18946 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8718 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100567 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114113 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14205 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97381 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42109 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-flexbox/table-as-item-specified-height.html, imported/w3c/web-platform-tests/css/css-flexbox/table-as-item-specified-width-vertical.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96183 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29025 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-flexbox/table-as-item-specified-height.html, imported/w3c/web-platform-tests/css/css-flexbox/table-as-item-specified-width-vertical.html (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/83789 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/title-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10273 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30369 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-flexbox/table-as-item-specified-height.html, imported/w3c/web-platform-tests/css/css-flexbox/table-as-item-specified-width-vertical.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11015 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7278 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-flexbox/table-as-item-specified-height.html, imported/w3c/web-platform-tests/css/css-flexbox/table-as-item-specified-width-vertical.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16423 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49966 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12601 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->