### PR TITLE
Add an option that makes the MiniBrowser main thread continually stall

### DIFF
--- a/Tools/MiniBrowser/mac/BrowserWindowController.h
+++ b/Tools/MiniBrowser/mac/BrowserWindowController.h
@@ -80,6 +80,9 @@
 
 - (IBAction)showHideWebInspector:(id)sender;
 
+- (IBAction)toggleMainThreadStalls:(id)sender;
+- (BOOL)mainThreadStallsEnabled;
+
 - (void)didChangeSettings;
 - (BOOL)webViewFillsWindow;
 - (void)setWebViewFillsWindow:(BOOL)fillWindow;

--- a/Tools/MiniBrowser/mac/BrowserWindowController.m
+++ b/Tools/MiniBrowser/mac/BrowserWindowController.m
@@ -28,7 +28,9 @@
 #import "AppDelegate.h"
 #import "SettingsController.h"
 
-@interface BrowserWindowController () <NSSharingServicePickerDelegate, NSSharingServiceDelegate>
+@interface BrowserWindowController () <NSSharingServicePickerDelegate, NSSharingServiceDelegate> {
+    NSTimer *_mainThreadStallTimer;
+}
 @end
 
 @implementation BrowserWindowController
@@ -262,6 +264,26 @@
 - (IBAction)toggleEditable:(id)sender
 {
     self.editable = !self.isEditable;
+}
+
+- (IBAction)toggleMainThreadStalls:(id)sender
+{
+    if (_mainThreadStallTimer) {
+        [_mainThreadStallTimer invalidate];
+        _mainThreadStallTimer = nil;
+        return;
+    }
+
+    const NSTimeInterval stallTimerRepeatInterval = 0.2;
+    _mainThreadStallTimer = [NSTimer scheduledTimerWithTimeInterval:stallTimerRepeatInterval repeats:YES block:^(NSTimer * _Nonnull timer) {
+        const NSTimeInterval stallDuration = 0.2;
+        usleep(stallDuration * USEC_PER_SEC);
+    }];
+}
+
+- (BOOL)mainThreadStallsEnabled
+{
+    return !!_mainThreadStallTimer;
 }
 
 #pragma mark -

--- a/Tools/MiniBrowser/mac/MainMenu.xib
+++ b/Tools/MiniBrowser/mac/MainMenu.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16085" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -584,22 +584,19 @@
                                                     <menuItem title="Paragraph" enabled="NO" id="PX7-T3-iSU">
                                                         <modifierMask key="keyEquivalentModifierMask"/>
                                                     </menuItem>
-                                                    <menuItem id="fYp-sh-nqB">
-                                                        <string key="title">    Default</string>
+                                                    <menuItem title="    Default" id="fYp-sh-nqB">
                                                         <modifierMask key="keyEquivalentModifierMask"/>
                                                         <connections>
                                                             <action selector="makeBaseWritingDirectionNatural:" target="-1" id="z9r-Q0-zcU"/>
                                                         </connections>
                                                     </menuItem>
-                                                    <menuItem id="7Kh-vB-DZW">
-                                                        <string key="title">    Left to Right</string>
+                                                    <menuItem title="    Left to Right" id="7Kh-vB-DZW">
                                                         <modifierMask key="keyEquivalentModifierMask"/>
                                                         <connections>
                                                             <action selector="makeBaseWritingDirectionLeftToRight:" target="-1" id="By6-Xc-sQg"/>
                                                         </connections>
                                                     </menuItem>
-                                                    <menuItem id="Efq-zm-Iex">
-                                                        <string key="title">    Right to Left</string>
+                                                    <menuItem title="    Right to Left" id="Efq-zm-Iex">
                                                         <modifierMask key="keyEquivalentModifierMask"/>
                                                         <connections>
                                                             <action selector="makeBaseWritingDirectionRightToLeft:" target="-1" id="J4w-YN-dtS"/>
@@ -609,22 +606,19 @@
                                                     <menuItem title="Selection" enabled="NO" id="hEQ-Jh-r5g">
                                                         <modifierMask key="keyEquivalentModifierMask"/>
                                                     </menuItem>
-                                                    <menuItem id="m9Q-d8-VVx">
-                                                        <string key="title">    Default</string>
+                                                    <menuItem title="    Default" id="m9Q-d8-VVx">
                                                         <modifierMask key="keyEquivalentModifierMask"/>
                                                         <connections>
                                                             <action selector="makeTextWritingDirectionNatural:" target="-1" id="Ilo-c7-jCj"/>
                                                         </connections>
                                                     </menuItem>
