### PR TITLE
[IFC][Integration][Pagination] Use shared pagination adjustment code

### DIFF
--- a/Source/WebCore/layout/integration/inline/InlineIteratorLineBox.cpp
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLineBox.cpp
@@ -93,6 +93,12 @@ LineBoxIterator lastLineBoxFor(const RenderBlockFlow& flow)
     return { LineBoxIteratorLegacyPath { flow.lastRootBox() } };
 }
 
+LineBoxIterator lineBoxFor(const LayoutIntegration::InlineContent& inlineContent, size_t lineIndex)
+{
+    return { LineBoxIteratorModernPath { inlineContent, lineIndex } };
+}
+
+
 LineBoxIterator LineBox::next() const
 {
     return LineBoxIterator(*this).traverseNext();

--- a/Source/WebCore/layout/integration/inline/InlineIteratorLineBox.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLineBox.h
@@ -131,6 +131,8 @@ private:
 
 WEBCORE_EXPORT LineBoxIterator firstLineBoxFor(const RenderBlockFlow&);
 LineBoxIterator lastLineBoxFor(const RenderBlockFlow&);
+LineBoxIterator lineBoxFor(const LayoutIntegration::InlineContent&, size_t lineIndex);
+
 LeafBoxIterator closestBoxForHorizontalPosition(const LineBox&, float horizontalPosition, bool editableOnly = false);
 
 // -----------------------------------------------

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -906,11 +906,16 @@ Vector<LineAdjustment> LineLayout::adjustContent()
     if (!m_inlineContent)
         return { };
 
-    auto adjustments = computeAdjustmentsForPagination(*m_inlineContent, flow());
+    auto& layoutState = *flow().view().frameView().layoutContext().layoutState();
 
-    adjustLinePositionsForPagination(*m_inlineContent, adjustments);
+    Vector<LineAdjustment> adjustments;
+
+    if (layoutState.isPaginated()) {
+        adjustments = computeAdjustmentsForPagination(*m_inlineContent, flow());
+        adjustLinePositionsForPagination(*m_inlineContent, adjustments);
+    }
+
     m_isPaginatedContent = !adjustments.isEmpty();
-
     return adjustments;
 }
 

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationPagination.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationPagination.cpp
@@ -33,122 +33,52 @@
 namespace WebCore {
 namespace LayoutIntegration {
 
-struct PaginatedLine {
-    LayoutUnit top;
-    LayoutUnit height;
-};
-using PaginatedLines = Vector<PaginatedLine, 20>;
-
-static PaginatedLine computeLineTopAndBottomWithOverflow(const RenderBlockFlow&, const InlineContent::Lines& lines, unsigned lineIndex, const Vector<LineAdjustment>& adjustments)
-{
-    auto offset = adjustments[lineIndex].offset;
-    auto overflowRect = LayoutRect(lines[lineIndex].inkOverflow());
-    return { overflowRect.y() + offset, overflowRect.height() };
-}
-
-static unsigned computeLineBreakIndex(unsigned breakCandidate, unsigned lineCount, int orphansNeeded, int widowsNeeded,
-    std::optional<unsigned> lastLineBreakIndex)
-{
-    // First line does not fit the current page.
-    if (!breakCandidate)
-        return breakCandidate;
-    
-    int widowsOnTheNextPage = lineCount - breakCandidate;
-    if (widowsNeeded <= widowsOnTheNextPage)
-        return breakCandidate;
-    // Only break after the first line with widows.
-    auto lineBreak = std::max<int>(lineCount - widowsNeeded, 1);
-    if (orphansNeeded > lineBreak)
-        return breakCandidate;
-    // Break on current page only.
-    if (!lastLineBreakIndex)
-        return lineBreak;
-    ASSERT(*lastLineBreakIndex + 1 < lineCount);
-    return std::max<unsigned>(*lastLineBreakIndex + 1, lineBreak);
-}
-
-static LayoutUnit computeOffsetAfterLineBreak(LayoutUnit lineBreakPosition, bool isFirstLine, bool atTheTopOfColumnOrPage, const RenderBlockFlow& flow)
-{
-    // No offset for top of the page lines unless widows pushed the line break.
-    LayoutUnit offset = isFirstLine ? flow.borderAndPaddingBefore() : 0_lu;
-    if (atTheTopOfColumnOrPage)
-        return offset;
-    return offset + flow.pageRemainingLogicalHeightForOffset(lineBreakPosition, RenderBlockFlow::ExcludePageBoundary);
-}
-
-static bool setPageBreakForLine(unsigned lineBreakIndex, PaginatedLines& lines, RenderBlockFlow& flow, Vector<LineAdjustment>& adjustments, bool atTheTopOfColumnOrPage, bool lineDoesNotFit)
-{
-    auto line = lines.at(lineBreakIndex);
-    auto remainingLogicalHeight = flow.pageRemainingLogicalHeightForOffset(line.top, RenderBlockFlow::ExcludePageBoundary);
-
-    if (atTheTopOfColumnOrPage)
-        flow.setPageBreak(line.top, line.height);
-    else
-        flow.setPageBreak(line.top, line.height - remainingLogicalHeight);
-
-    auto& style = flow.style();
-    auto firstLineDoesNotFit = !lineBreakIndex && line.height < flow.pageLogicalHeightForOffset(line.top);
-    auto moveOrphanToNextColumn = lineDoesNotFit && !style.hasAutoOrphans() && style.orphans() > (short)lineBreakIndex;
-    // Special table cell handling. See RenderBlockFlow::adjustLinePositionForPagination for details.
-    if ((firstLineDoesNotFit || moveOrphanToNextColumn) && !is<RenderTableCell>(flow)) {
-        auto firstLine = lines.first();
-        auto firstLineUpperOverhang = std::max(LayoutUnit(-firstLine.top), 0_lu);
-        flow.setPaginationStrut(line.top + remainingLogicalHeight + firstLineUpperOverhang);
-        return false;
-    }
-
-    auto offset = computeOffsetAfterLineBreak(lines[lineBreakIndex].top, !lineBreakIndex, atTheTopOfColumnOrPage, flow);
-
-    adjustments[lineBreakIndex].isFirstAfterPageBreak = true;
-    for (auto i = lineBreakIndex; i < adjustments.size(); ++i)
-        adjustments[i].offset += offset;
-    return true;
-}
-
-static void updateMinimumPageHeight(RenderBlockFlow& flow, const InlineContent& inlineContent, unsigned lineCount)
-{
-    auto& style = flow.style();
-    auto widows = style.hasAutoWidows() ? 1 : std::max<int>(style.widows(), 1);
-    auto orphans = style.hasAutoOrphans() ? 1 : std::max<int>(style.orphans(), 1);
-    auto minimumLineCount = std::min<unsigned>(std::max(widows, orphans), lineCount);
-    flow.updateMinimumPageHeight(0, LayoutUnit(inlineContent.lines[minimumLineCount - 1].lineBoxBottom()));
-}
-
 Vector<LineAdjustment> computeAdjustmentsForPagination(const InlineContent& inlineContent, RenderBlockFlow& flow)
 {
     auto lineCount = inlineContent.lines.size();
-    updateMinimumPageHeight(flow, inlineContent, lineCount);
-    // First pass with no pagination offset?
-    if (!flow.pageLogicalHeightForOffset(0))
-        return { };
-
-    auto widows = flow.style().hasAutoWidows() ? 1 : std::max<int>(flow.style().widows(), 1);
-    auto orphans = flow.style().hasAutoOrphans() ? 1 : std::max<int>(flow.style().orphans(), 1);
-    PaginatedLines lines;
-
     Vector<LineAdjustment> adjustments { lineCount };
-    std::optional<unsigned> lastLineBreakIndex;
-    for (size_t lineIndex = 0; lineIndex < lineCount; ++lineIndex) {
-        auto line = computeLineTopAndBottomWithOverflow(flow, inlineContent.lines, lineIndex, adjustments);
-        lines.append(line);
-        auto remainingHeight = flow.pageRemainingLogicalHeightForOffset(line.top, RenderBlockFlow::ExcludePageBoundary);
-        auto atTheTopOfColumnOrPage = flow.pageLogicalHeightForOffset(line.top) == remainingHeight;
-        auto lineDoesNotFit = line.height > remainingHeight;
-        if (lineDoesNotFit || (atTheTopOfColumnOrPage && lineIndex)) {
-            auto lineBreakIndex = computeLineBreakIndex(lineIndex, lineCount, orphans, widows, lastLineBreakIndex);
-            // Are we still at the top of the column/page?
-            atTheTopOfColumnOrPage = atTheTopOfColumnOrPage ? lineIndex == lineBreakIndex : false;
 
-            if (setPageBreakForLine(lineBreakIndex, lines, flow, adjustments, atTheTopOfColumnOrPage, lineDoesNotFit))
-                lastLineBreakIndex = lineBreakIndex;
+    std::optional<size_t> previousPageBreakIndex;
 
-            // Recompute line positions that we already visited but widow break pushed them to a new page.
-            for (auto i = lineBreakIndex; i < lines.size(); ++i)
-                lines.at(i) = computeLineTopAndBottomWithOverflow(flow, inlineContent.lines, i, adjustments);
+    size_t widows = flow.style().hasAutoWidows() ? 0 : flow.style().widows();
+    size_t orphans = flow.style().orphans();
+
+    auto accumulatedOffset = 0_lu;
+    for (size_t lineIndex = 0; lineIndex < lineCount;) {
+        auto line = InlineIterator::lineBoxFor(inlineContent, lineIndex);
+
+        auto adjustment = flow.computeLineAdjustmentForPagination(line, accumulatedOffset);
+
+        if (adjustment.isFirstAfterPageBreak) {
+            auto remainingLines = lineCount - lineIndex;
+            // Ignore the last line if it is completely empty.
+            if (inlineContent.lines.last().lineBoxRect().isEmpty())
+                remainingLines--;
+
+            // See if there are enough lines left to meet the widow requirement.
+            if (remainingLines < widows && !flow.didBreakAtLineToAvoidWidow()) {
+                auto previousPageLineCount = lineIndex - previousPageBreakIndex.value_or(0);
+                auto neededLines = widows - remainingLines;
+                auto availableLines = previousPageLineCount > orphans ? previousPageLineCount - orphans : 0;
+                auto breakIndex = lineIndex - std::min(neededLines, availableLines);
+                // Set the widow break and recompute the adjustments starting from that line.
+                flow.setBreakAtLineToAvoidWidow(breakIndex + 1);
+                lineIndex = breakIndex;
+                continue;
+            }
+
+            previousPageBreakIndex = lineIndex;
         }
+
+        accumulatedOffset += adjustment.strut;
+        adjustments[lineIndex] = LineAdjustment { accumulatedOffset, adjustment.isFirstAfterPageBreak };
+
+        ++lineIndex;
     }
 
-    if (!lastLineBreakIndex)
+    flow.clearDidBreakAtLineToAvoidWidow();
+
+    if (!previousPageBreakIndex)
         return { };
 
     return adjustments;

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -1854,13 +1854,13 @@ void RenderBlockFlow::adjustLinePositionForPagination(LegacyRootInlineBox* rootI
 {
     auto adjustment = computeLineAdjustmentForPagination(rootInlineBox, delta);
 
-    rootInlineBox->setPaginationStrut(adjustment.paginationStrut);
+    rootInlineBox->setPaginationStrut(adjustment.strut);
     rootInlineBox->setIsFirstAfterPageBreak(adjustment.isFirstAfterPageBreak);
 
-    delta += adjustment.paginationStrut;
+    delta += adjustment.strut;
 }
 
-RenderBlockFlow::LineAdjustment RenderBlockFlow::computeLineAdjustmentForPagination(const InlineIterator::LineBoxIterator& lineBox, LayoutUnit delta)
+RenderBlockFlow::LinePaginationAdjustment RenderBlockFlow::computeLineAdjustmentForPagination(const InlineIterator::LineBoxIterator& lineBox, LayoutUnit delta)
 {
     // FIXME: For now we paginate using line overflow. This ensures that lines don't overlap at all when we
     // put a strut between them for pagination purposes. However, this really isn't the desired rendering, since

--- a/Source/WebCore/rendering/RenderBlockFlow.h
+++ b/Source/WebCore/rendering/RenderBlockFlow.h
@@ -552,11 +552,11 @@ public:
     // Computes a deltaOffset value that put a line at the top of the next page if it doesn't fit on the current page.
     void adjustLinePositionForPagination(LegacyRootInlineBox*, LayoutUnit& deltaOffset);
 
-    struct LineAdjustment {
-        LayoutUnit paginationStrut { 0_lu };
+    struct LinePaginationAdjustment {
+        LayoutUnit strut { 0_lu };
         bool isFirstAfterPageBreak { false };
     };
-    LineAdjustment computeLineAdjustmentForPagination(const InlineIterator::LineBoxIterator&, LayoutUnit deltaOffset);
+    LinePaginationAdjustment computeLineAdjustmentForPagination(const InlineIterator::LineBoxIterator&, LayoutUnit deltaOffset);
     bool relayoutForPagination();
 
     bool hasRareBlockFlowData() const { return m_rareBlockFlowData.get(); }


### PR DESCRIPTION
#### 3fa3e382d441fa982f47391909f58857a91fae46
<pre>
[IFC][Integration][Pagination] Use shared pagination adjustment code
<a href="https://bugs.webkit.org/show_bug.cgi?id=252561">https://bugs.webkit.org/show_bug.cgi?id=252561</a>
rdar://105676940

Reviewed by Alan Baradlay.

Use the now iterator based RenderBlockFlow::computeLineAdjustmentForPagination instead of the custom code.

* Source/WebCore/layout/integration/inline/InlineIteratorLineBox.cpp:
(WebCore::InlineIterator::lineBoxFor):
* Source/WebCore/layout/integration/inline/InlineIteratorLineBox.h:
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::adjustContent):

Only invoke adjustment code in a paginated context.

* Source/WebCore/layout/integration/inline/LayoutIntegrationPagination.cpp:
(WebCore::LayoutIntegration::computeAdjustmentsForPagination):

Call to RenderBlockFlow::computeLineAdjustmentForPagination do the adjustments.
Widows/orphans still need to be handled here, similar to legacy.

(WebCore::LayoutIntegration::computeLineTopAndBottomWithOverflow): Deleted.
(WebCore::LayoutIntegration::computeLineBreakIndex): Deleted.
(WebCore::LayoutIntegration::computeOffsetAfterLineBreak): Deleted.
(WebCore::LayoutIntegration::setPageBreakForLine): Deleted.
(WebCore::LayoutIntegration::updateMinimumPageHeight): Deleted.

Delete the IFC specific pagination code.

* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::adjustLinePositionForPagination):
(WebCore::RenderBlockFlow::computeLineAdjustmentForPagination):

Reanme the adjustment struct to not have the same name in different namespaces.

* Source/WebCore/rendering/RenderBlockFlow.h:

Canonical link: <a href="https://commits.webkit.org/260543@main">https://commits.webkit.org/260543@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f8fb97fa9c0d68a51a7f0e0563d1fbe66fbec6d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108645 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17746 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41499 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117755 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/117956 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112528 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19197 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9023 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100877 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114412 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14393 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97626 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42360 "Found 1 new test failure: webgl/2.0.y/conformance2/vertex_arrays/vertex-array-object.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96369 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29264 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84096 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10554 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30614 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11312 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7529 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16703 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50210 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7286 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12900 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->