### PR TITLE
Continue porting CDM and video related types to the new serialization format

### DIFF
--- a/Source/WebCore/platform/encryptedmedia/CDMRestrictions.h
+++ b/Source/WebCore/platform/encryptedmedia/CDMRestrictions.h
@@ -36,39 +36,6 @@ struct CDMRestrictions {
     bool distinctiveIdentifierDenied { false };
     bool persistentStateDenied { false };
     HashSet<CDMSessionType, IntHash<CDMSessionType>, WTF::StrongEnumHashTraits<CDMSessionType>> deniedSessionTypes;
-
-    template<class Encoder>
-    void encode(Encoder& encoder) const
-    {
-        encoder << distinctiveIdentifierDenied;
-        encoder << persistentStateDenied;
-        encoder << deniedSessionTypes;
-    }
-
-    template <class Decoder>
-    static std::optional<CDMRestrictions> decode(Decoder& decoder)
-    {
-        std::optional<bool> distinctiveIdentifierDenied;
-        decoder >> distinctiveIdentifierDenied;
-        if (!distinctiveIdentifierDenied)
-            return std::nullopt;
-
-        std::optional<bool> persistentStateDenied;
-        decoder >> persistentStateDenied;
-        if (!persistentStateDenied)
-            return std::nullopt;
-
-        std::optional<HashSet<CDMSessionType, IntHash<CDMSessionType>, WTF::StrongEnumHashTraits<CDMSessionType>>> deniedSessionTypes;
-        decoder >> deniedSessionTypes;
-        if (!deniedSessionTypes)
-            return std::nullopt;
-
-        return {{
-            *distinctiveIdentifierDenied,
-            *persistentStateDenied,
-            WTFMove(*deniedSessionTypes),
-        }};
-    }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/PlatformAudioTrackConfiguration.h
+++ b/Source/WebCore/platform/graphics/PlatformAudioTrackConfiguration.h
@@ -35,9 +35,6 @@ struct PlatformAudioTrackConfiguration : PlatformTrackConfiguration {
     uint32_t sampleRate { 0 };
     uint32_t numberOfChannels { 0 };
     uint64_t bitrate { 0 };
-
-    template <class Encoder> void encode(Encoder&) const;
-    template <class Decoder> static WARN_UNUSED_RETURN bool decode(Decoder&, PlatformAudioTrackConfiguration&);
 };
 
 inline bool operator==(const PlatformAudioTrackConfiguration& a, const PlatformAudioTrackConfiguration& b)
@@ -46,24 +43,6 @@ inline bool operator==(const PlatformAudioTrackConfiguration& a, const PlatformA
         && a.sampleRate == b.sampleRate
         && a.numberOfChannels == b.numberOfChannels
         && a.bitrate == b.bitrate;
-}
-
-template <class Encoder>
-void PlatformAudioTrackConfiguration::encode(Encoder& encoder) const
-{
-    encoder << codec;
-    encoder << sampleRate;
-    encoder << numberOfChannels;
-    encoder << bitrate;
-}
-
-template <class Decoder>
-bool PlatformAudioTrackConfiguration::decode(Decoder& decoder, PlatformAudioTrackConfiguration& configuration)
-{
-    return decoder.decode(configuration.codec)
-        && decoder.decode(configuration.sampleRate)
-        && decoder.decode(configuration.numberOfChannels)
-        && decoder.decode(configuration.bitrate);
 }
 
 }

--- a/Source/WebCore/platform/graphics/PlatformVideoColorPrimaries.h
+++ b/Source/WebCore/platform/graphics/PlatformVideoColorPrimaries.h
@@ -45,25 +45,3 @@ enum class PlatformVideoColorPrimaries : uint8_t {
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::PlatformVideoColorPrimaries> {
-    using values = EnumValues<
-        WebCore::PlatformVideoColorPrimaries,
-        WebCore::PlatformVideoColorPrimaries::Bt709,
-        WebCore::PlatformVideoColorPrimaries::Bt470bg,
-        WebCore::PlatformVideoColorPrimaries::Smpte170m,
-        WebCore::PlatformVideoColorPrimaries::Bt470m,
-        WebCore::PlatformVideoColorPrimaries::Smpte240m,
-        WebCore::PlatformVideoColorPrimaries::Film,
-        WebCore::PlatformVideoColorPrimaries::Bt2020,
-        WebCore::PlatformVideoColorPrimaries::SmpteSt4281,
-        WebCore::PlatformVideoColorPrimaries::SmpteRp431,
-        WebCore::PlatformVideoColorPrimaries::SmpteEg432,
-        WebCore::PlatformVideoColorPrimaries::JedecP22Phosphors,
-        WebCore::PlatformVideoColorPrimaries::Unspecified
-    >;
-};
-
-}

