### PR TITLE
Move HTML fast parsing from createFragmentForMarkup() to DocumentFragment::parseHTML()

### DIFF
--- a/Source/WebCore/dom/DocumentFragment.cpp
+++ b/Source/WebCore/dom/DocumentFragment.cpp
@@ -26,8 +26,10 @@
 #include "Document.h"
 #include "ElementIterator.h"
 #include "HTMLDocumentParser.h"
+#include "HTMLDocumentParserFastPath.h"
 #include "Page.h"
 #include "XMLDocumentParser.h"
+#include "markup.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
@@ -85,6 +87,15 @@ Ref<Node> DocumentFragment::cloneNodeInternal(Document& targetDocument, CloningO
 void DocumentFragment::parseHTML(const String& source, Element* contextElement, OptionSet<ParserContentPolicy> parserContentPolicy)
 {
     ASSERT(contextElement);
+    if (tryFastParsingHTMLFragment(source, document(), *this, *contextElement, parserContentPolicy)) {
+#if ASSERT_ENABLED
+        // As a sanity check for the fast-path, create another fragment using the full parser and compare the results.
+        auto referenceFragment = DocumentFragment::create(document());
+        HTMLDocumentParser::parseDocumentFragment(source, referenceFragment, *contextElement, parserContentPolicy);
+        ASSERT(serializeFragment(*this, SerializedNodes::SubtreesOfChildren) == serializeFragment(referenceFragment, SerializedNodes::SubtreesOfChildren));
+#endif
+        return;
+    }
     HTMLDocumentParser::parseDocumentFragment(source, *this, *contextElement, parserContentPolicy);
 }
 

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -56,7 +56,6 @@
 #include "HTMLBRElement.h"
 #include "HTMLBodyElement.h"
 #include "HTMLDivElement.h"
-#include "HTMLDocumentParserFastPath.h"
 #include "HTMLHeadElement.h"
 #include "HTMLHtmlElement.h"
 #include "HTMLImageElement.h"
@@ -1347,16 +1346,7 @@ static ALWAYS_INLINE ExceptionOr<Ref<DocumentFragment>> createFragmentForMarkup(
     auto fragment = mode == DocumentFragmentMode::New ? DocumentFragment::create(document.get()) : document->documentFragmentForInnerOuterHTML();
     ASSERT(!fragment->hasChildNodes());
     if (document->isHTMLDocument()) {
-        bool parsedUsingFastPath = tryFastParsingHTMLFragment(markup, document, fragment, contextElement, parserContentPolicy);
-        if (parsedUsingFastPath) {
-#if ASSERT_ENABLED
-            // As a sanity check for the fast-path, create another fragment using the full parser and compare the results.
-            auto referenceFragment = DocumentFragment::create(document);
-            referenceFragment->parseHTML(markup, &contextElement, parserContentPolicy);
-            ASSERT(serializeFragment(fragment, SerializedNodes::SubtreesOfChildren) == serializeFragment(referenceFragment, SerializedNodes::SubtreesOfChildren));
-#endif
-        } else
-            fragment->parseHTML(markup, &contextElement, parserContentPolicy);
+        fragment->parseHTML(markup, &contextElement, parserContentPolicy);
         return fragment;
     }
 


### PR DESCRIPTION
#### 49be8f24f1f7b14df4a4e708744ed8b50bb53a2c
<pre>
Move HTML fast parsing from createFragmentForMarkup() to DocumentFragment::parseHTML()
<a href="https://bugs.webkit.org/show_bug.cgi?id=252514">https://bugs.webkit.org/show_bug.cgi?id=252514</a>

Reviewed by Ryosuke Niwa.

This change was suggested by Darin when I introduced the HTML fast parsing code
path. I have A/B tested it and it is perf-neutral on Speedometer.

This makes the code look a bit cleaner as the fast parsing logic is now hidden
under DocumentFragment::parseHTML(), making it look like a single code path
for parsing HTML.

* Source/WebCore/dom/DocumentFragment.cpp:
(WebCore::DocumentFragment::parseHTML):
* Source/WebCore/editing/markup.cpp:
(WebCore::createFragmentForMarkup):

Canonical link: <a href="https://commits.webkit.org/260519@main">https://commits.webkit.org/260519@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c383eaaf9f73d65c243fdc02feee55a78b167e4a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108458 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17554 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41308 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117563 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116920 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112345 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19005 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8832 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100684 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114226 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14243 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97462 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42201 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96221 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29107 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/83900 "Found 2 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state-changed, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10370 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30451 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11123 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7367 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16517 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50047 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7268 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12709 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->