### PR TITLE
[WebGPU] GPUCommandEncoder.clearBuffer does not appear to work

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUCommandEncoder.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUCommandEncoder.cpp
@@ -88,10 +88,10 @@ void GPUCommandEncoder::copyTextureToTexture(
 
 void GPUCommandEncoder::clearBuffer(
     const GPUBuffer& buffer,
-    GPUSize64 offset,
+    std::optional<GPUSize64> offset,
     std::optional<GPUSize64> size)
 {
-    m_backing->clearBuffer(buffer.backing(), offset, size);
+    m_backing->clearBuffer(buffer.backing(), offset.value_or(0), size);
 }
 
 void GPUCommandEncoder::pushDebugGroup(String&& groupLabel)

--- a/Source/WebCore/Modules/WebGPU/GPUCommandEncoder.h
+++ b/Source/WebCore/Modules/WebGPU/GPUCommandEncoder.h
@@ -83,7 +83,7 @@ public:
 
     void clearBuffer(
         const GPUBuffer&,
-        GPUSize64 offset,
+        std::optional<GPUSize64> offset,
         std::optional<GPUSize64>);
 
     void pushDebugGroup(String&& groupLabel);

--- a/Source/WebCore/Modules/WebGPU/GPUCommandEncoder.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUCommandEncoder.idl
@@ -62,9 +62,10 @@ interface GPUCommandEncoder {
         GPUImageCopyTexture destination,
         GPUExtent3D copySize);
 
+    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=240219, second parameter should have default value of 0
     undefined clearBuffer(
         GPUBuffer buffer,
-        optional GPUSize64 offset = 0,
+        optional GPUSize64 offset,
         optional GPUSize64 size);
 
     undefined writeTimestamp(GPUQuerySet querySet, GPUSize32 queryIndex);

--- a/Source/WebGPU/WebGPU/BindGroup.mm
+++ b/Source/WebGPU/WebGPU/BindGroup.mm
@@ -108,6 +108,7 @@ Ref<BindGroup> Device::createBindGroup(const WGPUBindGroupDescriptor& descriptor
                     return BindGroup::createInvalid(*this);
 
                 [argumentEncoder[stage] setBuffer:buffer offset:entry.offset atIndex:index++];
+                resources.append({ buffer, MTLResourceUsageRead, metalRenderStage(stage) });
             } else if (samplerIsPresent) {
                 id<MTLSamplerState> sampler = WebGPU::fromAPI(entry.sampler).samplerState();
                 [argumentEncoder[stage] setSamplerState:sampler atIndex:index++];

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -955,7 +955,7 @@ void CommandEncoder::clearBuffer(const Buffer& buffer, uint64_t offset, uint64_t
 {
     // https://gpuweb.github.io/gpuweb/#dom-gpucommandencoder-clearbuffer
 
-    if (!prepareTheEncoderState())
+    if (!prepareTheEncoderState() || !size)
         return;
 
     if (size == WGPU_WHOLE_SIZE) {


### PR DESCRIPTION
#### 033f8d13532716f63ffa02f477d541e9613c4eba
<pre>
[WebGPU] GPUCommandEncoder.clearBuffer does not appear to work
<a href="https://bugs.webkit.org/show_bug.cgi?id=252643">https://bugs.webkit.org/show_bug.cgi?id=252643</a>
&lt;radar://105708271&gt;

Reviewed by Myles C. Maxfield.

Changes were not being reflected because useResoure was not
being called.

* Source/WebCore/Modules/WebGPU/GPUCommandEncoder.cpp:
(WebCore::GPUCommandEncoder::clearBuffer):
* Source/WebCore/Modules/WebGPU/GPUCommandEncoder.h:
* Source/WebCore/Modules/WebGPU/GPUCommandEncoder.idl:
* Source/WebGPU/WebGPU/BindGroup.mm:
(WebGPU::Device::createBindGroup):
* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::clearBuffer):

Canonical link: <a href="https://commits.webkit.org/260707@main">https://commits.webkit.org/260707@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66d3f8a7ffdaca901c5183ba66bcd7c0aea0f702

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109015 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18094 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41836 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/550 "Updated wpe dependencies (failure)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118291 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112897 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19550 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9394 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101260 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114773 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14659 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97895 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42801 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96631 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29537 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84549 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10879 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30885 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11623 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7820 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17003 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50483 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7390 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13222 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->