### PR TITLE
[JSC] Add ProxyObjectStore IC to optimize "set" trap

### DIFF
--- a/JSTests/microbenchmarks/proxy-set-miss-handler.js
+++ b/JSTests/microbenchmarks/proxy-set-miss-handler.js
@@ -1,0 +1,6 @@
+(function() {
+    var proxy = new Proxy({}, {});
+
+    for (var i = 0; i < 1e6; ++i)
+        proxy.test = i;
+})();

--- a/JSTests/microbenchmarks/proxy-set.js
+++ b/JSTests/microbenchmarks/proxy-set.js
@@ -1,0 +1,10 @@
+(function() {
+    var proxy = new Proxy({}, {
+        set(target, propertyName, value, receiver) {
+            return true;
+        }
+    });
+
+    for (var i = 0; i < 1e6; ++i)
+        proxy.test = i;
+})();

--- a/JSTests/stress/proxy-set-failure-inline-cache.js
+++ b/JSTests/stress/proxy-set-failure-inline-cache.js
@@ -1,0 +1,80 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`Bad value: ${actual}!`);
+}
+
+function shouldThrow(fn, expectedError) {
+    let errorThrown = false;
+    try {
+        fn();
+    } catch (error) {
+        errorThrown = true;
+        if (error.toString() !== expectedError)
+            throw new Error(`Bad error: ${error}`);
+    }
+    if (!errorThrown)
+        throw new Error("Didn't throw!");
+}
+
+
+
+(function() {
+    var setCalls = 0;
+    var proxy = new Proxy({}, {
+        set(target, propertyName, value, receiver) {
+            "use strict";
+            setCalls++;
+            return value !== 1e7 - 10;
+        }
+    });
+
+    for (var i = 0; i < 1e7; ++i)
+        proxy.foo = i; // shouldn't throw
+
+    shouldBe(setCalls, 1e7);
+})();
+
+shouldThrow(function() {
+    "use strict";
+
+    var proxy = new Proxy({}, {
+        set(target, propertyName, value, receiver) {
+            return value !== 1e7 - 10;
+        }
+    });
+
+    for (var i = 0; i < 1e7; ++i)
+        proxy.foo = i;
+}, "TypeError: Proxy object's 'set' trap returned falsy value for property 'foo'");
+
+(function() {
+    var setCalls = 0;
+
+    var target = {};
+    var handler = { set() { "use strict"; setCalls++; return true; } };
+    var proxy = new Proxy(target, handler);
+    Object.defineProperty(target, "foo", { value: {}, writable: false, enumerable: true, configurable: true });
+
+    for (var i = 0; i < 1e7; ++i) {
+        if (i === 1e7 - 10)
+            handler.set = undefined;
+        proxy.foo = i; // shouldn't throw
+    }
+
+    shouldBe(setCalls, 1e7 - 10);
+})();
+
+shouldThrow(function() {
+    "use strict";
+
+    var target = {};
+    var handler = { set: () => true };
+    var proxy = new Proxy(target, handler);
+    Object.defineProperty(target, "foo", { value: {}, writable: false, enumerable: true, configurable: true });
+
+    for (var i = 0; i < 1e7; ++i) {
+        if (i === 1e7 - 10)
+            handler.set = null;
+        proxy.foo = i;
+    }
+}, "TypeError: Attempted to assign to readonly property.");

--- a/Source/JavaScriptCore/builtins/BuiltinNames.h
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.h
@@ -183,6 +183,8 @@ namespace JSC {
     macro(makeBoundFunction) \
     macro(hasOwnLengthProperty) \
     macro(handleProxyGetTrapResult) \
+    macro(handleProxySetTrapResultSloppy) \
+    macro(handleProxySetTrapResultStrict) \
     macro(importModule) \
     macro(copyDataProperties) \
     macro(meta) \

--- a/Source/JavaScriptCore/builtins/ProxyHelpers.js
+++ b/Source/JavaScriptCore/builtins/ProxyHelpers.js
@@ -49,3 +49,53 @@ function performProxyObjectGet(receiver, propertyName)
 
     return trapResult;
 }
