### PR TITLE
[WGSL] Fix overload resolution for addition

### DIFF
--- a/Source/WebGPU/WGSL/generator/main.js
+++ b/Source/WebGPU/WGSL/generator/main.js
@@ -15,6 +15,7 @@ class ConstrainedVariable {
 
     dump(out, counter) {
         out.line(`TypeVariable ${this.variable.name} { ${counter.typeId()}, TypeVariable::${this.constraint} };`)
+        out.line(`candidate.typeVariables.append(${this.variable.name});`)
     }
 }
 
@@ -29,6 +30,7 @@ class TypeVariable {
 
     dump(out, counter) {
         out.line(`TypeVariable ${this.name} { ${counter.typeId()} };`)
+        out.line(`candidate.typeVariables.append(${this.name});`)
     }
 
     toCpp() {
@@ -47,6 +49,8 @@ class NumericVariable {
 
     dump(out, counter) {
         out.line(`NumericVariable ${this.name} { ${counter.numericId()} };`)
+        out.line(`candidate.numericVariables.append(${this.name});`)
+
     }
 
     toCpp() {
@@ -70,7 +74,8 @@ class AbstractType {
 }
 
 class FunctionType {
-    constructor(variables, parameters, result) {
+    constructor(name, variables, parameters, result) {
+        this.name = name
         this.variables = variables
         this.parameters = parameters
         this.result = result
@@ -89,7 +94,7 @@ class FunctionType {
 
         out.line('([&]() -> OverloadCandidate {')
         out.indent(() => {
-            out.line(`// #{name} :: ${this.toString()}`)
+            out.line(`// ${this.toString()}`)
             out.line('OverloadCandidate candidate;')
             this.variables.forEach(v => v.dump(out, counter))
             this.parameters.forEach(p => {
@@ -144,7 +149,7 @@ class DSL {
 
         // helpers
         this.context.type = (name, variables, parameters, result) => {
-            const type = new FunctionType(variables, parameters, result)
+            const type = new FunctionType(name, variables, parameters, result)
             let declarations = this.declarations[name]
             if (!declarations)
                 declarations = this.declarations[name] = []

--- a/Tools/TestWebKitAPI/Tests/WGSL/MetalGenerationTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/MetalGenerationTests.cpp
@@ -73,7 +73,7 @@ fn main(@builtin(position) position : vec4<f32>,
         @builtin(sample_index) sample_index : u32,
         @builtin(sample_mask) sample_mask : u32) {
     let foo : vec4<f32> = position;
-    let bar : u32 = (sample_index - sample_mask);
+    let bar : u32 = (sample_index + sample_mask);
 })"_s, "main"_s);
 
     EXPECT_TRUE(mslSource.has_value());
@@ -84,7 +84,7 @@ using namespace metal;
 [[fragment]] void function0(unsigned parameter0 [[sample_mask]], unsigned parameter1 [[sample_id]], vec<float, 4> parameter2 [[position]])
 {
     vec<float, 4> local0 = parameter2;
-    unsigned local1 = parameter1 - parameter0;
+    unsigned local1 = parameter1 + parameter0;
 }
 
 )"_s);


### PR DESCRIPTION
#### 1ebcb3a273397522bcd8d856e3dfa3a81c2e9b67
<pre>
[WGSL] Fix overload resolution for addition
<a href="https://bugs.webkit.org/show_bug.cgi?id=252524">https://bugs.webkit.org/show_bug.cgi?id=252524</a>
rdar://105624218

Reviewed by Tadeu Zagallo.

The generator for TypeDeclarations.h required some care and feeding to correctly
initialize typeVariable and numericVariables fields of candidate.

Also added name to FunctionType and cleaned up the comment generation to not
print `// #{name} :: undefined`.

* Source/WebGPU/WGSL/generator/main.js:
(ConstrainedVariable.prototype.dump):
(ConstrainedVariable):
(TypeVariable.prototype.dump):
(NumericVariable.prototype.dump):
(FunctionType):
(FunctionType.prototype.dump):
(prototype.toString): Deleted.
(prototype.dump): Deleted.
(prototype.toCpp): Deleted.
* Tools/TestWebKitAPI/Tests/WGSL/MetalGenerationTests.cpp:
(TestWGSLAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/260588@main">https://commits.webkit.org/260588@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/997ed9ebc90662fc432df256359894611d519afe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108486 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17582 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41335 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117591 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/117797 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112372 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19033 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8860 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100712 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114253 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14265 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97487 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42224 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96243 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29128 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/83934 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10394 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30476 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11150 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7389 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16540 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50072 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7319 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12737 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->