### PR TITLE
REGRESSION(260457@main): WKView is still needed

### DIFF
--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -354,6 +354,7 @@ UIProcess/API/Cocoa/WKWindowFeatures.mm
 UIProcess/API/ios/WKWebViewIOS.mm
 UIProcess/API/ios/WKWebViewTestingIOS.mm
 
+UIProcess/API/mac/WKView.mm
 UIProcess/API/mac/WKWebViewMac.mm
 UIProcess/API/mac/WKWebViewTestingMac.mm
 

--- a/Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm
+++ b/Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm
@@ -31,6 +31,7 @@
 #import "WKAPICast.h"
 #import "WKNSURLExtras.h"
 #import "WKNavigationInternal.h"
+#import "WKViewInternal.h"
 #import "WKWebViewInternal.h"
 #import "WebPageGroup.h"
 #import "WebPageProxy.h"

--- a/Source/WebKit/UIProcess/API/Cocoa/WKBrowsingContextController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBrowsingContextController.mm
@@ -52,6 +52,7 @@
 #import "WKSharedAPICast.h"
 #import "WKURLRequestNS.h"
 #import "WKURLResponseNS.h"
+#import "WKViewInternal.h"
 #import "WebPageProxy.h"
 #import "WebProcessPool.h"
 #import "WebProtectionSpace.h"

--- a/Source/WebKit/UIProcess/API/Cocoa/WKView.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKView.h
@@ -39,7 +39,24 @@
 @class WKProcessGroup;
 @class WKViewData;
 
-// FIXME: Remove this file once rdar://105559864 and rdar://105560420 and rdar://105560497 are complete.
-// Note: rdar://105011969 tracks additional use of this file, but those are unused test utilities that are never built.
+WK_CLASS_DEPRECATED_WITH_REPLACEMENT("WKWebView", macos(10.10, 10.14.4), ios(8.0, 12.2))
+@interface WKView : NSView <NSTextInputClient> {
+@private
+    WKViewData *_data;
+    WK_UNUSED_INSTANCE_VARIABLE unsigned _unused;
+}
+
+- (id)initWithFrame:(NSRect)frame processGroup:(WKProcessGroup *)processGroup browsingContextGroup:(WKBrowsingContextGroup *)browsingContextGroup;
+- (id)initWithFrame:(NSRect)frame processGroup:(WKProcessGroup *)processGroup browsingContextGroup:(WKBrowsingContextGroup *)browsingContextGroup relatedToView:(WKView *)relatedView;
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+@property(readonly) WKBrowsingContextController *browsingContextController;
+#pragma clang diagnostic pop
+
+@property BOOL drawsBackground;
+@property BOOL drawsTransparentBackground;
+
+@end
 
 #endif

--- a/Source/WebKit/UIProcess/API/Cocoa/WKViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKViewPrivate.h
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2011, 2014 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !TARGET_OS_IPHONE
+
+#import <WebKit/WKBase.h>
+#import <WebKit/WKLayoutMode.h>
+#import <WebKit/WKView.h>
+#import <WebKit/_WKOverlayScrollbarStyle.h>
+
+@class _WKLinkIconParameters;
+
+@interface WKView (Private)
+
+/* C SPI support. */
+
+@property (readonly) WKPageRef pageRef;
+
+- (id)initWithFrame:(NSRect)frame contextRef:(WKContextRef)contextRef pageGroupRef:(WKPageGroupRef)pageGroupRef;
+- (id)initWithFrame:(NSRect)frame contextRef:(WKContextRef)contextRef pageGroupRef:(WKPageGroupRef)pageGroupRef relatedToPage:(WKPageRef)relatedPage;
+- (id)initWithFrame:(NSRect)frame configurationRef:(WKPageConfigurationRef)configuration;
+
+- (NSPrintOperation *)printOperationWithPrintInfo:(NSPrintInfo *)printInfo forFrame:(WKFrameRef)frameRef;
+- (BOOL)canChangeFrameLayout:(WKFrameRef)frameRef;
+
+- (void)setFrame:(NSRect)rect andScrollBy:(NSSize)offset;
+
+// Stops updating the size of the page as the WKView frame size updates.
+// This should always be followed by enableFrameSizeUpdates. Calls can be nested.
+- (void)disableFrameSizeUpdates;
+// Immediately updates the size of the page to match WKView's frame size
+// and allows subsequent updates as the frame size is set. Calls can be nested.
+- (void)enableFrameSizeUpdates;
+- (BOOL)frameSizeUpdatesDisabled;
+
++ (void)hideWordDefinitionWindow;
+
+@property (readwrite) NSSize minimumSizeForAutoLayout;
+@property (readwrite) NSSize sizeToContentAutoSizeMaximumSize;
+@property (readwrite) BOOL shouldClipToVisibleRect;
+@property (readwrite) BOOL shouldExpandToViewHeightForAutoLayout;
+@property (readonly, getter=isUsingUISideCompositing) BOOL usingUISideCompositing;
+@property (readwrite) BOOL allowsMagnification;
+@property (readwrite) double magnification;
+@property (readwrite, setter=_setIgnoresNonWheelEvents:) BOOL _ignoresNonWheelEvents;
+@property (readwrite, setter=_setIgnoresAllEvents:) BOOL _ignoresAllEvents;
+@property (readwrite) BOOL allowsBackForwardNavigationGestures;
+@property (nonatomic, setter=_setTopContentInset:) CGFloat _topContentInset;
+@property (nonatomic, setter=_setTotalHeightOfBanners:) CGFloat _totalHeightOfBanners;
+
+@property (nonatomic, setter=_setOverlayScrollbarStyle:) _WKOverlayScrollbarStyle _overlayScrollbarStyle;
+
+@property (nonatomic, setter=_setLayoutMode:) WKLayoutMode _layoutMode;
+// For use with _layoutMode = kWKLayoutModeFixedSize:
+@property (nonatomic, setter=_setFixedLayoutSize:) CGSize _fixedLayoutSize;
+
+@property (nonatomic, setter=_setViewScale:) CGFloat _viewScale;
+
+@property (nonatomic, setter=_setOverrideDeviceScaleFactor:) CGFloat _overrideDeviceScaleFactor WK_API_AVAILABLE(macos(10.11));
+
+@property (nonatomic, setter=_setAutomaticallyAdjustsContentInsets:) BOOL _automaticallyAdjustsContentInsets;
+
+@property (readonly) NSColor *_pageExtendedBackgroundColor;
+@property (copy, nonatomic) NSColor *underlayColor;
+
+@property (nonatomic, setter=_setBackgroundColor:) NSColor *_backgroundColor WK_API_AVAILABLE(macos(10.14));
+
+@property (strong, nonatomic, setter=_setInspectorAttachmentView:) NSView *_inspectorAttachmentView WK_API_AVAILABLE(macos(10.11));
+
+- (NSView*)fullScreenPlaceholderView;
+- (NSWindow*)createFullScreenWindow;
+
+- (void)beginDeferringViewInWindowChanges;
+- (void)endDeferringViewInWindowChanges;
+- (void)endDeferringViewInWindowChangesSync;
+- (BOOL)isDeferringViewInWindowChanges;
+- (void)_prepareForMoveToWindow:(NSWindow *)targetWindow withCompletionHandler:(void(^)(void))completionHandler;
+
+- (BOOL)windowOcclusionDetectionEnabled;
+- (void)setWindowOcclusionDetectionEnabled:(BOOL)flag;
+
+- (void)setMagnification:(double)magnification centeredAtPoint:(NSPoint)point;
+
+- (void)setAllowsLinkPreview:(BOOL)allowsLinkPreview;
+- (BOOL)allowsLinkPreview;
+
+- (void)saveBackForwardSnapshotForCurrentItem;
+- (void)saveBackForwardSnapshotForItem:(WKBackForwardListItemRef)item;
+
+// Views must be layer-backed, have no transform applied, be in back-to-front z-order, and the whole set must be a contiguous opaque rectangle.
+- (void)_setCustomSwipeViews:(NSArray *)customSwipeViews;
+// The top content inset is applied in the window's coordinate space, to the union of the custom swipe view's frames.
+- (void)_setCustomSwipeViewsTopContentInset:(float)topContentInset;
+- (BOOL)_tryToSwipeWithEvent:(NSEvent *)event ignoringPinnedState:(BOOL)ignoringPinnedState;
+// The rect returned is always that of the snapshot, and only if it is the view being manipulated by the swipe. This only works for layer-backed windows.
+- (void)_setDidMoveSwipeSnapshotCallback:(void(^)(CGRect swipeSnapshotRectInWindowCoordinates))callback;
+
+// Clients that want to maintain default behavior can return nil. To disable the immediate action entirely, return NSNull. And to
+// do something custom, return an object that conforms to the NSImmediateActionAnimationController protocol.
+- (id)_immediateActionAnimationControllerForHitTestResult:(WKHitTestResultRef)hitTestResult withType:(uint32_t)type userData:(WKTypeRef)userData;
+
+- (void)_prepareForImmediateActionAnimation;
+- (void)_cancelImmediateActionAnimation;
+- (void)_completeImmediateActionAnimation;
+
+- (void)_dismissContentRelativeChildWindows;
+- (void)_dismissContentRelativeChildWindowsWithAnimation:(BOOL)withAnimation;
+
+- (void)_didChangeContentSize:(NSSize)newSize;
+
+- (void)_gestureEventWasNotHandledByWebCore:(NSEvent *)event;
+- (void)_simulateMouseMove:(NSEvent *)event;
+
+- (void)_setShouldSuppressFirstResponderChanges:(BOOL)shouldSuppress WK_API_AVAILABLE(macos(10.13.4));
+
+@property (nonatomic, readwrite, setter=_setWantsMediaPlaybackControlsView:) BOOL _wantsMediaPlaybackControlsView;
+@property (nonatomic, readonly)  id _mediaPlaybackControlsView;
+- (void)_addMediaPlaybackControlsView:(id)mediaPlaybackControlsView;
+- (void)_removeMediaPlaybackControlsView;
+
+- (void)_doAfterNextPresentationUpdate:(void (^)(void))updateBlock WK_API_AVAILABLE(macos(10.13.4));
+
+@property (nonatomic, readwrite, setter=_setUseSystemAppearance:) BOOL _useSystemAppearance WK_API_AVAILABLE(macos(10.14));
+
+@end
+
+@interface WKView (PrivateForSubclassToDefine)
+
+// This a method that subclasses can define and WKView itself does not define. WKView will call the method if it is present.
+- (void)_shouldLoadIconWithParameters:(_WKLinkIconParameters *)parameters completionHandler:(void (^)(void (^)(NSData *)))completionHandler;
+
+@end
+
+#endif // !TARGET_OS_IPHONE

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -188,6 +188,7 @@
 #if PLATFORM(MAC)
 #import "AppKitSPI.h"
 #import "WKTextFinderClient.h"
+#import "WKViewInternal.h"
 #import <WebCore/ColorMac.h>
 #endif
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKThumbnailView.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKThumbnailView.h
@@ -29,11 +29,16 @@
 
 #import <AppKit/AppKit.h>
 
+@class WKView;
 @class WKWebView;
 
 WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
 @interface _WKThumbnailView : NSView
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+- (instancetype)initWithFrame:(NSRect)frame fromWKView:(WKView *)wkView;
+#pragma clang diagnostic pop
 - (instancetype)initWithFrame:(NSRect)frame fromWKWebView:(WKWebView *)webView;
 
 @property (nonatomic) CGFloat scale;

