### PR TITLE
Fix TestWGSLAPI test failures after 260433@main

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WGSL/MetalGenerationTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/MetalGenerationTests.cpp
@@ -73,7 +73,7 @@ fn main(@builtin(position) position : vec4<f32>,
         @builtin(sample_index) sample_index : u32,
         @builtin(sample_mask) sample_mask : u32) {
     let foo : vec4<f32> = position;
-    let bar : u32 = (sample_index + sample_mask);
+    let bar : u32 = (sample_index - sample_mask);
 })"_s, "main"_s);
 
     EXPECT_TRUE(mslSource.has_value());
@@ -84,7 +84,7 @@ using namespace metal;
 [[fragment]] void function0(unsigned parameter0 [[sample_mask]], unsigned parameter1 [[sample_id]], vec<float, 4> parameter2 [[position]])
 {
     vec<float, 4> local0 = parameter2;
-    unsigned local1 = parameter1 + parameter0;
+    unsigned local1 = parameter1 - parameter0;
 }
 
 )"_s);


### PR DESCRIPTION
#### d83e8c14cfc25cf075b58e918005db6fc726d6a0
<pre>
Fix TestWGSLAPI test failures after 260433@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=252522">https://bugs.webkit.org/show_bug.cgi?id=252522</a>
rdar://problem/105623109

Unreviewed build fix.

Switch from &apos;+&apos; to &apos;-&apos; to avoid bug in operator overload checking.

* Tools/TestWebKitAPI/Tests/WGSL/MetalGenerationTests.cpp:
(TestWGSLAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/260492@main">https://commits.webkit.org/260492@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5787fcc006591b6763b6356cfeafadec07dcca00

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/108480 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/17576 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41329 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117585 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/117793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/112366 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19027 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8854 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/100706 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/114248 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/97482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/100706 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/29124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/100706 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/10389 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/30471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11144 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/7383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/16535 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/50067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/12731 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3947 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->