### PR TITLE
Clean up WebCore::IDBKeyData

### DIFF
--- a/Source/WTF/wtf/CrossThreadCopier.h
+++ b/Source/WTF/wtf/CrossThreadCopier.h
@@ -220,6 +220,10 @@ template<typename T, typename U> struct CrossThreadCopierBase<false, false, Mark
     }
 };
 
+template<> struct CrossThreadCopierBase<false, false, std::nullptr_t> {
+    static std::nullptr_t copy(std::nullptr_t) { return nullptr; }
+};
+
 // Default specialization for std::variant of CrossThreadCopyable classes.
 template<typename... Types> struct CrossThreadCopierBase<false, false, std::variant<Types...>> {
     using Type = std::variant<Types...>;

--- a/Source/WebCore/Modules/indexeddb/IDBKeyData.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBKeyData.cpp
@@ -33,17 +33,13 @@
 namespace WebCore {
 
 IDBKeyData::IDBKeyData(const IDBKey* key)
-    : m_type(IndexedDB::KeyType::Invalid)
 {
-    if (!key) {
-        m_isNull = true;
+    if (!key)
         return;
-    }
 
-    m_type = key->type();
-
-    switch (m_type) {
+    switch (key->type()) {
     case IndexedDB::KeyType::Invalid:
+        m_value = Invalid { };
         break;
     case IndexedDB::KeyType::Array: {
         m_value = Vector<IDBKeyData>();
@@ -59,7 +55,7 @@ IDBKeyData::IDBKeyData(const IDBKey* key)
         m_value = key->string();
         break;
     case IndexedDB::KeyType::Date:
-        m_value = key->date();
+        m_value = Date { key->date() };
         break;
     case IndexedDB::KeyType::Number:
         m_value = key->number();
@@ -70,12 +66,39 @@ IDBKeyData::IDBKeyData(const IDBKey* key)
     }
 }
 
+IDBKeyData::IDBKeyData(const IDBKeyData& data, IsolatedCopyTag)
+    : m_value(crossThreadCopy(data.m_value)) { }
+
+IndexedDB::KeyType IDBKeyData::type() const
+{
+    switch (m_value.index()) {
+    case WTF::alternativeIndexV<std::nullptr_t, decltype(m_value)>:
+    case WTF::alternativeIndexV<Invalid, decltype(m_value)>:
+        return IndexedDB::KeyType::Invalid;
+    case WTF::alternativeIndexV<Vector<IDBKeyData>, decltype(m_value)>:
+        return IndexedDB::KeyType::Array;
+    case WTF::alternativeIndexV<String, decltype(m_value)>:
+        return IndexedDB::KeyType::String;
+    case WTF::alternativeIndexV<double, decltype(m_value)>:
+        return IndexedDB::KeyType::Number;
+    case WTF::alternativeIndexV<Date, decltype(m_value)>:
+        return IndexedDB::KeyType::Date;
+    case WTF::alternativeIndexV<ThreadSafeDataBuffer, decltype(m_value)>:
+        return IndexedDB::KeyType::Binary;
+    case WTF::alternativeIndexV<Min, decltype(m_value)>:
+        return IndexedDB::KeyType::Min;
+    case WTF::alternativeIndexV<Max, decltype(m_value)>:
+        return IndexedDB::KeyType::Max;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
 RefPtr<IDBKey> IDBKeyData::maybeCreateIDBKey() const
 {
-    if (m_isNull)
+    if (isNull())
         return nullptr;
 
-    switch (m_type) {
+    switch (type()) {
     case IndexedDB::KeyType::Invalid:
         return IDBKey::createInvalid();
     case IndexedDB::KeyType::Array: {
@@ -91,7 +114,7 @@ RefPtr<IDBKey> IDBKeyData::maybeCreateIDBKey() const
     case IndexedDB::KeyType::String:
         return IDBKey::createString(std::get<String>(m_value));
     case IndexedDB::KeyType::Date:
-        return IDBKey::createDate(std::get<double>(m_value));
+        return IDBKey::createDate(std::get<Date>(m_value).value);
     case IndexedDB::KeyType::Number:
         return IDBKey::createNumber(std::get<double>(m_value));
     case IndexedDB::KeyType::Max:
@@ -104,58 +127,20 @@ RefPtr<IDBKey> IDBKeyData::maybeCreateIDBKey() const
     return nullptr;
 }
 
-IDBKeyData::IDBKeyData(const IDBKeyData& that, IsolatedCopyTag)
-{
-    isolatedCopy(that, *this);
-}
-
 IDBKeyData IDBKeyData::isolatedCopy() const
 {
-    return { *this, IsolatedCopy };
-}
-
-void IDBKeyData::isolatedCopy(const IDBKeyData& source, IDBKeyData& destination)
-{
-    destination.m_type = source.m_type;
-    destination.m_isNull = source.m_isNull;
-
-    switch (source.m_type) {
-    case IndexedDB::KeyType::Invalid:
-        return;
-    case IndexedDB::KeyType::Array: {
-        destination.m_value = Vector<IDBKeyData>();
-        auto& destinationArray = std::get<Vector<IDBKeyData>>(destination.m_value);
-        for (auto& key : std::get<Vector<IDBKeyData>>(source.m_value))
-            destinationArray.append(key.isolatedCopy());
-        return;
-    }
-    case IndexedDB::KeyType::Binary:
-        destination.m_value = std::get<ThreadSafeDataBuffer>(source.m_value);
-        return;
-    case IndexedDB::KeyType::String:
-        destination.m_value = std::get<String>(source.m_value).isolatedCopy();
-        return;
-    case IndexedDB::KeyType::Date:
-    case IndexedDB::KeyType::Number:
-        destination.m_value = std::get<double>(source.m_value);
-        return;
-    case IndexedDB::KeyType::Max:
-    case IndexedDB::KeyType::Min:
-        return;
-    }
-
-    ASSERT_NOT_REACHED();
+    return { crossThreadCopy(m_value) };
 }
 
 void IDBKeyData::encode(KeyedEncoder& encoder) const
 {
-    encoder.encodeBool("null"_s, m_isNull);
-    if (m_isNull)
+    encoder.encodeBool("null"_s, isNull());
+    if (isNull())
         return;
 
-    encoder.encodeEnum("type"_s, m_type);
+    encoder.encodeEnum("type"_s, type());
 
-    switch (m_type) {
+    switch (type()) {
     case IndexedDB::KeyType::Invalid:
         return;
     case IndexedDB::KeyType::Array: {
@@ -189,10 +174,11 @@ void IDBKeyData::encode(KeyedEncoder& encoder) const
 
 bool IDBKeyData::decode(KeyedDecoder& decoder, IDBKeyData& result)
 {
-    if (!decoder.decodeBool("null"_s, result.m_isNull))
+    bool isNull;
+    if (!decoder.decodeBool("null"_s, isNull))
         return false;
 
-    if (result.m_isNull)
+    if (isNull)
         return true;
 
     auto enumFunction = [](IndexedDB::KeyType value) {
@@ -205,29 +191,29 @@ bool IDBKeyData::decode(KeyedDecoder& decoder, IDBKeyData& result)
             || value == IndexedDB::KeyType::Number
             || value == IndexedDB::KeyType::Min;
     };
-    if (!decoder.decodeEnum("type"_s, result.m_type, enumFunction))
+    IndexedDB::KeyType type;
+    if (!decoder.decodeEnum("type"_s, type, enumFunction))
         return false;
 
-    if (result.m_type == IndexedDB::KeyType::Invalid)
+    switch (type) {
+    case IndexedDB::KeyType::Invalid:
         return true;
-
-    if (result.m_type == IndexedDB::KeyType::Max)
+    case IndexedDB::KeyType::Max:
+        result.m_value = Max { };
         return true;
-
-    if (result.m_type == IndexedDB::KeyType::Min)
+    case IndexedDB::KeyType::Min:
+        result.m_value = Min { };
         return true;
-
-    if (result.m_type == IndexedDB::KeyType::String) {
+    case IndexedDB::KeyType::String:
         result.m_value = String();
         return decoder.decodeString("string"_s, std::get<String>(result.m_value));
-    }
-
-    if (result.m_type == IndexedDB::KeyType::Number || result.m_type == IndexedDB::KeyType::Date) {
+    case IndexedDB::KeyType::Number:
         result.m_value = 0.0;
         return decoder.decodeDouble("number"_s, std::get<double>(result.m_value));
-    }
-
-    if (result.m_type == IndexedDB::KeyType::Binary) {
+    case IndexedDB::KeyType::Date:
+        result.m_value = Date { };
+        return decoder.decodeDouble("number"_s, std::get<Date>(result.m_value).value);
+    case IndexedDB::KeyType::Binary: {
         result.m_value = ThreadSafeDataBuffer();
 
         bool hasBinaryData;
@@ -244,33 +230,36 @@ bool IDBKeyData::decode(KeyedDecoder& decoder, IDBKeyData& result)
         result.m_value = ThreadSafeDataBuffer::create(WTFMove(bytes));
         return true;
     }
+    case IndexedDB::KeyType::Array:
+        auto arrayFunction = [](KeyedDecoder& decoder, IDBKeyData& result) {
+            return decode(decoder, result);
+        };
 
-    ASSERT(result.m_type == IndexedDB::KeyType::Array);
-
-    auto arrayFunction = [](KeyedDecoder& decoder, IDBKeyData& result) {
-        return decode(decoder, result);
-    };
-    
-    result.m_value = Vector<IDBKeyData>();
-    return decoder.decodeObjects("array"_s, std::get<Vector<IDBKeyData>>(result.m_value), arrayFunction);
+        result.m_value = Vector<IDBKeyData>();
+        return decoder.decodeObjects("array"_s, std::get<Vector<IDBKeyData>>(result.m_value), arrayFunction);
+    }
+    RELEASE_ASSERT_NOT_REACHED();
 }
 
 int IDBKeyData::compare(const IDBKeyData& other) const
 {
-    if (m_type == IndexedDB::KeyType::Invalid) {
-        if (other.m_type != IndexedDB::KeyType::Invalid)
+    auto type = this->type();
+    auto otherType = other.type();
+
+    if (type == IndexedDB::KeyType::Invalid) {
+        if (otherType != IndexedDB::KeyType::Invalid)
             return -1;
-        if (other.m_type == IndexedDB::KeyType::Invalid)
+        if (otherType == IndexedDB::KeyType::Invalid)
             return 0;
-    } else if (other.m_type == IndexedDB::KeyType::Invalid)
+    } else if (otherType == IndexedDB::KeyType::Invalid)
         return 1;
 
-    // The IDBKey::m_type enum is in reverse sort order.
-    if (m_type != other.m_type)
-        return m_type < other.m_type ? 1 : -1;
+    // The IDBKey::type() enum is in reverse sort order.
+    if (type != otherType)
+        return type < otherType ? 1 : -1;
 
     // The types are the same, so handle actual value comparison.
-    switch (m_type) {
+    switch (type) {
     case IndexedDB::KeyType::Invalid:
         // Invalid type should have been fully handled above
         ASSERT_NOT_REACHED();
@@ -292,7 +281,14 @@ int IDBKeyData::compare(const IDBKeyData& other) const
         return compareBinaryKeyData(std::get<ThreadSafeDataBuffer>(m_value), std::get<ThreadSafeDataBuffer>(other.m_value));
     case IndexedDB::KeyType::String:
         return codePointCompare(std::get<String>(m_value), std::get<String>(other.m_value));
-    case IndexedDB::KeyType::Date:
+    case IndexedDB::KeyType::Date: {
+        auto number = std::get<Date>(m_value).value;
+        auto otherNumber = std::get<Date>(other.m_value).value;
+
+        if (number == otherNumber)
+            return 0;
+        return number > otherNumber ? 1 : -1;
+    }
     case IndexedDB::KeyType::Number: {
         auto number = std::get<double>(m_value);
         auto otherNumber = std::get<double>(other.m_value);
@@ -313,12 +309,12 @@ int IDBKeyData::compare(const IDBKeyData& other) const
 #if !LOG_DISABLED
 String IDBKeyData::loggingString() const
 {
-    if (m_isNull)
+    if (isNull())
         return "<null>"_s;
 
     String result;
 
-    switch (m_type) {
+    switch (type()) {
     case IndexedDB::KeyType::Invalid:
         return "<invalid>"_s;
     case IndexedDB::KeyType::Array: {
@@ -362,7 +358,7 @@ String IDBKeyData::loggingString() const
         result = "<string> - " + std::get<String>(m_value);
         break;
     case IndexedDB::KeyType::Date:
-        return makeString("<date> - ", std::get<double>(m_value));
+        return makeString("<date> - ", std::get<Date>(m_value).value);
     case IndexedDB::KeyType::Number:
         return makeString("<number> - ", std::get<double>(m_value));
     case IndexedDB::KeyType::Max:
@@ -380,50 +376,35 @@ String IDBKeyData::loggingString() const
 
 void IDBKeyData::setArrayValue(const Vector<IDBKeyData>& value)
 {
-    *this = IDBKeyData();
     m_value = value;
-    m_type = IndexedDB::KeyType::Array;
-    m_isNull = false;
 }
 
 void IDBKeyData::setBinaryValue(const ThreadSafeDataBuffer& value)
 {
-    *this = IDBKeyData();
     m_value = value;
-    m_type = IndexedDB::KeyType::Binary;
-    m_isNull = false;
 }
 
 void IDBKeyData::setStringValue(const String& value)
 {
-    *this = IDBKeyData();
     m_value = value;
-    m_type = IndexedDB::KeyType::String;
-    m_isNull = false;
 }
 
 void IDBKeyData::setDateValue(double value)
 {
-    *this = IDBKeyData();
-    m_value = value;
-    m_type = IndexedDB::KeyType::Date;
-    m_isNull = false;
+    m_value = Date { value };
 }
 
 void IDBKeyData::setNumberValue(double value)
 {
-    *this = IDBKeyData();
     m_value = value;
-    m_type = IndexedDB::KeyType::Number;
-    m_isNull = false;
 }
 
 bool IDBKeyData::isValid() const
 {
-    if (m_type == IndexedDB::KeyType::Invalid)
+    if (type() == IndexedDB::KeyType::Invalid)
         return false;
     
-    if (m_type == IndexedDB::KeyType::Array) {
+    if (type() == IndexedDB::KeyType::Array) {
         for (auto& key : array()) {
             if (!key.isValid())
                 return false;
@@ -440,16 +421,17 @@ bool IDBKeyData::operator<(const IDBKeyData& rhs) const
 
 bool IDBKeyData::operator==(const IDBKeyData& other) const
 {
-    if (m_type != other.m_type || m_isNull != other.m_isNull || m_isDeletedValue != other.m_isDeletedValue)
+    if (type() != other.type() || isNull() != other.isNull() || m_isDeletedValue != other.m_isDeletedValue)
         return false;
-    switch (m_type) {
+    switch (type()) {
     case IndexedDB::KeyType::Invalid:
     case IndexedDB::KeyType::Max:
     case IndexedDB::KeyType::Min:
         return true;
     case IndexedDB::KeyType::Number:
-    case IndexedDB::KeyType::Date:
         return std::get<double>(m_value) == std::get<double>(other.m_value);
+    case IndexedDB::KeyType::Date:
+        return std::get<Date>(m_value).value == std::get<Date>(other.m_value).value;
     case IndexedDB::KeyType::String:
         return std::get<String>(m_value) == std::get<String>(other.m_value);
     case IndexedDB::KeyType::Binary:
@@ -462,10 +444,10 @@ bool IDBKeyData::operator==(const IDBKeyData& other) const
 
 size_t IDBKeyData::size() const
 {
-    if (m_isNull)
+    if (isNull())
         return 0;
 
-    switch (m_type) {
+    switch (type()) {
     case IndexedDB::KeyType::Invalid:
         return 0;
     case IndexedDB::KeyType::Array: {
@@ -480,6 +462,7 @@ size_t IDBKeyData::size() const
     case IndexedDB::KeyType::String:
         return std::get<String>(m_value).sizeInBytes();
     case IndexedDB::KeyType::Date:
+        return sizeof(Date);
     case IndexedDB::KeyType::Number:
         return sizeof(double);
     case IndexedDB::KeyType::Max:

--- a/Source/WebCore/platform/ThreadSafeDataBuffer.h
+++ b/Source/WebCore/platform/ThreadSafeDataBuffer.h
@@ -72,9 +72,9 @@ public:
         return ThreadSafeDataBuffer(data, length);
     }
 
-    ThreadSafeDataBuffer()
-    {
-    }
+    ThreadSafeDataBuffer() = default;
+
+    ThreadSafeDataBuffer isolatedCopy() const { return *this; }
     
     const Vector<uint8_t>* data() const
     {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -246,10 +246,21 @@ struct WebCore::IDBDatabaseNameAndVersion {
     uint64_t m_resultInteger;
 }
 
-[LegacyPopulateFromEmptyConstructor, CustomMemberLayout] class WebCore::IDBKeyData {
-    [ReturnEarlyIfTrue] bool m_isNull;
-    WebCore::IndexedDB::KeyType m_type;
-    std::variant<Vector<WebCore::IDBKeyData>, String, double, WebCore::ThreadSafeDataBuffer> m_value;
+class WebCore::IDBKeyData {
+    std::variant<std::nullptr_t, WebCore::IDBKeyData::Invalid, Vector<WebCore::IDBKeyData>, String, double, WebCore::IDBKeyData::Date, WebCore::ThreadSafeDataBuffer, WebCore::IDBKeyData::Min, WebCore::IDBKeyData::Max> value()
+}
+
+[Nested] struct WebCore::IDBKeyData::Invalid {
+}
+
+[Nested] struct WebCore::IDBKeyData::Min {
+}
+
+[Nested] struct WebCore::IDBKeyData::Max {
+}
+
+[Nested] struct WebCore::IDBKeyData::Date {
+    double value
 }
 
 enum class WebCore::IndexedDB::KeyType : int8_t {


### PR DESCRIPTION
#### 7d84116a88ef2b79ebf76e99022aa38b78e6e42d
<pre>
Clean up WebCore::IDBKeyData
<a href="https://bugs.webkit.org/show_bug.cgi?id=252515">https://bugs.webkit.org/show_bug.cgi?id=252515</a>
rdar://105620836

Reviewed by Sihui Liu.

m_type and m_isNull were unnecessary and caused the serialization to
need the ReturnEarlyIfTrue attribute which can&apos;t be exposed to the IPC
testing API very well and was only used in two places, so this removes
half of it.  Also reduces memory use.

* Source/WTF/wtf/CrossThreadCopier.h:
* Source/WebCore/Modules/indexeddb/IDBKeyData.cpp:
(WebCore::IDBKeyData::IDBKeyData):
(WebCore::IDBKeyData::type const):
(WebCore::IDBKeyData::maybeCreateIDBKey const):
(WebCore::IDBKeyData::isolatedCopy const):
(WebCore::IDBKeyData::encode const):
(WebCore::IDBKeyData::decode):
(WebCore::IDBKeyData::compare const):
(WebCore::IDBKeyData::loggingString const):
(WebCore::IDBKeyData::setArrayValue):
(WebCore::IDBKeyData::setBinaryValue):
(WebCore::IDBKeyData::setStringValue):
(WebCore::IDBKeyData::setDateValue):
(WebCore::IDBKeyData::setNumberValue):
(WebCore::IDBKeyData::isValid const):
(WebCore::IDBKeyData::operator== const):
(WebCore::IDBKeyData::size const):
(WebCore::IDBKeyData::isolatedCopy): Deleted.
* Source/WebCore/Modules/indexeddb/IDBKeyData.h:
(WebCore::IDBKeyData::Date::isolatedCopy const):
(WebCore::IDBKeyData::Min::isolatedCopy const):
(WebCore::IDBKeyData::Max::isolatedCopy const):
(WebCore::IDBKeyData::IDBKeyData):
(WebCore::IDBKeyData::minimum):
(WebCore::IDBKeyData::maximum):
(WebCore::IDBKeyData::isNull const):
(WebCore::IDBKeyData::string const):
(WebCore::IDBKeyData::date const):
(WebCore::IDBKeyData::number const):
(WebCore::IDBKeyData::binary const):
(WebCore::IDBKeyData::array const):
(WebCore::IDBKeyData::value const):
(WebCore::IDBKeyData::type const): Deleted.
* Source/WebCore/Modules/indexeddb/server/IDBSerialization.cpp:
(WebCore::decodeKey):
* Source/WebCore/platform/ThreadSafeDataBuffer.h:
(WebCore::ThreadSafeDataBuffer::isolatedCopy const):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/260578@main">https://commits.webkit.org/260578@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d03f770b35af1896db51a9b9151d36ac51e1fed4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108712 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17819 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41567 "Built successfully") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/118018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112595 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19266 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9091 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100950 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114480 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97682 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/42429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29320 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/84275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/97842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10617 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30671 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/38/builds/98656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/8738 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11379 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/7597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/38/builds/98656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16766 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50261 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/106270 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12965 "Built successfully") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/26340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3976 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->