--- a/Source/WebKit/UIProcess/API/mac/WKView.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKView.mm
@@ -1,0 +1,1732 @@
+/*
+ * Copyright (C) 2010, 2011 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "WKViewInternal.h"
+
+#if PLATFORM(MAC)
+
+#import "APIHitTestResult.h"
+#import "APIIconLoadingClient.h"
+#import "APIPageConfiguration.h"
+#import "AppKitSPI.h"
+#import "WKBrowsingContextGroupPrivate.h"
+#import "WKNSData.h"
+#import "WKProcessGroupPrivate.h"
+#import "WKWebViewMac.h"
+#import "WebBackForwardListItem.h"
+#import "WebKit2Initialize.h"
+#import "WebPageGroup.h"
+#import "WebPageProxy.h"
+#import "WebPreferences.h"
+#import "WebProcessPool.h"
+#import "WebViewImpl.h"
+#import "_WKLinkIconParametersInternal.h"
+#import <WebCore/WebCoreObjCExtras.h>
+#import <WebCore/WebViewVisualIdentificationOverlay.h>
+#import <WebKit/WKDragDestinationAction.h>
+#import <pal/spi/cocoa/AVKitSPI.h>
+#import <pal/spi/mac/NSViewSPI.h>
+#import <wtf/BlockPtr.h>
+#import <wtf/NakedRef.h>
+
+@interface WKViewData : NSObject {
+@public
+    std::unique_ptr<WebKit::WebViewImpl> _impl;
+}
+
+@end
+
+@implementation WKViewData
+@end
+
+@interface WKView () <WebViewImplDelegate>
+@end
+
+#if HAVE(TOUCH_BAR)
+@interface WKView () <NSTouchBarProvider>
+@end
+#endif
+
+#if HAVE(NSSCROLLVIEW_SEPARATOR_TRACKING_ADAPTER)
+@interface WKView () <NSScrollViewSeparatorTrackingAdapter>
+@end
+#endif
+
+#if ENABLE(DRAG_SUPPORT)
+
+@interface WKView () <NSFilePromiseProviderDelegate, NSDraggingSource>
+@end
+
+#endif
+
+ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
+@implementation WKView
+ALLOW_DEPRECATED_IMPLEMENTATIONS_END
+
+- (id)initWithFrame:(NSRect)frame processGroup:(WKProcessGroup *)processGroup browsingContextGroup:(WKBrowsingContextGroup *)browsingContextGroup
+{
+    return [self initWithFrame:frame contextRef:processGroup._contextRef pageGroupRef:browsingContextGroup._pageGroupRef relatedToPage:nil];
+}
+
+- (id)initWithFrame:(NSRect)frame processGroup:(WKProcessGroup *)processGroup browsingContextGroup:(WKBrowsingContextGroup *)browsingContextGroup relatedToView:(WKView *)relatedView
+{
+    return [self initWithFrame:frame contextRef:processGroup._contextRef pageGroupRef:browsingContextGroup._pageGroupRef relatedToPage:relatedView ? relatedView.pageRef : nil];
+}
+
+- (void)dealloc
+{
+    if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKView.class, self))
+        return;
+
+    _data->_impl->page().setIconLoadingClient(nullptr);
+    _data->_impl = nullptr;
+
+    [_data release];
+    _data = nil;
+
+    [super dealloc];
+}
+
+- (WKBrowsingContextController *)browsingContextController
+{
+    return _data->_impl->browsingContextController();
+}
+
+- (void)setDrawsBackground:(BOOL)drawsBackground
+{
+    _data->_impl->setDrawsBackground(drawsBackground);
+}
+
+- (BOOL)drawsBackground
+{
+    return _data->_impl->drawsBackground();
+}
+
+- (NSColor *)_backgroundColor
+{
+    return _data->_impl->backgroundColor();
+}
+
+- (void)_setBackgroundColor:(NSColor *)backgroundColor
+{
+    _data->_impl->setBackgroundColor(backgroundColor);
+}
+
+- (void)setDrawsTransparentBackground:(BOOL)drawsTransparentBackground
+{
+    _data->_impl->setDrawsBackground(!drawsTransparentBackground);
+}
+
+- (BOOL)drawsTransparentBackground
+{
+    return !_data->_impl->drawsBackground();
+}
+
+- (BOOL)acceptsFirstResponder
+{
+    return _data->_impl->acceptsFirstResponder();
+}
+
+- (BOOL)becomeFirstResponder
+{
+    return _data->_impl->becomeFirstResponder();
+}
+
+- (BOOL)resignFirstResponder
+{
+    return _data->_impl->resignFirstResponder();
+}
+
+- (void)viewWillStartLiveResize
+{
+    _data->_impl->viewWillStartLiveResize();
+}
+
+- (void)viewDidEndLiveResize
+{
+    _data->_impl->viewDidEndLiveResize();
+}
+
+- (BOOL)isFlipped
+{
+    return YES;
+}
+
+- (NSSize)intrinsicContentSize
+{
+    return NSSizeFromCGSize(_data->_impl->intrinsicContentSize());
+}
+
+- (void)prepareContentInRect:(NSRect)rect
+{
+    _data->_impl->prepareContentInRect(NSRectToCGRect(rect));
+}
+
+- (void)setFrameSize:(NSSize)size
+{
+    [super setFrameSize:size];
+    _data->_impl->setFrameSize(NSSizeToCGSize(size));
+}
+
+#if USE(NSVIEW_SEMANTICCONTEXT)
+
+- (void)_setSemanticContext:(NSViewSemanticContext)semanticContext
+{
+    auto wasUsingFormSemanticContext = _data->_impl ? _data->_impl->useFormSemanticContext() : false;
+
+    [super _setSemanticContext:semanticContext];
+
+    if (!_data->_impl)
+        return;
+
+    if (wasUsingFormSemanticContext != _data->_impl->useFormSemanticContext())
+        _data->_impl->semanticContextDidChange();
+}
+
+#endif
+
+ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
+- (void)renewGState
+ALLOW_DEPRECATED_IMPLEMENTATIONS_END
+{
+    _data->_impl->renewGState();
+    [super renewGState];
+}
+
+#define WEBCORE_COMMAND(command) - (void)command:(id)sender { _data->_impl->executeEditCommandForSelector(_cmd); }
+
+WEBCORE_COMMAND(alignCenter)
+WEBCORE_COMMAND(alignJustified)
+WEBCORE_COMMAND(alignLeft)
+WEBCORE_COMMAND(alignRight)
+WEBCORE_COMMAND(copy)
+WEBCORE_COMMAND(copyFont)
+WEBCORE_COMMAND(cut)
+WEBCORE_COMMAND(delete)
+WEBCORE_COMMAND(deleteBackward)
+WEBCORE_COMMAND(deleteBackwardByDecomposingPreviousCharacter)
+WEBCORE_COMMAND(deleteForward)
+WEBCORE_COMMAND(deleteToBeginningOfLine)
+WEBCORE_COMMAND(deleteToBeginningOfParagraph)
+WEBCORE_COMMAND(deleteToEndOfLine)
+WEBCORE_COMMAND(deleteToEndOfParagraph)
+WEBCORE_COMMAND(deleteToMark)
+WEBCORE_COMMAND(deleteWordBackward)
+WEBCORE_COMMAND(deleteWordForward)
+WEBCORE_COMMAND(ignoreSpelling)
+WEBCORE_COMMAND(indent)
+WEBCORE_COMMAND(insertBacktab)
+WEBCORE_COMMAND(insertLineBreak)
+WEBCORE_COMMAND(insertNewline)
+WEBCORE_COMMAND(insertNewlineIgnoringFieldEditor)
+WEBCORE_COMMAND(insertParagraphSeparator)
+WEBCORE_COMMAND(insertTab)
+WEBCORE_COMMAND(insertTabIgnoringFieldEditor)
+WEBCORE_COMMAND(makeTextWritingDirectionLeftToRight)
+WEBCORE_COMMAND(makeTextWritingDirectionNatural)
+WEBCORE_COMMAND(makeTextWritingDirectionRightToLeft)
+WEBCORE_COMMAND(moveBackward)
+WEBCORE_COMMAND(moveBackwardAndModifySelection)
+WEBCORE_COMMAND(moveDown)
+WEBCORE_COMMAND(moveDownAndModifySelection)
+WEBCORE_COMMAND(moveForward)
+WEBCORE_COMMAND(moveForwardAndModifySelection)
+WEBCORE_COMMAND(moveLeft)
+WEBCORE_COMMAND(moveLeftAndModifySelection)
+WEBCORE_COMMAND(moveParagraphBackwardAndModifySelection)
+WEBCORE_COMMAND(moveParagraphForwardAndModifySelection)
+WEBCORE_COMMAND(moveRight)
+WEBCORE_COMMAND(moveRightAndModifySelection)
+WEBCORE_COMMAND(moveToBeginningOfDocument)
+WEBCORE_COMMAND(moveToBeginningOfDocumentAndModifySelection)
+WEBCORE_COMMAND(moveToBeginningOfLine)
+WEBCORE_COMMAND(moveToBeginningOfLineAndModifySelection)
+WEBCORE_COMMAND(moveToBeginningOfParagraph)
+WEBCORE_COMMAND(moveToBeginningOfParagraphAndModifySelection)
+WEBCORE_COMMAND(moveToBeginningOfSentence)
+WEBCORE_COMMAND(moveToBeginningOfSentenceAndModifySelection)
+WEBCORE_COMMAND(moveToEndOfDocument)
+WEBCORE_COMMAND(moveToEndOfDocumentAndModifySelection)
+WEBCORE_COMMAND(moveToEndOfLine)
+WEBCORE_COMMAND(moveToEndOfLineAndModifySelection)
+WEBCORE_COMMAND(moveToEndOfParagraph)
+WEBCORE_COMMAND(moveToEndOfParagraphAndModifySelection)
+WEBCORE_COMMAND(moveToEndOfSentence)
+WEBCORE_COMMAND(moveToEndOfSentenceAndModifySelection)
+WEBCORE_COMMAND(moveToLeftEndOfLine)
+WEBCORE_COMMAND(moveToLeftEndOfLineAndModifySelection)
+WEBCORE_COMMAND(moveToRightEndOfLine)
+WEBCORE_COMMAND(moveToRightEndOfLineAndModifySelection)
+WEBCORE_COMMAND(moveUp)
+WEBCORE_COMMAND(moveUpAndModifySelection)
+WEBCORE_COMMAND(moveWordBackward)
+WEBCORE_COMMAND(moveWordBackwardAndModifySelection)
+WEBCORE_COMMAND(moveWordForward)
+WEBCORE_COMMAND(moveWordForwardAndModifySelection)
+WEBCORE_COMMAND(moveWordLeft)
+WEBCORE_COMMAND(moveWordLeftAndModifySelection)
+WEBCORE_COMMAND(moveWordRight)
+WEBCORE_COMMAND(moveWordRightAndModifySelection)
+WEBCORE_COMMAND(outdent)
+WEBCORE_COMMAND(pageDown)
+WEBCORE_COMMAND(pageDownAndModifySelection)
+WEBCORE_COMMAND(pageUp)
+WEBCORE_COMMAND(pageUpAndModifySelection)
+WEBCORE_COMMAND(paste)
+WEBCORE_COMMAND(pasteAsPlainText)
+WEBCORE_COMMAND(pasteFont)
+WEBCORE_COMMAND(scrollPageDown)
+WEBCORE_COMMAND(scrollPageUp)
+WEBCORE_COMMAND(scrollLineDown)
+WEBCORE_COMMAND(scrollLineUp)
+WEBCORE_COMMAND(scrollToBeginningOfDocument)
+WEBCORE_COMMAND(scrollToEndOfDocument)
+WEBCORE_COMMAND(selectAll)
+WEBCORE_COMMAND(selectLine)
+WEBCORE_COMMAND(selectParagraph)
+WEBCORE_COMMAND(selectSentence)
+WEBCORE_COMMAND(selectToMark)
+WEBCORE_COMMAND(selectWord)
+WEBCORE_COMMAND(setMark)
+WEBCORE_COMMAND(subscript)
+WEBCORE_COMMAND(superscript)
+WEBCORE_COMMAND(swapWithMark)
+WEBCORE_COMMAND(takeFindStringFromSelection)
+WEBCORE_COMMAND(transpose)
+WEBCORE_COMMAND(underline)
+WEBCORE_COMMAND(unscript)
+WEBCORE_COMMAND(yank)
+WEBCORE_COMMAND(yankAndSelect)
+
+#undef WEBCORE_COMMAND
+
+- (BOOL)writeSelectionToPasteboard:(NSPasteboard *)pasteboard types:(NSArray *)types
+{
+    return _data->_impl->writeSelectionToPasteboard(pasteboard, types);
+}
+
+- (void)centerSelectionInVisibleArea:(id)sender 
+{ 
+    _data->_impl->centerSelectionInVisibleArea();
+}
+
+- (id)validRequestorForSendType:(NSString *)sendType returnType:(NSString *)returnType
+{
+    return _data->_impl->validRequestorForSendAndReturnTypes(sendType, returnType);
+}
+
+- (BOOL)readSelectionFromPasteboard:(NSPasteboard *)pasteboard 
+{
+    return _data->_impl->readSelectionFromPasteboard(pasteboard);
+}
+
+ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
+- (void)changeFont:(id)sender
+ALLOW_DEPRECATED_IMPLEMENTATIONS_END
+{
+    _data->_impl->changeFontFromFontManager();
+}
+
+/*
+
+When possible, editing-related methods should be implemented in WebCore with the
+EditorCommand mechanism and invoked via WEBCORE_COMMAND, rather than implementing
+individual methods here with Mac-specific code.
+
+Editing-related methods still unimplemented that are implemented in WebKit1:
+
+- (void)complete:(id)sender;
+- (void)makeBaseWritingDirectionLeftToRight:(id)sender;
+- (void)makeBaseWritingDirectionNatural:(id)sender;
+- (void)makeBaseWritingDirectionRightToLeft:(id)sender;
+- (void)scrollLineDown:(id)sender;
+- (void)scrollLineUp:(id)sender;
+- (void)showGuessPanel:(id)sender;
+
+Some other editing-related methods still unimplemented:
+
+- (void)changeCaseOfLetter:(id)sender;
+- (void)copyRuler:(id)sender;
+- (void)insertContainerBreak:(id)sender;
+- (void)insertDoubleQuoteIgnoringSubstitution:(id)sender;
+- (void)insertSingleQuoteIgnoringSubstitution:(id)sender;
+- (void)pasteRuler:(id)sender;
+- (void)toggleRuler:(id)sender;
+- (void)transposeWords:(id)sender;
+
+*/
+
+- (BOOL)validateUserInterfaceItem:(id <NSValidatedUserInterfaceItem>)item
+{
+    return _data->_impl->validateUserInterfaceItem(item);
+}
+
+- (IBAction)startSpeaking:(id)sender
+{
+    _data->_impl->startSpeaking();
+}
+
+- (IBAction)stopSpeaking:(id)sender
+{
+    _data->_impl->stopSpeaking(sender);
+}
+
+- (IBAction)showGuessPanel:(id)sender
+{
+    _data->_impl->showGuessPanel(sender);
+}
+
+- (IBAction)checkSpelling:(id)sender
+{
+    _data->_impl->checkSpelling();
+}
+
+- (void)changeSpelling:(id)sender
+{
+    _data->_impl->changeSpelling(sender);
+}
+
+- (IBAction)toggleContinuousSpellChecking:(id)sender
+{
+    _data->_impl->toggleContinuousSpellChecking();
+}
+
+- (BOOL)isGrammarCheckingEnabled
+{
+    return _data->_impl->isGrammarCheckingEnabled();
+}
+
+- (void)setGrammarCheckingEnabled:(BOOL)flag
+{
+    _data->_impl->setGrammarCheckingEnabled(flag);
+}
+
+- (IBAction)toggleGrammarChecking:(id)sender
+{
+    _data->_impl->toggleGrammarChecking();
+}
+
+- (IBAction)toggleAutomaticSpellingCorrection:(id)sender
+{
+    _data->_impl->toggleAutomaticSpellingCorrection();
+}
+
+- (void)orderFrontSubstitutionsPanel:(id)sender
+{
+    _data->_impl->orderFrontSubstitutionsPanel(sender);
+}
+
+- (IBAction)toggleSmartInsertDelete:(id)sender
+{
+    _data->_impl->toggleSmartInsertDelete();
+}
+
+- (BOOL)isAutomaticQuoteSubstitutionEnabled
+{
+    return _data->_impl->isAutomaticQuoteSubstitutionEnabled();
+}
+
+- (void)setAutomaticQuoteSubstitutionEnabled:(BOOL)flag
+{
+    _data->_impl->setAutomaticQuoteSubstitutionEnabled(flag);
+}
+
+- (void)toggleAutomaticQuoteSubstitution:(id)sender
+{
+    _data->_impl->toggleAutomaticQuoteSubstitution();
+}
+
+- (BOOL)isAutomaticDashSubstitutionEnabled
+{
+    return _data->_impl->isAutomaticDashSubstitutionEnabled();
+}
+
+- (void)setAutomaticDashSubstitutionEnabled:(BOOL)flag
+{
+    _data->_impl->setAutomaticDashSubstitutionEnabled(flag);
+}
+
+- (void)toggleAutomaticDashSubstitution:(id)sender
+{
+    _data->_impl->toggleAutomaticDashSubstitution();
+}
+
+- (BOOL)isAutomaticLinkDetectionEnabled
+{
+    return _data->_impl->isAutomaticLinkDetectionEnabled();
+}
+
+- (void)setAutomaticLinkDetectionEnabled:(BOOL)flag
+{
+    _data->_impl->setAutomaticLinkDetectionEnabled(flag);
+}
+
+- (void)toggleAutomaticLinkDetection:(id)sender
+{
+    _data->_impl->toggleAutomaticLinkDetection();
+}
+
+- (BOOL)isAutomaticTextReplacementEnabled
+{
+    return _data->_impl->isAutomaticTextReplacementEnabled();
+}
+
+- (void)setAutomaticTextReplacementEnabled:(BOOL)flag
+{
+    _data->_impl->setAutomaticTextReplacementEnabled(flag);
+}
+
+- (void)toggleAutomaticTextReplacement:(id)sender
+{
+    _data->_impl->toggleAutomaticTextReplacement();
+}
+
+- (void)uppercaseWord:(id)sender
+{
+    _data->_impl->uppercaseWord();
+}
+
+- (void)lowercaseWord:(id)sender
+{
+    _data->_impl->lowercaseWord();
+}
+
+- (void)capitalizeWord:(id)sender
+{
+    _data->_impl->capitalizeWord();
+}
+
+- (BOOL)_wantsKeyDownForEvent:(NSEvent *)event
+{
+    return _data->_impl->wantsKeyDownForEvent(event);
+}
+
+- (void)scrollWheel:(NSEvent *)event
+{
+    _data->_impl->scrollWheel(event);
+}
+
+- (void)swipeWithEvent:(NSEvent *)event
+{
+    _data->_impl->swipeWithEvent(event);
+}
+
+- (void)mouseDown:(NSEvent *)event
+{
+    _data->_impl->mouseDown(event);
+}
+
+- (void)mouseUp:(NSEvent *)event
+{
+    _data->_impl->mouseUp(event);
+}
+
+- (void)mouseDragged:(NSEvent *)event
+{
+    _data->_impl->mouseDragged(event);
+}
+
+- (void)otherMouseDown:(NSEvent *)event
+{
+    _data->_impl->otherMouseDown(event);
+}
+
+- (void)otherMouseDragged:(NSEvent *)event
+{
+    _data->_impl->otherMouseDragged(event);
+}
+
+- (void)otherMouseUp:(NSEvent *)event
+{
+    _data->_impl->otherMouseUp(event);
+}
+
+- (void)rightMouseDown:(NSEvent *)event
+{
+    _data->_impl->rightMouseDown(event);
+}
+
+- (void)rightMouseDragged:(NSEvent *)event
+{
+    _data->_impl->rightMouseDragged(event);
+}
+
+- (void)rightMouseUp:(NSEvent *)event
+{
+    _data->_impl->rightMouseUp(event);
+}
+
+- (void)pressureChangeWithEvent:(NSEvent *)event
+{
+    _data->_impl->pressureChangeWithEvent(event);
+}
+
+- (BOOL)acceptsFirstMouse:(NSEvent *)event
+{
+    return _data->_impl->acceptsFirstMouse(event);
+}
+
+- (BOOL)shouldDelayWindowOrderingForEvent:(NSEvent *)event
+{
+    return _data->_impl->shouldDelayWindowOrderingForEvent(event);
+}
+
+- (void)doCommandBySelector:(SEL)selector
+{
+    _data->_impl->doCommandBySelector(selector);
+}
+
+- (void)insertText:(id)string
+{
+    _data->_impl->insertText(string);
+}
+
+- (void)insertText:(id)string replacementRange:(NSRange)replacementRange
+{
+    _data->_impl->insertText(string, replacementRange);
+}
+
+- (NSTextInputContext *)inputContext
+{
+    return _data->_impl->inputContext();
+}
+
+- (BOOL)performKeyEquivalent:(NSEvent *)event
+{
+    return _data->_impl->performKeyEquivalent(event);
+}
+
+- (void)keyUp:(NSEvent *)theEvent
+{
+    _data->_impl->keyUp(theEvent);
+}
+
+- (void)keyDown:(NSEvent *)theEvent
+{
+    _data->_impl->keyDown(theEvent);
+}
+
+- (void)flagsChanged:(NSEvent *)theEvent
+{
+    _data->_impl->flagsChanged(theEvent);
+}
+
+- (void)setMarkedText:(id)string selectedRange:(NSRange)newSelectedRange replacementRange:(NSRange)replacementRange
+{
+    _data->_impl->setMarkedText(string, newSelectedRange, replacementRange);
+}
+
+- (void)unmarkText
+{
+    _data->_impl->unmarkText();
+}
+
+- (NSRange)selectedRange
+{
+    return _data->_impl->selectedRange();
+}
+
+- (BOOL)hasMarkedText
+{
+    return _data->_impl->hasMarkedText();
+}
+
+- (NSRange)markedRange
+{
+    return _data->_impl->markedRange();
+}
+
+- (NSAttributedString *)attributedSubstringForProposedRange:(NSRange)nsRange actualRange:(NSRangePointer)actualRange
+{
+    return _data->_impl->attributedSubstringForProposedRange(nsRange, actualRange);
+}
+
+- (NSUInteger)characterIndexForPoint:(NSPoint)thePoint
+{
+    return _data->_impl->characterIndexForPoint(thePoint);
+}
+
+- (NSRect)firstRectForCharacterRange:(NSRange)theRange actualRange:(NSRangePointer)actualRange
+{
+    return _data->_impl->firstRectForCharacterRange(theRange, actualRange);
+}
+
+- (void)selectedRangeWithCompletionHandler:(void(^)(NSRange selectedRange))completionHandlerPtr
+{
+    _data->_impl->selectedRangeWithCompletionHandler(completionHandlerPtr);
+}
+
+- (void)markedRangeWithCompletionHandler:(void(^)(NSRange markedRange))completionHandlerPtr
+{
+    _data->_impl->markedRangeWithCompletionHandler(completionHandlerPtr);
+}
+
+- (void)hasMarkedTextWithCompletionHandler:(void(^)(BOOL hasMarkedText))completionHandlerPtr
+{
+    _data->_impl->hasMarkedTextWithCompletionHandler(completionHandlerPtr);
+}
+
+- (void)attributedSubstringForProposedRange:(NSRange)nsRange completionHandler:(void(^)(NSAttributedString *attrString, NSRange actualRange))completionHandlerPtr
+{
+    _data->_impl->attributedSubstringForProposedRange(nsRange, completionHandlerPtr);
+}
+
+- (void)firstRectForCharacterRange:(NSRange)theRange completionHandler:(void(^)(NSRect firstRect, NSRange actualRange))completionHandlerPtr
+{
+    _data->_impl->firstRectForCharacterRange(theRange, completionHandlerPtr);
+}
+
+- (void)characterIndexForPoint:(NSPoint)thePoint completionHandler:(void(^)(NSUInteger))completionHandlerPtr
+{
+    _data->_impl->characterIndexForPoint(thePoint, completionHandlerPtr);
+}
+
+- (NSArray *)validAttributesForMarkedText
+{
+    return _data->_impl->validAttributesForMarkedText();
+}
+
+#if ENABLE(DRAG_SUPPORT)
+ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
+- (void)draggedImage:(NSImage *)image endedAt:(NSPoint)endPoint operation:(NSDragOperation)operation
+ALLOW_DEPRECATED_IMPLEMENTATIONS_END
+{
+    _data->_impl->draggedImage(image, NSPointToCGPoint(endPoint), operation);
+}
+
+- (NSDragOperation)draggingEntered:(id <NSDraggingInfo>)draggingInfo
+{
+    return _data->_impl->draggingEntered(draggingInfo);
+}
+
+- (NSDragOperation)draggingUpdated:(id <NSDraggingInfo>)draggingInfo
+{
+    return _data->_impl->draggingUpdated(draggingInfo);
+}
+
+- (void)draggingExited:(id <NSDraggingInfo>)draggingInfo
+{
+    _data->_impl->draggingExited(draggingInfo);
+}
+
+- (BOOL)prepareForDragOperation:(id <NSDraggingInfo>)draggingInfo
+{
+    return _data->_impl->prepareForDragOperation(draggingInfo);
+}
+
+- (BOOL)performDragOperation:(id <NSDraggingInfo>)draggingInfo
+{
+    return _data->_impl->performDragOperation(draggingInfo);
+}
+
+- (NSView *)_hitTest:(NSPoint *)point dragTypes:(NSSet *)types
+{
+    return _data->_impl->hitTestForDragTypes(NSPointToCGPoint(*point), types);
+}
+#endif // ENABLE(DRAG_SUPPORT)
+
+- (BOOL)_windowResizeMouseLocationIsInVisibleScrollerThumb:(NSPoint)point
+{
+    return _data->_impl->windowResizeMouseLocationIsInVisibleScrollerThumb(NSPointToCGPoint(point));
+}
+
+- (void)viewWillMoveToWindow:(NSWindow *)window
+{
+    _data->_impl->viewWillMoveToWindow(window);
+}
+
+- (void)viewDidMoveToWindow
+{
+    _data->_impl->viewDidMoveToWindow();
+}
+
+- (void)drawRect:(NSRect)rect
+{
+    _data->_impl->drawRect(NSRectToCGRect(rect));
+}
+
+- (BOOL)isOpaque
+{
+    return _data->_impl->isOpaque();
+}
+
+- (BOOL)mouseDownCanMoveWindow
+{
+    return WebKit::WebViewImpl::mouseDownCanMoveWindow();
+}
+
+- (void)viewDidHide
+{
+    _data->_impl->viewDidHide();
+}
+
+- (void)viewDidUnhide
+{
+    _data->_impl->viewDidUnhide();
+}
+
+- (void)viewDidChangeBackingProperties
+{
+    _data->_impl->viewDidChangeBackingProperties();
+}
+
+- (void)_activeSpaceDidChange:(NSNotification *)notification
+{
+    _data->_impl->activeSpaceDidChange();
+}
+
+- (id)accessibilityFocusedUIElement
+{
+    return _data->_impl->accessibilityFocusedUIElement();
+}
+
+ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
+- (BOOL)accessibilityIsIgnored
+ALLOW_DEPRECATED_IMPLEMENTATIONS_END
+{
+    return _data->_impl->accessibilityIsIgnored();
+}
+
+- (id)accessibilityHitTest:(NSPoint)point
+{
+    return _data->_impl->accessibilityHitTest(NSPointToCGPoint(point));
+}
+
+ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
+- (id)accessibilityAttributeValue:(NSString *)attribute
+ALLOW_DEPRECATED_IMPLEMENTATIONS_END
+{
+    return _data->_impl->accessibilityAttributeValue(attribute);
+}
+
+ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
+- (id)accessibilityAttributeValue:(NSString *)attribute forParameter:(id)parameter
+ALLOW_DEPRECATED_IMPLEMENTATIONS_END
+{
+    return _data->_impl->accessibilityAttributeValue(attribute, parameter);
+}
+
+ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
+- (NSArray<NSString *> *)accessibilityParameterizedAttributeNames
+ALLOW_DEPRECATED_IMPLEMENTATIONS_END
+{
+    NSArray<NSString *> *names = [super accessibilityParameterizedAttributeNames];
+    return [names arrayByAddingObject:@"AXConvertRelativeFrame"];
+}
+
+- (NSView *)hitTest:(NSPoint)point
+{
+    if (!_data)
+        return [super hitTest:point];
+    return _data->_impl->hitTest(NSPointToCGPoint(point));
+}
+
+- (NSInteger)conversationIdentifier
+{
+    return (NSInteger)self;
+}
+
+- (void)quickLookWithEvent:(NSEvent *)event
+{
+    _data->_impl->quickLookWithEvent(event);
+}
+
+- (NSTrackingRectTag)addTrackingRect:(NSRect)rect owner:(id)owner userData:(void *)data assumeInside:(BOOL)assumeInside
+{
+    return _data->_impl->addTrackingRect(NSRectToCGRect(rect), owner, data, assumeInside);
+}
+
+- (NSTrackingRectTag)_addTrackingRect:(NSRect)rect owner:(id)owner userData:(void *)data assumeInside:(BOOL)assumeInside useTrackingNum:(int)tag
+{
+    return _data->_impl->addTrackingRectWithTrackingNum(NSRectToCGRect(rect), owner, data, assumeInside, tag);
+}
+
+- (void)_addTrackingRects:(NSRect *)rects owner:(id)owner userDataList:(void **)userDataList assumeInsideList:(BOOL *)assumeInsideList trackingNums:(NSTrackingRectTag *)trackingNums count:(int)count
+{
+    CGRect *cgRects = (CGRect *)calloc(1, sizeof(CGRect));
+    for (int i = 0; i < count; i++)
+        cgRects[i] = NSRectToCGRect(rects[i]);
+    _data->_impl->addTrackingRectsWithTrackingNums(cgRects, owner, userDataList, assumeInsideList, trackingNums, count);
+    free(cgRects);
+}
+
+- (void)removeTrackingRect:(NSTrackingRectTag)tag
+{
+    if (!_data)
+        return;
+    _data->_impl->removeTrackingRect(tag);
+}
+
+- (void)_removeTrackingRects:(NSTrackingRectTag *)tags count:(int)count
+{
+    if (!_data)
+        return;
+    _data->_impl->removeTrackingRects(tags, count);
+}
+
+ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
+- (NSString *)view:(NSView *)view stringForToolTip:(NSToolTipTag)tag point:(NSPoint)point userData:(void *)data
+ALLOW_DEPRECATED_IMPLEMENTATIONS_END
+{
+    return _data->_impl->stringForToolTip(tag);
+}
+
+ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
+- (void)pasteboardChangedOwner:(NSPasteboard *)pasteboard
+ALLOW_DEPRECATED_IMPLEMENTATIONS_END
+{
+    _data->_impl->pasteboardChangedOwner(pasteboard);
+}
+
+ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
+- (void)pasteboard:(NSPasteboard *)pasteboard provideDataForType:(NSString *)type
+ALLOW_DEPRECATED_IMPLEMENTATIONS_END
+{
+    _data->_impl->provideDataForPasteboard(pasteboard, type);
+}
+
+ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
+- (NSArray *)namesOfPromisedFilesDroppedAtDestination:(NSURL *)dropDestination
+ALLOW_DEPRECATED_IMPLEMENTATIONS_END
+{
+    return _data->_impl->namesOfPromisedFilesDroppedAtDestination(dropDestination);
+}
+
+- (void)maybeInstallIconLoadingClient
+{
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    class IconLoadingClient : public API::IconLoadingClient {
+        WTF_MAKE_FAST_ALLOCATED;
+    public:
+        explicit IconLoadingClient(WKView *wkView)
+            : m_wkView(wkView)
+        {
+        }
+
+        static SEL delegateSelector()
+        {
+            return @selector(_shouldLoadIconWithParameters:completionHandler:);
+        }
+
+    private:
+        typedef void (^IconLoadCompletionHandler)(NSData*);
+
+        void getLoadDecisionForIcon(const WebCore::LinkIcon& linkIcon, CompletionHandler<void(CompletionHandler<void(API::Data*)>&&)>&& completionHandler) override
+        {
+            RetainPtr<_WKLinkIconParameters> parameters = adoptNS([[_WKLinkIconParameters alloc] _initWithLinkIcon:linkIcon]);
+
+            [m_wkView _shouldLoadIconWithParameters:parameters.get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler)](IconLoadCompletionHandler loadCompletionHandler) mutable {
+                ASSERT(RunLoop::isMain());
+                if (loadCompletionHandler) {
+                    completionHandler([loadCompletionHandler = makeBlockPtr(loadCompletionHandler)](API::Data* data) {
+                        loadCompletionHandler(wrapper(data));
+                    });
+                } else
+                    completionHandler(nullptr);
+            }).get()];
+        }
+
+        WKView *m_wkView;
+    };
+    ALLOW_DEPRECATED_DECLARATIONS_END
+
+    if ([self respondsToSelector:IconLoadingClient::delegateSelector()])
+        _data->_impl->page().setIconLoadingClient(makeUnique<IconLoadingClient>(self));
+}
+
+- (instancetype)initWithFrame:(NSRect)frame processPool:(NakedRef<WebKit::WebProcessPool>)processPool configuration:(Ref<API::PageConfiguration>&&)configuration
+{
+    self = [super initWithFrame:frame];
+    if (!self)
+        return nil;
+
+    WebKit::InitializeWebKit2();
+
+    _data = [[WKViewData alloc] init];
+    _data->_impl = makeUnique<WebKit::WebViewImpl>(self, nullptr, processPool.get(), WTFMove(configuration));
+
+    [self maybeInstallIconLoadingClient];
+    [WebViewVisualIdentificationOverlay installForWebViewIfNeeded:self kind:@"WKView" deprecated:YES];
+
+    return self;
+}
+
+- (void)_setThumbnailView:(_WKThumbnailView *)thumbnailView
+{
+    _data->_impl->setThumbnailView(thumbnailView);
+}
+
+- (_WKThumbnailView *)_thumbnailView
+{
+    if (!_data->_impl)
+        return nil;
+    return _data->_impl->thumbnailView();
+}
+
+- (NSTextInputContext *)_web_superInputContext
+{
+    return [super inputContext];
+}
+
+- (void)_web_superQuickLookWithEvent:(NSEvent *)event
+{
+    [super quickLookWithEvent:event];
+}
+
+- (void)_web_superSwipeWithEvent:(NSEvent *)event
+{
+    [super swipeWithEvent:event];
+}
+
+- (void)_web_superMagnifyWithEvent:(NSEvent *)event
+{
+    [super magnifyWithEvent:event];
+}
+
+- (void)_web_superSmartMagnifyWithEvent:(NSEvent *)event
+{
+    [super smartMagnifyWithEvent:event];
+}
+
+- (void)_web_superRemoveTrackingRect:(NSTrackingRectTag)tag
+{
+    [super removeTrackingRect:tag];
+}
+
+- (id)_web_superAccessibilityAttributeValue:(NSString *)attribute
+{
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    return [super accessibilityAttributeValue:attribute];
+    ALLOW_DEPRECATED_DECLARATIONS_END
+}
+
+- (void)_web_superDoCommandBySelector:(SEL)selector
+{
+    [super doCommandBySelector:selector];
+}
+
+- (BOOL)_web_superPerformKeyEquivalent:(NSEvent *)event
+{
+    return [super performKeyEquivalent:event];
+}
+
+- (void)_web_superKeyDown:(NSEvent *)event
+{
+    [super keyDown:event];
+}
+
+- (NSView *)_web_superHitTest:(NSPoint)point
+{
+    return [super hitTest:point];
+}
+
+- (id)_web_immediateActionAnimationControllerForHitTestResultInternal:(API::HitTestResult*)hitTestResult withType:(uint32_t)type userData:(API::Object*)userData
+{
+    return [self _immediateActionAnimationControllerForHitTestResult:WebKit::toAPI(hitTestResult) withType:type userData:WebKit::toAPI(userData)];
+}
+
+- (void)_web_prepareForImmediateActionAnimation
+{
+    [self _prepareForImmediateActionAnimation];
+}
+
+- (void)_web_cancelImmediateActionAnimation
+{
+    [self _cancelImmediateActionAnimation];
+}
+
+- (void)_web_completeImmediateActionAnimation
+{
+    [self _completeImmediateActionAnimation];
+}
+
+- (void)_web_didChangeContentSize:(NSSize)newSize
+{
+    [self _didChangeContentSize:newSize];
+}
+
+#if ENABLE(DRAG_SUPPORT)
+
+- (void)_web_didPerformDragOperation:(BOOL)handled
+{
+    UNUSED_PARAM(handled);
+}
+
+- (WKDragDestinationAction)_web_dragDestinationActionForDraggingInfo:(id <NSDraggingInfo>)draggingInfo
+{
+    return WKDragDestinationActionAny;
+}
+
+#endif
+
+- (void)_web_dismissContentRelativeChildWindows
+{
+    [self _dismissContentRelativeChildWindows];
+}
+
+- (void)_web_dismissContentRelativeChildWindowsWithAnimation:(BOOL)withAnimation
+{
+    [self _dismissContentRelativeChildWindowsWithAnimation:withAnimation];
+}
+
+- (void)_web_editorStateDidChange
+{
+}
+
+- (void)_web_gestureEventWasNotHandledByWebCore:(NSEvent *)event
+{
+    [self _gestureEventWasNotHandledByWebCore:event];
+}
+
+- (void)_didHandleAcceptedCandidate
+{
+}
+
+- (void)_didUpdateCandidateListVisibility:(BOOL)visible
+{
+}
+
+#if HAVE(TOUCH_BAR)
+
+@dynamic touchBar;
+
+- (NSTouchBar *)makeTouchBar
+{
+    return _data->_impl->makeTouchBar();
+}
+
+- (NSCandidateListTouchBarItem *)candidateListTouchBarItem
+{
+    return _data->_impl->candidateListTouchBarItem();
+}
+
+- (void)_web_didAddMediaControlsManager:(id)controlsManager
+{
+    [self _addMediaPlaybackControlsView:controlsManager];
+}
+
+- (void)_web_didRemoveMediaControlsManager
+{
+    [self _removeMediaPlaybackControlsView];
+}
+
+#endif // HAVE(TOUCH_BAR)
+
+#if HAVE(NSSCROLLVIEW_SEPARATOR_TRACKING_ADAPTER)
+
+- (NSRect)scrollViewFrame
+{
+    if (!_data->_impl)
+        return NSZeroRect;
+    return _data->_impl->scrollViewFrame();
+}
+
+- (BOOL)hasScrolledContentsUnderTitlebar
+{
+    if (!_data->_impl)
+        return NO;
+    return _data->_impl->hasScrolledContentsUnderTitlebar();
+}
+
+#endif // HAVE(NSSCROLLVIEW_SEPARATOR_TRACKING_ADAPTER)
+
+#if ENABLE(DRAG_SUPPORT)
+
+- (NSString *)filePromiseProvider:(NSFilePromiseProvider *)filePromiseProvider fileNameForType:(NSString *)fileType
+{
+    return _data->_impl->fileNameForFilePromiseProvider(filePromiseProvider, fileType);
+}
+
+- (void)filePromiseProvider:(NSFilePromiseProvider *)filePromiseProvider writePromiseToURL:(NSURL *)url completionHandler:(void (^)(NSError *error))completionHandler
+{
+    _data->_impl->writeToURLForFilePromiseProvider(filePromiseProvider, url, completionHandler);
+}
+
+- (NSDragOperation)draggingSession:(NSDraggingSession *)session sourceOperationMaskForDraggingContext:(NSDraggingContext)context
+{
+    return _data->_impl->dragSourceOperationMask(session, context);
+}
+
+- (void)draggingSession:(NSDraggingSession *)session endedAtPoint:(NSPoint)screenPoint operation:(NSDragOperation)operation
+{
+    _data->_impl->draggingSessionEnded(session, screenPoint, operation);
+}
+
+#endif // ENABLE(DRAG_SUPPORT)
+
+@end
+
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
+@implementation WKView (Private)
+ALLOW_DEPRECATED_IMPLEMENTATIONS_END
+
+- (void)saveBackForwardSnapshotForCurrentItem
+{
+    _data->_impl->saveBackForwardSnapshotForCurrentItem();
+}
+
+- (void)saveBackForwardSnapshotForItem:(WKBackForwardListItemRef)item
+{
+    _data->_impl->saveBackForwardSnapshotForItem(*WebKit::toImpl(item));
+}
+
+- (id)initWithFrame:(NSRect)frame contextRef:(WKContextRef)contextRef pageGroupRef:(WKPageGroupRef)pageGroupRef
+{
+    return [self initWithFrame:frame contextRef:contextRef pageGroupRef:pageGroupRef relatedToPage:nil];
+}
+
+#if PLATFORM(MAC)
+static WebCore::UserInterfaceLayoutDirection toUserInterfaceLayoutDirection(NSUserInterfaceLayoutDirection direction)
+{
+    switch (direction) {
+    case NSUserInterfaceLayoutDirectionLeftToRight:
+        return WebCore::UserInterfaceLayoutDirection::LTR;
+    case NSUserInterfaceLayoutDirectionRightToLeft:
+        return WebCore::UserInterfaceLayoutDirection::RTL;
+    }
+    return WebCore::UserInterfaceLayoutDirection::LTR;
+}
+#endif
+
+- (id)initWithFrame:(NSRect)frame contextRef:(WKContextRef)contextRef pageGroupRef:(WKPageGroupRef)pageGroupRef relatedToPage:(WKPageRef)relatedPage
+{
+    auto configuration = API::PageConfiguration::create();
+    configuration->setProcessPool(WebKit::toImpl(contextRef));
+    configuration->setPageGroup(WebKit::toImpl(pageGroupRef));
+    configuration->setRelatedPage(WebKit::toImpl(relatedPage));
+#if PLATFORM(MAC)
+    configuration->setPreferences(&configuration->pageGroup()->preferences());
+    configuration->preferences()->setSystemLayoutDirection(static_cast<uint32_t>(toUserInterfaceLayoutDirection(self.userInterfaceLayoutDirection)));
+#endif
+
+    return [self initWithFrame:frame processPool:*WebKit::toImpl(contextRef) configuration:WTFMove(configuration)];
+}
+
+- (id)initWithFrame:(NSRect)frame configurationRef:(WKPageConfigurationRef)configurationRef
+{
+    Ref<API::PageConfiguration> configuration = WebKit::toImpl(configurationRef)->copy();
+    auto& processPool = *configuration->processPool();
+
+    return [self initWithFrame:frame processPool:processPool configuration:WTFMove(configuration)];
+}
+
+- (BOOL)wantsUpdateLayer
+{
+    return WebKit::WebViewImpl::wantsUpdateLayer();
+}
+
+- (void)updateLayer
+{
+    _data->_impl->updateLayer();
+}
+
+- (WKPageRef)pageRef
+{
+    return WebKit::toAPI(&_data->_impl->page());
+}
+
+- (BOOL)canChangeFrameLayout:(WKFrameRef)frameRef
+{
+    return _data->_impl->canChangeFrameLayout(*WebKit::toImpl(frameRef));
+}
+
+- (NSPrintOperation *)printOperationWithPrintInfo:(NSPrintInfo *)printInfo forFrame:(WKFrameRef)frameRef
+{
+    return _data->_impl->printOperationWithPrintInfo(printInfo, *WebKit::toImpl(frameRef));
+}
+
+- (void)setFrame:(NSRect)rect andScrollBy:(NSSize)offset
+{
+    _data->_impl->setFrameAndScrollBy(NSRectToCGRect(rect), NSSizeToCGSize(offset));
+}
+
+- (void)disableFrameSizeUpdates
+{
+    _data->_impl->disableFrameSizeUpdates();
+}
+
+- (void)enableFrameSizeUpdates
+{
+    _data->_impl->enableFrameSizeUpdates();
+}
+
+- (BOOL)frameSizeUpdatesDisabled
+{
+    return _data->_impl->frameSizeUpdatesDisabled();
+}
+
++ (void)hideWordDefinitionWindow
+{
+    WebKit::WebViewImpl::hideWordDefinitionWindow();
+}
+
+- (NSSize)minimumSizeForAutoLayout
+{
+    return NSSizeFromCGSize(_data->_impl->minimumSizeForAutoLayout());
+}
+
+- (void)setMinimumSizeForAutoLayout:(NSSize)minimumSizeForAutoLayout
+{
+    _data->_impl->setMinimumSizeForAutoLayout(NSSizeToCGSize(minimumSizeForAutoLayout));
+}
+
+- (NSSize)sizeToContentAutoSizeMaximumSize
+{
+    return NSSizeFromCGSize(_data->_impl->sizeToContentAutoSizeMaximumSize());
+}
+
+- (void)setSizeToContentAutoSizeMaximumSize:(NSSize)sizeToContentAutoSizeMaximumSize
+{
+    _data->_impl->setSizeToContentAutoSizeMaximumSize(NSSizeToCGSize(sizeToContentAutoSizeMaximumSize));
+}
+
+- (BOOL)shouldExpandToViewHeightForAutoLayout
+{
+    return _data->_impl->shouldExpandToViewHeightForAutoLayout();
+}
+
+- (void)setShouldExpandToViewHeightForAutoLayout:(BOOL)shouldExpand
+{
+    return _data->_impl->setShouldExpandToViewHeightForAutoLayout(shouldExpand);
+}
+
+- (BOOL)shouldClipToVisibleRect
+{
+    return _data->_impl->clipsToVisibleRect();
+}
+
+- (void)setShouldClipToVisibleRect:(BOOL)clipsToVisibleRect
+{
+    _data->_impl->setClipsToVisibleRect(clipsToVisibleRect);
+}
+
+- (NSColor *)underlayColor
+{
+    return _data->_impl->underlayColor().autorelease();
+}
+
+- (void)setUnderlayColor:(NSColor *)underlayColor
+{
+    _data->_impl->setUnderlayColor(underlayColor);
+}
+
+- (NSView *)_inspectorAttachmentView
+{
+    return _data->_impl->inspectorAttachmentView();
+}
+
+- (void)_setInspectorAttachmentView:(NSView *)newView
+{
+    _data->_impl->setInspectorAttachmentView(newView);
+}
+
+- (NSView *)fullScreenPlaceholderView
+{
+    return _data->_impl->fullScreenPlaceholderView();
+}
+
+// FIXME: This returns an autoreleased object. Should it really be prefixed 'create'?
+- (NSWindow *)createFullScreenWindow
+{
+    return _data->_impl->fullScreenWindow();
+}
+
+- (void)beginDeferringViewInWindowChanges
+{
+    _data->_impl->beginDeferringViewInWindowChanges();
+}
+
+- (void)endDeferringViewInWindowChanges
+{
+    _data->_impl->endDeferringViewInWindowChanges();
+}
+
+- (void)endDeferringViewInWindowChangesSync
+{
+    _data->_impl->endDeferringViewInWindowChangesSync();
+}
+
+- (void)_prepareForMoveToWindow:(NSWindow *)targetWindow withCompletionHandler:(void(^)(void))completionHandler
+{
+    auto completionHandlerCopy = makeBlockPtr(completionHandler);
+    _data->_impl->prepareForMoveToWindow(targetWindow, [completionHandlerCopy] {
+        completionHandlerCopy();
+    });
+}
+
+- (BOOL)isDeferringViewInWindowChanges
+{
+    return _data->_impl->isDeferringViewInWindowChanges();
+}
+
+- (BOOL)windowOcclusionDetectionEnabled
+{
+    return _data->_impl->windowOcclusionDetectionEnabled();
+}
+
+- (void)setWindowOcclusionDetectionEnabled:(BOOL)enabled
+{
+    _data->_impl->setWindowOcclusionDetectionEnabled(enabled);
+}
+
+- (void)setAllowsBackForwardNavigationGestures:(BOOL)allowsBackForwardNavigationGestures
+{
+    _data->_impl->setAllowsBackForwardNavigationGestures(allowsBackForwardNavigationGestures);
+}
+
+- (BOOL)allowsBackForwardNavigationGestures
+{
+    return _data->_impl->allowsBackForwardNavigationGestures();
+}
+
+- (BOOL)allowsLinkPreview
+{
+    return _data->_impl->allowsLinkPreview();
+}
+
+- (void)setAllowsLinkPreview:(BOOL)allowsLinkPreview
+{
+    _data->_impl->setAllowsLinkPreview(allowsLinkPreview);
+}
+
+- (void)_setIgnoresAllEvents:(BOOL)ignoresAllEvents
+{
+    _data->_impl->setIgnoresAllEvents(ignoresAllEvents);
+}
+
+// Forward _setIgnoresNonWheelMouseEvents to _setIgnoresNonWheelEvents to avoid breaking existing clients.
+- (void)_setIgnoresNonWheelMouseEvents:(BOOL)ignoresNonWheelMouseEvents
+{
+    _data->_impl->setIgnoresNonWheelEvents(ignoresNonWheelMouseEvents);
+}
+
+- (void)_setIgnoresNonWheelEvents:(BOOL)ignoresNonWheelEvents
+{
+    _data->_impl->setIgnoresNonWheelEvents(ignoresNonWheelEvents);
+}
+
+- (BOOL)_ignoresNonWheelEvents
+{
+    return _data->_impl->ignoresNonWheelEvents();
+}
+
+- (BOOL)_ignoresAllEvents
+{
+    return _data->_impl->ignoresAllEvents();
+}
+
+- (void)_setOverrideDeviceScaleFactor:(CGFloat)deviceScaleFactor
+{
+    _data->_impl->page().setCustomDeviceScaleFactor(deviceScaleFactor);
+}
+
+- (CGFloat)_overrideDeviceScaleFactor
+{
+    return _data->_impl->page().customDeviceScaleFactor().value_or(0);
+}
+
+- (WKLayoutMode)_layoutMode
+{
+    return _data->_impl->layoutMode();
+}
+
+- (void)_setLayoutMode:(WKLayoutMode)layoutMode
+{
+    _data->_impl->setLayoutMode(layoutMode);
+}
+
+- (CGSize)_fixedLayoutSize
+{
+    return _data->_impl->fixedLayoutSize();
+}
+
+- (void)_setFixedLayoutSize:(CGSize)fixedLayoutSize
+{
+    _data->_impl->setFixedLayoutSize(fixedLayoutSize);
+}
+
+- (CGFloat)_viewScale
+{
+    return _data->_impl->viewScale();
+}
+
+- (void)_setViewScale:(CGFloat)viewScale
+{
+    if (viewScale <= 0 || isnan(viewScale) || isinf(viewScale))
+        [NSException raise:NSInvalidArgumentException format:@"View scale should be a positive number"];
+
+    _data->_impl->setViewScale(viewScale);
+}
+
+- (void)_setTopContentInset:(CGFloat)contentInset
+{
+    return _data->_impl->setTopContentInset(contentInset);
+}
+
+- (CGFloat)_topContentInset
+{
+    return _data->_impl->topContentInset();
+}
+
+- (void)_setTotalHeightOfBanners:(CGFloat)totalHeightOfBanners
+{
+    _data->_impl->setTotalHeightOfBanners(totalHeightOfBanners);
+}
+
+- (CGFloat)_totalHeightOfBanners
+{
+    return _data->_impl->totalHeightOfBanners();
+}
+
+- (void)_setOverlayScrollbarStyle:(_WKOverlayScrollbarStyle)scrollbarStyle
+{
+    _data->_impl->setOverlayScrollbarStyle(toCoreScrollbarStyle(scrollbarStyle));
+}
+
+- (_WKOverlayScrollbarStyle)_overlayScrollbarStyle
+{
+    return toAPIScrollbarStyle(_data->_impl->overlayScrollbarStyle());
+}
+
+- (NSColor *)_pageExtendedBackgroundColor
+{
+    return _data->_impl->pageExtendedBackgroundColor().autorelease();
+}
+
+- (BOOL)isUsingUISideCompositing
+{
+    return _data->_impl->isUsingUISideCompositing();
+}
+
+- (void)setAllowsMagnification:(BOOL)allowsMagnification
+{
+    _data->_impl->setAllowsMagnification(allowsMagnification);
+}
+
+- (BOOL)allowsMagnification
+{
+    return _data->_impl->allowsMagnification();
+}
+
+- (void)magnifyWithEvent:(NSEvent *)event
+{
+    _data->_impl->magnifyWithEvent(event);
+}
+
+#if ENABLE(MAC_GESTURE_EVENTS)
+- (void)rotateWithEvent:(NSEvent *)event
+{
+    _data->_impl->rotateWithEvent(event);
+}
+#endif
+
+- (void)_gestureEventWasNotHandledByWebCore:(NSEvent *)event
+{
+    _data->_impl->gestureEventWasNotHandledByWebCoreFromViewOnly(event);
+}
+
+- (void)_simulateMouseMove:(NSEvent *)event
+{
+    _data->_impl->mouseMoved(event);
+}
+
+- (void)smartMagnifyWithEvent:(NSEvent *)event
+{
+    _data->_impl->smartMagnifyWithEvent(event);
+}
+
+- (void)setMagnification:(double)magnification centeredAtPoint:(NSPoint)point
+{
+    _data->_impl->setMagnification(magnification, NSPointToCGPoint(point));
+}
+
+- (void)setMagnification:(double)magnification
+{
+    _data->_impl->setMagnification(magnification);
+}
+
+- (double)magnification
+{
+    return _data->_impl->magnification();
+}
+
+- (void)_setCustomSwipeViews:(NSArray *)customSwipeViews
+{
+    _data->_impl->setCustomSwipeViews(customSwipeViews);
+}
+
+- (void)_setCustomSwipeViewsTopContentInset:(float)topContentInset
+{
+    _data->_impl->setCustomSwipeViewsTopContentInset(topContentInset);
+}
+
+- (BOOL)_tryToSwipeWithEvent:(NSEvent *)event ignoringPinnedState:(BOOL)ignoringPinnedState
+{
+    return _data->_impl->tryToSwipeWithEvent(event, ignoringPinnedState);
+}
+
+- (void)_setDidMoveSwipeSnapshotCallback:(void(^)(CGRect))callback
+{
+    _data->_impl->setDidMoveSwipeSnapshotCallback(callback);
+}
+
+- (id)_immediateActionAnimationControllerForHitTestResult:(WKHitTestResultRef)hitTestResult withType:(uint32_t)type userData:(WKTypeRef)userData
+{
+    return nil;
+}
+
+- (void)_prepareForImmediateActionAnimation
+{
+}
+
+- (void)_cancelImmediateActionAnimation
+{
+}
+
+- (void)_completeImmediateActionAnimation
+{
+}
+
+- (void)_didChangeContentSize:(NSSize)newSize
+{
+}
+
+- (void)_dismissContentRelativeChildWindows
+{
+    _data->_impl->dismissContentRelativeChildWindowsFromViewOnly();
+}
+
+- (void)_dismissContentRelativeChildWindowsWithAnimation:(BOOL)withAnimation
+{
+    _data->_impl->dismissContentRelativeChildWindowsWithAnimationFromViewOnly(withAnimation);
+}
+
+- (void)_setAutomaticallyAdjustsContentInsets:(BOOL)automaticallyAdjustsContentInsets
+{
+    _data->_impl->setAutomaticallyAdjustsContentInsets(automaticallyAdjustsContentInsets);
+}
+
+- (BOOL)_automaticallyAdjustsContentInsets
+{
+    return _data->_impl->automaticallyAdjustsContentInsets();
+}
+
+- (void)setUserInterfaceLayoutDirection:(NSUserInterfaceLayoutDirection)userInterfaceLayoutDirection
+{
+    [super setUserInterfaceLayoutDirection:userInterfaceLayoutDirection];
+
+    _data->_impl->setUserInterfaceLayoutDirection(userInterfaceLayoutDirection);
+}
+
+- (BOOL)_wantsMediaPlaybackControlsView
+{
+#if HAVE(TOUCH_BAR)
+    return _data->_impl->clientWantsMediaPlaybackControlsView();
+#else
+    return NO;
+#endif
+}
+
+- (void)_setWantsMediaPlaybackControlsView:(BOOL)wantsMediaPlaybackControlsView
+{
+#if HAVE(TOUCH_BAR)
+    _data->_impl->setClientWantsMediaPlaybackControlsView(wantsMediaPlaybackControlsView);
+#endif
+}
+
+- (id)_mediaPlaybackControlsView
+{
+#if HAVE(TOUCH_BAR) && ENABLE(WEB_PLAYBACK_CONTROLS_MANAGER)
+    return _data->_impl->clientWantsMediaPlaybackControlsView() ? _data->_impl->mediaPlaybackControlsView() : nil;
+#else
+    return nil;
+#endif
+}
+
+// This method is for subclasses to override.
+- (void)_addMediaPlaybackControlsView:(id)mediaPlaybackControlsView
+{
+}
+
+// This method is for subclasses to override.
+- (void)_removeMediaPlaybackControlsView
+{
+}
+
+- (void)_doAfterNextPresentationUpdate:(void (^)(void))updateBlock
+{
+    auto updateBlockCopy = makeBlockPtr(updateBlock);
+    _data->_impl->page().callAfterNextPresentationUpdate([updateBlockCopy] {
+        if (updateBlockCopy)
+            updateBlockCopy();
+    });
+}
+
+- (void)_setShouldSuppressFirstResponderChanges:(BOOL)shouldSuppress
+{
+    _data->_impl->setShouldSuppressFirstResponderChanges(shouldSuppress);
+}
+
+- (void)viewDidChangeEffectiveAppearance
+{
+    // This can be called during [super initWithCoder:] and [super initWithFrame:].
+    // That is before _data or _impl is ready to be used, so check. <rdar://problem/39611236>
+    if (!_data || !_data->_impl)
+        return;
+
+    _data->_impl->effectiveAppearanceDidChange();
+}
+
+- (void)_setUseSystemAppearance:(BOOL)useSystemAppearance
+{
+    _data->_impl->setUseSystemAppearance(useSystemAppearance);
+}
+
+- (BOOL)_useSystemAppearance
+{
+    return _data->_impl->useSystemAppearance();
+}
+
+- (BOOL)acceptsPreviewPanelControl:(QLPreviewPanel *)panel
+{
+    return _data->_impl->acceptsPreviewPanelControl(panel);
+}
+
+- (void)beginPreviewPanelControl:(QLPreviewPanel *)panel
+{
+    _data->_impl->beginPreviewPanelControl(panel);
+}
+
+- (void)endPreviewPanelControl:(QLPreviewPanel *)panel
+{
+    _data->_impl->endPreviewPanelControl(panel);
+}
+
+@end
+ALLOW_DEPRECATED_DECLARATIONS_END
+
+#endif // PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/API/mac/WKViewInternal.h
+++ b/Source/WebKit/UIProcess/API/mac/WKViewInternal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2010 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,35 +23,17 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "config.h"
-#import "UIGamepadProvider.h"
+#if !TARGET_OS_IPHONE
 
