### PR TITLE
Shrink CSSSelector

### DIFF
--- a/Source/WebCore/css/CSSSelectorList.cpp
+++ b/Source/WebCore/css/CSSSelectorList.cpp
@@ -69,17 +69,17 @@ CSSSelectorList::CSSSelectorList(Vector<std::unique_ptr<CSSParserSelector>>&& se
                 operator delete (currentSelector);
             }
             if (current != first)
-                m_selectorArray[arrayIndex].setNotFirstInTagHistory();
+                m_selectorArray[arrayIndex].setIsFirstInTagHistory(false);
             current = current->tagHistory();
             ASSERT(!m_selectorArray[arrayIndex].isLastInSelectorList() || (flattenedSize == arrayIndex + 1));
             if (current)
-                m_selectorArray[arrayIndex].setNotLastInTagHistory();
+                m_selectorArray[arrayIndex].setIsLastInTagHistory(false);
             ++arrayIndex;
         }
         ASSERT(m_selectorArray[arrayIndex - 1].isLastInTagHistory());
     }
     ASSERT(flattenedSize == arrayIndex);
-    m_selectorArray[arrayIndex - 1].setLastInSelectorList();
+    m_selectorArray[arrayIndex - 1].setIsLastInSelectorList();
 }
 
 unsigned CSSSelectorList::componentCount() const

--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -268,7 +268,7 @@ Ref<StyleRule> StyleRule::createForSplitting(const Vector<const CSSSelector*>& s
     auto selectorListArray = makeUniqueArray<CSSSelector>(selectors.size());
     for (unsigned i = 0; i < selectors.size(); ++i)
         new (NotNull, &selectorListArray[i]) CSSSelector(*selectors.at(i));
-    selectorListArray[selectors.size() - 1].setLastInSelectorList();
+    selectorListArray[selectors.size() - 1].setIsLastInSelectorList();
     auto styleRule = StyleRule::create(WTFMove(properties), hasDocumentSecurityOrigin, CSSSelectorList(WTFMove(selectorListArray)));
     styleRule->markAsSplitRule();
     return styleRule;

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -234,7 +234,7 @@ CSSSelectorList CSSParserImpl::parsePageSelector(CSSParserTokenRange range, Styl
             selector->prependTagSelector(QualifiedName(nullAtom(), typeSelector, styleSheet->defaultNamespace()));
     }
 
-    selector->setForPage();
+    selector->setIsForPage();
     return CSSSelectorList { Vector<std::unique_ptr<CSSParserSelector>>::from(WTFMove(selector)) };
 }
 

--- a/Source/WebCore/css/parser/CSSParserSelector.h
+++ b/Source/WebCore/css/parser/CSSParserSelector.h
@@ -59,7 +59,7 @@ public:
     void setNth(int a, int b) { m_selector->setNth(a, b); }
     void setMatch(CSSSelector::Match value) { m_selector->setMatch(value); }
     void setRelation(CSSSelector::RelationType value) { m_selector->setRelation(value); }
