### PR TITLE
[Wasm-GC] Implement initial minimal JS API for Wasm GC

### DIFF
--- a/JSTests/wasm/gc/arrays.js
+++ b/JSTests/wasm/gc/arrays.js
@@ -87,67 +87,29 @@ function testArrayDeclaration() {
 }
 
 function testArrayJS() {
-  // JS API behavior not specified yet, import/export error for now.
-  assert.throws(
-    () => {
-      let m = instantiate(`
-        (module
-          (type (array i64))
-          (func (export "f") (result (ref null 0))
-            (ref.null 0))
-        )
-      `);
-      m.exports.f();
-    },
-    TypeError,
-    "Unsupported use of struct or array type"
-  )
+  // Wasm-allocated arrays can flow to JS and back.
+  {
+    let m = instantiate(`
+      (module
+        (type (array i64))
+        (func (export "f") (result (ref null 0))
+          (ref.null 0))
+      )
+    `);
+    assert.eq(m.exports.f(), null);
+  }
 
-  assert.throws(
-    () => {
-      let m = instantiate(`
-        (module
-          (type (array externref))
-          (func (export "f") (param (ref null 0)))
-        )
-      `);
-      m.exports.f(null);
-    },
-    TypeError,
-    "Unsupported use of struct or array type"
-  )
+  {
+    let m = instantiate(`
+      (module
+        (type (array i64))
+        (func (export "f") (param (ref null 0)))
+      )
+    `);
+    m.exports.f(null);
+  }
 
-  assert.throws(
-    () => {
-      let m = instantiate(`
-        (module
-          (type (array f32))
-          (import "m" "f" (func (param (ref null 0))))
-          (func (export "g") (call 0 (ref.null 0)))
-        )
-      `, { m: { f: (x) => { return; } } });
-      m.exports.g();
-    },
-    TypeError,
-    "Unsupported use of struct or array type"
-  )
-
-  assert.throws(
-    () => {
-      let m = instantiate(`
-        (module
-          (type (array i32))
-          (import "m" "f" (func (result (ref null 0))))
-          (func (export "g") (call 0) drop)
-        )
-      `, { m: { f: (x) => { return null; } } });
-      m.exports.g();
-    },
-    TypeError,
-    "Unsupported use of struct or array type"
-  )
-
-  // JS API behavior not specified yet, setting global errors for now.
+  // JS API behavior not implemented yet, setting global errors for now.
   assert.throws(
     () => {
       let m = instantiate(`

--- a/JSTests/wasm/gc/js-api.js
+++ b/JSTests/wasm/gc/js-api.js
@@ -1,0 +1,84 @@
+//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+
+import * as assert from "../assert.js";
+import { compile, instantiate } from "./wast-wrapper.js";
+
+function runWasmGCObjectTests(obj) {
+  assert.eq(obj.foo, undefined);
+  assert.eq(obj["foo"], undefined);
+  assert.eq(obj[0], undefined);
+  assert.eq(Object.getOwnPropertyNames(obj).length, 0);
+  assert.eq(Object.hasOwn(obj, "foo"), false);
+  assert.eq(Object.prototype.hasOwnProperty.apply(obj, ["foo"]), false);
+  assert.eq("foo" in obj, false);
+  assert.eq(Object.getOwnPropertyDescriptor(obj, "foo"), undefined);
+  assert.throws(
+    () => { obj.foo = 42; },
+    TypeError,
+    "Cannot set property for WebAssembly GC object"
+  );
+  assert.throws(
+    () => { obj[0] = 5; },
+    TypeError,
+    "Cannot set property for WebAssembly GC object"
+  );
+  assert.throws(
+    () => { delete obj.foo; },
+    TypeError,
+    "Cannot delete property for WebAssembly GC object"
+  );
+  assert.throws(
+    () => { delete obj[0]; },
+    TypeError,
+    "Cannot delete property for WebAssembly GC object"
+  );
+  assert.throws(
+    () => Object.defineProperty(obj, "foo", { value: 42 }),
+    TypeError,
+    "Cannot define property for WebAssembly GC object"
+  )
+  assert.eq(Object.getPrototypeOf(obj), null);
+  assert.throws(
+    () => Object.setPrototypeOf(obj, {}),
+    TypeError,
+    "Cannot set prototype of WebAssembly GC object"
+  )
+  assert.eq(Object.isExtensible(obj), false);
+  assert.throws(
+    () => Object.preventExtensions(obj),
+    TypeError,
+    "Cannot run preventExtensions operation on WebAssembly GC object"
+  )
+  assert.throws(
+    () => Object.seal(obj),
+    TypeError,
+    "Cannot run preventExtensions operation on WebAssembly GC object"
+  )
+}
+
+function testArray() {
+  let m = instantiate(`
+    (module
+      (type (array i32))
+      (func (export "make") (result (ref 0))
+        (array.new_canon 0 (i32.const 42) (i32.const 5)))
+    )
+  `);
+  const arr = m.exports.make();
+  runWasmGCObjectTests(arr, m.exports.make);
+}
+
+function testStruct() {
+  let m = instantiate(`
+    (module
+      (type (struct (field i32)))
+      (func (export "make") (result (ref 0))
+        (struct.new_canon 0 (i32.const 42)))
+    )
+  `);
+  const struct = m.exports.make();
+  runWasmGCObjectTests(struct, m.exports.make);
+}
+
+testArray();
+testStruct();

--- a/JSTests/wasm/gc/structs.js
+++ b/JSTests/wasm/gc/structs.js
@@ -125,67 +125,29 @@ function testStructDeclaration() {
 }
 
 function testStructJS() {
-  // JS API behavior not specified yet, import/export error for now.
-  assert.throws(
-    () => {
-      let m = instantiate(`
-        (module
-          (type (struct))
-          (func (export "f") (result (ref null 0))
-            (ref.null 0))
-        )
-      `);
-      m.exports.f();
-    },
-    TypeError,
-    "Unsupported use of struct or array type"
-  )
+  // Wasm-allocated structs can flow to JS and back.
+  {
+    let m = instantiate(`
+      (module
+        (type (struct))
+        (func (export "f") (result (ref null 0))
+          (ref.null 0))
+      )
+    `);
+    assert.eq(m.exports.f(), null);
+  }
 
-  assert.throws(
-    () => {
-      let m = instantiate(`
-        (module
-          (type (struct))
-          (func (export "f") (param (ref null 0)))
-        )
-      `);
-      m.exports.f(null);
-    },
-    TypeError,
-    "Unsupported use of struct or array type"
-  )
+  {
+    let m = instantiate(`
+      (module
+        (type (struct))
+        (func (export "f") (param (ref null 0)))
+      )
+    `);
+    m.exports.f(null);
+  }
 
-  assert.throws(
-    () => {
-      let m = instantiate(`
-        (module
-          (type (struct))
-          (import "m" "f" (func (param (ref null 0))))
-          (func (export "g") (call 0 (ref.null 0)))
-        )
-      `, { m: { f: (x) => { return; } } });
-      m.exports.g();
-    },
-    TypeError,
-    "Unsupported use of struct or array type"
-  )
-
-  assert.throws(
-    () => {
-      let m = instantiate(`
-        (module
-          (type (struct))
-          (import "m" "f" (func (result (ref null 0))))
-          (func (export "g") (call 0) drop)
-        )
-      `, { m: { f: (x) => { return null; } } });
-      m.exports.g();
-    },
-    TypeError,
-    "Unsupported use of struct or array type"
-  )
-
-  // JS API behavior not specified yet, setting global errors for now.
+  // JS API behavior not implemented yet, setting global errors for now.
   assert.throws(
     () => {
       let m = instantiate(`

--- a/Source/JavaScriptCore/wasm/WasmCallingConvention.h
+++ b/Source/JavaScriptCore/wasm/WasmCallingConvention.h
@@ -90,8 +90,6 @@ struct CallInformation {
 
     bool argumentsIncludeI64 : 1 { false };
     bool resultsIncludeI64 : 1 { false };
-    bool argumentsIncludeGCTypeIndex : 1 { false };
-    bool resultsIncludeGCTypeIndex : 1 { false };
     bool argumentsOrResultsIncludeV128 : 1 { false };
     ArgumentLocation thisArgument;
     Vector<ArgumentLocation> params;
@@ -245,8 +243,6 @@ public:
         const auto& signature = *type.as<FunctionSignature>();
         bool argumentsIncludeI64 = false;
         bool resultsIncludeI64 = false;
-        bool argumentsIncludeGCTypeIndex = false;
-        bool resultsIncludeGCTypeIndex = false;
         bool argumentsOrResultsIncludeV128 = false;
         size_t gpArgumentCount = 0;
         size_t fpArgumentCount = 0;
@@ -262,7 +258,6 @@ public:
         for (size_t i = 0; i < signature.argumentCount(); ++i) {
             argumentsIncludeI64 |= signature.argumentType(i).isI64();
             argumentsOrResultsIncludeV128 |= signature.argumentType(i).isV128();
-            argumentsIncludeGCTypeIndex |= isRefWithTypeIndex(signature.argumentType(i)) && !TypeInformation::get(signature.argumentType(i).index).is<FunctionSignature>();
             params[i] = marshallLocation(role, signature.argumentType(i), gpArgumentCount, fpArgumentCount, argStackOffset);
         }
         uint32_t stackArgs = argStackOffset - headerSize;
@@ -276,15 +271,12 @@ public:
         for (size_t i = 0; i < signature.returnCount(); ++i) {
             resultsIncludeI64 |= signature.returnType(i).isI64();
             argumentsOrResultsIncludeV128 |= signature.returnType(i).isV128();
-            resultsIncludeGCTypeIndex |= isRefWithTypeIndex(signature.returnType(i)) && !TypeInformation::get(signature.returnType(i).index).is<FunctionSignature>();
             results[i] = marshallLocation(role, signature.returnType(i), gpArgumentCount, fpArgumentCount, resultStackOffset);
         }
 
         CallInformation result(thisArgument, WTFMove(params), WTFMove(results), std::max(argStackOffset, resultStackOffset));
         result.argumentsIncludeI64 = argumentsIncludeI64;
         result.resultsIncludeI64 = resultsIncludeI64;
-        result.argumentsIncludeGCTypeIndex = argumentsIncludeGCTypeIndex;
-        result.resultsIncludeGCTypeIndex = resultsIncludeGCTypeIndex;
         result.argumentsOrResultsIncludeV128 = argumentsOrResultsIncludeV128;
         return result;
     }

--- a/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
@@ -75,13 +75,6 @@ void marshallJSResult(CCallHelpers& jit, const TypeDefinition& typeDefinition, c
         }
     };
 
-    // GC support is experimental and currently will throw a runtime error when struct
-    // and array type indices are exported via a function signature to JS.
-    if (Options::useWebAssemblyGC() && (wasmFrameConvention.argumentsIncludeGCTypeIndex || wasmFrameConvention.resultsIncludeGCTypeIndex)) {
-        emitThrowWasmToJSException(jit, GPRInfo::wasmContextInstancePointer, ExceptionType::InvalidGCTypeUse);
-        return;
-    }
-
     if (signature.returnsVoid())
         jit.moveTrustedValue(jsUndefined(), JSRInfo::returnValueJSR);
     else if (signature.returnCount() == 1) {

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(WEBASSEMBLY)
 
 #include "JSCInlines.h"
+#include "TypeError.h"
 #include "WasmFormat.h"
 #include "WasmTypeDefinition.h"
 
@@ -97,11 +98,6 @@ void JSWebAssemblyArray::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     ASSERT(inherits(info()));
-
-    // FIXME: When the JS API is further defined, the precise semantics of how
-    // the array should be exposed to JS may changed. For now, we seal it to
-    // ensure that nobody can accidentally depend on being able to extend arrays.
-    seal(vm);
 }
 
 void JSWebAssemblyArray::destroy(JSCell* cell)

--- a/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
+++ b/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
@@ -103,11 +103,6 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToJS(VM& vm
     callLinkInfo = OptimizingCallLinkInfo(CodeOrigin(), CallLinkInfo::UseDataIC::No);
     callLinkInfo.setUpCall(CallLinkInfo::Call, importJSCellGPRReg);
 
-    // GC support is experimental and currently will throw a runtime error when struct
-    // and array type indices are exported via a function signature to JS.
-    if (Options::useWebAssemblyGC() && (wasmCallInfo.argumentsIncludeGCTypeIndex || wasmCallInfo.resultsIncludeGCTypeIndex))
-        return handleBadImportTypeUse(jit, importIndex, Wasm::ExceptionType::InvalidGCTypeUse);
-
     // https://webassembly.github.io/spec/js-api/index.html#exported-function-exotic-objects
     // If parameters or results contain v128, throw a TypeError.
     // Note: the above error is thrown each time the [[Call]] method is invoked.

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyGCObjectBase.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyGCObjectBase.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(WEBASSEMBLY)
 
 #include "JSCInlines.h"
+#include "TypeError.h"
 
 namespace JSC {
 
@@ -54,6 +55,80 @@ void WebAssemblyGCObjectBase::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     ASSERT(inherits(info()));
+}
+
+bool WebAssemblyGCObjectBase::getOwnPropertySlot(JSObject* object, JSGlobalObject*, PropertyName, PropertySlot& slot)
+{
+    slot.setValue(object, static_cast<unsigned>(JSC::PropertyAttribute::None), jsUndefined());
+    return false;
+}
+
+bool WebAssemblyGCObjectBase::getOwnPropertySlotByIndex(JSObject* object, JSGlobalObject*, unsigned, PropertySlot& slot)
+{
+    slot.setValue(object, static_cast<unsigned>(JSC::PropertyAttribute::None), jsUndefined());
+    return false;
+}
+
+bool WebAssemblyGCObjectBase::put(JSCell*, JSGlobalObject* globalObject, PropertyName, JSValue, PutPropertySlot&)
+{
+    auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
+    return typeError(globalObject, scope, true, "Cannot set property for WebAssembly GC object"_s);
+}
+
+bool WebAssemblyGCObjectBase::putByIndex(JSCell*, JSGlobalObject* globalObject, unsigned, JSValue, bool)
+{
+    auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
+    return typeError(globalObject, scope, true, "Cannot set property for WebAssembly GC object"_s);
+}
+
+bool WebAssemblyGCObjectBase::deleteProperty(JSCell*, JSGlobalObject* globalObject, PropertyName, DeletePropertySlot&)
+{
+    auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
+    return typeError(globalObject, scope, true, "Cannot delete property for WebAssembly GC object"_s);
+}
+
+bool WebAssemblyGCObjectBase::deletePropertyByIndex(JSCell*, JSGlobalObject* globalObject, unsigned)
+{
+    auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
+    return typeError(globalObject, scope, true, "Cannot delete property for WebAssembly GC object"_s);
+}
+
+void WebAssemblyGCObjectBase::getOwnPropertyNames(JSObject*, JSGlobalObject*, PropertyNameArray& propertyNameArray, DontEnumPropertiesMode)
+{
+#if ASSERT_ENABLED
+    ASSERT(!propertyNameArray.size());
+#else
+    UNUSED_PARAM(propertyNameArray);
+#endif
+    return;
+}
+
+bool WebAssemblyGCObjectBase::defineOwnProperty(JSObject*, JSGlobalObject* globalObject, PropertyName, const PropertyDescriptor&, bool shouldThrow)
+{
+    auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
+    return typeError(globalObject, scope, shouldThrow, "Cannot define property for WebAssembly GC object"_s);
+}
+
+JSValue WebAssemblyGCObjectBase::getPrototype(JSObject*, JSGlobalObject*)
+{
+    return jsNull();
+}
+
+bool WebAssemblyGCObjectBase::setPrototype(JSObject*, JSGlobalObject* globalObject, JSValue, bool shouldThrowIfCantSet)
+{
+    auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
+    return typeError(globalObject, scope, shouldThrowIfCantSet, "Cannot set prototype of WebAssembly GC object"_s);
+}
+
+bool WebAssemblyGCObjectBase::isExtensible(JSObject*, JSGlobalObject*)
+{
+    return false;
+}
+
+bool WebAssemblyGCObjectBase::preventExtensions(JSObject*, JSGlobalObject* globalObject)
+{
+    auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
+    return typeError(globalObject, scope, true, "Cannot run preventExtensions operation on WebAssembly GC object"_s);
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyGCObjectBase.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyGCObjectBase.h
@@ -35,6 +35,7 @@ namespace JSC {
 class WebAssemblyGCObjectBase : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;
+    static constexpr unsigned StructureFlags = Base::StructureFlags | OverridesGetOwnPropertySlot | OverridesGetOwnPropertyNames | OverridesGetPrototype | OverridesPut | InterceptsGetOwnPropertySlotByIndexEvenWhenLengthIsNotZero;
 
     DECLARE_EXPORT_INFO;
 
@@ -48,6 +49,19 @@ protected:
     WebAssemblyGCObjectBase(VM&, Structure*, RefPtr<const Wasm::RTT>);
 
     void finishCreation(VM&);
+
+    JS_EXPORT_PRIVATE static bool getOwnPropertySlot(JSObject*, JSGlobalObject*, PropertyName, PropertySlot&);
+    JS_EXPORT_PRIVATE static bool getOwnPropertySlotByIndex(JSObject*, JSGlobalObject*, unsigned, PropertySlot&);
+    JS_EXPORT_PRIVATE static bool put(JSCell*, JSGlobalObject*, PropertyName, JSValue, PutPropertySlot&);
+    JS_EXPORT_PRIVATE static bool putByIndex(JSCell*, JSGlobalObject*, unsigned, JSValue, bool shouldThrow);
+    JS_EXPORT_PRIVATE static bool deleteProperty(JSCell*, JSGlobalObject*, PropertyName, DeletePropertySlot&);
+    JS_EXPORT_PRIVATE static bool deletePropertyByIndex(JSCell*, JSGlobalObject*, unsigned);
+    JS_EXPORT_PRIVATE static void getOwnPropertyNames(JSObject*, JSGlobalObject*, PropertyNameArray&, DontEnumPropertiesMode);
+    JS_EXPORT_PRIVATE static bool defineOwnProperty(JSObject*, JSGlobalObject*, PropertyName, const PropertyDescriptor&, bool shouldThrow);
+    JS_EXPORT_PRIVATE static JSValue getPrototype(JSObject*, JSGlobalObject*);
+    JS_EXPORT_PRIVATE static bool setPrototype(JSObject*, JSGlobalObject*, JSValue, bool shouldThrowIfCantSet);
+    JS_EXPORT_PRIVATE static bool isExtensible(JSObject*, JSGlobalObject*);
+    JS_EXPORT_PRIVATE static bool preventExtensions(JSObject*, JSGlobalObject*);
 
     RefPtr<const Wasm::RTT> m_rtt;
 };


### PR DESCRIPTION
#### 8591dc430ab945fcfe29a044871e9ec7bca53195
<pre>
[Wasm-GC] Implement initial minimal JS API for Wasm GC
<a href="https://bugs.webkit.org/show_bug.cgi?id=246769">https://bugs.webkit.org/show_bug.cgi?id=246769</a>

Reviewed by Yusuke Suzuki.

Implements the Wasm GC draft JS API described in:

  <a href="https://docs.google.com/document/d/17hCQXOyeSgogpJ0I0wir4LRmdvu4l7Oca6e1NkbVN8M/">https://docs.google.com/document/d/17hCQXOyeSgogpJ0I0wir4LRmdvu4l7Oca6e1NkbVN8M/</a>
  <a href="https://github.com/WebAssembly/gc/pull/352">https://github.com/WebAssembly/gc/pull/352</a>

This specifies that GC structs and arrays are opaque objects with
internal methods (on WebAssemblyGCObjectBase) that either lead to
throwing exceptions or returning some kind of null result.

This patch doesn&apos;t yet implement the ToWebAssemblyValue changes needed
to roundtrip these values back to Wasm or to access globals and tables
with these values from JS.

The patch also eliminates some of the restrictions on passing GC values
that were added before the JS API was specified.

* JSTests/wasm/gc/arrays.js:
* JSTests/wasm/gc/js-api.js: Added.
(runWasmGCObjectTests):
(testStruct):
* JSTests/wasm/gc/structs.js:
* Source/JavaScriptCore/wasm/WasmCallingConvention.h:
(JSC::Wasm::WasmCallingConvention::callInformationFor const):
* Source/JavaScriptCore/wasm/js/JSToWasm.cpp:
(JSC::Wasm::marshallJSResult):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.cpp:
(JSC::JSWebAssemblyArray::finishCreation):
* Source/JavaScriptCore/wasm/js/WasmToJS.cpp:
(JSC::Wasm::wasmToJS):
* Source/JavaScriptCore/wasm/js/WebAssemblyGCObjectBase.cpp:
(JSC::WebAssemblyGCObjectBase::getOwnPropertySlot):
(JSC::WebAssemblyGCObjectBase::getOwnPropertySlotByIndex):
(JSC::WebAssemblyGCObjectBase::put):
(JSC::WebAssemblyGCObjectBase::putByIndex):
(JSC::WebAssemblyGCObjectBase::deleteProperty):
(JSC::WebAssemblyGCObjectBase::deletePropertyByIndex):
(JSC::WebAssemblyGCObjectBase::getOwnPropertyNames):
(JSC::WebAssemblyGCObjectBase::defineOwnProperty):
(JSC::WebAssemblyGCObjectBase::getPrototype):
(JSC::WebAssemblyGCObjectBase::setPrototype):
(JSC::WebAssemblyGCObjectBase::isExtensible):
(JSC::WebAssemblyGCObjectBase::preventExtensions):
* Source/JavaScriptCore/wasm/js/WebAssemblyGCObjectBase.h:

Canonical link: <a href="https://commits.webkit.org/261544@main">https://commits.webkit.org/261544@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a708603e096364191bccb27068ca809dd844ba7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111791 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20920 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/407 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3565 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120499 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22278 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11993 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/3310 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117556 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16548 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99695 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104809 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98500 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/271 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45525 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/100268 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13384 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/272 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/92416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/11523 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13883 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9704 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/101513 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19325 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52274 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31552 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8044 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15866 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/109552 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26956 "Passed tests") | 
<!--EWS-Status-Bubble-End-->