### PR TITLE
[WebCore] Use Markable instead of std::variant in FontVariantAlternates

### DIFF
--- a/Source/WebCore/platform/text/TextFlags.cpp
+++ b/Source/WebCore/platform/text/TextFlags.cpp
@@ -112,7 +112,7 @@ void add(Hasher& hasher, const FontVariantAlternatesValues& key)
 
 void add(Hasher& hasher, const FontVariantAlternates& key)
 {
-    add(hasher, key.m_val.index());
+    add(hasher, !!key.m_values);
     if (!key.isNormal())
         add(hasher, key.values());
 }


### PR DESCRIPTION
#### 9b974f716f8653005fa2c35c2fbe5b5ba0dddcda
<pre>
[WebCore] Use Markable instead of std::variant in FontVariantAlternates
<a href="https://bugs.webkit.org/show_bug.cgi?id=252485">https://bugs.webkit.org/show_bug.cgi?id=252485</a>
rdar://105596793

Reviewed by Simon Fraser.

`FontVariantAlternates` used an `std::variant` to store either `FontVariantAlternatesValues`
or a no-op class, so it was effectively using it as an optional. By using Markable, we
reduce the size of `FontVariantAlternates` from 80 to 72 bytes, consequently reducing
`StyleInheritedData` to fit the next size class down (256 bytes).

* Source/WebCore/platform/text/TextFlags.cpp:
(WebCore::add):
* Source/WebCore/platform/text/TextFlags.h:
(WebCore::FontVariantAlternatesValues::MarkableTraits::isEmptyValue):
(WebCore::FontVariantAlternatesValues::MarkableTraits::emptyValue):
(WebCore::FontVariantAlternates::operator== const):
(WebCore::FontVariantAlternates::isNormal const):
(WebCore::FontVariantAlternates::values const):
(WebCore::FontVariantAlternates::valuesRef):
(WebCore::FontVariantAlternates::setValues):
(WebCore::FontVariantAlternates::Normal):
(WebCore::FontVariantAlternatesNormal::operator== const): Deleted.
(WebCore::FontVariantAlternatesNormal::operator!= const): Deleted.

Canonical link: <a href="https://commits.webkit.org/260565@main">https://commits.webkit.org/260565@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc62ccf4e4f44964a50f16a8bfcfe8b2beff0f4d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108370 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17465 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41233 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117486 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116854 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112257 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18965 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8744 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100593 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114137 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14216 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97405 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42130 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96194 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29050 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/83823 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10297 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30394 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11039 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7299 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16447 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49991 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7303 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12626 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->