### PR TITLE
Remove unused argument to URLWithUserTypedString

### DIFF
--- a/Source/WTF/wtf/cocoa/NSURLExtras.h
+++ b/Source/WTF/wtf/cocoa/NSURLExtras.h
@@ -33,7 +33,7 @@
 namespace WTF {
 
 WTF_EXPORT_PRIVATE NSString *userVisibleString(NSURL *);
-WTF_EXPORT_PRIVATE NSURL *URLWithUserTypedString(NSString *, NSURL *ignored = nil); // Return value of nil means error.
+WTF_EXPORT_PRIVATE NSURL *URLWithUserTypedString(NSString *); // Return value of nil means error.
 WTF_EXPORT_PRIVATE NSURL *URLByRemovingUserInfo(NSURL *);
 WTF_EXPORT_PRIVATE NSString *decodeHostName(NSString *); // Return value of nil means error.
 WTF_EXPORT_PRIVATE NSString *encodeHostName(NSString *); // Return value of nil means error.

--- a/Source/WTF/wtf/cocoa/NSURLExtras.mm
+++ b/Source/WTF/wtf/cocoa/NSURLExtras.mm
@@ -198,7 +198,7 @@ static NSData *dataWithUserTypedString(NSString *string)
     return [NSData dataWithBytesNoCopy:outBytes length:outLength]; // adopts outBytes
 }
 