-    void setForPage() { m_selector->setForPage(); }
+    void setIsForPage() { m_selector->setIsForPage(); }
 
     CSSSelector::Match match() const { return m_selector->match(); }
     CSSSelector::PseudoElementType pseudoElementType() const { return m_selector->pseudoElementType(); }

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -1187,17 +1187,14 @@ CSSSelectorList CSSSelectorParser::resolveNestingParent(const CSSSelectorList& n
                 auto lastSelector = parserSelector->leftmostSimpleSelector()->selector();
                 ASSERT(lastSelector);
                 bool isLastInSelectorList = lastSelector->isLastInSelectorList();
-                lastSelector->setNotLastInTagHistory();
-                lastSelector->setNotLastInSelectorList();
+                lastSelector->setIsLastInTagHistory(false);
+                lastSelector->setIsLastInSelectorList(false);
                 CSSSelector parentIsSelector;
                 parentIsSelector.setMatch(CSSSelector::Match::PseudoClass);
                 parentIsSelector.setPseudoClassType(CSSSelector::PseudoClassType::PseudoClassIs);
                 parentIsSelector.setSelectorList(makeUnique<CSSSelectorList>(*parentResolvedSelectorList));
-                parentIsSelector.setLastInTagHistory();
-                if (isLastInSelectorList)
-                    parentIsSelector.setLastInSelectorList();
-                else
-                    parentIsSelector.setNotLastInSelectorList();
+                parentIsSelector.setIsLastInTagHistory();
+                parentIsSelector.setIsLastInSelectorList(isLastInSelectorList);
 
                 auto uniqueParentIsSelector = makeUnique<CSSParserSelector>(parentIsSelector);
                 parserSelector->appendTagHistory(CSSSelector::RelationType::DescendantSpace, WTFMove(uniqueParentIsSelector));

--- a/Source/WebCore/style/RuleData.cpp
+++ b/Source/WebCore/style/RuleData.cpp
@@ -65,7 +65,7 @@ static inline MatchBasedOnRuleHash computeMatchBasedOnRuleHash(const CSSSelector
         return MatchBasedOnRuleHash::None;
 
     if (selector.match() == CSSSelector::Tag) {
-        const QualifiedName& tagQualifiedName = selector.tagQName();
+        auto tagQualifiedName = selector.tagQName();
         const AtomString& selectorNamespace = tagQualifiedName.namespaceURI();
         if (selectorNamespace == starAtom() || selectorNamespace == xhtmlNamespaceURI) {
             if (tagQualifiedName == anyQName())

--- a/Source/WebCore/style/RuleFeature.cpp
+++ b/Source/WebCore/style/RuleFeature.cpp
@@ -329,7 +329,7 @@ void RuleFeatureSet::collectFeatures(const RuleData& ruleData)
     auto addToMap = [&](auto& map, auto& entries, auto hostAffectingNames) {
         for (auto& entry : entries) {
             auto& [selector, matchElement, isNegation] = entry;
-            auto& name = selector->value();
+            auto name = selector->value();
 
             map.ensure(name, [] {
                 return makeUnique<RuleFeatureVector>();

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -147,7 +147,7 @@ void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerId
             idSelector = selector;
             break;
         case CSSSelector::Class: {
-            auto& className = selector->value();
+            auto className = selector->value();
             if (!classSelector) {
                 classSelector = selector;
                 classBucketSize = rulesCountForName(m_classRules, className);


### PR DESCRIPTION
#### 515dece23595831eac0cb6915cac06e07babee53
<pre>
Shrink CSSSelector
<a href="https://bugs.webkit.org/show_bug.cgi?id=252612">https://bugs.webkit.org/show_bug.cgi?id=252612</a>
&lt;rdar://problem/105696499&gt;

Reviewed by NOBODY (OOPS!).

This shrinks CSSSelector from 16 bytes to 8 bytes by moving the pseudo
type field to CSSSelector::RareData.

Testing with the PLT5 content, this causes us to create a RareData when
previously we wouldn&apos;t have, on ~3% of CSSSelector objects.

After loading the PLT5 content, there are ~440,000 CSSSelector objects
alive, and I calculate that this should save a bit over 2 MB of memory.

* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::CSSSelector):
(WebCore::CSSSelector::createRareData):
(WebCore::CSSSelector::operator== const):
(WebCore::CSSSelector::selectorText const):
(WebCore::CSSSelector::setAttribute):
(WebCore::CSSSelector::setArgument):
(WebCore::CSSSelector::setArgumentList):
(WebCore::CSSSelector::setSelectorList):
(WebCore::CSSSelector::setNth):
(WebCore::CSSSelector::matchNth const):
(WebCore::CSSSelector::nthA const):
(WebCore::CSSSelector::nthB const):
(WebCore::CSSSelector::RareData::RareData):
(WebCore::CSSSelector::RareData::deepCopy const):
* Source/WebCore/css/CSSSelector.h:
(WebCore::CSSSelector::tagHistory const):
(WebCore::CSSSelector::argument const):
(WebCore::CSSSelector::attributeValueMatchingIsCaseInsensitive const):
(WebCore::CSSSelector::argumentList const):
(WebCore::CSSSelector::selectorList const):
(WebCore::CSSSelector::selectorList):
(WebCore::CSSSelector::isLastInSelectorList const):
(WebCore::CSSSelector::isFirstInTagHistory const):
(WebCore::CSSSelector::isLastInTagHistory const):
(WebCore::CSSSelector::isForPage const):
(WebCore::CSSSelector::setIsLastInSelectorList):
(WebCore::CSSSelector::setIsFirstInTagHistory):
(WebCore::CSSSelector::setIsLastInTagHistory):
(WebCore::CSSSelector::setIsForPage):
(WebCore::CSSSelector::hasRareData const):
(WebCore::CSSSelector::hasNameWithCase const):
(WebCore::CSSSelector::tagIsForNamespaceRule const):
(WebCore::CSSSelector::caseInsensitiveAttributeValueMatching const):
(WebCore::CSSSelector::setHasRareData):
(WebCore::CSSSelector::setHasNameWithCase):
(WebCore::CSSSelector::setTagIsForNamespaceRule):
(WebCore::CSSSelector::setCaseInsensitiveAttributeValueMatching):
(WebCore::CSSSelector::valuePointer const):
(WebCore::CSSSelector::tagQNamePointer const):
(WebCore::CSSSelector::rareDataPointer const):
(WebCore::CSSSelector::nameWithCasePointer const):
(WebCore::CSSSelector::setValuePointer):
(WebCore::CSSSelector::setTagQNamePointer):
(WebCore::CSSSelector::setRareDataPointer):
(WebCore::CSSSelector::setNameWithCasePointer):
(WebCore::CSSSelector::tagHistory):
(WebCore::CSSSelector::pseudoType const):
(WebCore::CSSSelector::attribute const):
(WebCore::CSSSelector::attributeCanonicalLocalName const):
(WebCore::CSSSelector::setValue):
(WebCore::CSSSelector::~CSSSelector):
(WebCore::CSSSelector::tagQName const):
(WebCore::CSSSelector::tagLowercaseLocalName const):
(WebCore::CSSSelector::valueImpl const):
(WebCore::CSSSelector::value const):
(WebCore::CSSSelector::serializingValue const):
(WebCore::CSSSelector::pseudoClassType const):
(WebCore::CSSSelector::setPseudoClassType):
(WebCore::CSSSelector::pseudoElementType const):
(WebCore::CSSSelector::setPseudoElementType):
(WebCore::CSSSelector::pagePseudoClassType const):
(WebCore::CSSSelector::setPagePseudoType):
(WebCore::CSSSelector::relation const):
(WebCore::CSSSelector::setRelation):
(WebCore::CSSSelector::match const):
(WebCore::CSSSelector::setMatch):
(WebCore::CSSSelector::hasFlag const):
(WebCore::CSSSelector::setFlag):
(WebCore::CSSSelector::setLastInSelectorList): Deleted.
(WebCore::CSSSelector::setNotLastInSelectorList): Deleted.
(WebCore::CSSSelector::setNotFirstInTagHistory): Deleted.
(WebCore::CSSSelector::setNotLastInTagHistory): Deleted.
(WebCore::CSSSelector::setLastInTagHistory): Deleted.
(WebCore::CSSSelector::setForPage): Deleted.
* Source/WebCore/css/CSSSelectorList.cpp:
(WebCore::CSSSelectorList::CSSSelectorList):
* Source/WebCore/css/StyleRule.cpp:
(WebCore::StyleRule::createForSplitting):
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::parsePageSelector):
* Source/WebCore/css/parser/CSSParserSelector.h:
(WebCore::CSSParserSelector::setIsForPage):
(WebCore::CSSParserSelector::setForPage): Deleted.
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::resolveNestingParent):
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::constructFragmentsInternal):
(WebCore::SelectorCompiler::SelectorCodeGenerator::generateElementDataMatching):
(WebCore::SelectorCompiler::SelectorCodeGenerator::generateElementHasId):
* Source/WebCore/style/RuleData.cpp:
(WebCore::Style::computeMatchBasedOnRuleHash):
* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::RuleFeatureSet::collectFeatures):
* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::RuleSet::addRule):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/515dece23595831eac0cb6915cac06e07babee53

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108824 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17924 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41657 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/354 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118122 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112704 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19380 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9203 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101054 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114592 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14537 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97750 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42524 "Found 6 new test failures: webgl/2.0.y/conformance/glsl/bugs/character-set.html, webgl/2.0.y/conformance/glsl/misc/fragcolor-fragdata-invariant.html, webgl/2.0.y/conformance/misc/expando-loss.html, webgl/2.0.y/conformance/misc/invalid-passed-params.html, webgl/2.0.y/conformance2/renderbuffers/multisampled-depth-renderbuffer-initialization.html, webgl/2.0.y/conformance2/vertex_arrays/vertex-array-object.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96517 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29389 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84359 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10701 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30739 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11460 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7673 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16847 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50337 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13047 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->