+
+@linkTimeConstant
+function performProxyObjectSetSloppy(receiver, propertyName, value)
+{
+    "use strict";
+
+    var target = @getProxyInternalField(this, @proxyFieldTarget);
+    var handler = @getProxyInternalField(this, @proxyFieldHandler);
+
+    if (handler === null)
+        @throwTypeError("Proxy has already been revoked. No more operations are allowed to be performed on it");
+
+    var trap = handler.set;
+    if (@isUndefinedOrNull(trap)) {
+        @putByValWithThisSloppy(target, receiver, propertyName, value);
+        return;
+    }
+
+    if (!@isCallable(trap))
+        @throwTypeError("'set' property of a Proxy's handler should be callable");
+
+    var trapResult = trap.@call(handler, target, propertyName, value, receiver);
+
+    @handleProxySetTrapResultSloppy(trapResult, target, propertyName, value);
+}
+
+@linkTimeConstant
+function performProxyObjectSetStrict(receiver, propertyName, value)
+{
+    "use strict";
+
+    var target = @getProxyInternalField(this, @proxyFieldTarget);
+    var handler = @getProxyInternalField(this, @proxyFieldHandler);
+
+    if (handler === null)
+        @throwTypeError("Proxy has already been revoked. No more operations are allowed to be performed on it");
+
+    var trap = handler.set;
+    if (@isUndefinedOrNull(trap)) {
+        @putByValWithThisStrict(target, receiver, propertyName, value);
+        return;
+    }
+
+    if (!@isCallable(trap))
+        @throwTypeError("'set' property of a Proxy's handler should be callable");
+
+    var trapResult = trap.@call(handler, target, propertyName, value, receiver);
+
+    @handleProxySetTrapResultStrict(trapResult, target, propertyName, value);
+}

--- a/Source/JavaScriptCore/bytecode/AccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/AccessCase.cpp
@@ -83,6 +83,7 @@ Ref<AccessCase> AccessCase::create(VM& vm, JSCell* owner, AccessType type, Cache
     case ScopedArgumentsLength:
     case ModuleNamespaceLoad:
     case ProxyObjectLoad:
+    case ProxyObjectStore:
     case Replace:
     case InstanceOfGeneric:
     case IndexedInt32Load:
@@ -325,6 +326,7 @@ bool AccessCase::guardedByStructureCheckSkippingConstantIdentifierCheck() const
     case ScopedArgumentsLength:
     case ModuleNamespaceLoad:
     case ProxyObjectLoad:
+    case ProxyObjectStore:
     case InstanceOfHit:
     case InstanceOfMiss:
     case InstanceOfGeneric:
@@ -409,6 +411,7 @@ bool AccessCase::requiresIdentifierNameMatch() const
     case ScopedArgumentsLength:
     case ModuleNamespaceLoad:
     case ProxyObjectLoad:
+    case ProxyObjectStore:
     case CheckPrivateBrand:
     case SetPrivateBrand:
         return true;
@@ -494,6 +497,7 @@ bool AccessCase::requiresInt32PropertyCheck() const
     case ScopedArgumentsLength:
     case ModuleNamespaceLoad:
     case ProxyObjectLoad:
+    case ProxyObjectStore:
     case InstanceOfHit:
     case InstanceOfMiss:
     case InstanceOfGeneric:
@@ -580,6 +584,7 @@ bool AccessCase::needsScratchFPR() const
     case ScopedArgumentsLength:
     case ModuleNamespaceLoad:
     case ProxyObjectLoad:
+    case ProxyObjectStore:
     case InstanceOfHit:
     case InstanceOfMiss:
     case InstanceOfGeneric:
@@ -679,7 +684,8 @@ void AccessCase::forEachDependentCell(VM&, const Functor& functor) const
             functor(accessCase.moduleEnvironment());
         break;
     }
