### PR TITLE
[JSC] Make WEBASSEMBLY_SIGNALING_MEMORY hard requirement for WebAssembly

### DIFF
--- a/Source/JavaScriptCore/b3/B3WasmBoundsCheckValue.cpp
+++ b/Source/JavaScriptCore/b3/B3WasmBoundsCheckValue.cpp
@@ -50,10 +50,8 @@ WasmBoundsCheckValue::WasmBoundsCheckValue(Origin origin, Value* ptr, unsigned o
     , m_offset(offset)
     , m_boundsType(Type::Maximum)
 {
-#if ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
     size_t redzoneLimit = static_cast<uint64_t>(std::numeric_limits<uint32_t>::max()) + Wasm::Memory::fastMappedRedzoneBytes();
     ASSERT_UNUSED(redzoneLimit, maximum <= redzoneLimit);
-#endif
     m_bounds.maximum = maximum;
 }
 

--- a/Source/JavaScriptCore/runtime/BufferMemoryHandle.h
+++ b/Source/JavaScriptCore/runtime/BufferMemoryHandle.h
@@ -84,10 +84,8 @@ class BufferMemoryManager {
 public:
     friend class LazyNeverDestroyed<BufferMemoryManager>;
 
-#if ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
     BufferMemoryResult tryAllocateFastMemory();
     void freeFastMemory(void* basePtr);
-#endif
 
     BufferMemoryResult tryAllocateGrowableBoundsCheckingMemory(size_t mappedCapacity);
 
@@ -119,10 +117,8 @@ private:
     BufferMemoryManager() = default;
 
     Lock m_lock;
-#if ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
     unsigned m_maxFastMemoryCount { Options::maxNumWebAssemblyFastMemories() };
     Vector<void*> m_fastMemories;
-#endif
     StdSet<std::pair<uintptr_t, size_t>> m_growableBoundsCheckingMemories;
     size_t m_physicalBytes { 0 };
 };
@@ -156,10 +152,8 @@ public:
         m_size.store(size, order);
     }
 
-#if ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
     static size_t fastMappedRedzoneBytes();
     static size_t fastMappedBytes();
-#endif
 
     static void* nullBasePointer();
 

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -464,7 +464,7 @@ static void overrideDefaults()
     Options::usePollingTraps() = true;
 #endif
 
-#if !ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
+#if !ENABLE(WEBASSEMBLY)
     Options::useWebAssemblyFastMemory() = false;
     Options::useWasmFaultSignalHandler() = false;
 #endif
@@ -736,7 +736,7 @@ void Options::notifyOptionsChanged()
     if (Options::verboseVerifyGC())
         Options::verifyGC() = true;
 
-#if ASAN_ENABLED && OS(LINUX) && ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
+#if ASAN_ENABLED && OS(LINUX)
     if (Options::useWasmFaultSignalHandler()) {
         const char* asanOptions = getenv("ASAN_OPTIONS");
         bool okToUseWebAssemblyFastMemory = asanOptions

--- a/Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp
@@ -988,7 +988,6 @@ inline AirIRGenerator64::ExpressionType AirIRGenerator64::emitCheckAndPreparePoi
     }
 
     case MemoryMode::Signaling: {
-#if ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
         // We've virtually mapped 4GiB+redzone for this memory. Only the user-allocated pages are addressable, contiguously in range [0, current],
         // and everything above is mapped PROT_NONE. We don't need to perform any explicit bounds check in the 4GiB range because WebAssembly register
         // memory accesses are 32-bit. However WebAssembly register + offset accesses perform the addition in 64-bit which can push an access above
@@ -1018,7 +1017,6 @@ inline AirIRGenerator64::ExpressionType AirIRGenerator64::emitCheckAndPreparePoi
                 this->emitThrowException(jit, ExceptionType::OutOfBoundsMemoryAccess);
             });
         }
-#endif
         break;
     }
     }

--- a/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
@@ -1797,7 +1797,6 @@ inline Value* B3IRGenerator::emitCheckAndPreparePointer(Value* pointer, uint32_t
     }
 
     case MemoryMode::Signaling: {
-#if ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
         // We've virtually mapped 4GiB+redzone for this memory. Only the user-allocated pages are addressable, contiguously in range [0, current],
         // and everything above is mapped PROT_NONE. We don't need to perform any explicit bounds check in the 4GiB range because WebAssembly register
         // memory accesses are 32-bit. However WebAssembly register + offset accesses perform the addition in 64-bit which can push an access above
@@ -1812,7 +1811,6 @@ inline Value* B3IRGenerator::emitCheckAndPreparePointer(Value* pointer, uint32_t
             size_t maximum = m_info.memory.maximum() ? m_info.memory.maximum().bytes() : std::numeric_limits<uint32_t>::max();
             m_currentBlock->appendNew<WasmBoundsCheckValue>(m_proc, origin(), pointer, sizeOfOperation + offset - 1, maximum);
         }
-#endif
         break;
     }
     }

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -1692,7 +1692,6 @@ public:
             break;
         }
 
-#if ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
         case MemoryMode::Signaling: {
             // We've virtually mapped 4GiB+redzone for this memory. Only the user-allocated pages are addressable, contiguously in range [0, current],
             // and everything above is mapped PROT_NONE. We don't need to perform any explicit bounds check in the 4GiB range because WebAssembly register
@@ -1712,7 +1711,6 @@ public:
             }
             break;
         }
-#endif
         }
 
 #if CPU(ARM64)

