### PR TITLE
[GLib] Warning on WebKitNetworkSession documentation

### DIFF
--- a/Source/WebKit/gtk/migrating-to-webkitgtk-6.0.md
+++ b/Source/WebKit/gtk/migrating-to-webkitgtk-6.0.md
@@ -91,7 +91,7 @@ WebKit now uses a single global network process for all web contexts, and differ
 network sessions can be created and used in the same network process. All the networking
 APIs have been moved from [type@WebKit.WebContext] and [type@WebKit.WebsiteDataManager] to the new class
 [type@WebKit.NetworkSession]. There's a default global persistent session that you can get with
-[func@WebKit.NetworkSession.get_default]. You can also create new sessions with
+[id@webkit_network_session_get_default]. You can also create new sessions with
 [ctor@WebKit.NetworkSession.new] for persistent sessions and [ctor@WebKit.NetworkSession.new_ephemeral]
 for ephemeral sessions. It's no longer possible to create a [type@WebKit.WebsiteDataManager]; it's now
 created by the [type@WebKit.NetworkSession] automatically at construction time. The [type@WebKit.NetworkSession]


### PR DESCRIPTION
#### 9e0f5790eb66bb9edb808427ae89aa323745f122
<pre>
[GLib] Warning on WebKitNetworkSession documentation
<a href="https://bugs.webkit.org/show_bug.cgi?id=252468">https://bugs.webkit.org/show_bug.cgi?id=252468</a>

Reviewed by NOBODY (OOPS!).

* Source/WebKit/gtk/migrating-to-webkitgtk-6.0.md: Change link to
  webkit_network_session_get_default to use an [id@&lt;...&gt;] reference,
  it seems gi-docgen is getting confused by the exported GI namespace
  being WebKit2, but the reference using WebKit.&lt;...&gt; and the function
  being a &quot;static method&quot; which does not take an instance as first
  parameter.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e0f5790eb66bb9edb808427ae89aa323745f122

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108418 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17512 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41276 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117529 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116892 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18974 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8789 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100641 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114186 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14233 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97441 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42168 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96211 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29086 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/83867 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10338 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30430 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11084 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7332 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16487 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50026 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12671 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->