-    case ProxyObjectLoad: {
+    case ProxyObjectLoad:
+    case ProxyObjectStore: {
         auto& accessor = this->as<ProxyObjectAccessCase>();
         if (accessor.callLinkInfo())
             accessor.callLinkInfo()->forEachDependentCell(functor);
@@ -775,6 +781,7 @@ bool AccessCase::doesCalls(VM& vm, Vector<JSCell*>* cellsToMarkIfDoesCalls) cons
     case CustomValueSetter:
     case CustomAccessorSetter:
     case ProxyObjectLoad:
+    case ProxyObjectStore:
         doesCalls = true;
         break;
     case IntrinsicGetter: {
@@ -960,6 +967,7 @@ bool AccessCase::canReplace(const AccessCase& other) const
     case IndexedResizableTypedArrayFloat32Store:
     case IndexedResizableTypedArrayFloat64Store:
     case ProxyObjectLoad:
+    case ProxyObjectStore:
         return other.type() == type();
 
     case ModuleNamespaceLoad: {
@@ -1265,7 +1273,8 @@ void AccessCase::generateWithGuard(
         return;
     }
 
-    case ProxyObjectLoad: {
+    case ProxyObjectLoad:
+    case ProxyObjectStore: {
         ASSERT(!viaProxy());
         this->as<ProxyObjectAccessCase>().emit(state, fallThrough);
         return;
@@ -2768,6 +2777,7 @@ void AccessCase::generateImpl(AccessGenerationState& state)
     case ScopedArgumentsLength:
     case ModuleNamespaceLoad:
     case ProxyObjectLoad:
+    case ProxyObjectStore:
     case InstanceOfGeneric:
     case IndexedInt32Load:
     case IndexedDoubleLoad:
@@ -3004,6 +3014,7 @@ inline void AccessCase::runWithDowncast(const Func& func)
         break;
 
     case ProxyObjectLoad:
+    case ProxyObjectStore:
         func(static_cast<ProxyObjectAccessCase*>(this));
         break;
     }
@@ -3113,8 +3124,9 @@ bool AccessCase::canBeShared(const AccessCase& lhs, const AccessCase& rhs)
 
     case Getter:
     case Setter:
-    case ProxyObjectLoad: {
-        // Getter, Setter, and ProxyObjectLoad relies on CodeBlock, which makes sharing impossible.
+    case ProxyObjectLoad:
+    case ProxyObjectStore: {
+        // Getter / Setter / ProxyObjectLoad / ProxyObjectStore relies on CodeBlock, which makes sharing impossible.
         return false;
     }
 

--- a/Source/JavaScriptCore/bytecode/AccessCase.h
+++ b/Source/JavaScriptCore/bytecode/AccessCase.h
@@ -113,6 +113,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(AccessCase);
     macro(ScopedArgumentsLength) \
     macro(ModuleNamespaceLoad) \
     macro(ProxyObjectLoad) \
+    macro(ProxyObjectStore) \
     macro(InstanceOfHit) \
     macro(InstanceOfMiss) \
     macro(InstanceOfGeneric) \

--- a/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h
+++ b/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h
@@ -83,6 +83,8 @@ enum class LinkTimeConstant : int32_t;
     macro(putByIdDirect) \
     macro(putByIdDirectPrivate) \
     macro(putByValDirect) \
+    macro(putByValWithThisSloppy) \
+    macro(putByValWithThisStrict) \
     macro(putPromiseInternalField) \
     macro(putGeneratorInternalField) \
     macro(putAsyncGeneratorInternalField) \

--- a/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
+++ b/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
@@ -110,6 +110,8 @@ class JSGlobalObject;
     v(makeBoundFunction, nullptr) \
     v(hasOwnLengthProperty, nullptr) \
     v(handleProxyGetTrapResult, nullptr) \
+    v(handleProxySetTrapResultSloppy, nullptr) \
+    v(handleProxySetTrapResultStrict, nullptr) \
     v(dateTimeFormat, nullptr) \
     v(webAssemblyCompileStreamingInternal, nullptr) \
     v(webAssemblyInstantiateStreamingInternal, nullptr) \

--- a/Source/JavaScriptCore/bytecode/PolymorphicAccess.cpp
+++ b/Source/JavaScriptCore/bytecode/PolymorphicAccess.cpp
@@ -527,7 +527,8 @@ AccessGenerationResult PolymorphicAccess::regenerate(const GCSafeConcurrentJSLoc
         case AccessCase::Getter:
         case AccessCase::Setter:
         case AccessCase::ProxyObjectLoad:
-            // Getter / Setter / ProxyObjectLoad relies on stack-pointer adjustment, which is tied to the linked CodeBlock, which makes this code unshareable.
+        case AccessCase::ProxyObjectStore:
+            // Getter / Setter / ProxyObjectLoad / ProxyObjectStore relies on stack-pointer adjustment, which is tied to the linked CodeBlock, which makes this code unshareable.
             canBeShared = false;
             doesJSCalls = true;
             break;

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -2794,6 +2794,12 @@ RegisterID* BytecodeGenerator::emitPutByVal(RegisterID* base, RegisterID* thisVa
     return value;
 }
 
+RegisterID* BytecodeGenerator::emitPutByValWithECMAMode(RegisterID* base, RegisterID* thisValue, RegisterID* property, RegisterID* value, ECMAMode ecmaMode)
+{
+    OpPutByValWithThis::emit(this, base, thisValue, property, value, ecmaMode);
+    return value;
+}
+
 RegisterID* BytecodeGenerator::emitGetPrivateName(RegisterID* dst, RegisterID* base, RegisterID* property)
 {
     OpGetPrivateName::emit(this, dst, base, property);

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
@@ -763,6 +763,7 @@ namespace JSC {
 
         RegisterID* emitPutByVal(RegisterID* base, RegisterID* property, RegisterID* value);
         RegisterID* emitPutByVal(RegisterID* base, RegisterID* thisValue, RegisterID* property, RegisterID* value);
+        RegisterID* emitPutByValWithECMAMode(RegisterID* base, RegisterID* thisValue, RegisterID* property, RegisterID* value, ECMAMode);
         RegisterID* emitDirectPutByVal(RegisterID* base, RegisterID* property, RegisterID* value);
         RegisterID* emitDeleteByVal(RegisterID* dst, RegisterID* base, RegisterID* property);
 

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -1370,6 +1370,33 @@ RegisterID* BytecodeIntrinsicNode::emit_intrinsic_getByValWithThis(BytecodeGener
     return generator.emitGetByVal(generator.finalDestination(dst), base.get(), thisValue.get(), property.get());
 }
 
+static ALWAYS_INLINE void emitIntrinsicPutByValWithThis(BytecodeGenerator& generator, ArgumentListNode* node, ECMAMode ecmaMode)
+{
+    RefPtr<RegisterID> base = generator.emitNode(node);
+    node = node->m_next;
+    RefPtr<RegisterID> thisValue = generator.emitNode(node);
+    node = node->m_next;
+    RefPtr<RegisterID> property = generator.emitNodeForProperty(node);
+    node = node->m_next;
+    RefPtr<RegisterID> value = generator.emitNodeForProperty(node);
+
+    ASSERT(!node->m_next);
+
+    generator.emitPutByValWithECMAMode(base.get(), thisValue.get(), property.get(), value.get(), ecmaMode);
+}
+
+RegisterID* BytecodeIntrinsicNode::emit_intrinsic_putByValWithThisSloppy(BytecodeGenerator& generator, RegisterID* dst)
+{
+    emitIntrinsicPutByValWithThis(generator, m_args->m_listNode, ECMAMode::sloppy());
+    return dst;
+}
+
+RegisterID* BytecodeIntrinsicNode::emit_intrinsic_putByValWithThisStrict(BytecodeGenerator& generator, RegisterID* dst)
+{
+    emitIntrinsicPutByValWithThis(generator, m_args->m_listNode, ECMAMode::strict());
+    return dst;
+}
+
 RegisterID* BytecodeIntrinsicNode::emit_intrinsic_getPrototypeOf(BytecodeGenerator& generator, RegisterID* dst)
 {
     ArgumentListNode* node = m_args->m_listNode;

--- a/Source/JavaScriptCore/runtime/CacheableIdentifier.h
+++ b/Source/JavaScriptCore/runtime/CacheableIdentifier.h
@@ -26,16 +26,7 @@
 #pragma once
 
 #include "JSCJSValue.h"
-
-namespace WTF {
-
-class PrintStream;
-class UniquedStringImpl;
-
-} // namespace WTF
-
-using WTF::PrintStream;
-using WTF::UniquedStringImpl;
+#include <wtf/text/SymbolImpl.h>
 
 namespace JSC {
 
@@ -66,8 +57,10 @@ public:
     bool isCell() const { return !isUid(); }
     inline bool isSymbolCell() const;
     inline bool isStringCell() const;
+    inline void ensureIsCell(VM&);
 
     bool isSymbol() const { return m_bits && uid()->isSymbol(); }
+    bool isPrivateName() const { return isSymbol() && static_cast<SymbolImpl&>(*uid()).isPrivate(); }
 
     inline JSCell* cell() const;
     UniquedStringImpl* uid() const;

--- a/Source/JavaScriptCore/runtime/CacheableIdentifierInlines.h
+++ b/Source/JavaScriptCore/runtime/CacheableIdentifierInlines.h
@@ -117,6 +117,17 @@ inline bool CacheableIdentifier::isStringCell() const
     return isCell() && cell()->isString();
 }
 
+inline void CacheableIdentifier::ensureIsCell(VM& vm)
+{
+    if (!isCell()) {
+        if (uid()->isSymbol())
+            setCellBits(Symbol::create(vm, static_cast<SymbolImpl&>(*uid())));
+        else
+            setCellBits(jsString(vm, String(static_cast<AtomStringImpl*>(uid()))));
+    }
+    ASSERT(isCell());
+}
+
 inline void CacheableIdentifier::setCellBits(JSCell* cell)
 {
     RELEASE_ASSERT(isCacheableIdentifierCell(cell));

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -1666,9 +1666,17 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
             init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, "hasOwnLengthProperty"_s, hasOwnLengthProperty, ImplementationVisibility::Private));
         });
 
-    // Proxy prototype helpers.
+    // Proxy helpers.
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::handleProxyGetTrapResult)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 3, "handleProxyGetTrapResult"_s, globalFuncHandleProxyGetTrapResult, ImplementationVisibility::Private));
+        });
+
+    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::handleProxySetTrapResultSloppy)].initLater([] (const Initializer<JSCell>& init) {
+            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 4, "handleProxySetTrapResultSloppy"_s, globalFuncHandleProxySetTrapResultSloppy, ImplementationVisibility::Private));
+        });
+
+    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::handleProxySetTrapResultStrict)].initLater([] (const Initializer<JSCell>& init) {
+            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 4, "handleProxySetTrapResultStrict"_s, globalFuncHandleProxySetTrapResultStrict, ImplementationVisibility::Private));
         });
 
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::dateTimeFormat)].initLater([] (const Initializer<JSCell>& init) {

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -867,6 +867,8 @@ public:
     JSFunction* stringProtoSubstringFunction() const;
     JSFunction* performProxyObjectGetFunction() const;
     JSFunction* performProxyObjectGetFunctionConcurrently() const;
+    JSFunction* performProxyObjectSetSloppyFunction() const;
+    JSFunction* performProxyObjectSetStrictFunction() const;
     JSObject* regExpProtoSymbolReplaceFunction() const { return m_regExpProtoSymbolReplace.get(); }
     GetterSetter* regExpProtoGlobalGetter() const;
     GetterSetter* regExpProtoUnicodeGetter() const;

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
@@ -1003,4 +1003,33 @@ JSC_DEFINE_HOST_FUNCTION(globalFuncDateTimeFormat, (JSGlobalObject* globalObject
     RELEASE_AND_RETURN(scope, JSValue::encode(dateTimeFormat->format(globalObject, value)));
 }
 
+static ALWAYS_INLINE EncodedJSValue globalFuncHandleProxySetTrapResult(JSGlobalObject* globalObject, CallFrame* callFrame, ECMAMode ecmaMode)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue trapResult = callFrame->uncheckedArgument(0);
+    JSObject* target = asObject(callFrame->uncheckedArgument(1));
+
+    Identifier propertyName = callFrame->uncheckedArgument(2).toPropertyKey(globalObject);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    JSValue putValue = callFrame->uncheckedArgument(3);
+
+    scope.release();
+    ProxyObject::validateSetTrapResult(globalObject, trapResult, target, propertyName, putValue, ecmaMode.isStrict());
+
+    return JSValue::encode(jsUndefined());
+}
+
+JSC_DEFINE_HOST_FUNCTION(globalFuncHandleProxySetTrapResultSloppy, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    return globalFuncHandleProxySetTrapResult(globalObject, callFrame, ECMAMode::sloppy());
+}
+
+JSC_DEFINE_HOST_FUNCTION(globalFuncHandleProxySetTrapResultStrict, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    return globalFuncHandleProxySetTrapResult(globalObject, callFrame, ECMAMode::strict());
+}
+
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.h
@@ -61,6 +61,8 @@ JSC_DECLARE_HOST_FUNCTION(globalFuncImportMapStatus);
 JSC_DECLARE_HOST_FUNCTION(globalFuncImportModule);
 JSC_DECLARE_HOST_FUNCTION(globalFuncCopyDataProperties);
 JSC_DECLARE_HOST_FUNCTION(globalFuncDateTimeFormat);
+JSC_DECLARE_HOST_FUNCTION(globalFuncHandleProxySetTrapResultSloppy);
+JSC_DECLARE_HOST_FUNCTION(globalFuncHandleProxySetTrapResultStrict);
 
 JS_EXPORT_PRIVATE double jsToNumber(StringView);
 

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
@@ -194,6 +194,8 @@ inline JSFunction* JSGlobalObject::regExpProtoExecFunction() const { return jsCa
 inline JSFunction* JSGlobalObject::stringProtoSubstringFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::stringSubstring)); }
 inline JSFunction* JSGlobalObject::performProxyObjectGetFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::performProxyObjectGet)); }
 inline JSFunction* JSGlobalObject::performProxyObjectGetFunctionConcurrently() const { return linkTimeConstantConcurrently<JSFunction*>(LinkTimeConstant::performProxyObjectGet); }
