### PR TITLE
[Error] The `PDFViewerApplication.open` signature was updated, please use an object instead.

### DIFF
--- a/Source/WebCore/Modules/pdfjs-extras/content-script.js
+++ b/Source/WebCore/Modules/pdfjs-extras/content-script.js
@@ -52,7 +52,7 @@ const PDFJSContentScript = {
     },
 
     open(data) {
-        PDFViewerApplication.open(data);
+        PDFViewerApplication.open({ data });
     },
 
     init() {


### PR DESCRIPTION
#### 456e73f2be0f77a258355c50100e2f889d84d20e
<pre>
[Error] The `PDFViewerApplication.open` signature was updated, please use an object instead.
<a href="https://bugs.webkit.org/show_bug.cgi?id=252486">https://bugs.webkit.org/show_bug.cgi?id=252486</a>

Reviewed by Tim Nguyen.

We can avoid a deprecation warning if we add a pair of braces, so why
not?

* Source/WebCore/Modules/pdfjs-extras/content-script.js:
(const.PDFJSContentScript.open):

Canonical link: <a href="https://commits.webkit.org/260453@main">https://commits.webkit.org/260453@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f17aafd211f57a61d3783d0112d431efd0087c0d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108366 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17461 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41229 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117482 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112253 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/18961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8740 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100589 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114133 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14153 "Build was cancelled. Recent messages:Configured build (exception)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97397 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/42126 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/18961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29042 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10293 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30386 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11035 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/7296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16443 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49983 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12622 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3926 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->