### PR TITLE
Use an rvalue reference argument for the GstSpeechSynthesisWrapper constructor

### DIFF
--- a/Source/WebCore/platform/gstreamer/PlatformSpeechSynthesizerGStreamer.cpp
+++ b/Source/WebCore/platform/gstreamer/PlatformSpeechSynthesizerGStreamer.cpp
@@ -42,7 +42,7 @@ class GstSpeechSynthesisWrapper {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(GstSpeechSynthesisWrapper);
 public:
-    explicit GstSpeechSynthesisWrapper(Ref<PlatformSpeechSynthesizer>);
+    explicit GstSpeechSynthesisWrapper(Ref<PlatformSpeechSynthesizer>&&);
     ~GstSpeechSynthesisWrapper();
 
     void pause();
@@ -62,7 +62,7 @@ private:
     GRefPtr<GstElement> m_pitchElement;
 };
 
-GstSpeechSynthesisWrapper::GstSpeechSynthesisWrapper(Ref<PlatformSpeechSynthesizer> synthesizer)
+GstSpeechSynthesisWrapper::GstSpeechSynthesisWrapper(Ref<PlatformSpeechSynthesizer>&& synthesizer)
     : m_platformSynthesizer(synthesizer)
 {
     ensureGStreamerInitialized();


### PR DESCRIPTION
#### 5e6a4c1f5660fb96e455c1722ce2b3c24ed37fd2
<pre>
Use an rvalue reference argument for the GstSpeechSynthesisWrapper constructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=252653">https://bugs.webkit.org/show_bug.cgi?id=252653</a>

Reviewed by Philippe Normand.

Using an rvalue reference argument, we avoid an unnecessary copy of
PlatformSpeechSynthesizer in the GstSpeechSynthesisWrapper constructor.

* Source/WebCore/platform/gstreamer/PlatformSpeechSynthesizerGStreamer.cpp:
(WebCore::GstSpeechSynthesisWrapper::GstSpeechSynthesisWrapper):

Canonical link: <a href="https://commits.webkit.org/260600@main">https://commits.webkit.org/260600@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d0780f3ae516515750f481dab623717b1b1efa3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108830 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17930 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41663 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/363 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/118119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112710 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19386 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9209 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101062 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114598 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97752 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/42527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29391 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/84364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10707 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30741 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11464 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/7675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16853 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50339 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7321 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13051 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->