+inline JSFunction* JSGlobalObject::performProxyObjectSetSloppyFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::performProxyObjectSetSloppy)); }
+inline JSFunction* JSGlobalObject::performProxyObjectSetStrictFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::performProxyObjectSetStrict)); }
 inline GetterSetter* JSGlobalObject::regExpProtoGlobalGetter() const { return bitwise_cast<GetterSetter*>(linkTimeConstant(LinkTimeConstant::regExpProtoGlobalGetter)); }
 inline GetterSetter* JSGlobalObject::regExpProtoUnicodeGetter() const { return bitwise_cast<GetterSetter*>(linkTimeConstant(LinkTimeConstant::regExpProtoUnicodeGetter)); }
 

--- a/Source/JavaScriptCore/runtime/ProxyObject.cpp
+++ b/Source/JavaScriptCore/runtime/ProxyObject.cpp
@@ -433,6 +433,14 @@ bool ProxyObject::performPut(JSGlobalObject* globalObject, JSValue putValue, JSV
     ASSERT(!arguments.hasOverflowed());
     JSValue trapResult = call(globalObject, setMethod, callData, handler, arguments);
     RETURN_IF_EXCEPTION(scope, false);
+    RELEASE_AND_RETURN(scope, validateSetTrapResult(globalObject, trapResult, target, propertyName, putValue, shouldThrow));
+}
+
+bool ProxyObject::validateSetTrapResult(JSGlobalObject* globalObject, JSValue trapResult, JSObject* target, PropertyName propertyName, JSValue putValue, bool shouldThrow)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
     bool trapResultAsBool = trapResult.toBoolean(globalObject);
     RETURN_IF_EXCEPTION(scope, false);
     if (!trapResultAsBool) {
@@ -457,6 +465,7 @@ bool ProxyObject::performPut(JSGlobalObject* globalObject, JSValue putValue, JSV
             return false;
         }
     }
