### PR TITLE
[JSC] Implement RegExp Duplicate Named Capture Groups

### DIFF
--- a/JSTests/stress/regexp-duplicate-named-captures.js
+++ b/JSTests/stress/regexp-duplicate-named-captures.js
@@ -1,0 +1,189 @@
+// With verbose set to false, this test is successful if there is no output.  Set verbose to true to see expected matches.
+let verbose = false;
+
+function arrayToString(arr)
+{
+    let str = '';
+    arr.forEach(function(v, index) {
+        if (typeof v == "string")
+            str += "\"" + v + "\"";
+        else
+            str += v;
+
+        if (index != (arr.length - 1))
+            str += ',';
+      });
+  return str;
+}
+
+function objectToString(obj)
+{
+    let str = "";
+
+    firstEntry = true;
+
+    for (const [key, value] of Object.entries(obj)) {
+        if (!firstEntry)
+            str += ", ";
+
+        str += key + ": " + dumpValue(value);
+
+        firstEntry = false;
+    }
+
+    return "{ " + str + " }";
+}
+
+function dumpValue(v)
+{
+    if (v === null)
+        return "<null>";
+
+    if (v === undefined)
+        return "<undefined>";
+
+    if (typeof v == "string")
+        return "\"" + v + "\"";
+
+    let str = "";
+
+    if (v.length)
+        str += arrayToString(v);
+
+    if (v.groups) {
+        groupStr = objectToString(v.groups);
+
+        if (str.length) {
+            if ( groupStr.length)
+                str += ", " + groupStr;
+        } else
+            str = groupStr;
+    }
+
+    return "[ " + str + " ]";
+}
+
+function compareArray(expected, actual)
+{
+    if (expected === null && actual === null)
+        return true;
+
+    if (expected === null) {
+        print("### expected is null, actual is not null");
+        return false;
+    }
+
+    if (actual === null) {
+        print("### expected is not null, actual is null");
+        return false;
+    }
+
+    if (expected.length !== actual.length) {
+        print("### expected.length: " + expected.length + ", actual.length: " + actual.length);
+        return false;
+    }
+
+    for (var i = 0; i < expected.length; i++) {
+        if (expected[i] !== actual[i]) {
+            print("### expected[" + i + "]: \"" + expected[i] + "\" !== actual[" + i + "]: \"" + actual[i] + "\"");
+            return false;
+        }
+    }
+
+    return true;
+}
+
+function compareGroups(expected, actual)
+{
+    if (expected === null && actual === null)
+        return true;
+
+    if (expected === null) {
+        print("### expected group is null, actual group is not null");
+        return false;
+    }
+
+    if (actual === null) {
+        print("### expected group is not null, actual group is null");
+        return false;
+    }
+
+    for (const key in expected) {
+        if (expected[key] !== actual[key]) {
+            print("### expected." + key + ": " + dumpValue(expected[key]) + " !== actual." + key + ": " + dumpValue(actual[key]));
+            return false;
+        }
+    }
+
+    return true;
+}
+
+let testNumber = 0;
+
+function testRegExp(re, str, exp, groups)
+{
+    testNumber++;
+
+    if (groups)
+        exp.groups = groups;
+
+    let actual = re.exec(str);
+    let result = compareArray(exp, actual);;
+
+    if (exp.groups) {
+        if (!compareGroups(exp.groups, actual.groups))
+            result = false;
+    }
+
+    if (result) {
+        if (verbose)
+            print(re.toString() + ".exec(" + dumpValue(str) + "), passed ", dumpValue(exp));
+    } else
+        print(re.toString() + ".exec(" + dumpValue(str) + "), FAILED test #" + testNumber + ", Expected ", dumpValue(exp), " got ", dumpValue(actual));
+}
+
+function testRegExpSyntaxError(reString, flags, expError)
+{
+    testNumber++;
+
+    try {
+        let re = new RegExp(reString, flags);
+    } catch (e) {
+        if (e != expError)
+            print("FAILED test #" + testNumber + ", Expected /" + reString + "/" + flags + " to throw \"" + expError + "\" got \"" + e + "\"");
+        else if (verbose)
+            print("/" + reString + "/" + flags + " passed, it threw \"" + expError + "\" as expected");
+    }
+}
+
+// Test 1
+testRegExp(/(?<A>123)|(?<A>456)/, "123", ["123", "123", undefined], { A: "123" });
+testRegExp(/(?<A>123)|(?<A>456)/, "456", ["456", undefined, "456"], { A: "456" });
+testRegExp(/(?:(?<mon>[1-9]|1[0-2])\/(?<day>[1-9]|[12][0-9]|3[01])\/(?<yr>19[6-9][0-9]|20[0-2][0-9]))|(?:(?<day>[1-9]|[12][0-9]|3[01])\-(?<mon>[1-9]|1[0-2])\-(?<yr>19[6-9][0-9]|20[0-2][0-9]))/, "3/24/1992", ["3/24/1992", "3", "24", "1992", undefined, undefined, undefined], { mon: "3", day: "24", yr: "1992" });
+testRegExp(/(?:(?<mon>[1-9]|1[0-2])\/(?<day>[1-9]|[12][0-9]|3[01])\/(?<yr>19[6-9][0-9]|20[0-2][0-9]))|(?:(?<day>[1-9]|[12][0-9]|3[01])\-(?<mon>[1-9]|1[0-2])\-(?<yr>19[6-9][0-9]|20[0-2][0-9]))/, "24-3-1992", ["24-3-1992", undefined, undefined, undefined, "24", "3", "1992"], { mon: "3", day: "24", yr: "1992" });
+testRegExp(/(?<x>a)|(?<x>b)/, "bab", ["b", undefined, "b"]);
+
+// Test 6
+testRegExp(/(?:(?<x>a)|(?<x>b))\k<x>/, "bb", ["bb", undefined, "b"], { x: "b"});
+testRegExp(/(?:(?:(?<x>a)|(?<x>b))\k<x>){2}/, "aabb", ["aabb", undefined, "b"], { x: "b" });
+testRegExp(/(?<A>abc)x|(?<A>abc)y|abcz/, "abcx", ["abcx", "abc", undefined], { A: "abc" });
+testRegExp(/(?<A>abc)x|(?<A>abc)y|abcz/, "abcy", ["abcy", undefined, "abc"], { A: "abc" });
+testRegExp(/(?<A>abc)x|(?<A>abc)y|abcz/, "abcz", ["abcz", undefined, undefined], { A: undefined });
+
+// Test 11
+testRegExp(/(?<A>abc)x|(?<B>abc)y|abcz/, "abcz", ["abcz", undefined, undefined], { A: undefined, B: undefined });
+testRegExp(/(?<x>a)|(?<x>b)/, "ba", ["b", undefined, "b"], { x: "b"});
+testRegExp(/(?<=(?:\k<x>(?<x>c))|(?:\k<x>(?<x>a)))b/, "aab", ["b", undefined, "a"], { x: "a" });
+testRegExp(/(?<=(?:\k<x>(?<x>c))|(?:\k<x>))b/, "aab", ["b", undefined], { x: undefined });
+testRegExp(/(?<=(?:\k<x>(?<x>c))|(?:\k<y>(?<y>a)))b/, "aab", ["b", undefined, "a"], { x: undefined, y: "a" });
+
+// Test 16
+testRegExp(/^(?:(?<a>x)|(?<a>y)|z)\k<a>$/, "z", ["z", undefined, undefined]);
+testRegExp(/^(?:(?<a>x)|(?<a>y)|z){2}\k<a>$/, "xz", ["xz", undefined, undefined]);
+testRegExp(/(?<a>x)|(?:zy\k<a>)/, "zy", ["zy", undefined]);
+testRegExpSyntaxError("(?<A>123)(?<A>456)", "", "SyntaxError: Invalid regular expression: duplicate group specifier name");
+testRegExpSyntaxError("(?<A>123)(?:(?<A>456)|(?<A>789))", "", "SyntaxError: Invalid regular expression: duplicate group specifier name");
+
+// Test 21
+testRegExpSyntaxError("(?<=\\k<a>a)x", "", "SyntaxError: Invalid regular expression: duplicate group specifier name");
+

--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -16,7 +16,6 @@ skip:
     - FinalizationRegistry.prototype.cleanupSome
     - decorators
     - Intl.DurationFormat
-    - regexp-duplicate-named-groups
     - Intl.Locale-info # Getters are replaced with methods.
   paths:
     - test/built-ins/Temporal/Calendar

