### PR TITLE
Optimize NSMutableDictionary handling

### DIFF
--- a/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorXPCConnection.mm
+++ b/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorXPCConnection.mm
@@ -175,12 +175,13 @@ void RemoteInspectorXPCConnection::sendMessage(NSString *messageName, NSDictiona
     if (m_closed)
         return;
 
-    auto dictionary = adoptNS([[NSMutableDictionary alloc] init]);
-    [dictionary setObject:messageName forKey:RemoteInspectorXPCConnectionMessageNameKey];
+    NSDictionary *dictionary;
     if (userInfo)
-        [dictionary setObject:userInfo forKey:RemoteInspectorXPCConnectionUserInfoKey];
+        dictionary = @ { RemoteInspectorXPCConnectionMessageNameKey : messageName, RemoteInspectorXPCConnectionUserInfoKey : userInfo };
+    else
+        dictionary = @ { RemoteInspectorXPCConnectionMessageNameKey : messageName };
 
-    auto xpcDictionary = adoptOSObject(_CFXPCCreateXPCMessageWithCFObject((__bridge CFDictionaryRef)dictionary.get()));
+    auto xpcDictionary = adoptOSObject(_CFXPCCreateXPCMessageWithCFObject((__bridge CFDictionaryRef)dictionary));
     ASSERT_WITH_MESSAGE(xpcDictionary && xpc_get_type(xpcDictionary.get()) == XPC_TYPE_DICTIONARY, "Unable to serialize xpc message");
     if (!xpcDictionary)
         return;

--- a/Source/WebCore/Modules/webauthn/WebAuthenticationConstants.h
+++ b/Source/WebCore/Modules/webauthn/WebAuthenticationConstants.h
@@ -78,7 +78,7 @@ enum class ClientDataType : bool {
     Get
 };
 
-constexpr const char LocalAuthenticatorAccessGroup[] = "com.apple.webkit.webauthn";
+// constexpr const char LocalAuthenticatorAccessGroup[] = "com.apple.webkit.webauthn";
 
 // Credential serialization
 constexpr const char privateKeyKey[] = "priv";

--- a/Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.mm
+++ b/Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.mm
@@ -117,8 +117,7 @@ static PKPaymentErrorCode toPKPaymentErrorCode(WebCore::ApplePayErrorCode code)
 
 static NSError *toNSError(const WebCore::ApplePayError& error)
 {
-    auto userInfo = adoptNS([[NSMutableDictionary alloc] init]);
-    [userInfo setObject:error.message() forKey:NSLocalizedDescriptionKey];
+    auto userInfo = adoptNS([[NSMutableDictionary alloc] initWithObjectsAndKeys:error.message(), NSLocalizedDescriptionKey, nil]);
 
     if (auto contactField = error.contactField()) {
         NSString *pkContactField = nil;

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
@@ -212,9 +212,9 @@ void LocalAuthenticator::clearAllCredentials()
     // FIXME<rdar://problem/57171201>: We should guard the method with a first party entitlement once WebAuthn is avaliable for third parties.
     auto query = adoptNS([[NSMutableDictionary alloc] init]);
     [query setDictionary:@{
-        (id)kSecClass: (id)kSecClassKey,
-        (id)kSecAttrAccessGroup: @(LocalAuthenticatorAccessGroup),
-        (id)kSecUseDataProtectionKeychain: @YES
+        (id)kSecClass : (id)kSecClassKey,
+        (id)kSecAttrAccessGroup : @"com.apple.webkit.webauthn" /*WebCore::LocalAuthenticatorAccessGroup */,
+        (id)kSecUseDataProtectionKeychain : @YES
     }];
     updateQueryIfNecessary(query.get());
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalConnection.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalConnection.mm
@@ -168,11 +168,11 @@ void LocalConnection::verifyUser(SecAccessControlRef accessControl, LAContext *c
 RetainPtr<SecKeyRef> LocalConnection::createCredentialPrivateKey(LAContext *context, SecAccessControlRef accessControlRef, const String& secAttrLabel, NSData *secAttrApplicationTag) const
 {
     RetainPtr privateKeyAttributes = @{
-        (id)kSecAttrAccessControl: (id)accessControlRef,
-        (id)kSecAttrIsPermanent: @YES,
-        (id)kSecAttrAccessGroup: @(LocalAuthenticatorAccessGroup),
-        (id)kSecAttrLabel: secAttrLabel,
-        (id)kSecAttrApplicationTag: secAttrApplicationTag,
+        (id)kSecAttrAccessControl : (id)accessControlRef,
+        (id)kSecAttrIsPermanent : @YES,
+        (id)kSecAttrAccessGroup : @"com.apple.webkit.webauthn" /*WebCore::LocalAuthenticatorAccessGroup */,
+        (id)kSecAttrLabel : secAttrLabel,
+        (id)kSecAttrApplicationTag : secAttrApplicationTag,
     };
 
     if (context) {


### PR DESCRIPTION
<pre>
Optimize NSMutableDictionary handling
<a href="https://bugs.webkit.org/enter_bug.cgi">https://bugs.webkit.org/show_bug.cgi?id=#####</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* path/changed.ext:
(function):
(class.function):

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c881b30930d48da554d2bbd0b1888218576b58c9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/113274 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/22407 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42570 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/5047 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121728 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113800 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23775 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10156 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/6267 "Build is in progress. Recent messages:") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/119061 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15206 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100932 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/106372 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97169 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30090 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46720 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/101504 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14707 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31432 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/98973 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/12871 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/15415 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8372 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/103071 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20709 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53502 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/32128 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/17270 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/111124 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/27426 "Passed tests") | 
<!--EWS-Status-Bubble-End-->