+
     return true;
 }
 

--- a/Source/JavaScriptCore/runtime/ProxyObject.h
+++ b/Source/JavaScriptCore/runtime/ProxyObject.h
@@ -80,6 +80,8 @@ public:
     JSObject* target() const { return jsCast<JSObject*>(internalField(Field::Target).get()); }
     JSValue handler() const { return internalField(Field::Handler).get(); }
 
+    static bool validateSetTrapResult(JSGlobalObject*, JSValue trapResult, JSObject*, PropertyName, JSValue putValue, bool shouldThrow);
+
     static bool put(JSCell*, JSGlobalObject*, PropertyName, JSValue, PutPropertySlot&);
     static bool putByIndex(JSCell*, JSGlobalObject*, unsigned propertyName, JSValue, bool shouldThrow);
     bool putByIndexCommon(JSGlobalObject*, JSValue thisValue, unsigned propertyName, JSValue putValue, bool shouldThrow);


### PR DESCRIPTION
#### b45d2e9c3d34a09f74191f07275eef8cf57f6f4d
<pre>
[JSC] Add ProxyObjectStore IC to optimize &quot;set&quot; trap
<a href="https://bugs.webkit.org/show_bug.cgi?id=252602">https://bugs.webkit.org/show_bug.cgi?id=252602</a>
&lt;rdar://problem/105692284&gt;

