### PR TITLE
Lazily allocate ResourceResponse within CachedResource

### DIFF
--- a/Source/WebCore/loader/cache/CachedCSSStyleSheet.cpp
+++ b/Source/WebCore/loader/cache/CachedCSSStyleSheet.cpp
@@ -60,7 +60,7 @@ void CachedCSSStyleSheet::didAddClient(CachedResourceClient& client)
     CachedResource::didAddClient(client);
 
     if (!isLoading())
-        downcast<CachedStyleSheetClient>(client).setCSSStyleSheet(m_resourceRequest.url().string(), m_response.url(), String::fromLatin1(m_decoder->encoding().name()), this);
+        downcast<CachedStyleSheetClient>(client).setCSSStyleSheet(m_resourceRequest.url().string(), response().url(), String::fromLatin1(m_decoder->encoding().name()), this);
 }
 
 void CachedCSSStyleSheet::setEncoding(const String& chs)
@@ -123,17 +123,17 @@ void CachedCSSStyleSheet::checkNotify(const NetworkLoadMetrics&)
 
     CachedResourceClientWalker<CachedStyleSheetClient> walker(*this);
     while (CachedStyleSheetClient* c = walker.next())
-        c->setCSSStyleSheet(m_resourceRequest.url().string(), m_response.url(), String::fromLatin1(m_decoder->encoding().name()), this);
+        c->setCSSStyleSheet(m_resourceRequest.url().string(), response().url(), String::fromLatin1(m_decoder->encoding().name()), this);
 }
 
 String CachedCSSStyleSheet::responseMIMEType() const
 {
-    return extractMIMETypeFromMediaType(m_response.httpHeaderField(HTTPHeaderName::ContentType));
+    return extractMIMETypeFromMediaType(response().httpHeaderField(HTTPHeaderName::ContentType));
 }
 
 bool CachedCSSStyleSheet::mimeTypeAllowedByNosniff() const
 {
-    return parseContentTypeOptionsHeader(m_response.httpHeaderField(HTTPHeaderName::XContentTypeOptions)) != ContentTypeOptionsDisposition::Nosniff || equalLettersIgnoringASCIICase(responseMIMEType(), "text/css"_s);
+    return parseContentTypeOptionsHeader(response().httpHeaderField(HTTPHeaderName::XContentTypeOptions)) != ContentTypeOptionsDisposition::Nosniff || equalLettersIgnoringASCIICase(responseMIMEType(), "text/css"_s);
 }
 
 bool CachedCSSStyleSheet::canUseSheet(MIMETypeCheckHint mimeTypeCheckHint, bool* hasValidMIMEType) const

--- a/Source/WebCore/loader/cache/CachedImage.cpp
+++ b/Source/WebCore/loader/cache/CachedImage.cpp
@@ -88,7 +88,7 @@ CachedImage::CachedImage(const URL& url, Image* image, PAL::SessionID sessionID,
 
     // Use the incoming URL in the response field. This ensures that code using the response directly,
     // such as origin checks for security, actually see something.
-    m_response.setURL(url);
+    mutableResponse().setURL(url);
 }
 
 CachedImage::~CachedImage()
@@ -358,12 +358,12 @@ void CachedImage::checkShouldPaintBrokenImage()
 
 bool CachedImage::isPDFResource() const
 {
-    return Image::isPDFResource(m_response.mimeType(), url());
+    return Image::isPDFResource(response().mimeType(), url());
 }
 
 bool CachedImage::isPostScriptResource() const
 {
-    return Image::isPostScriptResource(m_response.mimeType(), url());
+    return Image::isPostScriptResource(response().mimeType(), url());
 }
 
 void CachedImage::clear()
@@ -613,11 +613,11 @@ void CachedImage::error(CachedResource::Status status)
     notifyObservers();
 }
 
-void CachedImage::responseReceived(const ResourceResponse& response)
+void CachedImage::responseReceived(const ResourceResponse& newResponse)
 {
-    if (!m_response.isNull())
+    if (!response().isNull())
         clear();
-    CachedResource::responseReceived(response);
+    CachedResource::responseReceived(newResponse);
 }
 
 void CachedImage::destroyDecodedData()

