### PR TITLE
Make Page::mainFrame() return an AbstractFrame

### DIFF
--- a/Source/WebCore/accessibility/atspi/AccessibilityRootAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityRootAtspi.cpp
@@ -205,7 +205,11 @@ AccessibilityObjectAtspi* AccessibilityRootAtspi::child() const
     if (!m_page)
         return nullptr;
 
-    Frame& frame = m_page->mainFrame();
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
+    if (!localMainFrame)
+        return nullptr;
+
+    Frame& frame = *localMainFrame;
     if (!frame.document())
         return nullptr;
 
@@ -300,7 +304,11 @@ IntRect AccessibilityRootAtspi::frameRect(Atspi::CoordinateType coordinateType) 
     if (!m_page)
         return { };
 
-    auto* frameView = m_page->mainFrame().view();
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
+    if (!localMainFrame)
+        return { };
+
+    auto* frameView = localMainFrame->view();
     if (!frameView)
         return { };
 

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -2964,7 +2964,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         }
     }
 
-    page->contextMenuController().showContextMenuAt(page->mainFrame(), rect.center());
+    if (auto* localMainFrame = dynamicDowncast<LocalFrame>(page->mainFrame()))
+        page->contextMenuController().showContextMenuAt(*localMainFrame, rect.center());
 }
 
 - (void)accessibilityScrollToVisible

--- a/Source/WebCore/editing/ReplaceSelectionCommand.cpp
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.cpp
@@ -182,7 +182,11 @@ ReplacementFragment::ReplacementFragment(DocumentFragment* fragment, const Visib
     }
 
     auto page = createPageForSanitizingWebContent();
-    RefPtr stagingDocument { page->mainFrame().document() };
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(page->mainFrame());
+    if (!localMainFrame)
+        return;
+
+    RefPtr stagingDocument { localMainFrame->document() };
     ASSERT(stagingDocument->body());
 
     ComputedStyleExtractor computedStyleOfEditableRoot(editableRoot.get());

--- a/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
+++ b/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
@@ -447,7 +447,11 @@ static std::optional<MarkupAndArchive> extractMarkupAndArchive(SharedBuffer& buf
 static String sanitizeMarkupWithArchive(Frame& frame, Document& destinationDocument, MarkupAndArchive& markupAndArchive, MSOListQuirks msoListQuirks, const std::function<bool(const String)>& canShowMIMETypeAsHTML)
 {
     auto page = createPageForSanitizingWebContent();
-    Document* stagingDocument = page->mainFrame().document();
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(page->mainFrame());
+    if (!localMainFrame)
+        return String();
+
+    Document* stagingDocument = localMainFrame->document();
     ASSERT(stagingDocument);
     auto fragment = createFragmentFromMarkup(*stagingDocument, markupAndArchive.markup, markupAndArchive.mainResource->url().string(), { });
 

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -193,7 +193,11 @@ std::unique_ptr<Page> createPageForSanitizingWebContent()
     page->settings().setPluginsEnabled(false);
     page->settings().setAcceleratedCompositingEnabled(false);
 
-    Frame& frame = page->mainFrame();
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(page->mainFrame());
+    if (!localMainFrame)
+        return page; 
+
+    Frame& frame = *localMainFrame;
     frame.setView(FrameView::create(frame, IntSize { 800, 600 }));
     frame.init();
 
@@ -205,7 +209,7 @@ std::unique_ptr<Page> createPageForSanitizingWebContent()
     writer.begin();
     writer.insertDataSynchronously(markup);
     writer.end();
-    RELEASE_ASSERT(page->mainFrame().document()->body());
+    RELEASE_ASSERT(frame.document()->body());
 
     return page;
 }
@@ -213,7 +217,11 @@ std::unique_ptr<Page> createPageForSanitizingWebContent()
 String sanitizeMarkup(const String& rawHTML, MSOListQuirks msoListQuirks, std::optional<Function<void(DocumentFragment&)>> fragmentSanitizer)
 {
     auto page = createPageForSanitizingWebContent();
-    Document* stagingDocument = page->mainFrame().document();
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(page->mainFrame());
+    if (!localMainFrame)
+        return String();
+
+    Document* stagingDocument = localMainFrame->document();
     ASSERT(stagingDocument);
 
     auto fragment = createFragmentFromMarkup(*stagingDocument, rawHTML, emptyString(), { });

--- a/Source/WebCore/inspector/InspectorFrontendAPIDispatcher.cpp
+++ b/Source/WebCore/inspector/InspectorFrontendAPIDispatcher.cpp
@@ -106,8 +106,12 @@ JSDOMGlobalObject* InspectorFrontendAPIDispatcher::frontendGlobalObject()
 {
     if (!m_frontendPage)
         return nullptr;
+
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_frontendPage->mainFrame());
+    if (!localMainFrame)
+        return nullptr;
     
-    return m_frontendPage->mainFrame().script().globalObject(mainThreadNormalWorld());
+    return localMainFrame->script().globalObject(mainThreadNormalWorld());
 }
 
 static String expressionForEvaluatingCommand(const String& command, Vector<Ref<JSON::Value>>&& arguments)
@@ -259,7 +263,9 @@ ValueOrException InspectorFrontendAPIDispatcher::evaluateExpression(const String
     ASSERT(m_queuedEvaluations.isEmpty());
 
     JSC::SuspendExceptionScope scope(m_frontendPage->inspectorController().vm());
-    return m_frontendPage->mainFrame().script().evaluateInWorld(ScriptSourceCode(expression), mainThreadNormalWorld());
+
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_frontendPage->mainFrame());
+    return localMainFrame->script().evaluateInWorld(ScriptSourceCode(expression), mainThreadNormalWorld());
 }
 
 void InspectorFrontendAPIDispatcher::evaluateExpressionForTesting(const String& expression)

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -311,7 +311,10 @@ void InspectorDOMAgent::didCreateFrontendAndBackend(Inspector::FrontendRouter*, 
     m_domEditor = makeUnique<DOMEditor>(*m_history);
 
     m_instrumentingAgents.setPersistentDOMAgent(this);
-    m_document = m_inspectedPage.mainFrame().document();
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_inspectedPage.mainFrame());
+    if (!localMainFrame)
+        return;
+    m_document = localMainFrame->document();
 
     // Force a layout so that we can collect additional information from the layout process.
     relayoutDocument();

--- a/Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp
@@ -669,11 +669,14 @@ void InspectorTimelineAgent::captureScreenshot()
     SetForScope isTakingScreenshot(m_isCapturingScreenshot, true);
 
     auto snapshotStartTime = timestamp();
-    auto& frame = m_inspectedPage.mainFrame();
-    auto viewportRect = m_inspectedPage.mainFrame().view()->unobscuredContentRect();
-    if (auto snapshot = snapshotFrameRect(frame, viewportRect, { { }, PixelFormat::BGRA8, DestinationColorSpace::SRGB() })) {
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_inspectedPage.mainFrame());
+    if (!localMainFrame)
+        return;
+
+    auto viewportRect = localMainFrame->view()->unobscuredContentRect();
+    if (auto snapshot = snapshotFrameRect(*localMainFrame, viewportRect, { { }, PixelFormat::BGRA8, DestinationColorSpace::SRGB() })) {
         auto snapshotRecord = TimelineRecordFactory::createScreenshotData(snapshot->toDataURL("image/png"_s));
-        pushCurrentRecord(WTFMove(snapshotRecord), TimelineRecordType::Screenshot, false, &frame, snapshotStartTime);
+        pushCurrentRecord(WTFMove(snapshotRecord), TimelineRecordType::Screenshot, false, localMainFrame, snapshotStartTime);
         didCompleteCurrentRecord(TimelineRecordType::Screenshot);
     }
 }

