### PR TITLE
Add a mechanism to inject random noise when exercising certain web audio APIs

### DIFF
--- a/Source/WebCore/Modules/webaudio/AnalyserNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AnalyserNode.cpp
@@ -61,6 +61,7 @@ ExceptionOr<Ref<AnalyserNode>> AnalyserNode::create(BaseAudioContext& context, c
 
 AnalyserNode::AnalyserNode(BaseAudioContext& context)
     : AudioBasicInspectorNode(context, NodeTypeAnalyser)
+    , m_analyser { context.noiseInjectionPolicy() }
 {
     addOutput(1);
     

--- a/Source/WebCore/Modules/webaudio/AudioBuffer.h
+++ b/Source/WebCore/Modules/webaudio/AudioBuffer.h
@@ -96,6 +96,8 @@ private:
 
     bool hasDetachedChannelBuffer() const;
 
+    void applyNoiseIfNeeded();
+
     // We do not currently support having the Float32Arrays in m_channels being more than 2GB,
     // and we have tests that we return an error promptly on trying to create such a huge AudioBuffer.
     static constexpr uint64_t s_maxLength = (1ull << 32) / sizeof(float);

--- a/Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp
@@ -217,6 +217,17 @@ void AudioWorkletNode::process(size_t framesToProcess)
     for (unsigned i = 0; i < numberOfOutputs(); ++i)
         m_outputs[i] = *output(i)->bus();
 
+    if (noiseInjectionPolicy() == NoiseInjectionPolicy::Minimal) {
+        for (unsigned inputIndex = 0; inputIndex < numberOfInputs(); ++inputIndex) {
+            if (auto& input = m_inputs[inputIndex]) {
+                for (unsigned channelIndex = 0; channelIndex < input->numberOfChannels(); ++channelIndex) {
+                    auto* channel = input->channel(channelIndex);
+                    AudioUtilities::applyNoise(channel->mutableData(), channel->length(), 0.001);
+                }
+            }
+        }
+    }
+
     for (auto& audioParam : m_parameters->map().values()) {
         auto* paramValues = m_paramValuesMap.get(audioParam->name());
         ASSERT(paramValues);

--- a/Source/WebCore/Modules/webaudio/RealtimeAnalyser.cpp
+++ b/Source/WebCore/Modules/webaudio/RealtimeAnalyser.cpp
@@ -42,9 +42,10 @@
 
 namespace WebCore {
 
-RealtimeAnalyser::RealtimeAnalyser()
+RealtimeAnalyser::RealtimeAnalyser(NoiseInjectionPolicy policy)
     : m_inputBuffer(InputBufferSize)
     , m_downmixBus(AudioBus::create(1, AudioUtilities::renderQuantumSize))
+    , m_noiseInjectionPolicy(policy)
 {
     m_analysisFrame = makeUnique<FFTFrame>(DefaultFFTSize);
 }
@@ -176,6 +177,9 @@ void RealtimeAnalyser::doFFTAnalysisIfNecessary()
         double scalarMagnitude = abs(c) * magnitudeScale;        
         destination[i] = static_cast<float>(k * destination[i] + (1 - k) * scalarMagnitude);
     }
+
+    if (m_noiseInjectionPolicy == NoiseInjectionPolicy::Minimal)
+        AudioUtilities::applyNoise(destination, n, 0.25);
 }
 
 void RealtimeAnalyser::getFloatFrequencyData(Float32Array& destinationArray)

--- a/Source/WebCore/Modules/webaudio/RealtimeAnalyser.h
+++ b/Source/WebCore/Modules/webaudio/RealtimeAnalyser.h
@@ -26,6 +26,7 @@
 
 #include "AudioArray.h"
 #include "AudioBus.h"
+#include "NoiseInjectionPolicy.h"
 #include <JavaScriptCore/Forward.h>
 #include <memory>
 #include <wtf/Forward.h>
@@ -39,7 +40,7 @@ class RealtimeAnalyser {
     WTF_MAKE_NONCOPYABLE(RealtimeAnalyser);
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    RealtimeAnalyser();
+    explicit RealtimeAnalyser(NoiseInjectionPolicy);
     virtual ~RealtimeAnalyser();
 
     size_t fftSize() const { return m_fftSize; }
@@ -99,6 +100,7 @@ private:
 
     // We should only do the FFT analysis once per render quantum.
     bool m_shouldDoFFTAnalysis { true };
+    NoiseInjectionPolicy m_noiseInjectionPolicy { NoiseInjectionPolicy::None };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/audio/AudioUtilities.cpp
+++ b/Source/WebCore/platform/audio/AudioUtilities.cpp
@@ -27,7 +27,9 @@
 #if ENABLE(WEB_AUDIO)
 
 #include "AudioUtilities.h"
+#include <wtf/CryptographicallyRandomNumber.h>
 #include <wtf/MathExtras.h>
+#include <wtf/WeakRandom.h>
 
 namespace WebCore {
 
@@ -74,6 +76,14 @@ size_t timeToSampleFrame(double time, double sampleRate, SampleFrameRounding rou
 
     return static_cast<size_t>(frame);
 }
+
+void applyNoise(float* values, size_t numberOfElementsToProcess, float magnitude)
+{
+    WeakRandom generator;
+    for (size_t i = 0; i < numberOfElementsToProcess; ++i)
+        values[i] *= 1 + magnitude * (2 * generator.get() - 1);
+}
+
 } // AudioUtilites
 
 } // WebCore

--- a/Source/WebCore/platform/audio/AudioUtilities.h
+++ b/Source/WebCore/platform/audio/AudioUtilities.h
@@ -64,6 +64,8 @@ inline float decibelsToLinear(float decibels)
     return powf(10, 0.05f * decibels);
 }
 
+void applyNoise(float* values, size_t numberOfElementsToProcess, float magnitude);
+
 } // AudioUtilites
 
 } // WebCore