-                                                    <menuItem id="5Ym-OR-TV9">
-                                                        <string key="title">    Left to Right</string>
+                                                    <menuItem title="    Left to Right" id="5Ym-OR-TV9">
                                                         <modifierMask key="keyEquivalentModifierMask"/>
                                                         <connections>
                                                             <action selector="makeTextWritingDirectionLeftToRight:" target="-1" id="9ca-bt-cYl"/>
                                                         </connections>
                                                     </menuItem>
-                                                    <menuItem id="blA-MU-vkf">
-                                                        <string key="title">    Right to Left</string>
+                                                    <menuItem title="    Right to Left" id="blA-MU-vkf">
                                                         <modifierMask key="keyEquivalentModifierMask"/>
                                                         <connections>
                                                             <action selector="makeTextWritingDirectionRightToLeft:" target="-1" id="0FR-dP-o2G"/>
@@ -809,6 +803,12 @@
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="toggleFullWindowWebView:" target="-1" id="X6E-15-0lw"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Main Thread Stalls" id="K3K-tr-Gix">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="toggleMainThreadStalls:" target="-1" id="djY-Q4-9vO"/>
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="553"/>

--- a/Tools/MiniBrowser/mac/WK1BrowserWindowController.m
+++ b/Tools/MiniBrowser/mac/WK1BrowserWindowController.m
@@ -175,6 +175,8 @@ static BOOL areEssentiallyEqual(double a, double b)
         menuItem.state = _webView.alwaysShowHorizontalScroller ? NSControlStateValueOn : NSControlStateValueOff;
     else if (action == @selector(toggleAlwaysShowsVerticalScroller:))
         menuItem.state = _webView.alwaysShowVerticalScroller ? NSControlStateValueOn : NSControlStateValueOff;
+    else if (action == @selector(toggleMainThreadStalls:))
+        menuItem.state = self.mainThreadStallsEnabled ? NSControlStateValueOn : NSControlStateValueOff;
 
     if (action == @selector(setPageScale:))
         [menuItem setState:areEssentiallyEqual([_webView _viewScaleFactor], [self pageScaleForMenuItemTag:[menuItem tag]])];

--- a/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
+++ b/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
@@ -274,6 +274,8 @@ static BOOL areEssentiallyEqual(double a, double b)
         menuItem.state = _webView._alwaysShowsHorizontalScroller ? NSControlStateValueOn : NSControlStateValueOff;
     else if (action == @selector(toggleAlwaysShowsVerticalScroller:))
         menuItem.state = _webView._alwaysShowsVerticalScroller ? NSControlStateValueOn : NSControlStateValueOff;
+    else if (action == @selector(toggleMainThreadStalls:))
+        menuItem.state = self.mainThreadStallsEnabled ? NSControlStateValueOn : NSControlStateValueOff;
 
     if (action == @selector(setPageScale:))
         [menuItem setState:areEssentiallyEqual([_webView _pageScale], [self pageScaleForMenuItemTag:[menuItem tag]])];


### PR DESCRIPTION
#### d1c55671822b5012f7648e9cf26bf03ca25d5076
<pre>
Add an option that makes the MiniBrowser main thread continually stall
<a href="https://bugs.webkit.org/show_bug.cgi?id=252647">https://bugs.webkit.org/show_bug.cgi?id=252647</a>
rdar://105710889

Reviewed by Wenson Hsieh.

Add an option to MiniBrowser that causes repeated main thread stalls (for 200ms every 200ms)
to simulate a poorly behaving app that has a sometimes-unresponsive main thread. This will be
used to test off-main-thread UI-side scrolling.

* Tools/MiniBrowser/mac/BrowserWindowController.h:
* Tools/MiniBrowser/mac/BrowserWindowController.m:
(-[BrowserWindowController toggleMainThreadStalls:]):
(-[BrowserWindowController mainThreadStallsEnabled]):
* Tools/MiniBrowser/mac/MainMenu.xib:
* Tools/MiniBrowser/mac/WK1BrowserWindowController.m:
(-[WK1BrowserWindowController validateMenuItem:]):
* Tools/MiniBrowser/mac/WK2BrowserWindowController.m:
(-[WK2BrowserWindowController validateMenuItem:]):

Canonical link: <a href="https://commits.webkit.org/260618@main">https://commits.webkit.org/260618@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e8ae290ae430cdfa2f13707e16dbb84572d2a70

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108871 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17975 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41708 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/413 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/118197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112753 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19433 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9254 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101112 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114641 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97796 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42675 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29437 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84416 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10749 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30786 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11504 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/7720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16893 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50382 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7335 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13091 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->