--- a/Source/WebCore/inspector/agents/page/PageAuditAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageAuditAgent.cpp
@@ -60,7 +60,9 @@ InjectedScript PageAuditAgent::injectedScriptForEval(std::optional<Protocol::Run
 {
     if (executionContextId)
         return injectedScriptManager().injectedScriptForId(*executionContextId);
-    return injectedScriptManager().injectedScriptFor(&mainWorldGlobalObject(m_inspectedPage.mainFrame()));
+    if (auto* localMainFrame = dynamicDowncast<LocalFrame>(m_inspectedPage.mainFrame()))
+        return injectedScriptManager().injectedScriptFor(&mainWorldGlobalObject(*localMainFrame));
+    return InjectedScript();
 }
 
 InjectedScript PageAuditAgent::injectedScriptForEval(Protocol::ErrorString& errorString, std::optional<Protocol::Runtime::ExecutionContextId>&& executionContextId)

--- a/Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp
@@ -106,7 +106,11 @@ void PageRuntimeAgent::didClearWindowObjectInWorld(Frame& frame, DOMWrapperWorld
 InjectedScript PageRuntimeAgent::injectedScriptForEval(Protocol::ErrorString& errorString, std::optional<Protocol::Runtime::ExecutionContextId>&& executionContextId)
 {
     if (!executionContextId) {
-        InjectedScript result = injectedScriptManager().injectedScriptFor(&mainWorldGlobalObject(m_inspectedPage.mainFrame()));
+        auto* localMainFrame = dynamicDowncast<LocalFrame>(m_inspectedPage.mainFrame());
+        if (!localMainFrame)
+            return InjectedScript();
+
+        InjectedScript result = injectedScriptManager().injectedScriptFor(&mainWorldGlobalObject(*localMainFrame));
         if (result.hasNoValue())
             errorString = "Internal error: main world execution context not found"_s;
         return result;

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -2606,7 +2606,8 @@ void FrameLoader::checkLoadCompleteForThisFrame()
         if (Page* page = m_frame.page()) {
             if (isBackForwardLoadType(loadType())) {
                 // Reset the back forward list to the last committed history item at the top level.
-                item = page->mainFrame().loader().history().currentItem();
+                if (auto* localMainFrame = dynamicDowncast<LocalFrame>(page->mainFrame()))
+                    item = localMainFrame->loader().history().currentItem();
             }
         }
 
@@ -4339,7 +4340,9 @@ RefPtr<Frame> createWindow(Frame& openerFrame, Frame& lookupFrame, FrameLoadRequ
     if (!page)
         return nullptr;
 
-    RefPtr<Frame> frame = &page->mainFrame();
+    RefPtr<Frame> frame = dynamicDowncast<LocalFrame>(page->mainFrame());
+    if (!frame)
+        return nullptr;
 
     if (isDocumentSandboxed(openerFrame, SandboxPropagatesToAuxiliaryBrowsingContexts))
         frame->loader().forceSandboxFlags(openerFrame.document()->sandboxFlags());

--- a/Source/WebCore/loader/archive/mhtml/MHTMLArchive.cpp
+++ b/Source/WebCore/loader/archive/mhtml/MHTMLArchive.cpp
@@ -145,15 +145,20 @@ Ref<FragmentedSharedBuffer> MHTMLArchive::generateMHTMLData(Page* page)
 
     StringBuilder stringBuilder;
     stringBuilder.append("From: <Saved by WebKit>\r\n");
-    stringBuilder.append("Subject: ");
-    // We replace non ASCII characters with '?' characters to match IE's behavior.
-    stringBuilder.append(replaceNonPrintableCharacters(page->mainFrame().document()->title()));
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(page->mainFrame());
+    if (localMainFrame) {
+        stringBuilder.append("Subject: ");
+        // We replace non ASCII characters with '?' characters to match IE's behavior.
+        stringBuilder.append(replaceNonPrintableCharacters(localMainFrame->document()->title()));
+    }
     stringBuilder.append("\r\nDate: ");
     stringBuilder.append(dateString);
     stringBuilder.append("\r\nMIME-Version: 1.0\r\n");
     stringBuilder.append("Content-Type: multipart/related;\r\n");
-    stringBuilder.append("\ttype=\"");
-    stringBuilder.append(page->mainFrame().document()->suggestedMIMEType());
+    if (localMainFrame) {
+        stringBuilder.append("\ttype=\"");
+        stringBuilder.append(localMainFrame->document()->suggestedMIMEType());
+    }
     stringBuilder.append("\";\r\n");
     stringBuilder.append("\tboundary=\"");
     stringBuilder.append(boundary);

--- a/Source/WebCore/page/AutoscrollController.cpp
+++ b/Source/WebCore/page/AutoscrollController.cpp
@@ -50,7 +50,7 @@ static const Seconds autoscrollInterval { 50_ms };
 static Frame* getMainFrame(Frame* frame)
 {
     Page* page = frame->page();
-    return page ? &page->mainFrame() : 0;
+    return page && dynamicDowncast<LocalFrame>(page->mainFrame()) ? dynamicDowncast<LocalFrame>(page->mainFrame()) : 0;
 }
 #endif
 

--- a/Source/WebCore/page/Chrome.cpp
+++ b/Source/WebCore/page/Chrome.cpp
@@ -219,7 +219,12 @@ void Chrome::runModal() const
 
     // JavaScript that runs within the nested event loop must not be run in the context of the
     // script that called showModalDialog. Null out entryScope to break the connection.
-    SetForScope entryScopeNullifier { m_page.mainFrame().document()->vm().entryScope, nullptr };
+
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
+    if (!localMainFrame)
+        return;
+
+    SetForScope entryScopeNullifier { localMainFrame->document()->vm().entryScope, nullptr };
 
     TimerBase::fireTimersInNestedEventLoop();
     m_client.runModal();
@@ -334,8 +339,12 @@ void Chrome::setStatusbarText(Frame& frame, const String& status)
 
 void Chrome::mouseDidMoveOverElement(const HitTestResult& result, unsigned modifierFlags)
 {
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
+    if (!localMainFrame)
+        return;
+
     if (result.innerNode() && result.innerNode()->document().isDNSPrefetchEnabled())
-        m_page.mainFrame().loader().client().prefetchDNS(result.absoluteLinkURL().host().toString());
+        localMainFrame->loader().client().prefetchDNS(result.absoluteLinkURL().host().toString());
 
     String toolTip;
     TextDirection toolTipDirection;

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -205,7 +205,8 @@ static void openNewWindow(const URL& urlToLoad, Frame& frame, Event* event, Shou
     if (!newPage)
         return;
     newPage->chrome().show();
-    newPage->mainFrame().loader().loadFrameRequest(WTFMove(frameLoadRequest), event, { });
+    if (auto* localMainFrame = dynamicDowncast<LocalFrame>(newPage->mainFrame()))
+        localMainFrame->loader().loadFrameRequest(WTFMove(frameLoadRequest), event, { });
 }
 
 #if PLATFORM(GTK)

--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -320,7 +320,10 @@ void DOMWindow::dispatchAllPendingUnloadEvents()
 // 5) Translate the window rect coordinates to be within the coordinate space of the screen.
 FloatRect DOMWindow::adjustWindowRect(Page& page, const FloatRect& pendingChanges)
 {
-    FloatRect screen = screenAvailableRect(page.mainFrame().view());
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(page.mainFrame());
+    if (!localMainFrame)
+        return FloatRect();
+    FloatRect screen = screenAvailableRect(localMainFrame->view());
     FloatRect window = page.chrome().windowRect();
 
     // Make sure we're in a valid state before adjusting dimensions.
@@ -1820,7 +1823,11 @@ void DOMWindow::moveTo(float x, float y) const
 
     auto* page = frame()->page();
     FloatRect fr = page->chrome().windowRect();
-    FloatRect sr = screenAvailableRect(page->mainFrame().view());
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(page->mainFrame());
+    if (!localMainFrame)
+        return;
+
+    FloatRect sr = screenAvailableRect(localMainFrame->view());
     fr.setLocation(sr.location());
     FloatRect update = fr;
     update.move(x, y);

--- a/Source/WebCore/page/DragController.cpp
+++ b/Source/WebCore/page/DragController.cpp
@@ -216,10 +216,11 @@ std::optional<DragOperation> DragController::dragEntered(DragData&& dragData)
 void DragController::dragExited(DragData&& dragData)
 {
     disallowFileAccessIfNeeded(dragData);
-
-    auto& mainFrame = m_page.mainFrame();
-    if (mainFrame.view())
-        mainFrame.eventHandler().cancelDragAndDrop(createMouseEvent(dragData), Pasteboard::create(dragData), dragData.draggingSourceOperationMask(), dragData.containsFiles());
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
+    if (!localMainFrame)
+        return;
+    if (localMainFrame->view())
+        localMainFrame->eventHandler().cancelDragAndDrop(createMouseEvent(dragData), Pasteboard::create(dragData), dragData.draggingSourceOperationMask(), dragData.containsFiles());
     mouseMovedIntoDocument(nullptr);
     if (m_fileInputElementUnderMouse)
         m_fileInputElementUnderMouse->setCanReceiveDroppedFiles(false);
@@ -251,7 +252,11 @@ bool DragController::performDragOperation(DragData&& dragData)
     SetForScope isPerformingDrop(m_isPerformingDrop, true);
     IgnoreSelectionChangeForScope ignoreSelectionChanges { m_page.focusController().focusedOrMainFrame() };
 
-    m_documentUnderMouse = m_page.mainFrame().documentAtPoint(dragData.clientPosition());
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
+    if (!localMainFrame)
+        return false;
+
+    m_documentUnderMouse = localMainFrame->documentAtPoint(dragData.clientPosition());
 
     disallowFileAccessIfNeeded(dragData);
 
@@ -261,10 +266,10 @@ bool DragController::performDragOperation(DragData&& dragData)
 
     if ((m_dragDestinationActionMask.contains(DragDestinationAction::DHTML)) && dragIsHandledByDocument(m_dragHandlingMethod)) {
         client().willPerformDragDestinationAction(DragDestinationAction::DHTML, dragData);
-        Ref<Frame> mainFrame(m_page.mainFrame());
+        Ref<Frame> protectedLocalMainFrame(*localMainFrame);
         bool preventedDefault = false;
-        if (mainFrame->view())
-            preventedDefault = mainFrame->eventHandler().performDragAndDrop(createMouseEvent(dragData), Pasteboard::create(dragData), dragData.draggingSourceOperationMask(), dragData.containsFiles());
+        if (protectedLocalMainFrame->view())
+            preventedDefault = protectedLocalMainFrame->eventHandler().performDragAndDrop(createMouseEvent(dragData), Pasteboard::create(dragData), dragData.draggingSourceOperationMask(), dragData.containsFiles());
         if (preventedDefault) {
             clearDragCaret();
             m_documentUnderMouse = nullptr;
@@ -292,10 +297,10 @@ bool DragController::performDragOperation(DragData&& dragData)
     client().willPerformDragDestinationAction(DragDestinationAction::Load, dragData);
     ResourceRequest resourceRequest { urlString };
     resourceRequest.setIsAppInitiated(false);
-    FrameLoadRequest frameLoadRequest { m_page.mainFrame(), resourceRequest };
+    FrameLoadRequest frameLoadRequest { *localMainFrame, resourceRequest };
     frameLoadRequest.setShouldOpenExternalURLsPolicy(shouldOpenExternalURLsPolicy);
     frameLoadRequest.setIsRequestFromClientOrUserInput();
-    m_page.mainFrame().loader().load(WTFMove(frameLoadRequest));
+    localMainFrame->loader().load(WTFMove(frameLoadRequest));
     return true;
 }
 
@@ -312,7 +317,10 @@ void DragController::mouseMovedIntoDocument(Document* newDocument)
 
 std::optional<DragOperation> DragController::dragEnteredOrUpdated(DragData&& dragData)
 {
-    mouseMovedIntoDocument(m_page.mainFrame().documentAtPoint(dragData.clientPosition()));
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
+    if (!localMainFrame)
+        return std::nullopt;
+    mouseMovedIntoDocument(localMainFrame->documentAtPoint(dragData.clientPosition()));
 
     m_dragDestinationActionMask = dragData.dragDestinationActionMask();
     if (m_dragDestinationActionMask.isEmpty()) {
@@ -504,7 +512,10 @@ OptionSet<DragSourceAction> DragController::delegateDragSourceAction(const IntPo
 
 std::optional<DragOperation> DragController::operationForLoad(const DragData& dragData)
 {
-    Document* document = m_page.mainFrame().documentAtPoint(dragData.clientPosition());
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
+    if (!localMainFrame)
+        return std::nullopt;
+    Document* document = localMainFrame->documentAtPoint(dragData.clientPosition());
 
     bool pluginDocumentAcceptsDrags = false;
     if (auto* pluginDocument = dynamicDowncast<PluginDocument>(document)) {
@@ -659,13 +670,16 @@ bool DragController::concludeEditDrag(const DragData& dragData)
 
 bool DragController::canProcessDrag(const DragData& dragData)
 {
-    IntPoint point = m_page.mainFrame().view()->windowToContents(dragData.clientPosition());
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
+    if (!localMainFrame)
+        return false;
+    IntPoint point = localMainFrame->view()->windowToContents(dragData.clientPosition());
     HitTestResult result = HitTestResult(point);
-    if (!m_page.mainFrame().contentRenderer())
+    if (!localMainFrame->contentRenderer())
         return false;
 
     constexpr OptionSet<HitTestRequest::Type> hitType { HitTestRequest::Type::ReadOnly, HitTestRequest::Type::Active, HitTestRequest::Type::AllowChildFrameContent };
-    result = m_page.mainFrame().eventHandler().hitTestResultAtPoint(point, hitType);
+    result = localMainFrame->eventHandler().hitTestResultAtPoint(point, hitType);
 
     auto* dragNode = result.innerNonSharedNode();
     if (!dragNode)
@@ -723,13 +737,17 @@ static std::optional<DragOperation> defaultOperationForDrag(OptionSet<DragOperat
 bool DragController::tryDHTMLDrag(const DragData& dragData, std::optional<DragOperation>& operation)
 {
     ASSERT(m_documentUnderMouse);
-    Ref<Frame> mainFrame(m_page.mainFrame());
-    RefPtr<FrameView> viewProtector = mainFrame->view();
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
+    if (!localMainFrame)
+        return false;
+
+    Ref<Frame> protectedLocalMainFrame(*localMainFrame);
+    RefPtr<FrameView> viewProtector = protectedLocalMainFrame->view();
     if (!viewProtector)
         return false;
 
     auto sourceOperationMask = dragData.draggingSourceOperationMask();
-    auto targetResponse = mainFrame->eventHandler().updateDragAndDrop(createMouseEvent(dragData), [&dragData]() {
+    auto targetResponse = protectedLocalMainFrame->eventHandler().updateDragAndDrop(createMouseEvent(dragData), [&dragData]() {
         return Pasteboard::create(dragData);
     }, sourceOperationMask, dragData.containsFiles());
     if (!targetResponse.accept)
@@ -1355,9 +1373,12 @@ void DragController::beginDrag(DragItem dragItem, Frame& frame, const IntPoint& 
     m_didInitiateDrag = true;
     m_dragInitiator = frame.document();
 
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
+    if (!localMainFrame)
+        return;
     // Protect this frame and view, as a load may occur mid drag and attempt to unload this frame
-    Ref<Frame> mainFrameProtector(m_page.mainFrame());
-    RefPtr<FrameView> viewProtector = mainFrameProtector->view();
+    Ref<Frame> protectedLocalMainFrame(*localMainFrame);
+    RefPtr<FrameView> viewProtector = protectedLocalMainFrame->view();
 
     auto mouseDownPointInRootViewCoordinates = viewProtector->rootViewToContents(frame.view()->contentsToRootView(mouseDownPoint));
     auto mouseDraggedPointInRootViewCoordinates = viewProtector->rootViewToContents(frame.view()->contentsToRootView(mouseDraggedPoint));
@@ -1378,9 +1399,12 @@ void DragController::doSystemDrag(DragImage image, const IntPoint& dragLoc, cons
 {
     m_didInitiateDrag = true;
     m_dragInitiator = frame.document();
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
+    if (!localMainFrame)
+        return;
     // Protect this frame and view, as a load may occur mid drag and attempt to unload this frame
-    Ref<Frame> frameProtector(m_page.mainFrame());
-    RefPtr<FrameView> viewProtector = frameProtector->view();
+    Ref<Frame> protectedLocalMainFrame(*localMainFrame);
+    RefPtr<FrameView> viewProtector = protectedLocalMainFrame->view();
 
     DragItem item;
     item.image = WTFMove(image);
@@ -1418,9 +1442,9 @@ void DragController::doSystemDrag(DragImage image, const IntPoint& dragLoc, cons
             item.url = frame.document()->completeURL(stripLeadingAndTrailingHTMLSpaces(link->getAttribute(HTMLNames::hrefAttr)));
         }
     }
-    client().startDrag(WTFMove(item), *state.dataTransfer, frameProtector.get());
+    client().startDrag(WTFMove(item), *state.dataTransfer, protectedLocalMainFrame.get());
     // DragClient::startDrag can cause our Page to dispear, deallocating |this|.
-    if (!frameProtector->page())
+    if (!protectedLocalMainFrame->page())
         return;
 
     cleanupAfterSystemDrag();
@@ -1564,7 +1588,10 @@ void DragController::finalizeDroppedImagePlaceholder(HTMLImageElement& placehold
 // Manual drag caret manipulation
 void DragController::placeDragCaret(const IntPoint& windowPoint)
 {
-    mouseMovedIntoDocument(m_page.mainFrame().documentAtPoint(windowPoint));
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
+    if (!localMainFrame)
+        return;
+    mouseMovedIntoDocument(localMainFrame->documentAtPoint(windowPoint));
     if (!m_documentUnderMouse)
         return;
     Frame* frame = m_documentUnderMouse->frame();

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -4008,8 +4008,10 @@ static void removeDraggedContentDocumentMarkersFromAllFramesInPage(Page& page)
         document.markers().removeMarkers(DocumentMarker::DraggedContent);
     });
 
-    if (auto* mainFrameRenderer = page.mainFrame().contentRenderer())
-        mainFrameRenderer->repaintRootContents();
+    if (auto* localMainFrame = dynamicDowncast<LocalFrame>(page.mainFrame())) {
+        if (auto* mainFrameRenderer = localMainFrame->contentRenderer())
+            mainFrameRenderer->repaintRootContents();
+    }
 }
 
 void EventHandler::dragCancelled()

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -312,7 +312,7 @@ private:
 
     Vector<std::pair<Ref<DOMWrapperWorld>, UniqueRef<UserScript>>> m_userScriptsAwaitingNotification;
 
-    Frame& m_mainFrame;
+    AbstractFrame& m_mainFrame;
     const RefPtr<Settings> m_settings;
     UniqueRef<FrameLoader> m_loader;
     mutable UniqueRef<NavigationScheduler> m_navigationScheduler;

--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -2582,21 +2582,24 @@ void FrameView::textFragmentIndicatorTimerFired()
         auto textRects = RenderFlexibleBox::absoluteTextRects(range);
         
         HitTestResult result;
-        result = page->mainFrame().eventHandler().hitTestResultAtPoint(LayoutPoint(textRects.first().center()), hitType);
+        auto* localMainFrame = dynamicDowncast<LocalFrame>(page->mainFrame());
+        if (!localMainFrame)
+            return;
+        result = localMainFrame->eventHandler().hitTestResultAtPoint(LayoutPoint(textRects.first().center()), hitType);
         if (!intersects(range, *result.targetNode()))
             return;
         
         if (textRects.size() >= 2) {
-            result = page->mainFrame().eventHandler().hitTestResultAtPoint(LayoutPoint(textRects[1].center()), hitType);
+            result = localMainFrame->eventHandler().hitTestResultAtPoint(LayoutPoint(textRects[1].center()), hitType);
             if (!intersects(range, *result.targetNode()))
                 return;
         }
         
         if (textRects.size() >= 4) {
-            result = page->mainFrame().eventHandler().hitTestResultAtPoint(LayoutPoint(textRects.last().center()), hitType);
+            result = localMainFrame->eventHandler().hitTestResultAtPoint(LayoutPoint(textRects.last().center()), hitType);
             if (!intersects(range, *result.targetNode()))
                 return;
-            result = page->mainFrame().eventHandler().hitTestResultAtPoint(LayoutPoint(textRects[textRects.size() - 2].center()), hitType);
+            result = localMainFrame->eventHandler().hitTestResultAtPoint(LayoutPoint(textRects[textRects.size() - 2].center()), hitType);
             if (!intersects(range, *result.targetNode()))
                 return;
         }
@@ -2979,7 +2982,11 @@ bool FrameView::shouldUpdateCompositingLayersAfterScrolling() const
     if (!page)
         return true;
 
-    if (&page->mainFrame() != m_frame.ptr())
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(page->mainFrame());
+    if (!localMainFrame)
+        return true;
+
+    if (localMainFrame != m_frame.ptr())
         return true;
 
     auto scrollingCoordinator = this->scrollingCoordinator();
@@ -5877,8 +5884,9 @@ void FrameView::firePaintRelatedMilestonesIfNeeded()
 
     m_milestonesPendingPaint = { };
 
-    if (milestonesAchieved)
-        page->mainFrame().loader().didReachLayoutMilestone(milestonesAchieved);
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(page->mainFrame());
+    if (milestonesAchieved && localMainFrame)
+        localMainFrame->loader().didReachLayoutMilestone(milestonesAchieved);
 }
 
 void FrameView::setVisualUpdatesAllowedByClient(bool visualUpdatesAllowed)

--- a/Source/WebCore/page/History.cpp
+++ b/Source/WebCore/page/History.cpp
@@ -225,7 +225,8 @@ ExceptionOr<void> History::stateObjectAdded(RefPtr<SerializedScriptValue>&& data
     if (!allowSandboxException && !documentSecurityOrigin.canRequest(fullURL) && (fullURL.path() != documentURL.path() || fullURL.query() != documentURL.query()))
         return createBlockedURLSecurityErrorWithMessageSuffix("Paths and fragments must match for a sandboxed document.");
 
-    auto* mainWindow = frame->page()->mainFrame().window();
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(frame->page()->mainFrame());
+    auto* mainWindow = localMainFrame ? localMainFrame->window() : nullptr;
     if (!mainWindow)
         return { };
 

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -30,6 +30,7 @@
 #include "EventTrackingRegions.h"
 #include "FilterRenderingMode.h"
 #include "FindOptions.h"
+#include "Frame.h"
 #include "FrameLoaderTypes.h"
 #include "IntRectHash.h"
 #include "KeyboardScrollingAnimator.h"
@@ -124,7 +125,6 @@ class EditorClient;
 class Element;
 class FocusController;
 class FormData;
-class Frame;
 class HTMLElement;
 class HTMLMediaElement;
 class HistoryItem;
@@ -308,8 +308,8 @@ public:
 
     EditorClient& editorClient() { return m_editorClient.get(); }
 
-    Frame& mainFrame() { return m_mainFrame.get(); }
-    const Frame& mainFrame() const { return m_mainFrame.get(); }
+    AbstractFrame& mainFrame() { return m_mainFrame.get(); }
+    const AbstractFrame& mainFrame() const { return m_mainFrame.get(); }
 
     bool openedByDOM() const;
     WEBCORE_EXPORT void setOpenedByDOM();

--- a/Source/WebCore/page/PageColorSampler.cpp
+++ b/Source/WebCore/page/PageColorSampler.cpp
@@ -169,11 +169,15 @@ std::optional<Color> PageColorSampler::sampleTop(Page& page)
         return Color();
     }
 
-    RefPtr mainDocument = page.mainFrame().document();
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(page.mainFrame());
+    if (!localMainFrame)
+        return std::nullopt;
+
+    RefPtr mainDocument = localMainFrame->document();
     if (!mainDocument)
         return std::nullopt;
 
-    RefPtr frameView = page.mainFrame().view();
+    RefPtr frameView = localMainFrame->view();
     if (!frameView)
         return std::nullopt;
 

--- a/Source/WebCore/page/PageDebuggable.cpp
+++ b/Source/WebCore/page/PageDebuggable.cpp
@@ -49,18 +49,26 @@ String PageDebuggable::name() const
     if (!m_nameOverride.isNull())
         return m_nameOverride;
 
-    if (!m_page.mainFrame().document())
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
+    if (!localMainFrame)
         return String();
 
-    return m_page.mainFrame().document()->title();
+    if (!localMainFrame->document())
+        return String();
+
+    return localMainFrame->document()->title();
 }
 
 String PageDebuggable::url() const
 {
-    if (!m_page.mainFrame().document())
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
+    if (!localMainFrame)
         return String();
 
-    String url = m_page.mainFrame().document()->url().string();
+    if (!localMainFrame->document())
+        return String();
+
+    String url = localMainFrame->document()->url().string();
     return url.isEmpty() ? "about:blank"_s : url;
 }
 

--- a/Source/WebCore/page/PageGroupLoadDeferrer.cpp
+++ b/Source/WebCore/page/PageGroupLoadDeferrer.cpp
@@ -37,11 +37,14 @@ PageGroupLoadDeferrer::PageGroupLoadDeferrer(Page& page, bool deferSelf)
             continue;
         if (otherPage.defersLoading())
             continue;
-        m_deferredFrames.append(&otherPage.mainFrame());
+        auto* localMainFrame = dynamicDowncast<LocalFrame>(otherPage.mainFrame());
+        if (!localMainFrame)
+            continue;
+        m_deferredFrames.append(localMainFrame);
 
         // This code is not logically part of load deferring, but we do not want JS code executed beneath modal
         // windows or sheets, which is exactly when PageGroupLoadDeferrer is used.
-        for (AbstractFrame* frame = &otherPage.mainFrame(); frame; frame = frame->tree().traverseNext()) {
+        for (AbstractFrame* frame = localMainFrame; frame; frame = frame->tree().traverseNext()) {
             auto* localFrame = dynamicDowncast<LocalFrame>(frame);
             if (!localFrame)
                 continue;

--- a/Source/WebCore/page/PageOverlayController.cpp
+++ b/Source/WebCore/page/PageOverlayController.cpp
@@ -72,8 +72,10 @@ void PageOverlayController::installedPageOverlaysChanged()
     else
         detachViewOverlayLayers();
 
-    if (auto* frameView = m_page.mainFrame().view())
-        frameView->setNeedsCompositingConfigurationUpdate();
+    if (auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame())) {
+        if (auto* frameView = localMainFrame->view())
+            frameView->setNeedsCompositingConfigurationUpdate();
+    }
 
     updateForceSynchronousScrollLayerPositionUpdates();
 }
@@ -207,8 +209,10 @@ void PageOverlayController::installPageOverlay(PageOverlay& overlay, PageOverlay
 
     overlay.setPage(&m_page);
 
-    if (FrameView* frameView = m_page.mainFrame().view())
-        frameView->enterCompositingMode();
+    if (auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame())) {
+        if (FrameView* frameView = localMainFrame->view())
+            frameView->enterCompositingMode();
+    }
 
     updateOverlayGeometry(overlay, rawLayer);
 

--- a/Source/WebCore/page/PageSerializer.cpp
+++ b/Source/WebCore/page/PageSerializer.cpp
@@ -172,7 +172,8 @@ PageSerializer::PageSerializer(Vector<PageSerializer::Resource>& resources)
 
 void PageSerializer::serialize(Page& page)
 {
-    serializeFrame(&page.mainFrame());
+    if (auto* localMainFrame = dynamicDowncast<LocalFrame>(page.mainFrame()))
+        serializeFrame(localMainFrame);
 }
 
 void PageSerializer::serializeFrame(Frame* frame)

--- a/Source/WebCore/page/PerformanceLogging.cpp
+++ b/Source/WebCore/page/PerformanceLogging.cpp
@@ -97,8 +97,10 @@ void PerformanceLogging::didReachPointOfInterest(PointOfInterest poi)
     UNUSED_VARIABLE(m_page);
 #else
     // Ignore synthetic main frames used internally by SVG and web inspector.
-    if (m_page.mainFrame().loader().client().isEmptyFrameLoaderClient())
-        return;
+    if (auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame())) {
+        if (localMainFrame->loader().client().isEmptyFrameLoaderClient())
+            return;
+    }
 
     RELEASE_LOG(PerformanceLogging, "Memory usage info dump at %s:", toString(poi));
     for (auto& it : memoryUsageStatistics(ShouldIncludeExpensiveComputations::No))

--- a/Source/WebCore/page/PerformanceMonitor.cpp
+++ b/Source/WebCore/page/PerformanceMonitor.cpp
@@ -144,7 +144,11 @@ enum class ReportingReason { HighCPUUsage, HighMemoryUsage };
 static void reportPageOverPostLoadResourceThreshold(Page& page, ReportingReason reason)
 {
 #if ENABLE(PUBLIC_SUFFIX_LIST)
-    auto* document = page.mainFrame().document();
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(page.mainFrame());
+    if (!localMainFrame)
+        return;
+
+    auto* document = localMainFrame->document();
     if (!document)
         return;
 

--- a/Source/WebCore/page/PointerCaptureController.cpp
+++ b/Source/WebCore/page/PointerCaptureController.cpp
@@ -484,7 +484,10 @@ void PointerCaptureController::cancelPointer(PointerID pointerId, const IntPoint
         if (capturingData->targetOverride)
             return capturingData->targetOverride;
         constexpr OptionSet<HitTestRequest::Type> hitType { HitTestRequest::Type::ReadOnly, HitTestRequest::Type::Active, HitTestRequest::Type::DisallowUserAgentShadowContent, HitTestRequest::Type::AllowChildFrameContent };
-        return Ref(m_page.mainFrame())->eventHandler().hitTestResultAtPoint(documentPoint, hitType).innerNonSharedElement();
+        auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
+        if (!localMainFrame)
+            return nullptr;
+        return Ref(*localMainFrame)->eventHandler().hitTestResultAtPoint(documentPoint, hitType).innerNonSharedElement();
     }();
 
     if (!target)

--- a/Source/WebCore/page/ResourceUsageOverlay.cpp
+++ b/Source/WebCore/page/ResourceUsageOverlay.cpp
@@ -51,18 +51,23 @@ ResourceUsageOverlay::ResourceUsageOverlay(Page& page)
 ResourceUsageOverlay::~ResourceUsageOverlay()
 {
     platformDestroy();
-
-    // FIXME: This is a hack so we don't try to uninstall the PageOverlay during Page destruction.
-    if (m_page.mainFrame().page())
-        m_page.pageOverlayController().uninstallPageOverlay(*m_overlay, PageOverlay::FadeMode::DoNotFade);
+    if (auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame())) {
+        // FIXME: This is a hack so we don't try to uninstall the PageOverlay during Page destruction.
+        if (localMainFrame->page())
+            m_page.pageOverlayController().uninstallPageOverlay(*m_overlay, PageOverlay::FadeMode::DoNotFade);
+    }
 }
 
 void ResourceUsageOverlay::initialize()
 {
-    if (!m_page.mainFrame().view())
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
+    if (!localMainFrame)
         return;
 
-    FrameView& frameView = *m_page.mainFrame().view();
+    if (!localMainFrame->view())
+        return;
+
+    FrameView& frameView = *localMainFrame->view();
 
     IntRect initialRect(frameView.width() / 2 - normalWidth / 2, frameView.height() - normalHeight - 20, normalWidth, normalHeight);
 
@@ -109,7 +114,10 @@ bool ResourceUsageOverlay::mouseEvent(PageOverlay&, const PlatformMouseEvent& ev
                 newFrame.setX(0);
             if (newFrame.y() < m_page.topContentInset())
                 newFrame.setY(m_page.topContentInset());
-            FrameView& frameView = *m_page.mainFrame().view();
+            auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
+            if (!localMainFrame)
+                break;
+            FrameView& frameView = *localMainFrame->view();
             if (newFrame.maxX() > frameView.width())
                 newFrame.setX(frameView.width() - newFrame.width());
             if (newFrame.maxY() > frameView.height())

--- a/Source/WebCore/page/SettingsBase.cpp
+++ b/Source/WebCore/page/SettingsBase.cpp
@@ -326,7 +326,11 @@ void SettingsBase::mediaTypeOverrideChanged()
     if (!m_page)
         return;
 
-    FrameView* view = m_page->mainFrame().view();
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
+    if (!localMainFrame)
+        return;
+
+    FrameView* view = localMainFrame->view();
     if (view)
         view->setMediaType(AtomString(m_page->settings().mediaTypeOverride()));
 
@@ -469,14 +473,16 @@ void SettingsBase::storageBlockingPolicyChanged()
 
 void SettingsBase::backgroundShouldExtendBeyondPageChanged()
 {
-    if (m_page)
-        m_page->mainFrame().view()->updateExtendBackgroundIfNecessary();
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
+    if (m_page && localMainFrame)
+        localMainFrame->view()->updateExtendBackgroundIfNecessary();
 }
 
 void SettingsBase::scrollingPerformanceTestingEnabledChanged()
 {
-    if (m_page && m_page->mainFrame().view())
-        m_page->mainFrame().view()->setScrollingPerformanceTestingEnabled(m_page->settings().scrollingPerformanceTestingEnabled());
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
+    if (m_page && localMainFrame && localMainFrame->view())
+        localMainFrame->view()->setScrollingPerformanceTestingEnabled(m_page->settings().scrollingPerformanceTestingEnabled());
 }
 
 void SettingsBase::hiddenPageDOMTimerThrottlingStateChanged()

--- a/Source/WebCore/page/SpatialNavigation.cpp
+++ b/Source/WebCore/page/SpatialNavigation.cpp
@@ -701,7 +701,10 @@ void distanceDataForNode(FocusDirection direction, const FocusCandidate& current
 
     float distance = euclidianDistance + sameAxisDistance + 2 * otherAxisDistance;
     candidate.distance = roundf(distance);
-    LayoutSize viewSize = candidate.visibleNode->document().page()->mainFrame().view()->visibleContentRect().size();
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(candidate.visibleNode->document().page()->mainFrame());
+    if (!localMainFrame)
+        return;
+    LayoutSize viewSize = localMainFrame->view()->visibleContentRect().size();
     candidate.alignment = alignmentForRects(direction, currentRect, nodeRect, viewSize);
 }
 

--- a/Source/WebCore/page/mac/DragControllerMac.mm
+++ b/Source/WebCore/page/mac/DragControllerMac.mm
@@ -100,8 +100,10 @@ void DragController::cleanupAfterSystemDrag()
     // call it anyway to be on the safe side.
     // We don't want to do this for WebKit2, since the client call to start the drag
     // is asynchronous.
-    if (m_page.mainFrame().view()->platformWidget())
-        dragEnded();
+    if (auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame())) {
+        if (localMainFrame->view()->platformWidget())
+            dragEnded();
+    }
 #endif
 }
 

--- a/Source/WebCore/page/mac/ImageOverlayControllerMac.mm
+++ b/Source/WebCore/page/mac/ImageOverlayControllerMac.mm
@@ -72,7 +72,11 @@ void ImageOverlayController::updateDataDetectorHighlights(const HTMLElement& ove
     if (dataDetectorResultElementsWithHighlights == dataDetectorResultElements)
         return;
 
-    RefPtr mainFrameView = m_page->mainFrame().view();
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
+    if (!localMainFrame)
+        return;
+
+    RefPtr mainFrameView = localMainFrame->view();
     if (!mainFrameView)
         return;
 
@@ -100,7 +104,11 @@ void ImageOverlayController::updateDataDetectorHighlights(const HTMLElement& ove
 
 bool ImageOverlayController::platformHandleMouseEvent(const PlatformMouseEvent& event)
 {
-    RefPtr mainFrameView = m_page->mainFrame().view();
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
+    if (!localMainFrame)
+        return false;
+
+    RefPtr mainFrameView = localMainFrame->view();
     if (!mainFrameView)
         return false;
 

--- a/Source/WebCore/page/mac/PageMac.mm
+++ b/Source/WebCore/page/mac/PageMac.mm
@@ -73,7 +73,10 @@ void Page::platformInitialize()
             WTFLogAlways("%u live pages:", numPages);
 
             Page::forEachPage([](Page& page) {
-                const auto* mainFrameDocument = page.mainFrame().document();
+                auto* localMainFrame = dynamicDowncast<LocalFrame>(page.mainFrame());
+                if (!localMainFrame)
+                    return;
+                const auto* mainFrameDocument = localMainFrame->document();
                 WTFLogAlways("Page %p with main document %p %s", &page, mainFrameDocument, mainFrameDocument ? mainFrameDocument->url().string().utf8().data() : "");
             });
 

--- a/Source/WebCore/page/mac/ServicesOverlayController.mm
+++ b/Source/WebCore/page/mac/ServicesOverlayController.mm
@@ -654,7 +654,9 @@ void ServicesOverlayController::handleClick(const IntPoint& clickPoint, DataDete
 
 Frame& ServicesOverlayController::mainFrame() const
 {
-    return m_page.mainFrame();
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame()); 
+    ASSERT(localMainFrame);
+    return *localMainFrame;
 }
 
 } // namespace WebKit

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -430,8 +430,9 @@ FrameView* AsyncScrollingCoordinator::frameViewForScrollingNode(ScrollingNodeID 
     if (!m_scrollingStateTree->rootStateNode())
         return nullptr;
     
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
     if (scrollingNodeID == m_scrollingStateTree->rootStateNode()->scrollingNodeID())
-        return m_page->mainFrame().view();
+        return localMainFrame ? localMainFrame->view() : nullptr;
 
     RefPtr stateNode = m_scrollingStateTree->stateNodeForID(scrollingNodeID);
     if (!stateNode)
@@ -444,7 +445,10 @@ FrameView* AsyncScrollingCoordinator::frameViewForScrollingNode(ScrollingNodeID 
     
     if (!parentNode)
         return nullptr;
-    
+
+    if (!localMainFrame)
+        return nullptr;
+
     // Walk the frame tree to find the matching FrameView. This is not ideal, but avoids back pointers to FrameViews
     // from ScrollingTreeStateNodes.
     for (AbstractFrame* frame = &m_page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
@@ -848,7 +852,11 @@ void AsyncScrollingCoordinator::setFrameScrollingNodeState(ScrollingNodeID nodeI
     if (!is<ScrollingStateFrameScrollingNode>(stateNode))
         return;
 
-    auto& settings = m_page->mainFrame().settings();
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
+    if (!localMainFrame)
+        return;
+
+    auto& settings = localMainFrame->settings();
     auto& frameScrollingNode = downcast<ScrollingStateFrameScrollingNode>(*stateNode);
 
     if (auto* localFrame = dynamicDowncast<LocalFrame>(frameView.frame()))
@@ -1128,7 +1136,10 @@ void AsyncScrollingCoordinator::reportSynchronousScrollingReasonsChanged(Monoton
 bool AsyncScrollingCoordinator::scrollAnimatorEnabled() const
 {
     ASSERT(isMainThread());
-    auto& settings = m_page->mainFrame().settings();
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
+    if (!localMainFrame)
+        return false;
+    auto& settings = localMainFrame->settings();
     return settings.scrollAnimatorEnabled();
 }
 

--- a/Source/WebCore/page/scrolling/ScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinator.cpp
@@ -195,7 +195,10 @@ EventTrackingRegions ScrollingCoordinator::absoluteEventTrackingRegionsForFrame(
 
 EventTrackingRegions ScrollingCoordinator::absoluteEventTrackingRegions() const
 {
-    return absoluteEventTrackingRegionsForFrame(m_page->mainFrame());
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
+    if (!localMainFrame)
+        return EventTrackingRegions();
+    return absoluteEventTrackingRegionsForFrame(*localMainFrame);
 }
 
 void ScrollingCoordinator::frameViewFixedObjectsDidChange(FrameView& frameView)
@@ -369,7 +372,11 @@ void ScrollingCoordinator::setForceSynchronousScrollLayerPositionUpdates(bool fo
 
 bool ScrollingCoordinator::shouldUpdateScrollLayerPositionSynchronously(const FrameView& frameView) const
 {
-    if (&frameView == m_page->mainFrame().view())
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
+    if (!localMainFrame)
+        return false;
+
+    if (&frameView == localMainFrame->view())
         return !synchronousScrollingReasons(frameView.scrollingNodeID()).isEmpty();
     
     return true;
@@ -434,8 +441,11 @@ String ScrollingCoordinator::synchronousScrollingReasonsAsText(OptionSet<Synchro
 
 String ScrollingCoordinator::synchronousScrollingReasonsAsText() const
 {
-    if (auto* frameView = m_page->mainFrame().view())
-        return synchronousScrollingReasonsAsText(synchronousScrollingReasons(frameView->scrollingNodeID()));
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
+    if (localMainFrame) {
+        if (auto* frameView = localMainFrame->view())
+            return synchronousScrollingReasonsAsText(synchronousScrollingReasons(frameView->scrollingNodeID()));
+    }
 
     return String();
 }

--- a/Source/WebCore/page/scrolling/mac/ScrollingCoordinatorMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingCoordinatorMac.mm
@@ -82,7 +82,11 @@ void ScrollingCoordinatorMac::didCompletePlatformRenderingUpdate()
 
 void ScrollingCoordinatorMac::updateTiledScrollingIndicator()
 {
-    FrameView* frameView = m_page->mainFrame().view();
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
+    if (!localMainFrame)
+        return;
+
+    FrameView* frameView = localMainFrame->view();
     if (!frameView)
         return;
     

--- a/Source/WebCore/plugins/PluginData.cpp
+++ b/Source/WebCore/plugins/PluginData.cpp
@@ -65,7 +65,8 @@ void PluginData::initPlugins()
 
 const Vector<PluginInfo>& PluginData::webVisiblePlugins() const
 {
-    auto documentURL = m_page.mainFrame().document() ? m_page.mainFrame().document()->url() : URL { };
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
+    auto documentURL = localMainFrame && localMainFrame->document() ? localMainFrame->document()->url() : URL { };
     if (!documentURL.isNull() && !protocolHostAndPortAreEqual(m_cachedVisiblePlugins.pageURL, documentURL)) {
         m_cachedVisiblePlugins.pageURL = WTFMove(documentURL);
         m_cachedVisiblePlugins.pluginList = std::nullopt;

--- a/Source/WebCore/plugins/PluginInfoProvider.cpp
+++ b/Source/WebCore/plugins/PluginInfoProvider.cpp
@@ -60,8 +60,10 @@ void PluginInfoProvider::refresh(bool reloadPages)
             auto* localFrame = dynamicDowncast<LocalFrame>(frame);
             if (!localFrame)
                 continue;
-            if (localFrame->loader().subframeLoader().containsPlugins())
-                framesNeedingReload.append(page.mainFrame());
+            if (localFrame->loader().subframeLoader().containsPlugins()) {
+                if (auto* localMainFrame = dynamicDowncast<LocalFrame>(page.mainFrame()))
+                    framesNeedingReload.append(*localMainFrame);
+            }
         }
     }
 

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -3835,7 +3835,8 @@ float RenderLayerCompositor::contentsScaleMultiplierForNewTiles(const GraphicsLa
 {
 #if PLATFORM(IOS_FAMILY)
     LegacyTileCache* tileCache = nullptr;
-    if (auto* frameView = page().mainFrame().view())
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(page().mainFrame());
+    if (auto* frameView = localMainFrame ? localMainFrame->view() : nullptr)
         tileCache = frameView->legacyTileCache();
 
     if (!tileCache)

--- a/Source/WebCore/replay/UserInputBridge.cpp
+++ b/Source/WebCore/replay/UserInputBridge.cpp
@@ -55,27 +55,42 @@ bool UserInputBridge::handleContextMenuEvent(const PlatformMouseEvent& mouseEven
 
 bool UserInputBridge::handleMousePressEvent(const PlatformMouseEvent& mouseEvent, InputSource)
 {
-    return Ref(m_page.mainFrame())->eventHandler().handleMousePressEvent(mouseEvent);
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
+    if (!localMainFrame)
+        return false;
+    return Ref(*localMainFrame)->eventHandler().handleMousePressEvent(mouseEvent);
 }
 
 bool UserInputBridge::handleMouseReleaseEvent(const PlatformMouseEvent& mouseEvent, InputSource)
 {
-    return Ref(m_page.mainFrame())->eventHandler().handleMouseReleaseEvent(mouseEvent);
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
+    if (!localMainFrame)
+        return false;
+    return Ref(*localMainFrame)->eventHandler().handleMouseReleaseEvent(mouseEvent);
 }
 
 bool UserInputBridge::handleMouseMoveEvent(const PlatformMouseEvent& mouseEvent, InputSource)
 {
-    return Ref(m_page.mainFrame())->eventHandler().mouseMoved(mouseEvent);
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
+    if (!localMainFrame)
+        return false;
+    return Ref(*localMainFrame)->eventHandler().mouseMoved(mouseEvent);
 }
 
 bool UserInputBridge::handleMouseMoveOnScrollbarEvent(const PlatformMouseEvent& mouseEvent, InputSource)
 {
-    return Ref(m_page.mainFrame())->eventHandler().passMouseMovedEventToScrollbars(mouseEvent);
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
+    if (!localMainFrame)
+        return false;
+    return Ref(*localMainFrame)->eventHandler().passMouseMovedEventToScrollbars(mouseEvent);
 }
 
 bool UserInputBridge::handleMouseForceEvent(const PlatformMouseEvent& mouseEvent, InputSource)
 {
-    return Ref(m_page.mainFrame())->eventHandler().handleMouseForceEvent(mouseEvent);
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
+    if (!localMainFrame)
+        return false;
+    return Ref(*localMainFrame)->eventHandler().handleMouseForceEvent(mouseEvent);
 }
 
 bool UserInputBridge::handleKeyEvent(const PlatformKeyboardEvent& keyEvent, InputSource)
@@ -90,7 +105,10 @@ bool UserInputBridge::handleAccessKeyEvent(const PlatformKeyboardEvent& keyEvent
 
 bool UserInputBridge::handleWheelEvent(const PlatformWheelEvent& wheelEvent, OptionSet<WheelEventProcessingSteps> processingSteps, InputSource)
 {
-    return Ref(m_page.mainFrame())->eventHandler().handleWheelEvent(wheelEvent, processingSteps);
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
+    if (!localMainFrame)
+        return false;
+    return Ref(*localMainFrame)->eventHandler().handleWheelEvent(wheelEvent, processingSteps);
 }
 
 void UserInputBridge::focusSetActive(bool active, InputSource)
@@ -118,7 +136,10 @@ void UserInputBridge::loadRequest(FrameLoadRequest&& request, InputSource)
 #if ENABLE(WEB_AUTHN)
     m_page.authenticatorCoordinator().resetUserGestureRequirement();
 #endif
-    Ref(m_page.mainFrame())->loader().load(WTFMove(request));
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
+    if (!localMainFrame)
+        return;
+    Ref(*localMainFrame)->loader().load(WTFMove(request));
 }
 
 void UserInputBridge::reloadFrame(Frame& frame, OptionSet<ReloadOption> options, InputSource)
@@ -136,7 +157,10 @@ void UserInputBridge::stopLoadingFrame(Frame& frame, InputSource)
 
 bool UserInputBridge::tryClosePage(InputSource)
 {
-    return Ref(m_page.mainFrame())->loader().shouldClose();
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
+    if (!localMainFrame)
+        return false;
+    return Ref(*localMainFrame)->loader().shouldClose();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/style/StyleScopeRuleSets.cpp
+++ b/Source/WebCore/style/StyleScopeRuleSets.cpp
@@ -120,12 +120,13 @@ void ScopeRuleSets::initializeUserStyle()
 
 #if ENABLE(APP_BOUND_DOMAINS)
     auto* page = m_styleResolver.document().page();
-    if (!extensionStyleSheets.injectedUserStyleSheets().isEmpty() && page && page->mainFrame().loader().client().shouldEnableInAppBrowserPrivacyProtections())
+    auto* localMainFrame = page ? dynamicDowncast<LocalFrame>(page->mainFrame()) : nullptr;
+    if (!extensionStyleSheets.injectedUserStyleSheets().isEmpty() && page && localMainFrame && localMainFrame->loader().client().shouldEnableInAppBrowserPrivacyProtections())
         m_styleResolver.document().addConsoleMessage(MessageSource::Security, MessageLevel::Warning, "Ignoring user style sheet for non-app bound domain."_s);
     else {
         collectRulesFromUserStyleSheets(extensionStyleSheets.injectedUserStyleSheets(), userStyle, mediaQueryEvaluator);
-        if (page && !extensionStyleSheets.injectedUserStyleSheets().isEmpty())
-            page->mainFrame().loader().client().notifyPageOfAppBoundBehavior();
+        if (page && localMainFrame && !extensionStyleSheets.injectedUserStyleSheets().isEmpty())
+            localMainFrame->loader().client().notifyPageOfAppBoundBehavior();
     }
 #else
     collectRulesFromUserStyleSheets(extensionStyleSheets.injectedUserStyleSheets(), userStyle, mediaQueryEvaluator);

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -1031,7 +1031,8 @@ static void suspendMemoryCacheClientCalls(Document& document)
 
     page->setMemoryCacheClientCallsEnabled(false);
 
-    memoryCacheClientCallsResumeQueue().append(&page->mainFrame());
+    if (auto* localMainFrame = dynamicDowncast<LocalFrame>(page->mainFrame()))
+        memoryCacheClientCallsResumeQueue().append(localMainFrame);
 }
 
 static unsigned resolutionNestingDepth;

--- a/Source/WebCore/svg/graphics/SVGImage.cpp
+++ b/Source/WebCore/svg/graphics/SVGImage.cpp
@@ -90,7 +90,12 @@ inline RefPtr<SVGSVGElement> SVGImage::rootElement() const
 {
     if (!m_page)
         return nullptr;
-    return DocumentSVG::rootElement(*m_page->mainFrame().document());
+
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
+    if (!localMainFrame)
+        return nullptr;
+
+    return DocumentSVG::rootElement(*localMainFrame->document());
 }
 
 bool SVGImage::renderingTaintsOrigin() const
@@ -343,7 +348,12 @@ FrameView* SVGImage::frameView() const
 {
     if (!m_page)
         return nullptr;
-    return m_page->mainFrame().view();
+
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
+    if (!localMainFrame)
+        return nullptr;
+
+    return localMainFrame->view();
 }
 
 bool SVGImage::hasRelativeWidth() const
@@ -432,7 +442,10 @@ bool SVGImage::isAnimating() const
 
 void SVGImage::reportApproximateMemoryCost() const
 {
-    RefPtr document = m_page->mainFrame().document();
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
+    if (!localMainFrame)
+        return;
+    RefPtr document = localMainFrame->document();
     size_t decodedImageMemoryCost = 0;
 
     for (RefPtr<Node> node = document; node; node = NodeTraversal::next(*node))
@@ -475,8 +488,11 @@ EncodedDataStatus SVGImage::dataChanged(bool allDataReceived)
         if (auto* observer = imageObserver())
             m_page->settings().setLayerBasedSVGEngineEnabled(observer->layerBasedSVGEngineEnabled());
 #endif
+        auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
+        if (!localMainFrame)
+            return EncodedDataStatus::Unknown;
 
-        Frame& frame = m_page->mainFrame();
+        Frame& frame = *localMainFrame;
         frame.setView(FrameView::create(frame));
         frame.init();
         FrameLoader& loader = frame.loader();

--- a/Source/WebCore/testing/InternalSettings.cpp
+++ b/Source/WebCore/testing/InternalSettings.cpp
@@ -176,7 +176,8 @@ Ref<InternalSettings> InternalSettings::create(Page* page)
 void InternalSettings::resetToConsistentState()
 {
     m_page->setPageScaleFactor(1, { 0, 0 });
-    m_page->mainFrame().setPageAndTextZoomFactors(1, 1);
+    if (auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame()))
+        localMainFrame->setPageAndTextZoomFactors(1, 1);
     m_page->setCanStartMedia(true);
     m_page->effectiveAppearanceDidChange(false, false);
 
@@ -525,10 +526,11 @@ ExceptionOr<void> InternalSettings::setUseElevatedUserInterfaceLevel(bool useEle
 
 ExceptionOr<void> InternalSettings::setAllowUnclampedScrollPosition(bool allowUnclamped)
 {
-    if (!m_page || !m_page->mainFrame().view())
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
+    if (!m_page || !localMainFrame || !localMainFrame->view())
         return Exception { InvalidAccessError };
 
-    m_page->mainFrame().view()->setAllowsUnclampedScrollPositionForTesting(allowUnclamped);
+    localMainFrame->view()->setAllowsUnclampedScrollPositionForTesting(allowUnclamped);
     return { };
 }
 

--- a/Source/WebCore/testing/MockPageOverlayClient.cpp
+++ b/Source/WebCore/testing/MockPageOverlayClient.cpp
@@ -105,8 +105,10 @@ void MockPageOverlayClient::drawRect(PageOverlay& overlay, GraphicsContext& cont
 
 bool MockPageOverlayClient::mouseEvent(PageOverlay& overlay, const PlatformMouseEvent& event)
 {
-    overlay.page()->mainFrame().document()->addConsoleMessage(MessageSource::Other, MessageLevel::Debug,
-        makeString("MockPageOverlayClient::mouseEvent location (", event.position().x(), ", ", event.position().y(), ')'));
+    if (auto* localMainFrame = dynamicDowncast<LocalFrame>(overlay.page()->mainFrame())) {
+        localMainFrame->document()->addConsoleMessage(MessageSource::Other, MessageLevel::Debug,
+            makeString("MockPageOverlayClient::mouseEvent location (", event.position().x(), ", ", event.position().y(), ')'));
+    }
     return false;
 }
 

--- a/Source/WebCore/workers/service/ServiceWorkerContainer.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerContainer.cpp
@@ -217,8 +217,12 @@ void ServiceWorkerContainer::willSettleRegistrationPromise(bool success)
     Page* page = is<Document>(context) ? downcast<Document>(*context).page() : nullptr;
     if (!page || !page->isServiceWorkerPage())
         return;
+    
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(page->mainFrame());
+    if (!localMainFrame)
+        return;
 
-    page->mainFrame().loader().client().didFinishServiceWorkerPageRegistration(success);
+    localMainFrame->loader().client().didFinishServiceWorkerPageRegistration(success);
 }
 
 void ServiceWorkerContainer::unregisterRegistration(ServiceWorkerRegistrationIdentifier registrationIdentifier, DOMPromiseDeferred<IDLBoolean>&& promise)

--- a/Source/WebCore/workers/service/ServiceWorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerGlobalScope.cpp
@@ -102,8 +102,10 @@ void ServiceWorkerGlobalScope::notifyServiceWorkerPageOfCreationIfNecessary()
 
     Vector<Ref<DOMWrapperWorld>> worlds;
     static_cast<JSVMClientData*>(vm().clientData)->getAllWorlds(worlds);
-    for (auto& world : worlds)
-        serviceWorkerPage->mainFrame().loader().client().dispatchServiceWorkerGlobalObjectAvailable(world);
+    if (auto* localMainFrame = dynamicDowncast<LocalFrame>(serviceWorkerPage->mainFrame())) {
+        for (auto& world : worlds)
+            localMainFrame->loader().client().dispatchServiceWorkerGlobalObjectAvailable(world);
+    }
 }
 
 Page* ServiceWorkerGlobalScope::serviceWorkerPage()

--- a/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
@@ -65,7 +65,7 @@ static HashSet<ServiceWorkerThreadProxy*>& allServiceWorkerThreadProxies()
 
 ServiceWorkerThreadProxy::ServiceWorkerThreadProxy(UniqueRef<Page>&& page, ServiceWorkerContextData&& contextData, ServiceWorkerData&& workerData, String&& userAgent, WorkerThreadMode workerThreadMode, CacheStorageProvider& cacheStorageProvider, std::unique_ptr<NotificationClient>&& notificationClient)
     : m_page(WTFMove(page))
-    , m_document(*m_page->mainFrame().document())
+    , m_document(*dynamicDowncast<LocalFrame>(m_page->mainFrame())->document())
 #if ENABLE(REMOTE_INSPECTOR)
     , m_remoteDebuggable(makeUnique<ServiceWorkerDebuggable>(*this, contextData))
 #endif

--- a/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp
+++ b/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp
@@ -97,7 +97,7 @@ bool SharedWorkerThreadProxy::hasInstances()
 
 SharedWorkerThreadProxy::SharedWorkerThreadProxy(UniqueRef<Page>&& page, SharedWorkerIdentifier sharedWorkerIdentifier, const ClientOrigin& clientOrigin, WorkerFetchResult&& workerFetchResult, WorkerOptions&& workerOptions, WorkerInitializationData&& initializationData, CacheStorageProvider& cacheStorageProvider)
     : m_page(WTFMove(page))
-    , m_document(*m_page->mainFrame().document())
+    , m_document(*dynamicDowncast<LocalFrame>(m_page->mainFrame())->document())
     , m_contextIdentifier(*initializationData.clientIdentifier)
     , m_workerThread(SharedWorkerThread::create(sharedWorkerIdentifier, generateWorkerParameters(workerFetchResult, WTFMove(workerOptions), WTFMove(initializationData), m_document), WTFMove(workerFetchResult.script), *this, *this, *this, *this, WorkerThreadStartMode::Normal, clientOrigin.topOrigin.securityOrigin(), m_document->idbConnectionProxy(), m_document->socketProvider(), JSC::RuntimeFlags::createAllEnabled()))
     , m_cacheStorageProvider(cacheStorageProvider)

--- a/Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.cpp
@@ -112,7 +112,6 @@ void MediaKeySystemPermissionRequestManagerProxy::grantRequest(MediaKeySystemPer
 Ref<MediaKeySystemPermissionRequestProxy> MediaKeySystemPermissionRequestManagerProxy::createRequestForFrame(MediaKeySystemRequestIdentifier mediaKeySystemID, FrameIdentifier frameID, Ref<SecurityOrigin>&& topLevelDocumentOrigin, const String& keySystem)
 {
     ALWAYS_LOG(LOGIDENTIFIER, mediaKeySystemID.toUInt64());
-
     auto request = MediaKeySystemPermissionRequestProxy::create(*this, mediaKeySystemID, m_page.mainFrame()->frameID(), frameID, WTFMove(topLevelDocumentOrigin), keySystem);
     m_pendingRequests.add(mediaKeySystemID, request.ptr());
     return request;

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -381,12 +381,14 @@ void WebFullScreenManager::close()
 
 void WebFullScreenManager::saveScrollPosition()
 {
-    m_scrollPosition = m_page->corePage()->mainFrame().view()->scrollPosition();
+    if (auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->corePage()->mainFrame()))
+        m_scrollPosition = localMainFrame->view()->scrollPosition();
 }
 
 void WebFullScreenManager::restoreScrollPosition()
 {
-    m_page->corePage()->mainFrame().view()->setScrollPosition(m_scrollPosition);
+    if (auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->corePage()->mainFrame()))
+        localMainFrame->view()->setScrollPosition(m_scrollPosition);
 }
 
 void WebFullScreenManager::setFullscreenInsets(const WebCore::FloatBoxExtent& insets)

--- a/Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.cpp
+++ b/Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.cpp
@@ -42,7 +42,7 @@ using namespace WebCore;
 
 static RegistrableDomain registrableDomainForPage(WebPage& page)
 {
-    auto* document = page.corePage() ? page.corePage()->mainFrame().document() : nullptr;
+    auto* document = page.corePage() && dynamicDowncast<LocalFrame>(page.corePage()->mainFrame()) ? dynamicDowncast<LocalFrame>(page.corePage()->mainFrame())->document() : nullptr;
     if (!document)
         return { };
     return RegistrableDomain { document->url() };
@@ -189,7 +189,7 @@ void WebGeolocationManager::resetPermissions(const WebCore::RegistrableDomain& r
         return;
 
     for (auto& page : copyToVector(it->value.pageSet)) {
-        if (auto* mainFrame = page->corePage() ? &page->corePage()->mainFrame() : nullptr)
+        if (auto* mainFrame = page->corePage() ? dynamicDowncast<LocalFrame>(page->corePage()->mainFrame()) : nullptr)
             mainFrame->resetAllGeolocationPermission();
     }
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
@@ -244,8 +244,12 @@ void* WKAccessibilityRootObject(WKBundlePageRef pageRef)
     WebCore::Page* page = WebKit::toImpl(pageRef)->corePage();
     if (!page)
         return 0;
+
+    auto* localMainFrame = dynamicDowncast<WebCore::LocalFrame>(page->mainFrame());
+    if (!localMainFrame)
+        return 0;
     
-    WebCore::Frame& core = page->mainFrame();
+    WebCore::Frame& core = *localMainFrame;
     if (!core.document())
         return 0;
     
@@ -299,8 +303,12 @@ bool WKAccessibilityCanUseSecondaryAXThread(WKBundlePageRef pageRef)
     WebCore::Page* page = WebKit::toImpl(pageRef)->corePage();
     if (!page)
         return false;
+    
+    auto* localMainFrame = dynamicDowncast<WebCore::LocalFrame>(page->mainFrame());
+    if (!localMainFrame)
+        return false;
 
-    WebCore::Frame& core = page->mainFrame();
+    WebCore::Frame& core = *localMainFrame;
     if (!core.document())
         return false;
 
@@ -738,8 +746,12 @@ void WKBundlePageCallAfterTasksAndTimers(WKBundlePageRef pageRef, WKBundlePageTe
     WebCore::Page* page = webPage ? webPage->corePage() : nullptr;
     if (!page)
         return;
+    
+    auto* localMainFrame = dynamicDowncast<WebCore::LocalFrame>(page->mainFrame());
+    if (!localMainFrame)
+        return;
 
-    WebCore::Document* document = page->mainFrame().document();
+    WebCore::Document* document = localMainFrame->document();
     if (!document)
         return;
 

--- a/Source/WebKit/WebProcess/Inspector/WebInspector.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspector.cpp
@@ -279,8 +279,11 @@ bool WebInspector::canAttachWindow()
         return true;
 
     // Don't allow the attach if the window would be too small to accommodate the minimum inspector size.
-    unsigned inspectedPageHeight = m_page->corePage()->mainFrame().view()->visibleHeight();
-    unsigned inspectedPageWidth = m_page->corePage()->mainFrame().view()->visibleWidth();
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->corePage()->mainFrame());
+    if (!localMainFrame)
+        return false;
+    unsigned inspectedPageHeight = localMainFrame->view()->visibleHeight();
+    unsigned inspectedPageWidth = localMainFrame->view()->visibleWidth();
     unsigned maximumAttachedHeight = inspectedPageHeight * maximumAttachedHeightRatio;
     return minimumAttachedHeight <= maximumAttachedHeight && minimumAttachedWidth <= inspectedPageWidth;
 }

--- a/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
+++ b/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
@@ -430,14 +430,17 @@ void WebUserContentController::addUserScriptInternal(InjectedBundleScriptWorld& 
         Page::forEachPage([&] (auto& page) {
             if (&page.userContentProvider() != this)
                 return;
+            
+            auto* localMainFrame = dynamicDowncast<LocalFrame>(page.mainFrame());
+            if (!localMainFrame)
+                return;
 
-            auto& mainFrame = page.mainFrame();
             if (userScript.injectedFrames() == UserContentInjectedFrames::InjectInTopFrameOnly) {
-                mainFrame.injectUserScriptImmediately(world.coreWorld(), userScript);
+                localMainFrame->injectUserScriptImmediately(world.coreWorld(), userScript);
                 return;
             }
 
-            for (AbstractFrame* frame = &mainFrame; frame; frame = frame->tree().traverseNext(&mainFrame)) {
+            for (AbstractFrame* frame = localMainFrame; frame; frame = frame->tree().traverseNext(localMainFrame)) {
                 auto* localFrame = dynamicDowncast<LocalFrame>(frame);
                 if (!localFrame)
                     continue;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -609,7 +609,11 @@ void WebChromeClient::invalidateRootView(const IntRect&)
 
 void WebChromeClient::invalidateContentsAndRootView(const IntRect& rect)
 {
-    if (Document* document = m_page.corePage()->mainFrame().document()) {
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.corePage()->mainFrame());
+    if (!localMainFrame)
+        return;
+
+    if (Document* document = localMainFrame->document()) {
         if (document->printing())
             return;
     }
@@ -619,7 +623,11 @@ void WebChromeClient::invalidateContentsAndRootView(const IntRect& rect)
 
 void WebChromeClient::invalidateContentsForSlowScroll(const IntRect& rect)
 {
-    if (Document* document = m_page.corePage()->mainFrame().document()) {
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.corePage()->mainFrame());
+    if (!localMainFrame)
+        return;
+
+    if (Document* document = localMainFrame->document()) {
         if (document->printing())
             return;
     }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.cpp
@@ -63,7 +63,10 @@ void WebContextMenuClient::searchWithGoogle(const WebCore::Frame* frame)
     auto searchURL = URL { "https://www.google.com/search?q=" + searchString + "&ie=UTF-8&oe=UTF-8" };
 
     WebCore::UserGestureIndicator indicator { WebCore::ProcessingUserGesture };
-    page->mainFrame().loader().changeLocation(searchURL, { }, nullptr, WebCore::ReferrerPolicy::EmptyString, WebCore::ShouldOpenExternalURLsPolicy::ShouldNotAllow);
+    auto* localMainFrame = dynamicDowncast<WebCore::LocalFrame>(page->mainFrame());
+    if (!localMainFrame)
+        return;
+    localMainFrame->loader().changeLocation(searchURL, { }, nullptr, WebCore::ReferrerPolicy::EmptyString, WebCore::ShouldOpenExternalURLsPolicy::ShouldNotAllow);
 }
 
 void WebContextMenuClient::lookUpInDictionary(WebCore::Frame*)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -875,7 +875,11 @@ Frame* WebFrameLoaderClient::dispatchCreatePage(const NavigationAction& navigati
     if (!newPage)
         return nullptr;
     
-    return &newPage->mainFrame();
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(newPage->mainFrame());
+    if (!localMainFrame)
+        return nullptr;
+
+    return localMainFrame;
 }
 
 void WebFrameLoaderClient::dispatchShow()

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebContextMenuClientMac.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebContextMenuClientMac.mm
@@ -74,11 +74,12 @@ void WebContextMenuClient::searchWithSpotlight()
     // FIXME: Why do we need to search all the frames like this?
     // Isn't there any function in WebCore that can do this?
     // If not, can we find a place in WebCore to put this?
-
-    Frame& mainFrame = m_page->corePage()->mainFrame();
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->corePage()->mainFrame());
+    if (!localMainFrame)
+        return;
 
     LocalFrame* selectionFrame = [&] () -> LocalFrame* {
-        for (AbstractFrame* selectionFrame = &mainFrame; selectionFrame; selectionFrame = selectionFrame->tree().traverseNext()) {
+        for (AbstractFrame* selectionFrame = localMainFrame; selectionFrame; selectionFrame = selectionFrame->tree().traverseNext()) {
             auto* localFrame = dynamicDowncast<LocalFrame>(selectionFrame);
             if (!localFrame)
                 continue;
@@ -88,7 +89,7 @@ void WebContextMenuClient::searchWithSpotlight()
         return nullptr;
     }();
     if (!selectionFrame)
-        selectionFrame = &mainFrame;
+        selectionFrame = localMainFrame;
 
     String selectedString = selectionFrame->displayStringModifiedByEncoding(selectionFrame->editor().selectedText());
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp
@@ -186,7 +186,8 @@ bool CompositingCoordinator::flushPendingLayerChanges(OptionSet<FinalizeRenderin
 
 double CompositingCoordinator::timestamp() const
 {
-    auto* document = m_page.corePage()->mainFrame().document();
+    auto* localMainFrame = dynamicDowncast<WebCore::LocalFrame>(m_page.corePage()->mainFrame());
+    auto* document = localMainFrame ? localMainFrame->document() : nullptr;
     if (!document)
         return 0;
     return document->domWindow() ? document->domWindow()->nowTimestamp().seconds() : document->monotonicTimestamp();
@@ -194,7 +195,8 @@ double CompositingCoordinator::timestamp() const
 
 void CompositingCoordinator::syncDisplayState()
 {
-    m_page.corePage()->mainFrame().view()->updateLayoutAndStyleIfNeededRecursive();
+    if (auto* localMainFrame = dynamicDowncast<WebCore::LocalFrame>(m_page.corePage()->mainFrame()))
+        localMainFrame->view()->updateLayoutAndStyleIfNeededRecursive();
 }
 
 double CompositingCoordinator::nextAnimationServiceTime() const
@@ -258,7 +260,8 @@ void CompositingCoordinator::setVisibleContentsRect(const FloatRect& rect)
             registeredLayer->setNeedsVisibleRectAdjustment();
     }
 
-    FrameView* view = m_page.corePage()->mainFrame().view();
+    auto* localMainFrame = dynamicDowncast<WebCore::LocalFrame>(m_page.corePage()->mainFrame());
+    FrameView* view = localMainFrame ? localMainFrame->view() : nullptr;
     if (view->useFixedLayout() && contentsRectDidChange) {
         // Round the rect instead of enclosing it to make sure that its size stays
         // the same while panning. This can have nasty effects on layout.

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -301,7 +301,10 @@ void LayerTreeHost::didChangeViewport()
     // When using non overlay scrollbars, the contents size doesn't include the scrollbars, but we need to include them
     // in the visible area used by the compositor to ensure that the scrollbar layers are also updated.
     // See https://bugs.webkit.org/show_bug.cgi?id=160450.
-    FrameView* view = m_webPage.corePage()->mainFrame().view();
+    auto* localMainFrame = dynamicDowncast<WebCore::LocalFrame>(m_webPage.corePage()->mainFrame());
+    FrameView* view = localMainFrame ? localMainFrame->view() : nullptr;
+    if (!view)
+        return;
     Scrollbar* scrollbar = view->verticalScrollbar();
     if (scrollbar && !scrollbar->isOverlayScrollbar())
         visibleRect.expand(scrollbar->width(), 0);

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.cpp
@@ -75,7 +75,10 @@ void LayerTreeHost::compositeLayersToContext()
 
 bool LayerTreeHost::flushPendingLayerChanges()
 {
-    FrameView* frameView = m_webPage.corePage()->mainFrame().view();
+    auto* localMainFrame = dynamicDowncast<WebCore::LocalFrame>(m_webPage.corePage()->mainFrame());
+    if (!localMainFrame)
+        return false;
+    FrameView* frameView = localMainFrame->view();
     m_rootLayer->flushCompositingStateForThisLayerOnly();
     if (!frameView->flushCompositingStateIncludingSubframes())
         return false;
@@ -290,7 +293,8 @@ void LayerTreeHost::paintContents(const GraphicsLayer*, GraphicsContext& context
 {
     context.save();
     context.clip(rectToPaint);
-    m_webPage.corePage()->mainFrame().view()->paint(context, enclosingIntRect(rectToPaint));
+    if (auto* localMainFrame = dynamicDowncast<WebCore::LocalFrame>(m_webPage.corePage()->mainFrame()))
+        localMainFrame->view()->paint(context, enclosingIntRect(rectToPaint));
     context.restore();
 }
 

--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -521,10 +521,13 @@ void FindController::redraw()
 Vector<FloatRect> FindController::rectsForTextMatchesInRect(IntRect clipRect)
 {
     Vector<FloatRect> rects;
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_webPage->corePage()->mainFrame());
+    if (!localMainFrame)
+        return rects;
 
-    FrameView* mainFrameView = m_webPage->corePage()->mainFrame().view();
+    FrameView* mainFrameView = localMainFrame->view();
 
-    for (AbstractFrame* frame = &m_webPage->corePage()->mainFrame(); frame; frame = frame->tree().traverseNext()) {
+    for (AbstractFrame* frame = localMainFrame; frame; frame = frame->tree().traverseNext()) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;

--- a/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
@@ -357,10 +357,13 @@ void WebFoundTextRangeController::flashTextIndicatorAndUpdateSelectionWithRange(
 Vector<WebCore::FloatRect> WebFoundTextRangeController::rectsForTextMatchesInRect(WebCore::IntRect clipRect)
 {
     Vector<WebCore::FloatRect> rects;
+    auto* localMainFrame = dynamicDowncast<WebCore::LocalFrame>(m_webPage->corePage()->mainFrame());
+    if (!localMainFrame)
+        return rects;
 
-    RefPtr mainFrameView = m_webPage->corePage()->mainFrame().view();
+    RefPtr mainFrameView = localMainFrame->view();
 
-    for (WebCore::AbstractFrame* frame = &m_webPage->corePage()->mainFrame(); frame; frame = frame->tree().traverseNext()) {
+    for (WebCore::AbstractFrame* frame = localMainFrame; frame; frame = frame->tree().traverseNext()) {
         auto* localFrame = dynamicDowncast<WebCore::LocalFrame>(frame);
         if (!localFrame)
             continue;
@@ -384,7 +387,11 @@ Vector<WebCore::FloatRect> WebFoundTextRangeController::rectsForTextMatchesInRec
 
 WebCore::Document* WebFoundTextRangeController::documentForFoundTextRange(const WebFoundTextRange& range) const
 {
-    auto& mainFrame = m_webPage->corePage()->mainFrame();
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_webPage->corePage()->mainFrame());
+    if (!localMainFrame)
+        return nullptr;
+
+    auto& mainFrame = *localMainFrame;
     if (range.frameIdentifier.isEmpty())
         return mainFrame.document();
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -746,7 +746,8 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
     // in modern WebKit.
     m_page->settings().setBackForwardCacheExpirationInterval(Seconds::infinity());
 
-    m_mainFrame->initWithCoreMainFrame(*this, m_page->mainFrame(), receivedMainFrameIdentifierFromUIProcess);
+    if (auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame()))
+        m_mainFrame->initWithCoreMainFrame(*this, *localMainFrame, receivedMainFrameIdentifierFromUIProcess);
 
     m_drawingArea->updatePreferences(parameters.store);
 
@@ -1337,7 +1338,8 @@ void WebPage::selectAll()
 
 bool WebPage::shouldDispatchSyntheticMouseEventsWhenModifyingSelection() const
 {
-    auto* document = m_page->mainFrame().document();
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
+    auto* document = localMainFrame ? localMainFrame->document() : nullptr;
     return document && document->quirks().shouldDispatchSyntheticMouseEventsWhenModifyingSelection();
 }
 
@@ -1773,8 +1775,10 @@ void WebPage::loadRequest(LoadParameters&& loadParameters)
     frameLoadRequest.setClientRedirectSourceForHistory(loadParameters.clientRedirectSourceForHistory);
     frameLoadRequest.setIsRequestFromClientOrUserInput();
 
-    if (loadParameters.effectiveSandboxFlags)
-        corePage()->mainFrame().loader().forceSandboxFlags(loadParameters.effectiveSandboxFlags);
+    if (loadParameters.effectiveSandboxFlags) {
+        if (auto* localMainFrame = dynamicDowncast<LocalFrame>(corePage()->mainFrame()))
+            localMainFrame->loader().forceSandboxFlags(loadParameters.effectiveSandboxFlags);
+    }
 
     corePage()->userInputBridge().loadRequest(WTFMove(frameLoadRequest));
 
@@ -1929,8 +1933,10 @@ void WebPage::goToBackForwardItem(uint64_t navigationID, const BackForwardItemId
     SendStopResponsivenessTimer stopper;
 
     m_lastNavigationWasAppInitiated = lastNavigationWasAppInitiated;
-    if (auto* documentLoader = corePage()->mainFrame().loader().documentLoader())
-        documentLoader->setLastNavigationWasAppInitiated(lastNavigationWasAppInitiated);
+    if (auto* localMainFrame = dynamicDowncast<LocalFrame>(corePage()->mainFrame())) {
+        if (auto* documentLoader = localMainFrame->loader().documentLoader())
+            documentLoader->setLastNavigationWasAppInitiated(lastNavigationWasAppInitiated);
+    }
 
     WebProcess::singleton().webLoaderStrategy().setExistingNetworkResourceLoadIdentifierToResume(existingNetworkResourceLoadIdentifierToResume);
     auto resumingLoadScope = makeScopeExit([] {
@@ -1960,7 +1966,8 @@ void WebPage::goToBackForwardItem(uint64_t navigationID, const BackForwardItemId
 
 void WebPage::tryRestoreScrollPosition()
 {
-    m_page->mainFrame().loader().history().restoreScrollPositionAndViewState();
+    if (auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame()))
+        localMainFrame->loader().history().restoreScrollPositionAndViewState();
 }
 
 WebPage& WebPage::fromCorePage(Page& page)
@@ -1974,7 +1981,9 @@ void WebPage::setSize(const WebCore::IntSize& viewSize)
         return;
 
     m_viewSize = viewSize;
-    FrameView* view = m_page->mainFrame().view();
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
+    FrameView* view = localMainFrame ? localMainFrame->view() : nullptr;
+
     view->resize(viewSize);
     m_drawingArea->setNeedsDisplay();
 
@@ -1987,7 +1996,11 @@ void WebPage::setSize(const WebCore::IntSize& viewSize)
 #if USE(COORDINATED_GRAPHICS)
 void WebPage::sendViewportAttributesChanged(const ViewportArguments& viewportArguments)
 {
-    FrameView* view = m_page->mainFrame().view();
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
+    if (!localMainFrame)
+        return;
+
+    FrameView* view = localMainFrame->view();
     ASSERT(view && view->useFixedLayout());
 
     // Viewport properties have no impact on zero sized fixed viewports.
@@ -2030,7 +2043,10 @@ void WebPage::sendViewportAttributesChanged(const ViewportArguments& viewportArg
 
 void WebPage::scrollMainFrameIfNotAtMaxScrollPosition(const IntSize& scrollOffset)
 {
-    FrameView* frameView = m_page->mainFrame().view();
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
+    if (!localMainFrame)
+        return;
+    FrameView* frameView = localMainFrame->view();
 
     ScrollPosition scrollPosition = frameView->scrollPosition();
     ScrollPosition maximumScrollPosition = frameView->maximumScrollPosition();
@@ -2052,7 +2068,10 @@ void WebPage::scrollMainFrameIfNotAtMaxScrollPosition(const IntSize& scrollOffse
 void WebPage::drawRect(GraphicsContext& graphicsContext, const IntRect& rect)
 {
 #if PLATFORM(MAC)
-    FrameView* mainFrameView = m_page->mainFrame().view();
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
+    if (!localMainFrame)
+        return;
+    FrameView* mainFrameView = localMainFrame->view();
     LocalDefaultSystemAppearance localAppearance(mainFrameView ? mainFrameView->useDarkAppearance() : false);
 #endif
 
@@ -2304,7 +2323,8 @@ void WebPage::scaleView(double scale)
     float pageScale = pageScaleFactor();
 
     IntPoint scrollPositionAtNewScale;
-    if (FrameView* mainFrameView = m_page->mainFrame().view()) {
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
+    if (FrameView* mainFrameView = localMainFrame ? localMainFrame->view() : nullptr) {
         double scaleRatio = scale / viewScaleFactor();
         scrollPositionAtNewScale = mainFrameView->scrollPosition();
         scrollPositionAtNewScale.scale(scaleRatio);
@@ -2491,7 +2511,8 @@ void WebPage::viewportPropertiesDidChange(const ViewportArguments& viewportArgum
 #endif
 
 #if USE(COORDINATED_GRAPHICS)
-    FrameView* view = m_page->mainFrame().view();
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
+    FrameView* view = localMainFrame ? localMainFrame->view() : nullptr;
     if (view && view->useFixedLayout())
         sendViewportAttributesChanged(viewportArguments);
     else
@@ -2754,8 +2775,10 @@ void WebPage::paintSnapshotAtSize(const IntRect& rect, const IntSize& bitmapSize
 static DestinationColorSpace snapshotColorSpace(SnapshotOptions options, WebPage& page)
 {
 #if USE(CG)
-    if (options & SnapshotOptionsUseScreenColorSpace)
-        return screenColorSpace(page.corePage()->mainFrame().view());
+    if (options & SnapshotOptionsUseScreenColorSpace) {
+        if (auto* localMainFrame = dynamicDowncast<LocalFrame>(page.corePage()->mainFrame()))
+            return screenColorSpace(localMainFrame->view());
+    }
 #endif
     return DestinationColorSpace::SRGB();
 }
@@ -2844,8 +2867,10 @@ void WebPage::pageDidScroll()
 
     m_pageScrolledHysteresis.impulse();
 
-    auto scrollPosition = m_page->mainFrame().view()->scrollPosition();
-    send(Messages::WebPageProxy::PageDidScroll(scrollPosition));
+    if (auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame())) {
+        auto scrollPosition = localMainFrame->view()->scrollPosition();
+        send(Messages::WebPageProxy::PageDidScroll(scrollPosition));
+    }
 }
 
 void WebPage::pageStoppedScrolling()
@@ -2875,7 +2900,10 @@ WebContextMenu* WebPage::contextMenuAtPointInWindow(const IntPoint& point)
     // Simulate a mouse click to generate the correct menu.
     PlatformMouseEvent mousePressEvent(point, point, RightButton, PlatformEvent::Type::MousePressed, 1, { }, WallTime::now(), WebCore::ForceAtClick, WebCore::NoTap);
     corePage()->userInputBridge().handleMousePressEvent(mousePressEvent);
-    Ref mainFrame = corePage()->mainFrame();
+    auto* localMainFrame = dynamicDowncast<WebCore::LocalFrame>(corePage()->mainFrame());
+    if (!localMainFrame)
+        return nullptr;
+    Ref mainFrame = *localMainFrame;
     bool handled = corePage()->userInputBridge().handleContextMenuEvent(mousePressEvent, mainFrame);
     auto* menu = handled ? &contextMenu() : nullptr;
     PlatformMouseEvent mouseReleaseEvent(point, point, RightButton, PlatformEvent::Type::MouseReleased, 1, { }, WallTime::now(), WebCore::ForceAtClick, WebCore::NoTap);
@@ -3065,11 +3093,14 @@ static bool isContextClick(const PlatformMouseEvent& event)
 
 static bool handleContextMenuEvent(const PlatformMouseEvent& platformMouseEvent, WebPage* page)
 {
-    IntPoint point = page->corePage()->mainFrame().view()->windowToContents(platformMouseEvent.position());
+    auto* localMainFrame = dynamicDowncast<WebCore::LocalFrame>(page->corePage()->mainFrame());
+    if (!localMainFrame)
+        return false;
+    IntPoint point = localMainFrame->view()->windowToContents(platformMouseEvent.position());
     constexpr OptionSet<HitTestRequest::Type> hitType { HitTestRequest::Type::ReadOnly, HitTestRequest::Type::Active, HitTestRequest::Type::DisallowUserAgentShadowContent,  HitTestRequest::Type::AllowChildFrameContent };
-    HitTestResult result = page->corePage()->mainFrame().eventHandler().hitTestResultAtPoint(point, hitType);
+    HitTestResult result = localMainFrame->eventHandler().hitTestResultAtPoint(point, hitType);
 
-    Ref frame = page->corePage()->mainFrame();
+    Ref frame = *localMainFrame;
     if (result.innerNonSharedNode())
         frame = *result.innerNonSharedNode()->document().frame();
 
@@ -3100,8 +3131,11 @@ void WebPage::contextMenuForKeyEvent()
 
 static bool handleMouseEvent(const WebMouseEvent& mouseEvent, WebPage* page)
 {
-    Frame& frame = page->corePage()->mainFrame();
-    if (!frame.view())
+    auto* localMainFrame = dynamicDowncast<WebCore::LocalFrame>(page->corePage()->mainFrame());
+    if (!localMainFrame)
+        return false;
+
+    if (!localMainFrame->view())
         return false;
 
     PlatformMouseEvent platformMouseEvent = platform(mouseEvent);
@@ -3122,7 +3156,7 @@ static bool handleMouseEvent(const WebMouseEvent& mouseEvent, WebPage* page)
         }
         case PlatformEvent::Type::MouseReleased:
             if (mouseEvent.gestureWasCancelled() == GestureWasCancelled::Yes)
-                frame.eventHandler().invalidateClick();
+                localMainFrame->eventHandler().invalidateClick();
             return page->corePage()->userInputBridge().handleMouseReleaseEvent(platformMouseEvent);
 
         case PlatformEvent::Type::MouseMoved:
@@ -3207,8 +3241,9 @@ bool WebPage::wheelEvent(const WebWheelEvent& wheelEvent, OptionSet<WheelEventPr
     CurrentEvent currentEvent(wheelEvent);
 
     auto dispatchWheelEvent = [&](const WebWheelEvent& wheelEvent, OptionSet<WheelEventProcessingSteps> processingSteps) {
-        auto& frame = m_page->mainFrame();
-        if (!frame.view())
+
+        auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
+        if (!localMainFrame || !localMainFrame->view())
             return false;
 
         auto platformWheelEvent = platform(wheelEvent);
@@ -3223,7 +3258,8 @@ bool WebPage::wheelEvent(const WebWheelEvent& wheelEvent, OptionSet<WheelEventPr
 void WebPage::dispatchWheelEventWithoutScrolling(const WebWheelEvent& wheelEvent, CompletionHandler<void(bool)>&& completionHandler)
 {
 #if ENABLE(KINETIC_SCROLLING)
-    auto gestureState = m_page->mainFrame().eventHandler().wheelScrollGestureState();
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
+    auto gestureState =  localMainFrame ? localMainFrame->eventHandler().wheelScrollGestureState() : std::nullopt;
     bool isCancelable = !gestureState || gestureState == WheelScrollGestureState::Blocking || wheelEvent.phase() == WebWheelEvent::PhaseBegan;
 #else
     bool isCancelable = true;
@@ -3235,7 +3271,11 @@ void WebPage::dispatchWheelEventWithoutScrolling(const WebWheelEvent& wheelEvent
 
 static bool handleKeyEvent(const WebKeyboardEvent& keyboardEvent, Page* page)
 {
-    if (!page->mainFrame().view())
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(page->mainFrame());
+    if (!localMainFrame)
+        return false;
+
+    if (!localMainFrame->view())
         return false;
 
     if (keyboardEvent.type() == WebEventType::Char && keyboardEvent.isSystemKey())
@@ -3339,7 +3379,8 @@ void WebPage::setCurrentHistoryItemForReattach(WebKit::BackForwardListItemState&
     auto historyItem = toHistoryItem(itemState);
     auto& historyItemRef = historyItem.get();
     static_cast<WebBackForwardListProxy&>(corePage()->backForward().client()).addItemFromUIProcess(itemState.identifier, WTFMove(historyItem), m_identifier, WebBackForwardListProxy::OverwriteExistingItem::Yes);
-    corePage()->mainFrame().loader().history().setCurrentItem(historyItemRef);
+    if (auto* localMainFrame = dynamicDowncast<WebCore::LocalFrame>(corePage()->mainFrame()))
+        localMainFrame->loader().history().setCurrentItem(historyItemRef);
 }
 
 void WebPage::requestFontAttributesAtSelectionStart(CompletionHandler<void(const WebCore::FontAttributes&)>&& completionHandler)
@@ -3358,10 +3399,11 @@ void WebPage::cancelCurrentInteractionInformationRequest()
 #if ENABLE(TOUCH_EVENTS)
 static bool handleTouchEvent(const WebTouchEvent& touchEvent, Page* page)
 {
-    if (!page->mainFrame().view())
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(page->mainFrame());
+    if (!localMainFrame || !localMainFrame->view())
         return false;
 
-    return page->mainFrame().eventHandler().handleTouchEvent(platform(touchEvent));
+    return localMainFrame->eventHandler().handleTouchEvent(platform(touchEvent));
 }
 #endif
 
@@ -3392,15 +3434,18 @@ void WebPage::updatePotentialTapSecurityOrigin(const WebTouchEvent& touchEvent, 
     if (touchEvent.type() != WebEventType::TouchStart)
         return;
 
-    auto& mainFrame = m_page->mainFrame();
-    auto document = mainFrame.document();
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
+    if (!localMainFrame)
+        return;
+
+    auto document = localMainFrame->document();
     if (!document)
         return;
 
     if (!document->handlingTouchEvent())
         return;
 
-    Frame* touchEventTargetFrame = &mainFrame;
+    Frame* touchEventTargetFrame = localMainFrame;
     while (auto subframe = touchEventTargetFrame->eventHandler().touchEventTargetSubframe())
         touchEventTargetFrame = subframe;
 
@@ -3437,10 +3482,11 @@ void WebPage::touchWithIdentifierWasRemoved(WebCore::PointerID pointerId)
 #if ENABLE(MAC_GESTURE_EVENTS)
 static bool handleGestureEvent(const WebGestureEvent& event, Page* page)
 {
-    if (!page->mainFrame().view())
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(page->mainFrame());
+    if (!localMainFrame || !localMainFrame->view())
         return false;
 
-    return page->mainFrame().eventHandler().handleGestureEvent(platform(event));
+    return localMainFrame->eventHandler().handleGestureEvent(platform(event));
 }
 
 void WebPage::gestureEvent(const WebGestureEvent& gestureEvent)
@@ -3745,7 +3791,8 @@ void WebPage::setNeedsDOMWindowResizeEvent()
     if (!m_page)
         return;
 
-    if (auto* document = m_page->mainFrame().document())
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
+    if (auto* document = localMainFrame ? localMainFrame->document() : nullptr)
         document->setNeedsDOMWindowResizeEvent();
 }
 
@@ -3862,7 +3909,8 @@ void WebPage::runJavaScript(WebFrame* frame, RunJavaScriptParameters&& parameter
 #if ENABLE(APP_BOUND_DOMAINS)
     if (frame->shouldEnableInAppBrowserPrivacyProtections()) {
         completionHandler({ }, ExceptionDetails { "Unable to execute JavaScript in a frame that is not in an app-bound domain"_s, 0, 0, ExceptionDetails::Type::AppBoundDomain });
-        if (auto* document = m_page->mainFrame().document())
+        auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
+        if (auto* document = localMainFrame ? localMainFrame->document() : nullptr)
             document->addConsoleMessage(MessageSource::Security, MessageLevel::Warning, "Ignoring user script injection for non-app bound domain."_s);
         WEBPAGE_RELEASE_LOG_ERROR(Loading, "runJavaScript: Ignoring user script injection for non app-bound domain");
         return;
@@ -4391,7 +4439,11 @@ void WebPage::detectDataInAllFrames(OptionSet<WebCore::DataDetectorType> dataDet
 #if PLATFORM(COCOA)
 void WebPage::willCommitLayerTree(RemoteLayerTreeTransaction& layerTransaction)
 {
-    FrameView* frameView = corePage()->mainFrame().view();
+    auto* localMainFrame = dynamicDowncast<WebCore::LocalFrame>(corePage()->mainFrame());
+    if (!localMainFrame)
+        return;
+
+    FrameView* frameView = localMainFrame->view();
     if (!frameView)
         return;
 
@@ -4773,12 +4825,13 @@ void WebPage::dragEnded(WebCore::IntPoint clientPosition, WebCore::IntPoint glob
     IntPoint adjustedGlobalPosition(globalPosition.x() + m_page->dragController().dragOffset().x(), globalPosition.y() + m_page->dragController().dragOffset().y());
 
     m_page->dragController().dragEnded();
-    FrameView* view = m_page->mainFrame().view();
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
+    FrameView* view = localMainFrame ? localMainFrame->view() : nullptr;
     if (!view)
         return;
     // FIXME: These are fake modifier keys here, but they should be real ones instead.
     PlatformMouseEvent event(adjustedClientPosition, adjustedGlobalPosition, LeftButton, PlatformEvent::Type::MouseMoved, 0, { }, WallTime::now(), 0, WebCore::NoTap);
-    m_page->mainFrame().eventHandler().dragSourceEndedAt(event, dragOperationMask);
+    localMainFrame->eventHandler().dragSourceEndedAt(event, dragOperationMask);
 
     send(Messages::WebPageProxy::DidEndDragging());
 
@@ -4800,13 +4853,15 @@ void WebPage::mayPerformUploadDragDestinationAction()
 void WebPage::didStartDrag()
 {
     m_isStartingDrag = false;
-    m_page->mainFrame().eventHandler().didStartDrag();
+    if (auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame()))
+        localMainFrame->eventHandler().didStartDrag();
 }
 
 void WebPage::dragCancelled()
 {
     m_isStartingDrag = false;
-    m_page->mainFrame().eventHandler().dragCancelled();
+    if (auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame()))
+        localMainFrame->eventHandler().dragCancelled();
 }
 
 #endif // ENABLE(DRAG_SUPPORT)
@@ -5601,8 +5656,8 @@ bool WebPage::hasLocalDataForURL(const URL& url)
 {
     if (url.isLocalFile())
         return true;
-
-    DocumentLoader* documentLoader = m_page->mainFrame().loader().documentLoader();
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
+    DocumentLoader* documentLoader = localMainFrame ? localMainFrame->loader().documentLoader() : nullptr;
     if (documentLoader && documentLoader->subresource(MemoryCache::removeFragmentIdentifierIfNeeded(url)))
         return true;
 
@@ -5611,7 +5666,8 @@ bool WebPage::hasLocalDataForURL(const URL& url)
 
 void WebPage::setCustomTextEncodingName(const String& encoding)
 {
-    m_page->mainFrame().loader().reloadWithOverrideEncoding(encoding);
+    if (auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame()))
+        localMainFrame->loader().reloadWithOverrideEncoding(encoding);
 }
 
 void WebPage::didRemoveBackForwardItem(const BackForwardItemIdentifier& itemID)
@@ -5776,7 +5832,11 @@ void WebPage::computePagesForPrintingImpl(FrameIdentifier frameID, const PrintIn
 #if PLATFORM(COCOA)
 void WebPage::drawToPDF(FrameIdentifier frameID, const std::optional<FloatRect>& rect, bool allowTransparentBackground,  CompletionHandler<void(RefPtr<WebCore::SharedBuffer>&&)>&& completionHandler)
 {
-    auto& frameView = *m_page->mainFrame().view();
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
+    if (!localMainFrame)
+        return;
+
+    auto& frameView = *localMainFrame->view();
     IntSize snapshotSize;
     if (rect)
         snapshotSize = IntSize(rect->size());
@@ -6154,7 +6214,7 @@ void WebPage::recomputeShortCircuitHorizontalWheelEventsState()
 
 Frame* WebPage::mainFrame() const
 {
-    return m_page ? &m_page->mainFrame() : nullptr;
+    return m_page ? dynamicDowncast<LocalFrame>(m_page->mainFrame()) : nullptr;
 }
 
 FrameView* WebPage::mainFrameView() const
@@ -6260,8 +6320,11 @@ void WebPage::getSelectedRangeAsync(CompletionHandler<void(const EditingRange&)>
 
 void WebPage::characterIndexForPointAsync(const WebCore::IntPoint& point, CompletionHandler<void(uint64_t)>&& completionHandler)
 {
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
+    if (!localMainFrame)
+        return;
     constexpr OptionSet<HitTestRequest::Type> hitType { HitTestRequest::Type::ReadOnly, HitTestRequest::Type::Active, HitTestRequest::Type::DisallowUserAgentShadowContent,  HitTestRequest::Type::AllowChildFrameContent };
-    auto result = m_page->mainFrame().eventHandler().hitTestResultAtPoint(point, hitType);
+    auto result = localMainFrame->eventHandler().hitTestResultAtPoint(point, hitType);
     Ref frame = result.innerNonSharedNode() ? *result.innerNodeFrame() : CheckedRef(m_page->focusController())->focusedOrMainFrame();
     auto range = frame->rangeForPoint(result.roundedPointInInnerNodeFrame());
     auto editingRange = EditingRange::fromRange(frame, range);
@@ -6610,7 +6673,12 @@ void WebPage::setAlwaysShowsHorizontalScroller(bool alwaysShowsHorizontalScrolle
         return;
 
     m_alwaysShowsHorizontalScroller = alwaysShowsHorizontalScroller;
-    auto view = corePage()->mainFrame().view();
+
+    auto* localMainFrame = dynamicDowncast<WebCore::LocalFrame>(corePage()->mainFrame());
+    if (!localMainFrame)
+        return;
+    
+    auto view = localMainFrame->view();
     if (!alwaysShowsHorizontalScroller)
         view->setHorizontalScrollbarLock(false);
     view->setHorizontalScrollbarMode(alwaysShowsHorizontalScroller ? ScrollbarMode::AlwaysOn : m_mainFrameIsScrollable ? ScrollbarMode::Auto : ScrollbarMode::AlwaysOff, alwaysShowsHorizontalScroller || !m_mainFrameIsScrollable);
@@ -6622,7 +6690,12 @@ void WebPage::setAlwaysShowsVerticalScroller(bool alwaysShowsVerticalScroller)
         return;
 
     m_alwaysShowsVerticalScroller = alwaysShowsVerticalScroller;
-    auto view = corePage()->mainFrame().view();
+
+    auto* localMainFrame = dynamicDowncast<WebCore::LocalFrame>(corePage()->mainFrame());
+    if (!localMainFrame)
+        return;
+
+    auto view = localMainFrame->view();
     if (!alwaysShowsVerticalScroller)
         view->setVerticalScrollbarLock(false);
     view->setVerticalScrollbarMode(alwaysShowsVerticalScroller ? ScrollbarMode::AlwaysOn : m_mainFrameIsScrollable ? ScrollbarMode::Auto : ScrollbarMode::AlwaysOff, alwaysShowsVerticalScroller || !m_mainFrameIsScrollable);
@@ -6634,12 +6707,17 @@ void WebPage::setMinimumSizeForAutoLayout(const IntSize& size)
         return;
 
     m_minimumSizeForAutoLayout = size;
+
+    auto* localMainFrame = dynamicDowncast<WebCore::LocalFrame>(corePage()->mainFrame());
+    if (!localMainFrame)
+        return;
+
     if (size.width() <= 0) {
-        corePage()->mainFrame().view()->enableFixedWidthAutoSizeMode(false, { });
+        localMainFrame->view()->enableFixedWidthAutoSizeMode(false, { });
         return;
     }
 
-    corePage()->mainFrame().view()->enableFixedWidthAutoSizeMode(true, { size.width(), std::max(size.height(), 1) });
+    localMainFrame->view()->enableFixedWidthAutoSizeMode(true, { size.width(), std::max(size.height(), 1) });
 }
 
 void WebPage::setSizeToContentAutoSizeMaximumSize(const IntSize& size)
@@ -6648,12 +6726,17 @@ void WebPage::setSizeToContentAutoSizeMaximumSize(const IntSize& size)
         return;
 
     m_sizeToContentAutoSizeMaximumSize = size;
+
+    auto* localMainFrame = dynamicDowncast<WebCore::LocalFrame>(corePage()->mainFrame());
+    if (!localMainFrame)
+        return;
+
     if (size.width() <= 0 || size.height() <= 0) {
-        corePage()->mainFrame().view()->enableSizeToContentAutoSizeMode(false, { });
+        localMainFrame->view()->enableSizeToContentAutoSizeMode(false, { });
         return;
     }
 
-    corePage()->mainFrame().view()->enableSizeToContentAutoSizeMode(true, size);
+    localMainFrame->view()->enableSizeToContentAutoSizeMode(true, size);
 }
 
 void WebPage::setAutoSizingShouldExpandToViewHeight(bool shouldExpand)
@@ -6663,7 +6746,8 @@ void WebPage::setAutoSizingShouldExpandToViewHeight(bool shouldExpand)
 
     m_autoSizingShouldExpandToViewHeight = shouldExpand;
 
-    corePage()->mainFrame().view()->setAutoSizeFixedMinimumHeight(shouldExpand ? m_viewSize.height() : 0);
+    if (auto* localMainFrame = dynamicDowncast<WebCore::LocalFrame>(corePage()->mainFrame()))
+        localMainFrame->view()->setAutoSizeFixedMinimumHeight(shouldExpand ? m_viewSize.height() : 0);
 }
 
 void WebPage::setViewportSizeForCSSViewportUnits(std::optional<WebCore::FloatSize> viewportSize)
@@ -6672,8 +6756,10 @@ void WebPage::setViewportSizeForCSSViewportUnits(std::optional<WebCore::FloatSiz
         return;
 
     m_viewportSizeForCSSViewportUnits = viewportSize;
-    if (m_viewportSizeForCSSViewportUnits)
-        corePage()->mainFrame().view()->setSizeForCSSDefaultViewportUnits(*m_viewportSizeForCSSViewportUnits);
+    if (m_viewportSizeForCSSViewportUnits) {
+        if (auto* localMainFrame = dynamicDowncast<WebCore::LocalFrame>(corePage()->mainFrame()))
+            localMainFrame->view()->setSizeForCSSDefaultViewportUnits(*m_viewportSizeForCSSViewportUnits);
+    }
 }
 
 bool WebPage::isSmartInsertDeleteEnabled()
@@ -6723,8 +6809,12 @@ bool WebPage::canShowMIMEType(const String& mimeType, const Function<bool(const 
 
     if (!mimeType.isNull() && m_mimeTypesWithCustomContentProviders.contains(mimeType))
         return true;
+    
+    auto* localMainFrame = dynamicDowncast<WebCore::LocalFrame>(corePage()->mainFrame());
+    if (!localMainFrame)
+        return false;
 
-    if (corePage()->mainFrame().arePluginsEnabled() && pluginsSupport(mimeType, PluginData::AllPlugins))
+    if (localMainFrame->arePluginsEnabled() && pluginsSupport(mimeType, PluginData::AllPlugins))
         return true;
 
     // We can use application plugins even if plugins aren't enabled.
@@ -7094,7 +7184,8 @@ void WebPage::updateWebsitePolicies(WebsitePoliciesData&& websitePolicies)
     if (!m_page)
         return;
 
-    auto* documentLoader = m_page->mainFrame().loader().documentLoader();
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
+    auto* documentLoader = localMainFrame ? localMainFrame->loader().documentLoader() : nullptr;
     if (!documentLoader)
         return;
 
@@ -7125,7 +7216,8 @@ unsigned WebPage::extendIncrementalRenderingSuppression()
         token++;
 
     m_activeRenderingSuppressionTokens.add(token);
-    m_page->mainFrame().view()->setVisualUpdatesAllowedByClient(false);
+    if (auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame()))
+        localMainFrame->view()->setVisualUpdatesAllowedByClient(false);
 
     m_maximumRenderingSuppressionToken = token;
 
@@ -7137,13 +7229,15 @@ void WebPage::stopExtendingIncrementalRenderingSuppression(unsigned token)
     if (!m_activeRenderingSuppressionTokens.remove(token))
         return;
 
-    m_page->mainFrame().view()->setVisualUpdatesAllowedByClient(!shouldExtendIncrementalRenderingSuppression());
+    if (auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame()))
+        localMainFrame->view()->setVisualUpdatesAllowedByClient(!shouldExtendIncrementalRenderingSuppression());
 }
     
 void WebPage::setScrollPinningBehavior(WebCore::ScrollPinningBehavior pinning)
 {
     m_scrollPinningBehavior = pinning;
-    m_page->mainFrame().view()->setScrollPinningBehavior(m_scrollPinningBehavior);
+    if (auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame()))
+        localMainFrame->view()->setScrollPinningBehavior(m_scrollPinningBehavior);
 }
 
 void WebPage::setScrollbarOverlayStyle(std::optional<uint32_t> scrollbarStyle)
@@ -7152,7 +7246,9 @@ void WebPage::setScrollbarOverlayStyle(std::optional<uint32_t> scrollbarStyle)
         m_scrollbarOverlayStyle = static_cast<ScrollbarOverlayStyle>(scrollbarStyle.value());
     else
         m_scrollbarOverlayStyle = std::optional<ScrollbarOverlayStyle>();
-    m_page->mainFrame().view()->recalculateScrollbarOverlayStyle();
+    
+    if (auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame()))
+        localMainFrame->view()->recalculateScrollbarOverlayStyle();
 }
 
 Ref<DocumentLoader> WebPage::createDocumentLoader(Frame& frame, const ResourceRequest& request, const SubstituteData& substituteData)
@@ -7378,7 +7474,10 @@ void WebPage::didLosePointerLock()
 
 void WebPage::didGetLoadDecisionForIcon(bool decision, CallbackID loadIdentifier, CompletionHandler<void(const IPC::SharedBufferReference&)>&& completionHandler)
 {
-    auto* documentLoader = corePage()->mainFrame().loader().documentLoader();
+    auto* localMainFrame = dynamicDowncast<WebCore::LocalFrame>(corePage()->mainFrame());
+    if (!localMainFrame)
+        return completionHandler({ });
+    auto* documentLoader = localMainFrame->loader().documentLoader();
     if (!documentLoader)
         return completionHandler({ });
 
@@ -7389,7 +7488,8 @@ void WebPage::didGetLoadDecisionForIcon(bool decision, CallbackID loadIdentifier
 
 void WebPage::setUseIconLoadingClient(bool useIconLoadingClient)
 {
-    static_cast<WebFrameLoaderClient&>(corePage()->mainFrame().loader().client()).setUseIconLoadingClient(useIconLoadingClient);
+    if (auto* localMainFrame = dynamicDowncast<WebCore::LocalFrame>(corePage()->mainFrame()))
+        static_cast<WebFrameLoaderClient&>(localMainFrame->loader().client()).setUseIconLoadingClient(useIconLoadingClient);
 }
 
 WebURLSchemeHandlerProxy* WebPage::urlSchemeHandlerForScheme(StringView scheme)
@@ -7794,7 +7894,8 @@ void WebPage::startTextManipulations(Vector<WebCore::TextManipulationController:
     if (!m_page)
         return;
 
-    RefPtr mainDocument = m_page->mainFrame().document();
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
+    RefPtr mainDocument = localMainFrame ? localMainFrame->document() : nullptr;
     if (!mainDocument)
         return;
 
@@ -7821,7 +7922,8 @@ void WebPage::completeTextManipulation(const Vector<WebCore::TextManipulationIte
         return;
     }
 
-    RefPtr mainDocument = m_page->mainFrame().document();
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
+    RefPtr mainDocument = localMainFrame ? localMainFrame->document() : nullptr;
     if (!mainDocument) {
         completionHandler(true, { });
         return;
@@ -8069,8 +8171,14 @@ void WebPage::updateWithTextRecognitionResult(const TextRecognitionResult& resul
         return;
     }
 
+    auto* localMainFrame = dynamicDowncast<WebCore::LocalFrame>(corePage()->mainFrame());
+    if (!localMainFrame) {
+        completionHandler(TextRecognitionUpdateResult::NoText);
+        return;
+    }
+
     ImageOverlay::updateWithTextRecognitionResult(downcast<HTMLElement>(*elementToUpdate), result);
-    auto hitTestResult = corePage()->mainFrame().eventHandler().hitTestResultAtPoint(roundedIntPoint(location), {
+    auto hitTestResult = localMainFrame->eventHandler().hitTestResultAtPoint(roundedIntPoint(location), {
         HitTestRequest::Type::ReadOnly,
         HitTestRequest::Type::Active,
         HitTestRequest::Type::AllowVisibleChildFrameContentOnly,
@@ -8379,7 +8487,8 @@ void WebPage::clearNotificationPermissionState()
 
 void WebPage::generateTestReport(String&& message, String&& group)
 {
-    if (RefPtr document = m_page->mainFrame().document())
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
+    if (RefPtr document = localMainFrame ? localMainFrame->document() : nullptr)
         document->reportingScope().generateTestReport(WTFMove(message), WTFMove(group));
 }
 

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm
@@ -57,11 +57,11 @@ namespace ax = WebCore::Accessibility;
     if (!page)
         return nullptr;
 
-    auto& core = page->mainFrame();
-    if (!core.document())
+    auto* localMainFrame = dynamicDowncast<WebCore::LocalFrame>(page->mainFrame());
+    if (!localMainFrame || !localMainFrame->document())
         return nullptr;
 
-    return core.document()->axObjectCache();
+    return localMainFrame->document()->axObjectCache();
 }
 
 - (id)accessibilityPluginObject

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebDragClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebDragClient.mm
@@ -114,7 +114,7 @@ static WebHTMLView *getTopHTMLView(Frame* frame)
 {
     ASSERT(frame);
     ASSERT(frame->page());
-    return (WebHTMLView*)[[kit(&frame->page()->mainFrame()) frameView] documentView];
+    return (WebHTMLView*)[[kit(dynamicDowncast<WebCore::LocalFrame>(frame->page()->mainFrame())) frameView] documentView];
 }
 
 void WebDragClient::willPerformDragDestinationAction(WebCore::DragDestinationAction action, const WebCore::DragData& dragData)

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebPluginInfoProvider.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebPluginInfoProvider.mm
@@ -62,7 +62,11 @@ Vector<WebCore::PluginInfo> WebPluginInfoProvider::pluginInfo(WebCore::Page& pag
 
 
     // WebKit1 has no application plug-ins, so we don't need to add them here.
-    if (!page.mainFrame().arePluginsEnabled())
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(page.mainFrame());
+    if (!localMainFrame)
+        return plugins;
+
+    if (!localMainFrame->arePluginsEnabled())
         return plugins;
 
     for (WebPluginPackage *plugin in [WebPluginDatabase sharedDatabase].plugins)

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -4277,8 +4277,10 @@ IGNORE_WARNINGS_END
 
     if (!_private->ignoringMouseDraggedEvents) {
         if (auto* frame = core([self _frame])) {
-            if (auto* page = frame->page())
-                page->mainFrame().eventHandler().mouseDragged(event, [[self _webView] _pressureEvent]);
+            if (auto* page = frame->page()) {
+                if (auto* localMainFrame = dynamicDowncast<WebCore::LocalFrame>(page->mainFrame()))
+                    localMainFrame->eventHandler().mouseDragged(event, [[self _webView] _pressureEvent]);
+            }
         }
     }
 
@@ -4454,11 +4456,14 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     [self _stopAutoscrollTimer];
     if (auto* frame = core([self _frame])) {
         if (auto* page = frame->page()) {
+            auto* localMainFrame = dynamicDowncast<WebCore::LocalFrame>(page->mainFrame());
+            if (localMainFrame) {
 #if PLATFORM(IOS_FAMILY)
-            page->mainFrame().eventHandler().mouseUp(event);
+                localMainFrame->eventHandler().mouseUp(event);
 #else
-            page->mainFrame().eventHandler().mouseUp(event, [[self _webView] _pressureEvent]);
+                localMainFrame->eventHandler().mouseUp(event, [[self _webView] _pressureEvent]);
 #endif
+            }
         }
     }
 


### PR DESCRIPTION
#### 6ea95fe00133c4a2cba4cafcb7501a64dc553169
<pre>
Make Page::mainFrame() return an AbstractFrame
<a href="https://bugs.webkit.org/show_bug.cgi?id=252775">https://bugs.webkit.org/show_bug.cgi?id=252775</a>
rdar://105693029

Reviewed by Alex Christensen.

In preparation for site isolation, we need to support LocalFrame and
RemoteFrame, which is why Page::mainFrame() needs to return an
AbstractFrame.

* Source/WebCore/accessibility/atspi/AccessibilityRootAtspi.cpp:
(WebCore::AccessibilityRootAtspi::child const):
(WebCore::AccessibilityRootAtspi::frameRect const):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper _accessibilityShowContextMenu]):
* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
(WebCore::ReplacementFragment::ReplacementFragment):
* Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm:
(WebCore::sanitizeMarkupWithArchive):
* Source/WebCore/editing/markup.cpp:
(WebCore::createPageForSanitizingWebContent):
(WebCore::sanitizeMarkup):
* Source/WebCore/history/BackForwardCache.cpp:
(WebCore::canCachePage):
(WebCore::BackForwardCache::markPagesForDeviceOrPageScaleChanged):
(WebCore::BackForwardCache::markPagesForContentsSizeChanged):
(WebCore::BackForwardCache::trySuspendPage):
* Source/WebCore/history/CachedPage.cpp:
(WebCore::CachedPage::CachedPage):
(WebCore::firePageShowEvent):
(WebCore::CachedPage::restore):
* Source/WebCore/inspector/InspectorFrontendAPIDispatcher.cpp:
(WebCore::InspectorFrontendAPIDispatcher::frontendGlobalObject):
(WebCore::InspectorFrontendAPIDispatcher::evaluateExpression):
* Source/WebCore/inspector/InspectorFrontendClientLocal.cpp:
(WebCore::InspectorFrontendClientLocal::canAttachWindow):
(WebCore::InspectorFrontendClientLocal::changeAttachedWindowHeight):
(WebCore::InspectorFrontendClientLocal::changeAttachedWindowWidth):
(WebCore::InspectorFrontendClientLocal::openURLExternally):
(WebCore::InspectorFrontendClientLocal::restoreAttachedWindowHeight):
* Source/WebCore/inspector/InspectorFrontendHost.cpp:
(WebCore::InspectorFrontendHost::addSelfToGlobalObjectInWorld):
(WebCore::InspectorFrontendHost::setZoomFactor):
(WebCore::InspectorFrontendHost::zoomFactor):
(WebCore::InspectorFrontendHost::copyText):
(WebCore::InspectorFrontendHost::showContextMenu):
* Source/WebCore/inspector/InspectorOverlay.cpp:
(WebCore::buildRendererHighlight):
(WebCore::drawShapeHighlight):
(WebCore::InspectorOverlay::paint):
(WebCore::InspectorOverlay::highlightQuad):
(WebCore::InspectorOverlay::update):
(WebCore::InspectorOverlay::showPaintRect):
(WebCore::InspectorOverlay::drawBounds):
(WebCore::InspectorOverlay::drawRulers):
(WebCore::InspectorOverlay::drawElementTitle):
(WebCore::InspectorOverlay::buildGridOverlay):
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::didCreateFrontendAndBackend):
* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
(WebCore::InspectorPageAgent::reload):
(WebCore::InspectorPageAgent::navigate):
(WebCore::InspectorPageAgent::getResourceTree):
(WebCore::InspectorPageAgent::setEmulatedMedia):
(WebCore::InspectorPageAgent::snapshotNode):
(WebCore::InspectorPageAgent::snapshotRect):
(WebCore::InspectorPageAgent::archive):
(WebCore::InspectorPageAgent::setScreenSizeOverride):
* Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp:
(WebCore::InspectorTimelineAgent::captureScreenshot):
* Source/WebCore/inspector/agents/page/PageAuditAgent.cpp:
(WebCore::PageAuditAgent::injectedScriptForEval):
* Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp:
(WebCore::PageDebuggerAgent::sourceMapURLForScript):
(WebCore::PageDebuggerAgent::injectedScriptForEval):
* Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp:
(WebCore::PageRuntimeAgent::injectedScriptForEval):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::checkLoadCompleteForThisFrame):
(WebCore::createWindow):
* Source/WebCore/loader/archive/mhtml/MHTMLArchive.cpp:
(WebCore::MHTMLArchive::generateMHTMLData):
* Source/WebCore/page/AutoscrollController.cpp:
(WebCore::getMainFrame):
* Source/WebCore/page/Chrome.cpp:
(WebCore::Chrome::runModal const):
(WebCore::Chrome::mouseDidMoveOverElement):
* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::openNewWindow):
* Source/WebCore/page/DOMWindow.cpp:
(WebCore::DOMWindow::adjustWindowRect):
(WebCore::DOMWindow::moveTo const):
* Source/WebCore/page/DebugPageOverlays.cpp:
(WebCore::InteractionRegionOverlay::activeLayer const):
(WebCore::InteractionRegionOverlay::activeRegion const):
(WebCore::InteractionRegionOverlay::rectForSettingAtIndex const):
(WebCore::InteractionRegionOverlay::mouseEvent):
* Source/WebCore/page/DragController.cpp:
(WebCore::DragController::dragExited):
(WebCore::DragController::performDragOperation):
(WebCore::DragController::dragEnteredOrUpdated):
(WebCore::DragController::operationForLoad):
(WebCore::DragController::canProcessDrag):
(WebCore::DragController::tryDHTMLDrag):
(WebCore::DragController::beginDrag):
(WebCore::DragController::doSystemDrag):
(WebCore::DragController::placeDragCaret):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::removeDraggedContentDocumentMarkersFromAllFramesInPage):
* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::focusedOrMainFrame const):
(WebCore::FocusController::setFocusedInternal):
(WebCore::FocusController::advanceFocusInDocumentOrder):
(WebCore::shouldClearSelectionWhenChangingFocusedElement):
(WebCore::FocusController::setActiveInternal):
(WebCore::FocusController::setIsVisibleAndActiveInternal):
(WebCore::updateFocusCandidateIfNeeded):
* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::Frame):
(WebCore::Frame::~Frame):
(WebCore::Frame::fromJSContext):
* Source/WebCore/page/Frame.h:
* Source/WebCore/page/FrameView.cpp:
(WebCore::FrameView::textFragmentIndicatorTimerFired):
(WebCore::FrameView::shouldUpdateCompositingLayersAfterScrolling const):
(WebCore::FrameView::firePaintRelatedMilestonesIfNeeded):
* Source/WebCore/page/History.cpp:
(WebCore::History::stateObjectAdded):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::clearPreviousItemFromAllPages):
(WebCore::Page::disabledAdaptations const):
(WebCore::Page::viewportArguments const):
(WebCore::Page::setOverrideViewportArguments):
(WebCore::Page::accessibilityTreeData const):
(WebCore::Page::showAllPlugins const):
(WebCore::Page::setEditableRegionEnabled):
(WebCore::Page::editableElementsInRect const):
(WebCore::Page::setInteractionRegionsEnabled):
(WebCore::Page::setZoomedOutPageScaleFactor):
(WebCore::Page::setPageScaleFactor):
(WebCore::Page::setDeviceScaleFactor):
(WebCore::Page::screenPropertiesDidChange):
(WebCore::Page::windowScreenDidChange):
(WebCore::Page::setTopContentInset):
(WebCore::Page::lockAllOverlayScrollbarsToHidden):
(WebCore::Page::setVerticalScrollElasticity):
(WebCore::Page::setHorizontalScrollElasticity):
(WebCore::Page::pageCount const):
(WebCore::Page::doAfterUpdateRendering):
(WebCore::Page::finalizeRenderingUpdate):
(WebCore::Page::willStartRenderingUpdateDisplay):
(WebCore::Page::didCompleteRenderingUpdateDisplay):
(WebCore::Page::prioritizeVisibleResources):
(WebCore::Page::subframeCount const):
(WebCore::Page::resumeAnimatingImages):
(WebCore::Page::setIsVisibleInternal):
(WebCore::Page::setHeaderHeight):
(WebCore::Page::setFooterHeight):
(WebCore::Page::isLoadingInHeadlessMode const):
(WebCore::Page::themeColor const):
(WebCore::Page::pageExtendedBackgroundColor const):
(WebCore::Page::setUnderPageBackgroundColorOverride):
(WebCore::Page::addRelevantRepaintedObject):
(WebCore::Page::startMonitoringWheelEvents):
(WebCore::Page::useDarkAppearance const):
(WebCore::Page::forEachDocument const):
(WebCore::Page::setMediaSessionCoordinator):
(WebCore::Page::invalidateMediaSessionCoordinator):
(WebCore::Page::setupForRemoteWorker):
(WebCore::Page::updatePlayStateForAllAnimations):
* Source/WebCore/page/Page.h:
(WebCore::Page::mainFrame):
(WebCore::Page::mainFrame const):
* Source/WebCore/page/PageColorSampler.cpp:
(WebCore::PageColorSampler::sampleTop):
* Source/WebCore/page/PageConsoleClient.cpp:
(WebCore::PageConsoleClient::takeHeapSnapshot):
(WebCore::PageConsoleClient::time):
(WebCore::PageConsoleClient::timeLog):
(WebCore::PageConsoleClient::timeEnd):
(WebCore::PageConsoleClient::timeStamp):
(WebCore::PageConsoleClient::screenshot):
* Source/WebCore/page/PageDebuggable.cpp:
(WebCore::PageDebuggable::name const):
(WebCore::PageDebuggable::url const):
* Source/WebCore/page/PageGroupLoadDeferrer.cpp:
(WebCore::PageGroupLoadDeferrer::PageGroupLoadDeferrer):
* Source/WebCore/page/PageOverlay.cpp:
(WebCore::PageOverlay::bounds const):
(WebCore::PageOverlay::viewToOverlayOffset const):
(WebCore::PageOverlay::drawRect):
(WebCore::PageOverlay::mouseEvent):
* Source/WebCore/page/PageOverlayController.cpp:
(WebCore::PageOverlayController::installedPageOverlaysChanged):
(WebCore::PageOverlayController::installPageOverlay):
* Source/WebCore/page/PageSerializer.cpp:
(WebCore::PageSerializer::serialize):
* Source/WebCore/page/PerformanceLogging.cpp:
(WebCore::PerformanceLogging::didReachPointOfInterest):
* Source/WebCore/page/PerformanceMonitor.cpp:
(WebCore::reportPageOverPostLoadResourceThreshold):
* Source/WebCore/page/PointerCaptureController.cpp:
(WebCore::PointerCaptureController::cancelPointer):
* Source/WebCore/page/ResourceUsageOverlay.cpp:
(WebCore::ResourceUsageOverlay::~ResourceUsageOverlay):
(WebCore::ResourceUsageOverlay::initialize):
(WebCore::ResourceUsageOverlay::mouseEvent):
* Source/WebCore/page/SettingsBase.cpp:
(WebCore::SettingsBase::mediaTypeOverrideChanged):
(WebCore::SettingsBase::backgroundShouldExtendBeyondPageChanged):
(WebCore::SettingsBase::scrollingPerformanceTestingEnabledChanged):
* Source/WebCore/page/SpatialNavigation.cpp:
(WebCore::distanceDataForNode):
* Source/WebCore/page/mac/DragControllerMac.mm:
(WebCore::DragController::cleanupAfterSystemDrag):
* Source/WebCore/page/mac/ImageOverlayControllerMac.mm:
(WebCore::ImageOverlayController::updateDataDetectorHighlights):
(WebCore::ImageOverlayController::platformHandleMouseEvent):
* Source/WebCore/page/mac/PageMac.mm:
(WebCore::Page::platformInitialize):
* Source/WebCore/page/mac/ServicesOverlayController.mm:
(WebCore::ServicesOverlayController::mainFrame const):
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::frameViewForScrollingNode const):
(WebCore::AsyncScrollingCoordinator::setFrameScrollingNodeState):
(WebCore::AsyncScrollingCoordinator::scrollAnimatorEnabled const):
* Source/WebCore/page/scrolling/ScrollingCoordinator.cpp:
(WebCore::ScrollingCoordinator::absoluteEventTrackingRegions const):
(WebCore::ScrollingCoordinator::shouldUpdateScrollLayerPositionSynchronously const):
(WebCore::ScrollingCoordinator::synchronousScrollingReasonsAsText const):
* Source/WebCore/page/scrolling/mac/ScrollingCoordinatorMac.mm:
(WebCore::ScrollingCoordinatorMac::updateTiledScrollingIndicator):
* Source/WebCore/plugins/PluginData.cpp:
(WebCore::PluginData::webVisiblePlugins const):
* Source/WebCore/plugins/PluginInfoProvider.cpp:
(WebCore::PluginInfoProvider::refresh):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::contentsScaleMultiplierForNewTiles const):
* Source/WebCore/replay/UserInputBridge.cpp:
(WebCore::UserInputBridge::handleMousePressEvent):
(WebCore::UserInputBridge::handleMouseReleaseEvent):
(WebCore::UserInputBridge::handleMouseMoveEvent):
(WebCore::UserInputBridge::handleMouseMoveOnScrollbarEvent):
(WebCore::UserInputBridge::handleMouseForceEvent):
(WebCore::UserInputBridge::handleWheelEvent):
(WebCore::UserInputBridge::loadRequest):
(WebCore::UserInputBridge::tryClosePage):
* Source/WebCore/style/StyleScopeRuleSets.cpp:
(WebCore::Style::ScopeRuleSets::initializeUserStyle):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::suspendMemoryCacheClientCalls):
* Source/WebCore/svg/graphics/SVGImage.cpp:
(WebCore::SVGImage::rootElement const):
(WebCore::SVGImage::frameView const):
(WebCore::SVGImage::reportApproximateMemoryCost const):
(WebCore::SVGImage::dataChanged):
* Source/WebCore/testing/InternalSettings.cpp:
(WebCore::InternalSettings::resetToConsistentState):
(WebCore::InternalSettings::setAllowUnclampedScrollPosition):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::resetToConsistentState):
(WebCore::Internals::frameIdentifier const):
(WebCore::Internals::openDummyInspectorFrontend):
* Source/WebCore/testing/MockPageOverlayClient.cpp:
(WebCore::MockPageOverlayClient::mouseEvent):
* Source/WebCore/workers/service/ServiceWorkerContainer.cpp:
(WebCore::ServiceWorkerContainer::willSettleRegistrationPromise):
* Source/WebCore/workers/service/ServiceWorkerGlobalScope.cpp:
(WebCore::ServiceWorkerGlobalScope::notifyServiceWorkerPageOfCreationIfNecessary):
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp:
(WebCore::ServiceWorkerThreadProxy::ServiceWorkerThreadProxy):
* Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp:
(WebCore::SharedWorkerThreadProxy::SharedWorkerThreadProxy):
* Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.cpp:
(WebKit::MediaKeySystemPermissionRequestManagerProxy::createRequestForFrame):
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::saveScrollPosition):
(WebKit::WebFullScreenManager::restoreScrollPosition):
* Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.cpp:
(WebKit::registrableDomainForPage):
(WebKit::WebGeolocationManager::resetPermissions):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp:
(WKAccessibilityRootObject):
(WKAccessibilityCanUseSecondaryAXThread):
(WKBundlePageCallAfterTasksAndTimers):
* Source/WebKit/WebProcess/Inspector/WebInspector.cpp:
(WebKit::WebInspector::canAttachWindow):
* Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp:
(WebKit::WebUserContentController::addUserScriptInternal):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::invalidateContentsAndRootView):
(WebKit::WebChromeClient::invalidateContentsForSlowScroll):
* Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.cpp:
(WebKit::WebContextMenuClient::searchWithGoogle):
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::dispatchCreatePage):
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebContextMenuClientMac.mm:
(WebKit::WebContextMenuClient::searchWithSpotlight):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::performDictionaryLookupAtLocation):
(WebKit::WebPage::getContentsAsAttributedString):
(WebKit::WebPage::clickableNodeAtLocation const):
(WebKit::WebPage::getEvasionRectsAroundSelection const):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp:
(WebKit::CompositingCoordinator::timestamp const):
(WebKit::CompositingCoordinator::syncDisplayState):
(WebKit::CompositingCoordinator::setVisibleContentsRect):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::didChangeViewport):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.cpp:
(WebKit::LayerTreeHost::flushPendingLayerChanges):
(WebKit::LayerTreeHost::paintContents):
* Source/WebKit/WebProcess/WebPage/FindController.cpp:
(WebKit::FindController::rectsForTextMatchesInRect):
* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp:
(WebKit::WebFoundTextRangeController::rectsForTextMatchesInRect):
(WebKit::WebFoundTextRangeController::documentForFoundTextRange const):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_appHighlightsVisible):
(WebKit::WebPage::shouldDispatchSyntheticMouseEventsWhenModifyingSelection const):
(WebKit::WebPage::loadRequest):
(WebKit::WebPage::goToBackForwardItem):
(WebKit::WebPage::tryRestoreScrollPosition):
(WebKit::WebPage::setSize):
(WebKit::WebPage::sendViewportAttributesChanged):
(WebKit::WebPage::scrollMainFrameIfNotAtMaxScrollPosition):
(WebKit::WebPage::drawRect):
(WebKit::WebPage::scaleView):
(WebKit::WebPage::viewportPropertiesDidChange):
(WebKit::snapshotColorSpace):
(WebKit::WebPage::pageDidScroll):
(WebKit::WebPage::contextMenuAtPointInWindow):
(WebKit::handleContextMenuEvent):
(WebKit::handleMouseEvent):
(WebKit::WebPage::wheelEvent):
(WebKit::WebPage::dispatchWheelEventWithoutScrolling):
(WebKit::handleKeyEvent):
(WebKit::WebPage::setCurrentHistoryItemForReattach):
(WebKit::handleTouchEvent):
(WebKit::WebPage::updatePotentialTapSecurityOrigin):
(WebKit::handleGestureEvent):
(WebKit::WebPage::setNeedsDOMWindowResizeEvent):
(WebKit::WebPage::runJavaScript):
(WebKit::WebPage::willCommitLayerTree):
(WebKit::WebPage::dragEnded):
(WebKit::WebPage::didStartDrag):
(WebKit::WebPage::dragCancelled):
(WebKit::WebPage::hasLocalDataForURL):
(WebKit::WebPage::setCustomTextEncodingName):
(WebKit::WebPage::drawToPDF):
(WebKit::WebPage::mainFrame const):
(WebKit::WebPage::characterIndexForPointAsync):
(WebKit::WebPage::setAlwaysShowsHorizontalScroller):
(WebKit::WebPage::setAlwaysShowsVerticalScroller):
(WebKit::WebPage::setMinimumSizeForAutoLayout):
(WebKit::WebPage::setSizeToContentAutoSizeMaximumSize):
(WebKit::WebPage::setAutoSizingShouldExpandToViewHeight):
(WebKit::WebPage::setViewportSizeForCSSViewportUnits):
(WebKit::WebPage::canShowMIMEType const):
(WebKit::WebPage::updateWebsitePolicies):
(WebKit::WebPage::extendIncrementalRenderingSuppression):
(WebKit::WebPage::stopExtendingIncrementalRenderingSuppression):
(WebKit::WebPage::setScrollPinningBehavior):
(WebKit::WebPage::setScrollbarOverlayStyle):
(WebKit::WebPage::didGetLoadDecisionForIcon):
(WebKit::WebPage::setUseIconLoadingClient):
(WebKit::WebPage::startTextManipulations):
(WebKit::WebPage::completeTextManipulation):
(WebKit::WebPage::updateWithTextRecognitionResult):
(WebKit::WebPage::generateTestReport):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::restorePageState):
(WebKit::WebPage::rectForElementAtInteractionLocation const):
(WebKit::WebPage::handleSyntheticClick):
(WebKit::WebPage::didFinishContentChangeObserving):
(WebKit::WebPage::completeSyntheticClick):
(WebKit::WebPage::attemptSyntheticClick):
(WebKit::WebPage::handleDoubleTapForDoubleClickAtPoint):
(WebKit::WebPage::requestDragStart):
(WebKit::WebPage::requestAdditionalItemsForDragSession):
(WebKit::WebPage::sendTapHighlightForNodeIfNecessary):
(WebKit::WebPage::handleTwoFingerTapAtPoint):
(WebKit::WebPage::potentialTapAtPosition):
(WebKit::WebPage::commitPotentialTap):
(WebKit::WebPage::commitPotentialTapFailed):
(WebKit::WebPage::cancelPotentialTap):
(WebKit::WebPage::didRecognizeLongPress):
(WebKit::WebPage::tapHighlightAtPosition):
(WebKit::WebPage::inspectorNodeSearchMovedToPosition):
(WebKit::WebPage::inspectorNodeSearchEndedAtPosition):
(WebKit::WebPage::dispatchSyntheticMouseEventsForSelectionGesture):
(WebKit::WebPage::startAutoscrollAtPosition):
(WebKit::WebPage::cancelAutoscroll):
(WebKit::WebPage::setFocusedFrameBeforeSelectingTextAtLocation):
(WebKit::WebPage::prepareSelectionForContextMenuWithLocationInView):
(WebKit::selectionPositionInformation):
(WebKit::textInteractionPositionInformation):
(WebKit::WebPage::positionInformation):
(WebKit::WebPage::startInteractionWithElementContextOrPosition):
(WebKit::WebPage::setDeviceOrientation):
(WebKit::WebPage::dynamicViewportSizeUpdate):
(WebKit::WebPage::resetIdempotentTextAutosizingIfNeeded):
(WebKit::WebPage::shouldIgnoreMetaViewport const):
(WebKit::WebPage::updateVisibleContentRects):
(WebKit::WebPage::drawToPDFiOS):
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm:
(-[WKAccessibilityWebPageObjectBase axObjectCache]):
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::performImmediateActionHitTestAtLocation):
(WebKit::WebPage::lookupTextAtLocation):
(WebKit::WebPage::immediateActionDidUpdate):
(WebKit::WebPage::immediateActionDidCancel):
(WebKit::WebPage::immediateActionDidComplete):
(WebKit::WebPage::dataDetectorsDidHideUI):
(WebKit::WebPage::didEndMagnificationGesture):
* Source/WebKitLegacy/mac/WebCoreSupport/WebDragClient.mm:
(getTopHTMLView):
* Source/WebKitLegacy/mac/WebCoreSupport/WebPluginInfoProvider.mm:
(WebPluginInfoProvider::pluginInfo):
* Source/WebKitLegacy/mac/WebView/WebFrame.mm:
(+[WebFrame _createMainFrameWithPage:frameName:frameView:]):
(+[WebFrame _createMainFrameWithSimpleHTMLDocumentWithPage:frameView:style:]):
* Source/WebKitLegacy/mac/WebView/WebHTMLView.mm:
(-[WebHTMLView mouseDragged:]):
(-[WebHTMLView mouseUp:]):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _requestStartDataInteraction:globalPosition:]):
(-[WebView _loadBackForwardListFromOtherView:]):
(-[WebView _cachedResponseForURL:]):
(-[WebView _clearMainFrameName]):
(-[WebView mainFrame]):
(-[WebView editableDOMRangeForPoint:]):
(-[WebView _mainCoreFrame]):

Canonical link: <a href="https://commits.webkit.org/260724@main">https://commits.webkit.org/260724@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e7d5df611a09b806cf19733b2bc69e1baa59840

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109145 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18227 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41964 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/677 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118392 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113028 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19686 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9529 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101386 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114903 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14760 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97992 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42934 "Found 2 new test failures: webgl/2.0.y/conformance2/extensions/promoted-extensions-in-shaders.html, webgl/2.0.y/conformance2/extensions/webgl-multi-draw-instanced-base-vertex-base-instance.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96732 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29646 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84672 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11007 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30989 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11738 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7923 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17107 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50592 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13354 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4050 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->