### PR TITLE
REGRESSION(253223@main): PDF.js viewer fails to load PDF: [Error] TypeError: null is not an object (evaluating 'PDFViewerApplication.eventBus.on')

### DIFF
--- a/Source/WebCore/Modules/pdfjs-extras/content-script.js
+++ b/Source/WebCore/Modules/pdfjs-extras/content-script.js
@@ -56,9 +56,11 @@ const PDFJSContentScript = {
     },
 
     init() {
-        this.overrideSettings();
-        PDFViewerApplication.eventBus.on("pagesinit", () => {
-            this.autoResize();
+        PDFViewerApplication.initializedPromise.then(() => {
+            this.overrideSettings();
+            PDFViewerApplication.eventBus.on("pagesinit", () => {
+                this.autoResize();
+            });
         });
 
         window.addEventListener("message", (event) => {


### PR DESCRIPTION
#### f6ae4b26c6021a679da8605890edf6faeddeba7f
<pre>
REGRESSION(253223@main): PDF.js viewer fails to load PDF: [Error] TypeError: null is not an object (evaluating &apos;PDFViewerApplication.eventBus.on&apos;)
<a href="https://bugs.webkit.org/show_bug.cgi?id=251887">https://bugs.webkit.org/show_bug.cgi?id=251887</a>

Reviewed by Tim Nguyen.

The PDF document is not loading reliably due to a race condition between
our content script and PDF.js. We need to wait until PDF.js has
initialized itself before trying to use it. This solution is based on a
suggestion by Tim Nguyen, which is itself based on the PDF.js
documentation <a href="https://github.com/mozilla/pdf.js/wiki/Third-party-viewer-usage#initialization-promise">https://github.com/mozilla/pdf.js/wiki/Third-party-viewer-usage#initialization-promise</a>
but modified to avoid waiting on an event that does not seem to actually
happen (possibly it occurs before our content script is injected).

* Source/WebCore/Modules/pdfjs-extras/content-script.js:
(const.PDFJSContentScript.init):

Canonical link: <a href="https://commits.webkit.org/260485@main">https://commits.webkit.org/260485@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e71ec2d706c917058662671c64c081c710fd2058

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108451 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17547 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41301 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117556 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112338 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18998 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8825 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100677 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114219 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/97457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/42193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/29102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10364 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/30446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11116 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/7361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16511 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50042 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7251 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12702 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->