### PR TITLE
REGRESSION(260471@main): The platform graphics context colorspace should not be adopted

### DIFF
--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -221,9 +221,9 @@ const DestinationColorSpace& GraphicsContextCG::colorSpace() const
 
     // FIXME: Need to handle kCGContextTypePDF.
     if (CGContextGetType(context) == kCGContextTypeIOSurface)
-        colorSpace = adoptCF(CGIOSurfaceContextGetColorSpace(context));
+        colorSpace = CGIOSurfaceContextGetColorSpace(context);
     else if (CGContextGetType(context) == kCGContextTypeBitmap)
-        colorSpace = adoptCF(CGBitmapContextGetColorSpace(context));
+        colorSpace = CGBitmapContextGetColorSpace(context);
     else
         colorSpace = adoptCF(CGContextCopyDeviceColorSpace(context));
 


### PR DESCRIPTION
#### fab6d531c24fb7f031b60684f8f00b983b26d8f8
<pre>
REGRESSION(260471@main): The platform graphics context colorspace should not be adopted
<a href="https://bugs.webkit.org/show_bug.cgi?id=252629">https://bugs.webkit.org/show_bug.cgi?id=252629</a>
rdar://105637444

Reviewed by Darin Adler.

When storing the return raw pointer of CGIOSurfaceContextGetColorSpace() or
CGBitmapContextGetColorSpace() in a RetainPtr, we should not be using adoptCF().
The refcount of the colorspace should be incremented when WebKit references it.

* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::colorSpace const):

Canonical link: <a href="https://commits.webkit.org/260609@main">https://commits.webkit.org/260609@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69c70cb154bcb53679d08152895f7cc822878e46

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108779 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17878 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41619 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/96 "Updated wpe dependencies (failure)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118088 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112662 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19332 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9155 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101011 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114547 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14511 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97724 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42477 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96484 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29362 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84324 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10669 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30713 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11430 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7645 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16817 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50303 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7327 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13017 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->