### PR TITLE
Remove ReturnEarlyIfTrue serialization attribute

### DIFF
--- a/Source/WebCore/Modules/indexeddb/IDBIndex.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBIndex.cpp
@@ -298,7 +298,7 @@ ExceptionOr<Ref<IDBRequest>> IDBIndex::doGet(ExceptionOr<IDBKeyRangeData> range)
         return range.releaseException();
     auto keyRange = range.releaseReturnValue();
 
-    if (keyRange.isNull)
+    if (keyRange.isNull())
         return Exception { DataError };
 
     return transaction.requestGetValue(*this, keyRange);
@@ -337,7 +337,7 @@ ExceptionOr<Ref<IDBRequest>> IDBIndex::doGetKey(ExceptionOr<IDBKeyRangeData> ran
         return range.releaseException();
     auto keyRange = range.releaseReturnValue();
     
-    if (keyRange.isNull)
+    if (keyRange.isNull())
         return Exception { DataError };
 
     return transaction.requestGetKey(*this, keyRange);

--- a/Source/WebCore/Modules/indexeddb/IDBKeyRangeData.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBKeyRangeData.cpp
@@ -33,14 +33,12 @@ namespace WebCore {
 IDBKeyRangeData::IDBKeyRangeData(IDBKey* key)
     : lowerKey(key)
     , upperKey(key)
-    , isNull(!key)
 {
 }
 
 IDBKeyRangeData::IDBKeyRangeData(const IDBKeyData& keyData)
     : lowerKey(keyData)
     , upperKey(keyData)
-    , isNull(keyData.isNull())
 {
 }
 
@@ -48,7 +46,6 @@ IDBKeyRangeData IDBKeyRangeData::isolatedCopy() const
 {
     IDBKeyRangeData result;
 
-    result.isNull = isNull;
     result.lowerKey = lowerKey.isolatedCopy();
     result.upperKey = upperKey.isolatedCopy();
     result.lowerOpen = lowerOpen;
@@ -57,17 +54,9 @@ IDBKeyRangeData IDBKeyRangeData::isolatedCopy() const
     return result;
 }
 
-RefPtr<IDBKeyRange> IDBKeyRangeData::maybeCreateIDBKeyRange() const
-{
-    if (isNull)
-        return nullptr;
-
-    return IDBKeyRange::create(lowerKey.maybeCreateIDBKey(), upperKey.maybeCreateIDBKey(), lowerOpen, upperOpen);
-}
-
 bool IDBKeyRangeData::isExactlyOneKey() const
 {
-    if (isNull || lowerOpen || upperOpen || !upperKey.isValid() || !lowerKey.isValid())
+    if (isNull() || lowerOpen || upperOpen || !upperKey.isValid() || !lowerKey.isValid())
         return false;
 
     return !lowerKey.compare(upperKey);
@@ -95,7 +84,7 @@ bool IDBKeyRangeData::containsKey(const IDBKeyData& key) const
 
 bool IDBKeyRangeData::isValid() const
 {
-    if (isNull)
+    if (isNull())
         return false;
 
     if (!lowerKey.isValid() && !lowerKey.isNull())

--- a/Source/WebCore/Modules/indexeddb/IDBKeyRangeData.h
+++ b/Source/WebCore/Modules/indexeddb/IDBKeyRangeData.h
@@ -34,14 +34,12 @@ class IDBKey;
 
 struct IDBKeyRangeData {
     IDBKeyRangeData()
-        : isNull(true)
     {
     }
 
     static IDBKeyRangeData allKeys()
     {
         IDBKeyRangeData result;
-        result.isNull = false;
         result.lowerKey = IDBKeyData::minimum();
         result.upperKey = IDBKeyData::maximum();
         return result;
@@ -51,9 +49,8 @@ struct IDBKeyRangeData {
     IDBKeyRangeData(const IDBKeyData&);
 
     IDBKeyRangeData(IDBKeyRange* keyRange)
-        : isNull(!keyRange)
     {
-        if (isNull)
+        if (!keyRange)
             return;
 
         lowerKey = keyRange->lower();
@@ -62,18 +59,15 @@ struct IDBKeyRangeData {
         upperOpen = keyRange->upperOpen();
     }
 
-    IDBKeyRangeData(bool isNull, IDBKeyData&& lowerKey, IDBKeyData&& upperKey, bool lowerOpen, bool upperOpen)
+    IDBKeyRangeData(IDBKeyData&& lowerKey, IDBKeyData&& upperKey, bool lowerOpen, bool upperOpen)
         : lowerKey(WTFMove(lowerKey))
         , upperKey(WTFMove(upperKey))
         , lowerOpen(WTFMove(lowerOpen))
         , upperOpen(WTFMove(upperOpen))
-        , isNull(isNull)
     {
     }
 
     WEBCORE_EXPORT IDBKeyRangeData isolatedCopy() const;
-
-    WEBCORE_EXPORT RefPtr<IDBKeyRange> maybeCreateIDBKeyRange() const;
 
     WEBCORE_EXPORT bool isExactlyOneKey() const;
     bool containsKey(const IDBKeyData&) const;
@@ -85,7 +79,7 @@ struct IDBKeyRangeData {
     bool lowerOpen { false };
     bool upperOpen { false };
 
-    bool isNull;
+    bool isNull() const { return lowerKey.isNull() && upperKey.isNull(); };
 
 #if !LOG_DISABLED
     String loggingString() const;

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
@@ -1004,7 +1004,7 @@ Ref<IDBRequest> IDBTransaction::requestGetRecord(IDBObjectStore& objectStore, co
 {
     LOG(IndexedDB, "IDBTransaction::requestGetRecord");
     ASSERT(isActive());
-    ASSERT(!getRecordData.keyRangeData.isNull);
+    ASSERT(!getRecordData.keyRangeData.isNull());
     ASSERT(canCurrentThreadAccessThreadLocalData(m_database->originThread()));
 
     IndexedDB::ObjectStoreRecordType type = getRecordData.type == IDBGetRecordDataType::KeyAndValue ? IndexedDB::ObjectStoreRecordType::ValueOnly : IndexedDB::ObjectStoreRecordType::KeyOnly;
@@ -1042,7 +1042,7 @@ Ref<IDBRequest> IDBTransaction::requestIndexRecord(IDBIndex& index, IndexedDB::I
 {
     LOG(IndexedDB, "IDBTransaction::requestGetValue");
     ASSERT(isActive());
-    ASSERT(!range.isNull);
+    ASSERT(!range.isNull());
     ASSERT(canCurrentThreadAccessThreadLocalData(m_database->originThread()));
 
     auto request = IDBRequest::createIndexGet(*scriptExecutionContext(), index, type, *this);
@@ -1105,7 +1105,7 @@ Ref<IDBRequest> IDBTransaction::requestCount(IDBObjectStore& objectStore, const 
 {
     LOG(IndexedDB, "IDBTransaction::requestCount (IDBObjectStore)");
     ASSERT(isActive());
-    ASSERT(!range.isNull);
+    ASSERT(!range.isNull());
     ASSERT(canCurrentThreadAccessThreadLocalData(m_database->originThread()));
 
     auto request = IDBRequest::create(*scriptExecutionContext(), objectStore, *this);
@@ -1125,7 +1125,7 @@ Ref<IDBRequest> IDBTransaction::requestCount(IDBIndex& index, const IDBKeyRangeD
 {
     LOG(IndexedDB, "IDBTransaction::requestCount (IDBIndex)");
     ASSERT(isActive());
-    ASSERT(!range.isNull);
+    ASSERT(!range.isNull());
     ASSERT(canCurrentThreadAccessThreadLocalData(m_database->originThread()));
 
     auto request = IDBRequest::create(*scriptExecutionContext(), index, *this);
@@ -1162,7 +1162,7 @@ Ref<IDBRequest> IDBTransaction::requestDeleteRecord(IDBObjectStore& objectStore,
 {
     LOG(IndexedDB, "IDBTransaction::requestDeleteRecord");
     ASSERT(isActive());
-    ASSERT(!range.isNull);
+    ASSERT(!range.isNull());
     ASSERT(canCurrentThreadAccessThreadLocalData(m_database->originThread()));
 
     auto request = IDBRequest::create(*scriptExecutionContext(), objectStore, *this);

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.cpp
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.cpp
@@ -246,7 +246,7 @@ void IDBConnectionToServer::getRecord(const IDBRequestData& requestData, const I
 {
     LOG(IndexedDB, "IDBConnectionToServer::getRecord");
     ASSERT(isMainThread());
-    ASSERT(!getRecordData.keyRangeData.isNull);
+    ASSERT(!getRecordData.keyRangeData.isNull());
 
     if (m_serverConnectionIsValid)
         m_delegate->getRecord(requestData, getRecordData);
@@ -281,7 +281,7 @@ void IDBConnectionToServer::getCount(const IDBRequestData& requestData, const ID
 {
     LOG(IndexedDB, "IDBConnectionToServer::getCount");
     ASSERT(isMainThread());
-    ASSERT(!keyRangeData.isNull);
+    ASSERT(!keyRangeData.isNull());
 
     if (m_serverConnectionIsValid)
         m_delegate->getCount(requestData, keyRangeData);
@@ -299,7 +299,7 @@ void IDBConnectionToServer::deleteRecord(const IDBRequestData& requestData, cons
 {
     LOG(IndexedDB, "IDBConnectionToServer::deleteRecord");
     ASSERT(isMainThread());
-    ASSERT(!keyRangeData.isNull);
+    ASSERT(!keyRangeData.isNull());
 
     if (m_serverConnectionIsValid)
         m_delegate->deleteRecord(requestData, keyRangeData);

--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -40,7 +40,6 @@ import sys
 #
 # BitField - work around the need for http://wg21.link/P0572 and don't check that the serialization order matches the memory layout.
 # Nullable - check if the member is truthy before serializing.
-# ReturnEarlyIfTrue - if this member is truthy then don't serialize the other members.
 
 class SerializedType(object):
     def __init__(self, struct_or_class, namespace, name, parent_class_name, members, condition, attributes, other_metadata=None):
@@ -365,9 +364,6 @@ def encode_type(type):
             result.append('    }')
         else:
             result.append('    encoder << instance.' + member.name + ('()' if type.serialize_with_function_calls else '') + ';')
-            if 'ReturnEarlyIfTrue' in member.attributes:
-                result.append('    if (instance.' + member.name + ')')
-                result.append('        return;')
         if member.condition is not None:
             result.append('#endif')
 
@@ -398,9 +394,6 @@ def decode_type(type):
             result.append('    auto ' + sanitized_variable_name + ' = IPC::decode<' + match.groups()[0] + '>(decoder, @[ ' + decodable_classes[0] + ' ]);')
             result.append('    if (!' + sanitized_variable_name + ')')
             result.append('        return std::nullopt;')
-            if 'ReturnEarlyIfTrue' in member.attributes:
-                result.append('    if (*' + sanitized_variable_name + ')')
-                result.append('        return { ' + type.namespace_and_name() + ' { } };')
         elif member.is_subclass:
             result.append('    if (type == ' + type.subclass_enum_name() + "::" + member.name + ') {')
             typename = member.namespace + "::" + member.name
@@ -432,9 +425,6 @@ def decode_type(type):
                 if 'Nullable' in member.attributes:
                     result.append('    } else')
                     result.append('        ' + sanitized_variable_name + ' = std::optional<' + member.type + '> { ' + member.type + ' { } };')
-                elif 'ReturnEarlyIfTrue' in member.attributes:
-                    result.append('    if (*' + sanitized_variable_name + ')')
-                    result.append('        return { ' + type.namespace_and_name() + ' { } };')
             elif 'Nullable' in member.attributes:
                 result.append('    auto has' + sanitized_variable_name + ' = decoder.decode<bool>();')
                 result.append('    if (!has' + sanitized_variable_name + ')')
@@ -452,9 +442,6 @@ def decode_type(type):
                 result.append('    auto ' + sanitized_variable_name + ' = decoder.decode<' + member.type + '>();')
                 result.append('    if (!' + sanitized_variable_name + ')')
                 result.append('        return std::nullopt;')
-                if 'ReturnEarlyIfTrue' in member.attributes:
-                    result.append('    if (*' + sanitized_variable_name + ')')
-                    result.append('        return { ' + type.namespace_and_name() + ' { } };')
         for attribute in member.attributes:
             match = re.search(r'Validator=\'(.*)\'', attribute)
             if match:

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -160,8 +160,6 @@ void ArgumentCoder<Namespace::OtherClass>::encode(Encoder& encoder, const Namesp
         , offsetof(Namespace::OtherClass, dataDetectorResults)
     >::value);
     encoder << instance.isNull;
-    if (instance.isNull)
-        return;
     encoder << instance.a;
     encoder << instance.b;
     encoder << instance.dataDetectorResults;
@@ -172,8 +170,6 @@ std::optional<Namespace::OtherClass> ArgumentCoder<Namespace::OtherClass>::decod
     auto isNull = decoder.decode<bool>();
     if (!isNull)
         return std::nullopt;
-    if (*isNull)
-        return { Namespace::OtherClass { } };
 
     auto a = decoder.decode<int>();
     if (!a)
@@ -276,8 +272,6 @@ void ArgumentCoder<Namespace::EmptyConstructorNullable>::encode(Encoder& encoder
 #endif
     >::value);
     encoder << instance.m_isNull;
-    if (instance.m_isNull)
-        return;
 #if CONDITION_AROUND_M_TYPE_AND_M_VALUE
     encoder << instance.m_type;
 #endif
@@ -291,8 +285,6 @@ std::optional<Namespace::EmptyConstructorNullable> ArgumentCoder<Namespace::Empt
     auto m_isNull = decoder.decode<bool>();
     if (!m_isNull)
         return std::nullopt;
-    if (*m_isNull)
-        return { Namespace::EmptyConstructorNullable { } };
 
 #if CONDITION_AROUND_M_TYPE_AND_M_VALUE
     auto m_type = decoder.decode<MemberType>();

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -149,9 +149,7 @@ class WebCore::IDBDatabaseInfo {
     HashMap<uint64_t, WebCore::IDBObjectStoreInfo> m_objectStoreMap
 }
 
-[CustomMemberLayout] struct WebCore::IDBKeyRangeData {
-    [ReturnEarlyIfTrue] bool isNull;
-
+struct WebCore::IDBKeyRangeData {
     WebCore::IDBKeyData lowerKey;
     WebCore::IDBKeyData upperKey;
 


### PR DESCRIPTION
#### 585d92ca632aa4c79df0ce07a2a52e7edc6cc4fa
<pre>
Remove ReturnEarlyIfTrue serialization attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=252640">https://bugs.webkit.org/show_bug.cgi?id=252640</a>
rdar://105707231

Reviewed by Sihui Liu.

It&apos;s not needed, and can&apos;t be exposed to the IPC testing API very well.

* Source/WebCore/Modules/indexeddb/IDBIndex.cpp:
(WebCore::IDBIndex::doGet):
(WebCore::IDBIndex::doGetKey):
* Source/WebCore/Modules/indexeddb/IDBKeyRangeData.cpp:
(WebCore::IDBKeyRangeData::IDBKeyRangeData):
(WebCore::IDBKeyRangeData::isolatedCopy const):
(WebCore::IDBKeyRangeData::isExactlyOneKey const):
(WebCore::IDBKeyRangeData::isValid const):
(WebCore::IDBKeyRangeData::maybeCreateIDBKeyRange const): Deleted.
* Source/WebCore/Modules/indexeddb/IDBKeyRangeData.h:
(WebCore::IDBKeyRangeData::IDBKeyRangeData):
(WebCore::IDBKeyRangeData::allKeys):
(WebCore::IDBKeyRangeData::isNull const):
* Source/WebCore/Modules/indexeddb/IDBTransaction.cpp:
(WebCore::IDBTransaction::requestGetRecord):
(WebCore::IDBTransaction::requestIndexRecord):
(WebCore::IDBTransaction::requestCount):
(WebCore::IDBTransaction::requestDeleteRecord):
* Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.cpp:
(WebCore::IDBClient::IDBConnectionToServer::getRecord):
(WebCore::IDBClient::IDBConnectionToServer::getCount):
(WebCore::IDBClient::IDBConnectionToServer::deleteRecord):
* Source/WebKit/Scripts/generate-serializers.py:
(encode_type):
(decode_type):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
(IPC::ArgumentCoder&lt;Namespace::OtherClass&gt;::encode):
(IPC::ArgumentCoder&lt;Namespace::OtherClass&gt;::decode):
(IPC::ArgumentCoder&lt;Namespace::EmptyConstructorNullable&gt;::encode):
(IPC::ArgumentCoder&lt;Namespace::EmptyConstructorNullable&gt;::decode):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/260615@main">https://commits.webkit.org/260615@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43c9a419b8104392d33ed02c570a644ee58d731a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108873 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17977 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41710 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/415 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/118198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112755 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19435 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9256 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101114 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114643 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97795 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/42684 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/112398 "Found 1 webkitpy python3 test failure: webkit.messages_unittest.GeneratedFileContentsTest.test_message_argument_description") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29433 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/84418 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10751 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30785 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11506 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/7721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16895 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50381 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13093 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3998 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->