--- a/Source/WebCore/loader/cache/CachedRawResource.cpp
+++ b/Source/WebCore/loader/cache/CachedRawResource.cpp
@@ -185,8 +185,8 @@ void CachedRawResource::didAddClient(CachedResourceClient& c)
             CachedResource::didAddClient(*client);
         };
 
-        if (!m_response.isNull()) {
-            ResourceResponse response(m_response);
+        if (!response().isNull()) {
+            ResourceResponse response(CachedResource::response());
             if (validationCompleting())
                 response.setSource(ResourceResponse::Source::MemoryCacheAfterValidation);
             else {
@@ -229,15 +229,15 @@ void CachedRawResource::redirectReceived(ResourceRequest&& request, const Resour
     }
 }
 
-void CachedRawResource::responseReceived(const ResourceResponse& response)
+void CachedRawResource::responseReceived(const ResourceResponse& newResponse)
 {
     CachedResourceHandle<CachedRawResource> protectedThis(this);
     if (!m_identifier)
         m_identifier = m_loader->identifier();
-    CachedResource::responseReceived(response);
+    CachedResource::responseReceived(newResponse);
     CachedResourceClientWalker<CachedRawResourceClient> walker(*this);
     while (CachedRawResourceClient* c = walker.next())
-        c->responseReceived(*this, m_response, nullptr);
+        c->responseReceived(*this, response(), nullptr);
 }
 
 bool CachedRawResource::shouldCacheResponse(const ResourceResponse& response)
@@ -357,13 +357,13 @@ void CachedRawResource::clear()
 }
 
 #if USE(QUICK_LOOK)
-void CachedRawResource::previewResponseReceived(const ResourceResponse& response)
+void CachedRawResource::previewResponseReceived(const ResourceResponse& newResponse)
 {
     CachedResourceHandle<CachedRawResource> protectedThis(this);
-    CachedResource::previewResponseReceived(response);
+    CachedResource::previewResponseReceived(newResponse);
     CachedResourceClientWalker<CachedRawResourceClient> walker(*this);
     while (CachedRawResourceClient* c = walker.next())
-        c->previewResponseReceived(*this, m_response);
+        c->previewResponseReceived(*this, response());
 }
 
 #endif

--- a/Source/WebCore/loader/cache/CachedScript.cpp
+++ b/Source/WebCore/loader/cache/CachedScript.cpp
@@ -71,7 +71,7 @@ StringView CachedScript::script(ShouldDecodeAsUTF8Only shouldDecodeAsUTF8Only)
 
         // If the encoded and decoded data are the same, there is no decoded data cost!
         setDecodedSize(0);
-        m_decodedDataDeletionTimer.stop();
+        stopDecodedDataDeletionTimer();
 
         m_scriptHash = StringHasher::computeHashAndMaskTop8Bits(contiguousData.data(), m_data->size());
     }
@@ -95,7 +95,7 @@ StringView CachedScript::script(ShouldDecodeAsUTF8Only shouldDecodeAsUTF8Only)
         setDecodedSize(m_script.sizeInBytes());
     }
 
-    m_decodedDataDeletionTimer.restart();
+    restartDecodedDataDeletionTimer();
     return m_script;
 }
 

--- a/Source/WebCore/loader/cache/CachedXSLStyleSheet.cpp
+++ b/Source/WebCore/loader/cache/CachedXSLStyleSheet.cpp
@@ -48,7 +48,7 @@ void CachedXSLStyleSheet::didAddClient(CachedResourceClient& client)
 {
     ASSERT(client.resourceClientType() == CachedStyleSheetClient::expectedType());
     if (!isLoading())
-        downcast<CachedStyleSheetClient>(client).setXSLStyleSheet(m_resourceRequest.url().string(), m_response.url(), m_sheet);
+        downcast<CachedStyleSheetClient>(client).setXSLStyleSheet(m_resourceRequest.url().string(), response().url(), m_sheet);
 }
 
 void CachedXSLStyleSheet::setEncoding(const String& chs)
@@ -83,7 +83,7 @@ void CachedXSLStyleSheet::checkNotify(const NetworkLoadMetrics&)
     
     CachedResourceClientWalker<CachedStyleSheetClient> walker(*this);
     while (CachedStyleSheetClient* c = walker.next())
-        c->setXSLStyleSheet(m_resourceRequest.url().string(), m_response.url(), m_sheet);
+        c->setXSLStyleSheet(m_resourceRequest.url().string(), response().url(), m_sheet);
 }
 
 #endif


