### PR TITLE
Introduce plumbing for a policy flag that introduces noise when using some web audio APIs

### DIFF
--- a/Source/WebCore/Modules/webaudio/AudioBuffer.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioBuffer.cpp
@@ -151,6 +151,7 @@ void AudioBuffer::releaseMemory()
     Locker locker { m_channelsLock };
     m_channels = { };
     m_channelWrappers = { };
+    m_needsAdditionalNoise = false;
 }
 
 ExceptionOr<JSC::JSValue> AudioBuffer::getChannelData(JSDOMGlobalObject& globalObject, unsigned channelIndex)
@@ -303,6 +304,7 @@ bool AudioBuffer::copyTo(AudioBuffer& other) const
     for (unsigned channelIndex = 0; channelIndex < numberOfChannels(); ++channelIndex)
         memcpy(other.rawChannelData(channelIndex), m_channels[channelIndex]->data(), length() * sizeof(float));
 
+    other.m_needsAdditionalNoise = m_needsAdditionalNoise;
     return true;
 }
 

--- a/Source/WebCore/Modules/webaudio/AudioBuffer.h
+++ b/Source/WebCore/Modules/webaudio/AudioBuffer.h
@@ -86,6 +86,8 @@ public:
     
     bool topologyMatches(const AudioBuffer&) const;
 
+    void setNeedsAdditionalNoise() { m_needsAdditionalNoise = true; }
+
 private:
     AudioBuffer(unsigned numberOfChannels, size_t length, float sampleRate, LegacyPreventDetaching = LegacyPreventDetaching::No);
     explicit AudioBuffer(AudioBus&);
@@ -104,6 +106,7 @@ private:
     FixedVector<JSValueInWrappedObject> m_channelWrappers;
     bool m_isDetachable { true };
     mutable Lock m_channelsLock;
+    bool m_needsAdditionalNoise { false };
 };
 
 WebCoreOpaqueRoot root(AudioBuffer*);

--- a/Source/WebCore/Modules/webaudio/AudioNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioNode.cpp
@@ -712,6 +712,11 @@ const BaseAudioContext& AudioNode::context() const
     });
 }
 
+NoiseInjectionPolicy AudioNode::noiseInjectionPolicy() const
+{
+    return context().noiseInjectionPolicy();
+}
+
 #if DEBUG_AUDIONODE_REFERENCES
 
 bool AudioNode::s_isNodeCountInitialized = false;

--- a/Source/WebCore/Modules/webaudio/AudioNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioNode.h
@@ -43,6 +43,8 @@ class AudioNodeOutput;
 class AudioParam;
 class BaseAudioContext;
 
+enum class NoiseInjectionPolicy : bool;
+
 // An AudioNode is the basic building block for handling audio within an AudioContext.
 // It may be an audio source, an intermediate processing module, or an audio destination.
 // Each AudioNode can have inputs and/or outputs. An AudioSourceNode has no inputs and a single output.
@@ -194,6 +196,8 @@ public:
     // We rely on this flag to avoid unnecessary linear searches in those vectors.
     bool isTailProcessing() const { return m_isTailProcessing; }
     void setIsTailProcessing(bool isTailProcessing) { m_isTailProcessing = isTailProcessing; }
+
+    NoiseInjectionPolicy noiseInjectionPolicy() const;
 
 protected:
     // Inputs and outputs must be created before the AudioNode is initialized.

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
@@ -94,6 +94,19 @@
 #include "GStreamerCommon.h"
 #endif
 
+#if __has_include(<WebKitAdditions/BaseAudioContextAdditions.cpp>)
+#include <WebKitAdditions/BaseAudioContextAdditions.cpp>
+#else
+namespace WebCore {
+
+static NoiseInjectionPolicy noiseInjectionPolicy(const Document&)
+{
+    return NoiseInjectionPolicy::None;
+}
+
+} // namespace WebCore
+#endif
+
 namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(BaseAudioContext);
@@ -126,6 +139,7 @@ BaseAudioContext::BaseAudioContext(Document& document)
     , m_contextID(generateContextID())
     , m_worklet(AudioWorklet::create(*this))
     , m_listener(AudioListener::create(*this))