-NSURL *URLWithUserTypedString(NSString *string, NSURL *)
+NSURL *URLWithUserTypedString(NSString *string)
 {
     if (!string)
         return nil;
@@ -213,7 +213,7 @@ NSURL *URLWithUserTypedString(NSString *string, NSURL *)
         return nil;
 
     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=186057
-    // We should be able to use url.createCFURL instead of using directly CFURL parsing routines.
+    // We should be able to use url.createCFURL instead of directly using CFURL parsing routines.
     NSData *data = dataWithUserTypedString(mappedString);
     if (!data)
         return [NSURL URLWithString:@""];

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
@@ -222,8 +222,8 @@ TEST(WTF_URLExtras, URLExtras_DivisionSign)
     // Selected the division sign as an example of a non-ASCII character that is allowed in host names, since it's a lookalike character.
 
     // Code path similar to the one used when typing in a URL.
-    EXPECT_STREQ("http://site.xn--comothersite-kjb.org", originalDataAsString(WTF::URLWithUserTypedString(@"http://site.com\xC3\xB7othersite.org", nil)));
-    EXPECT_STREQ("http://site.com\xC3\xB7othersite.org", userVisibleString(WTF::URLWithUserTypedString(@"http://site.com\xC3\xB7othersite.org", nil)));
+    EXPECT_STREQ("http://site.xn--comothersite-kjb.org", originalDataAsString(WTF::URLWithUserTypedString(@"http://site.com\xC3\xB7othersite.org")));
+    EXPECT_STREQ("http://site.com\xC3\xB7othersite.org", userVisibleString(WTF::URLWithUserTypedString(@"http://site.com\xC3\xB7othersite.org")));
 
     // Code paths similar to the ones used for URLs found in webpages or HTTP responses.
     EXPECT_STREQ("http://site.com\xC3\xB7othersite.org", originalDataAsString(literalURL("http://site.com\xC3\xB7othersite.org")));
@@ -241,8 +241,8 @@ TEST(WTF, URLExtras_Solidus)
     // Selected full width solidus, which looks like the solidus, which is the character that indicates the end of the host name.
 
     // Code path similar to the one used when typing in a URL.
-    EXPECT_STREQ("http://site.com/othersite.org", originalDataAsString(WTF::URLWithUserTypedString(@"http://site.com\xEF\xBC\x8Fothersite.org", nil)));
-    EXPECT_STREQ("http://site.com/othersite.org", userVisibleString(WTF::URLWithUserTypedString(@"http://site.com\xEF\xBC\x8Fothersite.org", nil)));
+    EXPECT_STREQ("http://site.com/othersite.org", originalDataAsString(WTF::URLWithUserTypedString(@"http://site.com\xEF\xBC\x8Fothersite.org")));
+    EXPECT_STREQ("http://site.com/othersite.org", userVisibleString(WTF::URLWithUserTypedString(@"http://site.com\xEF\xBC\x8Fothersite.org")));
 
     // Code paths similar to the ones used for URLs found in webpages or HTTP responses.
     EXPECT_STREQ("http://site.com\xEF\xBC\x8Fothersite.org", originalDataAsString(literalURL("http://site.com\xEF\xBC\x8Fothersite.org")));
@@ -260,8 +260,8 @@ TEST(WTF_URLExtras, URLExtras_Space)
     // Selected ideographic space, which looks like the ASCII space, which is not allowed unescaped.
 
     // Code path similar to the one used when typing in a URL.
-    EXPECT_STREQ("http://site.com%20othersite.org", originalDataAsString(WTF::URLWithUserTypedString(@"http://site.com\xE3\x80\x80othersite.org", nil)));
-    EXPECT_STREQ("http://site.com%20othersite.org", userVisibleString(WTF::URLWithUserTypedString(@"http://site.com\xE3\x80\x80othersite.org", nil)));
+    EXPECT_STREQ("http://site.com%20othersite.org", originalDataAsString(WTF::URLWithUserTypedString(@"http://site.com\xE3\x80\x80othersite.org")));
+    EXPECT_STREQ("http://site.com%20othersite.org", userVisibleString(WTF::URLWithUserTypedString(@"http://site.com\xE3\x80\x80othersite.org")));
 
     // Code paths similar to the ones used for URLs found in webpages or HTTP responses.
     EXPECT_STREQ("http://site.com\xE3\x80\x80othersite.org", originalDataAsString(literalURL("http://site.com\xE3\x80\x80othersite.org")));
@@ -276,13 +276,13 @@ TEST(WTF_URLExtras, URLExtras_Space)
 
 TEST(WTF_URLExtras, URLExtras_File)
 {
-    EXPECT_STREQ("file:///%E2%98%83", [[WTF::URLWithUserTypedString(@"file:///☃", nil) absoluteString] UTF8String]);
+    EXPECT_STREQ("file:///%E2%98%83", [[WTF::URLWithUserTypedString(@"file:///☃") absoluteString] UTF8String]);
 }
 
 TEST(WTF_URLExtras, URLExtras_ParsingError)
 {
     // Expect IDN failure.
-    NSURL *url = WTF::URLWithUserTypedString(@"http://.com", nil);
+    NSURL *url = WTF::URLWithUserTypedString(@"http://.com");
     EXPECT_TRUE(url == nil);
 
     NSString *encodedHostName = WTF::encodeHostName(@"http://.com");


### PR DESCRIPTION
#### 8e1bd72311a67d1d2e62dfb9c1e4b56798fb88d8
<pre>
Remove unused argument to URLWithUserTypedString
<a href="https://bugs.webkit.org/show_bug.cgi?id=252571">https://bugs.webkit.org/show_bug.cgi?id=252571</a>

URLWithUserTypedString is not used as a callback, and is a private function to WTF.

There is no benefit or need to have a second argument here if it is going to be ignored.

*Source\WTF\wtf\cocoa\NSURLExtras.h:
*Source\WTF\wtf\cocoa\NSURLExtras.mm:
*Tools\TestWebKitAPI\Tests\WTF\cocoa\URLExtras.mm:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e1bd72311a67d1d2e62dfb9c1e4b56798fb88d8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109047 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18127 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41868 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/580 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118314 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112932 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19586 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9429 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101285 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114806 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14680 "Found 2 new test failures: fast/images/text-recognition/ios/show-data-detector-context-menu.html, system-preview/badge.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97918 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42818 "Found 4 new test failures: webgl/2.0.y/conformance/glsl/bugs/character-set.html, webgl/2.0.y/conformance/glsl/misc/fragcolor-fragdata-invariant.html, webgl/2.0.y/conformance/misc/invalid-passed-params.html, webgl/2.0.y/conformance/programs/program-test.html (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96652 "3 api tests failed or timed out") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29568 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84568 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/98082 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10911 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30915 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/98874 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/9003 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11651 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7842 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31020 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17026 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50513 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/106543 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13254 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26406 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->