### PR TITLE
Update JavaScriptCore TBA versions for macOS 13.3 and iOS 16.4

### DIFF
--- a/Source/JavaScriptCore/API/APIIntegrityPrivate.h
+++ b/Source/JavaScriptCore/API/APIIntegrityPrivate.h
@@ -41,7 +41,7 @@ extern "C" {
 @result JSContextRef that was passed in.
 @discussion This function will crash if the audit detects any errors.
  */
-JS_EXPORT JSContextRef jsAuditJSContextRef(JSContextRef ctx) JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
+JS_EXPORT JSContextRef jsAuditJSContextRef(JSContextRef ctx) JSC_API_AVAILABLE(macos(13.0), ios(16.1));
 
 /*!
 @function
@@ -50,7 +50,7 @@ JS_EXPORT JSContextRef jsAuditJSContextRef(JSContextRef ctx) JSC_API_AVAILABLE(m
 @result JSGlobalContextRef that was passed in.
 @discussion This function will crash if the audit detects any errors.
  */
-JS_EXPORT JSGlobalContextRef jsAuditJSGlobalContextRef(JSGlobalContextRef ctx) JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
+JS_EXPORT JSGlobalContextRef jsAuditJSGlobalContextRef(JSGlobalContextRef ctx) JSC_API_AVAILABLE(macos(13.0), ios(16.1));
 
 /*!
 @function
@@ -59,7 +59,7 @@ JS_EXPORT JSGlobalContextRef jsAuditJSGlobalContextRef(JSGlobalContextRef ctx) J
 @result JSObjectRef that was passed in.
 @discussion This function will crash if the audit detects any errors.
  */
-JS_EXPORT JSObjectRef jsAuditJSObjectRef(JSObjectRef obj) JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
+JS_EXPORT JSObjectRef jsAuditJSObjectRef(JSObjectRef obj) JSC_API_AVAILABLE(macos(13.0), ios(16.1));
 
 /*!
 @function
@@ -68,7 +68,7 @@ JS_EXPORT JSObjectRef jsAuditJSObjectRef(JSObjectRef obj) JSC_API_AVAILABLE(maco
 @result JSValueRef that was passed in.
 @discussion This function will crash if the audit detects any errors.
  */
-JS_EXPORT JSValueRef jsAuditJSValueRef(JSValueRef value) JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
+JS_EXPORT JSValueRef jsAuditJSValueRef(JSValueRef value) JSC_API_AVAILABLE(macos(13.0), ios(16.1));
 
 #ifdef __cplusplus
 }

--- a/Source/JavaScriptCore/API/JSContext.h
+++ b/Source/JavaScriptCore/API/JSContext.h
@@ -179,7 +179,7 @@ JSC_CLASS_AVAILABLE(macos(10.9), ios(7.0))
 @property
 @discussion Controls whether this @link JSContext @/link is inspectable in Web Inspector. The default value is NO.
 */
-@property (nonatomic, getter=isInspectable) BOOL inspectable JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA)) NS_SWIFT_NAME(isInspectable);
+@property (nonatomic, getter=isInspectable) BOOL inspectable JSC_API_AVAILABLE(macos(13.3), ios(16.4)) NS_SWIFT_NAME(isInspectable);
 
 @end
 

--- a/Source/JavaScriptCore/API/JSContextPrivate.h
+++ b/Source/JavaScriptCore/API/JSContextPrivate.h
@@ -69,7 +69,7 @@
 @property
 @discussion Remote inspection setting of the JSContext. Default value is YES.
 */
-@property (setter=_setRemoteInspectionEnabled:) BOOL _remoteInspectionEnabled JSC_API_DEPRECATED_WITH_REPLACEMENT("inspectable", macos(10.10, JSC_MAC_TBA), ios(8.0, JSC_IOS_TBA));
+@property (setter=_setRemoteInspectionEnabled:) BOOL _remoteInspectionEnabled JSC_API_DEPRECATED_WITH_REPLACEMENT("inspectable", macos(10.10, 13.3), ios(8.0, 16.4));
 
 /*!
 @property

--- a/Source/JavaScriptCore/API/JSContextRef.h
+++ b/Source/JavaScriptCore/API/JSContextRef.h
@@ -161,7 +161,7 @@ JS_EXPORT void JSGlobalContextSetName(JSGlobalContextRef ctx, JSStringRef name) 
 @param ctx The JSGlobalContext that you want to change the inspectability of.
 @result Whether the context is inspectable in Web Inspector.
 */
-JS_EXPORT bool JSGlobalContextIsInspectable(JSGlobalContextRef ctx) JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
+JS_EXPORT bool JSGlobalContextIsInspectable(JSGlobalContextRef ctx) JSC_API_AVAILABLE(macos(13.3), ios(16.4));
 
 /*!
 @function
@@ -169,7 +169,7 @@ JS_EXPORT bool JSGlobalContextIsInspectable(JSGlobalContextRef ctx) JSC_API_AVAI
 @param ctx The JSGlobalContext that you want to change the inspectability of.
 @param inspectable YES to allow Web Inspector to connect to the context, otherwise NO.
 */
-JS_EXPORT void JSGlobalContextSetInspectable(JSGlobalContextRef ctx, bool inspectable) JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
+JS_EXPORT void JSGlobalContextSetInspectable(JSGlobalContextRef ctx, bool inspectable) JSC_API_AVAILABLE(macos(13.3), ios(16.4));
 
 #ifdef __cplusplus
 }