--- a/Source/WebCore/platform/graphics/PlatformVideoColorSpace.h
+++ b/Source/WebCore/platform/graphics/PlatformVideoColorSpace.h
@@ -39,8 +39,6 @@ struct PlatformVideoColorSpace {
     std::optional<PlatformVideoTransferCharacteristics> transfer;
     std::optional<PlatformVideoMatrixCoefficients> matrix;
     std::optional<bool> fullRange;
-    template <class Encoder> void encode(Encoder&) const;
-    template <class Decoder> static WARN_UNUSED_RETURN bool decode(Decoder&, PlatformVideoColorSpace&);
 };
 
 inline bool operator==(const PlatformVideoColorSpace& a, const PlatformVideoColorSpace& b)
@@ -54,29 +52,6 @@ inline bool operator==(const PlatformVideoColorSpace& a, const PlatformVideoColo
 inline bool operator!=(const PlatformVideoColorSpace& a, const PlatformVideoColorSpace& b)
 {
     return !(a == b);
-}
-
-template <class Encoder>
-void PlatformVideoColorSpace::encode(Encoder& encoder) const
-{
-    encoder << primaries;
-    encoder << transfer;
-    encoder << matrix;
-    encoder << fullRange;
-}
-
-template <class Decoder>
-bool PlatformVideoColorSpace::decode(Decoder& decoder, PlatformVideoColorSpace& colorSpace)
-{
-    if (!decoder.decode(colorSpace.primaries))
-        return false;
-    if (!decoder.decode(colorSpace.transfer))
-        return false;
-    if (!decoder.decode(colorSpace.matrix))
-        return false;
-    if (!decoder.decode(colorSpace.fullRange))
-        return false;
-    return true;
 }
 
 }

--- a/Source/WebCore/platform/graphics/PlatformVideoMatrixCoefficients.h
+++ b/Source/WebCore/platform/graphics/PlatformVideoMatrixCoefficients.h
@@ -43,23 +43,3 @@ enum class PlatformVideoMatrixCoefficients : uint8_t {
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::PlatformVideoMatrixCoefficients> {
-    using values = EnumValues<
-        WebCore::PlatformVideoMatrixCoefficients,
-        WebCore::PlatformVideoMatrixCoefficients::Rgb,
-        WebCore::PlatformVideoMatrixCoefficients::Bt709,
-        WebCore::PlatformVideoMatrixCoefficients::Bt470bg,
-        WebCore::PlatformVideoMatrixCoefficients::Smpte170m,
-        WebCore::PlatformVideoMatrixCoefficients::Smpte240m,
-        WebCore::PlatformVideoMatrixCoefficients::Fcc,
-        WebCore::PlatformVideoMatrixCoefficients::YCgCo,
-        WebCore::PlatformVideoMatrixCoefficients::Bt2020NonconstantLuminance,
-        WebCore::PlatformVideoMatrixCoefficients::Bt2020ConstantLuminance,
-        WebCore::PlatformVideoMatrixCoefficients::Unspecified
-    >;
-};
-
-}

--- a/Source/WebCore/platform/graphics/PlatformVideoTrackConfiguration.h
+++ b/Source/WebCore/platform/graphics/PlatformVideoTrackConfiguration.h
@@ -38,9 +38,6 @@ struct PlatformVideoTrackConfiguration : PlatformTrackConfiguration {
     PlatformVideoColorSpace colorSpace;
     double framerate { 0 };
     uint64_t bitrate { 0 };
-
-    template <class Encoder> void encode(Encoder&) const;
-    template <class Decoder> static WARN_UNUSED_RETURN bool decode(Decoder&, PlatformVideoTrackConfiguration&);
 };
 
 inline bool operator==(const PlatformVideoTrackConfiguration& a, const PlatformVideoTrackConfiguration& b)
@@ -51,28 +48,6 @@ inline bool operator==(const PlatformVideoTrackConfiguration& a, const PlatformV
         && a.colorSpace == b.colorSpace
         && a.framerate == b.framerate
         && a.bitrate == b.bitrate;
-}
-
-template <class Encoder>
-void PlatformVideoTrackConfiguration::encode(Encoder& encoder) const
-{
-    encoder << codec;
-    encoder << width;
-    encoder << height;
-    encoder << colorSpace;
-    encoder << framerate;
-    encoder << bitrate;
-}
-
-template <class Decoder>
-bool PlatformVideoTrackConfiguration::decode(Decoder& decoder, PlatformVideoTrackConfiguration& configuration)
-{
-    return decoder.decode(configuration.codec)
-        && decoder.decode(configuration.width)
-        && decoder.decode(configuration.height)
-        && decoder.decode(configuration.colorSpace)
-        && decoder.decode(configuration.framerate)
-        && decoder.decode(configuration.bitrate);
 }
 
 }

