### PR TITLE
NotificationEvent interface exists but Notification interface does not on iOS 16.4

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -4434,10 +4434,10 @@ NotificationEventEnabled:
   condition: ENABLE(NOTIFICATION_EVENT)
   defaultValue:
     WebCore:
-      "ENABLE(NOTIFICATION_EVENT)": true
+      "ENABLE(NOTIFICATION_EVENT) && !PLATFORM(IOS_FAMILY)": true
       default: false
     WebKit:
-      "ENABLE(NOTIFICATION_EVENT)": true
+      "ENABLE(NOTIFICATION_EVENT) && !PLATFORM(IOS_FAMILY)": true
       default: false
 
 NotificationsEnabled:
@@ -4445,7 +4445,7 @@ NotificationsEnabled:
   status: developer
   category: dom
   humanReadableName: "Notifications"
-  humanReadableDescription: "Enable push notifications"
+  humanReadableDescription: "Enable the Notifications API"
   condition: ENABLE(NOTIFICATIONS)
   defaultValue:
     WebKitLegacy:

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
@@ -1551,6 +1551,16 @@ static WebCore::EditableLinkBehavior toEditableLinkBehavior(_WKEditableLinkBehav
     return _preferences->notificationsEnabled();
 }
 
+- (void)_setNotificationEventEnabled:(BOOL)enabled
+{
+    _preferences->setNotificationEventEnabled(enabled);
+}
+
+- (BOOL)_notificationEventEnabled
+{
+    return _preferences->notificationEventEnabled();
+}
+
 - (BOOL)_pushAPIEnabled
 {
     return _preferences->pushAPIEnabled();

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
@@ -180,6 +180,7 @@ typedef NS_ENUM(NSInteger, _WKPitchCorrectionAlgorithm) {
 @property (nonatomic, setter=_setStorageAPIEnabled:) BOOL _storageAPIEnabled WK_API_AVAILABLE(macos(13.0), ios(16.0));
 @property (nonatomic, setter=_setAccessHandleEnabled:) BOOL _accessHandleEnabled WK_API_AVAILABLE(macos(13.0), ios(16.0));
 @property (nonatomic, setter=_setNotificationsEnabled:) BOOL _notificationsEnabled WK_API_AVAILABLE(macos(10.13.4), ios(16.0));
+@property (nonatomic, setter=_setNotificationEventEnabled:) BOOL _notificationEventEnabled WK_API_AVAILABLE(macos(13.3), ios(16.4));
 @property (nonatomic, setter=_setPushAPIEnabled:) BOOL _pushAPIEnabled WK_API_AVAILABLE(macos(13.0), ios(16.0));
 @property (nonatomic, setter=_setModelDocumentEnabled:) BOOL _modelDocumentEnabled WK_API_AVAILABLE(macos(13.0), ios(16.0));
 @property (nonatomic, setter=_setInteractionRegionMinimumCornerRadius:) double _interactionRegionMinimumCornerRadius WK_API_AVAILABLE(macos(13.3), ios(16.4));

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PushAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PushAPI.mm
@@ -138,6 +138,14 @@ static bool waitUntilEvaluatesToTrue(const Function<bool()>& f)
     return false;
 }
 
+static RetainPtr<WKWebViewConfiguration> createConfigurationWithNotificationsEnabled()
+{
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [[configuration preferences] _setNotificationsEnabled:YES];
+    [[configuration preferences] _setNotificationEventEnabled:YES];
+    return configuration;
+}
+
 TEST(PushAPI, firePushEvent)
 {
     TestWebKitAPI::HTTPServer server({
@@ -147,7 +155,7 @@ TEST(PushAPI, firePushEvent)
 
     [WKWebsiteDataStore _allowWebsiteDataRecordsForAllOrigins];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    auto configuration = createConfigurationWithNotificationsEnabled();
 
     auto provider = TestWebKitAPI::TestNotificationProvider({ [[configuration processPool] _notificationManagerForTesting], WKNotificationManagerGetSharedServiceWorkerNotificationManager() });
     provider.setPermission(server.origin(), true);
@@ -228,7 +236,7 @@ TEST(PushAPI, firePushEventDataStoreDelegate)
     [WKWebsiteDataStore _allowWebsiteDataRecordsForAllOrigins];
 
     auto messageHandler = adoptNS([[PushAPIMessageHandlerWithExpectedMessage alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    auto configuration = createConfigurationWithNotificationsEnabled();
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
     clearWebsiteDataStore([configuration websiteDataStore]);
@@ -323,7 +331,7 @@ TEST(PushAPI, firePushEventWithNoPagesSuccessful)
 
     [WKWebsiteDataStore _allowWebsiteDataRecordsForAllOrigins];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    auto configuration = createConfigurationWithNotificationsEnabled();
     clearWebsiteDataStore([configuration websiteDataStore]);
 
     auto provider = TestWebKitAPI::TestNotificationProvider({ [[configuration processPool] _notificationManagerForTesting], WKNotificationManagerGetSharedServiceWorkerNotificationManager() });
@@ -371,7 +379,7 @@ TEST(PushAPI, firePushEventWithNoPagesFail)
 
     [WKWebsiteDataStore _allowWebsiteDataRecordsForAllOrigins];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    auto configuration = createConfigurationWithNotificationsEnabled();
     clearWebsiteDataStore([configuration websiteDataStore]);
 
     auto provider = TestWebKitAPI::TestNotificationProvider({ [[configuration processPool] _notificationManagerForTesting], WKNotificationManagerGetSharedServiceWorkerNotificationManager() });
@@ -423,7 +431,7 @@ TEST(PushAPI, firePushEventWithNoPagesTimeout)
     [dataStoreConfiguration setServiceWorkerProcessTerminationDelayEnabled:NO];
     auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    auto configuration = createConfigurationWithNotificationsEnabled();
     configuration.get().websiteDataStore = dataStore.get();
     clearWebsiteDataStore([configuration websiteDataStore]);
 
@@ -506,7 +514,7 @@ TEST(PushAPI, pushEventsAndInspectedServiceWorker)
 
     [WKWebsiteDataStore _allowWebsiteDataRecordsForAllOrigins];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    auto configuration = createConfigurationWithNotificationsEnabled();
     clearWebsiteDataStore([configuration websiteDataStore]);
 
     auto context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
@@ -625,7 +633,7 @@ static void testInspectedServiceWorkerWithoutPage(bool enableServiceWorkerInspec
     [dataStoreConfiguration setServiceWorkerProcessTerminationDelayEnabled:NO];
     auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    auto configuration = createConfigurationWithNotificationsEnabled();
     configuration.get().websiteDataStore = dataStore.get();
     clearWebsiteDataStore([configuration websiteDataStore]);
 
@@ -773,7 +781,7 @@ TEST(PushAPI, fireNotificationClickEvent)
 
     [WKWebsiteDataStore _allowWebsiteDataRecordsForAllOrigins];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    auto configuration = createConfigurationWithNotificationsEnabled();
 
     auto provider = TestWebKitAPI::TestNotificationProvider({ [[configuration processPool] _notificationManagerForTesting], WKNotificationManagerGetSharedServiceWorkerNotificationManager() });
     provider.setPermission(server.origin(), true);
@@ -828,7 +836,7 @@ TEST(PushAPI, fireNotificationCloseEvent)
 
     [WKWebsiteDataStore _allowWebsiteDataRecordsForAllOrigins];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    auto configuration = createConfigurationWithNotificationsEnabled();
 
     auto provider = TestWebKitAPI::TestNotificationProvider({ [[configuration processPool] _notificationManagerForTesting], WKNotificationManagerGetSharedServiceWorkerNotificationManager() });
     provider.setPermission(server.origin(), true);
@@ -943,7 +951,7 @@ TEST(PushAPI, callNotificationClose)
 
     [WKWebsiteDataStore _allowWebsiteDataRecordsForAllOrigins];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    auto configuration = createConfigurationWithNotificationsEnabled();
 
     auto provider = TestWebKitAPI::TestNotificationProvider({ [[configuration processPool] _notificationManagerForTesting], WKNotificationManagerGetSharedServiceWorkerNotificationManager() });
     provider.setPermission(server.origin(), true);


### PR DESCRIPTION
#### b8064a7a1a7b4a20279f29b11d423dae483436c9
<pre>
NotificationEvent interface exists but Notification interface does not on iOS 16.4
<a href="https://bugs.webkit.org/show_bug.cgi?id=252625">https://bugs.webkit.org/show_bug.cgi?id=252625</a>
rdar://105697554

Reviewed by Chris Dumez.

On iOS, NotificationEvent is enabled by default but Notification is disabled by default. This
doesn&apos;t make any sense, since a NotificationEvent contains a Notification. Furthermore, you can&apos;t
actually even get a NotificationEvent on iOS with a default browser since the supporting machinery
to generate and fire the notification event only exists in Web.app. So it should definitely not
default to true.

To fix this, we only enable NotificationEvent where we used to (i.e. on macOS &gt;= 13). Web.app will
enable this preference at runtime so that Web Push and NotificationEvent work as expected in that
app.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm:
(-[WKPreferences _setNotificationEventEnabled:]):
(-[WKPreferences _notificationEventEnabled]):
* Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PushAPI.mm:

Canonical link: <a href="https://commits.webkit.org/260685@main">https://commits.webkit.org/260685@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18e0566176bfa33c715d6791ff645d7877d78b33

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109081 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18163 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41903 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/617 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/118347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112966 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19622 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9465 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101322 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114841 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/97943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/42874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/29596 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/84606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/98109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10945 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/30942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/38/builds/98901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/83/builds/9035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11683 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/7874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/38/builds/98901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/17057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50541 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/106575 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7375 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13290 "Built successfully") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/26413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | | | | 
<!--EWS-Status-Bubble-End-->