### PR TITLE
[Multicolumn] Margins incorrectly accounted for before forced breaks

### DIFF
--- a/LayoutTests/fast/multicol/margin-bottom-and-break-after-expected.txt
+++ b/LayoutTests/fast/multicol/margin-bottom-and-break-after-expected.txt
@@ -1,0 +1,8 @@
+A block that follows a block with -webkit-column-break-after:always; should be positioned at the *top* of the *next* column. Margins may need to be ignored to achieve this.
+
+PASS child.offsetLeft + child.offsetWidth is mc.offsetLeft + mc.offsetWidth
+PASS child.offsetTop is mc.offsetTop
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/multicol/margin-bottom-and-break-after.html
+++ b/LayoutTests/fast/multicol/margin-bottom-and-break-after.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<p>A block that follows a block with -webkit-column-break-after:always; should be positioned at the
+    *top* of the *next* column. Margins may need to be ignored to achieve this.</p>
+<div id="mc" style="-webkit-column-count:2; column-fill:auto; width:100px; height:200px;">
+    <div style="height:150px; margin-bottom:150px; -webkit-column-break-after:always;"></div>
+    <div id="child" style="height:100px;"></div>
+</div>
+<div id="console"></div>
+<script src="../../resources/js-test.js"></script>
+<script>
+    var mc = document.getElementById('mc');
+    var child = document.getElementById('child');
+    shouldBe("child.offsetLeft + child.offsetWidth", "mc.offsetLeft + mc.offsetWidth");
+    shouldBe("child.offsetTop", "mc.offsetTop");
+</script>

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -3,7 +3,7 @@
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2007 David Smith (catfish.man@gmail.com)
  * Copyright (C) 2003-2023 Apple Inc. All rights reserved.
- * Copyright (C) 2014 Google Inc. All rights reserved.
+ * Copyright (C) 2014-2015 Google Inc. All rights reserved.
  * Copyright (C) Research In Motion Limited 2010. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -1707,7 +1707,6 @@ LayoutUnit RenderBlockFlow::applyAfterBreak(RenderBox& child, LayoutUnit logical
     bool checkAfterAlways = (checkColumnBreaks && child.style().breakAfter() == BreakBetween::Column)
         || (checkPageBreaks && alwaysPageBreak(child.style().breakAfter()));
     if (checkAfterAlways && inNormalFlow(child) && hasNextPage(logicalOffset, IncludePageBoundary)) {
-        LayoutUnit marginOffset = marginInfo.canCollapseWithMarginBefore() ? 0_lu : marginInfo.margin();
 
         // So our margin doesn't participate in the next collapsing steps.
         marginInfo.clearMargin();
@@ -1718,8 +1717,8 @@ LayoutUnit RenderBlockFlow::applyAfterBreak(RenderBox& child, LayoutUnit logical
         }
         if (checkFragmentBreaks) {
             LayoutUnit offsetBreakAdjustment;
-            if (fragmentedFlow->addForcedFragmentBreak(this, offsetFromLogicalTopOfFirstPage() + logicalOffset + marginOffset, &child, false, &offsetBreakAdjustment))
-                return logicalOffset + marginOffset + offsetBreakAdjustment;
+            if (fragmentedFlow->addForcedFragmentBreak(this, offsetFromLogicalTopOfFirstPage() + logicalOffset, &child, false, &offsetBreakAdjustment))
+                return logicalOffset + offsetBreakAdjustment;
         }
         return nextPageLogicalTop(logicalOffset, IncludePageBoundary);
     }


### PR DESCRIPTION
#### e75a5cd7e299cc3e318f0f720ff991856c201155
<pre>
[Multicolumn] Margins incorrectly accounted for before forced breaks

<a href="https://bugs.webkit.org/show_bug.cgi?id=252507">https://bugs.webkit.org/show_bug.cgi?id=252507</a>

Reviewed by Alan Baradlay.

This patch is to align WebKit with Gecko / Firefox and Blink / Chromium.

Merge - <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=188456

The spec [1] basically says that margins should be ignored at column boundaries,
although it&apos;s explicitly ambiguous about what should happen to top margins
after a forced break. This CL is solely about margins before a break, though,
and they should all be set to 0, so that contents that follow start at the top
of the next column, instead of leaving one column blank and skipping to the
next one after that.

[1] <a href="https://www.w3.org/TR/CSS2/page.html#allowed-page-breaks">https://www.w3.org/TR/CSS2/page.html#allowed-page-breaks</a>

* Source/WebCore/rendering/RenderBlockFlow.cpp:
(RenderBlockFlow::applyAfterBreak): Remove &quot;marginOffset&quot; usecase
* LayoutTests/fast/multicol/margin-bottom-and-break-after.html: Add Test Case
* LayoutTests/fast/multicol/margin-bottom-and-break-after-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/260510@main">https://commits.webkit.org/260510@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f9e9d9ec28d69bb80223d6712bf7b9dae6cbb2b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108442 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17538 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41292 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117547 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116906 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112329 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18989 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8814 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100667 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114210 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14235 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97447 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42184 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96213 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29092 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10355 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30436 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11107 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7349 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16502 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50032 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7264 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12693 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->