--- a/Source/WebCore/platform/graphics/PlatformVideoTransferCharacteristics.h
+++ b/Source/WebCore/platform/graphics/PlatformVideoTransferCharacteristics.h
@@ -50,30 +50,3 @@ enum class PlatformVideoTransferCharacteristics : uint8_t {
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::PlatformVideoTransferCharacteristics> {
-    using values = EnumValues<
-        WebCore::PlatformVideoTransferCharacteristics,
-        WebCore::PlatformVideoTransferCharacteristics::Bt709,
-        WebCore::PlatformVideoTransferCharacteristics::Smpte170m,
-        WebCore::PlatformVideoTransferCharacteristics::Iec6196621,
-        WebCore::PlatformVideoTransferCharacteristics::Gamma22curve,
-        WebCore::PlatformVideoTransferCharacteristics::Gamma28curve,
-        WebCore::PlatformVideoTransferCharacteristics::Smpte240m,
-        WebCore::PlatformVideoTransferCharacteristics::Linear,
-        WebCore::PlatformVideoTransferCharacteristics::Log,
-        WebCore::PlatformVideoTransferCharacteristics::LogSqrt,
-        WebCore::PlatformVideoTransferCharacteristics::Iec6196624,
-        WebCore::PlatformVideoTransferCharacteristics::Bt1361ExtendedColourGamut,
-        WebCore::PlatformVideoTransferCharacteristics::Bt2020_10bit,
-        WebCore::PlatformVideoTransferCharacteristics::Bt2020_12bit,
-        WebCore::PlatformVideoTransferCharacteristics::SmpteSt2084,
-        WebCore::PlatformVideoTransferCharacteristics::SmpteSt4281,
-        WebCore::PlatformVideoTransferCharacteristics::AribStdB67Hlg,
-        WebCore::PlatformVideoTransferCharacteristics::Unspecified
-    >;
-};
-
-}

--- a/Source/WebCore/platform/graphics/SourceImage.h
+++ b/Source/WebCore/platform/graphics/SourceImage.h
@@ -50,29 +50,10 @@ public:
     RenderingResourceIdentifier imageIdentifier() const;
     IntSize size() const;
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<SourceImage> decode(Decoder&);
-
 private:
     ImageVariant m_imageVariant;
     mutable std::optional<ImageVariant> m_transformedImageVariant;
 };
 
-template<class Encoder>
-void SourceImage::encode(Encoder& encoder) const
-{
-    encoder << imageIdentifier();
-}
-
-template<class Decoder>
-std::optional<SourceImage> SourceImage::decode(Decoder& decoder)
-{
-    std::optional<RenderingResourceIdentifier> imageIdentifier;
-    decoder >> imageIdentifier;
-    if (!imageIdentifier)
-        return std::nullopt;
-
-    return SourceImage(*imageIdentifier);
-}
 
 } // namespace WebCore

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2975,17 +2975,27 @@ header: <WebCore/ScrollingStateNode.h>
 };
 
 #if ENABLE(ENCRYPTED_MEDIA)
+
 enum class WebCore::CDMEncryptionScheme : bool
+
 struct WebCore::CDMMediaCapability {
     String contentType;
     String robustness;
     std::optional<WebCore::CDMEncryptionScheme> encryptionScheme;
 };
+
 enum class WebCore::CDMSessionType : uint8_t {
     Temporary,
     PersistentUsageRecord,
     PersistentLicense
 };
