### PR TITLE
Get DisplayLink-related code out of WebProcessPool

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
@@ -104,7 +104,7 @@ DisplayLink* RemoteLayerTreeDrawingAreaProxyMac::exisingDisplayLink()
     if (!m_displayID)
         return nullptr;
     
-    return m_webPageProxy.process().processPool().displayLinks().displayLinkForDisplay(*m_displayID);
+    return m_webPageProxy.process().processPool().displayLinks().existingDisplayLinkForDisplay(*m_displayID);
 }
 
 DisplayLink& RemoteLayerTreeDrawingAreaProxyMac::ensureDisplayLink()
@@ -112,13 +112,7 @@ DisplayLink& RemoteLayerTreeDrawingAreaProxyMac::ensureDisplayLink()
     ASSERT(m_displayID);
 
     auto& displayLinks = m_webPageProxy.process().processPool().displayLinks();
-    auto* displayLink = displayLinks.displayLinkForDisplay(*m_displayID);
-    if (!displayLink) {
-        auto newDisplayLink = makeUnique<DisplayLink>(*m_displayID);
-        displayLink = newDisplayLink.get();
-        displayLinks.add(WTFMove(newDisplayLink));
-    }
-    return *displayLink;
+    return displayLinks.displayLinkForDisplay(*m_displayID);
 }
 
 void RemoteLayerTreeDrawingAreaProxyMac::removeObserver(std::optional<DisplayLinkObserverID>& observerID)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -3091,7 +3091,7 @@ void WebPageProxy::updateDisplayLinkFrequency()
 
     bool wantsFullSpeedUpdates = m_hasActiveAnimatedScroll || m_wheelEventActivityHysteresis.state() == PAL::HysteresisState::Started;
     if (wantsFullSpeedUpdates != m_registeredForFullSpeedUpdates) {
-        process().processPool().setDisplayLinkForDisplayWantsFullSpeedUpdates(process(), *m_displayID, wantsFullSpeedUpdates);
+        process().setDisplayLinkForDisplayWantsFullSpeedUpdates(*m_displayID, wantsFullSpeedUpdates);
         m_registeredForFullSpeedUpdates = wantsFullSpeedUpdates;
     }
 }
