### PR TITLE
Use ASCIILiteral in HTMLFastPathParser instead of const char*

### DIFF
--- a/Source/WTF/wtf/text/ASCIILiteral.h
+++ b/Source/WTF/wtf/text/ASCIILiteral.h
@@ -37,7 +37,7 @@ class PrintStream;
 
 class ASCIILiteral final {
 public:
-    operator const char*() const { return m_characters; }
+    constexpr operator const char*() const { return m_characters; }
 
     static constexpr ASCIILiteral fromLiteralUnsafe(const char* string)
     {


### PR DESCRIPTION
#### 349ea5cbfb91aee026f397acb9200096b58bccd8
<pre>
Use ASCIILiteral in HTMLFastPathParser instead of const char*
<a href="https://bugs.webkit.org/show_bug.cgi?id=252484">https://bugs.webkit.org/show_bug.cgi?id=252484</a>

Reviewed by Ryosuke Niwa.

We prefer to represent all string literals using ASCIILiteral in WebKit.

* Source/WTF/wtf/text/ASCIILiteral.h:
* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
(WebCore::operator==):
(WebCore::onlyContainsLowercaseASCIILetters):
(WebCore::tagNameHash):
(WebCore::HTMLFastPathParser::parse):
(WebCore::HTMLFastPathParser::scanHTMLCharacterReference):

Canonical link: <a href="https://commits.webkit.org/260463@main">https://commits.webkit.org/260463@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5e59f9a22bd4c1efa9ec2a9f6e03165cab41e2b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108375 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17470 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41238 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117491 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116859 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112262 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18856 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8749 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100598 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114142 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97409 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/42143 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29054 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/97547 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10302 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30398 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/38/builds/96886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/8412 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11044 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/7307 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/38/builds/96886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16452 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49994 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/105964 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7236 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12631 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26227 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->