### PR TITLE
[contain-intrinsic-size] auto-009.html is failing

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-009-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-009-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Only recording last remembered inline size assert_equals: Using last remembered inline size - clientHeight expected 1 but got 50
-FAIL Only recording last remembered block size assert_equals: Using last remembered block size - clientWidth expected 2 but got 100
+PASS Only recording last remembered inline size
+PASS Only recording last remembered block size
 

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -681,7 +681,7 @@ ExceptionOr<void> ContainerNode::removeChild(Node& oldChild)
     dispatchSubtreeModifiedEvent();
 
     auto* element = dynamicDowncast<Element>(oldChild);
-    if (element && element->lastRememberedSize()) {
+    if (element && (element->lastRememberedLogicalWidth() || element->lastRememberedLogicalHeight())) {
         // The disconnected element could be unobserved because of other properties, here we need to make sure it is observed,
         // so that deliver could be triggered and it would clear lastRememberedSize.
         document().observeForContainIntrinsicSize(*element);

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -394,7 +394,8 @@ static void CallbackForContainIntrinsicSize(const Vector<Ref<ResizeObserverEntry
         if (auto* target = entry->target()) {
             if (!target->isConnected()) {
                 observer.unobserve(*target);
-                target->clearLastRememberedSize();
+                target->clearLastRememberedLogicalWidth();
+                target->clearLastRememberedLogicalHeight();
                 continue;
             }
 
@@ -407,7 +408,10 @@ static void CallbackForContainIntrinsicSize(const Vector<Ref<ResizeObserverEntry
             ASSERT(box->style().hasAutoLengthContainIntrinsicSize());
 
             auto contentBoxSize = entry->contentBoxSize().at(0);
-            target->setLastRememberedSize(ResizeObserverSize::create(contentBoxSize->inlineSize(), contentBoxSize->blockSize()));
+            if (box->style().containIntrinsicLogicalWidthType() == ContainIntrinsicSizeType::AutoAndLength)
+                target->setLastRememberedLogicalWidth(LayoutUnit(contentBoxSize->inlineSize()));
+            if (box->style().containIntrinsicLogicalHeightType() == ContainIntrinsicSizeType::AutoAndLength)
+                target->setLastRememberedLogicalHeight(LayoutUnit(contentBoxSize->blockSize()));
         }
     }
 }

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -4572,20 +4572,40 @@ ResizeObserverData* Element::resizeObserverData()
     return hasRareData() ? elementRareData()->resizeObserverData() : nullptr;
 }
 
-ResizeObserverSize* Element::lastRememberedSize() const
+std::optional<LayoutUnit> Element::lastRememberedLogicalWidth() const
 {
-    return hasRareData() ? elementRareData()->lastRememberedSize() : nullptr;
+    return hasRareData() ? elementRareData()->lastRememberedLogicalWidth() : std::nullopt;
 }
 
-void Element::setLastRememberedSize(Ref<ResizeObserverSize>&& size)
+std::optional<LayoutUnit> Element::lastRememberedLogicalHeight() const
 {
-    ensureElementRareData().setLastRememberedSize(WTFMove(size));
+    return hasRareData() ? elementRareData()->lastRememberedLogicalHeight() : std::nullopt;
 }
 
-void Element::clearLastRememberedSize()
+void Element::setLastRememberedLogicalWidth(LayoutUnit width)
 {
-    if (hasRareData())
-        elementRareData()->clearLastRememberedSize();
+    ASSERT(width >= 0);
+    ensureElementRareData().setLastRememberedLogicalWidth(width);
+}
+
+void Element::clearLastRememberedLogicalWidth()
+{
+    if (!hasRareData())
+        return;
+    elementRareData()->clearLastRememberedLogicalWidth();
+}
+
+void Element::setLastRememberedLogicalHeight(LayoutUnit height)
+{
+    ASSERT(height >= 0);
+    ensureElementRareData().setLastRememberedLogicalHeight(height);
+}
+
+void Element::clearLastRememberedLogicalHeight()
+{
+    if (!hasRareData())
+        return;
+    elementRareData()->clearLastRememberedLogicalHeight();
 }
 
 bool Element::isSpellCheckingEnabled() const

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -76,7 +76,6 @@ class PopoverData;
 class PseudoElement;
 class RenderStyle;
 class RenderTreePosition;
-class ResizeObserverSize;
 class SpaceSplitString;
 class StylePropertyMap;
 class StylePropertyMapReadOnly;
@@ -700,9 +699,12 @@ public:
     ResizeObserverData& ensureResizeObserverData();
     ResizeObserverData* resizeObserverData();
 
-    ResizeObserverSize* lastRememberedSize() const;
-    void setLastRememberedSize(Ref<ResizeObserverSize>&&);
-    void clearLastRememberedSize();
+    std::optional<LayoutUnit> lastRememberedLogicalWidth() const;
+    std::optional<LayoutUnit> lastRememberedLogicalHeight() const;
+    void setLastRememberedLogicalWidth(LayoutUnit);
+    void clearLastRememberedLogicalWidth();
+    void setLastRememberedLogicalHeight(LayoutUnit);
+    void clearLastRememberedLogicalHeight();
 
     Element* findAnchorElementForLink(String& outAnchorName);
 

--- a/Source/WebCore/dom/ElementRareData.cpp
+++ b/Source/WebCore/dom/ElementRareData.cpp
@@ -40,7 +40,7 @@ struct SameSizeAsElementRareData : NodeRareData {
     void* intersectionObserverData;
     void* typedOMData[2];
     void* resizeObserverData;
-    void* resizeObserverSize;
+    Markable<LayoutUnit, LayoutUnitMarkableTraits> lastRemembedSize[2];
     ExplicitlySetAttrElementsMap explicitlySetAttrElementsMap;
 };
 

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -5624,8 +5624,8 @@ std::optional<LayoutUnit> RenderBox::explicitIntrinsicInnerWidth() const
         return std::nullopt;
 
     if (element() && style().containIntrinsicWidthType() == ContainIntrinsicSizeType::AutoAndLength && shouldSkipContent()) {
-        if (auto lastRememberedSize = element()->lastRememberedSize())
-            return isHorizontalWritingMode() ? LayoutUnit(lastRememberedSize->inlineSize()) : LayoutUnit(lastRememberedSize->blockSize());
+        if (auto width = isHorizontalWritingMode() ? element()->lastRememberedLogicalWidth() : element()->lastRememberedLogicalHeight())
+            return width;
     }
 
     auto width = style().containIntrinsicWidth();
@@ -5640,8 +5640,8 @@ std::optional<LayoutUnit> RenderBox::explicitIntrinsicInnerHeight() const
         return std::nullopt;
 
     if (element() && style().containIntrinsicHeightType() == ContainIntrinsicSizeType::AutoAndLength && shouldSkipContent()) {
-        if (auto lastRememberedSize = element()->lastRememberedSize())
-            return isHorizontalWritingMode() ? LayoutUnit(lastRememberedSize->blockSize()) : LayoutUnit(lastRememberedSize->inlineSize());
+        if (auto height = isHorizontalWritingMode() ? element()->lastRememberedLogicalHeight() : element()->lastRememberedLogicalWidth())
+            return height;
     }
 
     auto height = style().containIntrinsicHeight();

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -606,6 +606,8 @@ public:
 
     ContainIntrinsicSizeType containIntrinsicWidthType() const { return static_cast<ContainIntrinsicSizeType>(m_nonInheritedData->rareData->containIntrinsicWidthType); }
     ContainIntrinsicSizeType containIntrinsicHeightType() const { return static_cast<ContainIntrinsicSizeType>(m_nonInheritedData->rareData->containIntrinsicHeightType); }
+    ContainIntrinsicSizeType containIntrinsicLogicalWidthType() const { return isHorizontalWritingMode() ? containIntrinsicWidthType() : containIntrinsicHeightType(); }
+    ContainIntrinsicSizeType containIntrinsicLogicalHeightType() const { return isHorizontalWritingMode() ? containIntrinsicHeightType() : containIntrinsicWidthType(); }
     std::optional<Length> containIntrinsicWidth() const { return m_nonInheritedData->rareData->containIntrinsicWidth; }
     std::optional<Length> containIntrinsicHeight() const { return m_nonInheritedData->rareData->containIntrinsicHeight; }
     bool hasAutoLengthContainIntrinsicSize() const { return containIntrinsicWidthType() == ContainIntrinsicSizeType::AutoAndLength || containIntrinsicHeightType() == ContainIntrinsicSizeType::AutoAndLength; }

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -348,8 +348,12 @@ void RenderTreeUpdater::updateElementRenderer(Element& element, const Style::Ele
     else
         element.clearDisplayContentsStyle();
 
-    if (!hasDisplayContents && !elementUpdateStyle.hasAutoLengthContainIntrinsicSize())
-        element.clearLastRememberedSize();
+    if (!hasDisplayContents) {
+        if (elementUpdateStyle.containIntrinsicLogicalWidthType() != ContainIntrinsicSizeType::AutoAndLength)
+            element.clearLastRememberedLogicalWidth();
+        if (elementUpdateStyle.containIntrinsicLogicalHeightType() != ContainIntrinsicSizeType::AutoAndLength)
+            element.clearLastRememberedLogicalHeight();
+    }
     auto scopeExit = makeScopeExit([&] {
         if (!hasDisplayContents) {
             auto* box = element.renderBox();


### PR DESCRIPTION
#### d8e31024efa9bde474278105ad85152131220b40
<pre>
[contain-intrinsic-size] auto-009.html is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=249919">https://bugs.webkit.org/show_bug.cgi?id=249919</a>

Reviewed by Oriol Brufau.

According to [1], &quot;last remembered size&quot; is tracked for the two axises independently, and can be invoked independently.
This patch supports &quot;last remembered size&quot; in a single direction. It replaces the m_lastRememberedSize of
m_lastRememberedLogicalWidth and m_lastRememberedLogicalHeight in ElementRareData. The value -1 means there is
no last remembered width/height.

[1] <a href="https://github.com/w3c/csswg-drafts/issues/7529">https://github.com/w3c/csswg-drafts/issues/7529</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-009-expected.txt:
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::removeChild):
* Source/WebCore/dom/Document.cpp:
(WebCore::CallbackForContainIntrinsicSize):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::lastRememberedLogicalWidth const):
(WebCore::Element::lastRememberedLogicalHeight const):
(WebCore::Element::setLastRememberedLogicalWidth):
(WebCore::Element::clearLastRememberedLogicalWidth):
(WebCore::Element::setLastRememberedLogicalHeight):
(WebCore::Element::clearLastRememberedLogicalHeight):
(WebCore::Element::lastRememberedSize const): Deleted.
(WebCore::Element::setLastRememberedSize): Deleted.
(WebCore::Element::clearLastRememberedSize): Deleted.
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/ElementRareData.cpp:
* Source/WebCore/dom/ElementRareData.h:
(WebCore::LayoutUnitMarkableTraits::isEmptyValue):
(WebCore::LayoutUnitMarkableTraits::emptyValue):
(WebCore::ElementRareData::lastRememberedLogicalWidth const):
(WebCore::ElementRareData::lastRememberedLogicalHeight const):
(WebCore::ElementRareData::setLastRememberedLogicalWidth):
(WebCore::ElementRareData::setLastRememberedLogicalHeight):
(WebCore::ElementRareData::clearLastRememberedLogicalWidth):
(WebCore::ElementRareData::clearLastRememberedLogicalHeight):
(WebCore::ElementRareData::useTypes const):
(WebCore::ElementRareData::lastRememberedSize const): Deleted.
(WebCore::ElementRareData::setLastRememberedSize): Deleted.
(WebCore::ElementRareData::clearLastRememberedSize): Deleted.
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::explicitIntrinsicInnerWidth const):
(WebCore::RenderBox::explicitIntrinsicInnerHeight const):
* Source/WebCore/rendering/style/RenderStyle.h:
(WebCore::RenderStyle::containIntrinsicLogicalWidthType const):
(WebCore::RenderStyle::containIntrinsicLogicalHeightType const):
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::RenderTreeUpdater::updateElementRenderer):

Canonical link: <a href="https://commits.webkit.org/260939@main">https://commits.webkit.org/260939@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2495ccf6c889450cc84a524c3c2e7d178fe5b3c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109998 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19098 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42680 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1441 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119044 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113951 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20564 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10291 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102256 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115744 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43527 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30180 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85351 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11801 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31520 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12423 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8477 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17791 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51131 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7583 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14218 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->