### PR TITLE
Don't initialize signal handing machinery if we're not going to use it.

### DIFF
--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -1,6 +1,6 @@
 /*
  *  Copyright (C) 1999-2000 Harri Porten (porten@kde.org)
- *  Copyright (C) 2004-2022 Apple Inc. All rights reserved.
+ *  Copyright (C) 2004-2023 Apple Inc. All rights reserved.
  *  Copyright (C) 2006 Bjoern Graf (bjoern.graf@gmail.com)
  *
  *  This library is free software; you can redistribute it and/or
@@ -3072,6 +3072,8 @@ JSC_DEFINE_HOST_FUNCTION(functionDropAllLocks, (JSGlobalObject* globalObject, Ca
 #define EXCEPT(x)
 #endif
 
+static BinarySemaphore waitToExit;
+
 int jscmain(int argc, char** argv);
 
 #if OS(DARWIN) || OS(LINUX)
@@ -3219,19 +3221,6 @@ int main(int argc, char** argv)
     WTF::initialize();
 #if PLATFORM(COCOA)
     WTF::disableForwardingVPrintfStdErrToOSLog();
-#endif
-
-#if OS(UNIX)
-    BinarySemaphore waitToExit;
-
-    if (getenv("JS_SHELL_WAIT_FOR_SIGUSR2_TO_EXIT")) {
-        addSignalHandler(Signal::Usr, SignalHandler([&] (Signal, SigInfo&, PlatformRegisters&) {
-            dataLogLn("Signal handler hit, we can exit now.");
-            waitToExit.signal();
-            return SignalAction::Handled;
-        }));
-        activateSignalHandlersFor(Signal::Usr);
-    }
 #endif
 
     // We can't use destructors in the following code because it uses Windows
@@ -3672,6 +3661,8 @@ void CommandLine::parseArguments(int argc, char** argv)
         }
         if (!strcmp(arg, "-s")) {
 #if OS(UNIX)
+            initializeSignalHandling();
+
             SignalAction (*exit)(Signal, SigInfo&, PlatformRegisters&) = [] (Signal, SigInfo&, PlatformRegisters&) {
                 dataLogLn("Signal handler hit. Exiting with status 0");
                 _exit(0);
@@ -3954,6 +3945,19 @@ int jscmain(int argc, char** argv)
     // Note that the options parsing can affect VM creation, and thus
     // comes first.
     mainCommandLine.construct(argc, argv);
+
+#if OS(UNIX)
+
+    if (getenv("JS_SHELL_WAIT_FOR_SIGUSR2_TO_EXIT")) {
+        initializeSignalHandling();
+        addSignalHandler(Signal::Usr, SignalHandler([&] (Signal, SigInfo&, PlatformRegisters&) {
+            dataLogLn("Signal handler hit, we can exit now.");
+            waitToExit.signal();
+            return SignalAction::Handled;
+        }));
+        activateSignalHandlersFor(Signal::Usr);
+    }
+#endif
 
     {
         Options::AllowUnfinalizedAccessScope scope;

--- a/Source/JavaScriptCore/runtime/InitializeThreading.cpp
+++ b/Source/JavaScriptCore/runtime/InitializeThreading.cpp
@@ -119,14 +119,16 @@ void initialize()
         if (VM::isInMiniMode())
             WTF::fastEnableMiniMode();
 
-#if HAVE(MACH_EXCEPTIONS)
-        // JSLock::lock() can call registerThreadForMachExceptionHandling() which crashes if this has not been called first.
-        WTF::startMachExceptionHandlerThread();
-#endif
-        VMTraps::initializeSignals();
-#if ENABLE(WEBASSEMBLY)
-        Wasm::prepareSignalingMemory();
-#endif
+        if (Wasm::isSupported() || !Options::usePollingTraps()) {
+            // JSLock::lock() can call registerThreadForMachExceptionHandling() which crashes if this has not been called first.
+            initializeSignalHandling();
+
+            if (!Options::usePollingTraps())
+                VMTraps::initializeSignals();
+            if (Wasm::isSupported())
+                Wasm::prepareSignalingMemory();
+        } else
+            disableSignalHandling();
 
         WTF::compilerFence();
         RELEASE_ASSERT(!g_jscConfig.initializeHasBeenCalled);

--- a/Source/JavaScriptCore/runtime/VMEntryScope.cpp
+++ b/Source/JavaScriptCore/runtime/VMEntryScope.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,6 +33,7 @@
 #include "WasmMachineThreads.h"
 #include "Watchdog.h"
 #include <wtf/SystemTracing.h>
+#include <wtf/WTFConfig.h>
 
 namespace JSC {
 
@@ -47,12 +48,10 @@ VMEntryScope::VMEntryScope(VM& vm, JSGlobalObject* globalObject)
         if (UNLIKELY(!thread.isJSThread())) {
             Thread::registerJSThread(thread);
 
-#if ENABLE(WEBASSEMBLY)
-                if (Wasm::isSupported())
-                    Wasm::startTrackingCurrentThread();
-#endif
-
+            if (Wasm::isSupported())
+                Wasm::startTrackingCurrentThread();
 #if HAVE(MACH_EXCEPTIONS)
+            if (g_wtfConfig.signalHandlers.initState == WTF::SignalHandlers::InitState::AddedHandlers)
                 registerThreadForMachExceptionHandling(thread);
 #endif
         }

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -3644,11 +3644,7 @@ JSC_DEFINE_HOST_FUNCTION(functionParseCount, (JSGlobalObject*, CallFrame*))
 JSC_DEFINE_HOST_FUNCTION(functionIsWasmSupported, (JSGlobalObject*, CallFrame*))
 {
     DollarVMAssertScope assertScope;
-#if ENABLE(WEBASSEMBLY)
     return JSValue::encode(jsBoolean(Wasm::isSupported()));
-#else
-    return JSValue::encode(jsBoolean(false));
-#endif
 }
 
 JSC_DEFINE_HOST_FUNCTION(functionMake16BitStringIfPossible, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/JavaScriptCore/wasm/WasmCapabilities.h
+++ b/Source/JavaScriptCore/wasm/WasmCapabilities.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,9 +31,15 @@
 namespace JSC {
 namespace Wasm {
 
+#if ENABLE(WEBASSEMBLY)
+
 inline bool isSupported()
 {
     return Options::useWebAssembly();
 }
+
+#else
+inline bool isSupported() { return false; }
+#endif
 
 } } // namespace JSC::Wasm

--- a/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.h
+++ b/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,15 +25,16 @@
 
 #pragma once
 
-#if ENABLE(WEBASSEMBLY)
-
 namespace JSC {
 
 namespace Wasm {
 
+#if ENABLE(WEBASSEMBLY)
 void activateSignalingMemory();
 void prepareSignalingMemory();
+#else
+inline void activateSignalingMemory() { }
+inline void prepareSignalingMemory() { }
+#endif // ENABLE(WEBASSEMBLY)
 
 } } // namespace JSC::Wasm
-
-#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/WasmMachineThreads.h
+++ b/Source/JavaScriptCore/wasm/WasmMachineThreads.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -40,6 +40,15 @@ void startTrackingCurrentThread();
 
 void resetInstructionCacheOnAllThreads();
     
+} } // namespace JSC::Wasm
+
+#else // not ENABLE(WEBASSEMBLY)
+
+namespace JSC { namespace Wasm {
+
+inline void startTrackingCurrentThread() { }
+inline void resetInstructionCacheOnAllThreads() { }
+
 } } // namespace JSC::Wasm
 
 #endif // ENABLE(WEBASSEMBLY)

--- a/Source/WTF/wtf/threads/Signals.cpp
+++ b/Source/WTF/wtf/threads/Signals.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -88,6 +88,10 @@ void SignalHandlers::add(Signal signal, SignalHandler&& handler)
     // partially initialized handler.
     storeStoreFence();
     numberOfHandlers[signalIndex]++;
+#if HAVE(MACH_EXCEPTIONS)
+    RELEASE_ASSERT(initState >= InitState::InitializedHandlerThread);
+    initState = InitState::AddedHandlers;
+#endif
     loadLoadFence();
 }
 
@@ -111,10 +115,16 @@ inline void SignalHandlers::forEachHandler(Signal signal, const Func& func) cons
 
 static constexpr size_t maxMessageSize = 1 * KB;
 
-void startMachExceptionHandlerThread()
+void initMachExceptionHandlerThread(bool enable)
 {
     static std::once_flag once;
-    std::call_once(once, [] {
+    std::call_once(once, [=] {
+        RELEASE_ASSERT(g_wtfConfig.signalHandlers.initState == SignalHandlers::InitState::Uninitialized);
+        g_wtfConfig.signalHandlers.initState = SignalHandlers::InitState::InitializedHandlerThread;
+
+        if (!enable || !g_wtfConfig.signalHandlers.useMach)
+            return;
+
         Config::AssertNotFrozenScope assertScope;
         SignalHandlers& handlers = g_wtfConfig.signalHandlers;
         kern_return_t kr = mach_port_allocate(mach_task_self(), MACH_PORT_RIGHT_RECEIVE, &handlers.exceptionPort);
@@ -464,6 +474,7 @@ static ThreadGroup& activeThreads()
 
 void registerThreadForMachExceptionHandling(Thread& thread)
 {
+    RELEASE_ASSERT(g_wtfConfig.signalHandlers.initState == SignalHandlers::InitState::AddedHandlers);
     Locker locker { activeThreads().getLock() };
     if (activeThreads().add(locker, thread) == ThreadGroupAddResult::NewlyAdded)
         setExceptionPorts(locker, thread);
@@ -485,10 +496,8 @@ void addSignalHandler(Signal signal, SignalHandler&& handler)
     SignalHandlers& handlers = g_wtfConfig.signalHandlers;
     ASSERT(signal < Signal::Unknown);
     ASSERT(!handlers.useMach || signal != Signal::Usr);
-
 #if HAVE(MACH_EXCEPTIONS)
-    if (handlers.useMach)
-        startMachExceptionHandlerThread();
+    RELEASE_ASSERT(handlers.initState >= SignalHandlers::InitState::InitializedHandlerThread);
 #endif
 
     static std::once_flag initializeOnceFlags[static_cast<size_t>(Signal::NumberOfSignals)];
@@ -520,6 +529,7 @@ void activateSignalHandlersFor(Signal signal)
     UNUSED_PARAM(signal);
 #if HAVE(MACH_EXCEPTIONS)
     const SignalHandlers& handlers = g_wtfConfig.signalHandlers;
+    RELEASE_ASSERT(handlers.initState >= SignalHandlers::InitState::InitializedHandlerThread);
     ASSERT(signal < Signal::Unknown);
     ASSERT(!handlers.useMach || signal != Signal::Usr);
 

--- a/Source/WTF/wtf/threads/Signals.h
+++ b/Source/WTF/wtf/threads/Signals.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -119,6 +119,13 @@ struct SignalHandlers {
     mach_port_t exceptionPort;
     exception_mask_t addedExceptions;
     bool useMach;
+
+    enum class InitState : uint8_t {
+        Uninitialized = 0,
+        InitializedHandlerThread,
+        AddedHandlers
+    };
+    InitState initState;
 #else
     static constexpr bool useMach = false;
 #endif
@@ -141,9 +148,14 @@ WTF_EXPORT_PRIVATE void activateSignalHandlersFor(Signal);
 #if HAVE(MACH_EXCEPTIONS)
 class Thread;
 void registerThreadForMachExceptionHandling(Thread&);
-void startMachExceptionHandlerThread();
+WTF_EXPORT_PRIVATE void initMachExceptionHandlerThread(bool);
+inline void initializeSignalHandling() { initMachExceptionHandlerThread(true); }
+inline void disableSignalHandling() { initMachExceptionHandlerThread(false); }
 
 void handleSignalsWithMach();
+#else
+inline void initializeSignalHandling() { }
+inline void disableSignalHandling() { }
 #endif // HAVE(MACH_EXCEPTIONS)
 
 } // namespace WTF
@@ -161,5 +173,7 @@ using WTF::SignalAction;
 using WTF::SignalHandler;
 using WTF::addSignalHandler;
 using WTF::activateSignalHandlersFor;
+using WTF::initializeSignalHandling;
+using WTF::disableSignalHandling;
 
 #endif // OS(UNIX)

--- a/Tools/TestWebKitAPI/Tests/WTF/Signals.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Signals.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -40,6 +40,7 @@ public:
 TEST(Signals, SignalsWorkOnExit)
 {
     static bool handlerRan = false;
+    initializeSignalHandling();
     addSignalHandler(Signal::Usr, [] (Signal signal, SigInfo&, PlatformRegisters&) -> SignalAction {
         RELEASE_ASSERT(signal == Signal::Usr);
 


### PR DESCRIPTION
#### 0051847d2a3954b88fc4669e9238f730df68cfd4
<pre>
Don&apos;t initialize signal handing machinery if we&apos;re not going to use it.
<a href="https://bugs.webkit.org/show_bug.cgi?id=252651">https://bugs.webkit.org/show_bug.cgi?id=252651</a>
rdar://105712893

Reviewed by Yusuke Suzuki.

This saves some memory when the signal handling machinery is not needed.

1. Move the handling of JS_SHELL_WAIT_FOR_SIGUSR2_TO_EXIT in jsc.cpp into jscmain.
   This is because addSignalHandler() depends on JSC Options, and the Options have
   not be initialized yet at its previous location.

2. Make signal handling stages explicit with an InitState in WTF::Config.  The
   InitState can go from Uninitialized to InitializedHandlerThread, and then to
   AddedHandlers.  The InitState cannot go in reverse.

   The client must call initializeSignalHandling() to advance the InitState from
   Uninitialized to InitializedHandlerThread.

   The client must have called addSignalHandler() in order to advance the InitState
   from InitializedHandlerThread to AddedHandlers.  If addSignalHandler() is called
   without first calling initializeSignalHandling(), a RELEASE_ASSERT will fail.

   The client can only call registerThreadForMachExceptionHandling() after one or
   more addSignalHandler() has been called.  registerThreadForMachExceptionHandling()
   will not RELEASE_ASSERT that the InitState is AddedHandlers.

3. Added stub functions for Wasm::isSupported(), Wasm::activateSignalingMemory(),
   Wasm::prepareSignalingMemory(), Wasm::startTrackingCurrentThread(), and
   Wasm::resetInstructionCacheOnAllThreads() so that they can be called without first
   checking #if on some WASM #define variable.

* Source/JavaScriptCore/jsc.cpp:
(main):
(CommandLine::parseArguments):
(jscmain):
* Source/JavaScriptCore/runtime/InitializeThreading.cpp:
(JSC::initialize):
* Source/JavaScriptCore/runtime/VMEntryScope.cpp:
(JSC::VMEntryScope::VMEntryScope):
* Source/JavaScriptCore/tools/JSDollarVM.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/wasm/WasmCapabilities.h:
(JSC::Wasm::isSupported):
* Source/JavaScriptCore/wasm/WasmFaultSignalHandler.h:
(JSC::Wasm::activateSignalingMemory):
(JSC::Wasm::prepareSignalingMemory):
* Source/JavaScriptCore/wasm/WasmMachineThreads.h:
(JSC::Wasm::startTrackingCurrentThread):
(JSC::Wasm::resetInstructionCacheOnAllThreads):
* Source/WTF/wtf/threads/Signals.cpp:
(WTF::SignalHandlers::add):
(WTF::initMachExceptionHandlerThread):
(WTF::registerThreadForMachExceptionHandling):
(WTF::addSignalHandler):
(WTF::activateSignalHandlersFor):
(WTF::startMachExceptionHandlerThread): Deleted.
* Source/WTF/wtf/threads/Signals.h:
(WTF::initializeSignalHandling):
(WTF::disableSignalHandling):
(WTF::registerThreadForMachExceptionHandling):
* Tools/TestWebKitAPI/Tests/WTF/Signals.cpp:
(TEST):

Canonical link: <a href="https://commits.webkit.org/260623@main">https://commits.webkit.org/260623@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1cae4adc610dadf1d53c59c6f5ce70269dad40a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108837 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17939 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41672 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/372 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118124 "Hash d1cae4ad for PR 10431 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112718 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19395 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9218 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101071 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114605 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14560 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97759 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42531 "Failed to checkout and rebase branch from PR 10431") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29399 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84368 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/97931 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10715 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30748 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/38/builds/98739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/8842 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11470 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7682 "Passed tests") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/38/builds/98739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16859 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50347 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/106363 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7340 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13057 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26367 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->