### PR TITLE
Prepare MomentumEventDispatcher to be used with UI-side compositing

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp
+++ b/Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp
@@ -188,13 +188,6 @@ void EventDispatcher::wheelEvent(PageIdentifier pageID, const WebWheelEvent& whe
     internalWheelEvent(pageID, wheelEvent, rubberBandableEdges, WheelEventOrigin::UIProcess);
 }
 
-#if ENABLE(MOMENTUM_EVENT_DISPATCHER)
-void EventDispatcher::setScrollingAccelerationCurve(PageIdentifier pageID, std::optional<ScrollingAccelerationCurve> curve)
-{
-    m_momentumEventDispatcher->setScrollingAccelerationCurve(pageID, curve);
-}
-#endif
-
 #if ENABLE(MAC_GESTURE_EVENTS)
 void EventDispatcher::gestureEvent(PageIdentifier pageID, const WebKit::WebGestureEvent& gestureEvent)
 {
@@ -341,5 +334,27 @@ void EventDispatcher::pageScreenDidChange(PageIdentifier pageID, PlatformDisplay
     UNUSED_PARAM(displayID);
 #endif
 }
+
+#if ENABLE(MOMENTUM_EVENT_DISPATCHER)
+void EventDispatcher::setScrollingAccelerationCurve(PageIdentifier pageID, std::optional<ScrollingAccelerationCurve> curve)
+{
+    m_momentumEventDispatcher->setScrollingAccelerationCurve(pageID, curve);
+}
+
+void EventDispatcher::handleSyntheticWheelEvent(WebCore::PageIdentifier pageIdentifier, const WebWheelEvent& event, WebCore::RectEdges<bool> rubberBandableEdges)
+{
+    internalWheelEvent(pageIdentifier, event, rubberBandableEdges, WheelEventOrigin::MomentumEventDispatcher);
+}
+
+#if ENABLE(MOMENTUM_EVENT_DISPATCHER_TEMPORARY_LOGGING)
+void EventDispatcher::flushMomentumEventLoggingSoon()
+{
+    // FIXME: Nothing keeps this alive.
+    queue().dispatchAfter(1_s, [this] {
+        m_momentumEventDispatcher->flushLog();
+    });
+}
+#endif
+#endif // ENABLE(MOMENTUM_EVENT_DISPATCHER)
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/EventDispatcher.h
+++ b/Source/WebKit/WebProcess/WebPage/EventDispatcher.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "MessageReceiver.h"
+#include "MomentumEventDispatcher.h"
 #include "WebEvent.h"
 #include <WebCore/PageIdentifier.h>
 #include <WebCore/PlatformWheelEvent.h>
@@ -61,10 +62,16 @@ class WebWheelEvent;
 class WebTouchEvent;
 #endif
 
-class EventDispatcher final : private IPC::MessageReceiver {
+class EventDispatcher final :
+#if ENABLE(MOMENTUM_EVENT_DISPATCHER)
+    public MomentumEventDispatcher::Client,
+#endif
+    private IPC::MessageReceiver {
 public:
     EventDispatcher();
     ~EventDispatcher();
+
+    enum class WheelEventOrigin : bool { UIProcess, MomentumEventDispatcher };
 
     WorkQueue& queue() { return m_queue.get(); }
 
@@ -81,9 +88,6 @@ public:
     void initializeConnection(IPC::Connection&);
 
     void notifyScrollingTreesDisplayWasRefreshed(WebCore::PlatformDisplayID);
-
-    enum class WheelEventOrigin : bool { UIProcess, MomentumEventDispatcher };
-    void internalWheelEvent(WebCore::PageIdentifier, const WebWheelEvent&, WebCore::RectEdges<bool> rubberBandableEdges, WheelEventOrigin);
 
 private:
     // IPC::MessageReceiver overrides.
@@ -106,6 +110,8 @@ private:
     void dispatchWheelEvent(WebCore::PageIdentifier, const WebWheelEvent&, OptionSet<WebCore::WheelEventProcessingSteps>, WheelEventOrigin);
     void dispatchWheelEventViaMainThread(WebCore::PageIdentifier, const WebWheelEvent&, OptionSet<WebCore::WheelEventProcessingSteps>, WheelEventOrigin);
 
+    void internalWheelEvent(WebCore::PageIdentifier, const WebWheelEvent&, WebCore::RectEdges<bool> rubberBandableEdges, WheelEventOrigin);
+
 #if ENABLE(IOS_TOUCH_EVENTS)
     void dispatchTouchEvents();
 #endif
@@ -121,6 +127,14 @@ private:
 
 #if ENABLE(SCROLLING_THREAD)
     void displayDidRefreshOnScrollingThread(WebCore::PlatformDisplayID);
+#endif
+
+#if ENABLE(MOMENTUM_EVENT_DISPATCHER)
+    // EventDispatcher::Client
+    void handleSyntheticWheelEvent(WebCore::PageIdentifier, const WebWheelEvent&, WebCore::RectEdges<bool> rubberBandableEdges) override;
+#if ENABLE(MOMENTUM_EVENT_DISPATCHER_TEMPORARY_LOGGING)
+    void flushMomentumEventLoggingSoon() override;
+#endif
 #endif
 
     void pageScreenDidChange(WebCore::PageIdentifier, WebCore::PlatformDisplayID, std::optional<unsigned> nominalFramesPerSecond);

--- a/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.h
+++ b/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.h
@@ -48,13 +48,23 @@ using PlatformDisplayID = uint32_t;
 
 namespace WebKit {
 
-class EventDispatcher;
-
 class MomentumEventDispatcher {
     WTF_MAKE_NONCOPYABLE(MomentumEventDispatcher);
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    MomentumEventDispatcher(EventDispatcher&);
+    class Client {
+    friend class MomentumEventDispatcher;
+    public:
+        virtual ~Client() = default;
+
+    private:
+        virtual void handleSyntheticWheelEvent(WebCore::PageIdentifier, const WebWheelEvent&, WebCore::RectEdges<bool> rubberBandableEdges) = 0;
+#if ENABLE(MOMENTUM_EVENT_DISPATCHER_TEMPORARY_LOGGING)
+        virtual void flushMomentumEventLoggingSoon() = 0;
+#endif
+    };
+
+    MomentumEventDispatcher(Client&);
     ~MomentumEventDispatcher();
 
     bool handleWheelEvent(WebCore::PageIdentifier, const WebWheelEvent&, WebCore::RectEdges<bool> rubberBandableEdges);
@@ -64,6 +74,10 @@ public:
     void displayWasRefreshed(WebCore::PlatformDisplayID, const WebCore::DisplayUpdate&);
 
     void pageScreenDidChange(WebCore::PageIdentifier, WebCore::PlatformDisplayID, std::optional<unsigned> nominalFramesPerSecond);
+
+#if ENABLE(MOMENTUM_EVENT_DISPATCHER_TEMPORARY_LOGGING)
+    void flushLog();
+#endif
 
 private:
     void didStartMomentumPhase(WebCore::PageIdentifier, const WebWheelEvent&);
@@ -96,7 +110,6 @@ private:
 
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER_TEMPORARY_LOGGING)
     void pushLogEntry(uint32_t generatedPhase, uint32_t eventPhase);
-    void flushLog();
 
     WebCore::FloatSize m_lastActivePhaseDelta;
 
@@ -158,7 +171,7 @@ private:
 
     HashMap<WebCore::PageIdentifier, DisplayProperties> m_displayProperties;
     HashMap<WebCore::PageIdentifier, std::optional<ScrollingAccelerationCurve>> m_accelerationCurves;
-    EventDispatcher& m_dispatcher;
+    Client& m_client;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### dacbd7c36056647c1867f34236ade6815002e1f1
<pre>
Prepare MomentumEventDispatcher to be used with UI-side compositing
<a href="https://bugs.webkit.org/show_bug.cgi?id=252537">https://bugs.webkit.org/show_bug.cgi?id=252537</a>
rdar://105635572

Reviewed by Tim Horton.

Give MomentumEventDispatcher a Client interface that&apos;s implemented by EventDispatcher.

MomentumEventDispatcher needs public inheritance from IPC::MessageReceiver so we can make a WeakPtr
from it.

* Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp:
(WebKit::EventDispatcher::setScrollingAccelerationCurve):
(WebKit::EventDispatcher::handleSyntheticWheelEvent):
(WebKit::EventDispatcher::flushMomentumEventLoggingSoon):
* Source/WebKit/WebProcess/WebPage/EventDispatcher.h:
* Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp:
(WebKit::MomentumEventDispatcher::MomentumEventDispatcher):
(WebKit::MomentumEventDispatcher::dispatchSyntheticMomentumEvent):
(WebKit::MomentumEventDispatcher::didEndMomentumPhase):
* Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.h:

Canonical link: <a href="https://commits.webkit.org/260522@main">https://commits.webkit.org/260522@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e343e067e8417816797435421d3bb31c0e0b7164

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108538 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17635 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41388 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117644 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/117842 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19086 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8913 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100766 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114305 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14303 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97530 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42271 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96280 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29171 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10445 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30520 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11202 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7430 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16592 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50115 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7269 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12790 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->