### PR TITLE
[Wasm-GC] Generate correct LLInt code for structs containing reference types

### DIFF
--- a/JSTests/wasm/gc/bug252538.js
+++ b/JSTests/wasm/gc/bug252538.js
@@ -1,0 +1,65 @@
+//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+
+import * as assert from "../assert.js";
+import { compile, instantiate } from "./wast-wrapper.js";
+
+function module(bytes, valid = true) {
+  let buffer = new ArrayBuffer(bytes.length);
+  let view = new Uint8Array(buffer);
+  for (let i = 0; i < bytes.length; ++i) {
+    view[i] = bytes.charCodeAt(i);
+  }
+  return new WebAssembly.Module(buffer);
+}
+
+function testStructOfInts() {
+
+  let m = instantiate(`
+    (module
+      (type $s (struct (field i32) (field i32) (field i32)))
+
+      (func $new (result (ref $s))
+         (struct.new_canon $s (i32.const 5) (i32.const 17) (i32.const 0)))
+
+      (func (export "get0") (result i32)
+         (struct.get $s 0 (call $new)))
+      (func (export "get1") (result i32)
+         (struct.get $s 1 (call $new)))
+      (func (export "get2") (result i32)
+         (struct.get $s 2 (call $new))))`);
+
+    assert.eq(m.exports.get0(), 5);
+    assert.eq(m.exports.get1(), 17);
+    assert.eq(m.exports.get2(), 0);
+}
+
+function testStructDeclaration() {
+
+  let m = instantiate(`
+    (module
+      (type $a (array i32))
+      (type $s (struct (field (ref $a)) (field (ref $a)) (field (ref $a))))
+
+      (func $new (result (ref $s))
+         (struct.new_canon $s (array.new_canon_default $a (i32.const 5))
+                              (array.new_canon_default $a (i32.const 17))
+                              (array.new_canon_default $a (i32.const 0))))
+
+      (func (export "len0") (result i32)
+         (struct.get $s 0 (call $new))
+         (array.len))
+      (func (export "len1") (result i32)
+         (struct.get $s 1 (call $new))
+         (array.len))
+      (func (export "len2") (result i32)
+         (struct.get $s 2 (call $new))
+         (array.len)))`);
+
+    assert.eq(m.exports.len0(), 5);
+    assert.eq(m.exports.len1(), 17);
+    assert.eq(m.exports.len2(), 0);
+}
+
+// for comparison
+testStructOfInts();
+testStructDeclaration();

--- a/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
+++ b/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
@@ -137,6 +137,7 @@ inline void arraySet(Instance* instance, uint32_t typeIndex, EncodedJSValue arra
     arrayObject->set(vm, index, value);
 }
 
+// structNew() expects the `arguments` array (when used) to be in reverse order
 inline EncodedJSValue structNew(Instance* instance, uint32_t typeIndex, bool useDefault, uint64_t* arguments)
 {
     JSWebAssemblyInstance* jsInstance = instance->owner();
@@ -160,10 +161,12 @@ inline EncodedJSValue structNew(Instance* instance, uint32_t typeIndex, bool use
         }
     } else {
         ASSERT(arguments);
-        for (unsigned i = 0; i < structType.fieldCount(); ++i) {
+        for (unsigned dstIndex = 0; dstIndex < structType.fieldCount(); ++dstIndex) {
             // FIXME: https://bugs.webkit.org/show_bug.cgi?id=246981
-            ASSERT(structType.field(i).type.is<Type>());
-            structValue->set(globalObject, i, toJSValue(globalObject, structType.field(i).type.as<Type>(), arguments[i]));
+            ASSERT(structType.field(dstIndex).type.is<Type>());
+            // Arguments are in reverse order!
+            unsigned srcIndex = structType.fieldCount() - dstIndex - 1;
+            structValue->set(globalObject, dstIndex, toJSValue(globalObject, structType.field(dstIndex).type.as<Type>(), arguments[srcIndex]));
         }
     }
     return JSValue::encode(structValue);


### PR DESCRIPTION
#### 400ec97f086fbbdbc2a4233c5a7a2bb64d721746
<pre>
[Wasm-GC] Generate correct LLInt code for structs containing reference types
<a href="https://bugs.webkit.org/show_bug.cgi?id=252538">https://bugs.webkit.org/show_bug.cgi?id=252538</a>

Reviewed by Justin Michaud.

The LLInt generated code for `addStructNew` only worked if the struct
initializers weren&apos;t on the stack, as it overwrote live stack slots.
Fixed it to not overwrite live data.

* JSTests/wasm/gc/bug252538.js: Added.
(module):
(testStructOfInts):
(testStructDeclaration):
* Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp:
(JSC::Wasm::LLIntGenerator::addStructNew):
* Source/JavaScriptCore/wasm/WasmOperationsInlines.h:
(JSC::Wasm::structNew):

Canonical link: <a href="https://commits.webkit.org/261902@main">https://commits.webkit.org/261902@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/863525474246eb95453623a21ed22841013351b3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112816 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/22004 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1522 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4626 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121350 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23350 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13171 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5797 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118586 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17350 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100599 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105935 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99309 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1137 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46363 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/101114 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14304 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1177 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/12447 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/15006 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10519 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/102639 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20321 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53170 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/32030 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8318 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16855 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/110685 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/27333 "Passed tests") | 
<!--EWS-Status-Bubble-End-->