### PR TITLE
location.href should throw "SyntaxError" DOMException on URL parser failure

### DIFF
--- a/LayoutTests/fast/dom/location-new-window-no-crash-expected.txt
+++ b/LayoutTests/fast/dom/location-new-window-no-crash-expected.txt
@@ -14,11 +14,11 @@ PASS testWindow.location.search is ''
 PASS testWindow.location.hash is ''
 PASS testWindow.location.href = 'data:text/plain,b' is 'data:text/plain,b'
 PASS testWindow.location.protocol = 'data' is 'data'
-PASS testWindow.location.host = 'c' threw exception TypeError: Invalid URL.
-PASS testWindow.location.hostname = 'd' threw exception TypeError: Invalid URL.
-PASS testWindow.location.port = 'e' threw exception TypeError: Invalid URL.
-PASS testWindow.location.pathname = 'f' threw exception TypeError: Invalid URL.
-PASS testWindow.location.search = 'g' threw exception TypeError: Invalid URL.
+PASS testWindow.location.host = 'c' threw exception SyntaxError: Invalid URL.
+PASS testWindow.location.hostname = 'd' threw exception SyntaxError: Invalid URL.
+PASS testWindow.location.port = 'e' threw exception SyntaxError: Invalid URL.
+PASS testWindow.location.pathname = 'f' threw exception SyntaxError: Invalid URL.
+PASS testWindow.location.search = 'g' threw exception SyntaxError: Invalid URL.
 PASS testWindow.location.hash = 'h' is 'h'
 PASS testWindow.location.assign('data:text/plain,i') is undefined
 PASS testWindow.location.replace('data:text/plain,j') is undefined

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/navigate-to-unparseable-url-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/navigate-to-unparseable-url-expected.txt
@@ -1,6 +1,4 @@
 
-FAIL location.href setter throws a SyntaxError DOMException for unparseable URLs assert_throws_dom: location.href setter throws a SyntaxError DOMException function "() => {
-    win.location.href = kUnparseableURL;
-  }" threw object "TypeError: Invalid URL" that is not a DOMException SyntaxError: property "code" is equal to undefined, expected 12
+PASS location.href setter throws a SyntaxError DOMException for unparseable URLs
 PASS <a> tag navigate fails for unparseable URLs
 

--- a/LayoutTests/imported/w3c/web-platform-tests/url/failure.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/failure.html
@@ -5,7 +5,6 @@
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <div id=log></div>
-<iframe></iframe>
 <script>
 promise_test(() => fetch("resources/urltestdata.json").then(res => res.json()).then(runTests), "Loading data…")
 
@@ -41,9 +40,11 @@ function runTests(testData) {
         assert_throws_js(TypeError, () => self.navigator.sendBeacon(test.input))
       }, "sendBeacon(): " + name)
 
-      self.test(() => {
-        assert_throws_js(self[0].TypeError, () => self[0].location = test.input)
-      }, "Location's href: " + name)
+      self.test(t => {
+        const frame = document.body.appendChild(document.createElement("iframe"));
+        t.add_cleanup(() => frame.remove());
+        assert_throws_dom("SyntaxError", frame.contentWindow.DOMException, () => frame.contentWindow.location = test.input);
+      }, "Location's href: " + name);
 
       self.test(() => {
         assert_throws_dom("SyntaxError", () => self.open(test.input).close())

--- a/Source/WebCore/page/Location.cpp
+++ b/Source/WebCore/page/Location.cpp
@@ -283,7 +283,7 @@ ExceptionOr<void> Location::setLocation(DOMWindow& incumbentWindow, DOMWindow& f
     URL completedURL = firstFrame->document()->completeURL(urlString);
 
     if (!completedURL.isValid())
-        return Exception { TypeError, "Invalid URL"_s };
+        return Exception { SyntaxError, "Invalid URL"_s };
 
     if (!incumbentWindow.document()->canNavigate(frame, completedURL))
         return Exception { SecurityError };


### PR DESCRIPTION
#### 37c7b03669eb1e595bba2ff9967b163434607848
<pre>
location.href should throw &quot;SyntaxError&quot; DOMException on URL parser failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=252535">https://bugs.webkit.org/show_bug.cgi?id=252535</a>
rdar://105631453

Reviewed by Sihui Liu.

* LayoutTests/fast/dom/location-new-window-no-crash-expected.txt:
Rebaseline existing test due to different exception type.

* LayoutTests/imported/w3c/web-platform-tests/url/failure.html:
Resync WPT test after <a href="https://github.com/web-platform-tests/wpt/pull/38581.">https://github.com/web-platform-tests/wpt/pull/38581.</a>

* Source/WebCore/page/Location.cpp:
(WebCore::Location::setLocation):
Throw a SyntaxError instead of a TypeError when URL parsing failed.

Canonical link: <a href="https://commits.webkit.org/260539@main">https://commits.webkit.org/260539@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30821c86ff9c2fe287ec2ea173ae0442d1c7954a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108600 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17701 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41454 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117710 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/117909 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112483 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19152 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8978 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100832 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114367 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14354 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97588 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42325 "Found 2 new test failures: webgl/2.0.y/conformance2/renderbuffers/multisampled-depth-renderbuffer-initialization.html, webgl/2.0.y/conformance2/vertex_arrays/vertex-array-object.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96330 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29226 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84042 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10509 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30576 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/98582 "Build is in progress. Recent messages:Running worker_preparation") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11267 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7488 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/38/builds/98582 "Build is in progress. Recent messages:Running worker_preparation") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16658 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50172 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7284 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12855 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->