### PR TITLE
Table-layout:fixed is not applied when width is max-content

### DIFF
--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -3,7 +3,7 @@
  *           (C) 2000 Antti Koivisto (koivisto@kde.org)
  *           (C) 2000 Dirk Mueller (mueller@kde.org)
  * Copyright (C) 2003-2023 Apple Inc. All rights reserved.
- * Copyright (C) 2014 Google Inc. All rights reserved.
+ * Copyright (C) 2014-2021 Google Inc. All rights reserved.
  * Copyright (C) 2006 Graham Dennis (graham.dennis@gmail.com)
  *
  * This library is free software; you can redistribute it and/or
@@ -499,7 +499,7 @@ public:
     ListStyleType listStyleType() const { return static_cast<ListStyleType>(m_inheritedFlags.listStyleType); }
     StyleImage* listStyleImage() const;
     ListStylePosition listStylePosition() const { return static_cast<ListStylePosition>(m_inheritedFlags.listStylePosition); }
-    bool isFixedTableLayout() const { return tableLayout() == TableLayoutType::Fixed && !logicalWidth().isAuto(); }
+    bool isFixedTableLayout() const { return tableLayout() == TableLayoutType::Fixed && (logicalWidth().isSpecified() || logicalWidth().isFitContent() || logicalWidth().isMinContent()); }
 
     const Length& marginTop() const { return m_nonInheritedData->surroundData->margin.top(); }
     const Length& marginBottom() const { return m_nonInheritedData->surroundData->margin.bottom(); }


### PR DESCRIPTION
#### f4a3552fc9e6f99ec970c124cb30733d438fac9e
<pre>
Table-layout:fixed is not applied when width is max-content

<a href="https://bugs.webkit.org/show_bug.cgi?id=252495">https://bugs.webkit.org/show_bug.cgi?id=252495</a>

Reviewed by Alan Baradlay.

This patch aligns WebKit with Blink / Chromium and Gecko / Firefox.

Merge - <a href="https://chromium.googlesource.com/chromium/src/+/8353c86f025f1556fa9fd18b516751259d49a7cf">https://chromium.googlesource.com/chromium/src/+/8353c86f025f1556fa9fd18b516751259d49a7cf</a>

This patch updates &apos;isFixedTableLayout&apos; function to align with web-specification [1] and
fixes sizing issue in case of max-content.

[1] <a href="https://www.w3.org/TR/css-tables-3/#table-layout-property">https://www.w3.org/TR/css-tables-3/#table-layout-property</a>

In local testing, it has progressed following:

WPT Test: <a href="http://wpt.live/css/css-tables/fixed-layout-2.html">http://wpt.live/css/css-tables/fixed-layout-2.html</a>
Sub-Test Progressed: Table-layout:fixed is not applied when width is max-content

* Source/WebCore/rendering/style/RenderStyle.h: Update as per above

Canonical link: <a href="https://commits.webkit.org/260501@main">https://commits.webkit.org/260501@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5361b2f63c2376fe079c56ca0cd69c65cbc76f40

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108382 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17478 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41247 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117499 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116867 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112269 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18864 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8758 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100607 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114149 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14163 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97414 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42140 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96140 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29059 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/83831 "Found 1 new API test failure: /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/cut-copy-paste/non-editable (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10310 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30403 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11053 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7309 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16460 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49999 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7258 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12639 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->