--- a/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp
@@ -50,8 +50,6 @@ static constexpr bool verbose = false;
 }
 }
 
-#if ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
-
 static SignalAction trapHandler(Signal signal, SigInfo& sigInfo, PlatformRegisters& context)
 {
     RELEASE_ASSERT(signal == Signal::AccessFault);
@@ -102,11 +100,8 @@ static SignalAction trapHandler(Signal signal, SigInfo& sigInfo, PlatformRegiste
     return SignalAction::NotHandled;
 }
 
-#endif // ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
-
 void activateSignalingMemory()
 {
-#if ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
     static std::once_flag once;
     std::call_once(once, [] {
         if (!Wasm::isSupported())
@@ -117,12 +112,10 @@ void activateSignalingMemory()
 
         activateSignalHandlersFor(Signal::AccessFault);
     });
-#endif // ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
 }
 
 void prepareSignalingMemory()
 {
-#if ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
     static std::once_flag once;
     std::call_once(once, [] {
         if (!Wasm::isSupported())
@@ -135,7 +128,6 @@ void prepareSignalingMemory()
             return trapHandler(signal, sigInfo, ucontext);
         });
     });
-#endif // ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
 }
     
 } } // namespace JSC::Wasm

--- a/Source/JavaScriptCore/wasm/WasmMemory.h
+++ b/Source/JavaScriptCore/wasm/WasmMemory.h
@@ -70,11 +70,9 @@ public:
 
     JS_EXPORT_PRIVATE ~Memory();
 
-#if ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
     static size_t fastMappedRedzoneBytes() { return BufferMemoryHandle::fastMappedRedzoneBytes(); }
     static size_t fastMappedBytes() { return BufferMemoryHandle::fastMappedBytes(); } // Includes redzone.
-#else
-#endif
+
     static bool addressIsInGrowableOrFastMemory(void*);
 
     void* basePointer() const { return m_handle->memory(); }

--- a/Source/WTF/wtf/PlatformEnable.h
+++ b/Source/WTF/wtf/PlatformEnable.h
@@ -736,10 +736,6 @@
 #define ENABLE_SAMPLING_PROFILER 1
 #endif
 
-#if ENABLE(WEBASSEMBLY) && HAVE(MACHINE_CONTEXT)
-#define ENABLE_WEBASSEMBLY_SIGNALING_MEMORY 1
-#endif
-
 /* Counts uses of write barriers using sampling counters. Be sure to also
    set ENABLE_SAMPLING_COUNTERS to 1. */
 #if !defined(ENABLE_WRITE_BARRIER_PROFILING)


### PR DESCRIPTION
#### cdbf645e4854f058e82651b196fbafc73e4cb6e1
<pre>
[JSC] Make WEBASSEMBLY_SIGNALING_MEMORY hard requirement for WebAssembly
<a href="https://bugs.webkit.org/show_bug.cgi?id=252517">https://bugs.webkit.org/show_bug.cgi?id=252517</a>
rdar://105621940

Reviewed by Mark Lam.

Now, all wasm platforms have signaling memory implementation. And signaling memory
is part of wasm shared memory. Thus, we should make this mandatory for wasm implementation.
This patch makes WEBASSEMBLY_SIGNALING_MEMORY hard requirement for wasm. And remove WEBASSEMBLY_SIGNALING_MEMORY
flag.

* Source/JavaScriptCore/b3/B3WasmBoundsCheckValue.cpp:
(JSC::B3::WasmBoundsCheckValue::WasmBoundsCheckValue):
* Source/JavaScriptCore/runtime/BufferMemoryHandle.cpp:
(JSC::BufferMemoryHandle::fastMappedBytes):
(JSC::BufferMemoryManager::freeFastMemory):
(JSC::BufferMemoryManager::isInGrowableOrFastMemory):
(JSC::BufferMemoryManager::dump const):
(JSC::BufferMemoryHandle::BufferMemoryHandle):
(JSC::BufferMemoryHandle::~BufferMemoryHandle):
* Source/JavaScriptCore/runtime/BufferMemoryHandle.h:
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::overrideDefaults):
(JSC::Options::notifyOptionsChanged):
* Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp:
(JSC::Wasm::AirIRGenerator64::emitCheckAndPreparePointer):
* Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp:
(JSC::Wasm::B3IRGenerator::emitCheckAndPreparePointer):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJIT::emitCheckAndPreparePointer):
* Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp:
(JSC::Wasm::activateSignalingMemory):
(JSC::Wasm::prepareSignalingMemory):
* Source/JavaScriptCore/wasm/WasmMemory.cpp:
(JSC::Wasm::Memory::tryCreate):
(JSC::Wasm::Memory::growShared):
(JSC::Wasm::Memory::grow):
* Source/JavaScriptCore/wasm/WasmMemory.h:
* Source/WTF/wtf/PlatformEnable.h:

Canonical link: <a href="https://commits.webkit.org/260502@main">https://commits.webkit.org/260502@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84e909e3d0216543fb1e52fd717eb24edec7e063

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108485 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17581 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41334 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117590 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/117796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19032 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8859 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100711 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114252 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97486 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42228 "Found 2 new test failures: webgl/2.0.y/conformance2/renderbuffers/multisampled-depth-renderbuffer-initialization.html, webgl/2.0.y/conformance2/vertex_arrays/vertex-array-object.html (failure)") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29127 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/97631 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10393 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30475 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/38/builds/98469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/8512 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11149 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7388 "Passed tests") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/38/builds/98469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16539 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50071 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/106055 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12736 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26251 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3954 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->