### PR TITLE
Add an animation feature category

### DIFF
--- a/Source/WTF/Scripts/GeneratePreferences.rb
+++ b/Source/WTF/Scripts/GeneratePreferences.rb
@@ -260,7 +260,7 @@ class Preferences
   STATUSES = %w{ embedder unstable internal developer testable preview stable mature }
 
   # Corresponds to WebFeatureCategory enum cases.
-  CATEGORIES = %w{ css dom javascript media networking privacy security }
+  CATEGORIES = %w{ animation css dom javascript media networking privacy security }
 
   def initializeParsedPreferences(parsedPreferences)
     result = []

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -6190,6 +6190,7 @@ ThirdPartyIframeRedirectBlockingEnabled:
 ThreadedAnimationResolutionEnabled:
   type: bool
   status: unstable
+  category: animation
   humanReadableName: "Threaded animation resolution"
   humanReadableDescription: "Run accelerated animations on a separate thread"
   condition: ENABLE(THREADED_ANIMATION_RESOLUTION)
@@ -6786,7 +6787,7 @@ WebAPIsInShadowRealmEnabled:
 WebAnimationsCompositeOperationsEnabled:
   type: bool
   status: stable
-  category: dom
+  category: animation
   humanReadableName: "Web Animations composite operations"
   humanReadableDescription: "Support for the CompositeOperation enum and properties consuming it"
   defaultValue:
@@ -6800,7 +6801,7 @@ WebAnimationsCompositeOperationsEnabled:
 WebAnimationsCustomEffectsEnabled:
   type: bool
   status: testable
-  category: dom
+  category: animation
   humanReadableName: "Web Animations custom effects"
   humanReadableDescription: "Support for the CustomEffect interface"
   defaultValue:
@@ -6814,7 +6815,7 @@ WebAnimationsCustomEffectsEnabled:
 WebAnimationsCustomFrameRateEnabled:
   type: bool
   status: testable
-  category: dom
+  category: animation
   humanReadableName: "Web Animations custom frame rate"
   humanReadableDescription: "Support for specifying a custom frame rate for Web Animations"
   defaultValue:
@@ -6828,7 +6829,7 @@ WebAnimationsCustomFrameRateEnabled:
 WebAnimationsIterationCompositeEnabled:
   type: bool
   status: stable
-  category: dom
+  category: animation
   humanReadableName: "Web Animations iteration composite"
   humanReadableDescription: "Support for the KeyframeEffect.iterationComposite property"
   defaultValue:
@@ -6842,7 +6843,7 @@ WebAnimationsIterationCompositeEnabled:
 WebAnimationsMutableTimelinesEnabled:
   type: bool
   status: stable
-  category: dom
+  category: animation
   humanReadableName: "Web Animations mutable timelines"
   humanReadableDescription: "Support for setting the timeline property of an Animation object"
   defaultValue:

--- a/Source/WebKit/UIProcess/API/APIFeatureStatus.h
+++ b/Source/WebKit/UIProcess/API/APIFeatureStatus.h
@@ -47,6 +47,7 @@ enum class FeatureStatus : uint8_t {
 
 enum class FeatureCategory : uint8_t {
     None,
+    Animation,
     CSS,
     DOM,
     Javascript,

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKFeature.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKFeature.mm
@@ -81,6 +81,8 @@
     switch (_wrappedFeature->category()) {
     case API::FeatureCategory::None:
         return WebFeatureCategoryNone;
+    case API::FeatureCategory::Animation:
+        return WebFeatureCategoryAnimation;
     case API::FeatureCategory::CSS:
         return WebFeatureCategoryCSS;
     case API::FeatureCategory::DOM:

--- a/Source/WebKitLegacy/mac/WebView/WebFeature.h
+++ b/Source/WebKitLegacy/mac/WebView/WebFeature.h
@@ -56,6 +56,7 @@ typedef NS_ENUM(NSUInteger, WebFeatureStatus) {
  */
 typedef NS_ENUM(NSUInteger, WebFeatureCategory) {
     WebFeatureCategoryNone,
+    WebFeatureCategoryAnimation,
     WebFeatureCategoryCSS,
     WebFeatureCategoryDOM,
     WebFeatureCategoryJavascript,


### PR DESCRIPTION
#### d2e01c8987f940e48d6d9239a708cb7e07e558be
<pre>
Add an animation feature category
<a href="https://bugs.webkit.org/show_bug.cgi?id=252532">https://bugs.webkit.org/show_bug.cgi?id=252532</a>

Reviewed by Patrick Angle.

* Source/WTF/Scripts/GeneratePreferences.rb:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebKit/UIProcess/API/APIFeatureStatus.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKFeature.mm:
(-[_WKFeature category]):
* Source/WebKitLegacy/mac/WebView/WebFeature.h:

Canonical link: <a href="https://commits.webkit.org/260571@main">https://commits.webkit.org/260571@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1424193a9777d5326d82250dfad4277198d8820

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108502 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17599 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41352 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117608 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/117812 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19050 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8877 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100730 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114269 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14279 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97504 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42241 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96257 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29144 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/83949 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/97648 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10409 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30493 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/98539 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/8529 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11166 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7404 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30954 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16556 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50089 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/106072 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7309 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12754 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26276 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->