### PR TITLE
[GTK] gdk_memory_texture_new: assertion 'width > 0' failed in cairoSurfaceToGdkTexture

### DIFF
--- a/Source/WebCore/platform/graphics/gtk/GdkCairoUtilities.cpp
+++ b/Source/WebCore/platform/graphics/gtk/GdkCairoUtilities.cpp
@@ -48,6 +48,8 @@ GRefPtr<GdkTexture> cairoSurfaceToGdkTexture(cairo_surface_t* surface)
     ASSERT(cairo_image_surface_get_format(surface) == CAIRO_FORMAT_ARGB32);
     auto width = cairo_image_surface_get_width(surface);
     auto height = cairo_image_surface_get_height(surface);
+    if (width <= 0 || height <= 0)
+        return nullptr;
     auto stride = cairo_image_surface_get_stride(surface);
     auto* data = cairo_image_surface_get_data(surface);
     GRefPtr<GBytes> bytes = adoptGRef(g_bytes_new_with_free_func(data, height * stride, [](gpointer data) {

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -5041,7 +5041,12 @@ cairo_surface_t* webkit_web_view_get_snapshot_finish(WebKitWebView* webView, GAs
 
 #if USE(GTK4)
     auto image = adoptRef(static_cast<cairo_surface_t*>(g_task_propagate_pointer(G_TASK(result), error)));
-    return image ? cairoSurfaceToGdkTexture(image.get()).leakRef() : nullptr;
+    auto texture = image ? cairoSurfaceToGdkTexture(image.get()) : nullptr;
+    if (texture)
+        return texture.leakRef();
+    if (error && !*error)
+        g_set_error_literal(error, WEBKIT_SNAPSHOT_ERROR, WEBKIT_SNAPSHOT_ERROR_FAILED_TO_CREATE, _("There was an error creating the snapshot"));
+    return nullptr;
 #else
     return static_cast<cairo_surface_t*>(g_task_propagate_pointer(G_TASK(result), error));
 #endif


### PR DESCRIPTION
#### 39559cbd2d257dc88ed4d7119f110e7a6268f276
<pre>
[GTK] gdk_memory_texture_new: assertion &apos;width &gt; 0&apos; failed in cairoSurfaceToGdkTexture
<a href="https://bugs.webkit.org/show_bug.cgi?id=252435">https://bugs.webkit.org/show_bug.cgi?id=252435</a>

Reviewed by Carlos Garcia Campos.

If the cairo surface does not have positive width and height, we need to
not attempt to create a GdkTexture, and return a valid error.

* Source/WebCore/platform/graphics/gtk/GdkCairoUtilities.cpp:
(WebCore::cairoSurfaceToGdkTexture):
* Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp:
(webkit_favicon_database_get_favicon_finish):
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:

Canonical link: <a href="https://commits.webkit.org/273907@main">https://commits.webkit.org/273907@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/761024a5898b6f62d2ef2c9b61e60736bc9a0a36

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108449 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17545 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41299 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117554 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116913 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112336 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18996 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8821 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114217 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14231 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97454 "Passed tests") | [⏳ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/API-Tests-WPE-EWS "Waiting to run tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29099 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100674 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96209 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30443 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42202 "Found 1 new test failure: webgl/2.0.y/conformance2/vertex_arrays/vertex-array-object.html (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10362 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7358 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/83902 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11114 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50039 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8391 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16509 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12700 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->