### PR TITLE
CSS @imports in HTML missing quote marks are mistakenly hidden from the Preload Scanner

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/loading/preloader-css-import-no-quote.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/loading/preloader-css-import-no-quote.tentative-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Imported inline CSS with no quote is not blocked on pending CSS
+

--- a/LayoutTests/imported/w3c/web-platform-tests/loading/preloader-css-import-no-quote.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/loading/preloader-css-import-no-quote.tentative.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+    var t = async_test('Imported inline CSS with no quote is not blocked on pending CSS');
+</script>
+<link rel=stylesheet href="resources/dummy.css?first-preloader-css-import-no-quote&pipe=trickle(d1)">
+<script>
+    var this_script_is_necessary_to_block_the_inline_style_processing = true;
+</script>
+<style>
+@import url(resources/dummy.css?second-preloader-css-import-no-quote);
+</style>
+<script>
+    window.addEventListener("load", t.step_func_done(() => {
+        let entries = performance.getEntriesByType('resource');
+        let first;
+        let second;
+        for (entry of entries) {
+            if (entry.name.includes("first")) {
+                first = entry;
+            }
+            if (entry.name.includes("second")) {
+                second = entry;
+            }
+        }
+        assert_true(first.responseEnd > second.startTime, "The second resource start time should not be blocked on the first resource response");
+    }));
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/loading/resources/dummy.css
+++ b/LayoutTests/imported/w3c/web-platform-tests/loading/resources/dummy.css
@@ -1,0 +1,1 @@
+/* dummy css */

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/loading/preloader-css-import-no-quote.tentative-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/loading/preloader-css-import-no-quote.tentative-expected.txt
@@ -1,0 +1,8 @@
+main frame - didStartProvisionalLoadForFrame
+main frame - didCommitLoadForFrame
+main frame - didFinishDocumentLoadForFrame
+main frame - didHandleOnloadEventsForFrame
+main frame - didFinishLoadForFrame
+
+PASS Imported inline CSS with no quote is not blocked on pending CSS
+

--- a/Source/WebCore/html/parser/CSSPreloadScanner.cpp
+++ b/Source/WebCore/html/parser/CSSPreloadScanner.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (C) 2008, 2010, 2013, 2014 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2008-2023 Apple Inc. All Rights Reserved.
  * Copyright (C) 2009 Torch Mobile, Inc. http://www.torchmobile.com/
- * Copyright (C) 2010 Google Inc. All Rights Reserved.
+ * Copyright (C) 2010-2018 Google Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -163,13 +163,16 @@ static String parseCSSStringOrURL(const UChar* characters, size_t length)
     size_t offset = 0;
     size_t reducedLength = length;
 
+    // Remove whitespace from the rule start
     while (reducedLength && isHTMLSpace(characters[offset])) {
         ++offset;
         --reducedLength;
     }
+    // Remove whitespace from the rule end
     while (reducedLength && isHTMLSpace(characters[offset + reducedLength - 1]))
         --reducedLength;
 
+    // Skip the "url(" prefix and the ")" suffix
     if (reducedLength >= 5
             && (characters[offset] == 'u' || characters[offset] == 'U')
             && (characters[offset + 1] == 'r' || characters[offset + 1] == 'R')
@@ -180,24 +183,21 @@ static String parseCSSStringOrURL(const UChar* characters, size_t length)
         reducedLength -= 5;
     }
 
+    // Skip whitespace before and after the URL inside the "url()" parenthesis.
     while (reducedLength && isHTMLSpace(characters[offset])) {
         ++offset;
         --reducedLength;
     }
     while (reducedLength && isHTMLSpace(characters[offset + reducedLength - 1]))
         --reducedLength;
-
-    if (reducedLength < 2 || characters[offset] != characters[offset + reducedLength - 1] || !(characters[offset] == '\'' || characters[offset] == '"'))
-        return String();
-    offset++;
-    reducedLength -= 2;
-
-    while (reducedLength && isHTMLSpace(characters[offset])) {
-        ++offset;
-        --reducedLength;
-    }
-    while (reducedLength && isHTMLSpace(characters[offset + reducedLength - 1]))
-        --reducedLength;
+    
+    // Remove single-quotes or double-quotes from the URL
+    if ((reducedLength >= 2) 
+        && (characters[offset] == characters[offset + reducedLength - 1])
+        && (characters[offset] == '\'' || characters[offset] == '"')) {
+            ++offset;
+            reducedLength -= 2;            
+        }
 
     return String(characters + offset, reducedLength);
 }


### PR DESCRIPTION
#### 6851ca14bf62fb07839b4416333db9d5af417f38
<pre>
CSS @imports in HTML missing quote marks are mistakenly hidden from the Preload Scanner

<a href="https://bugs.webkit.org/show_bug.cgi?id=191466">https://bugs.webkit.org/show_bug.cgi?id=191466</a>

Reviewed by Chris Dumez.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Partial Merge - <a href="https://chromium.googlesource.com/chromium/src.git/+/30ecdaf63da0c5e1d81caf93c9836ec5564d9647">https://chromium.googlesource.com/chromium/src.git/+/30ecdaf63da0c5e1d81caf93c9836ec5564d9647</a>

This fixes a couple of bugs with the CSSPreloadScanner that made it miss
rules in which the URL wasn&apos;t quoted or the rule didn&apos;t end with a
semicolon etc.

* Source/WebCore/html/parser/CSSPreloadScanner.cpp:
(parseCSSStringOrURL): Add comments and also add &quot;if&quot; clause for &apos;single&apos; and
&apos;double&apos; clauses and do other clean-ups
* LayoutTests/imported/w3c/web-platform-tests/loading/preloader-css-import-no-quote.tentative.html: Add Test Case
* LayoutTests/imported/w3c/web-platform-tests/loading/preloader-css-import-no-quote.tentative-expected.txt: Add Test Case Expectation
* LayoutTests/imported/w3c/web-platform-tests/loading/resources/dummy.css: Add Test Resource
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/loading/preloader-css-import-no-quote.tentative-expected.txt: Add Platform Specific Expectation

Canonical link: <a href="https://commits.webkit.org/261254@main">https://commits.webkit.org/261254@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/111405bae166e1165481c3ca5eb027986328bf9d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109652 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18772 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42397 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1133 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118775 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113548 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20239 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9971 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/619 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115405 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15063 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98295 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101921 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97037 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29947 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43281 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11503 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31289 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85062 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12159 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8229 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17525 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50898 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7804 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13903 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->