### PR TITLE
[WebCryptoAPI] Secure Curves have no namedCurve

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/util/helpers.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/util/helpers.js
@@ -130,6 +130,10 @@ function assert_goodCryptoKey(key, algorithm, extractable, usages, kind) {
         assert_equals(key.algorithm.hash.name.toUpperCase(), algorithm.hash.toUpperCase(), "Correct hash function");
     }
 
+    if (/^(?:Ed|X)(?:25519|448)$/.test(key.algorithm.name)) {
+        assert_false('namedCurve' in key.algorithm, "Does not have a namedCurve property");
+    }
+
     // usages is expected to be provided for a key pair, but we are checking
     // only a single key. The publicKey and privateKey portions of a key pair
     // recognize only some of the usages appropriate for a key pair.

--- a/Source/WebCore/crypto/keys/CryptoKeyOKP.cpp
+++ b/Source/WebCore/crypto/keys/CryptoKeyOKP.cpp
@@ -194,19 +194,7 @@ bool CryptoKeyOKP::isValidOKPAlgorithm(CryptoAlgorithmIdentifier algorithm)
 
 auto CryptoKeyOKP::algorithm() const -> KeyAlgorithm
 {
-    CryptoEcKeyAlgorithm result;
-    result.name = CryptoAlgorithmRegistry::singleton().name(algorithmIdentifier());
-
-    switch (m_curve) {
-    case NamedCurve::X25519:
-        result.namedCurve = X25519;
-        break;
-    case NamedCurve::Ed25519:
-        result.namedCurve = Ed25519;
-        break;
-    }
-
-    return result;
+    return CryptoKeyAlgorithm { CryptoAlgorithmRegistry::singleton().name(algorithmIdentifier()) };
 }
 
 #if !PLATFORM(COCOA)


### PR DESCRIPTION
#### 8722815f4f9c461a6853d8bccee66ea0688ebdb0
<pre>
[WebCryptoAPI] Secure Curves have no namedCurve
<a href="https://bugs.webkit.org/show_bug.cgi?id=252555">https://bugs.webkit.org/show_bug.cgi?id=252555</a>
rdar://problem/105666277

Reviewed by Chris Dumez.

As per <a href="https://wicg.github.io/webcrypto-secure-curves/#ed25519-description">https://wicg.github.io/webcrypto-secure-curves/#ed25519-description</a>, the key algorithm is a simple KeyAlgorithm.
Update code accordingly.
Covered by test change cherry-picked from WPT upstream.

* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/util/helpers.js:
(assert_goodCryptoKey):
* Source/WebCore/crypto/keys/CryptoKeyOKP.cpp:
(WebCore::CryptoKeyOKP::algorithm const):

Canonical link: <a href="https://commits.webkit.org/260599@main">https://commits.webkit.org/260599@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da54f41dc097b49cf19487dc489d81b32ba1a110

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108836 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17938 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41671 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/371 "Updated wpe dependencies (failure)") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/118123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112717 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19394 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9217 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101070 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114604 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/97755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/42589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29395 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/84378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10714 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/30744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11469 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/7680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16858 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50343 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7320 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13056 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->