### PR TITLE
[GLib] Installed API headers are unusable with the new 2022 API

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitJavascriptResult.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitJavascriptResult.h.in
@@ -26,7 +26,7 @@
 #include <glib-object.h>
 #include <@API_INCLUDE_PREFIX@/WebKitDefines.h>
 
-#if PLATFORM(GTK)
+#if PLATFORM(GTK) && !ENABLE(2022_GLIB_API)
 #include <JavaScriptCore/JSBase.h>
 #endif
 
@@ -46,7 +46,7 @@ webkit_javascript_result_ref                (WebKitJavascriptResult *js_result);
 WEBKIT_API void
 webkit_javascript_result_unref              (WebKitJavascriptResult *js_result);
 
-#if PLATFORM(GTK) && !USE(GTK4)
+#if PLATFORM(GTK) && !ENABLE(2022_GLIB_API)
 WEBKIT_DEPRECATED JSGlobalContextRef
 webkit_javascript_result_get_global_context (WebKitJavascriptResult *js_result);
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
@@ -59,7 +59,9 @@
 #endif
 
 #if PLATFORM(GTK)
+#if !ENABLE(2022_GLIB_API)
 #include <JavaScriptCore/JSBase.h>
+#endif
 #include <webkit/WebKitColorChooserRequest.h>
 #include <webkit/WebKitWebInspector.h>
 #include <webkit/WebKitWebViewBase.h>
@@ -628,7 +630,7 @@ webkit_web_view_execute_editing_command_with_argument(WebKitWebView             
 WEBKIT_API WebKitFindController *
 webkit_web_view_get_find_controller                  (WebKitWebView             *web_view);
 
-#if PLATFORM(GTK) && !USE(GTK4)
+#if PLATFORM(GTK) && !ENABLE(2022_GLIB_API)
 WEBKIT_DEPRECATED JSGlobalContextRef
 webkit_web_view_get_javascript_global_context        (WebKitWebView             *web_view);
 #endif


### PR DESCRIPTION
#### 5f8dc9d4cc01a31e53670acdcf7a9c4ea4626f58
<pre>
[GLib] Installed API headers are unusable with the new 2022 API
<a href="https://bugs.webkit.org/show_bug.cgi?id=252562">https://bugs.webkit.org/show_bug.cgi?id=252562</a>

Reviewed by Michael Catanzaro.

* Source/WebKit/UIProcess/API/glib/WebKitJavascriptResult.h.in: Only
  include JavaScriptCore/JSBase.h with the old API, change a !USE(GTK4)
  guard to !ENABLE(2022_GLIB_API) as it is more correct.
* Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in: Ditto.

Canonical link: <a href="https://commits.webkit.org/260537@main">https://commits.webkit.org/260537@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/166cdf23242165c9c84f621a4121c80432211c50

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108646 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17747 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41500 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117756 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/117957 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19198 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9024 "Built successfully") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100878 "Reverted pull request changes (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114413 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14394 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97627 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/100878 "Reverted pull request changes (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96370 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29265 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/100878 "Reverted pull request changes (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10555 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30615 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11313 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7528 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16704 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50211 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7283 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12901 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->