Reviewed by Yusuke Suzuki.

This change adds ProxyObjectLoad IC for Proxy &quot;set&quot; trap, which detects ProxyObject and calls
a variant of @performProxyObjectSet JS function, ensuring that errors for both reflection
in case of missing trap and falsy trap result are thrown only in strict mode.

Results in 1.7-6.6x speed-up on provided microbenchmarks, while JetStream3 Proxy tests are neutral
due to very modest usage of Proxy &quot;set&quot; trap (MobX doesn&apos;t call it at all, only setters).

Also, factors out a few helpers as CacheableIdentifier instance methods and extracts
ProxyObject::validateSetTrapResult() method to allow for maximum code reuse.

                                   ToT                      patch

proxy-set-miss-handler      129.6017+-0.8690     ^     19.7623+-0.1588        ^ definitely 6.5580x faster
proxy-set                    57.8925+-0.4492     ^     33.9117+-0.2406        ^ definitely 1.7072x faster

* JSTests/microbenchmarks/proxy-set-miss-handler.js: Added.
* JSTests/microbenchmarks/proxy-set.js: Added.
* JSTests/stress/proxy-set-failure-inline-cache.js: Added.
* Source/JavaScriptCore/builtins/BuiltinNames.h:
* Source/JavaScriptCore/builtins/ProxyHelpers.js:
(linkTimeConstant.performProxyObjectSetSloppy):
(linkTimeConstant.performProxyObjectSetStrict):
* Source/JavaScriptCore/bytecode/AccessCase.cpp:
(JSC::AccessCase::create):
(JSC::AccessCase::guardedByStructureCheckSkippingConstantIdentifierCheck const):
(JSC::AccessCase::requiresIdentifierNameMatch const):
(JSC::AccessCase::requiresInt32PropertyCheck const):
(JSC::AccessCase::needsScratchFPR const):
(JSC::AccessCase::forEachDependentCell const):
(JSC::AccessCase::doesCalls const):
(JSC::AccessCase::canReplace const):
(JSC::AccessCase::generateWithGuard):
(JSC::AccessCase::generateImpl):
(JSC::AccessCase::runWithDowncast):
(JSC::AccessCase::canBeShared):
* Source/JavaScriptCore/bytecode/AccessCase.h:
* Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h:
* Source/JavaScriptCore/bytecode/LinkTimeConstant.h:
* Source/JavaScriptCore/bytecode/PolymorphicAccess.cpp:
(JSC::PolymorphicAccess::regenerate):
* Source/JavaScriptCore/bytecode/ProxyObjectAccessCase.cpp:
(JSC::ProxyObjectAccessCase::emit):
* Source/JavaScriptCore/bytecode/Repatch.cpp:
(JSC::tryCacheGetBy):
(JSC::tryCachePutBy):
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::emitPutByVal):
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h:
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::emitIntrinsicPutByValWithThis):
(JSC::BytecodeIntrinsicNode::emit_intrinsic_putByValWithThisSloppy):
(JSC::BytecodeIntrinsicNode::emit_intrinsic_putByValWithThisStrict):
* Source/JavaScriptCore/runtime/CacheableIdentifier.h:
(JSC::CacheableIdentifier::isPrivateName const):
* Source/JavaScriptCore/runtime/CacheableIdentifierInlines.h:
(JSC::CacheableIdentifier::ensureIsCell):
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::globalFuncHandleProxySetTrapResult):
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::JSGlobalObject::init):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
* Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h:
(JSC::JSGlobalObject::performProxyObjectSetSloppyFunction const):
(JSC::JSGlobalObject::performProxyObjectSetStrictFunction const):
* Source/JavaScriptCore/runtime/ProxyObject.cpp:
(JSC::ProxyObject::performPut):
(JSC::ProxyObject::validateSetTrapResult):
* Source/JavaScriptCore/runtime/ProxyObject.h:

Canonical link: <a href="https://commits.webkit.org/260803@main">https://commits.webkit.org/260803@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce49dc74039cf3b3c1e0d9a8845802b17251c6bb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109463 "7 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18587 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42225 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/961 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118627 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20053 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9784 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101739 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115219 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14942 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98165 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43146 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96914 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29818 "Found 1 new test failure: imported/w3c/web-platform-tests/preload/onerror-event.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84908 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/98377 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11331 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31161 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/99265 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/9354 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11994 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8093 "Passed tests") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/31067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17360 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50765 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/107243 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13726 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26476 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4080 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->