### PR TITLE
Type info for members with Nullable attribute should pretend it's std::optional

### DIFF
--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -665,7 +665,10 @@ def generate_serialized_type_info(serialized_types, serialized_enums, headers, t
         for i in range(len(type.members)):
             if i == 0:
                 result.append('            {')
-            result.append('                "' + type.members[i].type + '"_s,')
+            if 'Nullable' in type.members[i].attributes:
+                result.append('                "std::optional<' + type.members[i].type + '>"_s,')
+            else:
+                result.append('                "' + type.members[i].type + '"_s,')
             result.append('                "' + type.members[i].name + '"_s')
             if i == len(type.members) - 1:
                 result.append('            }')

--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -60,7 +60,7 @@ Vector<SerializedTypeInfo> allSerializedTypes()
                 "SecondMemberType"_s,
                 "secondMemberName"_s
             }, {
-                "RetainPtr<CFTypeRef>"_s,
+                "std::optional<RetainPtr<CFTypeRef>>"_s,
                 "nullableTestMember"_s
             }
         } },
@@ -165,7 +165,7 @@ Vector<SerializedTypeInfo> allSerializedTypes()
         } },
         { "NullableSoftLinkedMember"_s, {
             {
-                "RetainPtr<DDActionContext>"_s,
+                "std::optional<RetainPtr<DDActionContext>>"_s,
                 "firstMember"_s
             }, {
                 "RetainPtr<DDActionContext>"_s,


### PR DESCRIPTION
#### daa46e4da058728633f7580887914ce24bbcf56c
<pre>
Type info for members with Nullable attribute should pretend it&apos;s std::optional
<a href="https://bugs.webkit.org/show_bug.cgi?id=252645">https://bugs.webkit.org/show_bug.cgi?id=252645</a>

Reviewed by Wenson Hsieh.

The generated serialization treats these members the same as std::optional,
so exposing the type info as std::optional makes the scripts that read it more correct.

* Source/WebKit/Scripts/generate-serializers.py:
(generate_serialized_type_info):
* Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp:
(WebKit::allSerializedTypes):

Canonical link: <a href="https://commits.webkit.org/260624@main">https://commits.webkit.org/260624@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8cd067fb3016ed32f4337112dd2df6c705fceaf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108804 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17904 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41635 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/157 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118102 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19358 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9181 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101033 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114572 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14522 "Found 1 new test failure: fast/mediastream/mock-media-source-webaudio.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97738 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42493 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/112330 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96505 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29376 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84343 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10685 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30727 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11445 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7660 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16832 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50318 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7341 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13032 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->