--- a/LayoutTests/js/regexp-named-capture-groups-expected.txt
+++ b/LayoutTests/js/regexp-named-capture-groups-expected.txt
@@ -64,7 +64,6 @@ PASS "Give me \'k2\'!".match(/Give me \'\k2\'/u)[0] threw exception SyntaxError:
 PASS "Give me a \'kat\'!".match(/Give me a \'\kat\'/u)[0] threw exception SyntaxError: Invalid regular expression: invalid escaped character for Unicode pattern.
 PASS "10/20/1930".replace(/(?<month>\d{2})\/(?<day>\d{2})\/(?<year>\d{4})/, "$<day>-$<mouth>-$<year>") is "20--1930"
 PASS "10/20/1930".replace(/(?<month>\d{2})\/(?<day>\d{2})\/(?<year>\d{4})/, "$<day>-$<month>-$<year") is "20-10-$<year"
-PASS let r = new RegExp("/(?<groupName1>abc)|(?<groupName1>def)/") threw exception SyntaxError: Invalid regular expression: duplicate group specifier name.
 PASS let r = new RegExp("/(?< groupName1>abc)/") threw exception SyntaxError: Invalid regular expression: invalid group specifier name.
 PASS let r = new RegExp("/(?<g=oupName1>abc)/") threw exception SyntaxError: Invalid regular expression: invalid group specifier name.
 PASS let r = new RegExp("/(?<𐆐groupName1>abc)/u") threw exception SyntaxError: Invalid regular expression: invalid group specifier name.

--- a/LayoutTests/js/script-tests/regexp-named-capture-groups.js
+++ b/LayoutTests/js/script-tests/regexp-named-capture-groups.js
@@ -104,7 +104,6 @@ shouldBe('"10/20/1930".replace(/(?<month>\\d{2})\\\/(?<day>\\d{2})\\\/(?<year>\\
 shouldBe('"10/20/1930".replace(/(?<month>\\d{2})\\\/(?<day>\\d{2})\\\/(?<year>\\d{4})/, "$<day>-$<month>-$<year")', '"20-10-$<year"');
 
 // Check invalid group name exceptions.
-shouldThrow('let r = new RegExp("/(?<groupName1>abc)|(?<groupName1>def)/")', '"SyntaxError: Invalid regular expression: duplicate group specifier name"');
 shouldThrow('let r = new RegExp("/(?< groupName1>abc)/")', '"SyntaxError: Invalid regular expression: invalid group specifier name"');
 shouldThrow('let r = new RegExp("/(?<g=oupName1>abc)/")', '"SyntaxError: Invalid regular expression: invalid group specifier name"');
 

--- a/Source/JavaScriptCore/runtime/RegExp.cpp
+++ b/Source/JavaScriptCore/runtime/RegExp.cpp
@@ -163,10 +163,11 @@ void RegExp::finishCreation(VM& vm)
     }
 
     m_numSubpatterns = pattern.m_numSubpatterns;
-    if (!pattern.m_captureGroupNames.isEmpty() || !pattern.m_namedGroupToParenIndex.isEmpty()) {
+    if (!pattern.m_captureGroupNames.isEmpty() || !pattern.m_namedGroupToParenIndeces.isEmpty()) {
         m_rareData = makeUnique<RareData>();
+        m_rareData->m_numDuplicateNamedCaptureGroups = pattern.m_numDuplicateNamedCaptureGroups;
         m_rareData->m_captureGroupNames.swap(pattern.m_captureGroupNames);
-        m_rareData->m_namedGroupToParenIndex.swap(pattern.m_namedGroupToParenIndex);
+        m_rareData->m_namedGroupToParenIndeces.swap(pattern.m_namedGroupToParenIndeces);
     }
 }
 

--- a/Source/JavaScriptCore/runtime/RegExp.h
+++ b/Source/JavaScriptCore/runtime/RegExp.h
@@ -91,27 +91,43 @@ public:
     
     unsigned numSubpatterns() const { return m_numSubpatterns; }
 
-    bool hasNamedCaptures()
+    unsigned offsetVectorBaseForNamedCaptures() const
+    {
+        return (numSubpatterns() + 1) * 2;
+    }
+
+    int offsetVectorSize() const
+    {
+        if (!hasNamedCaptures())
+            return offsetVectorBaseForNamedCaptures();
+        return offsetVectorBaseForNamedCaptures() + m_rareData->m_numDuplicateNamedCaptureGroups;
+    }
+
+    bool hasNamedCaptures() const
     {
         return m_rareData && !m_rareData->m_captureGroupNames.isEmpty();
     }
 
-    String getCaptureGroupName(unsigned i)
+    String getCaptureGroupNameForSubpatternId(unsigned i) const
     {
-        if (!i || !m_rareData || m_rareData->m_captureGroupNames.size() <= i)
+        if (!i || !m_rareData || m_rareData->m_captureGroupNames.isEmpty())
             return String();
         ASSERT(m_rareData);
         return m_rareData->m_captureGroupNames[i];
     }
 
-    unsigned subpatternForName(StringView groupName)
+    template <typename Offsets>
+    unsigned subpatternIdForGroupName(StringView groupName, const Offsets ovector) const
     {
         if (!m_rareData)
             return 0;
-        auto it = m_rareData->m_namedGroupToParenIndex.find<StringViewHashTranslator>(groupName);
-        if (it == m_rareData->m_namedGroupToParenIndex.end())
+        auto it = m_rareData->m_namedGroupToParenIndeces.find<StringViewHashTranslator>(groupName);
+        if (it == m_rareData->m_namedGroupToParenIndeces.end())
             return 0;
-        return it->value;
+        if (it->value.size() == 1)
+            return it->value[0];
+
+        return ovector[offsetVectorBaseForNamedCaptures() + it->value[0] - 1];
     }
 
     bool hasCode()
@@ -185,8 +201,13 @@ private:
 
     struct RareData {
         WTF_MAKE_STRUCT_FAST_ALLOCATED;
+        unsigned m_numDuplicateNamedCaptureGroups;
         Vector<String> m_captureGroupNames;
-        HashMap<String, unsigned> m_namedGroupToParenIndex;
+
+        // This first element of the RHS vector is the subpatternId in the non-duplicate case.
+        // For the duplicate case, the first element is the namedCaptureGroupId.
+        // The remaining elements are the subpatternIds for each of the duplicate groups.
+        HashMap<String, Vector<unsigned>> m_namedGroupToParenIndeces;
     };
 
     String m_patternString;

--- a/Source/JavaScriptCore/runtime/RegExpInlines.h
+++ b/Source/JavaScriptCore/runtime/RegExpInlines.h
@@ -123,8 +123,7 @@ ALWAYS_INLINE int RegExp::matchInline(JSGlobalObject* nullOrGlobalObject, VM& vm
     if (m_state == ParseError)
         return throwError();
 
-    int offsetVectorSize = (m_numSubpatterns + 1) * 2;
-    ovector.resize(offsetVectorSize);
+    ovector.resize(offsetVectorSize());
     int* offsetVector = ovector.data();
 
     int result;
@@ -290,11 +289,10 @@ ALWAYS_INLINE MatchResult RegExp::matchInline(JSGlobalObject* nullOrGlobalObject
     }
 #endif
 
-    int offsetVectorSize = (m_numSubpatterns + 1) * 2;
     int* offsetVector;
     int result;
     Vector<int, 32> nonReturnedOvector;
-    nonReturnedOvector.grow(offsetVectorSize);
+    nonReturnedOvector.grow(offsetVectorSize());
     offsetVector = nonReturnedOvector.data();
     {
         constexpr bool usesPatternContextBuffer = false;

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -221,7 +221,7 @@ NEVER_INLINE void substituteBackreferencesSlow(StringBuilder& result, StringView
                 continue;
 
             unsigned nameLength = closingBracket - i - 2;
-            unsigned backrefIndex = reg->subpatternForName(replacement.substring(i + 2, nameLength));
+            unsigned backrefIndex = reg->subpatternIdForGroupName(replacement.substring(i + 2, nameLength), ovector);
 
             if (!backrefIndex || backrefIndex > reg->numSubpatterns()) {
                 backrefStart = 0;
@@ -458,9 +458,24 @@ static ALWAYS_INLINE JSString* replaceUsingRegExpSearch(
                 cachedCall.appendArgument(patternValue);
 
                 if (i && hasNamedCaptures) {
-                    String groupName = regExp->getCaptureGroupName(i);
-                    if (!groupName.isEmpty())
-                        groups->putDirect(vm, Identifier::fromString(vm, groupName), patternValue);
+                    String groupName = regExp->getCaptureGroupNameForSubpatternId(i);
+                    if (!groupName.isEmpty()) {
+                        auto captureIndex = regExp->subpatternIdForGroupName(groupName, ovector);
+
+                        if (captureIndex == i)
+                            groups->putDirect(vm, Identifier::fromString(vm, groupName), patternValue);
+                        else if (captureIndex > 0) {
+                            int captureStart = ovector[captureIndex * 2];
+                            int captureLen = ovector[captureIndex * 2 + 1] - captureStart;
+                            JSValue captureValue;
+                            if (captureStart < 0)
+                                captureValue = jsUndefined();
+                            else
+                                captureValue = jsSubstring(vm, source, captureStart, captureLen);
+                            groups->putDirect(vm, Identifier::fromString(vm, groupName), captureValue);
+                        } else
+                            groups->putDirect(vm, Identifier::fromString(vm, groupName), jsUndefined());
+                    }
                 }
             }
 
@@ -521,9 +536,26 @@ static ALWAYS_INLINE JSString* replaceUsingRegExpSearch(
                     args.append(patternValue);
 
                     if (i && hasNamedCaptures) {
-                        String groupName = regExp->getCaptureGroupName(i);
-                        if (!groupName.isEmpty())
-                            groups->putDirect(vm, Identifier::fromString(vm, groupName), patternValue);
+                        String groupName = regExp->getCaptureGroupNameForSubpatternId(i);
+                        if (!groupName.isEmpty()) {
+                            auto captureIndex = regExp->subpatternIdForGroupName(groupName, ovector);
+
+                            if (captureIndex == i)
+                                groups->putDirect(vm, Identifier::fromString(vm, groupName), patternValue);
+                            else if (captureIndex > 0) {
+                                int captureStart = ovector[captureIndex * 2];
+                                int captureLen = ovector[captureIndex * 2 + 1] - captureStart;
+                                JSValue captureValue;
+                                if (captureStart < 0)
+                                    captureValue = jsUndefined();
+                                else {
+                                    captureValue = jsSubstring(vm, source, captureStart, captureLen);
+                                    RETURN_IF_EXCEPTION(scope, nullptr);
+                                }
+                                groups->putDirect(vm, Identifier::fromString(vm, groupName), captureValue);
+                            } else
+                                groups->putDirect(vm, Identifier::fromString(vm, groupName), jsUndefined());
+                        }
                     }
                 }
 

--- a/Source/JavaScriptCore/yarr/Yarr.h
+++ b/Source/JavaScriptCore/yarr/Yarr.h
@@ -34,7 +34,7 @@ namespace JSC { namespace Yarr {
 
 #define YarrStackSpaceForBackTrackInfoPatternCharacter 2 // Only for !fixed quantifiers.
 #define YarrStackSpaceForBackTrackInfoCharacterClass 2 // Only for !fixed quantifiers.
-#define YarrStackSpaceForBackTrackInfoBackReference 2
+#define YarrStackSpaceForBackTrackInfoBackReference 3
 #define YarrStackSpaceForBackTrackInfoAlternative 1 // One per alternative.
 #define YarrStackSpaceForBackTrackInfoParentheticalAssertion 1
 #define YarrStackSpaceForBackTrackInfoParenthesesOnce 2

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
@@ -31,6 +31,7 @@
 #include "SuperSampler.h"
 #include "Yarr.h"
 #include "YarrCanonicalize.h"
+#include <wtf/BitVector.h>
 #include <wtf/BumpPointerAllocator.h>
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/DataLog.h>
@@ -132,17 +133,26 @@ public:
 
     struct ParenthesesDisjunctionContext
     {
-        ParenthesesDisjunctionContext(unsigned* output, ByteTerm& term)
-        {
-            unsigned firstSubpatternId = term.subpatternId();
-            unsigned numNestedSubpatterns = term.atom.parenthesesDisjunction->m_numSubpatterns;
+        ParenthesesDisjunctionContext(BytecodePattern* pattern, unsigned* output, ByteTerm& term, unsigned numDuplicateNamedGroups, BitVector& duplicateNamedGroups)
+            : m_pattern(pattern)
+            , m_numNestedSubpatterns(term.atom.parenthesesDisjunction->m_numSubpatterns)
+            , m_duplicateNamedGroups(duplicateNamedGroups)
 
-            for (unsigned i = 0; i < (numNestedSubpatterns << 1); ++i) {
-                subpatternBackup[i] = output[(firstSubpatternId << 1) + i];
+        {
+            m_numBackupIds = m_numNestedSubpatterns * 2 + numDuplicateNamedGroups;
+            unsigned firstSubpatternId = term.subpatternId();
+
+            for (unsigned i = 0; i < (m_numNestedSubpatterns << 1); ++i) {
+                subpatternAndGroupIdBackup[i] = output[(firstSubpatternId << 1) + i];
                 output[(firstSubpatternId << 1) + i] = offsetNoMatch;
             }
 
-            new (getDisjunctionContext(term)) DisjunctionContext();
+            for (unsigned duplicateNamedGroupId : m_duplicateNamedGroups) {
+                subpatternAndGroupIdBackup[backupOffsetForDuplicateNamedGroup(duplicateNamedGroupId)] = output[m_pattern->offsetForDuplicateNamedGroupId(duplicateNamedGroupId)];
+                output[pattern->offsetForDuplicateNamedGroupId(duplicateNamedGroupId)] = 0;
+            }
+
+            new (getDisjunctionContext()) DisjunctionContext();
         }
 
         void* operator new(size_t, void* where)
@@ -150,36 +160,71 @@ public:
             return where;
         }
 
-        void restoreOutput(unsigned* output, unsigned firstSubpatternId, unsigned numNestedSubpatterns)
+        void restoreOutput(unsigned* output, unsigned firstSubpatternId)
         {
-            for (unsigned i = 0; i < (numNestedSubpatterns << 1); ++i)
-                output[(firstSubpatternId << 1) + i] = subpatternBackup[i];
+            for (unsigned i = 0; i < (m_numNestedSubpatterns << 1); ++i)
+                output[(firstSubpatternId << 1) + i] = subpatternAndGroupIdBackup[i];
+
+            for (unsigned duplicateNamedGroupId : m_duplicateNamedGroups)
+                output[m_pattern->offsetForDuplicateNamedGroupId(duplicateNamedGroupId)] = subpatternAndGroupIdBackup[backupOffsetForDuplicateNamedGroup(duplicateNamedGroupId)];
         }
 
-        DisjunctionContext* getDisjunctionContext(ByteTerm& term)
+        DisjunctionContext* getDisjunctionContext()
         {
-            return bitwise_cast<DisjunctionContext*>(bitwise_cast<uintptr_t>(this) + allocationSize(term.atom.parenthesesDisjunction->m_numSubpatterns));
+            return bitwise_cast<DisjunctionContext*>(bitwise_cast<uintptr_t>(this) + allocationSize(m_numBackupIds));
         }
 
-        static size_t allocationSize(unsigned numberOfSubpatterns)
+        unsigned backupOffsetForDuplicateNamedGroup(unsigned duplicateNamedGroup)
+        {
+            ASSERT(duplicateNamedGroup);
+            return (m_numNestedSubpatterns << 1) + duplicateNamedGroup - 1;
+        }
+
+        static size_t allocationSize(unsigned numberOfSubpatterns, unsigned numDuplicateNamedGroups)
+        {
+            Checked<size_t> numBackupIds = (Checked<size_t>(numberOfSubpatterns) * 2U) + Checked<size_t>(numDuplicateNamedGroups);
+            return allocationSize(numBackupIds.value());
+        }
+
+        static size_t allocationSize(unsigned numBackupIds)
         {
             static_assert(alignof(ParenthesesDisjunctionContext) <= sizeof(void*));
-            size_t rawSize = sizeof(ParenthesesDisjunctionContext) - sizeof(unsigned) + (Checked<size_t>(numberOfSubpatterns) * 2U) * sizeof(unsigned);
+            size_t rawSize = sizeof(ParenthesesDisjunctionContext) + Checked<size_t>(numBackupIds) * sizeof(unsigned);
             size_t roundedSize = roundUpToMultipleOf<sizeof(void*)>(rawSize);
             RELEASE_ASSERT(roundedSize >= rawSize);
             return roundedSize;
         }
 
         ParenthesesDisjunctionContext* next { nullptr };
-        unsigned subpatternBackup[1];
+        BytecodePattern* m_pattern;
+        unsigned m_numNestedSubpatterns;
+        size_t m_numBackupIds;
+        BitVector m_duplicateNamedGroups;
+        unsigned subpatternAndGroupIdBackup[1];
     };
 
     ParenthesesDisjunctionContext* allocParenthesesDisjunctionContext(ByteDisjunction* disjunction, unsigned* output, ByteTerm& term)
     {
-        size_t size = Checked<size_t>(ParenthesesDisjunctionContext::allocationSize(term.atom.parenthesesDisjunction->m_numSubpatterns)) + DisjunctionContext::allocationSize(disjunction->m_frameSize);
+        BitVector duplicateNamedCaptureGroups;
+        unsigned firstSubpatternId = term.subpatternId();
+        unsigned numNestedSubpatterns = term.atom.parenthesesDisjunction->m_numSubpatterns;
+        unsigned numDuplicateNamedGroups = 0;
+
+        if (pattern->hasDuplicateNamedCaptureGroups()) {
+            for (unsigned i = 0; i < numNestedSubpatterns; ++i) {
+                unsigned subpatternId = firstSubpatternId + i;
+                unsigned duplicateNamedGroup = pattern->m_duplicateNamedGroupForSubpatternId[subpatternId];
+                if (duplicateNamedGroup)
+                    duplicateNamedCaptureGroups.set(duplicateNamedGroup);
+            }
+
+            numDuplicateNamedGroups = duplicateNamedCaptureGroups.bitCount();
+        }
+
+        size_t size = Checked<size_t>(ParenthesesDisjunctionContext::allocationSize(numNestedSubpatterns, numDuplicateNamedGroups)) + DisjunctionContext::allocationSize(disjunction->m_frameSize);
         allocatorPool = allocatorPool->ensureCapacity(size);
         RELEASE_ASSERT(allocatorPool);
-        return new (allocatorPool->alloc(size)) ParenthesesDisjunctionContext(output, term);
+        return new (allocatorPool->alloc(size)) ParenthesesDisjunctionContext(pattern, output, term, numDuplicateNamedGroups, duplicateNamedCaptureGroups);
     }
 
     void freeParenthesesDisjunctionContext(ParenthesesDisjunctionContext* context)
@@ -893,8 +938,19 @@ public:
         ASSERT(term.type == ByteTerm::Type::BackReference);
         BackTrackInfoBackReference* backTrack = reinterpret_cast<BackTrackInfoBackReference*>(context->frame + term.frameLocation);
 
-        unsigned matchBegin = output[(term.subpatternId() << 1)];
-        unsigned matchEnd = output[(term.subpatternId() << 1) + 1];
+        unsigned subpatternId;
+
+        if (auto duplicateNamedGroupId = term.duplicateNamedGroupId()) {
+            subpatternId = output[pattern->offsetForDuplicateNamedGroupId(duplicateNamedGroupId)];
+            if (subpatternId < 1) {
+                // If we don't have a subpattern that matched, then the string to match is empty.
+                return true;
+            }
+        } else
+            subpatternId = term.subpatternId();
+
+        unsigned matchBegin = output[(subpatternId << 1)];
+        unsigned matchEnd = output[(subpatternId << 1) + 1];
 
         // If the end position of the referenced match hasn't set yet then the backreference in the same parentheses where it references to that.
         // In this case the result of match is empty string like when it references to a parentheses with zero-width match.
@@ -927,6 +983,7 @@ public:
             while ((matchAmount < term.atom.quantityMaxCount) && tryConsumeBackReference(matchBegin, matchEnd, term))
                 ++matchAmount;
             backTrack->matchAmount = matchAmount;
+            backTrack->backReferenceSize = matchEnd - matchBegin;
             return true;
         }
 
@@ -965,7 +1022,7 @@ public:
         case QuantifierType::Greedy:
             if (backTrack->matchAmount) {
                 --backTrack->matchAmount;
-                input.rewind(matchEnd - matchBegin);
+                input.rewind(backTrack->backReferenceSize);
                 return true;
             }
             break;
@@ -986,23 +1043,23 @@ public:
     {
         if (term.capture()) {
             unsigned subpatternId = term.subpatternId();
-            // For Backward matches, the captured indexes where recorded end then start.
-            output[(subpatternId << 1) + term.matchDirection()] = context->getDisjunctionContext(term)->matchBegin - term.inputPosition;
-            output[(subpatternId << 1) + 1 - term.matchDirection()] = context->getDisjunctionContext(term)->matchEnd - term.inputPosition;
+            // For Backward matches, the captured indexes are recorded end then start.
+            output[(subpatternId << 1) + term.matchDirection()] = context->getDisjunctionContext()->matchBegin - term.inputPosition;
+            output[(subpatternId << 1) + 1 - term.matchDirection()] = context->getDisjunctionContext()->matchEnd - term.inputPosition;
         }
     }
     void resetMatches(ByteTerm& term, ParenthesesDisjunctionContext* context)
     {
         unsigned firstSubpatternId = term.subpatternId();
-        unsigned count = term.atom.parenthesesDisjunction->m_numSubpatterns;
-        context->restoreOutput(output, firstSubpatternId, count);
+        context->restoreOutput(output, firstSubpatternId);
     }
+
     JSRegExpResult parenthesesDoBacktrack(ByteTerm& term, BackTrackInfoParentheses* backTrack)
     {
         while (backTrack->matchAmount) {
             ParenthesesDisjunctionContext* context = backTrack->lastContext;
 
-            JSRegExpResult result = matchDisjunction(term.atom.parenthesesDisjunction, context->getDisjunctionContext(term), true);
+            JSRegExpResult result = matchDisjunction(term.atom.parenthesesDisjunction, context->getDisjunctionContext(), true);
             if (result == JSRegExpResult::Match)
                 return JSRegExpResult::Match;
 
@@ -1041,7 +1098,7 @@ public:
 
         if (term.capture()) {
             unsigned subpatternId = term.subpatternId();
-            // For Backward matches, the captured indexes where recorded end then start.
+            // For Backward matches, the captured indexes are recorded end then start.
             output[(subpatternId << 1) + term.matchDirection()] = input.getPos() - term.inputPosition;
         }
 
@@ -1055,8 +1112,13 @@ public:
 
         if (term.capture()) {
             unsigned subpatternId = term.subpatternId();
-            // For Backward matches, the captured indexes where recorded end then start.
+            // For Backward matches, the captured indexes are recorded end then start.
             output[(subpatternId << 1) + 1 - term.matchDirection()] = input.getPos() - term.inputPosition;
+
+            if (term.duplicateNamedGroupId()) {
+                // Record which of the duplicate named subpatterns matched.
+                output[pattern->offsetForDuplicateNamedGroupId(term.duplicateNamedGroupId())] = subpatternId;
+            }
         }
 
         if (term.atom.quantityType == QuantifierType::FixedCount)
@@ -1077,6 +1139,11 @@ public:
             unsigned subpatternId = term.subpatternId();
             output[(subpatternId << 1)] = offsetNoMatch;
             output[(subpatternId << 1) + 1] = offsetNoMatch;
+
+            if (term.duplicateNamedGroupId()) {
+                // Clear matching subpatternId.
+                output[pattern->offsetForDuplicateNamedGroupId(term.duplicateNamedGroupId())] = 0;
+            }
         }
 
         switch (term.atom.quantityType) {
@@ -1120,7 +1187,7 @@ public:
                     ASSERT((&term - term.atom.parenthesesWidth)->type == ByteTerm::Type::ParenthesesSubpatternOnceBegin);
                     ASSERT((&term - term.atom.parenthesesWidth)->inputPosition == term.inputPosition);
                     unsigned subpatternId = term.subpatternId();
-                    // For Backward matches, the captured indexes where recorded end then start.
+                    // For Backward matches, the captured indexes are recorded end then start.
                     output[(subpatternId << 1) + term.matchDirection()] = input.getPos() - term.inputPosition;
                 }
                 context->term -= term.atom.parenthesesWidth;
@@ -1274,7 +1341,7 @@ public:
             while (backTrack->matchAmount < minimumMatchCount) {
                 // Try to do a match, and it it succeeds, add it to the list.
                 ParenthesesDisjunctionContext* context = allocParenthesesDisjunctionContext(disjunctionBody, output, term);
-                fixedMatchResult = matchDisjunction(disjunctionBody, context->getDisjunctionContext(term));
+                fixedMatchResult = matchDisjunction(disjunctionBody, context->getDisjunctionContext());
                 if (fixedMatchResult == JSRegExpResult::Match)
                     appendParenthesesDisjunctionContext(backTrack, context);
                 else {
@@ -1303,7 +1370,7 @@ public:
         case QuantifierType::Greedy: {
             while (backTrack->matchAmount < term.atom.quantityMaxCount) {
                 ParenthesesDisjunctionContext* context = allocParenthesesDisjunctionContext(disjunctionBody, output, term);
-                JSRegExpResult result = matchNonZeroDisjunction(disjunctionBody, context->getDisjunctionContext(term));
+                JSRegExpResult result = matchNonZeroDisjunction(disjunctionBody, context->getDisjunctionContext());
                 if (result == JSRegExpResult::Match)
                     appendParenthesesDisjunctionContext(backTrack, context);
                 else {
@@ -1363,7 +1430,7 @@ public:
             while (backTrack->matchAmount < term.atom.quantityMaxCount) {
                 // Try to do a match, and it it succeeds, add it to the list.
                 context = allocParenthesesDisjunctionContext(disjunctionBody, output, term);
-                result = matchDisjunction(disjunctionBody, context->getDisjunctionContext(term));
+                result = matchDisjunction(disjunctionBody, context->getDisjunctionContext());
 
                 if (result == JSRegExpResult::Match)
                     appendParenthesesDisjunctionContext(backTrack, context);
@@ -1391,11 +1458,11 @@ public:
                 return JSRegExpResult::NoMatch;
 
             ParenthesesDisjunctionContext* context = backTrack->lastContext;
-            JSRegExpResult result = matchNonZeroDisjunction(disjunctionBody, context->getDisjunctionContext(term), true);
+            JSRegExpResult result = matchNonZeroDisjunction(disjunctionBody, context->getDisjunctionContext(), true);
             if (result == JSRegExpResult::Match) {
                 while (backTrack->matchAmount < term.atom.quantityMaxCount) {
                     ParenthesesDisjunctionContext* context = allocParenthesesDisjunctionContext(disjunctionBody, output, term);
-                    JSRegExpResult parenthesesResult = matchNonZeroDisjunction(disjunctionBody, context->getDisjunctionContext(term));
+                    JSRegExpResult parenthesesResult = matchNonZeroDisjunction(disjunctionBody, context->getDisjunctionContext());
                     if (parenthesesResult == JSRegExpResult::Match)
                         appendParenthesesDisjunctionContext(backTrack, context);
                     else {
@@ -1440,7 +1507,7 @@ public:
             // If we've not reached the limit, try to add one more match.
             if (backTrack->matchAmount < term.atom.quantityMaxCount) {
                 ParenthesesDisjunctionContext* context = allocParenthesesDisjunctionContext(disjunctionBody, output, term);
-                JSRegExpResult result = matchNonZeroDisjunction(disjunctionBody, context->getDisjunctionContext(term));
+                JSRegExpResult result = matchNonZeroDisjunction(disjunctionBody, context->getDisjunctionContext());
                 if (result == JSRegExpResult::Match) {
                     appendParenthesesDisjunctionContext(backTrack, context);
                     recordParenthesesMatch(term, context);
@@ -1457,7 +1524,7 @@ public:
             // Nope - okay backtrack looking for an alternative.
             while (backTrack->matchAmount) {
                 ParenthesesDisjunctionContext* context = backTrack->lastContext;
-                JSRegExpResult result = matchNonZeroDisjunction(disjunctionBody, context->getDisjunctionContext(term), true);
+                JSRegExpResult result = matchNonZeroDisjunction(disjunctionBody, context->getDisjunctionContext(), true);
                 if (result == JSRegExpResult::Match) {
                     // successful backtrack! we're back in the game!
                     if (backTrack->matchAmount) {
@@ -2052,6 +2119,9 @@ public:
         for (unsigned i = 0; i < pattern->m_body->m_numSubpatterns + 1; ++i)
             output[i << 1] = offsetNoMatch;
 
+        for (unsigned i = pattern->m_offsetVectorBaseForNamedCaptures; i < pattern->m_offsetsSize; ++i)
+            output[i] = 0;
+
         allocatorPool = pattern->m_allocator->startAllocator();
         RELEASE_ASSERT(allocatorPool);
 
@@ -2136,7 +2206,7 @@ public:
             ByteTermDumper(&m_pattern).dumpDisjunction(m_bodyDisjunction.get());
 #endif
 
-        return makeUnique<BytecodePattern>(WTFMove(m_bodyDisjunction), m_allParenthesesInfo, m_pattern, allocator, lock);
+        return makeUnique<BytecodePattern>(WTFMove(m_bodyDisjunction), m_allParenthesesInfo, m_pattern, allocator, lock, m_pattern.offsetVectorBaseForNamedCaptures(), m_pattern.offsetsSize());
     }
 
     void checkInput(unsigned count)
@@ -2204,6 +2274,11 @@ public:
 
         m_bodyDisjunction->terms.append(ByteTerm::BackReference(subpatternId, matchDirection, inputPosition));
 
+        if (m_pattern.hasDuplicateNamedCaptureGroups()) {
+            auto duplicateNamedGroupId = m_pattern.m_duplicateNamedGroupForSubpatternId[subpatternId];
+            if (duplicateNamedGroupId)
+                m_bodyDisjunction->terms.last().atom.parenIds.duplicateNamedGroupId = duplicateNamedGroupId;
+        }
         m_bodyDisjunction->terms.last().atom.quantityMaxCount = quantityMaxCount;
         m_bodyDisjunction->terms.last().atom.quantityType = quantityType;
         m_bodyDisjunction->terms.last().frameLocation = frameLocation;
@@ -2252,11 +2327,11 @@ public:
         m_currentAlternativeIndex = beginTerm + 1;
     }
 
-    void atomParentheticalAssertionBegin(unsigned subpatternId, unsigned minimumSize, bool invert, MatchDirection matchDirection, unsigned frameLocation, unsigned alternativeFrameLocation)
+    void atomParentheticalAssertionBegin(unsigned subpatternId, bool invert, MatchDirection matchDirection, unsigned frameLocation, unsigned alternativeFrameLocation)
     {
         unsigned beginTerm = m_bodyDisjunction->terms.size();
 
-        m_bodyDisjunction->terms.append(ByteTerm(ByteTerm::Type::ParentheticalAssertionBegin, subpatternId, false, invert, matchDirection, minimumSize));
+        m_bodyDisjunction->terms.append(ByteTerm::ParentheticalAssertionBegin(subpatternId, invert, matchDirection));
         m_bodyDisjunction->terms.last().frameLocation = frameLocation;
         m_bodyDisjunction->terms.append(ByteTerm::AlternativeBegin());
         m_bodyDisjunction->terms.last().frameLocation = alternativeFrameLocation;
@@ -2265,7 +2340,7 @@ public:
         m_currentAlternativeIndex = beginTerm + 1;
     }
 
-    void atomParentheticalAssertionEnd(unsigned inputPosition, unsigned lastSubpatternId, unsigned frameLocation, Checked<unsigned> quantityMaxCount, QuantifierType quantityType)
+    void atomParentheticalAssertionEnd(unsigned lastSubpatternId, unsigned frameLocation, Checked<unsigned> quantityMaxCount, QuantifierType quantityType)
     {
         unsigned beginTerm = popParenthesesStack();
         closeAlternative(beginTerm + 1);
@@ -2277,11 +2352,9 @@ public:
         MatchDirection matchDirection = m_bodyDisjunction->terms[beginTerm].matchDirection();
         unsigned subpatternId = m_bodyDisjunction->terms[beginTerm].subpatternId();
 
-        m_bodyDisjunction->terms.append(ByteTerm(ByteTerm::Type::ParentheticalAssertionEnd, subpatternId, false, invert, matchDirection, inputPosition));
+        m_bodyDisjunction->terms.append(ByteTerm::ParentheticalAssertionEnd(subpatternId, lastSubpatternId, invert, matchDirection));
         m_bodyDisjunction->terms[beginTerm].atom.parenthesesWidth = endTerm - beginTerm;
         m_bodyDisjunction->terms[endTerm].atom.parenthesesWidth = endTerm - beginTerm;
-        m_bodyDisjunction->terms[beginTerm].atom.ids.lastSubpatternId = lastSubpatternId;
-        m_bodyDisjunction->terms[endTerm].atom.ids.lastSubpatternId = lastSubpatternId;
         m_bodyDisjunction->terms[endTerm].frameLocation = frameLocation;
 
         m_bodyDisjunction->terms[beginTerm].atom.quantityMaxCount = quantityMaxCount;
@@ -2386,6 +2459,14 @@ public:
         m_bodyDisjunction->terms.last().m_matchDirection = parenthesesMatchDirection;
         m_allParenthesesInfo.append(WTFMove(parenthesesDisjunction));
 
+        if (m_pattern.hasDuplicateNamedCaptureGroups() && m_bodyDisjunction->terms[beginTerm].capture()) {
+            auto duplicateNamedGroupId = m_pattern.m_duplicateNamedGroupForSubpatternId[subpatternId];
+            if (duplicateNamedGroupId) {
+                m_bodyDisjunction->terms[endTerm].atom.parenIds.duplicateNamedGroupId = duplicateNamedGroupId;
+                m_bodyDisjunction->terms[beginTerm].atom.parenIds.duplicateNamedGroupId = duplicateNamedGroupId;
+            }
+        }
+
         m_bodyDisjunction->terms[beginTerm].atom.quantityMinCount = quantityMinCount;
         m_bodyDisjunction->terms[beginTerm].atom.quantityMaxCount = quantityMaxCount;
         m_bodyDisjunction->terms[beginTerm].atom.quantityType = quantityType;
@@ -2409,6 +2490,15 @@ public:
             m_bodyDisjunction->terms[endTerm].inputPosition = m_bodyDisjunction->terms[beginTerm].inputPosition;
             m_bodyDisjunction->terms[beginTerm].inputPosition = inputPosition;
         }
+
+        if (m_pattern.hasDuplicateNamedCaptureGroups() && m_bodyDisjunction->terms[beginTerm].capture()) {
+            auto duplicateNamedGroupId = m_pattern.m_duplicateNamedGroupForSubpatternId[subpatternId];
+            if (duplicateNamedGroupId) {
+                m_bodyDisjunction->terms[endTerm].atom.parenIds.duplicateNamedGroupId = duplicateNamedGroupId;
+                m_bodyDisjunction->terms[beginTerm].atom.parenIds.duplicateNamedGroupId = duplicateNamedGroupId;
+            }
+        }
+
         m_bodyDisjunction->terms[beginTerm].atom.parenthesesWidth = endTerm - beginTerm;
         m_bodyDisjunction->terms[endTerm].atom.parenthesesWidth = endTerm - beginTerm;
         m_bodyDisjunction->terms[endTerm].frameLocation = frameLocation;
@@ -2439,6 +2529,14 @@ public:
         m_bodyDisjunction->terms[beginTerm].atom.parenthesesWidth = endTerm - beginTerm;
         m_bodyDisjunction->terms[endTerm].atom.parenthesesWidth = endTerm - beginTerm;
         m_bodyDisjunction->terms[endTerm].frameLocation = frameLocation;
+
+        if (m_pattern.hasDuplicateNamedCaptureGroups() && m_bodyDisjunction->terms[beginTerm].capture()) {
+            auto duplicateNamedGroupId = m_pattern.m_duplicateNamedGroupForSubpatternId[subpatternId];
+            if (duplicateNamedGroupId) {
+                m_bodyDisjunction->terms[endTerm].atom.parenIds.duplicateNamedGroupId = duplicateNamedGroupId;
+                m_bodyDisjunction->terms[beginTerm].atom.parenIds.duplicateNamedGroupId = duplicateNamedGroupId;
+            }
+        }
 
         m_bodyDisjunction->terms[beginTerm].atom.quantityMinCount = quantityMinCount;
         m_bodyDisjunction->terms[beginTerm].atom.quantityMaxCount = quantityMaxCount;
@@ -2600,10 +2698,10 @@ public:
                                 return ErrorCode::OffsetTooLarge;
                         }
 
-                        atomParentheticalAssertionBegin(term.parentheses.subpatternId, 0, term.invert(), term.matchDirection(), term.frameLocation, alternativeFrameLocation);
+                        atomParentheticalAssertionBegin(term.parentheses.subpatternId, term.invert(), term.matchDirection(), term.frameLocation, alternativeFrameLocation);
                         if (auto error = emitDisjunction(term.parentheses.disjunction, currentCountAlreadyChecked, positiveInputOffset - uncheckAmount, term.matchDirection()))
                             return error;
-                        atomParentheticalAssertionEnd(0, term.parentheses.lastSubpatternId, term.frameLocation, term.quantityMaxCount, term.quantityType);
+                        atomParentheticalAssertionEnd(term.parentheses.lastSubpatternId, term.frameLocation, term.quantityMaxCount, term.quantityType);
                         if (uncheckAmount) {
                             checkInput(uncheckAmount);
                             currentCountAlreadyChecked += uncheckAmount;
@@ -2627,11 +2725,11 @@ public:
                                 haveCheckedInput(checkedCountForLookbehind);
                             }
                         }
-                        atomParentheticalAssertionBegin(term.parentheses.subpatternId, term.parentheses.disjunction->m_minimumSize, term.invert(), term.matchDirection(), term.frameLocation, alternativeFrameLocation);
+                        atomParentheticalAssertionBegin(term.parentheses.subpatternId, term.invert(), term.matchDirection(), term.frameLocation, alternativeFrameLocation);
 
                         if (auto error = emitDisjunction(term.parentheses.disjunction, checkedCountForLookbehind, positiveInputOffset + minimumSize, term.matchDirection()))
                             return error;
-                        atomParentheticalAssertionEnd(0, term.parentheses.lastSubpatternId, term.frameLocation, term.quantityMaxCount, term.quantityType);
+                        atomParentheticalAssertionEnd(term.parentheses.lastSubpatternId, term.frameLocation, term.quantityMaxCount, term.quantityType);
 
                         if (uncheckAmount) {
                             checkInput(uncheckAmount);
@@ -2864,6 +2962,7 @@ void ByteTermDumper::dumpTerm(size_t idx, ByteTerm term)
         dumpMatchDirection(term);
         break;
     case ByteTerm::Type::BackReference:
+        //  Need to update this for named capture group back references
         outputTermIndexAndNest(idx, m_nesting);
         out.print("BackReference #", term.subpatternId());
         dumpInputPosition(term);

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.h
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.h
@@ -51,8 +51,12 @@ struct ByteTerm {
                 CharacterClass* characterClass;
                 struct {
                     unsigned subpatternId;
+                    unsigned duplicateNamedGroupId;
+                } parenIds;
+                struct {
+                    unsigned firstSubpatternId;
                     unsigned lastSubpatternId;
-                } ids;
+                } assertionIds;
             };
             union {
                 ByteDisjunction* parenthesesDisjunction;
@@ -191,7 +195,8 @@ struct ByteTerm {
         , m_matchDirection(Forward)
         , inputPosition(inputPos)
     {
-        atom.ids.subpatternId = subpatternId;
+        atom.parenIds.subpatternId = subpatternId;
+        atom.parenIds.duplicateNamedGroupId = 0;
         atom.parenthesesDisjunction = parenthesesInfo;
         atom.quantityType = QuantifierType::FixedCount;
         atom.quantityMinCount = 1;
@@ -216,7 +221,8 @@ struct ByteTerm {
         , m_matchDirection(Forward)
         , inputPosition(inputPos)
     {
-        atom.ids.subpatternId = subpatternId;
+        atom.parenIds.subpatternId = subpatternId;
+        atom.parenIds.duplicateNamedGroupId = 0;
         atom.quantityType = QuantifierType::FixedCount;
         atom.quantityMinCount = 1;
         atom.quantityMaxCount = 1;
@@ -229,7 +235,8 @@ struct ByteTerm {
         , m_matchDirection(matchDirection)
         , inputPosition(inputPos)
     {
-        atom.ids.subpatternId = subpatternId;
+        atom.parenIds.subpatternId = subpatternId;
+        atom.parenIds.duplicateNamedGroupId = 0;
         atom.quantityType = QuantifierType::FixedCount;
         atom.quantityMinCount = 1;
         atom.quantityMaxCount = 1;
@@ -346,7 +353,26 @@ struct ByteTerm {
     {
         return ByteTerm(Type::SubpatternEnd);
     }
-    
+
+    static ByteTerm ParentheticalAssertionBegin(unsigned firstSubpatternId, bool invert, MatchDirection matchDirection)
+    {
+        ByteTerm term(Type::ParentheticalAssertionBegin);
+        term.atom.assertionIds.firstSubpatternId = firstSubpatternId;
+        term.m_invert = invert;
+        term.m_matchDirection = matchDirection;
+        return term;
+    }
+
+    static ByteTerm ParentheticalAssertionEnd(unsigned firstSubpatternId, unsigned lastSubpatternId, bool invert, MatchDirection matchDirection)
+    {
+        ByteTerm term(Type::ParentheticalAssertionEnd);
+        term.atom.assertionIds.firstSubpatternId = firstSubpatternId;
+        term.atom.assertionIds.lastSubpatternId = lastSubpatternId;
+        term.m_invert = invert;
+        term.m_matchDirection = matchDirection;
+        return term;
+    }
+
     static ByteTerm DotStarEnclosure(bool bolAnchor, bool eolAnchor)
     {
         ByteTerm term(Type::DotStarEnclosure);
@@ -374,17 +400,27 @@ struct ByteTerm {
     {
         ASSERT(this->type == Type::ParentheticalAssertionBegin
             || this->type == Type::ParentheticalAssertionEnd);
-        return lastSubpatternId() >= subpatternId();
+        return lastSubpatternId() >= firstSubpatternId();
     }
 
     unsigned subpatternId()
     {
-        return atom.ids.subpatternId;
+        return atom.parenIds.subpatternId;
+    }
+
+    unsigned duplicateNamedGroupId()
+    {
+        return atom.parenIds.duplicateNamedGroupId;
+    }
+
+    unsigned firstSubpatternId()
+    {
+        return atom.assertionIds.firstSubpatternId;
     }
 
     unsigned lastSubpatternId()
     {
-        return atom.ids.lastSubpatternId;
+        return atom.assertionIds.lastSubpatternId;
     }
     bool invert()
     {
@@ -421,11 +457,14 @@ public:
 struct BytecodePattern {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    BytecodePattern(std::unique_ptr<ByteDisjunction> body, Vector<std::unique_ptr<ByteDisjunction>>& parenthesesInfoToAdopt, YarrPattern& pattern, BumpPointerAllocator* allocator, ConcurrentJSLock* lock)
+    BytecodePattern(std::unique_ptr<ByteDisjunction> body, Vector<std::unique_ptr<ByteDisjunction>>& parenthesesInfoToAdopt, YarrPattern& pattern, BumpPointerAllocator* allocator, ConcurrentJSLock* lock, unsigned offsetVectorBaseForNamedCaptures, unsigned offsetsSize)
         : m_body(WTFMove(body))
         , m_flags(pattern.m_flags)
         , m_allocator(allocator)
         , m_lock(lock)
+        , m_offsetVectorBaseForNamedCaptures(offsetVectorBaseForNamedCaptures)
+        , m_offsetsSize(offsetsSize)
+        , m_duplicateNamedGroupForSubpatternId(pattern.m_duplicateNamedGroupForSubpatternId)
     {
         m_body->terms.shrinkToFit();
 
@@ -440,10 +479,20 @@ public:
 
         m_userCharacterClasses.swap(pattern.m_userCharacterClasses);
         m_userCharacterClasses.shrinkToFit();
+
+        m_numDuplicateNamedCaptureGroups = pattern.m_numDuplicateNamedCaptureGroups;
     }
 
     size_t estimatedSizeInBytes() const { return m_body->estimatedSizeInBytes(); }
-    
+
+    bool hasDuplicateNamedCaptureGroups() const { return !!m_numDuplicateNamedCaptureGroups; }
+
+    unsigned offsetForDuplicateNamedGroupId(unsigned duplicateNamedGroupId)
+    {
+        ASSERT(duplicateNamedGroupId);
+        return m_offsetVectorBaseForNamedCaptures + duplicateNamedGroupId - 1;
+    }
+
     bool ignoreCase() const { return m_flags.contains(Flags::IgnoreCase); }
     bool multiline() const { return m_flags.contains(Flags::Multiline); }
     bool hasIndices() const { return m_flags.contains(Flags::HasIndices); }
@@ -457,6 +506,11 @@ public:
     // with a VM.  Cache a pointer to our VM's m_regExpAllocator.
     BumpPointerAllocator* m_allocator;
     ConcurrentJSLock* m_lock;
+
+    unsigned m_numDuplicateNamedCaptureGroups;
+    unsigned m_offsetVectorBaseForNamedCaptures;
+    unsigned m_offsetsSize;
+    Vector<unsigned> m_duplicateNamedGroupForSubpatternId;
 
     CharacterClass* newlineCharacterClass;
     CharacterClass* wordcharCharacterClass;

--- a/Source/JavaScriptCore/yarr/YarrJITRegisters.h
+++ b/Source/JavaScriptCore/yarr/YarrJITRegisters.h
@@ -68,7 +68,7 @@ public:
     static constexpr GPRReg regT2 = ARM64Registers::x8;
     static constexpr GPRReg remainingMatchCount = ARM64Registers::x9;
     static constexpr GPRReg regUnicodeInputAndTrail = ARM64Registers::x10;
-    static constexpr GPRReg unicodeTemp = ARM64Registers::x5;
+    static constexpr GPRReg unicodeAndSubpatternIdTemp = ARM64Registers::x5;
     static constexpr GPRReg initialStart = ARM64Registers::x11;
     static constexpr GPRReg supplementaryPlanesBase = ARM64Registers::x12;
     static constexpr GPRReg leadingSurrogateTag = ARM64Registers::x13;
@@ -132,7 +132,7 @@ public:
     static constexpr GPRReg remainingMatchCount = X86Registers::esi;
 #endif
     static constexpr GPRReg regUnicodeInputAndTrail = X86Registers::r13;
-    static constexpr GPRReg unicodeTemp = X86Registers::r14;
+    static constexpr GPRReg unicodeAndSubpatternIdTemp = X86Registers::r14;
     static constexpr GPRReg endOfStringAddress = X86Registers::r15;
 
     static constexpr GPRReg returnRegister = X86Registers::eax;
@@ -158,7 +158,7 @@ public:
     static constexpr GPRReg regT2 = RISCV64Registers::x5;
     static constexpr GPRReg remainingMatchCount = RISCV64Registers::x6;
     static constexpr GPRReg regUnicodeInputAndTrail = RISCV64Registers::x7;
-    static constexpr GPRReg unicodeTemp = RISCV64Registers::x15;
+    static constexpr GPRReg unicodeAndSubpatternIdTemp = RISCV64Registers::x15;
     static constexpr GPRReg initialStart = RISCV64Registers::x28;
     static constexpr GPRReg endOfStringAddress = RISCV64Registers::x29;
 
@@ -225,7 +225,7 @@ public:
     // Unicode character processing
     GPRReg remainingMatchCount { InvalidGPRReg };
     GPRReg regUnicodeInputAndTrail { InvalidGPRReg };
-    GPRReg unicodeTemp { InvalidGPRReg };
+    GPRReg unicodeAndSubpatternIdTemp { InvalidGPRReg };
     GPRReg endOfStringAddress { InvalidGPRReg };
 
     const MacroAssembler::TrustedImm32 supplementaryPlanesBase = MacroAssembler::TrustedImm32(0x10000);


### PR DESCRIPTION
#### 9ed7d9c4e36677ce84c2bd2b2b225d240365fa19
<pre>
[JSC] Implement RegExp Duplicate Named Capture Groups
<a href="https://bugs.webkit.org/show_bug.cgi?id=252553">https://bugs.webkit.org/show_bug.cgi?id=252553</a>
rdar://100335581

Reviewed by Yusuke Suzuki.

This change implements RegExp Duplicate Named Capture Groups (<a href="https://github.com/tc39/ecma262/tree/duplicate-named-capture-groups).">https://github.com/tc39/ecma262/tree/duplicate-named-capture-groups).</a>
Duplicate named captures have a unique positive ID like subpatternIds.  When matching, either in the interpreter or JIT,
space for an unsgined is added in the &quot;output&quot; vector for each duplicate named capture.  When a subpattern that is one of the
duplicates for a named capture matches, that subpattern&apos;s ID is saved in its duplicate named capture location of the output
vector.  When such a subpattern doesn&apos;t match or backtrackes, a zero is written in the named capture&apos;s output location.
When either matching a backreference for a named capture or creating the match result, the participating subpattern for a
duplicate named capture is indirectly accessed via the named capture&apos;s output location.

YarrPatterns now contains a map from a duplicate named capture to a vector of unsigneds.  The first value in that vector is
that duplicate named group&apos;s unique ID.  The remaining values are the subpatternIds that are part of the named group.
There is also a vector were the value at subpatternId index contains its duplicate named group&apos;s ID.  These allow for
finding the subpatternId&apos;s for a given duplicate named capture group as well as finding the duplicated named capture ID
for a given subpatternId.

Updated existing LayoutTests/js/regexp-named-capture-groups.html to no longer fail with duplcxate capture names.
Enabled duplicate named capture tests in test262.

* JSTests/test262/config.yaml: Enabled regexp-duplicate-named-groups
* JSTests/stress/regexp-duplicate-named-captures.js: Added.
(arrayToString):
(objectToString):
(dumpValue):
(compareArray):
(compareGroups):
(testRegExp):
(testRegExpSyntaxError):
(testRegExp.x.a):
(testRegExp.a.x):
* LayoutTests/js/regexp-named-capture-groups-expected.txt: Removed test for syntax error with a duplicate group name.
* LayoutTests/js/script-tests/regexp-named-capture-groups.js: Removed test for syntax error with a duplicate group name.
* Source/JavaScriptCore/runtime/RegExp.cpp:
(JSC::RegExp::finishCreation):
* Source/JavaScriptCore/runtime/RegExp.h:
* Source/JavaScriptCore/runtime/RegExpInlines.h:
(JSC::RegExp::matchInline):
* Source/JavaScriptCore/runtime/RegExpMatchesArray.h:
(JSC::createRegExpMatchesArray):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::substituteBackreferencesSlow):
(JSC::replaceUsingRegExpSearch):
* Source/JavaScriptCore/yarr/Yarr.h:
* Source/JavaScriptCore/yarr/YarrInterpreter.cpp:
(JSC::Yarr::Interpreter::ParenthesesDisjunctionContext::ParenthesesDisjunctionContext):
(JSC::Yarr::Interpreter::ParenthesesDisjunctionContext::restoreOutput):
(JSC::Yarr::Interpreter::ParenthesesDisjunctionContext::getDisjunctionContext):
(JSC::Yarr::Interpreter::ParenthesesDisjunctionContext::backupOffsetForDuplicateNamedGroup):
(JSC::Yarr::Interpreter::ParenthesesDisjunctionContext::allocationSize):
(JSC::Yarr::Interpreter::allocParenthesesDisjunctionContext):
(JSC::Yarr::Interpreter::matchBackReference):
(JSC::Yarr::Interpreter::backtrackBackReference):
(JSC::Yarr::Interpreter::recordParenthesesMatch):
(JSC::Yarr::Interpreter::resetMatches):
(JSC::Yarr::Interpreter::parenthesesDoBacktrack):
(JSC::Yarr::Interpreter::matchParenthesesOnceBegin):
(JSC::Yarr::Interpreter::matchParenthesesOnceEnd):
(JSC::Yarr::Interpreter::backtrackParenthesesOnceBegin):
(JSC::Yarr::Interpreter::backtrackParenthesesOnceEnd):
(JSC::Yarr::Interpreter::matchParentheses):
(JSC::Yarr::Interpreter::backtrackParentheses):
(JSC::Yarr::ByteCompiler::compile):
(JSC::Yarr::ByteCompiler::atomBackReference):
(JSC::Yarr::ByteCompiler::atomParentheticalAssertionBegin):
(JSC::Yarr::ByteCompiler::atomParentheticalAssertionEnd):
(JSC::Yarr::ByteCompiler::atomParenthesesSubpatternEnd):
(JSC::Yarr::ByteCompiler::atomParenthesesOnceEnd):
(JSC::Yarr::ByteCompiler::atomParenthesesTerminalEnd):
(JSC::Yarr::ByteCompiler::emitDisjunction):
(JSC::Yarr::ByteTermDumper::dumpTerm):
* Source/JavaScriptCore/yarr/YarrInterpreter.h:
(JSC::Yarr::ByteTerm::ByteTerm):
(JSC::Yarr::ByteTerm::ParentheticalAssertionBegin):
(JSC::Yarr::ByteTerm::ParentheticalAssertionEnd):
(JSC::Yarr::ByteTerm::containsAnyCaptures):
(JSC::Yarr::ByteTerm::subpatternId):
(JSC::Yarr::ByteTerm::duplicateNamedGroupId):
(JSC::Yarr::ByteTerm::firstSubpatternId):
(JSC::Yarr::ByteTerm::lastSubpatternId):
(JSC::Yarr::BytecodePattern::BytecodePattern):
(JSC::Yarr::BytecodePattern::hasDuplicateNamedCaptureGroups const):
(JSC::Yarr::BytecodePattern::offsetForDuplicateNamedGroupId):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
(JSC::Yarr::loadSubPatternIdForDuplicateNamedGroup):
(JSC::Yarr::loadSubPattern):
(JSC::Yarr::loadSubPatternEnd):
(JSC::Yarr::YarrGenerator):
(JSC::Yarr::compile):
(JSC::Yarr::compileInline):
(JSC::Yarr::dumpCompileFailure): Deleted.
(JSC::Yarr::jitCompile): Deleted.
(JSC::Yarr::jitCompileInlinedTest): Deleted.
* Source/JavaScriptCore/yarr/YarrJITRegisters.h:
* Source/JavaScriptCore/yarr/YarrParser.h:
(JSC::Yarr::Parser::NamedCaptureGroups::NamedCaptureGroups):
(JSC::Yarr::Parser::NamedCaptureGroups::contains):
(JSC::Yarr::Parser::NamedCaptureGroups::isEmpty):
(JSC::Yarr::Parser::NamedCaptureGroups::reset):
(JSC::Yarr::Parser::NamedCaptureGroups::nextAlternative):
(JSC::Yarr::Parser::NamedCaptureGroups::pushParenthesis):
(JSC::Yarr::Parser::NamedCaptureGroups::popParenthesis):
(JSC::Yarr::Parser::NamedCaptureGroups::add):
(JSC::Yarr::Parser::parseEscape):
(JSC::Yarr::Parser::parseParenthesesBegin):
(JSC::Yarr::Parser::parseParenthesesEnd):
(JSC::Yarr::Parser::parseTokens):
(JSC::Yarr::Parser::parse):
(JSC::Yarr::Parser::handleIllegalReferences):
(JSC::Yarr::Parser::containsIllegalNamedForwardReference):
(JSC::Yarr::Parser::resetForReparsing):
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::YarrPatternConstructor::UnresolvedForwardReference::UnresolvedForwardReference):
(JSC::Yarr::YarrPatternConstructor::UnresolvedForwardReference::hasNamedGroup):
(JSC::Yarr::YarrPatternConstructor::UnresolvedForwardReference::namedGroup):
(JSC::Yarr::YarrPatternConstructor::namedCaptureGroupIdForName):
(JSC::Yarr::YarrPatternConstructor::tryConvertingForwardReferencesToBackreferences):
(JSC::Yarr::YarrPatternConstructor::atomParenthesesSubpatternBegin):
(JSC::Yarr::YarrPatternConstructor::atomParenthesesEnd):
(JSC::Yarr::YarrPatternConstructor::atomNamedBackReference):
(JSC::Yarr::YarrPatternConstructor::atomNamedForwardReference):
(JSC::Yarr::YarrPatternConstructor::disjunction):
(JSC::Yarr::YarrPatternConstructor::setupDuplicateNamedCaptures):
(JSC::Yarr::YarrPattern::compile):
* Source/JavaScriptCore/yarr/YarrPattern.h:
(JSC::Yarr::PatternTerm::ForwardReference):
(JSC::Yarr::YarrPattern::resetForReparsing):
(JSC::Yarr::YarrPattern::offsetVectorBaseForNamedCaptures const):
(JSC::Yarr::YarrPattern::offsetsSize const):
(JSC::Yarr::YarrPattern::offsetForDuplicateNamedGroupId):
(JSC::Yarr::YarrPattern::hasDuplicateNamedCaptureGroups const):
(JSC::Yarr::BackTrackInfoBackReference::backReferenceSizeIndex):

Canonical link: <a href="https://commits.webkit.org/260692@main">https://commits.webkit.org/260692@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4baebc7198e97b0049a1a64056e661fe71449b5d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109070 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18152 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41892 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/605 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118337 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19611 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9454 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101311 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114830 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97938 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42868 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29591 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84598 "Passed tests") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/98099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10934 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/30937 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/98891 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/9025 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11673 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/7867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/31024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17047 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50536 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/106565 "Built successfully") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7378 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13279 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26412 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->