+    , m_noiseInjectionPolicy(WebCore::noiseInjectionPolicy(document))
 {
     liveAudioContexts().add(m_contextID);
 

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.h
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.h
@@ -32,6 +32,7 @@
 #include "AudioIOCallback.h"
 #include "EventTarget.h"
 #include "JSDOMPromiseDeferredForward.h"
+#include "NoiseInjectionPolicy.h"
 #include "OscillatorType.h"
 #include "PeriodicWaveConstraints.h"
 #include <atomic>
@@ -231,6 +232,8 @@ public:
     void addAudioParamDescriptors(const String& processorName, Vector<AudioParamDescriptor>&&);
     const MemoryCompactRobinHoodHashMap<String, Vector<AudioParamDescriptor>>& parameterDescriptorMap() const { return m_parameterDescriptorMap; }
 
+    NoiseInjectionPolicy noiseInjectionPolicy() const { return m_noiseInjectionPolicy; }
+
 protected:
     explicit BaseAudioContext(Document&);
 
@@ -368,6 +371,7 @@ private:
     bool m_isAudioThreadFinished { false };
     bool m_automaticPullNodesNeedUpdating { false };
     bool m_hasFinishedAudioSourceNodes { false };
+    NoiseInjectionPolicy m_noiseInjectionPolicy { NoiseInjectionPolicy::None };
 };
 
 } // WebCore

--- a/Source/WebCore/Modules/webaudio/NoiseInjectionPolicy.h
+++ b/Source/WebCore/Modules/webaudio/NoiseInjectionPolicy.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+enum class NoiseInjectionPolicy : bool {
+    None,
+    Minimal
+};
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/webaudio/OfflineAudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/OfflineAudioContext.cpp
@@ -50,6 +50,8 @@ OfflineAudioContext::OfflineAudioContext(Document& document, const OfflineAudioC
 {
     if (!renderTarget())
         document.addConsoleMessage(MessageSource::JS, MessageLevel::Warning, makeString("Failed to construct internal AudioBuffer with ", options.numberOfChannels, " channel(s), a sample rate of ", options.sampleRate, " and a length of ", options.length, "."));
+    else if (noiseInjectionPolicy() == NoiseInjectionPolicy::Minimal)
+        renderTarget()->setNeedsAdditionalNoise();
 }
 
 ExceptionOr<Ref<OfflineAudioContext>> OfflineAudioContext::create(ScriptExecutionContext& context, const OfflineAudioContextOptions& options)


### PR DESCRIPTION
#### f9c441099509da64d9be105a21d01c9bbcf8cee2
<pre>
Introduce plumbing for a policy flag that introduces noise when using some web audio APIs
<a href="https://bugs.webkit.org/show_bug.cgi?id=252498">https://bugs.webkit.org/show_bug.cgi?id=252498</a>

Reviewed by Chris Dumez.

Introduce a new enum flag, `NoiseInjectionPolicy`, and plumb it through some web audio codepaths.
See below for more details. No test yet, since there is no change in behavior.

* Source/WebCore/Modules/webaudio/AudioBuffer.cpp:
(WebCore::AudioBuffer::releaseMemory):
(WebCore::AudioBuffer::copyTo const):

Add a simple boolean `m_needsAdditionalNoise` flag to `AudioBuffer`. This will be turned on by
either audio nodes or the audio context itself, with the intent that `AudioBuffer` will reset it to
`false` once noise has been applied.

* Source/WebCore/Modules/webaudio/AudioBuffer.h:
(WebCore::AudioBuffer::setNeedsAdditionalNoise):
* Source/WebCore/Modules/webaudio/AudioNode.cpp:
(WebCore::AudioNode::noiseInjectionPolicy const):

Expose a helper method on `AudioNode` that returns the context&apos;s policy flag.

* Source/WebCore/Modules/webaudio/AudioNode.h:
* Source/WebCore/Modules/webaudio/BaseAudioContext.cpp:
(WebCore::noiseInjectionPolicy):
(WebCore::BaseAudioContext::BaseAudioContext):
* Source/WebCore/Modules/webaudio/BaseAudioContext.h:
(WebCore::BaseAudioContext::noiseInjectionPolicy const):

Consult the `Document` here upon initialization, to determine whether or not noise injection is
needed. This noise injection policy is then propagated to any nodes attached to the context.

* Source/WebCore/Modules/webaudio/NoiseInjectionPolicy.h: Added.
* Source/WebCore/Modules/webaudio/OfflineAudioContext.cpp:
(WebCore::OfflineAudioContext::OfflineAudioContext):
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/260478@main">https://commits.webkit.org/260478@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/850fcdfebbd7eedbd7635a2ed41cacff5e2b4463

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108397 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17490 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41258 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117511 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116875 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112282 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18867 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8770 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100622 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114163 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14171 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97424 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42153 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96149 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29069 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10320 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30413 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11065 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7319 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16469 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50009 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7245 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12651 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->