### PR TITLE
[GTK][WPE] UI process release log not shown

### DIFF
--- a/Source/WTF/wtf/unix/LoggingUnix.cpp
+++ b/Source/WTF/wtf/unix/LoggingUnix.cpp
@@ -34,6 +34,10 @@ String logLevelString()
 {
     char* logEnv = getenv("WEBKIT_DEBUG");
 
+    // Disable all log channels if WEBKIT_DEBUG is unset.
+    if (!logEnv || !*logEnv)
+        return makeString("-all"_s);
+
     // We set up the logs anyway because some of our logging, such as Soup's is available in release builds.
 #if defined(NDEBUG) && RELEASE_LOG_DISABLED
     WTFLogAlways("WEBKIT_DEBUG is not empty, but this is a release build. Notice that many log messages will only appear in a debug build.");

--- a/Source/WebCore/platform/unix/LoggingUnix.cpp
+++ b/Source/WebCore/platform/unix/LoggingUnix.cpp
@@ -24,26 +24,19 @@
 
 #if !LOG_DISABLED || !RELEASE_LOG_DISABLED
 
-#include <string.h>
+#include <wtf/LogInitialization.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
 String logLevelString()
 {
-    char* logEnv = getenv("WEBKIT_DEBUG");
-
-    // Disable all log channels if WEBKIT_DEBUG is unset.
-    if (!logEnv)
-        return makeString("-all"_s);
-
-    // We set up the logs anyway because some of our logging, such as Soup's is available in release builds.
-#if defined(NDEBUG) && RELEASE_LOG_DISABLED
-    WTFLogAlways("WEBKIT_DEBUG is not empty, but this is a release build. Notice that many log messages will only appear in a debug build.");
-#endif
+    auto logLevel = WTF::logLevelString();
+    if (logLevel == "-all"_s)
+        return logLevel;
 
     // To disable logging notImplemented set the DISABLE_NI_WARNING environment variable to 1.
-    return makeString("NotYetImplemented,"_s, logEnv);
+    return makeString("NotYetImplemented,"_s, logLevel);
 }
 
 } // namespace WebCore

--- a/Source/WebKit/Platform/unix/LoggingUnix.cpp
+++ b/Source/WebKit/Platform/unix/LoggingUnix.cpp
@@ -27,19 +27,18 @@
 #include "config.h"
 #include "Logging.h"
 
-namespace WebKit {
-
 #if !LOG_DISABLED || !RELEASE_LOG_DISABLED
+
+#include <wtf/LogInitialization.h>
+
+namespace WebKit {
 
 String logLevelString()
 {
-#if !LOG_DISABLED
-    return String::fromLatin1(getenv("WEBKIT_DEBUG"));
-#else
-    return String();
-#endif
+    return WTF::logLevelString();
 }
+
+} // namespace WebKit
 
 #endif // !LOG_DISABLED || !RELEASE_LOG_DISABLED
 
-}

--- a/Source/WebKit/Shared/WebKit2Initialize.cpp
+++ b/Source/WebKit/Shared/WebKit2Initialize.cpp
@@ -26,13 +26,10 @@
 #include "config.h"
 #include "WebKit2Initialize.h"
 
-#include "LogInitialization.h"
 #include <JavaScriptCore/InitializeThreading.h>
 #include <WebCore/CommonAtomStrings.h>
-#include <WebCore/LogInitialization.h>
 #include <WebCore/WebCoreJITOperations.h>
 #include <wtf/GenerateProfiles.h>
-#include <wtf/LogInitialization.h>
 #include <wtf/MainThread.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RunLoop.h>
@@ -48,12 +45,6 @@ void InitializeWebKit2()
     WebCore::initializeCommonAtomStrings();
 
     WTF::RefCountedBase::enableThreadingChecksGlobally();
-
-#if !LOG_DISABLED || !RELEASE_LOG_DISABLED
-    WTF::logChannels().initializeLogChannelsIfNecessary();
-    WebCore::logChannels().initializeLogChannelsIfNecessary();
-    WebKit::logChannels().initializeLogChannelsIfNecessary();
-#endif // !LOG_DISABLED || !RELEASE_LOG_DISABLED
 
     WebCore::populateJITOperations();
 }


### PR DESCRIPTION
#### 173e3ebecf4fc597db7b4ce959e7bf451fa09ca4
<pre>
[GTK][WPE] UI process release log not shown
<a href="https://bugs.webkit.org/show_bug.cgi?id=252558">https://bugs.webkit.org/show_bug.cgi?id=252558</a>

Reviewed by Michael Catanzaro.

The problem is that logLevelString() implementation in WebKit layer
doesn&apos;t take RELEASE_LOG_DISABLED into account. Actually the
implementation of logLevelString() in all layers does the same, getting
th value of WEBKIT_DEBUG env var, but with a few differences. We can
have a single implementation in WTF and use WTF::logLevelString() from
WebCore and WebKit.

* Source/WTF/wtf/unix/LoggingUnix.cpp:
(WTF::logLevelString):
* Source/WebCore/platform/unix/LoggingUnix.cpp:
(WebCore::logLevelString):
* Source/WebKit/Platform/unix/LoggingUnix.cpp:
(WebKit::logLevelString):
* Source/WebKit/Shared/WebKit2Initialize.cpp:
(WebKit::InitializeWebKit2): Remove log initialization here since it&apos;s already done in UIProcessLogInitialization.cpp.

Canonical link: <a href="https://commits.webkit.org/260601@main">https://commits.webkit.org/260601@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8dc834be08e7697e3d36f92b26fd8b6e8542b70

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108638 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17739 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41492 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117748 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/117949 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112521 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19190 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9016 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100879 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114405 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14388 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97621 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42363 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96364 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29259 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84095 "Found 2 new API test failures: /TestWebKit:WebKit.OnDeviceChangeCrash, /TestWebKit:WebKit.PrivateBrowsingPushStateNoHistoryCallback (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/97771 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10547 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30609 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/98604 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/8663 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11305 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7523 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30965 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16696 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50205 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/106198 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12893 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26323 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3992 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->