### PR TITLE
Refactor marked text paint logic to reduce code duplication

### DIFF
--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -659,7 +659,7 @@ static FloatRoundedRect::Radii radiiForUnderline(const CompositionUnderline&, un
 }
 
 template<typename TextBoxPath>
-void TextBoxPainter<TextBoxPath>::fillCompositionUnderline(float start, float width, const CompositionUnderline& underline, const FloatRoundedRect::Radii&, bool) const
+void TextBoxPainter<TextBoxPath>::fillCompositionUnderline(float start, float width, const CompositionUnderline& underline, const FloatRoundedRect::Radii&) const
 {
     // Thick marked text underlines are 2px thick as long as there is room for the 2px line under the baseline.
     // All other marked text underlines are 1px thick.
@@ -693,15 +693,10 @@ void TextBoxPainter<TextBoxPath>::paintCompositionUnderlines()
     if (!underlineCount)
         return;
 
-    auto hasLiveConversion = false;
-
     auto markedTextStartOffset = underlines[0].startOffset;
     auto markedTextEndOffset = underlines[0].endOffset;
 
     for (const auto& underline : underlines) {
-        if (underline.thick)
-            hasLiveConversion = true;
-
         if (underline.startOffset < markedTextStartOffset)
             markedTextStartOffset = underline.startOffset;
 
@@ -724,7 +719,7 @@ void TextBoxPainter<TextBoxPath>::paintCompositionUnderlines()
         auto underlineRadii = radiiForUnderline(underline, markedTextStartOffset, markedTextEndOffset);
 
         // Underline intersects this run. Paint it.
-        paintCompositionUnderline(underline, underlineRadii, hasLiveConversion);
+        paintCompositionUnderline(underline, underlineRadii);
 
         if (underline.endOffset > textBox().end())
             break; // Underline also runs into the next run. Bail now, no more marker advancement.
@@ -749,7 +744,7 @@ float TextBoxPainter<TextBoxPath>::textPosition()
 }
 
 template<typename TextBoxPath>
-void TextBoxPainter<TextBoxPath>::paintCompositionUnderline(const CompositionUnderline& underline, const FloatRoundedRect::Radii& radii, bool hasLiveConversion)
+void TextBoxPainter<TextBoxPath>::paintCompositionUnderline(const CompositionUnderline& underline, const FloatRoundedRect::Radii& radii)
 {
     float start = 0; // start of line to draw, relative to tx
     float width = m_logicalRect.width(); // how much line to draw
@@ -774,7 +769,7 @@ void TextBoxPainter<TextBoxPath>::paintCompositionUnderline(const CompositionUnd
         mirrorRTLSegment(m_logicalRect.width(), textBox().direction(), start, width);
     }
 
-    fillCompositionUnderline(start, width, underline, radii, hasLiveConversion);
+    fillCompositionUnderline(start, width, underline, radii);
 }
 
 template<typename TextBoxPath>

--- a/Source/WebCore/rendering/TextBoxPainter.h
+++ b/Source/WebCore/rendering/TextBoxPainter.h
@@ -73,8 +73,8 @@ protected:
     TextDecorationPainter createDecorationPainter(const StyledMarkedText&, const FloatRect&);
     void paintBackgroundDecorations(TextDecorationPainter&, const StyledMarkedText&, const FloatRect&);
     void paintForegroundDecorations(TextDecorationPainter&, const StyledMarkedText&, const FloatRect&);
-    void paintCompositionUnderline(const CompositionUnderline&, const FloatRoundedRect::Radii&, bool hasLiveConversion);
-    void fillCompositionUnderline(float start, float width, const CompositionUnderline&, const FloatRoundedRect::Radii&, bool hasLiveConversion) const;
+    void paintCompositionUnderline(const CompositionUnderline&, const FloatRoundedRect::Radii&);
+    void fillCompositionUnderline(float start, float width, const CompositionUnderline&, const FloatRoundedRect::Radii&) const;
     void paintPlatformDocumentMarker(const MarkedText&);
 
     float textPosition();

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -391,6 +391,7 @@ UIProcess/Cocoa/GPUProcessProxyCocoa.mm
 UIProcess/Cocoa/GlobalFindInPageState.mm
 UIProcess/Cocoa/IconLoadingDelegate.mm
 UIProcess/Cocoa/LegacyCustomProtocolManagerClient.mm
+UIProcess/Cocoa/MarkedTextComposition.mm
 UIProcess/Cocoa/MediaUtilities.mm
 UIProcess/Cocoa/MediaPermissionUtilities.mm
 UIProcess/Cocoa/ModalContainerControlClassifier.mm

--- a/Source/WebKit/UIProcess/Cocoa/MarkedTextComposition.h
+++ b/Source/WebKit/UIProcess/Cocoa/MarkedTextComposition.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#import "WKFoundation.h"
+#import <WebCore/CompositionHighlight.h>
+#import <WebCore/CompositionUnderline.h>
+
+namespace WebKit {
+
+using MarkedTextComposition = std::variant<std::monostate, Vector<WebCore::CompositionUnderline>, Vector<WebCore::CompositionHighlight>>;
+
+MarkedTextComposition extractMarkedTextComposition(NSAttributedString *);
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/MarkedTextComposition.mm
+++ b/Source/WebKit/UIProcess/Cocoa/MarkedTextComposition.mm
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "MarkedTextComposition.h"
+
+#import <WebCore/ColorCocoa.h>
+#import <pal/spi/cocoa/NSAttributedStringSPI.h>
+
+namespace WebKit {
+
+enum class MarkedTextCompositionMode : uint8_t {
+    None, Underline, Highlight
+};
+
+template<typename T>
+static bool compositionRangeComparator(const T& a, const T& b)
+{
+    if (a.startOffset < b.startOffset)
+        return true;
+    if (a.startOffset > b.startOffset)
+        return false;
+    return a.endOffset < b.endOffset;
+}
+
+static MarkedTextCompositionMode markedTextCompositionModeForString(NSAttributedString *string)
+{
+    __block MarkedTextCompositionMode mode = MarkedTextCompositionMode::None;
+
+    [string enumerateAttributesInRange:NSMakeRange(0, string.length) options:0 usingBlock:^(NSDictionary<NSAttributedStringKey, id> *attributes, NSRange, BOOL *stop) {
+        BOOL hasUnderlineStyle = !![attributes objectForKey:NSUnderlineStyleAttributeName];
+        BOOL hasUnderlineColor = !![attributes objectForKey:NSUnderlineColorAttributeName];
+
+        BOOL hasBackgroundColor = !![attributes objectForKey:NSBackgroundColorAttributeName];
+        BOOL hasForegroundColor = !![attributes objectForKey:NSForegroundColorAttributeName];
+
+        // Marked text may be represented either as an underline or a highlight; this mode is dictated
+        // by the attributes it has, and therefore having both types of attributes is not allowed.
+        ASSERT(!((hasUnderlineStyle || hasUnderlineColor) && (hasBackgroundColor || hasForegroundColor)));
+
+        if (hasUnderlineStyle || hasUnderlineColor) {
+            mode = MarkedTextCompositionMode::Underline;
+            *stop = YES;
+        } else if (hasBackgroundColor || hasForegroundColor) {
+            mode = MarkedTextCompositionMode::Highlight;
+            *stop = YES;
+        }
+    }];
+
+    return mode;
+}
+
+static Vector<WebCore::CompositionUnderline> extractUnderlines(NSAttributedString *string)
+{
+    __block Vector<WebCore::CompositionUnderline> underlines;
+    [string enumerateAttributesInRange:NSMakeRange(0, string.length) options:0 usingBlock:^(NSDictionary<NSAttributedStringKey, id> *attributes, NSRange range, BOOL *) {
+        NSNumber *style = [attributes objectForKey:NSUnderlineStyleAttributeName];
+        CocoaColor *cocoaColor = [attributes objectForKey:NSUnderlineColorAttributeName];
+        if (!style || !cocoaColor)
+            return;
+
+        WebCore::Color underlineColor = WebCore::colorFromCocoaColor(cocoaColor);
+        underlines.append({ static_cast<unsigned>(range.location), static_cast<unsigned>(NSMaxRange(range)), WebCore::CompositionUnderlineColor::GivenColor, underlineColor, style.intValue > 1 });
+    }];
+
+    if (underlines.isEmpty())
+        return { };
+
+    std::sort(underlines.begin(), underlines.end(), &compositionRangeComparator<WebCore::CompositionUnderline>);
+
+    Vector<WebCore::CompositionUnderline> mergedUnderlines;
+
+    auto firstInactiveUnderlineIndex = underlines.findIf([](auto& underline) {
+        return !underline.thick;
+    });
+
+    if (firstInactiveUnderlineIndex != notFound) {
+        auto& firstInactiveUnderline = underlines[firstInactiveUnderlineIndex];
+        firstInactiveUnderline.startOffset = underlines.first().startOffset;
+        firstInactiveUnderline.endOffset = underlines.last().endOffset;
+        mergedUnderlines.append(firstInactiveUnderline);
+    }
+
+    for (auto& underline : underlines) {
+        if (underline.thick)
+            mergedUnderlines.append(underline);
+    }
+
+    return mergedUnderlines;
+}
+
+static Vector<WebCore::CompositionHighlight> compositionHighlights(NSAttributedString *string)
+{
+    if (!string.length)
+        return { };
+
+    __block Vector<WebCore::CompositionHighlight> highlights;
+    [string enumerateAttributesInRange:NSMakeRange(0, string.length) options:0 usingBlock:^(NSDictionary<NSAttributedStringKey, id> *attributes, NSRange range, BOOL *) {
+        std::optional<WebCore::Color> backgroundHighlightColor;
+        std::optional<WebCore::Color> foregroundHighlightColor;
+
+        if (CocoaColor *backgroundColor = attributes[NSBackgroundColorAttributeName])
+            backgroundHighlightColor = WebCore::colorFromCocoaColor(backgroundColor);
+
+        if (CocoaColor *foregroundColor = attributes[NSForegroundColorAttributeName])
+            foregroundHighlightColor = WebCore::colorFromCocoaColor(foregroundColor);
+
+        highlights.append({ static_cast<unsigned>(range.location), static_cast<unsigned>(NSMaxRange(range)), backgroundHighlightColor, foregroundHighlightColor });
+    }];
+
+    std::sort(highlights.begin(), highlights.end(), &compositionRangeComparator<WebCore::CompositionHighlight>);
+
+    Vector<WebCore::CompositionHighlight> mergedHighlights;
+    mergedHighlights.reserveInitialCapacity(highlights.size());
+    for (auto& highlight : highlights) {
+        if (mergedHighlights.isEmpty() || mergedHighlights.last().backgroundColor != highlight.backgroundColor || mergedHighlights.last().foregroundColor != highlight.foregroundColor)
+            mergedHighlights.append(highlight);
+        else
+            mergedHighlights.last().endOffset = highlight.endOffset;
+    }
+
+    return mergedHighlights;
+}
+
+MarkedTextComposition extractMarkedTextComposition(NSAttributedString *string)
+{
+    if (!string.length)
+        return { };
+
+    auto mode = markedTextCompositionModeForString(string);
+
+    switch (mode) {
+    case MarkedTextCompositionMode::None:
+        return { };
+
+    case MarkedTextCompositionMode::Underline:
+        return extractUnderlines(string);
+
+    case MarkedTextCompositionMode::Highlight:
+        return compositionHighlights(string);
+    }
+}
+
+} // namespace WebKit

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2761,6 +2761,8 @@
 		076E884D1A13CADF005E90FC /* APIContextMenuClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APIContextMenuClient.h; sourceTree = "<group>"; };
 		076E884F1A13CBC6005E90FC /* APIInjectedBundlePageContextMenuClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APIInjectedBundlePageContextMenuClient.h; sourceTree = "<group>"; };
 		077BA570260E8F630072F19F /* MediaSessionCoordinatorProxyPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MediaSessionCoordinatorProxyPrivate.h; sourceTree = "<group>"; };
+		0782D85E29A18C0D0051FD35 /* MarkedTextComposition.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MarkedTextComposition.h; sourceTree = "<group>"; };
+		0782D85F29A18C0D0051FD35 /* MarkedTextComposition.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MarkedTextComposition.mm; sourceTree = "<group>"; };
 		07923130239B3B0C009598E2 /* RemoteMediaPlayerManager.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteMediaPlayerManager.cpp; sourceTree = "<group>"; };
 		07923131239B3B0C009598E2 /* MediaPlayerPrivateRemote.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MediaPlayerPrivateRemote.cpp; sourceTree = "<group>"; };
 		07923132239B3B0C009598E2 /* MediaPlayerPrivateRemote.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MediaPlayerPrivateRemote.h; sourceTree = "<group>"; };
@@ -8203,6 +8205,8 @@
 				7A821F4D1E2F679E00604577 /* LegacyCustomProtocolManagerClient.mm */,
 				A1DF631118E0B7C8003A3E2A /* LegacyDownloadClient.h */,
 				A1DF631018E0B7C8003A3E2A /* LegacyDownloadClient.mm */,
+				0782D85E29A18C0D0051FD35 /* MarkedTextComposition.h */,
+				0782D85F29A18C0D0051FD35 /* MarkedTextComposition.mm */,
 				9342588F2555DCA50059EEDD /* MediaPermissionUtilities.mm */,
 				411286EF21C8A90C003A8550 /* MediaUtilities.h */,
 				411286F021C8A90D003A8550 /* MediaUtilities.mm */,


### PR DESCRIPTION
#### a3ab05dda99ae804dcbc3a5d4d003d42b6c4ec90
<pre>
Refactor marked text paint logic to reduce code duplication
<a href="https://bugs.webkit.org/show_bug.cgi?id=252540">https://bugs.webkit.org/show_bug.cgi?id=252540</a>
rdar://105411314

Reviewed by NOBODY (OOPS!).

This builds upon <a href="https://github.com/WebKit/WebKit/pull/10184">https://github.com/WebKit/WebKit/pull/10184</a> to reduce
code duplication when creating marked text compositions.

* Source/WebCore/rendering/TextBoxPainter.cpp:
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::fillCompositionUnderline const):
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::paintCompositionUnderlines):
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::paintCompositionUnderline):
* Source/WebCore/rendering/TextBoxPainter.h:
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/Cocoa/MarkedTextComposition.h: Added.
* Source/WebKit/UIProcess/Cocoa/MarkedTextComposition.mm: Added.
(WebKit::compositionRangeComparator):
(WebKit::markedTextCompositionModeForString):
(WebKit::extractUnderlines):
(WebKit::compositionHighlights):
(WebKit::extractMarkedTextComposition):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView setMarkedText:selectedRange:]):
(shouldExtractMarkedTextComposition):
(-[WKContentView setAttributedMarkedText:selectedRange:]):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::shouldExtractMarkedTextComposition):
(WebKit::WebViewImpl::setMarkedText):
(WebKit::extractInitialUnderlines): Deleted.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3ab05dda99ae804dcbc3a5d4d003d42b6c4ec90

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108958 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18038 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41782 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/486 "Reverted pull request changes (failure)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118249 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112841 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19494 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9333 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101189 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114714 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14620 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97851 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42741 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96592 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29492 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84500 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10820 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30841 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11568 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7777 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16956 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50437 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13164 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->