### PR TITLE
Regression(252852@main) Games on kongregate.com are no longer loading

### DIFF
--- a/LayoutTests/fast/frames/about-blank-frame-no-lazy-loading-expected.txt
+++ b/LayoutTests/fast/frames/about-blank-frame-no-lazy-loading-expected.txt
@@ -1,0 +1,10 @@
+Tests that it is possible to access frame.contentWindow synchronously on an about:blank iframe, even if marked as lazily loading.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS iframe.contentWindow.location.href is "about:blank"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/frames/about-blank-frame-no-lazy-loading.html
+++ b/LayoutTests/fast/frames/about-blank-frame-no-lazy-loading.html
@@ -1,0 +1,15 @@
+<DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script>
+description("Tests that it is possible to access frame.contentWindow synchronously on an about:blank iframe, even if marked as lazily loading.");
+
+let iframe = document.createElement("iframe");
+iframe.loading = "lazy";
+document.body.append(iframe);
+
+shouldBeEqualToString("iframe.contentWindow.location.href", "about:blank");
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/HTMLFrameElementBase.cpp
+++ b/Source/WebCore/html/HTMLFrameElementBase.cpp
@@ -91,6 +91,8 @@ void HTMLFrameElementBase::openURL(LockHistory lockHistory, LockBackForwardList 
     if (m_frameURL.isEmpty())
         m_frameURL = AtomString { aboutBlankURL().string() };
 
+    // FIXME: This should delay the navigation to m_frameURL but shouldn't delay the creation
+    // of the Frame object or the load of the intially empty document.
     if (shouldLoadFrameLazily())
         return;
 

--- a/Source/WebCore/html/HTMLIFrameElement.cpp
+++ b/Source/WebCore/html/HTMLIFrameElement.cpp
@@ -167,8 +167,11 @@ void HTMLIFrameElement::setLoadingForBindings(const AtomString& value)
     setAttributeWithoutSynchronization(loadingAttr, value);
 }
 
-static bool isFrameLazyLoadable(const Document& document, const AtomString& loadingAttributeValue)
+static bool isFrameLazyLoadable(const Document& document, const URL& url, const AtomString& loadingAttributeValue)
 {
+    if (!url.isValid() || url.isAboutBlank())
+        return false;
+
     if (!document.frame() || !document.frame()->script().canExecuteScripts(NotAboutToExecuteScript))
         return false;
 
@@ -178,9 +181,9 @@ static bool isFrameLazyLoadable(const Document& document, const AtomString& load
 bool HTMLIFrameElement::shouldLoadFrameLazily()
 {
     if (!m_lazyLoadFrameObserver && document().settings().lazyIframeLoadingEnabled() && !document().quirks().shouldDisableLazyIframeLoadingQuirk()) {
-        if (isFrameLazyLoadable(document(), attributeWithoutSynchronization(HTMLNames::loadingAttr))) {
+        URL completeURL = document().completeURL(frameURL());
+        if (isFrameLazyLoadable(document(), completeURL, attributeWithoutSynchronization(HTMLNames::loadingAttr))) {
             auto currentReferrerPolicy = referrerPolicy();
-            URL completeURL = document().completeURL(frameURL());
             lazyLoadFrameObserver().observe(AtomString { completeURL.string() }, currentReferrerPolicy);
             return true;
         }


### PR DESCRIPTION
#### b57dc1f8ff99678c9b9012ba6f89c444ad72de2f
<pre>
Regression(252852@main) Games on kongregate.com are no longer loading
<a href="https://bugs.webkit.org/show_bug.cgi?id=252636">https://bugs.webkit.org/show_bug.cgi?id=252636</a>
rdar://104392542

Reviewed by Ryosuke Niwa.

Do not lazy load iframes that have no valid URL or &quot;about:blank&quot; as URL. Lazily
loading such iframes has no performance benefits and can actually cause breakage
as JS (like on kongregate.com) may expect them to load synchronously.

Note that we have a more general problem where we fail to create the Frame &amp;
initial empty document when we decide to lazy load an iframe. This is not correct,
and we should only delay the navigation to the frame URL *after* the creation of
the initial empty document. However, fixing this is a larger change and this is
not a regression from 252852@main. As a result, I am merely adding a FIXME comment
in this patch and will address separately.

* LayoutTests/fast/frames/about-blank-frame-no-lazy-loading-expected.txt: Added.
* LayoutTests/fast/frames/about-blank-frame-no-lazy-loading.html: Added.
Add layout test coverage.

* Source/WebCore/html/HTMLFrameElementBase.cpp:
(WebCore::HTMLFrameElementBase::openURL):
* Source/WebCore/html/HTMLIFrameElement.cpp:
(WebCore::isFrameLazyLoadable):
(WebCore::HTMLIFrameElement::shouldLoadFrameLazily):

Canonical link: <a href="https://commits.webkit.org/260612@main">https://commits.webkit.org/260612@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b506f4e190732f86567443fff82e4bf6624aaed

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108777 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17876 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41617 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/93 "Updated wpe dependencies (failure)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118087 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112660 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19330 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9153 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101009 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114545 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14507 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97723 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42476 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96480 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29361 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84323 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10667 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30712 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11429 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7642 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16816 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50302 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7326 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13016 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->