+
+struct WebCore::CDMRestrictions {
+    bool distinctiveIdentifierDenied;
+    bool persistentStateDenied;
+    HashSet<WebCore::CDMSessionType, IntHash<WebCore::CDMSessionType>, WTF::StrongEnumHashTraits<WebCore::CDMSessionType>> deniedSessionTypes;
+}
+
 #endif
 
 struct WebCore::MediaSelectionOption {
@@ -4132,6 +4142,83 @@ class WebCore::RealtimeMediaSourceCapabilities {
 
 #endif
 
+enum class WebCore::PlatformVideoColorPrimaries : uint8_t {
+    Bt709,
+    Bt470bg,
+    Smpte170m,
+    Bt470m,
+    Smpte240m,
+    Film,
+    Bt2020,
+    SmpteSt4281,
+    SmpteRp431,
+    SmpteEg432,
+    JedecP22Phosphors,
+    Unspecified,
+};
+
+enum class WebCore::PlatformVideoTransferCharacteristics : uint8_t {
+    Bt709,
+    Smpte170m,
+    Iec6196621,
+    Gamma22curve,
+    Gamma28curve,
+    Smpte240m,
+    Linear,
+    Log,
+    LogSqrt,
+    Iec6196624,
+    Bt1361ExtendedColourGamut,
+    Bt2020_10bit,
+    Bt2020_12bit,
+    SmpteSt2084,
+    SmpteSt4281,
+    AribStdB67Hlg,
+    Unspecified
+};
+
+enum class WebCore::PlatformVideoMatrixCoefficients : uint8_t {
+    Rgb,
+    Bt709,
+    Bt470bg,
+    Smpte170m,
+    Smpte240m,
+    Fcc,
+    YCgCo,
+    Bt2020NonconstantLuminance,
+    Bt2020ConstantLuminance,
+    Unspecified,
+};
+
+[AdditionalEncoder=StreamConnectionEncoder] struct WebCore::PlatformVideoColorSpace {
+    std::optional<WebCore::PlatformVideoColorPrimaries> primaries;
+    std::optional<WebCore::PlatformVideoTransferCharacteristics> transfer;
+    std::optional<WebCore::PlatformVideoMatrixCoefficients> matrix;
+    std::optional<bool> fullRange;
+};
+
+#if ENABLE(VIDEO)
+
+struct WebCore::PlatformTrackConfiguration {
+    String codec;
+};
+
+struct WebCore::PlatformAudioTrackConfiguration : WebCore::PlatformTrackConfiguration {
+    uint32_t sampleRate;
+    uint32_t numberOfChannels;
+    uint64_t bitrate;
+};
+
+struct WebCore::PlatformVideoTrackConfiguration : WebCore::PlatformTrackConfiguration {
+    uint32_t width;
+    uint32_t height;
+    WebCore::PlatformVideoColorSpace colorSpace;
+    double framerate;
+    uint64_t bitrate;
+};
+
+#endif
+
 #if ENABLE(WEB_RTC)
 
 header: <WebCore/RTCDataChannelHandler.h>
@@ -4296,4 +4383,8 @@ enum class WebCore::COEPDisposition : bool;
   WebCore::CORPViolationReportBody,
   WebCore::DeprecationReportBody
   WebCore::TestReportBody
+};
+
+[AdditionalEncoder=StreamConnectionEncoder] class WebCore::SourceImage {
+    WebCore::RenderingResourceIdentifier imageIdentifier();
 }


### PR DESCRIPTION
#### 85e62f3c9f8df1299227979f9f98778499e04011
<pre>
Continue porting CDM and video related types to the new serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=252570">https://bugs.webkit.org/show_bug.cgi?id=252570</a>
rdar://105681446

Reviewed by Alex Christensen.

Performs further porting to the new serialization format. This change
includes porting of the following types:
    - CDMRestrictions
    - PlatformVideoColorPrimaries
    - PlatformVideoTransferCharacteristics
    - PlatformVideoMatrixCoefficients
    - PlatformVideoColorSpace
    - PlatformTrackConfiguration
    - PlatformAudioTrackConfiguration
    - PlatformVideoTrackConfiguration
    - SourceImage

* Source/WebCore/platform/encryptedmedia/CDMRestrictions.h:
(WebCore::CDMRestrictions::encode const): Deleted.
(WebCore::CDMRestrictions::decode): Deleted.
* Source/WebCore/platform/graphics/PlatformAudioTrackConfiguration.h:
(WebCore::PlatformAudioTrackConfiguration::encode const): Deleted.
(WebCore::PlatformAudioTrackConfiguration::decode): Deleted.
* Source/WebCore/platform/graphics/PlatformVideoColorPrimaries.h:
* Source/WebCore/platform/graphics/PlatformVideoColorSpace.h:
(WebCore::PlatformVideoColorSpace::encode const): Deleted.
(WebCore::PlatformVideoColorSpace::decode): Deleted.
* Source/WebCore/platform/graphics/PlatformVideoMatrixCoefficients.h:
* Source/WebCore/platform/graphics/PlatformVideoTrackConfiguration.h:
(WebCore::PlatformVideoTrackConfiguration::encode const): Deleted.
(WebCore::PlatformVideoTrackConfiguration::decode): Deleted.
* Source/WebCore/platform/graphics/PlatformVideoTransferCharacteristics.h:
* Source/WebCore/platform/graphics/SourceImage.h:
(WebCore::SourceImage::encode const): Deleted.
(WebCore::SourceImage::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/260676@main">https://commits.webkit.org/260676@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1dfeaab8991727d33009684d35e141eb6b5e0b0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109045 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18125 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41866 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/578 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118312 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112930 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19584 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9427 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101283 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114804 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/97914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/42823 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/29562 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/84574 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10909 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30909 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11649 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/7843 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17024 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50507 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7370 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13252 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->