### PR TITLE
Replace bridge + CFRetain with CFBridgingRetain

### DIFF
--- a/Source/JavaScriptCore/API/ObjCCallbackFunction.mm
+++ b/Source/JavaScriptCore/API/ObjCCallbackFunction.mm
@@ -728,10 +728,8 @@ JSObjectRef objCCallbackFunctionForMethod(JSContext *context, Class cls, Protoco
     NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:[NSMethodSignature signatureWithObjCTypes:types]];
     [invocation setSelector:sel];
     if (!isInstanceMethod) {
-        [invocation setTarget:cls];
         // We need to retain the target Class because m_invocation doesn't retain it by default (and we don't want it to).
-        // FIXME: What releases it?
-        CFRetain((__bridge CFTypeRef)cls);
+        [invocation setTarget:[cls retain]];
     }
     return objCCallbackFunctionForInvocation(context, invocation, isInstanceMethod ? CallbackInstanceMethod : CallbackClassMethod, isInstanceMethod ? cls : nil, _protocol_getMethodTypeEncoding(protocol, sel, YES, isInstanceMethod));
 }

--- a/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
+++ b/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
@@ -122,7 +122,11 @@ static NSDictionary *attributesForAttributedStringConversion()
     NSURL *baseURL = URL::fakeURLWithRelativePart(emptyString());
 
     // The output base URL needs +1 refcount to work around the fact that NSHTMLReader over-releases it.
+#if !__has_feature(objc_arc)
+    [baseURL retain];
+#else
     CFRetain((__bridge CFTypeRef)baseURL);
+#endif
 
     return @{
         NSExcludedElementsDocumentAttribute: excludedElements.get(),

--- a/Source/WebKitLegacy/mac/DOM/ObjCEventListener.mm
+++ b/Source/WebKitLegacy/mac/DOM/ObjCEventListener.mm
@@ -72,8 +72,8 @@ ObjCEventListener::~ObjCEventListener()
 {
     listenerMap->remove(m_listener.get());
     // Avoid executing arbitrary code during GC; e.g. inside Node::~Node. Use CF* to be ARC safe.
-    CFRetain((__bridge CFTypeRef)m_listener.get());
-    CFAutorelease((__bridge CFTypeRef)m_listener.get());
+    CFTypeRef listener = CFBridgingRetain(m_listener.get());
+    CFAutorelease(listener);
 }
 
 void ObjCEventListener::handleEvent(ScriptExecutionContext&, Event& event)


### PR DESCRIPTION
#### dfa1dc0e94dea1f956f02fd7f0bed2dadd2f392f
<pre>
Replace bridge + CFRetain with CFBridgingRetain
<a href="https://bugs.webkit.org/show_bug.cgi?id=252574">https://bugs.webkit.org/show_bug.cgi?id=252574</a>

Reviewed by NOBODY (OOPS!).

CFBridgingRetain serves this purpose.

* Source/JavaScriptCore/API/ObjCCallbackFunction.mm:
* Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm:
* Source/WebKitLegacy/mac/DOM/ObjCEventListener.mm:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dfa1dc0e94dea1f956f02fd7f0bed2dadd2f392f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1339 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1378 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1422 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2242 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1193 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1324 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1430 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1438 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1345 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1351 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1261 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1230 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2088 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1265 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1215 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1198 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/1172 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1224 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1250 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2321 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/1307 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1291 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1161 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/1373 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1205 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1222 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/284 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1308 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/1377 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/280 "Passed tests") | 
<!--EWS-Status-Bubble-End-->