--- a/Source/JavaScriptCore/API/JSContextRefPrivate.h
+++ b/Source/JavaScriptCore/API/JSContextRefPrivate.h
@@ -101,7 +101,7 @@ JS_EXPORT void JSContextGroupClearExecutionTimeLimit(JSContextGroupRef group) JS
 @result The value of the setting, true if remote inspection is enabled, otherwise false.
 @discussion Remote inspection is true by default.
 */
-JS_EXPORT bool JSGlobalContextGetRemoteInspectionEnabled(JSGlobalContextRef ctx) JSC_API_DEPRECATED_WITH_REPLACEMENT("JSGlobalContextIsInspectable", macos(10.10, JSC_MAC_TBA), ios(8.0, JSC_IOS_TBA));
+JS_EXPORT bool JSGlobalContextGetRemoteInspectionEnabled(JSGlobalContextRef ctx) JSC_API_DEPRECATED_WITH_REPLACEMENT("JSGlobalContextIsInspectable", macos(10.10, 13.3), ios(8.0, 16.4));
 
 /*!
 @function
@@ -109,7 +109,7 @@ JS_EXPORT bool JSGlobalContextGetRemoteInspectionEnabled(JSGlobalContextRef ctx)
 @param ctx The JSGlobalContext that you want to change.
 @param enabled The new remote inspection enabled setting for the context.
 */
-JS_EXPORT void JSGlobalContextSetRemoteInspectionEnabled(JSGlobalContextRef ctx, bool enabled) JSC_API_DEPRECATED_WITH_REPLACEMENT("JSGlobalContextSetInspectable", macos(10.10, JSC_MAC_TBA), ios(8.0, JSC_IOS_TBA));
+JS_EXPORT void JSGlobalContextSetRemoteInspectionEnabled(JSGlobalContextRef ctx, bool enabled) JSC_API_DEPRECATED_WITH_REPLACEMENT("JSGlobalContextSetInspectable", macos(10.10, 13.3), ios(8.0, 16.4));
 
 /*!
 @function
@@ -145,7 +145,7 @@ JS_EXPORT void JSGlobalContextSetUnhandledRejectionCallback(JSGlobalContextRef c
 @param enabled The new eval enabled setting for the context.
 @param message The error message to display when user attempts to call eval (or the Function constructor). Pass NULL when setting enabled to true.
 */
-JS_EXPORT void JSGlobalContextSetEvalEnabled(JSGlobalContextRef ctx, bool enabled, JSStringRef message) JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
+JS_EXPORT void JSGlobalContextSetEvalEnabled(JSGlobalContextRef ctx, bool enabled, JSStringRef message) JSC_API_AVAILABLE(macos(12.3), ios(15.4));
 
 #ifdef __cplusplus
 }

--- a/Source/JavaScriptCore/API/JSRemoteInspector.h
+++ b/Source/JavaScriptCore/API/JSRemoteInspector.h
@@ -48,7 +48,7 @@ JS_EXPORT void JSRemoteInspectorSetParentProcessInformation(JSProcessID, const u
 JS_EXPORT void JSRemoteInspectorSetLogToSystemConsole(bool) JSC_API_AVAILABLE(macos(10.11), ios(9.0));
 
 JS_EXPORT bool JSRemoteInspectorGetInspectionEnabledByDefault(void) JSC_API_AVAILABLE(macos(10.11), ios(9.0));
-JS_EXPORT void JSRemoteInspectorSetInspectionEnabledByDefault(bool) JSC_API_DEPRECATED("Use JSGlobalContextSetInspectable on a single JSGlobalContextRef.", macos(10.11, JSC_MAC_TBA), ios(9.0, JSC_IOS_TBA));
+JS_EXPORT void JSRemoteInspectorSetInspectionEnabledByDefault(bool) JSC_API_DEPRECATED("Use JSGlobalContextSetInspectable on a single JSGlobalContextRef.", macos(10.11, 13.3), ios(9.0, 16.4));
 
 JS_EXPORT bool JSRemoteInspectorGetInspectionFollowsInternalPolicies(void) JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
 JS_EXPORT void JSRemoteInspectorSetInspectionFollowsInternalPolicies(bool) JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));


### PR DESCRIPTION
#### 75ee90767a643d903a09955acaf5e75e62587d47
<pre>
Update JavaScriptCore TBA versions for macOS 13.3 and iOS 16.4
<a href="https://bugs.webkit.org/show_bug.cgi?id=252649">https://bugs.webkit.org/show_bug.cgi?id=252649</a>
rdar://105682433

Reviewed by Patrick Angle and Yusuke Suzuki.

Finalize the availability version numbers for API/SPI that are newly
available in the latest seed, plus some older declarations that were
never updated.

* Source/JavaScriptCore/API/APIIntegrityPrivate.h:
* Source/JavaScriptCore/API/JSContext.h:
* Source/JavaScriptCore/API/JSContextPrivate.h:
* Source/JavaScriptCore/API/JSContextRef.h:
* Source/JavaScriptCore/API/JSContextRefPrivate.h:
* Source/JavaScriptCore/API/JSRemoteInspector.h:

Canonical link: <a href="https://commits.webkit.org/260895@main">https://commits.webkit.org/260895@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0c97376d184bf1bcab215231c1c4c9f25668084

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108820 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17920 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41653 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/319 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118114 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19376 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9199 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101050 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114588 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14535 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97748 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42519 "Failed to checkout and rebase branch from PR 10430") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96515 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29387 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84390 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/97921 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10699 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30737 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/98732 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/8827 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11458 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7671 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30988 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16845 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50333 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/106349 "Built successfully") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7556 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13045 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26362 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->