### PR TITLE
Allow MomentumEventDispatcher's acceleration curve to be set in a thread safe way

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp
+++ b/Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp
@@ -312,7 +312,7 @@ void EventDispatcher::displayWasRefreshed(PlatformDisplayID displayID, const Dis
     ASSERT(!RunLoop::isMain());
 
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER)
-    m_momentumEventDispatcher->displayWasRefreshed(displayID, displayUpdate);
+    m_momentumEventDispatcher->displayWasRefreshed(displayID);
 #endif
 
     notifyScrollingTreesDisplayWasRefreshed(displayID);

--- a/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.h
+++ b/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.h
@@ -74,7 +74,7 @@ public:
 
     void setScrollingAccelerationCurve(WebCore::PageIdentifier, std::optional<ScrollingAccelerationCurve>);
 
-    void displayWasRefreshed(WebCore::PlatformDisplayID, const WebCore::DisplayUpdate&);
+    void displayWasRefreshed(WebCore::PlatformDisplayID);
 
     void pageScreenDidChange(WebCore::PageIdentifier, WebCore::PlatformDisplayID, std::optional<unsigned> nominalFramesPerSecond);
 
@@ -87,6 +87,8 @@ private:
     void didEndMomentumPhase();
 
     bool eventShouldStartSyntheticMomentumPhase(WebCore::PageIdentifier, const WebWheelEvent&) const;
+
+    std::optional<ScrollingAccelerationCurve> scrollingAccelerationCurveForPage(WebCore::PageIdentifier) const;
 
     void startDisplayLink();
     void stopDisplayLink();
@@ -171,6 +173,8 @@ private:
     } m_currentGesture;
 
     HashMap<WebCore::PageIdentifier, DisplayProperties> m_displayProperties;
+
+    mutable Lock m_accelerationCurvesLock;
     HashMap<WebCore::PageIdentifier, std::optional<ScrollingAccelerationCurve>> m_accelerationCurves;
     Client& m_client;
 };


### PR DESCRIPTION
#### e17ecef9906f930f002bc0a85e246f1b62009551
<pre>
Allow MomentumEventDispatcher&apos;s acceleration curve to be set in a thread safe way
<a href="https://bugs.webkit.org/show_bug.cgi?id=252646">https://bugs.webkit.org/show_bug.cgi?id=252646</a>
rdar://105710770

Reviewed by Tim Horton.

UI-side compositing will want to set MomentumEventDispatcher&apos;s scrollingAccelerationCurve while another
thread is potentially reading it for the current gesture, so lock around reading and writing the m_accelerationCurves.

Also remove the DisplayUpdate argument to displayWasRefreshed() since it&apos;s unused.

* Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp:
(WebKit::EventDispatcher::displayWasRefreshed):
* Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp:
(WebKit::MomentumEventDispatcher::eventShouldStartSyntheticMomentumPhase const):
(WebKit::MomentumEventDispatcher::didStartMomentumPhase):
(WebKit::MomentumEventDispatcher::setScrollingAccelerationCurve):
(WebKit::MomentumEventDispatcher::scrollingAccelerationCurveForPage const):
(WebKit::MomentumEventDispatcher::displayWasRefreshed):
* Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.h:

Canonical link: <a href="https://commits.webkit.org/260617@main">https://commits.webkit.org/260617@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9440610921675032f7fa4ba712183328ae85c649

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108814 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17914 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41645 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/239 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118110 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19368 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9191 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101043 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114582 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14530 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97745 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42505 "Failed to checkout and rebase branch from PR 10426") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29384 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84352 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10694 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30734 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11453 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7665 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16840 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50329 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7337 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13040 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->