@@ -4142,7 +4142,7 @@ void WebPageProxy::windowScreenDidChange(PlatformDisplayID displayID, std::optio
 {
 #if HAVE(CVDISPLAYLINK)
     if (hasRunningProcess() && m_displayID && m_registeredForFullSpeedUpdates)
-        process().processPool().setDisplayLinkForDisplayWantsFullSpeedUpdates(process(), *m_displayID, false);
+        process().setDisplayLinkForDisplayWantsFullSpeedUpdates(*m_displayID, false);
 
     m_registeredForFullSpeedUpdates = false;
 #endif

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -253,14 +253,6 @@ public:
 
 #if HAVE(CVDISPLAYLINK)
     DisplayLinkCollection& displayLinks() { return m_displayLinks; }
-
-    std::optional<WebCore::FramesPerSecond> nominalFramesPerSecondForDisplay(WebCore::PlatformDisplayID);
-
-    void startDisplayLink(WebProcessProxy&, DisplayLinkObserverID, WebCore::PlatformDisplayID, WebCore::FramesPerSecond);
-    void stopDisplayLink(WebProcessProxy&, DisplayLinkObserverID, WebCore::PlatformDisplayID);
-    void setDisplayLinkPreferredFramesPerSecond(WebProcessProxy&, DisplayLinkObserverID, WebCore::PlatformDisplayID, WebCore::FramesPerSecond);
-    void stopDisplayLinks(WebProcessProxy&);
-    void setDisplayLinkForDisplayWantsFullSpeedUpdates(WebProcessProxy&, WebCore::PlatformDisplayID, bool wantsFullSpeedUpdates);
 #endif
 
     void addSupportedPlugin(String&& matchingDomain, String&& name, HashSet<String>&& mimeTypes, HashSet<String> extensions);

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -340,7 +340,7 @@ WebProcessProxy::~WebProcessProxy()
     WebPasteboardProxy::singleton().removeWebProcessProxy(*this);
 
 #if HAVE(CVDISPLAYLINK)
-    processPool().stopDisplayLinks(*this);
+    processPool().displayLinks().stopDisplayLinks(m_displayLinkClient);
 #endif
 
     auto isResponsiveCallbacks = WTFMove(m_isResponsiveCallbacks);
@@ -576,7 +576,7 @@ void WebProcessProxy::processWillShutDown(IPC::Connection& connection)
 
 #if HAVE(CVDISPLAYLINK)
     m_displayLinkClient.setConnection(nullptr);
-    processPool().stopDisplayLinks(*this);
+    processPool().displayLinks().stopDisplayLinks(m_displayLinkClient);
 #endif
 }
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -335,10 +335,12 @@ public:
 
 #if HAVE(CVDISPLAYLINK)
     DisplayLink::Client& displayLinkClient() { return m_displayLinkClient; }
+    std::optional<unsigned> nominalFramesPerSecondForDisplay(WebCore::PlatformDisplayID);
 
     void startDisplayLink(DisplayLinkObserverID, WebCore::PlatformDisplayID, WebCore::FramesPerSecond);
     void stopDisplayLink(DisplayLinkObserverID, WebCore::PlatformDisplayID);
     void setDisplayLinkPreferredFramesPerSecond(DisplayLinkObserverID, WebCore::PlatformDisplayID, WebCore::FramesPerSecond);
+    void setDisplayLinkForDisplayWantsFullSpeedUpdates(WebCore::PlatformDisplayID, bool wantsFullSpeedUpdates);
 #endif
 
     // Called when the web process has crashed or we know that it will terminate soon.

--- a/Source/WebKit/UIProcess/mac/DisplayLink.cpp
+++ b/Source/WebKit/UIProcess/mac/DisplayLink.cpp
@@ -36,9 +36,11 @@
 
 namespace WebKit {
 
+using namespace WebCore;
+
 constexpr unsigned maxFireCountWithoutObservers { 20 };
 
-DisplayLink::DisplayLink(WebCore::PlatformDisplayID displayID)
+DisplayLink::DisplayLink(PlatformDisplayID displayID)
     : m_displayID(displayID)
 {
     // FIXME: We can get here with displayID == 0 (webkit.org/b/212120), in which case CVDisplayLinkCreateWithCGDisplay()
@@ -74,17 +76,17 @@ DisplayLink::~DisplayLink()
     CVDisplayLinkRelease(m_displayLink);
 }
 
-WebCore::FramesPerSecond DisplayLink::nominalFramesPerSecondFromDisplayLink(CVDisplayLinkRef displayLink)
+FramesPerSecond DisplayLink::nominalFramesPerSecondFromDisplayLink(CVDisplayLinkRef displayLink)
 {
     CVTime refreshPeriod = CVDisplayLinkGetNominalOutputVideoRefreshPeriod(displayLink);
     if (!refreshPeriod.timeValue)
-        return WebCore::FullSpeedFramesPerSecond;
+        return FullSpeedFramesPerSecond;
 
-    WebCore::FramesPerSecond result = round((double)refreshPeriod.timeScale / (double)refreshPeriod.timeValue);
-    return result ?: WebCore::FullSpeedFramesPerSecond;
+    FramesPerSecond result = round((double)refreshPeriod.timeScale / (double)refreshPeriod.timeValue);
+    return result ?: FullSpeedFramesPerSecond;
 }
 
-void DisplayLink::addObserver(Client& client, DisplayLinkObserverID observerID, WebCore::FramesPerSecond preferredFramesPerSecond)
+void DisplayLink::addObserver(Client& client, DisplayLinkObserverID observerID, FramesPerSecond preferredFramesPerSecond)
 {
     ASSERT(RunLoop::isMain());
 
@@ -190,7 +192,7 @@ void DisplayLink::displayPropertiesChanged()
     // FIXME: Detect whether the refresh frequency changed.
 }
 
-void DisplayLink::setObserverPreferredFramesPerSecond(Client& client, DisplayLinkObserverID observerID, WebCore::FramesPerSecond preferredFramesPerSecond)
+void DisplayLink::setObserverPreferredFramesPerSecond(Client& client, DisplayLinkObserverID observerID, FramesPerSecond preferredFramesPerSecond)
 {
     LOG_WITH_STREAM(DisplayLink, stream << "[UI ] DisplayLink " << this << " setPreferredFramesPerSecond - display " << m_displayID << " observer " << observerID << " fps " << preferredFramesPerSecond);
 
@@ -222,7 +224,7 @@ void DisplayLink::notifyObserversDisplayWasRefreshed()
     Locker locker { m_clientsLock };
 
     auto maxFramesPerSecond = [](const Vector<ObserverInfo>& observers) {
-        std::optional<WebCore::FramesPerSecond> observersMaxFramesPerSecond;
+        std::optional<FramesPerSecond> observersMaxFramesPerSecond;
         for (const auto& observer : observers)
             observersMaxFramesPerSecond = std::max(observersMaxFramesPerSecond.value_or(0), observer.preferredFramesPerSecond);
         return observersMaxFramesPerSecond;
@@ -236,7 +238,7 @@ void DisplayLink::notifyObserversDisplayWasRefreshed()
         anyConnectionHadObservers = true;
 
         auto observersMaxFramesPerSecond = maxFramesPerSecond(clientInfo.observers);
-        bool anyObserverWantsCallback = m_currentUpdate.relevantForUpdateFrequency(observersMaxFramesPerSecond.value_or(WebCore::FullSpeedFramesPerSecond));
+        bool anyObserverWantsCallback = m_currentUpdate.relevantForUpdateFrequency(observersMaxFramesPerSecond.value_or(FullSpeedFramesPerSecond));
 
         LOG_WITH_STREAM(DisplayLink, stream << "[UI ] DisplayLink " << this << " for display " << m_displayID << " (display fps " << m_displayNominalFramesPerSecond << ") update " << m_currentUpdate << " " << clientInfo.observers.size()
             << " observers, maxFramesPerSecond " << observersMaxFramesPerSecond << " full speed client count " << clientInfo.fullSpeedUpdatesClientCount << " relevant " << anyObserverWantsCallback);
@@ -257,7 +259,18 @@ void DisplayLink::notifyObserversDisplayWasRefreshed()
     m_fireCountWithoutObservers = 0;
 }
 
-DisplayLink* DisplayLinkCollection::displayLinkForDisplay(WebCore::PlatformDisplayID displayID) const
+DisplayLink& DisplayLinkCollection::displayLinkForDisplay(PlatformDisplayID displayID)
+{
+    if (auto* displayLink = existingDisplayLinkForDisplay(displayID))
+        return *displayLink;
+
+    auto displayLink = makeUnique<DisplayLink>(displayID);
+    auto displayLinkPtr = displayLink.get();
+    add(WTFMove(displayLink));
+    return *displayLinkPtr;
+}
+
+DisplayLink* DisplayLinkCollection::existingDisplayLinkForDisplay(PlatformDisplayID displayID) const
 {
     for (auto& displayLink : m_displayLinks) {
         if (displayLink->displayID() == displayID)
@@ -271,6 +284,53 @@ void DisplayLinkCollection::add(std::unique_ptr<DisplayLink>&& displayLink)
 {
     ASSERT(!m_displayLinks.containsIf([&](auto &entry) { return entry->displayID() == displayLink->displayID(); }));
     m_displayLinks.append(WTFMove(displayLink));
+}
+
+std::optional<unsigned> DisplayLinkCollection::nominalFramesPerSecondForDisplay(PlatformDisplayID displayID)
+{
+    // Note that this may create a DisplayLink with no observers, but it's highly likely that we'll soon call startDisplayLink() for it.
+    auto& displayLink = displayLinkForDisplay(displayID);
+    return displayLink.nominalFramesPerSecond();
+}
+
+void DisplayLinkCollection::startDisplayLink(DisplayLink::Client& client, DisplayLinkObserverID observerID, PlatformDisplayID displayID, FramesPerSecond preferredFramesPerSecond)
+{
+    auto& displayLink = displayLinkForDisplay(displayID);
+    displayLink.addObserver(client, observerID, preferredFramesPerSecond);
+}
+
+void DisplayLinkCollection::stopDisplayLink(DisplayLink::Client& client, DisplayLinkObserverID observerID, PlatformDisplayID displayID)
+{
+    if (auto* displayLink = existingDisplayLinkForDisplay(displayID))
+        displayLink->removeObserver(client, observerID);
+
+    // FIXME: Remove unused display links?
+}
+
+void DisplayLinkCollection::stopDisplayLinks(DisplayLink::Client& client)
+{
+    for (auto& displayLink : m_displayLinks)
+        displayLink->removeClient(client);
+    
+    // FIXME: Remove unused display links?
+}
+
+void DisplayLinkCollection::setDisplayLinkPreferredFramesPerSecond(DisplayLink::Client& client, DisplayLinkObserverID observerID, PlatformDisplayID displayID, FramesPerSecond preferredFramesPerSecond)
+{
+    LOG_WITH_STREAM(DisplayLink, stream << "[UI ] WebProcessPool::setDisplayLinkPreferredFramesPerSecond - display " << displayID << " observer " << observerID << " fps " << preferredFramesPerSecond);
+
+    if (auto* displayLink = existingDisplayLinkForDisplay(displayID))
+        displayLink->setObserverPreferredFramesPerSecond(client, observerID, preferredFramesPerSecond);
+}
+
+void DisplayLinkCollection::setDisplayLinkForDisplayWantsFullSpeedUpdates(DisplayLink::Client& client, PlatformDisplayID displayID, bool wantsFullSpeedUpdates)
+{
+    if (auto* displayLink = existingDisplayLinkForDisplay(displayID)) {
+        if (wantsFullSpeedUpdates)
+            displayLink->incrementFullSpeedRequestClientCount(client);
+        else
+            displayLink->decrementFullSpeedRequestClientCount(client);
+    }
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/mac/DisplayLink.h
+++ b/Source/WebKit/UIProcess/mac/DisplayLink.h
@@ -98,13 +98,19 @@ private:
 
 class DisplayLinkCollection {
 public:
-    void add(std::unique_ptr<DisplayLink>&&);
+    DisplayLink& displayLinkForDisplay(WebCore::PlatformDisplayID);
+    DisplayLink* existingDisplayLinkForDisplay(WebCore::PlatformDisplayID) const;
 
-    DisplayLink* displayLinkForDisplay(WebCore::PlatformDisplayID) const;
-
-    const Vector<std::unique_ptr<DisplayLink>>& displayLinks() const { return m_displayLinks; }
+    std::optional<unsigned> nominalFramesPerSecondForDisplay(WebCore::PlatformDisplayID);
+    void startDisplayLink(DisplayLink::Client&, DisplayLinkObserverID, WebCore::PlatformDisplayID, WebCore::FramesPerSecond preferredFramesPerSecond);
+    void stopDisplayLink(DisplayLink::Client&, DisplayLinkObserverID, WebCore::PlatformDisplayID);
+    void stopDisplayLinks(DisplayLink::Client&);
+    void setDisplayLinkPreferredFramesPerSecond(DisplayLink::Client&, DisplayLinkObserverID, WebCore::PlatformDisplayID, WebCore::FramesPerSecond preferredFramesPerSecond);
+    void setDisplayLinkForDisplayWantsFullSpeedUpdates(DisplayLink::Client&, WebCore::PlatformDisplayID, bool wantsFullSpeedUpdates);
 
 private:
+    void add(std::unique_ptr<DisplayLink>&&);
+
     Vector<std::unique_ptr<DisplayLink>> m_displayLinks;
 };
 

--- a/Source/WebKit/UIProcess/mac/WebProcessProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebProcessProxyMac.mm
@@ -59,20 +59,30 @@ bool WebProcessProxy::shouldAllowNonValidInjectedCode() const
     return !path.isEmpty() && !path.startsWith("/System/"_s);
 }
 
+std::optional<unsigned> WebProcessProxy::nominalFramesPerSecondForDisplay(WebCore::PlatformDisplayID displayID)
+{
+    return processPool().displayLinks().nominalFramesPerSecondForDisplay(displayID);
+}
+
 void WebProcessProxy::startDisplayLink(DisplayLinkObserverID observerID, WebCore::PlatformDisplayID displayID, WebCore::FramesPerSecond preferredFramesPerSecond)
 {
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
-    processPool().startDisplayLink(*this, observerID, displayID, preferredFramesPerSecond);
+    processPool().displayLinks().startDisplayLink(m_displayLinkClient, observerID, displayID, preferredFramesPerSecond);
 }
 
 void WebProcessProxy::stopDisplayLink(DisplayLinkObserverID observerID, WebCore::PlatformDisplayID displayID)
 {
-    processPool().stopDisplayLink(*this, observerID, displayID);
+    processPool().displayLinks().stopDisplayLink(m_displayLinkClient, observerID, displayID);
 }
 
 void WebProcessProxy::setDisplayLinkPreferredFramesPerSecond(DisplayLinkObserverID observerID, WebCore::PlatformDisplayID displayID, WebCore::FramesPerSecond preferredFramesPerSecond)
 {
-    processPool().setDisplayLinkPreferredFramesPerSecond(*this, observerID, displayID, preferredFramesPerSecond);
+    processPool().displayLinks().setDisplayLinkPreferredFramesPerSecond(m_displayLinkClient, observerID, displayID, preferredFramesPerSecond);
+}
+
+void WebProcessProxy::setDisplayLinkForDisplayWantsFullSpeedUpdates(WebCore::PlatformDisplayID displayID, bool wantsFullSpeedUpdates)
+{
+    processPool().displayLinks().setDisplayLinkForDisplayWantsFullSpeedUpdates(m_displayLinkClient, displayID, wantsFullSpeedUpdates);
 }
 
 void WebProcessProxy::platformSuspendProcess()

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -2024,7 +2024,7 @@ void WebViewImpl::windowDidChangeScreen()
 {
     NSWindow *window = m_targetWindowForMovePreparation ? m_targetWindowForMovePreparation.get() : [m_view window];
     auto displayID = WebCore::displayID(window.screen);
-    auto framesPerSecond = m_page->process().processPool().nominalFramesPerSecondForDisplay(displayID);
+    auto framesPerSecond = m_page->process().nominalFramesPerSecondForDisplay(displayID);
     m_page->windowScreenDidChange(displayID, framesPerSecond);
 }
 


### PR DESCRIPTION
#### 9bda52bd8803e05570d63a56e6fa9ef62dea2e7b
<pre>
Get DisplayLink-related code out of WebProcessPool
<a href="https://bugs.webkit.org/show_bug.cgi?id=252505">https://bugs.webkit.org/show_bug.cgi?id=252505</a>
rdar://105613366

Reviewed by Tim Horton.

The list of DisplayLink objects is stored on WebProcessPool, since they are shared between all
WebPageProxy objects that use the same process pool. However, we don&apos;t need to pollute the
WebProcessPool API with DisplayLink-related functions; instead, just expose `DisplayLinkCollection`
and move the functionality into that class.

WebProcessProxy gains a couple more wrapper functions related to DisplayLinks.

Move to the more conventional `displayLinkForDisplay()` and `existingDisplayLinkForDisplay()`
terminology.

* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::displayPropertiesChanged):
(WebKit::WebProcessPool::nominalFramesPerSecondForDisplay): Deleted.
(WebKit::WebProcessPool::startDisplayLink): Deleted.
(WebKit::WebProcessPool::stopDisplayLink): Deleted.
(WebKit::WebProcessPool::stopDisplayLinks): Deleted.
(WebKit::WebProcessPool::setDisplayLinkPreferredFramesPerSecond): Deleted.
(WebKit::WebProcessPool::setDisplayLinkForDisplayWantsFullSpeedUpdates): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::exisingDisplayLink):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::ensureDisplayLink):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::updateDisplayLinkFrequency):
(WebKit::WebPageProxy::windowScreenDidChange):
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::~WebProcessProxy):
(WebKit::WebProcessProxy::processWillShutDown):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/UIProcess/mac/DisplayLink.cpp:
(WebKit::DisplayLink::DisplayLink):
(WebKit::DisplayLink::nominalFramesPerSecondFromDisplayLink):
(WebKit::DisplayLink::addObserver):
(WebKit::DisplayLink::setObserverPreferredFramesPerSecond):
(WebKit::DisplayLink::notifyObserversDisplayWasRefreshed):
(WebKit::DisplayLinkCollection::displayLinkForDisplay):
(WebKit::DisplayLinkCollection::existingDisplayLinkForDisplay const):
(WebKit::DisplayLinkCollection::nominalFramesPerSecondForDisplay):
(WebKit::DisplayLinkCollection::startDisplayLink):
(WebKit::DisplayLinkCollection::stopDisplayLink):
(WebKit::DisplayLinkCollection::stopDisplayLinks):
(WebKit::DisplayLinkCollection::setDisplayLinkPreferredFramesPerSecond):
(WebKit::DisplayLinkCollection::setDisplayLinkForDisplayWantsFullSpeedUpdates):
(WebKit::DisplayLinkCollection::displayLinkForDisplay const): Deleted.
* Source/WebKit/UIProcess/mac/DisplayLink.h:
(WebKit::DisplayLinkCollection::displayLinks const): Deleted.
* Source/WebKit/UIProcess/mac/WebProcessProxyMac.mm:
(WebKit::WebProcessProxy::nominalFramesPerSecondForDisplay):
(WebKit::WebProcessProxy::startDisplayLink):
(WebKit::WebProcessProxy::stopDisplayLink):
(WebKit::WebProcessProxy::setDisplayLinkPreferredFramesPerSecond):
(WebKit::WebProcessProxy::setDisplayLinkForDisplayWantsFullSpeedUpdates):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::windowDidChangeScreen):

Canonical link: <a href="https://commits.webkit.org/260489@main">https://commits.webkit.org/260489@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87303f98f049137c60d7a2a6d62d60af444702ba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108427 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17523 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41281 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117535 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116895 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18978 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8799 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100652 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114195 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97439 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42174 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29084 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10343 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30428 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11093 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7339 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16491 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50024 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7254 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12679 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->