### PR TITLE
css/css-transitions/transition-base-response-002.html is a unique failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transition-base-response-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transition-base-response-002-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL Transitioning font-size on root affects rem units assert_equals: expected "25px" but got "24px"
+PASS Transitioning font-size on root affects rem units
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transition-base-response-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transition-base-response-002.html
@@ -6,9 +6,9 @@
 <style>
   :root {
     font-size: 20px;
-    transition: font-size steps(2, start) 10s;
   }
   :root.change {
+    transition: font-size steps(2, start) 10s;
     font-size: 30px;
   }
 


### PR DESCRIPTION
#### b950a86d454a2f4913770bafad3ee882cd6d7a99
<pre>
css/css-transitions/transition-base-response-002.html is a unique failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=235135">https://bugs.webkit.org/show_bug.cgi?id=235135</a>
rdar://problem/87785135

Reviewed by Antti Koivisto.

The goal of this test is to check that a transition for the `font-size` on the `:root` is
accounted for when resolving `rem` units on child elements.

However, this test failed in WebKit because it loads scripts in a blocking way prior to
parsing the `&lt;style&gt;` element containing this rule:

    :root {
        font-size: 20px;
        transition: font-size steps(2, start) 10s;
    }

What may happen though is that before we get to parsing this `&lt;style&gt;` element the `:root`
styles may be resolved and the default `font-size` is computed (to 16px in WebKit). Then,
when the `&lt;style&gt;` element is parsed and styles are resolved due to the first line of the
test:

    let unused = getComputedStyle(document.documentElement).getPropertyValue(&apos;font-size&apos;);

… we start a transition from the previously resolved value of 16px to the newly specified
value of 20px in the `&lt;style&gt;` element. This is clearly not the intention of the test, and
yet that is an acceptable behavior because what constitutes a &quot;style change event&quot; is not
specified by CSS Transitions (<a href="https://drafts.csswg.org/css-transitions/#style-change-event)">https://drafts.csswg.org/css-transitions/#style-change-event)</a>:

    Since this specification does not define when a style change event occurs, and thus what
    changes to computed values are considered simultaneous, authors should be aware that
    changing any of the transition properties a small amount of time after making a change
    that might transition can result in behavior that varies between implementations, since
    the changes might be considered simultaneous in some implementations but not others.

So we update this test to be more explicit about when the transition may start by setting the
`transition` property only in the `:root.changed` rule which is set by the test and sandwiched
between two explicit style recomputations on the first and third lines:

    let unused = getComputedStyle(document.documentElement).getPropertyValue(&apos;font-size&apos;);
    document.documentElement.className = &apos;change&apos;;
    assert_equals(getComputedStyle(target1).getPropertyValue(&apos;width&apos;), &apos;25px&apos;);

As a result of this change, Chrome, Firefox and Safari all pass the test reliably.

* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transition-base-response-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transition-base-response-002.html:

Canonical link: <a href="https://commits.webkit.org/260506@main">https://commits.webkit.org/260506@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/119d1d1d09bf37a445d5ff01b844c0c89d238fbb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108435 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17530 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41286 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117540 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116900 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18983 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8807 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100659 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114203 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14224 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97443 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42179 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96202 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29088 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10348 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30432 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11100 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7347 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16496 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50028 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12686 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3955 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->