-#if ENABLE(GAMEPAD) && PLATFORM(MAC)
+#import "WKViewPrivate.h"
 
-#import "WebPageProxy.h"
-#import "WKAPICast.h"
-#import "WKViewInternal.h"
-#import "WKWebViewInternal.h"
-#import <wtf/ProcessPrivilege.h>
+#import <wtf/Forward.h>
+#import <wtf/RetainPtr.h>
+#import <wtf/Vector.h>
 
-namespace WebKit {
+@class _WKThumbnailView;
 
-WebPageProxy* UIGamepadProvider::platformWebPageProxyForGamepadInput()
-{
-    ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
-    auto responder = [[NSApp keyWindow] firstResponder];
-
-    if ([responder isKindOfClass:[WKWebView class]])
-        return ((WKWebView *)responder)->_page.get();
-
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    if ([responder isKindOfClass:[WKView class]])
-        return toImpl(((WKView *)responder).pageRef);
-    ALLOW_DEPRECATED_DECLARATIONS_END
-
-    return nullptr;
-}
-
-}
-
-#endif // ENABLE(GAMEPAD) && PLATFORM(MAC)
+@interface WKView ()
+@property (nonatomic, setter=_setThumbnailView:) _WKThumbnailView *_thumbnailView;
+@end
+#endif