### PR DESCRIPTION
#### 98761d6864f7dac2f22655a51bb8a00a2172edc3
<pre>
Lazily allocate ResourceResponse within CachedResource
<a href="https://bugs.webkit.org/show_bug.cgi?id=252637">https://bugs.webkit.org/show_bug.cgi?id=252637</a>

Reviewed by Cameron McCormack.

CachedResource objects often don&apos;t have an initialised ResourceResponse, especially in the case of Fonts.

We can move the ResourceResponse (and associated response data) into a lazily allocated inner structure to save memory

* Source/WebCore/loader/cache/CachedCSSStyleSheet.cpp:
(WebCore::CachedCSSStyleSheet::didAddClient):
(WebCore::CachedCSSStyleSheet::checkNotify):
(WebCore::CachedCSSStyleSheet::responseMIMEType const):
(WebCore::CachedCSSStyleSheet::mimeTypeAllowedByNosniff const):
* Source/WebCore/loader/cache/CachedImage.cpp:
(WebCore::CachedImage::CachedImage):
(WebCore::CachedImage::isPDFResource const):
(WebCore::CachedImage::isPostScriptResource const):
(WebCore::CachedImage::responseReceived):
* Source/WebCore/loader/cache/CachedRawResource.cpp:
(WebCore::CachedRawResource::didAddClient):
(WebCore::CachedRawResource::responseReceived):
(WebCore::CachedRawResource::previewResponseReceived):
* Source/WebCore/loader/cache/CachedResource.cpp:
(WebCore::CachedResource::CachedResource):
(WebCore::CachedResource::setBodyDataFrom):
(WebCore::CachedResource::cancelLoad):
(WebCore::CachedResource::isExpired const):
(WebCore::CachedResource::setResponse):
(WebCore::CachedResource::didAddClient):
(WebCore::CachedResource::addClientToSet):
(WebCore::CachedResource::destroyDecodedDataIfNeeded):
(WebCore::CachedResource::setDecodedSize):
(WebCore::CachedResource::setEncodedSize):
(WebCore::CachedResource::updateResponseAfterRevalidation):
(WebCore::CachedResource::canUseCacheValidator const):
(WebCore::CachedResource::makeRevalidationDecision const):
(WebCore::CachedResource::overheadSize const):
(WebCore::CachedResource::ResponseData::ResponseData):
(WebCore::CachedResource::mutableResponseData const):
(WebCore::CachedResource::mutableResponse):
(WebCore::CachedResource::response const):
(WebCore::CachedResource::stopDecodedDataDeletionTimer):
(WebCore::CachedResource::restartDecodedDataDeletionTimer):
(WebCore::CachedResource::resourceError const):
(WebCore::CachedResource::wasCanceled const):
(WebCore::CachedResource::loadFailedOrCanceled const):
(WebCore::CachedResource::encodedSize const):
(WebCore::CachedResource::decodedSize const):
* Source/WebCore/loader/cache/CachedResource.h:
(WebCore::CachedResource::setResourceError):
(WebCore::CachedResource::mimeType const):
(WebCore::CachedResource::expectedContentLength const):
(WebCore::CachedResource::takeNetworkLoadMetrics):
(WebCore::CachedResource::resourceError const): Deleted.
(WebCore::CachedResource::encodedSize const): Deleted.
(WebCore::CachedResource::decodedSize const): Deleted.
(WebCore::CachedResource::response const): Deleted.
(WebCore::CachedResource::wasCanceled const): Deleted.
(WebCore::CachedResource::loadFailedOrCanceled const): Deleted.
* Source/WebCore/loader/cache/CachedScript.cpp:
(WebCore::CachedScript::script):
* Source/WebCore/loader/cache/CachedXSLStyleSheet.cpp:
(WebCore::CachedXSLStyleSheet::didAddClient):
(WebCore::CachedXSLStyleSheet::checkNotify):

Canonical link: <a href="https://commits.webkit.org/260788@main">https://commits.webkit.org/260788@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f338295282d8d804388baf7ce1c06e06370ecb3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109437 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18561 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42199 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/935 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/118601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113322 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20026 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9758 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101712 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115193 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/43119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/29797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84872 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11305 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/31140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/9328 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11969 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/17335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/50744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7467 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13700 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->