### PR TITLE
[GStreamer] Harness: graph dump support

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -81,6 +81,8 @@ GST_DEBUG_CATEGORY(webkit_gst_common_debug);
 
 namespace WebCore {
 
+static GstClockTime s_webkitGstInitTime;
+
 GstPad* webkitGstGhostPadFromStaticTemplate(GstStaticPadTemplate* staticPadTemplate, const gchar* name, GstPad* target)
 {
     GstPad* pad;
@@ -296,6 +298,7 @@ bool ensureGStreamerInitialized()
 
         GUniqueOutPtr<GError> error;
         isGStreamerInitialized = gst_init_check(&argc, &argv, &error.outPtr());
+        s_webkitGstInitTime = gst_util_get_timestamp();
         ASSERT_WITH_MESSAGE(isGStreamerInitialized, "GStreamer initialization failed: %s", error ? error->message : "unknown error occurred");
         g_strfreev(argv);
         GST_DEBUG_CATEGORY_INIT(webkit_gst_common_debug, "webkitcommon", 0, "WebKit Common utilities");
@@ -752,6 +755,11 @@ GstClockTime webkitGstElementGetCurrentRunningTime(GstElement* element)
     return clockTime - baseTime;
 }
 #endif
+
+GstClockTime webkitGstInitTime()
+{
+    return s_webkitGstInitTime;
+}
 
 PlatformVideoColorSpace videoColorSpaceFromCaps(const GstCaps* caps)
 {

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -337,6 +337,8 @@ GstClockTime webkitGstElementGetCurrentRunningTime(GstElement*);
 #define gst_element_get_current_running_time webkitGstElementGetCurrentRunningTime
 #endif
 
+GstClockTime webkitGstInitTime();
+
 PlatformVideoColorSpace videoColorSpaceFromCaps(const GstCaps*);
 PlatformVideoColorSpace videoColorSpaceFromInfo(const GstVideoInfo&);
 void fillVideoInfoColorimetryFromColorSpace(GstVideoInfo*, const PlatformVideoColorSpace&);

--- a/Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp
@@ -24,8 +24,10 @@
 
 #include "GStreamerCommon.h"
 
+#include <wtf/FileSystem.h>
 #include <wtf/PrintStream.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/text/StringBuilder.h>
 #include <wtf/text/StringConcatenate.h>
 #include <wtf/text/StringConcatenateNumbers.h>
 
@@ -76,6 +78,12 @@ static GstStaticPadTemplate s_harnessSinkPadTemplate = GST_STATIC_PAD_TEMPLATE("
  *
  * The harness can work on elements exposing either a static source pad, or one-to-many "sometimes"
  * source pads. Support for different topologies can be added as-needed.
+ *
+ * In cases where a graph dump of the harness and its downstream harnesses is needed for debugging
+ * purposes, it can be done by calling the `dumpGraph()` method. At runtime you need to set the
+ * `$WEBKIT_GST_HARNESS_DUMP_DIR` environment variable to a filesystem directory path where `mmd`
+ * [Mermaid](https://mermaid.js.org/) files will be created. Those can then be exported to SVG or
+ * PNG using the mermaid CLI tools or the [live editor](https://mermaid.live).
  */
 
 GStreamerElementHarness::GStreamerElementHarness(GRefPtr<GstElement>&& element, ProcessBufferCallback&& processOutputBufferCallback, std::optional<PadLinkCallback>&& padLinkCallback)
@@ -116,6 +124,7 @@ GStreamerElementHarness::GStreamerElementHarness(GRefPtr<GstElement>&& element, 
             }
 
             harness.m_outputStreams.append(GStreamerElementHarness::Stream::create(WTFMove(outputPad), WTFMove(downstreamHarness)));
+            harness.dumpGraph("pad-added");
         }), this);
 
         g_signal_connect(m_element.get(), "pad-removed", reinterpret_cast<GCallback>(+[](GstElement* element, GstPad* pad, gpointer userData) {
@@ -387,6 +396,221 @@ void GStreamerElementHarness::flush()
     m_inputCaps.clear();
     m_stickyEventsSent.store(false);
     GST_DEBUG_OBJECT(element(), "Flushing done");
+}
+
+#ifndef GST_DISABLE_GST_DEBUG
+class MermaidBuilder {
+public:
+    MermaidBuilder();
+    void process(GStreamerElementHarness&, bool generateFooter = true);
+    Span<uint8_t> span();
+
+private:
+    String generatePadId(GStreamerElementHarness&,  GstPad*);
+    String getPadClass(const GRefPtr<GstPad>&);
+    String describeCaps(const GRefPtr<GstCaps>&);
+    void dumpPad(GStreamerElementHarness&, GstPad* = nullptr);
+    void dumpElement(GStreamerElementHarness&, GstElement* = nullptr);
+
+    StringBuilder m_stringBuilder;
+    uint64_t m_invisibleLinesCounter { 0 };
+    uint64_t m_elementCounter { 0 };
+    Vector<std::tuple<GStreamerElementHarness&, GRefPtr<GstPad>, GRefPtr<GstPad>>> m_padLinks;
+};
+
+MermaidBuilder::MermaidBuilder()
+{
+    m_stringBuilder.append("flowchart LR\n"_s);
+}
+
+String MermaidBuilder::generatePadId(GStreamerElementHarness& harness, GstPad* pad)
+{
+    auto parent = adoptGRef(gst_pad_get_parent(GST_OBJECT_CAST(pad)));
+    if (!parent)
+        return makeString(GST_ELEMENT_NAME(harness.element()), "-harness-", GST_PAD_NAME(pad));
+    return makeString(GST_OBJECT_NAME(parent.get()), '_', GST_PAD_NAME(pad));
+}
+
+String MermaidBuilder::getPadClass(const GRefPtr<GstPad>& pad)
+{
+    auto direction = gst_pad_get_direction(pad.get());
+    if (GST_IS_GHOST_PAD(pad.get()))
+        return direction == GST_PAD_SRC ? "ghostSrcPadClass"_s : "ghostSinkPadClass"_s;
+
+    return direction == GST_PAD_SRC ? "srcPadClass"_s : "sinkPadClass"_s;
+}
+
+void MermaidBuilder::process(GStreamerElementHarness& harness, bool generateFooter)
+{
+    dumpElement(harness);
+    dumpPad(harness);
+
+    for (auto& outputStream : harness.outputStreams()) {
+        auto pad = outputStream->targetPad();
+        auto padId = generatePadId(harness, pad.get());
+        m_stringBuilder.append("subgraph "_s, padId, " [", GST_PAD_NAME(pad.get()), "]\n");
+        m_stringBuilder.append("end\n"_s);
+
+        auto downstreamHarness = outputStream->downstreamHarness();
+        if (!downstreamHarness)
+            continue;
+        process(*downstreamHarness, false);
+        m_stringBuilder.append(padId, "--->"_s, generatePadId(*downstreamHarness, downstreamHarness->inputPad()), '\n');
+    }
+
+    if (!generateFooter)
+        return;
+
+    for (auto& [padHarness, srcPad, sinkPad] : m_padLinks) {
+        m_stringBuilder.append(generatePadId(padHarness, srcPad.get()), ":::"_s, getPadClass(srcPad));
+        if (GST_IS_PROXY_PAD(srcPad.get()))
+            m_stringBuilder.append("--->"_s);
+        else if (auto srcCaps = adoptGRef(gst_pad_get_current_caps(srcPad.get()))) {
+            auto capsString = describeCaps(srcCaps.get());
+            m_stringBuilder.append("--\""_s, capsString, "\"-->"_s);
+        } else
+            m_stringBuilder.append("--->"_s);
+        m_stringBuilder.append(generatePadId(padHarness, sinkPad.get()), ":::"_s, getPadClass(sinkPad), '\n');
+    }
+
+    m_stringBuilder.append("classDef srcPadClass fill:#ffaaaa\n"_s);
+    m_stringBuilder.append("classDef sinkPadClass fill:#aaaaff\n"_s);
+    m_stringBuilder.append("classDef ghostSrcPadClass fill:#ffdddd\n"_s);
+    m_stringBuilder.append("classDef ghostSinkPadClass fill:#ddddff\n"_s);
+    m_stringBuilder.append("classDef elementClass fill:#aaffaa\n"_s);
+}
+
+void MermaidBuilder::dumpPad(GStreamerElementHarness& harness, GstPad* pad)
+{
+    if (!pad)
+        pad = harness.inputPad();
+    m_stringBuilder.append("subgraph "_s, generatePadId(harness, pad), " ["_s, GST_PAD_NAME(pad), "]\n"_s);
+
+    if (gst_pad_is_linked(pad)) {
+        auto peerPad = adoptGRef(gst_pad_get_peer(pad));
+        if (gst_pad_get_direction(pad) == GST_PAD_SRC) {
+            m_padLinks.append({ harness, pad, peerPad });
+            if (GST_IS_PROXY_PAD(pad)) {
+                auto internalPad = adoptGRef(gst_proxy_pad_get_internal(GST_PROXY_PAD(pad)));
+                m_padLinks.append({ harness, GST_PAD_CAST(internalPad.get()), pad });
+            }
+        }
+    }
+
+    m_stringBuilder.append("end\n"_s);
+    if (!GST_IS_GHOST_PAD(pad))
+        return;
+
+    auto padTarget = adoptGRef(gst_ghost_pad_get_target(GST_GHOST_PAD_CAST(pad)));
+    if (!padTarget)
+        return;
+
+    auto peerPad = adoptGRef(gst_pad_get_peer(padTarget.get()));
+    if (!peerPad)
+        return;
+    dumpPad(harness, peerPad.get());
+}
+
+void MermaidBuilder::dumpElement(GStreamerElementHarness& harness, GstElement* element)
+{
+    if (!element)
+        element= harness.element();
+    auto elementId = makeString(GST_ELEMENT_NAME(element), '_', m_elementCounter);
+    m_elementCounter++;
+    m_stringBuilder.append("subgraph "_s, elementId, " [<center>"_s, G_OBJECT_TYPE_NAME(element), "\\n<small>"_s, GST_ELEMENT_NAME(element), "]\n"_s);
+
+    if (GST_IS_BIN(element)) {
+        for (auto element : GstIteratorAdaptor<GstElement>(GUniquePtr<GstIterator>(gst_bin_iterate_recurse(GST_BIN_CAST(element)))))
+            dumpElement(harness, element);
+    }
+
+    GRefPtr<GstPad> firstSinkPad, firstSrcPad;
+    for (auto pad : GstIteratorAdaptor<GstPad>(GUniquePtr<GstIterator>(gst_element_iterate_sink_pads(element)))) {
+        if (!firstSinkPad)
+            firstSinkPad = pad;
+        dumpPad(harness, pad);
+    }
+    for (auto pad : GstIteratorAdaptor<GstPad>(GUniquePtr<GstIterator>(gst_element_iterate_src_pads(element)))) {
+        if (!firstSrcPad)
+            firstSrcPad = pad;
+        dumpPad(harness, pad);
+    }
+
+    // There is no clean way to maintain subgraph ordering, so draw invisible links between pads.
+    // Upstream bug report: https://github.com/mermaid-js/mermaid/issues/815
+    if (firstSinkPad && firstSrcPad) {
+        m_stringBuilder.append(generatePadId(harness, firstSinkPad.get()), "---"_s, generatePadId(harness, firstSrcPad.get()), '\n');
+        m_stringBuilder.append("linkStyle "_s, m_invisibleLinesCounter, " stroke-width:0px\n"_s);
+        m_invisibleLinesCounter++;
+    }
+
+    m_stringBuilder.append("end\n"_s);
+    if (GST_IS_BIN(element))
+        return;
+
+    m_stringBuilder.append("class "_s, elementId, " elementClass\n"_s);
+}
+
+String MermaidBuilder::describeCaps(const GRefPtr<GstCaps>& caps)
+{
+    if (gst_caps_is_any(caps.get()) || gst_caps_is_empty(caps.get())) {
+        GUniquePtr<char> capsString(gst_caps_to_string(caps.get()));
+        return makeString(capsString.get());
+    }
+
+    StringBuilder builder;
+    unsigned capsSize = gst_caps_get_size(caps.get());
+    for (unsigned i = 0; i < capsSize; i++) {
+        auto* features = gst_caps_get_features(caps.get(), i);
+        const auto* structure = gst_caps_get_structure(caps.get(), i);
+        builder.append(gst_structure_get_name(structure), "<br/>"_s);
+        if (features && (gst_caps_features_is_any(features) || !gst_caps_features_is_equal(features, GST_CAPS_FEATURES_MEMORY_SYSTEM_MEMORY))) {
+            GUniquePtr<char> serializedFeature(gst_caps_features_to_string(features));
+            builder.append('(', serializedFeature.get(), ')');
+        }
+
+        gst_structure_foreach(structure, [](GQuark field, const GValue* value, gpointer builderPointer) -> gboolean {
+            auto* builder = reinterpret_cast<StringBuilder*>(builderPointer);
+            builder->append(g_quark_to_string(field), ": "_s);
+
+            GUniquePtr<char> serializedValue(gst_value_serialize(value));
+            auto valueString = makeString(serializedValue.get());
+            if (valueString.length() > 25)
+                builder->append(valueString.substring(0, 25), "…"_s);
+            else
+                builder->append(valueString);
+            builder->append("<br/>"_s);
+            return TRUE;
+        }, &builder);
+    }
+    return builder.toString();
+}
+
+Span<uint8_t> MermaidBuilder::span()
+{
+    auto data = m_stringBuilder.span<uint8_t>();
+    return Span { const_cast<uint8_t*>(data.data()), data.size_bytes() };
+}
+#endif
+
+void GStreamerElementHarness::dumpGraph(const char* filenamePrefix)
+{
+#ifndef GST_DISABLE_GST_DEBUG
+    const char* dumpPath = g_getenv("WEBKIT_GST_HARNESS_DUMP_DIR");
+    if (!dumpPath)
+        return;
+
+    auto elapsed = gst_util_get_timestamp() - webkitGstInitTime();
+    GUniquePtr<char> elapsedTimeStamp(gst_info_strdup_printf("%" GST_TIME_FORMAT, GST_TIME_ARGS(elapsed)));
+    auto filename = makeString(elapsedTimeStamp.get(), '-', filenamePrefix, "-harness-"_s, GST_ELEMENT_NAME(m_element.get()), ".mmd"_s);
+
+    MermaidBuilder builder;
+    builder.process(*this);
+    auto path = FileSystem::pathByAppendingComponent(makeString(dumpPath), filename);
+    FileSystem::overwriteEntireFile(path, builder.span());
+#else
+    UNUSED_PARAM(filenamePrefix);
+#endif
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/gstreamer/GStreamerElementHarness.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerElementHarness.h
@@ -52,7 +52,10 @@ public:
         bool sendEvent(GstEvent*);
 
         const GRefPtr<GstPad>& pad() const { return m_pad; }
+        const GRefPtr<GstPad>& targetPad() const { return m_targetPad; }
         const GRefPtr<GstCaps>& outputCaps();
+
+        const RefPtr<GStreamerElementHarness> downstreamHarness() const { return m_downstreamHarness; }
 
     private:
         Stream(GRefPtr<GstPad>&&, RefPtr<GStreamerElementHarness>&&);
@@ -95,6 +98,8 @@ public:
 
     void processOutputBuffers();
     void flush();
+
+    void dumpGraph(const char* filenamePrefix);
 
 private:
     GStreamerElementHarness(GRefPtr<GstElement>&&, ProcessBufferCallback&&, std::optional<PadLinkCallback>&&);

--- a/Tools/Scripts/webkitpy/port/glib.py
+++ b/Tools/Scripts/webkitpy/port/glib.py
@@ -96,6 +96,7 @@ class GLibPort(Port):
         self._copy_value_from_environ_if_set(environment, 'WEBKIT_JHBUILD')
         self._copy_value_from_environ_if_set(environment, 'WEBKIT_TOP_LEVEL')
         self._copy_value_from_environ_if_set(environment, 'WEBKIT_DEBUG')
+        self._copy_value_from_environ_if_set(environment, 'WEBKIT_GST_HARNESS_DUMP_DIR')
         self._copy_value_from_environ_if_set(environment, 'WEBKIT_GST_USE_PLAYBIN3')
         self._copy_value_from_environ_if_set(environment, 'AT_SPI_BUS_ADDRESS')
         for gst_variable in ('DEBUG', 'DEBUG_DUMP_DOT_DIR', 'DEBUG_FILE', 'DEBUG_NO_COLOR',


### PR DESCRIPTION
#### b646f7463534ccf698faecc5818b0a17a2efc4a3
<pre>
[GStreamer] Harness: graph dump support
<a href="https://bugs.webkit.org/show_bug.cgi?id=252559">https://bugs.webkit.org/show_bug.cgi?id=252559</a>

Reviewed by Xabier Rodriguez-Calvar.

In cases where a graph dump of the harness and its downstream harnesses is needed for debugging
purposes, it can be done by calling the `dumpGraph()` method. At runtime you need to set the
`$WEBKIT_GST_HARNESS_DUMP_DIR` environment variable to a filesystem directory path where `mmd`
[Mermaid](<a href="https://mermaid.js.org/)">https://mermaid.js.org/)</a> files will be created. Those can then be exported to SVG or
PNG using the mermaid CLI tools or the [live editor](<a href="https://mermaid.live).">https://mermaid.live).</a>

* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::ensureGStreamerInitialized):
(WebCore::webkitGstInitTime):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:
* Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp:
(WebCore::GStreamerElementHarness::GStreamerElementHarness):
(WebCore::MermaidBuilder::MermaidBuilder):
(WebCore::MermaidBuilder::generatePadId):
(WebCore::MermaidBuilder::getPadClass):
(WebCore::MermaidBuilder::process):
(WebCore::MermaidBuilder::dumpPad):
(WebCore::MermaidBuilder::dumpElement):
(WebCore::MermaidBuilder::describeCaps):
(WebCore::MermaidBuilder::span):
(WebCore::GStreamerElementHarness::dumpGraph):
* Source/WebCore/platform/gstreamer/GStreamerElementHarness.h:
(WebCore::GStreamerElementHarness::Stream::targetPad const):
(WebCore::GStreamerElementHarness::Stream::downstreamHarness const):
* Tools/Scripts/webkitpy/port/glib.py:
(GLibPort.setup_environ_for_server):

Canonical link: <a href="https://commits.webkit.org/260670@main">https://commits.webkit.org/260670@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c7cb393eb3b590696e585e6878b8f8f7cf7307c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108643 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17744 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41497 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117753 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/117954 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112526 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19195 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9021 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100875 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114410 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14392 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97625 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42368 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/112173 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96368 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29263 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84100 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10552 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30613 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11310 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7527 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16701 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50209 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7369 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12898 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->