--- a/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
@@ -36,6 +36,7 @@
 #import "WKInspectorPrivateMac.h"
 #import "WKInspectorViewController.h"
 #import "WKObject.h"
+#import "WKViewInternal.h"
 #import "WKWebViewInternal.h"
 #import "WebInspectorUIMessages.h"
 #import "WebPageGroup.h"

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -79,6 +79,9 @@ OBJC_CLASS UIScrollEvent;
 OBJC_CLASS UIScrollView;
 OBJC_CLASS _WKRemoteObjectRegistry;
 
+#if USE(APPKIT)
+OBJC_CLASS WKView;
+#endif
 #endif
 
 namespace API {

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -35,6 +35,7 @@
 #include <wtf/Forward.h>
 
 @class WKEditorUndoTarget;
+@class WKView;
 
 namespace WebCore {
 class AlternativeTextUIController;

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -45,6 +45,7 @@
 #import "WKAPICast.h"
 #import "WKFullScreenWindowController.h"
 #import "WKStringCF.h"
+#import "WKViewInternal.h"
 #import "WKWebViewInternal.h"
 #import "WKWebViewPrivateForTesting.h"
 #import "WebColorPickerMac.h"

--- a/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.h
+++ b/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.h
@@ -39,6 +39,7 @@ namespace WebCore {
 class IntRect;
 }
 
+@class WKView;
 @class WebCoreFullScreenPlaceholderView;
 
 typedef enum FullScreenState : NSInteger FullScreenState;

--- a/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
+++ b/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
@@ -33,6 +33,8 @@
 #import "NativeWebMouseEvent.h"
 #import "VideoFullscreenManagerProxy.h"
 #import "WKAPICast.h"
+#import "WKViewInternal.h"
+#import "WKViewPrivate.h"
 #import "WebFullScreenManagerProxy.h"
 #import "WebPageProxy.h"
 #import <QuartzCore/QuartzCore.h>

--- a/Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.h
+++ b/Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.h
@@ -32,6 +32,7 @@
 #include <wtf/RetainPtr.h>
 
 OBJC_CLASS NSPopUpButtonCell;
+OBJC_CLASS WKView;
 
 namespace WebKit {
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1878,6 +1878,7 @@
 		BC857FB512B830E600EDEB2E /* APIOpenPanelParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = BC857FB312B830E600EDEB2E /* APIOpenPanelParameters.h */; };
 		BC857FE612B843D800EDEB2E /* WKOpenPanelParametersRef.h in Headers */ = {isa = PBXBuildFile; fileRef = BC857FE412B843D800EDEB2E /* WKOpenPanelParametersRef.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC8699B5116AADAA002A925B /* WKView.h in Headers */ = {isa = PBXBuildFile; fileRef = BC8699B2116AADAA002A925B /* WKView.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BC8699B7116AADAA002A925B /* WKViewInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = BC8699B4116AADAA002A925B /* WKViewInternal.h */; };
 		BC8A501511765F5600757573 /* WKRetainPtr.h in Headers */ = {isa = PBXBuildFile; fileRef = BC8A501411765F5600757573 /* WKRetainPtr.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC8ACA1316670D89004C1941 /* ObjCObjectGraph.h in Headers */ = {isa = PBXBuildFile; fileRef = BC8ACA0F16670D7A004C1941 /* ObjCObjectGraph.h */; };
 		BC8F2F2B16273A2C005FACB5 /* WKWebProcessPlugInBrowserContextController.h in Headers */ = {isa = PBXBuildFile; fileRef = BC8F2F2916273A2C005FACB5 /* WKWebProcessPlugInBrowserContextController.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1948,6 +1949,7 @@
 		BCF69FA21176D01400471A52 /* APINavigationData.h in Headers */ = {isa = PBXBuildFile; fileRef = BCF69FA01176D01400471A52 /* APINavigationData.h */; };
 		BCF69FA91176D1CB00471A52 /* WKNavigationDataRef.h in Headers */ = {isa = PBXBuildFile; fileRef = BCF69FA71176D1CB00471A52 /* WKNavigationDataRef.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BCFD548C132D82680055D816 /* WKErrorCF.h in Headers */ = {isa = PBXBuildFile; fileRef = BCFD548A132D82680055D816 /* WKErrorCF.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BFA6179F12F0B99D0033E0CA /* WKViewPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = BFA6179E12F0B99D0033E0CA /* WKViewPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		C09AE5E9125257C20025825D /* WKNativeEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = C09AE5E8125257C20025825D /* WKNativeEvent.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		C0CE72A01247E71D00BC0EC4 /* WebPageMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C0CE729E1247E71D00BC0EC4 /* WebPageMessageReceiver.cpp */; };
 		C0CE72A11247E71D00BC0EC4 /* WebPageMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = C0CE729F1247E71D00BC0EC4 /* WebPageMessages.h */; };
@@ -6473,6 +6475,8 @@
 		BC857FE412B843D800EDEB2E /* WKOpenPanelParametersRef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKOpenPanelParametersRef.h; sourceTree = "<group>"; };
 		BC857FE512B843D800EDEB2E /* WKOpenPanelParametersRef.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WKOpenPanelParametersRef.cpp; sourceTree = "<group>"; };
 		BC8699B2116AADAA002A925B /* WKView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKView.h; sourceTree = "<group>"; };
+		BC8699B3116AADAA002A925B /* WKView.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKView.mm; sourceTree = "<group>"; };
+		BC8699B4116AADAA002A925B /* WKViewInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKViewInternal.h; sourceTree = "<group>"; };
 		BC87DFA91018101400564216 /* libicucore.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libicucore.dylib; path = /usr/lib/libicucore.dylib; sourceTree = "<absolute>"; };
 		BC8A501411765F5600757573 /* WKRetainPtr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKRetainPtr.h; sourceTree = "<group>"; };
 		BC8ACA0F16670D7A004C1941 /* ObjCObjectGraph.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ObjCObjectGraph.h; sourceTree = "<group>"; };
@@ -6597,6 +6601,7 @@
 		BCF69FA81176D1CB00471A52 /* WKNavigationDataRef.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WKNavigationDataRef.cpp; sourceTree = "<group>"; };
 		BCFD5489132D82680055D816 /* WKErrorCF.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WKErrorCF.cpp; sourceTree = "<group>"; };
 		BCFD548A132D82680055D816 /* WKErrorCF.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKErrorCF.h; sourceTree = "<group>"; };
+		BFA6179E12F0B99D0033E0CA /* WKViewPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKViewPrivate.h; sourceTree = "<group>"; };
 		C01A260012662F2100C9ED55 /* ShareableBitmapCG.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ShareableBitmapCG.cpp; sourceTree = "<group>"; };
 		C02BFF1512514FD8009CCBEA /* NativeWebKeyboardEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NativeWebKeyboardEvent.h; sourceTree = "<group>"; };
 		C02BFF1D1251502E009CCBEA /* NativeWebKeyboardEventMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = NativeWebKeyboardEventMac.mm; sourceTree = "<group>"; };
@@ -7652,6 +7657,7 @@
 				7CD5EBBD1746B04C000C1C45 /* WKTypeRefWrapper.h */,
 				7CD5EBBC1746B04C000C1C45 /* WKTypeRefWrapper.mm */,
 				BC8699B2116AADAA002A925B /* WKView.h */,
+				BFA6179E12F0B99D0033E0CA /* WKViewPrivate.h */,
 			);
 			name = Deprecated;
 			sourceTree = "<group>";
@@ -12422,6 +12428,8 @@
 		BC111B47112F616900337BAB /* mac */ = {
 			isa = PBXGroup;
 			children = (
+				BC8699B3116AADAA002A925B /* WKView.mm */,
+				BC8699B4116AADAA002A925B /* WKViewInternal.h */,
 				0FFED99023A3203800EEF459 /* WKWebViewMac.h */,
 				0FFED98F23A3203700EEF459 /* WKWebViewMac.mm */,
 				0F45A333239D89AF00294ABF /* WKWebViewPrivateForTestingMac.h */,
@@ -15190,7 +15198,9 @@
 				7C882DFA1C7E9973006BF731 /* WKUserScriptPrivate.h in Headers */,
 				7C89D2A41A678875003A5FDE /* WKUserScriptRef.h in Headers */,
 				BC8699B5116AADAA002A925B /* WKView.h in Headers */,
+				BC8699B7116AADAA002A925B /* WKViewInternal.h in Headers */,
 				2D28A4971AF965A100F190C9 /* WKViewLayoutStrategy.h in Headers */,
+				BFA6179F12F0B99D0033E0CA /* WKViewPrivate.h in Headers */,
 				5136E516236A62110074FD5D /* WKWebArchive.h in Headers */,
 				5136E514236A60DC0074FD5D /* WKWebArchiveRef.h in Headers */,
 				C5E1AFEB16B20B7E006CC1F2 /* WKWebArchiveResource.h in Headers */,


### PR DESCRIPTION
#### ae2abefb80e64a4d6e531f08d7657564a0631890
<pre>
REGRESSION(260457@main): WKView is still needed
<a href="https://bugs.webkit.org/show_bug.cgi?id=252572">https://bugs.webkit.org/show_bug.cgi?id=252572</a>

Unreviewed.

It&apos;s still used for perf testing.  This reverts the source changes.

* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKBrowsingContextController.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKView.h:
(WK_CLASS_DEPRECATED_WITH_REPLACEMENT):
* Source/WebKit/UIProcess/API/Cocoa/WKViewPrivate.h: Added.
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
* Source/WebKit/UIProcess/API/Cocoa/_WKThumbnailView.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKThumbnailView.mm:
(-[_WKThumbnailView initWithFrame:fromWKView:]):
(-[_WKThumbnailView _viewWasUnparented]):
(-[_WKThumbnailView _viewWasParented]):
* Source/WebKit/UIProcess/API/mac/WKView.mm: Added.
(-[WKView initWithFrame:processGroup:browsingContextGroup:]):
(-[WKView initWithFrame:processGroup:browsingContextGroup:relatedToView:]):
(-[WKView dealloc]):
(-[WKView browsingContextController]):
(-[WKView setDrawsBackground:]):
(-[WKView drawsBackground]):
(-[WKView _backgroundColor]):
(-[WKView _setBackgroundColor:]):
(-[WKView setDrawsTransparentBackground:]):
(-[WKView drawsTransparentBackground]):
(-[WKView acceptsFirstResponder]):
(-[WKView becomeFirstResponder]):
(-[WKView resignFirstResponder]):
(-[WKView viewWillStartLiveResize]):
(-[WKView viewDidEndLiveResize]):
(-[WKView isFlipped]):
(-[WKView intrinsicContentSize]):
(-[WKView prepareContentInRect:]):
(-[WKView setFrameSize:]):
(-[WKView _setSemanticContext:]):
(-[WKView ALLOW_DEPRECATED_IMPLEMENTATIONS_END]):
(-[WKView writeSelectionToPasteboard:types:]):
(-[WKView centerSelectionInVisibleArea:]):
(-[WKView validRequestorForSendType:returnType:]):
(-[WKView readSelectionFromPasteboard:]):
(-[WKView changeFont:]):
(-[WKView validateUserInterfaceItem:]):
(-[WKView startSpeaking:]):
(-[WKView stopSpeaking:]):
(-[WKView showGuessPanel:]):
(-[WKView checkSpelling:]):
(-[WKView changeSpelling:]):
(-[WKView toggleContinuousSpellChecking:]):
(-[WKView isGrammarCheckingEnabled]):
(-[WKView setGrammarCheckingEnabled:]):
(-[WKView toggleGrammarChecking:]):
(-[WKView toggleAutomaticSpellingCorrection:]):
(-[WKView orderFrontSubstitutionsPanel:]):
(-[WKView toggleSmartInsertDelete:]):
(-[WKView isAutomaticQuoteSubstitutionEnabled]):
(-[WKView setAutomaticQuoteSubstitutionEnabled:]):
(-[WKView toggleAutomaticQuoteSubstitution:]):
(-[WKView isAutomaticDashSubstitutionEnabled]):
(-[WKView setAutomaticDashSubstitutionEnabled:]):
(-[WKView toggleAutomaticDashSubstitution:]):
(-[WKView isAutomaticLinkDetectionEnabled]):
(-[WKView setAutomaticLinkDetectionEnabled:]):
(-[WKView toggleAutomaticLinkDetection:]):
(-[WKView isAutomaticTextReplacementEnabled]):
(-[WKView setAutomaticTextReplacementEnabled:]):
(-[WKView toggleAutomaticTextReplacement:]):
(-[WKView uppercaseWord:]):
(-[WKView lowercaseWord:]):
(-[WKView capitalizeWord:]):
(-[WKView _wantsKeyDownForEvent:]):
(-[WKView scrollWheel:]):
(-[WKView swipeWithEvent:]):
(-[WKView mouseDown:]):
(-[WKView mouseUp:]):
(-[WKView mouseDragged:]):
(-[WKView otherMouseDown:]):
(-[WKView otherMouseDragged:]):
(-[WKView otherMouseUp:]):
(-[WKView rightMouseDown:]):
(-[WKView rightMouseDragged:]):
(-[WKView rightMouseUp:]):
(-[WKView pressureChangeWithEvent:]):
(-[WKView acceptsFirstMouse:]):
(-[WKView shouldDelayWindowOrderingForEvent:]):
(-[WKView doCommandBySelector:]):
(-[WKView insertText:]):
(-[WKView insertText:replacementRange:]):
(-[WKView inputContext]):
(-[WKView performKeyEquivalent:]):
(-[WKView keyUp:]):
(-[WKView keyDown:]):
(-[WKView flagsChanged:]):
(-[WKView setMarkedText:selectedRange:replacementRange:]):
(-[WKView unmarkText]):
(-[WKView selectedRange]):
(-[WKView hasMarkedText]):
(-[WKView markedRange]):
(-[WKView attributedSubstringForProposedRange:actualRange:]):
(-[WKView characterIndexForPoint:]):
(-[WKView firstRectForCharacterRange:actualRange:]):
(-[WKView selectedRangeWithCompletionHandler:]):
(-[WKView markedRangeWithCompletionHandler:]):
(-[WKView hasMarkedTextWithCompletionHandler:]):
(-[WKView attributedSubstringForProposedRange:completionHandler:]):
(-[WKView firstRectForCharacterRange:completionHandler:]):
(-[WKView characterIndexForPoint:completionHandler:]):
(-[WKView validAttributesForMarkedText]):
(-[WKView draggedImage:endedAt:operation:]):
(-[WKView draggingEntered:]):
(-[WKView draggingUpdated:]):
(-[WKView draggingExited:]):
(-[WKView prepareForDragOperation:]):
(-[WKView performDragOperation:]):
(-[WKView _hitTest:dragTypes:]):
(-[WKView _windowResizeMouseLocationIsInVisibleScrollerThumb:]):
(-[WKView viewWillMoveToWindow:]):
(-[WKView viewDidMoveToWindow]):
(-[WKView drawRect:]):
(-[WKView isOpaque]):
(-[WKView mouseDownCanMoveWindow]):
(-[WKView viewDidHide]):
(-[WKView viewDidUnhide]):
(-[WKView viewDidChangeBackingProperties]):
(-[WKView _activeSpaceDidChange:]):
(-[WKView accessibilityFocusedUIElement]):
(-[WKView accessibilityHitTest:]):
(-[WKView accessibilityAttributeValue:]):
(-[WKView accessibilityAttributeValue:forParameter:]):
(-[WKView hitTest:]):
(-[WKView conversationIdentifier]):
(-[WKView quickLookWithEvent:]):
(-[WKView addTrackingRect:owner:userData:assumeInside:]):
(-[WKView _addTrackingRect:owner:userData:assumeInside:useTrackingNum:]):
(-[WKView _addTrackingRects:owner:userDataList:assumeInsideList:trackingNums:count:]):
(-[WKView removeTrackingRect:]):
(-[WKView _removeTrackingRects:count:]):
(-[WKView view:stringForToolTip:point:userData:]):
(-[WKView pasteboardChangedOwner:]):
(-[WKView pasteboard:provideDataForType:]):
(-[WKView namesOfPromisedFilesDroppedAtDestination:]):
(-[WKView maybeInstallIconLoadingClient]):
(-[WKView initWithFrame:processPool:configuration:]):
(-[WKView _setThumbnailView:]):
(-[WKView _thumbnailView]):
(-[WKView _web_superInputContext]):
(-[WKView _web_superQuickLookWithEvent:]):
(-[WKView _web_superSwipeWithEvent:]):
(-[WKView _web_superMagnifyWithEvent:]):
(-[WKView _web_superSmartMagnifyWithEvent:]):
(-[WKView _web_superRemoveTrackingRect:]):
(-[WKView _web_superAccessibilityAttributeValue:]):
(-[WKView _web_superDoCommandBySelector:]):
(-[WKView _web_superPerformKeyEquivalent:]):
(-[WKView _web_superKeyDown:]):
(-[WKView _web_superHitTest:]):
(-[WKView _web_immediateActionAnimationControllerForHitTestResultInternal:withType:userData:]):
(-[WKView _web_prepareForImmediateActionAnimation]):
(-[WKView _web_cancelImmediateActionAnimation]):
(-[WKView _web_completeImmediateActionAnimation]):
(-[WKView _web_didChangeContentSize:]):
(-[WKView _web_didPerformDragOperation:]):
(-[WKView _web_dragDestinationActionForDraggingInfo:]):
(-[WKView _web_dismissContentRelativeChildWindows]):
(-[WKView _web_dismissContentRelativeChildWindowsWithAnimation:]):
(-[WKView _web_editorStateDidChange]):
(-[WKView _web_gestureEventWasNotHandledByWebCore:]):
(-[WKView _didHandleAcceptedCandidate]):
(-[WKView _didUpdateCandidateListVisibility:]):
(-[WKView makeTouchBar]):
(-[WKView candidateListTouchBarItem]):
(-[WKView _web_didAddMediaControlsManager:]):
(-[WKView _web_didRemoveMediaControlsManager]):
(-[WKView scrollViewFrame]):
(-[WKView hasScrolledContentsUnderTitlebar]):
(-[WKView filePromiseProvider:fileNameForType:]):
(-[WKView filePromiseProvider:writePromiseToURL:completionHandler:]):
(-[WKView draggingSession:sourceOperationMaskForDraggingContext:]):
(-[WKView draggingSession:endedAtPoint:operation:]):
(-[WKView saveBackForwardSnapshotForCurrentItem]):
(-[WKView saveBackForwardSnapshotForItem:]):
(-[WKView initWithFrame:contextRef:pageGroupRef:]):
(toUserInterfaceLayoutDirection):
(-[WKView initWithFrame:contextRef:pageGroupRef:relatedToPage:]):
(-[WKView initWithFrame:configurationRef:]):
(-[WKView wantsUpdateLayer]):
(-[WKView updateLayer]):
(-[WKView pageRef]):
(-[WKView canChangeFrameLayout:]):
(-[WKView printOperationWithPrintInfo:forFrame:]):
(-[WKView setFrame:andScrollBy:]):
(-[WKView disableFrameSizeUpdates]):
(-[WKView enableFrameSizeUpdates]):
(-[WKView frameSizeUpdatesDisabled]):
(+[WKView hideWordDefinitionWindow]):
(-[WKView minimumSizeForAutoLayout]):
(-[WKView setMinimumSizeForAutoLayout:]):
(-[WKView sizeToContentAutoSizeMaximumSize]):
(-[WKView setSizeToContentAutoSizeMaximumSize:]):
(-[WKView shouldExpandToViewHeightForAutoLayout]):
(-[WKView setShouldExpandToViewHeightForAutoLayout:]):
(-[WKView shouldClipToVisibleRect]):
(-[WKView setShouldClipToVisibleRect:]):
(-[WKView underlayColor]):
(-[WKView setUnderlayColor:]):
(-[WKView _inspectorAttachmentView]):
(-[WKView _setInspectorAttachmentView:]):
(-[WKView fullScreenPlaceholderView]):
(-[WKView createFullScreenWindow]):
(-[WKView beginDeferringViewInWindowChanges]):
(-[WKView endDeferringViewInWindowChanges]):
(-[WKView endDeferringViewInWindowChangesSync]):
(-[WKView _prepareForMoveToWindow:withCompletionHandler:]):
(-[WKView isDeferringViewInWindowChanges]):
(-[WKView windowOcclusionDetectionEnabled]):
(-[WKView setWindowOcclusionDetectionEnabled:]):
(-[WKView setAllowsBackForwardNavigationGestures:]):
(-[WKView allowsBackForwardNavigationGestures]):
(-[WKView allowsLinkPreview]):
(-[WKView setAllowsLinkPreview:]):
(-[WKView _setIgnoresAllEvents:]):
(-[WKView _setIgnoresNonWheelMouseEvents:]):
(-[WKView _setIgnoresNonWheelEvents:]):
(-[WKView _ignoresNonWheelEvents]):
(-[WKView _ignoresAllEvents]):
(-[WKView _setOverrideDeviceScaleFactor:]):
(-[WKView _overrideDeviceScaleFactor]):
(-[WKView _layoutMode]):
(-[WKView _setLayoutMode:]):
(-[WKView _fixedLayoutSize]):
(-[WKView _setFixedLayoutSize:]):
(-[WKView _viewScale]):
(-[WKView _setViewScale:]):
(-[WKView _setTopContentInset:]):
(-[WKView _topContentInset]):
(-[WKView _setTotalHeightOfBanners:]):
(-[WKView _totalHeightOfBanners]):
(-[WKView _setOverlayScrollbarStyle:]):
(-[WKView _overlayScrollbarStyle]):
(-[WKView _pageExtendedBackgroundColor]):
(-[WKView isUsingUISideCompositing]):
(-[WKView setAllowsMagnification:]):
(-[WKView allowsMagnification]):
(-[WKView magnifyWithEvent:]):
(-[WKView rotateWithEvent:]):
(-[WKView _gestureEventWasNotHandledByWebCore:]):
(-[WKView _simulateMouseMove:]):
(-[WKView smartMagnifyWithEvent:]):
(-[WKView setMagnification:centeredAtPoint:]):
(-[WKView setMagnification:]):
(-[WKView magnification]):
(-[WKView _setCustomSwipeViews:]):
(-[WKView _setCustomSwipeViewsTopContentInset:]):
(-[WKView _tryToSwipeWithEvent:ignoringPinnedState:]):
(-[WKView _setDidMoveSwipeSnapshotCallback:]):
(-[WKView _immediateActionAnimationControllerForHitTestResult:withType:userData:]):
(-[WKView _prepareForImmediateActionAnimation]):
(-[WKView _cancelImmediateActionAnimation]):
(-[WKView _completeImmediateActionAnimation]):
(-[WKView _didChangeContentSize:]):
(-[WKView _dismissContentRelativeChildWindows]):
(-[WKView _dismissContentRelativeChildWindowsWithAnimation:]):
(-[WKView _setAutomaticallyAdjustsContentInsets:]):
(-[WKView _automaticallyAdjustsContentInsets]):
(-[WKView setUserInterfaceLayoutDirection:]):
(-[WKView _wantsMediaPlaybackControlsView]):
(-[WKView _setWantsMediaPlaybackControlsView:]):
(-[WKView _mediaPlaybackControlsView]):
(-[WKView _addMediaPlaybackControlsView:]):
(-[WKView _removeMediaPlaybackControlsView]):
(-[WKView _doAfterNextPresentationUpdate:]):
(-[WKView _setShouldSuppressFirstResponderChanges:]):
(-[WKView viewDidChangeEffectiveAppearance]):
(-[WKView _setUseSystemAppearance:]):
(-[WKView _useSystemAppearance]):
(-[WKView acceptsPreviewPanelControl:]):
(-[WKView beginPreviewPanelControl:]):
(-[WKView endPreviewPanelControl:]):
* Source/WebKit/UIProcess/API/mac/WKViewInternal.h: Copied from Source/WebKit/UIProcess/API/Cocoa/WKView.h.
* Source/WebKit/UIProcess/Gamepad/mac/UIGamepadProviderMac.mm:
(WebKit::UIGamepadProvider::platformWebPageProxyForGamepadInput):
* Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm:
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
* Source/WebKit/UIProcess/mac/WKFullScreenWindowController.h:
* Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm:
* Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/260541@main">https://commits.webkit.org/260541@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59a84242368fefb483afb37231eff408444963c7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/108676 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17777 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/41528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/117786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/117982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/19228 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/9054 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/100909 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/114443 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/19228 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/41528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/100909 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/19228 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/41528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/100909 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/10582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/41528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/11342 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/9054 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/16731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/41528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12930 "Failed to checkout and rebase branch from PR 10369") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3967 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->