### PR DESCRIPTION
#### 8c46a53a1bce8226185353af0c7d6fc600492dda
<pre>
Add a mechanism to inject random noise when exercising certain web audio APIs
<a href="https://bugs.webkit.org/show_bug.cgi?id=252566">https://bugs.webkit.org/show_bug.cgi?id=252566</a>

Reviewed by Chris Dumez.

Consult the audio context&apos;s `NoiseInjectionPolicy` by adding small amounts of random noise, where
appropriate. See below for more details.

* Source/WebCore/Modules/webaudio/AnalyserNode.cpp:
(WebCore::AnalyserNode::AnalyserNode):

Plumb the `NoiseInjectionPolicy` over to the `RealtimeAnalyser`; see below for more details.

* Source/WebCore/Modules/webaudio/AudioBuffer.cpp:
(WebCore::AudioBuffer::getChannelData):
(WebCore::AudioBuffer::copyFromChannel):
(WebCore::AudioBuffer::copyToChannel):
(WebCore::AudioBuffer::zero):

Clear the `m_needsAdditionalNoise` flag from the `AudioBuffer` when it is either replaced with a
separate data buffer, or zeroed out.

(WebCore::AudioBuffer::applyNoiseIfNeeded):

Add a helper method to inject noise into the `AudioBuffer` if the policy flag is set. This is only
performed lazily, upon either copying from the `AudioBuffer` using `copyFromChannel` or reading
values in the form of a float array via `getChannelData`.

* Source/WebCore/Modules/webaudio/AudioBuffer.h:
* Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp:
(WebCore::AudioWorkletNode::process):

Add a small amount of noise before handing data to an audio worklet for processing.

* Source/WebCore/Modules/webaudio/RealtimeAnalyser.cpp:
(WebCore::RealtimeAnalyser::RealtimeAnalyser):
(WebCore::RealtimeAnalyser::doFFTAnalysisIfNecessary):

Add a larger amount of random noise when transforming a signal from time to frequency domain, using
an analyser.

* Source/WebCore/Modules/webaudio/RealtimeAnalyser.h:
* Source/WebCore/platform/audio/AudioUtilities.cpp:
(WebCore::AudioUtilities::applyNoise):

Add a new utility method to randomly scale values in the input array by random values in the range
`[1 - m, 1 + m]` where `m` is the magnitude of the random noise. For instance, `m = 0.1` denotes
that each original value will be set to a value that is somewhere between 10% less or 10% greater
than what it was originally.

* Source/WebCore/platform/audio/AudioUtilities.h:

Canonical link: <a href="https://commits.webkit.org/260559@main">https://commits.webkit.org/260559@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/156a1c160169a640f6c6c9c93e3640002424e6e0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108671 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17772 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41523 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117781 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/117978 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112553 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19223 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9049 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100904 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114438 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14412 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97645 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42388 "Found 1 new test failure: fast/scrolling/gtk/user-scroll-snapping-interaction.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96387 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29283 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/84128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10577 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30633 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11337 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7548 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16726 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50229 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7297 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12925 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->