### PR TITLE
Add dataStoreIdentifier getter to WKNotificationRef

### DIFF
--- a/Source/WebKit/UIProcess/API/C/WKNotification.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKNotification.cpp
@@ -89,6 +89,12 @@ uint64_t WKNotificationGetID(WKNotificationRef notification)
     return toImpl(notification)->notificationID();
 }
 
+WKStringRef WKNotificationCopyDataStoreIdentifier(WKNotificationRef notification)
+{
+    auto identifier = toImpl(notification)->dataStoreIdentifier();
+    return identifier ? toCopiedAPI(identifier->toString()) : nullptr;
+}
+
 WKDataRef WKNotificationCopyCoreIDForTesting(WKNotificationRef notification)
 {
     auto identifier = toImpl(notification)->coreNotificationID();

--- a/Source/WebKit/UIProcess/API/C/WKNotification.h
+++ b/Source/WebKit/UIProcess/API/C/WKNotification.h
@@ -42,6 +42,7 @@ WK_EXPORT WKStringRef WKNotificationCopyLang(WKNotificationRef notification);
 WK_EXPORT WKStringRef WKNotificationCopyDir(WKNotificationRef notification);
 WK_EXPORT WKSecurityOriginRef WKNotificationGetSecurityOrigin(WKNotificationRef notification);
 WK_EXPORT uint64_t WKNotificationGetID(WKNotificationRef notification);
+WK_EXPORT WKStringRef WKNotificationCopyDataStoreIdentifier(WKNotificationRef notification);
 WK_EXPORT WKDataRef WKNotificationCopyCoreIDForTesting(WKNotificationRef notification);
 WK_EXPORT bool WKNotificationGetIsPersistent(WKNotificationRef notification);
 

--- a/Source/WebKit/UIProcess/Notifications/WebNotification.cpp
+++ b/Source/WebKit/UIProcess/Notifications/WebNotification.cpp
@@ -31,10 +31,11 @@
 
 namespace WebKit {
 
-WebNotification::WebNotification(const WebCore::NotificationData& data, WebPageProxyIdentifier pageIdentifier, IPC::Connection& sourceConnection)
+WebNotification::WebNotification(const WebCore::NotificationData& data, WebPageProxyIdentifier pageIdentifier, const std::optional<UUID>& dataStoreIdentifier, IPC::Connection& sourceConnection)
     : m_data(data)
     , m_origin(API::SecurityOrigin::createFromString(data.originString))
     , m_pageIdentifier(pageIdentifier)
+    , m_dataStoreIdentifier(dataStoreIdentifier)
     , m_sourceConnection(sourceConnection)
 {
 }

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp
@@ -108,7 +108,20 @@ void WebNotificationManagerProxy::show(WebPageProxy* webPage, IPC::Connection& c
 {
     LOG(Notifications, "WebPageProxy (%p) asking to show notification (%s)", webPage, notificationData.notificationID.toString().utf8().data());
 
-    auto notification = WebNotification::create(notificationData, identifierForPagePointer(webPage), connection);
+    auto notification = WebNotification::createNonPersistent(notificationData, identifierForPagePointer(webPage), connection);
+    showImpl(webPage, WTFMove(notification), WTFMove(notificationResources));
+}
+
+void WebNotificationManagerProxy::show(const WebsiteDataStore& dataStore, IPC::Connection& connection, const WebCore::NotificationData& notificationData, RefPtr<WebCore::NotificationResources>&& notificationResources)
+{
+    LOG(Notifications, "WebsiteDataStore (%p) asking to show notification (%s)", &dataStore, notificationData.notificationID.toString().utf8().data());
+
+    auto notification = WebNotification::createPersistent(notificationData, dataStore.configuration().identifier(), connection);
+    showImpl(nullptr, WTFMove(notification), WTFMove(notificationResources));
+}
+
+void WebNotificationManagerProxy::showImpl(WebPageProxy* webPage, Ref<WebNotification>&& notification, RefPtr<WebCore::NotificationResources>&& notificationResources)
+{
     m_globalNotificationMap.set(notification->notificationID(), notification->coreNotificationID());
     m_notifications.set(notification->coreNotificationID(), notification);
     m_provider->show(webPage, notification.get(), WTFMove(notificationResources));

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.h
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.h
@@ -51,6 +51,7 @@ namespace WebKit {
 class WebNotification;
 class WebPageProxy;
 class WebProcessPool;
+class WebsiteDataStore;
 
 class WebNotificationManagerProxy : public API::ObjectImpl<API::Object::Type::NotificationManager>, public WebContextSupplement {
 public:
@@ -65,6 +66,7 @@ public:
     HashMap<String, bool> notificationPermissions();
 
     void show(WebPageProxy*, IPC::Connection&, const WebCore::NotificationData&, RefPtr<WebCore::NotificationResources>&&);
+    void show(const WebsiteDataStore&, IPC::Connection&, const WebCore::NotificationData&, RefPtr<WebCore::NotificationResources>&&);
     void cancel(WebPageProxy*, const UUID& pageNotificationID);
     void clearNotifications(WebPageProxy*);
     void clearNotifications(WebPageProxy*, const Vector<UUID>& pageNotificationIDs);
@@ -89,6 +91,8 @@ private:
     void processPoolDestroyed() override;
     void refWebContextSupplement() override;
     void derefWebContextSupplement() override;
+
+    void showImpl(WebPageProxy*, Ref<WebNotification>&&, RefPtr<WebCore::NotificationResources>&&);
 
     std::unique_ptr<API::NotificationProvider> m_provider;
 

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -2249,7 +2249,7 @@ void WebsiteDataStore::showServiceWorkerNotification(IPC::Connection& connection
     if (m_client->showNotification(notificationData))
         return;
 
-    WebNotificationManagerProxy::sharedServiceWorkerManager().show(nullptr, connection, notificationData, nullptr);
+    WebNotificationManagerProxy::sharedServiceWorkerManager().show(*this, connection, notificationData, nullptr);
 }
 
 void WebsiteDataStore::cancelServiceWorkerNotification(const UUID& notificationID)

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -330,7 +330,7 @@ public:
     VirtualAuthenticatorManager& virtualAuthenticatorManager();
 #endif
 
-    const WebsiteDataStoreConfiguration& configuration() { return m_configuration.get(); }
+    const WebsiteDataStoreConfiguration& configuration() const { return m_configuration.get(); }
 
     WebsiteDataStoreClient& client() { return m_client.get(); }
     void setClient(UniqueRef<WebsiteDataStoreClient>&& client) { m_client = WTFMove(client); }

--- a/Tools/TestWebKitAPI/TestNotificationProvider.cpp
+++ b/Tools/TestWebKitAPI/TestNotificationProvider.cpp
@@ -133,6 +133,8 @@ void TestNotificationProvider::showWebNotification(WKPageRef page, WKNotificatio
 
     WKRetain(notificationManager);
     m_pendingNotification = std::make_pair(notificationManager, identifier);
+
+    m_lastNotificationDataStoreIdentifier = adoptWK(WKNotificationCopyDataStoreIdentifier(notification));
 }
 
 void TestNotificationProvider::closeWebNotification(WKNotificationRef notification)

--- a/Tools/TestWebKitAPI/TestNotificationProvider.h
+++ b/Tools/TestWebKitAPI/TestNotificationProvider.h
@@ -48,6 +48,7 @@ public:
     void closeWebNotification(WKNotificationRef);
     bool simulateNotificationClick();
     bool simulateNotificationClose();
+    WKStringRef lastNotificationDataStoreIdentifier() const { return m_lastNotificationDataStoreIdentifier.get(); };
 
     bool hasReceivedShowNotification() const { return m_hasReceivedShowNotification; }
     bool hasReceivedCloseNotification() const { return m_hasReceivedCloseNotification; }
@@ -61,6 +62,7 @@ private:
     bool m_hasReceivedShowNotification { false };
     bool m_hasReceivedCloseNotification { false };
     std::pair<WKNotificationManagerRef, uint64_t> m_pendingNotification;
+    WKRetainPtr<WKStringRef> m_lastNotificationDataStoreIdentifier;
 };
 
 }


### PR DESCRIPTION
#### 4d6ca3abbe3be49adfb405146a324b0f5edde083
<pre>
Add dataStoreIdentifier getter to WKNotificationRef
<a href="https://bugs.webkit.org/show_bug.cgi?id=252527">https://bugs.webkit.org/show_bug.cgi?id=252527</a>
rdar://problem/105626458

Reviewed by Brady Eidson.

When we show a persistent notification, we need to tell the embedder the data store identifier that
the notification is associated with. This way the embedder will know which data store to send
notificationclick and notificationclose events to when the notification is eventually clicked or
closed.

To do this, we add a dataStoreIdentifier getter to WebNotification and WKNotificationRef that is
populated when WebNotificationManagerProxy shows a persistent notification.

* Source/WebKit/UIProcess/API/C/WKNotification.cpp:
(WKNotificationCopyDataStoreIdentifier):
* Source/WebKit/UIProcess/API/C/WKNotification.h:
* Source/WebKit/UIProcess/Notifications/WebNotification.cpp:
(WebKit::WebNotification::WebNotification):
* Source/WebKit/UIProcess/Notifications/WebNotification.h:
(WebKit::WebNotification::createNonPersistent):
(WebKit::WebNotification::createPersistent):
(WebKit::WebNotification::dataStoreIdentifier const):
(WebKit::WebNotification::create): Deleted.
* Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp:
(WebKit::WebNotificationManagerProxy::show):
(WebKit::WebNotificationManagerProxy::showImpl):
* Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::showServiceWorkerNotification):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
(WebKit::WebsiteDataStore::configuration const):
(WebKit::WebsiteDataStore::configuration): Deleted.
* Tools/TestWebKitAPI/TestNotificationProvider.cpp:
(TestWebKitAPI::TestNotificationProvider::showWebNotification):
* Tools/TestWebKitAPI/TestNotificationProvider.h:
(TestWebKitAPI::TestNotificationProvider::lastNotificationDataStoreIdentifier const):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:

Canonical link: <a href="https://commits.webkit.org/260540@main">https://commits.webkit.org/260540@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0bd83a6030358398750fe19169134b9716321e7b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108620 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17721 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41474 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117730 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/117931 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112503 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19172 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8998 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100852 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114387 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14371 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97604 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42342 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96347 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29242 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84068 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10529 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30592 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11287 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7507 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16678 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50188 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7289 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12875 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->