### PR TITLE
Add a functional background fetch backend

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -515,6 +515,12 @@ imported/w3c/web-platform-tests/x-frame-options/invalid.html [ DumpJSConsoleLogI
 imported/w3c/web-platform-tests/x-frame-options/multiple.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/x-frame-options/sameorigin.sub.html [ DumpJSConsoleLogInStdErr ]
 
+# Timing out tests.
+imported/w3c/web-platform-tests/background-fetch/fetch-uploads.https.window.html [ Skip ]
+imported/w3c/web-platform-tests/background-fetch/match.https.window.html [ Skip ]
+imported/w3c/web-platform-tests/background-fetch/update-ui.https.window.html [ Skip ]
+imported/w3c/web-platform-tests/background-fetch/fetch.https.window.html [ Skip ]
+
 # Skip some WPT that require cross-origin testrunner features we don't yet support, causing timeouts.
 imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic.http-rp/opt-in/xhr.https.html [ Skip ]
 imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module.http-rp/opt-in/xhr.https.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/background-fetch/abort.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/background-fetch/abort.https.window-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Aborting the same registration twice fails promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL Calling BackgroundFetchRegistration.abort sets the correct fields and responses are still available promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL An aborted fetch throws a DOM exception when accessing an incomplete record promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+PASS Aborting the same registration twice fails
+PASS Calling BackgroundFetchRegistration.abort sets the correct fields and responses are still available
+PASS An aborted fetch throws a DOM exception when accessing an incomplete record
 

--- a/LayoutTests/imported/w3c/web-platform-tests/background-fetch/content-security-policy.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/background-fetch/content-security-policy.https.window-expected.txt
@@ -1,5 +1,3 @@
 
-FAIL fetch blocked by CSP should reject promise_rejects_js: function "function () { throw e }" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+FAIL fetch blocked by CSP should reject assert_unreached: Should have rejected: undefined Reached unreachable code
 

--- a/LayoutTests/imported/w3c/web-platform-tests/background-fetch/fetch-uploads.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/background-fetch/fetch-uploads.https.window-expected.txt
@@ -1,5 +1,7 @@
 
-FAIL Fetch with an upload should work promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL Progress event includes uploaded bytes promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL Duplicate upload requests work and can be distinguished. promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+Harness Error (TIMEOUT), message = null
+
+FAIL Fetch with an upload should work assert_equals: expected 17 but got 0
+TIMEOUT Progress event includes uploaded bytes Test timed out
+NOTRUN Duplicate upload requests work and can be distinguished.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/background-fetch/fetch.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/background-fetch/fetch.https.window-expected.txt
@@ -1,20 +1,18 @@
 
-FAIL Background Fetch requires an activated Service Worker promise_rejects_js: fetch() must reject on pending and installing workers function "function () { throw e }" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+Harness Error (TIMEOUT), message = null
+
+FAIL Background Fetch requires an activated Service Worker assert_unreached: Should have rejected: fetch() must reject on pending and installing workers Reached unreachable code
 PASS Argument verification is done for BackgroundFetchManager.fetch()
-FAIL IDs must be unique among active Background Fetch registrations promise_rejects_js: function "function () { throw e }" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Empty URL is OK. promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL Requests with PUT method require CORS Preflight and succeed. promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL Requests with text/json content type require CORS Preflight and succeed. promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL Using Background Fetch to successfully fetch a single resource promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL Registration object gets updated values when a background fetch completes. promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL Background Fetch that exceeds the quota throws a QuotaExceededError promise_rejects_dom: This fetch should have thrown a quota exceeded error function "function () { throw e }" threw object "NotSupportedError: The operation is not supported." that is not a DOMException QUOTA_EXCEEDED_ERR: property "code" is equal to 9, expected 22
-FAIL Fetches can have requests with duplicate URLs promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL recordsAvailable is false after onbackgroundfetchsuccess finishes execution. promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL Using Background Fetch to fetch a non-existent resource should fail. promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL Fetches with mixed content should fail. promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL Responses failing CORS checks are not leaked promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+PASS IDs must be unique among active Background Fetch registrations
+PASS Empty URL is OK.
+TIMEOUT Requests with PUT method require CORS Preflight and succeed. Test timed out
+NOTRUN Requests with text/json content type require CORS Preflight and succeed.
+NOTRUN Using Background Fetch to successfully fetch a single resource
+NOTRUN Registration object gets updated values when a background fetch completes.
+NOTRUN Background Fetch that exceeds the quota throws a QuotaExceededError
+NOTRUN Fetches can have requests with duplicate URLs
+NOTRUN recordsAvailable is false after onbackgroundfetchsuccess finishes execution.
+NOTRUN Using Background Fetch to fetch a non-existent resource should fail.
+NOTRUN Fetches with mixed content should fail.
+NOTRUN Responses failing CORS checks are not leaked
 

--- a/LayoutTests/imported/w3c/web-platform-tests/background-fetch/get-ids.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/background-fetch/get-ids.https.window-expected.txt
@@ -1,4 +1,4 @@
 
 PASS BackgroundFetchManager.getIds() does not require an activated worker
-FAIL The BackgroundFetchManager exposes active fetches promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+PASS The BackgroundFetchManager exposes active fetches
 

--- a/LayoutTests/imported/w3c/web-platform-tests/background-fetch/get.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/background-fetch/get.https.window-expected.txt
@@ -1,5 +1,5 @@
 
 FAIL BackgroundFetchManager.get() does not require an activated worker assert_equals: expected (undefined) undefined but got (object) null
 FAIL Getting non-existing registrations yields `undefined` assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL Getting an existing registration has the expected values promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+PASS Getting an existing registration has the expected values
 

--- a/LayoutTests/imported/w3c/web-platform-tests/background-fetch/match.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/background-fetch/match.https.window-expected.txt
@@ -1,7 +1,9 @@
 
-FAIL Matching to a single request should work promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL Matching to a non-existing request should work promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL Matching multiple times on the same request works as expected. promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL Access to active fetches is supported. promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL Match with query options. promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+Harness Error (TIMEOUT), message = null
+
+FAIL Matching to a single request should work assert_equals: expected "Background Fetch" but got ""
+TIMEOUT Matching to a non-existing request should work Test timed out
+NOTRUN Matching multiple times on the same request works as expected.
+NOTRUN Access to active fetches is supported.
+NOTRUN Match with query options.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/background-fetch/mixed-content-and-allowed-schemes.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/background-fetch/mixed-content-and-allowed-schemes.https.window-expected.txt
@@ -1,18 +1,10 @@
 
-FAIL https: fetch should register ok promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL loopback IPv4 http: fetch should register ok promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL loopback IPv6 http: fetch should register ok promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL localhost http: fetch should register ok promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL wss: fetch should reject promise_rejects_js: function "function () { throw e }" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL file: fetch should reject promise_rejects_js: function "function () { throw e }" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL data: fetch should reject promise_rejects_js: function "function () { throw e }" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL unknown scheme fetch should reject promise_rejects_js: function "function () { throw e }" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS https: fetch should register ok
+PASS loopback IPv4 http: fetch should register ok
+PASS loopback IPv6 http: fetch should register ok
+PASS localhost http: fetch should register ok
+FAIL wss: fetch should reject assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL file: fetch should reject assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL data: fetch should reject assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL unknown scheme fetch should reject assert_unreached: Should have rejected: undefined Reached unreachable code
 

--- a/LayoutTests/imported/w3c/web-platform-tests/background-fetch/port-blocking.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/background-fetch/port-blocking.https.window-expected.txt
@@ -1,10 +1,8 @@
 
-FAIL fetch to default https port should register ok promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL fetch to default http port should register ok promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL fetch to port 443 should register ok promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL fetch to port 80 should register ok, even over https promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL fetch to non-default non-bad port (8080) should register ok promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL fetch to bad port (SMTP) should reject promise_rejects_js: function "function () { throw e }" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS fetch to default https port should register ok
+PASS fetch to default http port should register ok
+PASS fetch to port 443 should register ok
+PASS fetch to port 80 should register ok, even over https
+PASS fetch to non-default non-bad port (8080) should register ok
+FAIL fetch to bad port (SMTP) should reject assert_unreached: Should have rejected: undefined Reached unreachable code
 

--- a/LayoutTests/imported/w3c/web-platform-tests/background-fetch/update-ui.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/background-fetch/update-ui.https.window-expected.txt
@@ -1,5 +1,7 @@
 
-FAIL Background Fetch updateUI resolves promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL Background Fetch updateUI called twice fails promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL Background Fetch updateUI fails when event is not active promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT Background Fetch updateUI resolves Test timed out
+NOTRUN Background Fetch updateUI called twice fails
+NOTRUN Background Fetch updateUI fails when event is not active
 

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2260,13 +2260,16 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     workers/service/ServiceWorkerTypes.h
     workers/service/ServiceWorkerUpdateViaCache.h
 
+    workers/service/background-fetch/BackgroundFetch.h
     workers/service/background-fetch/BackgroundFetchFailureReason.h
     workers/service/background-fetch/BackgroundFetchInformation.h
     workers/service/background-fetch/BackgroundFetchOptions.h
     workers/service/background-fetch/BackgroundFetchRecordIdentifier.h
     workers/service/background-fetch/BackgroundFetchRecordInformation.h
+    workers/service/background-fetch/BackgroundFetchRecordLoader.h
     workers/service/background-fetch/BackgroundFetchRequest.h
     workers/service/background-fetch/BackgroundFetchResult.h
+    workers/service/background-fetch/BackgroundFetchStore.h
     workers/service/background-fetch/BackgroundFetchUIOptions.h
     workers/service/background-fetch/ImageResource.h
 

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2947,6 +2947,8 @@ workers/service/ServiceWorkerRegistrationKey.cpp
 workers/service/ServiceWorkerRegistrationOptions.cpp
 workers/service/ServiceWorkerWindowClient.cpp
 workers/service/WorkerSWClientConnection.cpp
+workers/service/background-fetch/BackgroundFetch.cpp
+workers/service/background-fetch/BackgroundFetchEngine.cpp
 workers/service/background-fetch/BackgroundFetchEvent.cpp
 workers/service/background-fetch/BackgroundFetchManager.cpp
 workers/service/background-fetch/BackgroundFetchRecord.cpp

--- a/Source/WebCore/workers/service/ServiceWorkerRegistrationKey.h
+++ b/Source/WebCore/workers/service/ServiceWorkerRegistrationKey.h
@@ -40,9 +40,9 @@ public:
     ServiceWorkerRegistrationKey() = default;
     WEBCORE_EXPORT ServiceWorkerRegistrationKey(SecurityOriginData&& topOrigin, URL&& scope);
 
-    static ServiceWorkerRegistrationKey emptyKey();
+    WEBCORE_EXPORT static ServiceWorkerRegistrationKey emptyKey();
 
-    bool operator==(const ServiceWorkerRegistrationKey&) const;
+    WEBCORE_EXPORT bool operator==(const ServiceWorkerRegistrationKey&) const;
     bool operator!=(const ServiceWorkerRegistrationKey& key) const { return !(*this == key); }
     bool isEmpty() const { return *this == emptyKey(); }
     WEBCORE_EXPORT bool isMatching(const SecurityOriginData& topOrigin, const URL& clientURL) const;

--- a/Source/WebCore/workers/service/WorkerSWClientConnection.cpp
+++ b/Source/WebCore/workers/service/WorkerSWClientConnection.cpp
@@ -490,15 +490,14 @@ void WorkerSWClientConnection::matchBackgroundFetch(ServiceWorkerRegistrationIde
     });
 }
 
-using CrossThreadResponseDataOrException = ExceptionOr<ResourceResponse::CrossThreadData>;
-static CrossThreadResponseDataOrException toCrossThreadData(ExceptionOr<ResourceResponse>&& data)
+static ExceptionOr<ResourceResponse::CrossThreadData> toCrossThreadData(ExceptionOr<ResourceResponse>&& data)
 {
     if (data.hasException())
         return data.releaseException().isolatedCopy();
     return data.releaseReturnValue().crossThreadData();
 }
 
-static ExceptionOr<ResourceResponse> fromCrossThreadData(CrossThreadResponseDataOrException&& data)
+static ExceptionOr<ResourceResponse> fromCrossThreadData(ExceptionOr<ResourceResponse::CrossThreadData>&& data)
 {
     if (data.hasException())
         return data.releaseException();

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetch.cpp
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetch.cpp
@@ -1,0 +1,351 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "BackgroundFetch.h"
+
+#if ENABLE(SERVICE_WORKER)
+
+#include "BackgroundFetchInformation.h"
+#include "BackgroundFetchRecordInformation.h"
+#include "CacheQueryOptions.h"
+#include "ExceptionData.h"
+#include "SWServerRegistration.h"
+
+namespace WebCore {
+
+BackgroundFetch::BackgroundFetch(SWServerRegistration& registration, const String& identifier, Vector<BackgroundFetchRequest>&& requests, BackgroundFetchOptions&& options, Ref<BackgroundFetchStore>&& store, NotificationCallback&& notificationCallback)
+    : m_identifier(identifier)
+    , m_options(WTFMove(options))
+    , m_registrationKey(registration.key())
+    , m_registrationIdentifier(registration.identifier())
+    , m_store(WTFMove(store))
+    , m_notificationCallback(WTFMove(notificationCallback))
+    , m_origin { m_registrationKey.topOrigin(), SecurityOriginData::fromURL(m_registrationKey.scope()) }
+{
+    size_t index = 0;
+    m_records.reserveInitialCapacity(requests.size());
+    for (auto& request : requests)
+        m_records.uncheckedAppend(Record::create(*this, WTFMove(request), index++));
+    doStore();
+}
+
+BackgroundFetch::~BackgroundFetch()
+{
+    abort();
+}
+
+BackgroundFetchInformation BackgroundFetch::information() const
+{
+    return { m_registrationIdentifier, m_identifier, m_uploadTotal, m_currentUploadSize, downloadTotal(), m_currentDownloadSize, m_result, m_failureReason, m_recordsAvailableFlag };
+}
+
+void BackgroundFetch::match(const RetrieveRecordsOptions& options, MatchBackgroundFetchCallback&& callback)
+{
+    WebCore::CacheQueryOptions queryOptions { options.ignoreSearch, options.ignoreMethod, options.ignoreVary };
+
+    Vector<Ref<Record>> records;
+    for (auto& record : m_records) {
+        if (options.request.url().isNull() || record->isMatching(options.request, queryOptions))
+            records.append(record);
+    }
+
+    callback(WTFMove(records));
+}
+
+bool BackgroundFetch::abort()
+{
+    if (m_abortFlag)
+        return false;
+
+    m_abortFlag = true;
+    m_isActive = false;
+
+    for (auto& record : m_records)
+        record->abort();
+
+    updateBackgroundFetchStatus(BackgroundFetchResult::Failure, BackgroundFetchFailureReason::Aborted);
+    return true;
+}
+
+void BackgroundFetch::perform(const CreateLoaderCallback& createLoaderCallback)
+{
+    m_currentDownloadSize = 0;
+    for (auto& record : m_records)
+        record->complete(createLoaderCallback);
+}
+
+void BackgroundFetch::storeResponse(size_t index, ResourceResponse&& response)
+{
+    UNUSED_PARAM(index);
+    ASSERT(index < m_records.size());
+    if (!response.isSuccessful()) {
+        updateBackgroundFetchStatus(BackgroundFetchResult::Failure, BackgroundFetchFailureReason::BadStatus);
+        return;
+    }
+    doStore();
+}
+
+void BackgroundFetch::storeResponseBodyChunk(size_t index, const SharedBuffer& data)
+{
+    ASSERT(index < m_records.size());
+    m_currentDownloadSize += data.size();
+    if (downloadTotal() && m_currentDownloadSize >= downloadTotal()) {
+        updateBackgroundFetchStatus(BackgroundFetchResult::Failure, BackgroundFetchFailureReason::DownloadTotalExceeded);
+        return;
+    }
+
+    updateBackgroundFetchStatus(m_result, m_failureReason);
+    m_store->storeFetchResponseBodyChunk(m_registrationKey, m_identifier, index, data, [weakThis = WeakPtr { *this }](auto result) {
+        if (weakThis)
+            weakThis->handleStoreResult(result);
+    });
+}
+
+void BackgroundFetch::didSendData(uint64_t size)
+{
+    m_currentUploadSize += size;
+    updateBackgroundFetchStatus(m_result, m_failureReason);
+}
+
+void BackgroundFetch::didFinishRecord(size_t index, const ResourceError& error)
+{
+    ASSERT(index < m_records.size());
+    if (error.isNull()) {
+        recordIsCompleted(index);
+        return;
+    }
+    // FIXME: We probably want to handle recoverable errors (We could use NetworkStateNotifier). For now, all errors are terminal.
+    updateBackgroundFetchStatus(BackgroundFetchResult::Failure, BackgroundFetchFailureReason::FetchError);
+}
+
+void BackgroundFetch::handleStoreResult(BackgroundFetchStore::StoreResult result)
+{
+    switch (result) {
+    case BackgroundFetchStore::StoreResult::OK:
+        return;
+    case BackgroundFetchStore::StoreResult::QuotaError:
+        updateBackgroundFetchStatus(BackgroundFetchResult::Failure, BackgroundFetchFailureReason::QuotaExceeded);
+        return;
+    case BackgroundFetchStore::StoreResult::InternalError:
+        updateBackgroundFetchStatus(BackgroundFetchResult::Failure, BackgroundFetchFailureReason::FetchError);
+        return;
+    }
+}
+
+void BackgroundFetch::recordIsCompleted(size_t index)
+{
+    m_records[index]->setAsCompleted();
+    if (anyOf(m_records, [](auto& record) { return !record->isCompleted(); }))
+        return;
+    updateBackgroundFetchStatus(BackgroundFetchResult::Success, BackgroundFetchFailureReason::EmptyString);
+}
+
+void BackgroundFetch::updateBackgroundFetchStatus(BackgroundFetchResult result, BackgroundFetchFailureReason failureReason)
+{
+    if (m_result != BackgroundFetchResult::EmptyString)
+        return;
+    ASSERT(m_failureReason == BackgroundFetchFailureReason::EmptyString);
+
+    m_result = result;
+    m_failureReason = failureReason;
+    m_isActive = m_result == BackgroundFetchResult::EmptyString && m_failureReason == BackgroundFetchFailureReason::EmptyString;
+    m_notificationCallback(information());
+}
+
+void BackgroundFetch::unsetRecordsAvailableFlag()
+{
+    ASSERT(m_recordsAvailableFlag);
+    m_recordsAvailableFlag = false;
+    m_store->clearFetch(m_registrationKey, m_identifier);
+    m_notificationCallback(information());
+}
+
+BackgroundFetch::Record::Record(BackgroundFetch& fetch, BackgroundFetchRequest&& request, size_t index)
+    : m_fetch(fetch)
+    , m_identifier(BackgroundFetchRecordIdentifier::generate())
+    , m_fetchIdentifier(fetch.m_identifier)
+    , m_registrationKey(fetch.m_registrationKey)
+    , m_request(WTFMove(request))
+    , m_index(index)
+{
+}
+
+BackgroundFetch::Record::~Record()
+{
+    auto callbacks = std::exchange(m_responseCallbacks, { });
+    for (auto& callback : callbacks)
+        callback(makeUnexpected(ExceptionData { TypeError, "Record is gone"_s }));
+
+    auto bodyCallbacks = std::exchange(m_responseBodyCallbacks, { });
+    for (auto& callback : bodyCallbacks)
+        callback(makeUnexpected(ResourceError { errorDomainWebKitInternal, 0, { }, "Record is gone"_s }));
+}
+
+bool BackgroundFetch::Record::isMatching(const ResourceRequest& request, const CacheQueryOptions& options) const
+{
+    return DOMCacheEngine::queryCacheMatch(request, m_request.internalRequest, m_response, options);
+}
+
+BackgroundFetchRecordInformation BackgroundFetch::Record::information() const
+{
+    return BackgroundFetchRecordInformation { m_identifier, m_request.internalRequest, m_request.options, m_request.guard, m_request.httpHeaders, m_request.referrer };
+}
+
+void BackgroundFetch::Record::complete(const CreateLoaderCallback& createLoaderCallback)
+{
+    ASSERT(!m_loader);
+    // FIXME: Handle Range headers
+    m_loader = createLoaderCallback(*this, ResourceRequest { m_request.internalRequest }, FetchOptions { m_request.options }, m_fetch->m_origin);
+    if (!m_loader)
+        abort();
+}
+
+void BackgroundFetch::Record::abort()
+{
+    if (m_isAborted)
+        return;
+
+    m_isAborted = true;
+
+    auto callbacks = std::exchange(m_responseCallbacks, { });
+    for (auto& callback : callbacks)
+        callback(makeUnexpected(ExceptionData { AbortError, "Background fetch was aborted"_s }));
+
+    auto bodyCallbacks = std::exchange(m_responseBodyCallbacks, { });
+    for (auto& callback : bodyCallbacks)
+        callback(makeUnexpected(ResourceError { errorDomainWebKitInternal, 0, { }, "Background fetch was aborted"_s, ResourceError::Type::Cancellation }));
+
+    if (!m_loader)
+        return;
+    m_loader->abort();
+    m_loader = nullptr;
+}
+
+void BackgroundFetch::Record::didSendData(uint64_t size)
+{
+    if (m_fetch)
+        m_fetch->didSendData(size);
+}
+
+void BackgroundFetch::Record::didReceiveResponse(ResourceResponse&& response)
+{
+    m_response = response;
+    auto callbacks = std::exchange(m_responseCallbacks, { });
+    for (auto& callback : callbacks)
+        callback(ResourceResponse { m_response });
+    if (m_fetch)
+        m_fetch->storeResponse(m_index, WTFMove(response));
+}
+
+void BackgroundFetch::Record::didReceiveResponseBodyChunk(const SharedBuffer& data)
+{
+    m_responseDataSize += data.size();
+    if (m_fetch)
+        m_fetch->storeResponseBodyChunk(m_index, data);
+
+    if (!m_responseBodyCallbacks.isEmpty()) {
+        RefPtr buffer = SharedBuffer::create(data.data(), data.size());
+        for (auto& callback : m_responseBodyCallbacks)
+            callback(buffer.copyRef());
+    }
+}
+
+void BackgroundFetch::Record::didFinish(const ResourceError& error)
+{
+    auto callbacks = std::exchange(m_responseCallbacks, { });
+    for (auto& callback : callbacks)
+        callback(makeUnexpected(ExceptionData { TypeError, "Fetch failed"_s }));
+
+    auto bodyCallbacks = std::exchange(m_responseBodyCallbacks, { });
+    for (auto& callback : bodyCallbacks) {
+        if (!error.isNull())
+            callback(makeUnexpected(error));
+        else
+            callback(RefPtr<SharedBuffer> { });
+    }
+
+    if (m_fetch)
+        m_fetch->didFinishRecord(m_index, error);
+}
+
+void BackgroundFetch::Record::retrieveResponse(BackgroundFetchStore&, RetrieveRecordResponseCallback&& callback)
+{
+    if (m_isAborted) {
+        callback(makeUnexpected(ExceptionData { AbortError, "Background fetch was aborted"_s }));
+        return;
+    }
+
+    if (!m_response.isNull()) {
+        callback(ResourceResponse { m_response });
+        return;
+    }
+
+    m_responseCallbacks.append(WTFMove(callback));
+}
+
+void BackgroundFetch::Record::retrieveRecordResponseBody(BackgroundFetchStore& store, RetrieveRecordResponseBodyCallback&& callback)
+{
+    if (m_isAborted) {
+        callback(makeUnexpected(ResourceError { errorDomainWebKitInternal, 0, { }, "Background fetch was aborted"_s, ResourceError::Type::Cancellation }));
+        return;
+    }
+
+    ASSERT(!m_response.isNull());
+
+    store.retrieveResponseBody(m_registrationKey, m_fetchIdentifier, m_index, [weakThis = WeakPtr { *this }, callback = WTFMove(callback)](auto&& result) mutable {
+        if (!result.has_value()) {
+            callback(makeUnexpected(WTFMove(result.error())));
+            return;
+        }
+
+        callback(WTFMove(result.value()));
+
+        if (!weakThis) {
+            callback(makeUnexpected(ResourceError { errorDomainWebKitInternal, 0, { }, "Record is gone"_s }));
+            return;
+        }
+
+        if (weakThis->m_isAborted) {
+            callback(makeUnexpected(ResourceError { errorDomainWebKitInternal, 0, { }, "Background fetch was aborted"_s, ResourceError::Type::Cancellation }));
+            return;
+        }
+
+        if (weakThis->m_isCompleted) {
+            callback(RefPtr<SharedBuffer> { });
+            return;
+        }
+        weakThis->m_responseBodyCallbacks.append(WTFMove(callback));
+    });
+}
+
+void BackgroundFetch::doStore()
+{
+    // FIXME: TODO.
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(SERVICE_WORKER)

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetch.h
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetch.h
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(SERVICE_WORKER)
+
+#include "BackgroundFetchFailureReason.h"
+#include "BackgroundFetchOptions.h"
+#include "BackgroundFetchRecordIdentifier.h"
+#include "BackgroundFetchRecordLoader.h"
+#include "BackgroundFetchRequest.h"
+#include "BackgroundFetchResult.h"
+#include "BackgroundFetchStore.h"
+#include "ClientOrigin.h"
+#include "ResourceResponse.h"
+#include "ServiceWorkerRegistrationKey.h"
+#include "ServiceWorkerTypes.h"
+#include <wtf/WeakPtr.h>
+
+namespace WebCore {
+
+class BackgroundFetchRecordLoader;
+class SharedBuffer;
+
+struct BackgroundFetchRequest;
+struct CacheQueryOptions;
+
+class BackgroundFetch : public CanMakeWeakPtr<BackgroundFetch> {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    using NotificationCallback = Function<void(BackgroundFetchInformation&&)>;
+    BackgroundFetch(SWServerRegistration&, const String&, Vector<BackgroundFetchRequest>&&, BackgroundFetchOptions&&, Ref<BackgroundFetchStore>&&, NotificationCallback&&);
+    ~BackgroundFetch();
+
+    String identifier() const { return m_identifier; }
+    BackgroundFetchInformation information() const;
+
+    using RetrieveRecordResponseCallback = CompletionHandler<void(Expected<ResourceResponse, ExceptionData>&&)>;
+    using RetrieveRecordResponseBodyCallback = Function<void(Expected<RefPtr<SharedBuffer>, ResourceError>&&)>;
+    using CreateLoaderCallback = Function<std::unique_ptr<BackgroundFetchRecordLoader>(BackgroundFetchRecordLoader::Client&, ResourceRequest&&, FetchOptions&&, const ClientOrigin&)>;
+
+    class Record final : public BackgroundFetchRecordLoader::Client, public RefCounted<Record> {
+        WTF_MAKE_FAST_ALLOCATED;
+    public:
+        static Ref<Record> create(BackgroundFetch& fetch, BackgroundFetchRequest&& request, size_t size) { return adoptRef(*new Record(fetch, WTFMove(request), size)); }
+        ~Record();
+
+        void complete(const CreateLoaderCallback&);
+        void abort();
+
+        void setAsCompleted() { m_isCompleted = true; }
+        bool isCompleted() const { return m_isCompleted; }
+
+        uint64_t responseDataSize() const { return m_responseDataSize; }
+        bool isMatching(const ResourceRequest&, const CacheQueryOptions&) const;
+        BackgroundFetchRecordInformation information() const;
+
+        void retrieveResponse(BackgroundFetchStore&, RetrieveRecordResponseCallback&&);
+        void retrieveRecordResponseBody(BackgroundFetchStore&, RetrieveRecordResponseBodyCallback&&);
+
+    private:
+        Record(BackgroundFetch&, BackgroundFetchRequest&&, size_t);
+
+        void didSendData(uint64_t) final;
+        void didReceiveResponse(ResourceResponse&&) final;
+        void didReceiveResponseBodyChunk(const SharedBuffer&) final;
+        void didFinish(const ResourceError&) final;
+
+        WeakPtr<BackgroundFetch> m_fetch;
+        BackgroundFetchRecordIdentifier m_identifier;
+        String m_fetchIdentifier;
+        ServiceWorkerRegistrationKey m_registrationKey;
+        BackgroundFetchRequest m_request;
+        size_t m_index { 0 };
+        ResourceResponse m_response;
+        std::unique_ptr<BackgroundFetchRecordLoader> m_loader;
+        uint64_t m_responseDataSize { 0 };
+        bool m_isCompleted { false };
+        bool m_isAborted { false };
+        Vector<RetrieveRecordResponseCallback> m_responseCallbacks;
+        Vector<RetrieveRecordResponseBodyCallback> m_responseBodyCallbacks;
+    };
+
+    using MatchBackgroundFetchCallback = CompletionHandler<void(Vector<Ref<Record>>&&)>;
+    void match(const RetrieveRecordsOptions&, MatchBackgroundFetchCallback&&);
+
+    bool abort();
+
+    void perform(const CreateLoaderCallback&);
+
+    bool isActive() const { return m_isActive; }
+    const ClientOrigin& origin() const { return m_origin; }
+    uint64_t downloadTotal() const { return  m_options.downloadTotal; }
+    uint64_t uploadTotal() const { return m_uploadTotal; }
+
+    void unsetRecordsAvailableFlag();
+
+private:
+    void didSendData(uint64_t);
+    void storeResponse(size_t, ResourceResponse&&);
+    void storeResponseBodyChunk(size_t, const SharedBuffer&);
+    void didFinishRecord(size_t, const ResourceError&);
+
+    void recordIsCompleted(size_t);
+    void handleStoreResult(BackgroundFetchStore::StoreResult);
+    void updateBackgroundFetchStatus(BackgroundFetchResult, BackgroundFetchFailureReason);
+
+    void doStore();
+
+    String m_identifier;
+    Vector<Ref<Record>> m_records;
+    BackgroundFetchOptions m_options;
+    ServiceWorkerRegistrationKey m_registrationKey;
+    ServiceWorkerRegistrationIdentifier m_registrationIdentifier;
+
+    BackgroundFetchResult m_result { BackgroundFetchResult::EmptyString };
+    BackgroundFetchFailureReason m_failureReason { BackgroundFetchFailureReason::EmptyString };
+
+    bool m_recordsAvailableFlag { true };
+    bool m_abortFlag { false };
+    bool m_isActive { true };
+
+    uint64_t m_uploadTotal { 0 };
+    uint64_t m_currentDownloadSize { 0 };
+    uint64_t m_currentUploadSize { 0 };
+
+    Ref<BackgroundFetchStore> m_store;
+    NotificationCallback m_notificationCallback;
+    ClientOrigin m_origin;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(SERVICE_WORKER)

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchEngine.cpp
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchEngine.cpp
@@ -1,0 +1,270 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "BackgroundFetchEngine.h"
+
+#if ENABLE(SERVICE_WORKER)
+
+#include "ExceptionData.h"
+#include "Logging.h"
+#include "SWServerToContextConnection.h"
+
+namespace WebCore {
+
+BackgroundFetchEngine::BackgroundFetchEngine(SWServer& server)
+    : m_server(server)
+    , m_store(server.createBackgroundFetchStore())
+{
+}
+
+// https://wicg.github.io/background-fetch/#dom-backgroundfetchmanager-fetch starting from step 8.3
+void BackgroundFetchEngine::startBackgroundFetch(SWServerRegistration& registration, const String& backgroundFetchIdentifier, Vector<BackgroundFetchRequest>&& requests, BackgroundFetchOptions&& options, ExceptionOrBackgroundFetchInformationCallback&& callback)
+{
+    auto iterator = m_fetches.find(registration.key());
+    if (iterator == m_fetches.end()) {
+        m_store->initializeFetches(*this, registration.key(), [weakThis = WeakPtr { *this }, registration = WeakPtr { registration }, backgroundFetchIdentifier, requests = WTFMove(requests), options = WTFMove(options), callback = WTFMove(callback)]() mutable {
+            if (!weakThis || !registration) {
+                callback(makeUnexpected(ExceptionData { InvalidStateError, "BackgroundFetchEngine is gone"_s }));
+                return;
+            }
+            weakThis->m_fetches.ensure(registration->key(), [] {
+                return FetchesMap();
+            });
+            weakThis->startBackgroundFetch(*registration, backgroundFetchIdentifier, WTFMove(requests), WTFMove(options), WTFMove(callback));
+        });
+        return;
+    }
+
+    auto result = iterator->value.ensure(backgroundFetchIdentifier, [&]() mutable {
+        return makeUnique<BackgroundFetch>(registration, backgroundFetchIdentifier, WTFMove(requests), WTFMove(options), Ref { m_store }, [weakThis = WeakPtr { *this }](auto&& information) {
+            if (weakThis)
+                weakThis->notifyBackgroundFetchUpdate(WTFMove(information));
+        });
+    });
+    if (!result.isNewEntry) {
+        callback(makeUnexpected(ExceptionData { TypeError, "A background fetch registration already exists"_s }));
+        return;
+    }
+
+    WeakPtr fetch { *result.iterator->value };
+
+    // FIXME: We should wait for upload data to be fully read.
+    uint64_t expectedSpace;
+    bool isSafe = WTF::safeAdd(fetch->downloadTotal(), fetch->uploadTotal(), expectedSpace);
+    if (!isSafe) {
+        callback(makeUnexpected(ExceptionData { QuotaExceededError, "Background fetch requested space is above quota"_s }));
+        return;
+    }
+
+    m_server->requestBackgroundFetchSpace(fetch->origin(), expectedSpace, [server = m_server, fetch = WTFMove(fetch), callback = WTFMove(callback)](bool result) mutable {
+        if (!fetch || !server) {
+            callback(makeUnexpected(ExceptionData { TypeError, "Background fetch is gone"_s }));
+            return;
+        }
+        if (!result) {
+            callback(makeUnexpected(ExceptionData { QuotaExceededError, "Background fetch requested space is above quota"_s }));
+            return;
+        }
+
+        fetch->perform([server = WTFMove(server)](auto& client, auto&& request, auto&& options, auto& origin) mutable {
+            return server ? server->createBackgroundFetchRecordLoader(client, WTFMove(request), WTFMove(options), origin) : nullptr;
+        });
+
+        callback(fetch->information());
+    });
+}
+
+// https://wicg.github.io/background-fetch/#update-background-fetch-instance-algorithm
+void BackgroundFetchEngine::notifyBackgroundFetchUpdate(BackgroundFetchInformation&& information)
+{
+    auto* registration = m_server->getRegistration(information.registrationIdentifier);
+    if (!registration)
+        return;
+
+    // Progress event.
+    registration->forEachConnection([&](auto& connection) {
+        connection.updateBackgroundFetchRegistration(information);
+    });
+
+    if (information.result == BackgroundFetchResult::EmptyString)
+        return;
+
+    m_server->fireBackgroundFetchEvent(*registration, WTFMove(information));
+}
+
+void BackgroundFetchEngine::backgroundFetchInformation(SWServerRegistration& registration, const String& backgroundFetchIdentifier, ExceptionOrBackgroundFetchInformationCallback&& callback)
+{
+    auto iterator = m_fetches.find(registration.key());
+    if (iterator == m_fetches.end()) {
+        m_store->initializeFetches(*this, registration.key(), [weakThis = WeakPtr { *this }, registration = WeakPtr { registration }, backgroundFetchIdentifier, callback = WTFMove(callback)]() mutable {
+            if (!weakThis || !registration) {
+                callback(makeUnexpected(ExceptionData { InvalidStateError, "BackgroundFetchEngine is gone"_s }));
+                return;
+            }
+            weakThis->m_fetches.ensure(registration->key(), [] {
+                return FetchesMap();
+            });
+            weakThis->backgroundFetchInformation(*registration, backgroundFetchIdentifier, WTFMove(callback));
+        });
+        return;
+    }
+
+    auto& map = iterator->value;
+    auto fetchIterator = map.find(backgroundFetchIdentifier);
+    if (fetchIterator == map.end()) {
+        callback(BackgroundFetchInformation { });
+        return;
+    }
+    callback(fetchIterator->value->information());
+}
+
+// https://wicg.github.io/background-fetch/#dom-backgroundfetchmanager-getids
+void BackgroundFetchEngine::backgroundFetchIdentifiers(SWServerRegistration& registration, BackgroundFetchIdentifiersCallback&& callback)
+{
+    auto iterator = m_fetches.find(registration.key());
+    if (iterator == m_fetches.end()) {
+        m_store->initializeFetches(*this, registration.key(), [weakThis = WeakPtr { *this }, registration = WeakPtr { registration }, callback = WTFMove(callback)]() mutable {
+            if (!weakThis || !registration) {
+                callback({ });
+                return;
+            }
+            weakThis->m_fetches.ensure(registration->key(), [] {
+                return FetchesMap();
+            });
+            weakThis->backgroundFetchIdentifiers(*registration, WTFMove(callback));
+        });
+        return;
+    }
+
+    Vector<String> identifiers;
+    identifiers.reserveInitialCapacity(iterator->value.size());
+    for (auto& keyValue : iterator->value) {
+        if (keyValue.value->isActive())
+            identifiers.uncheckedAppend(keyValue.key);
+    }
+    callback(WTFMove(identifiers));
+}
+
+// https://wicg.github.io/background-fetch/#background-fetch-registration-abort starting from step 3
+void BackgroundFetchEngine::abortBackgroundFetch(SWServerRegistration& registration, const String& backgroundFetchIdentifier, AbortBackgroundFetchCallback&& callback)
+{
+    auto iterator = m_fetches.find(registration.key());
+    if (iterator == m_fetches.end()) {
+        m_store->initializeFetches(*this, registration.key(), [weakThis = WeakPtr { *this }, registration = WeakPtr { registration }, backgroundFetchIdentifier, callback = WTFMove(callback)]() mutable {
+            if (!weakThis || !registration) {
+                callback(false);
+                return;
+            }
+            weakThis->m_fetches.ensure(registration->key(), [] {
+                return FetchesMap();
+            });
+            weakThis->abortBackgroundFetch(*registration, backgroundFetchIdentifier, WTFMove(callback));
+        });
+        return;
+    }
+
+    auto& map = iterator->value;
+    auto fetchIterator = map.find(backgroundFetchIdentifier);
+    if (fetchIterator == map.end()) {
+        callback(false);
+        return;
+    }
+    callback(fetchIterator->value->abort());
+}
+
+// https://wicg.github.io/background-fetch/#dom-backgroundfetchregistration-matchall starting from step 3
+void BackgroundFetchEngine::matchBackgroundFetch(SWServerRegistration& registration, const String& backgroundFetchIdentifier, RetrieveRecordsOptions&& options, MatchBackgroundFetchCallback&& callback)
+{
+    auto iterator = m_fetches.find(registration.key());
+    if (iterator == m_fetches.end()) {
+        m_store->initializeFetches(*this, registration.key(), [weakThis = WeakPtr { *this }, registration = WeakPtr { registration }, backgroundFetchIdentifier, options = WTFMove(options), callback = WTFMove(callback)]() mutable {
+            if (!weakThis || !registration) {
+                callback({ });
+                return;
+            }
+            weakThis->m_fetches.ensure(registration->key(), [] {
+                return FetchesMap();
+            });
+            weakThis->matchBackgroundFetch(*registration, backgroundFetchIdentifier, WTFMove(options), WTFMove(callback));
+        });
+        return;
+    }
+
+    auto& map = iterator->value;
+    auto fetchIterator = map.find(backgroundFetchIdentifier);
+    if (fetchIterator == map.end()) {
+        callback({ });
+        return;
+    }
+    fetchIterator->value->match(options, [weakThis = WeakPtr { *this }, callback = WTFMove(callback)](auto&& records) mutable {
+        if (!weakThis) {
+            callback({ });
+            return;
+        }
+        Vector<BackgroundFetchRecordInformation> recordsInformation;
+        recordsInformation.reserveInitialCapacity(records.size());
+        for (auto& record : records) {
+            // FIXME: We need a way to remove the record from m_records.
+            auto information = record->information();
+            weakThis->m_records.add(information.identifier, WTFMove(record));
+            recordsInformation.uncheckedAppend(WTFMove(information));
+        }
+        callback(WTFMove(recordsInformation));
+    });
+}
+
+void BackgroundFetchEngine::remove(SWServerRegistration& registration)
+{
+    // FIXME: We skip the initialization step, which might invalidate some results, maybe we should have a specific handling here.
+    auto fetches = m_fetches.take(registration.key());
+    for (auto& fetch : fetches.values())
+        fetch->abort();
+    m_store->clearAllFetches(registration.key());
+}
+
+void BackgroundFetchEngine::retrieveRecordResponse(BackgroundFetchRecordIdentifier recordIdentifier, RetrieveRecordResponseCallback&& callback)
+{
+    auto record = m_records.get(recordIdentifier);
+    if (!record) {
+        callback(makeUnexpected(ExceptionData { InvalidStateError, "Record not found"_s }));
+        return;
+    }
+    record->retrieveResponse(m_store.get(), WTFMove(callback));
+}
+
+void BackgroundFetchEngine::retrieveRecordResponseBody(BackgroundFetchRecordIdentifier recordIdentifier, RetrieveRecordResponseBodyCallback&& callback)
+{
+    auto record = m_records.get(recordIdentifier);
+    if (!record) {
+        callback(makeUnexpected(ResourceError { errorDomainWebKitInternal, 0, { }, "Record not found"_s }));
+        return;
+    }
+    record->retrieveRecordResponseBody(m_store.get(), WTFMove(callback));
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(SERVICE_WORKER)

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchEngine.h
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchEngine.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(SERVICE_WORKER)
+
+#include "BackgroundFetch.h"
+
+namespace WebCore {
+
+class BackgroundFetchStore;
+class ResourceResponse;
+class SWServer;
+
+class BackgroundFetchEngine : public CanMakeWeakPtr<BackgroundFetchEngine> {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    explicit BackgroundFetchEngine(SWServer&);
+
+    using ExceptionOrBackgroundFetchInformationCallback = CompletionHandler<void(Expected<BackgroundFetchInformation, ExceptionData>&&)>;
+    void startBackgroundFetch(SWServerRegistration&, const String&, Vector<BackgroundFetchRequest>&&, BackgroundFetchOptions&&, ExceptionOrBackgroundFetchInformationCallback&&);
+    void backgroundFetchInformation(SWServerRegistration&, const String&, ExceptionOrBackgroundFetchInformationCallback&&);
+    using BackgroundFetchIdentifiersCallback = CompletionHandler<void(Vector<String>&&)>;
+    void backgroundFetchIdentifiers(SWServerRegistration&, BackgroundFetchIdentifiersCallback&&);
+    using AbortBackgroundFetchCallback = CompletionHandler<void(bool)>;
+    void abortBackgroundFetch(SWServerRegistration&, const String&, AbortBackgroundFetchCallback&&);
+    using MatchBackgroundFetchCallback = CompletionHandler<void(Vector<BackgroundFetchRecordInformation>&&)>;
+    void matchBackgroundFetch(SWServerRegistration&, const String&, RetrieveRecordsOptions&&, MatchBackgroundFetchCallback&&);
+    using RetrieveRecordResponseCallback = BackgroundFetch::RetrieveRecordResponseCallback;
+    void retrieveRecordResponse(BackgroundFetchRecordIdentifier, RetrieveRecordResponseCallback&&);
+    using RetrieveRecordResponseBodyCallback = BackgroundFetch::RetrieveRecordResponseBodyCallback;
+    void retrieveRecordResponseBody(BackgroundFetchRecordIdentifier, RetrieveRecordResponseBodyCallback&&);
+
+    void remove(SWServerRegistration&);
+
+private:
+    void notifyBackgroundFetchUpdate(BackgroundFetchInformation&&);
+
+    WeakPtr<SWServer> m_server;
+    Ref<BackgroundFetchStore> m_store;
+
+    using FetchesMap = HashMap<String, std::unique_ptr<BackgroundFetch>>;
+    HashMap<ServiceWorkerRegistrationKey, FetchesMap> m_fetches;
+
+    HashMap<BackgroundFetchRecordIdentifier, Ref<BackgroundFetch::Record>> m_records;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(SERVICE_WORKER)

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchRecordLoader.h
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchRecordLoader.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(SERVICE_WORKER)
+
+#include <wtf/Span.h>
+#include <wtf/WeakPtr.h>
+
+namespace WebCore {
+
+class ResourceError;
+class ResourceResponse;
+class SharedBuffer;
+
+class BackgroundFetchRecordLoader {
+public:
+    virtual ~BackgroundFetchRecordLoader() = default;
+
+    class Client : public CanMakeWeakPtr<Client> {
+    public:
+        virtual ~Client() = default;
+
+        virtual void didSendData(uint64_t) = 0;
+        virtual void didReceiveResponse(ResourceResponse&&) = 0;
+        virtual void didReceiveResponseBodyChunk(const SharedBuffer&) = 0;
+        virtual void didFinish(const ResourceError&) = 0;
+    };
+
+    virtual void abort() = 0;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(SERVICE_WORKER)

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchStore.h
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchStore.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(SERVICE_WORKER)
+
+#include "ServiceWorkerRegistrationKey.h"
+#include <wtf/CompletionHandler.h>
+#include <wtf/Expected.h>
+#include <wtf/RefCounted.h>
+#include <wtf/Vector.h>
+#include <wtf/WeakPtr.h>
+
+namespace WebCore {
+
+class BackgroundFetchEngine;
+class ResourceError;
+class ResourceResponse;
+class SWServerRegistration;
+class SharedBuffer;
+
+struct BackgroundFetchInformation;
+struct BackgroundFetchOptions;
+struct BackgroundFetchRecordInformation;
+struct BackgroundFetchRequest;
+struct ExceptionData;
+struct RetrieveRecordsOptions;
+
+class BackgroundFetchStore : public RefCounted<BackgroundFetchStore>, public CanMakeWeakPtr<BackgroundFetchStore> {
+public:
+    virtual ~BackgroundFetchStore() = default;
+
+    virtual void initializeFetches(BackgroundFetchEngine&, const ServiceWorkerRegistrationKey&, CompletionHandler<void()>&&) = 0;
+    virtual void clearFetch(const ServiceWorkerRegistrationKey&, const String&, CompletionHandler<void()>&& = [] { }) = 0;
+    virtual void clearAllFetches(const ServiceWorkerRegistrationKey&, CompletionHandler<void()>&& = [] { }) = 0;
+
+    enum class StoreResult : uint8_t { OK, QuotaError, InternalError };
+    virtual void storeFetch(const ServiceWorkerRegistrationKey&, const String&, Vector<uint8_t>&&, CompletionHandler<void(StoreResult)>&&) = 0;
+    virtual void storeFetchResponseBodyChunk(const ServiceWorkerRegistrationKey&, const String&, size_t, const SharedBuffer&, CompletionHandler<void(StoreResult)>&&) = 0;
+
+    using RetrieveRecordResponseBodyCallback = Function<void(Expected<RefPtr<SharedBuffer>, ResourceError>&&)>;
+    virtual void retrieveResponseBody(const ServiceWorkerRegistrationKey&, const String&, size_t, RetrieveRecordResponseBodyCallback&&) = 0;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(SERVICE_WORKER)

--- a/Source/WebCore/workers/service/context/SWContextManager.cpp
+++ b/Source/WebCore/workers/service/context/SWContextManager.cpp
@@ -144,6 +144,15 @@ void SWContextManager::fireNotificationEvent(ServiceWorkerIdentifier identifier,
     serviceWorker->fireNotificationEvent(WTFMove(data), eventType, WTFMove(callback));
 }
 
+void SWContextManager::fireBackgroundFetchEvent(ServiceWorkerIdentifier identifier, BackgroundFetchInformation&& info, CompletionHandler<void(bool)>&& callback)
+{
+    auto* serviceWorker = serviceWorkerThreadProxy(identifier);
+    if (!serviceWorker)
+        return;
+
+    serviceWorker->fireBackgroundFetchEvent(WTFMove(info), WTFMove(callback));
+}
+
 void SWContextManager::terminateWorker(ServiceWorkerIdentifier identifier, Seconds timeout, Function<void()>&& completionHandler)
 {
     RELEASE_LOG(ServiceWorker, "SWContextManager::terminateWorker");

--- a/Source/WebCore/workers/service/context/SWContextManager.h
+++ b/Source/WebCore/workers/service/context/SWContextManager.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(SERVICE_WORKER)
 
+#include "BackgroundFetchInformation.h"
 #include "ExceptionOr.h"
 #include "PageIdentifier.h"
 #include "PushSubscriptionData.h"
@@ -105,6 +106,7 @@ public:
     WEBCORE_EXPORT void firePushEvent(ServiceWorkerIdentifier, std::optional<Vector<uint8_t>>&&, CompletionHandler<void(bool)>&&);
     WEBCORE_EXPORT void firePushSubscriptionChangeEvent(ServiceWorkerIdentifier, std::optional<PushSubscriptionData>&& newSubscriptionData, std::optional<PushSubscriptionData>&& oldSubscriptionData);
     WEBCORE_EXPORT void fireNotificationEvent(ServiceWorkerIdentifier, NotificationData&&, NotificationEventType, CompletionHandler<void(bool)>&&);
+    WEBCORE_EXPORT void fireBackgroundFetchEvent(ServiceWorkerIdentifier, BackgroundFetchInformation&&, CompletionHandler<void(bool)>&&);
 
     WEBCORE_EXPORT void terminateWorker(ServiceWorkerIdentifier, Seconds timeout, Function<void()>&&);
 

--- a/Source/WebCore/workers/service/context/ServiceWorkerThread.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThread.cpp
@@ -28,6 +28,8 @@
 
 #if ENABLE(SERVICE_WORKER)
 
+#include "BackgroundFetchManager.h"
+#include "BackgroundFetchUpdateUIEvent.h"
 #include "CacheStorageProvider.h"
 #include "CommonAtomStrings.h"
 #include "ContentSecurityPolicyResponseHeaders.h"
@@ -47,6 +49,7 @@
 #include "SecurityOrigin.h"
 #include "ServiceWorkerFetch.h"
 #include "ServiceWorkerGlobalScope.h"
+#include "ServiceWorkerRegistrationBackgroundFetchAPI.h"
 #include "ServiceWorkerWindowClient.h"
 #include "WorkerDebuggerProxy.h"
 #include "WorkerLoaderProxy.h"
@@ -316,6 +319,44 @@ void ServiceWorkerThread::queueTaskToFireNotificationEvent(NotificationData&& da
     });
 }
 #endif
+
+void ServiceWorkerThread::queueTaskToFireBackgroundFetchEvent(BackgroundFetchInformation&& info, Function<void(bool)>&& callback)
+{
+    auto& serviceWorkerGlobalScope = downcast<ServiceWorkerGlobalScope>(*globalScope());
+    serviceWorkerGlobalScope.eventLoop().queueTask(TaskSource::DOMManipulation, [weakThis = WeakPtr { *this }, serviceWorkerGlobalScope = Ref { serviceWorkerGlobalScope }, info = crossThreadCopy(WTFMove(info)), callback = WTFMove(callback)]() mutable {
+        RELEASE_LOG(ServiceWorker, "ServiceWorkerThread::queueTaskToFireBackgroundFetchEvent firing event for worker %" PRIu64, serviceWorkerGlobalScope->thread().identifier().toUInt64());
+
+        Ref manager = ServiceWorkerRegistrationBackgroundFetchAPI::backgroundFetch(serviceWorkerGlobalScope->registration());
+        BackgroundFetchEventInit eventInit { { }, manager->backgroundFetchRegistrationInstance(serviceWorkerGlobalScope, WTFMove(info)) };
+        RefPtr<ExtendableEvent> event;
+        switch (info.failureReason) {
+        case BackgroundFetchFailureReason::EmptyString:
+            event = BackgroundFetchUpdateUIEvent::create(eventNames().backgroundfetchsuccessEvent, WTFMove(eventInit));
+            break;
+        case BackgroundFetchFailureReason::Aborted:
+            event = BackgroundFetchEvent::create(eventNames().backgroundfetchabortEvent, WTFMove(eventInit));
+            break;
+        default:
+            event = BackgroundFetchEvent::create(eventNames().backgroundfetchfailEvent, WTFMove(eventInit));
+            break;
+        };
+
+        serviceWorkerGlobalScope->dispatchEvent(*event);
+
+        event->whenAllExtendLifetimePromisesAreSettled([serviceWorkerGlobalScope, callback = WTFMove(callback)](auto&& extendLifetimePromises) mutable {
+            bool success = true;
+            for (auto& promise : extendLifetimePromises) {
+                if (promise->status() == DOMPromise::Status::Rejected) {
+                    success = false;
+                    break;
+                }
+            }
+
+            RELEASE_LOG_ERROR_IF(!success, ServiceWorker, "ServiceWorkerThread::queueTaskToFireBackgroundFetchEvent failed to process background fetch event");
+            callback(success);
+        });
+    });
+}
 
 void ServiceWorkerThread::finishedEvaluatingScript()
 {

--- a/Source/WebCore/workers/service/context/ServiceWorkerThread.h
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThread.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(SERVICE_WORKER)
 
+#include "BackgroundFetchInformation.h"
 #include "NotificationClient.h"
 #include "NotificationEventType.h"
 #include "PushSubscriptionData.h"
@@ -76,6 +77,7 @@ public:
 #if ENABLE(NOTIFICATION_EVENT)
     void queueTaskToFireNotificationEvent(NotificationData&&, NotificationEventType, Function<void(bool)>&&);
 #endif
+    void queueTaskToFireBackgroundFetchEvent(BackgroundFetchInformation&&, Function<void(bool)>&&);
 
     ServiceWorkerIdentifier identifier() const { return m_serviceWorkerIdentifier; }
     std::optional<ServiceWorkerJobDataIdentifier> jobDataIdentifier() const { return m_jobDataIdentifier; }

--- a/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
@@ -423,6 +423,28 @@ void ServiceWorkerThreadProxy::fireNotificationEvent(NotificationData&& data, No
 #endif
 }
 
+void ServiceWorkerThreadProxy::fireBackgroundFetchEvent(BackgroundFetchInformation&& info, CompletionHandler<void(bool)>&& callback)
+{
+    if (m_ongoingFunctionalEventTasks.isEmpty())
+        thread().startFunctionalEventMonitoring();
+
+    auto identifier = ++m_functionalEventTasksCounter;
+    ASSERT(!m_ongoingFunctionalEventTasks.contains(identifier));
+    m_ongoingFunctionalEventTasks.add(identifier, WTFMove(callback));
+    bool isPosted = postTaskForModeToWorkerOrWorkletGlobalScope([this, protectedThis = Ref { *this }, identifier, info = crossThreadCopy(WTFMove(info))](auto&) mutable {
+        thread().queueTaskToFireBackgroundFetchEvent(WTFMove(info), [this, protectedThis = WTFMove(protectedThis), identifier](bool result) mutable {
+            callOnMainThread([this, protectedThis = WTFMove(protectedThis), identifier, result]() mutable {
+                if (auto callback = m_ongoingFunctionalEventTasks.take(identifier))
+                    callback(result);
+                if (m_ongoingFunctionalEventTasks.isEmpty())
+                    thread().stopFunctionalEventMonitoring();
+            });
+        });
+    }, WorkerRunLoop::defaultMode());
+    if (!isPosted)
+        m_ongoingFunctionalEventTasks.take(identifier)(false);
+}
+
 void ServiceWorkerThreadProxy::setAppBadge(std::optional<uint64_t> badge)
 {
     ASSERT(!isMainThread());

--- a/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h
@@ -90,6 +90,7 @@ public:
     void firePushEvent(std::optional<Vector<uint8_t>>&&, CompletionHandler<void(bool)>&&);
     void firePushSubscriptionChangeEvent(std::optional<PushSubscriptionData>&& newSubscriptionData, std::optional<PushSubscriptionData>&& oldSubscriptionData);
     void fireNotificationEvent(NotificationData&&, NotificationEventType, CompletionHandler<void(bool)>&&);
+    void fireBackgroundFetchEvent(BackgroundFetchInformation&&, CompletionHandler<void(bool)>&&);
 
     WEBCORE_EXPORT void didSaveScriptsToDisk(ScriptBuffer&&, HashMap<URL, ScriptBuffer>&& importedScripts);
 

--- a/Source/WebCore/workers/service/server/SWServer.cpp
+++ b/Source/WebCore/workers/service/server/SWServer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,6 +28,7 @@
 
 #if ENABLE(SERVICE_WORKER)
 
+#include "BackgroundFetchEngine.h"
 #include "BackgroundFetchInformation.h"
 #include "BackgroundFetchOptions.h"
 #include "BackgroundFetchRecordInformation.h"
@@ -258,6 +259,8 @@ void SWServer::removeRegistration(ServiceWorkerRegistrationIdentifier registrati
     m_originStore->remove(registration->key().topOrigin());
     if (m_registrationStore)
         m_registrationStore->removeRegistration(registration->key());
+
+    backgroundFetchEngine().remove(*registration);
 }
 
 Vector<ServiceWorkerRegistrationData> SWServer::getRegistrations(const SecurityOriginData& topOrigin, const URL& clientURL)
@@ -1539,6 +1542,36 @@ void SWServer::processNotificationEvent(NotificationData&& data, NotificationEve
     });
 }
 
+void SWServer::fireBackgroundFetchEvent(SWServerRegistration& registration, BackgroundFetchInformation&& info)
+{
+    RefPtr worker = registration.activeWorker();
+    if (!worker) {
+        RELEASE_LOG_ERROR(ServiceWorker, "Cannot process background fetch update message: No active worker for scope %" PRIVATE_LOG_STRING, registration.key().scope().string().utf8().data());
+        return;
+    }
+
+    fireFunctionalEvent(registration, [weakThis = WeakPtr { *this }, worker = worker.releaseNonNull(), info = WTFMove(info)](auto&& connectionOrStatus) mutable {
+        if (!connectionOrStatus.has_value())
+            return;
+
+        auto serviceWorkerIdentifier = worker->identifier();
+
+        worker->incrementFunctionalEventCounter();
+        auto terminateWorkerTimer = makeUnique<Timer>([worker] {
+            RELEASE_LOG_ERROR(ServiceWorker, "Service worker is taking too much time to process a background fetch event");
+            worker->decrementFunctionalEventCounter();
+        });
+        terminateWorkerTimer->startOneShot(weakThis && weakThis->m_isProcessTerminationDelayEnabled ? defaultTerminationDelay : defaultFunctionalEventDuration);
+        connectionOrStatus.value()->fireBackgroundFetchEvent(serviceWorkerIdentifier, info, [terminateWorkerTimer = WTFMove(terminateWorkerTimer), worker = WTFMove(worker)](bool succeeded) mutable {
+            RELEASE_LOG_ERROR_IF(!succeeded, ServiceWorker, "Background fetch event was not successfully handled");
+            if (terminateWorkerTimer->isActive()) {
+                worker->decrementFunctionalEventCounter();
+                terminateWorkerTimer->stop();
+            }
+        });
+    });
+}
+
 // https://w3c.github.io/ServiceWorker/#fire-functional-event-algorithm, just for push right now.
 void SWServer::fireFunctionalEvent(SWServerRegistration& registration, CompletionHandler<void(Expected<SWServerToContextConnection*, ShouldSkipEvent>)>&& callback)
 {
@@ -1602,46 +1635,69 @@ void SWServer::Connection::startBackgroundFetch(ServiceWorkerRegistrationIdentif
             return;
         }
 
-        // FIXME: To implement.
-        callback(makeUnexpected(ExceptionData { NotSupportedError, emptyString() }));
+        server->backgroundFetchEngine().startBackgroundFetch(*registration, backgroundFetchIdentifier, WTFMove(requests), WTFMove(options), WTFMove(callback));
     });
-
 }
 
-void SWServer::Connection::backgroundFetchInformation(ServiceWorkerRegistrationIdentifier, const String&, ExceptionOrBackgroundFetchInformationCallback&& callback)
+BackgroundFetchEngine& SWServer::backgroundFetchEngine()
 {
-    // FIXME: To implement.
-    callback({ });
+    if (!m_backgroundFetchEngine)
+        m_backgroundFetchEngine = makeUnique<BackgroundFetchEngine>(*this);
+    return *m_backgroundFetchEngine;
 }
 
-void SWServer::Connection::backgroundFetchIdentifiers(ServiceWorkerRegistrationIdentifier, BackgroundFetchIdentifiersCallback&& callback)
+void SWServer::Connection::backgroundFetchInformation(ServiceWorkerRegistrationIdentifier registrationIdentifier, const String& backgroundFetchIdentifier, BackgroundFetchEngine::ExceptionOrBackgroundFetchInformationCallback&& callback)
 {
-    // FIXME: To implement.
-    callback({ });
+    auto* registration = server().getRegistration(registrationIdentifier);
+    if (!registration) {
+        callback(makeUnexpected(ExceptionData { InvalidStateError, "No registration found"_s }));
+        return;
+    }
+
+    server().backgroundFetchEngine().backgroundFetchInformation(*registration, backgroundFetchIdentifier, WTFMove(callback));
 }
 
-void SWServer::Connection::abortBackgroundFetch(ServiceWorkerRegistrationIdentifier, const String&, AbortBackgroundFetchCallback&& callback)
+void SWServer::Connection::backgroundFetchIdentifiers(ServiceWorkerRegistrationIdentifier registrationIdentifier, BackgroundFetchEngine::BackgroundFetchIdentifiersCallback&& callback)
 {
-    // FIXME: To implement.
-    callback(false);
+    auto* registration = server().getRegistration(registrationIdentifier);
+    if (!registration) {
+        callback({ });
+        return;
+    }
+
+    server().backgroundFetchEngine().backgroundFetchIdentifiers(*registration, WTFMove(callback));
 }
 
-void SWServer::Connection::matchBackgroundFetch(ServiceWorkerRegistrationIdentifier, const String&, RetrieveRecordsOptions&&, MatchBackgroundFetchCallback&& callback)
+void SWServer::Connection::abortBackgroundFetch(ServiceWorkerRegistrationIdentifier registrationIdentifier, const String& backgroundFetchIdentifier, BackgroundFetchEngine::AbortBackgroundFetchCallback&& callback)
 {
-    // FIXME: To implement.
-    callback({ });
+    auto* registration = server().getRegistration(registrationIdentifier);
+    if (!registration) {
+        callback(false);
+        return;
+    }
+
+    server().backgroundFetchEngine().abortBackgroundFetch(*registration, backgroundFetchIdentifier, WTFMove(callback));
 }
 
-void SWServer::Connection::retrieveRecordResponse(BackgroundFetchRecordIdentifier, RetrieveRecordResponseCallback&& callback)
+void SWServer::Connection::matchBackgroundFetch(ServiceWorkerRegistrationIdentifier registrationIdentifier, const String& backgroundFetchIdentifier, RetrieveRecordsOptions&& options, BackgroundFetchEngine::MatchBackgroundFetchCallback&& callback)
 {
-    // FIXME: To implement.
-    callback({ });
+    auto* registration = server().getRegistration(registrationIdentifier);
+    if (!registration) {
+        callback({ });
+        return;
+    }
+
+    server().backgroundFetchEngine().matchBackgroundFetch(*registration, backgroundFetchIdentifier, WTFMove(options), WTFMove(callback));
 }
 
-void SWServer::Connection::retrieveRecordResponseBody(BackgroundFetchRecordIdentifier, RetrieveRecordResponseBodyCallback&& callback)
+void SWServer::Connection::retrieveRecordResponse(BackgroundFetchRecordIdentifier recordIdentifier, BackgroundFetchEngine::RetrieveRecordResponseCallback&& callback)
 {
-    // FIXME: To implement.
-    callback({ });
+    server().backgroundFetchEngine().retrieveRecordResponse(recordIdentifier, WTFMove(callback));
+}
+
+void SWServer::Connection::retrieveRecordResponseBody(BackgroundFetchRecordIdentifier recordIdentifier, BackgroundFetchEngine::RetrieveRecordResponseBodyCallback&& callback)
+{
+    server().backgroundFetchEngine().retrieveRecordResponseBody(recordIdentifier, WTFMove(callback));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/workers/service/server/SWServerDelegate.h
+++ b/Source/WebCore/workers/service/server/SWServerDelegate.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(SERVICE_WORKER)
 
+#include "BackgroundFetchRecordLoader.h"
 #include "ProcessIdentifier.h"
 #include "ScriptExecutionContextIdentifier.h"
 #include <wtf/CompletionHandler.h>
@@ -35,8 +36,12 @@
 
 namespace WebCore {
 
+class BackgroundFetchRecordLoader;
+class BackgroundFetchStore;
 class RegistrableDomain;
 class ResourceRequest;
+
+struct BackgroundFetchRequest;
 struct ServiceWorkerJobData;
 struct WorkerFetchResult;
 
@@ -50,6 +55,9 @@ public:
     virtual void addAllowedFirstPartyForCookies(ProcessIdentifier, std::optional<ProcessIdentifier>, RegistrableDomain&&) = 0;
     
     virtual void requestBackgroundFetchPermission(const ClientOrigin&, CompletionHandler<void(bool)>&&) = 0;
+    virtual std::unique_ptr<BackgroundFetchRecordLoader> createBackgroundFetchRecordLoader(BackgroundFetchRecordLoader::Client&, ResourceRequest&&, FetchOptions&&, const WebCore::ClientOrigin&) = 0;
+    virtual void requestBackgroundFetchSpace(const ClientOrigin&, uint64_t size, CompletionHandler<void(bool)>&&) = 0;
+    virtual Ref<BackgroundFetchStore> createBackgroundFetchStore() = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/workers/service/server/SWServerToContextConnection.h
+++ b/Source/WebCore/workers/service/server/SWServerToContextConnection.h
@@ -71,6 +71,7 @@ public:
     virtual void matchAllCompleted(uint64_t requestIdentifier, const Vector<ServiceWorkerClientData>&) = 0;
     virtual void firePushEvent(ServiceWorkerIdentifier, const std::optional<Vector<uint8_t>>&, CompletionHandler<void(bool)>&&) = 0;
     virtual void fireNotificationEvent(ServiceWorkerIdentifier, const NotificationData&, NotificationEventType, CompletionHandler<void(bool)>&&) = 0;
+    virtual void fireBackgroundFetchEvent(ServiceWorkerIdentifier, const BackgroundFetchInformation&, CompletionHandler<void(bool)>&&) = 0;
     virtual ProcessIdentifier webProcessIdentifier() const = 0;
 
     // Messages back from the SW host process

--- a/Source/WebKit/NetworkProcess/BackgroundFetchLoad.cpp
+++ b/Source/WebKit/NetworkProcess/BackgroundFetchLoad.cpp
@@ -1,0 +1,219 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "BackgroundFetchLoad.h"
+
+#include "AuthenticationChallengeDisposition.h"
+#include "AuthenticationManager.h"
+#include "Logging.h"
+#include "NetworkConnectionToWebProcess.h"
+#include "NetworkLoadChecker.h"
+#include "NetworkProcess.h"
+#include "WebErrors.h"
+#include <WebCore/ClientOrigin.h>
+
+#define BGLOAD_RELEASE_LOG(fmt, ...) RELEASE_LOG(Network, "%p - BackgroundFetchLoad::" fmt, this, ##__VA_ARGS__)
+
+namespace WebKit {
+
+using namespace WebCore;
+
+BackgroundFetchLoad::BackgroundFetchLoad(NetworkProcess& networkProcess, PAL::SessionID sessionID, Client& client, ResourceRequest&& request, FetchOptions&& options, const ClientOrigin& clientOrigin)
+    : m_sessionID(WTFMove(sessionID))
+    , m_client(client)
+    , m_request(WTFMove(request))
+    , m_networkLoadChecker(makeUniqueRef<NetworkLoadChecker>(networkProcess, nullptr, nullptr, WTFMove(options), m_sessionID, WebPageProxyIdentifier { }, WebCore::HTTPHeaderMap { }, URL { m_request.url() }, URL { }, clientOrigin.clientOrigin.securityOrigin(), clientOrigin.topOrigin.securityOrigin(), RefPtr<SecurityOrigin> { }, PreflightPolicy::Consider, m_request.httpReferrer(), true, OptionSet<NetworkConnectionIntegrity> { }))
+{
+    m_networkLoadChecker->enableContentExtensionsCheck();
+    m_networkLoadChecker->check(ResourceRequest { m_request }, nullptr, [this, weakThis = WeakPtr { *this }, networkProcess = Ref { networkProcess }] (auto&& result) {
+        if (!weakThis)
+            return;
+        WTF::switchOn(result,
+            [this] (ResourceError& error) {
+                this->didFinish(error);
+            },
+            [] (NetworkLoadChecker::RedirectionTriplet& triplet) {
+                // We should never send a synthetic redirect for BackgroundFetchLoads.
+                ASSERT_NOT_REACHED();
+            },
+            [&] (ResourceRequest& request) {
+                this->loadRequest(networkProcess, WTFMove(request));
+            }
+        );
+    });
+}
+
+BackgroundFetchLoad::~BackgroundFetchLoad()
+{
+    abort();
+}
+
+void BackgroundFetchLoad::abort()
+{
+    if (!m_task)
+        return;
+
+    ASSERT(m_task->client() == this);
+    m_task->clearClient();
+    m_task->cancel();
+    m_task = nullptr;
+}
+
+void BackgroundFetchLoad::didFinish(const ResourceError& error, const ResourceResponse& response)
+{
+    m_client->didFinish(error);
+}
+
+void BackgroundFetchLoad::loadRequest(NetworkProcess& networkProcess, ResourceRequest&& request)
+{
+    BGLOAD_RELEASE_LOG("startNetworkLoad");
+    auto* networkSession = networkProcess.networkSession(m_sessionID);
+    ASSERT(networkSession);
+    if (!networkSession)
+        return;
+
+    NetworkLoadParameters loadParameters;
+    loadParameters.request = WTFMove(request);
+    loadParameters.topOrigin = m_networkLoadChecker->topOrigin();
+    loadParameters.sourceOrigin = m_networkLoadChecker->origin();
+    loadParameters.storedCredentialsPolicy = m_networkLoadChecker->options().credentials == FetchOptions::Credentials::Include ? StoredCredentialsPolicy::Use : StoredCredentialsPolicy::DoNotUse;
+    loadParameters.clientCredentialPolicy = ClientCredentialPolicy::CannotAskClientForCredentials;
+
+    m_task = NetworkDataTask::create(*networkSession, *this, WTFMove(loadParameters));
+    m_task->resume();
+}
+
+void BackgroundFetchLoad::willPerformHTTPRedirection(ResourceResponse&& redirectResponse, ResourceRequest&& request, RedirectCompletionHandler&& completionHandler)
+{
+    m_networkLoadChecker->checkRedirection(ResourceRequest { }, WTFMove(request), WTFMove(redirectResponse), nullptr, [weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)] (auto&& result) mutable {
+        if (!result.has_value()) {
+            weakThis->didFinish(result.error());
+            completionHandler({ });
+            return;
+        }
+        auto request = WTFMove(result->redirectRequest);
+        if (!request.url().protocolIsInHTTPFamily()) {
+            weakThis->didFinish(ResourceError { String { }, 0, request.url(), "Redirection to URL with a scheme that is not HTTP(S)"_s, ResourceError::Type::AccessControl });
+            completionHandler({ });
+            return;
+        }
+
+        completionHandler(WTFMove(request));
+    });
+}
+
+void BackgroundFetchLoad::didReceiveChallenge(AuthenticationChallenge&& challenge, NegotiatedLegacyTLS negotiatedLegacyTLS, ChallengeCompletionHandler&& completionHandler)
+{
+    BGLOAD_RELEASE_LOG("didReceiveChallenge");
+    if (challenge.protectionSpace().authenticationScheme() == ProtectionSpace::AuthenticationScheme::ServerTrustEvaluationRequested) {
+        m_networkLoadChecker->networkProcess().authenticationManager().didReceiveAuthenticationChallenge(m_sessionID, { },  m_parameters.topOrigin ? &m_parameters.topOrigin->data() : nullptr, challenge, negotiatedLegacyTLS, WTFMove(completionHandler));
+        return;
+    }
+    WeakPtr weakThis { *this };
+    completionHandler(AuthenticationChallengeDisposition::Cancel, { });
+    if (!weakThis)
+        return;
+    didFinish(ResourceError { String(), 0, currentURL(), "Failed HTTP authentication"_s, ResourceError::Type::AccessControl });
+}
+
+void BackgroundFetchLoad::didReceiveResponse(ResourceResponse&& response, NegotiatedLegacyTLS, PrivateRelayed, ResponseCompletionHandler&& completionHandler)
+{
+    BGLOAD_RELEASE_LOG("didReceiveResponse - httpStatusCode=%d", response.httpStatusCode());
+
+    auto error = m_networkLoadChecker->validateResponse(m_request, response);
+    if (!error.isNull()) {
+        BGLOAD_RELEASE_LOG("didReceiveResponse: NetworkLoadChecker::validateResponse returned an error (error.domain=%" PUBLIC_LOG_STRING ", error.code=%d)", error.domain().utf8().data(), error.errorCode());
+
+        WeakPtr weakThis { *this };
+        completionHandler(PolicyAction::Ignore);
+        if (!weakThis)
+            return;
+
+        didFinish(error);
+        return;
+    }
+
+    WeakPtr weakThis { *this };
+    completionHandler(PolicyAction::Use);
+    if (!weakThis)
+        return;
+
+    m_client->didReceiveResponse(WTFMove(response));
+}
+
+void BackgroundFetchLoad::didReceiveData(const SharedBuffer& data)
+{
+    BGLOAD_RELEASE_LOG("didReceiveData");
+    m_client->didReceiveResponseBodyChunk(data);
+}
+
+void BackgroundFetchLoad::didCompleteWithError(const ResourceError& error, const NetworkLoadMetrics&)
+{
+    if (error.isNull())
+        BGLOAD_RELEASE_LOG("didComplete");
+    else
+        BGLOAD_RELEASE_LOG("didCompleteWithError, error_code=%d", error.errorCode());
+
+    didFinish(error);
+}
+
+void BackgroundFetchLoad::didSendData(uint64_t totalBytesSent, uint64_t totalBytesExpectedToSend)
+{
+    m_client->didSendData(totalBytesSent);
+}
+
+void BackgroundFetchLoad::wasBlocked()
+{
+    BGLOAD_RELEASE_LOG("wasBlocked");
+    didFinish(blockedError(ResourceRequest { currentURL() }));
+}
+
+void BackgroundFetchLoad::cannotShowURL()
+{
+    BGLOAD_RELEASE_LOG("cannotShowURL");
+    didFinish(cannotShowURLError(ResourceRequest { currentURL() }));
+}
+
+void BackgroundFetchLoad::wasBlockedByRestrictions()
+{
+    BGLOAD_RELEASE_LOG("wasBlockedByRestrictions");
+    didFinish(wasBlockedByRestrictionsError(ResourceRequest { currentURL() }));
+}
+
+void BackgroundFetchLoad::wasBlockedByDisabledFTP()
+{
+    BGLOAD_RELEASE_LOG("wasBlockedByDisabledFTP");
+    didFinish(ftpDisabledError(ResourceRequest(currentURL())));
+}
+
+const URL& BackgroundFetchLoad::currentURL() const
+{
+    return m_networkLoadChecker->url();
+}
+
+} // namespace WebKit
+
+#undef BGLOAD_RELEASE_LOG

--- a/Source/WebKit/NetworkProcess/BackgroundFetchLoad.h
+++ b/Source/WebKit/NetworkProcess/BackgroundFetchLoad.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "NetworkDataTask.h"
+#include "NetworkResourceLoadParameters.h"
+#include <WebCore/BackgroundFetchRecordLoader.h>
+#include <WebCore/ResourceError.h>
+#include <WebCore/ResourceRequest.h>
+#include <wtf/CompletionHandler.h>
+#include <wtf/UniqueRef.h>
+#include <wtf/WeakPtr.h>
+
+namespace WebCore {
+class ResourceRequest;
+
+struct ClientOrigin;
+struct FetchOptions;
+};
+
+namespace WebKit {
+
+class NetworkLoadChecker;
+class NetworkProcess;
+
+class BackgroundFetchLoad final : public WebCore::BackgroundFetchRecordLoader, public CanMakeWeakPtr<BackgroundFetchLoad>, private NetworkDataTaskClient {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    BackgroundFetchLoad(NetworkProcess&, PAL::SessionID, Client&, WebCore::ResourceRequest&&, WebCore::FetchOptions&&, const WebCore::ClientOrigin&);
+    ~BackgroundFetchLoad();
+
+private:
+    const URL& currentURL() const;
+
+    // NetworkDataTaskClient
+    void willPerformHTTPRedirection(WebCore::ResourceResponse&&, WebCore::ResourceRequest&&, RedirectCompletionHandler&&) final;
+    void didReceiveChallenge(WebCore::AuthenticationChallenge&&, NegotiatedLegacyTLS, ChallengeCompletionHandler&&) final;
+    void didReceiveResponse(WebCore::ResourceResponse&&, NegotiatedLegacyTLS, PrivateRelayed, ResponseCompletionHandler&&) final;
+    void didReceiveData(const WebCore::SharedBuffer&) final;
+    void didCompleteWithError(const WebCore::ResourceError&, const WebCore::NetworkLoadMetrics&) final;
+    void didSendData(uint64_t totalBytesSent, uint64_t totalBytesExpectedToSend) final;
+    void wasBlocked() final;
+    void cannotShowURL() final;
+    void wasBlockedByRestrictions() final;
+    void wasBlockedByDisabledFTP() final;
+
+    // WebCore::BackgroundFetchRecordLoader
+    void abort() final;
+
+    void loadRequest(NetworkProcess&, WebCore::ResourceRequest&&);
+
+    void didFinish(const WebCore::ResourceError& = { }, const WebCore::ResourceResponse& response = { });
+
+    PAL::SessionID m_sessionID;
+    WeakPtr<Client> m_client;
+    WebCore::ResourceRequest m_request;
+    NetworkResourceLoadParameters m_parameters;
+    RefPtr<NetworkDataTask> m_task;
+    UniqueRef<NetworkLoadChecker> m_networkLoadChecker;
+    Vector<RefPtr<WebCore::BlobDataFileReference>> m_blobFiles;
+};
+
+}

--- a/Source/WebKit/NetworkProcess/NetworkLoadChecker.h
+++ b/Source/WebKit/NetworkProcess/NetworkLoadChecker.h
@@ -104,6 +104,11 @@ public:
 
     void enableContentExtensionsCheck() { m_checkContentExtensions = true; }
 
+    RefPtr<WebCore::SecurityOrigin> origin() const { return m_origin; }
+    RefPtr<WebCore::SecurityOrigin> topOrigin() const { return m_topOrigin; }
+
+    const WebCore::FetchOptions& options() const { return m_options; }
+
 private:
     WebCore::ContentSecurityPolicy* contentSecurityPolicy();
     bool isChecking() const { return !!m_corsPreflightChecker; }

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -27,6 +27,7 @@
 #include "NetworkResourceLoader.h"
 
 #include "FormDataReference.h"
+#include "LoadedWebArchive.h"
 #include "Logging.h"
 #include "NetworkCache.h"
 #include "NetworkCacheSpeculativeLoadManager.h"

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "NetworkSession.h"
 
+#include "BackgroundFetchLoad.h"
+#include "BackgroundFetchStoreImpl.h"
 #include "CacheStorageEngine.h"
 #include "LoadedWebArchive.h"
 #include "Logging.h"
@@ -737,6 +739,21 @@ void NetworkSession::addAllowedFirstPartyForCookies(WebCore::ProcessIdentifier w
         return;
     }
     m_networkProcess->addAllowedFirstPartyForCookies(webProcessIdentifier, WTFMove(firstPartyForCookies), LoadedWebArchive::No, [] { });
+}
+
+std::unique_ptr<BackgroundFetchRecordLoader> NetworkSession::createBackgroundFetchRecordLoader(BackgroundFetchRecordLoader::Client& client, ResourceRequest&& request, FetchOptions&& options, const ClientOrigin& clientOrigin)
+{
+    return makeUnique<BackgroundFetchLoad>(m_networkProcess.get(), m_sessionID, client, WTFMove(request), WTFMove(options), clientOrigin);
+}
+
+void NetworkSession::requestBackgroundFetchSpace(const ClientOrigin& origin, uint64_t size, CompletionHandler<void(bool)>&& callback)
+{
+    m_storageManager->requestSpace(origin, size, WTFMove(callback));
+}
+
+Ref<BackgroundFetchStore> NetworkSession::createBackgroundFetchStore()
+{
+    return BackgroundFetchStoreImpl::create();
 }
 #endif // ENABLE(SERVICE_WORKER)
 

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -268,11 +268,15 @@ protected:
 #endif
 
 #if ENABLE(SERVICE_WORKER)
+    // SWServerDelegate
     void softUpdate(WebCore::ServiceWorkerJobData&&, bool shouldRefreshCache, WebCore::ResourceRequest&&, CompletionHandler<void(WebCore::WorkerFetchResult&&)>&&) final;
     void createContextConnection(const WebCore::RegistrableDomain&, std::optional<WebCore::ProcessIdentifier>, std::optional<WebCore::ScriptExecutionContextIdentifier>, CompletionHandler<void()>&&) final;
     void appBoundDomains(CompletionHandler<void(HashSet<WebCore::RegistrableDomain>&&)>&&) final;
     void addAllowedFirstPartyForCookies(WebCore::ProcessIdentifier, std::optional<WebCore::ProcessIdentifier>, WebCore::RegistrableDomain&&) final;
     void requestBackgroundFetchPermission(const WebCore::ClientOrigin&, CompletionHandler<void(bool)>&&) final;
+    std::unique_ptr<WebCore::BackgroundFetchRecordLoader> createBackgroundFetchRecordLoader(WebCore::BackgroundFetchRecordLoader::Client&, WebCore::ResourceRequest&&, WebCore::FetchOptions&&, const WebCore::ClientOrigin&) final;
+    void requestBackgroundFetchSpace(const WebCore::ClientOrigin&, uint64_t size, CompletionHandler<void(bool)>&&) final;
+    Ref<WebCore::BackgroundFetchStore> createBackgroundFetchStore() final;
 #endif // ENABLE(SERVICE_WORKER)
 
     PAL::SessionID m_sessionID;

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
@@ -100,6 +100,7 @@ private:
     void matchAllCompleted(uint64_t requestIdentifier, const Vector<WebCore::ServiceWorkerClientData>&) final;
     void firePushEvent(WebCore::ServiceWorkerIdentifier, const std::optional<Vector<uint8_t>>&, CompletionHandler<void(bool)>&&) final;
     void fireNotificationEvent(WebCore::ServiceWorkerIdentifier, const WebCore::NotificationData&, WebCore::NotificationEventType, CompletionHandler<void(bool)>&&) final;
+    void fireBackgroundFetchEvent(WebCore::ServiceWorkerIdentifier, const WebCore::BackgroundFetchInformation&, CompletionHandler<void(bool)>&&) final;
     void close() final;
     void focus(WebCore::ScriptExecutionContextIdentifier, CompletionHandler<void(std::optional<WebCore::ServiceWorkerClientData>&&)>&&);
     void navigate(WebCore::ScriptExecutionContextIdentifier, WebCore::ServiceWorkerIdentifier, const URL&, CompletionHandler<void(Expected<std::optional<WebCore::ServiceWorkerClientData>, WebCore::ExceptionData>&&)>&&);

--- a/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.cpp
+++ b/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "BackgroundFetchStoreImpl.h"
+
+#if ENABLE(SERVICE_WORKER)
+
+#include <WebCore/ResourceError.h>
+#include <WebCore/SharedBuffer.h>
+
+namespace WebKit {
+
+using namespace WebCore;
+
+// FIXME: Handle quota.
+
+BackgroundFetchStoreImpl::BackgroundFetchStoreImpl()
+{
+}
+
+BackgroundFetchStoreImpl::~BackgroundFetchStoreImpl()
+{
+}
+
+void BackgroundFetchStoreImpl::initializeFetches(BackgroundFetchEngine& engine, const ServiceWorkerRegistrationKey& key, CompletionHandler<void()>&& callback)
+{
+    callback();
+}
+
+void BackgroundFetchStoreImpl::clearFetch(const ServiceWorkerRegistrationKey& key, const String& identifier, CompletionHandler<void()>&& callback)
+{
+    callback();
+}
+
+void BackgroundFetchStoreImpl::clearAllFetches(const ServiceWorkerRegistrationKey& key, CompletionHandler<void()>&& callback)
+{
+    callback();
+}
+
+void BackgroundFetchStoreImpl::storeFetch(const ServiceWorkerRegistrationKey& key, const String& identifier, Vector<uint8_t>&& fetch, CompletionHandler<void(StoreResult)>&& callback)
+{
+    callback(StoreResult::OK);
+}
+
+void BackgroundFetchStoreImpl::storeFetchResponseBodyChunk(const ServiceWorkerRegistrationKey& key, const String& identifier, size_t index, const SharedBuffer& data, CompletionHandler<void(StoreResult)>&& callback)
+{
+    callback(StoreResult::OK);
+}
+
+void BackgroundFetchStoreImpl::retrieveResponseBody(const ServiceWorkerRegistrationKey& key, const String& identifier, size_t index, RetrieveRecordResponseBodyCallback&& callback)
+{
+    callback(RefPtr<SharedBuffer> { });
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(SERVICE_WORKER)

--- a/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.h
+++ b/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#pragma once
+
+#if ENABLE(SERVICE_WORKER)
+
+#include <WebCore/BackgroundFetchStore.h>
+#include <WebCore/ClientOrigin.h>
+#include <wtf/HashMap.h>
+
+namespace WTF {
+class WorkQueue;
+}
+
+namespace WebKit {
+
+class BackgroundFetchStoreImpl :  public WebCore::BackgroundFetchStore {
+public:
+    static Ref<BackgroundFetchStoreImpl> create() { return adoptRef(*new BackgroundFetchStoreImpl()); }
+    ~BackgroundFetchStoreImpl();
+
+private:
+    BackgroundFetchStoreImpl();
+
+    void initializeFetches(WebCore::BackgroundFetchEngine&, const WebCore::ServiceWorkerRegistrationKey&, CompletionHandler<void()>&&) final;
+    void clearFetch(const WebCore::ServiceWorkerRegistrationKey&, const String&, CompletionHandler<void()>&&) final;
+    void clearAllFetches(const WebCore::ServiceWorkerRegistrationKey&, CompletionHandler<void()>&&) final;
+    void storeFetch(const WebCore::ServiceWorkerRegistrationKey&, const String&, Vector<uint8_t>&&, CompletionHandler<void(StoreResult)>&&) final;
+    void storeFetchResponseBodyChunk(const WebCore::ServiceWorkerRegistrationKey&, const String&, size_t, const WebCore::SharedBuffer&, CompletionHandler<void(StoreResult)>&&) final;
+    void retrieveResponseBody(const WebCore::ServiceWorkerRegistrationKey&, const String&, size_t, RetrieveRecordResponseBodyCallback&&) final;
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(SERVICE_WORKER)

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -51,6 +51,7 @@ class SharedFileHandle;
 }
 
 namespace WebCore {
+class BackgroundFetchStore;
 class IDBCursorInfo;
 class IDBKeyData;
 class IDBIndexInfo;

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -87,6 +87,7 @@ GPUProcess/webrtc/RemoteMediaRecorderManager.cpp
 GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.cpp
 GPUProcess/webrtc/RemoteSampleBufferDisplayLayerManager.cpp
 
+NetworkProcess/BackgroundFetchLoad.cpp
 NetworkProcess/DatabaseUtilities.cpp
 NetworkProcess/NetworkActivityTracker.cpp
 NetworkProcess/NetworkBroadcastChannelRegistry.cpp
@@ -149,6 +150,7 @@ NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp
 NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.cpp
 NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.cpp
 
+NetworkProcess/storage/BackgroundFetchStoreImpl.cpp
 NetworkProcess/storage/CacheStorageCache.cpp
 NetworkProcess/storage/CacheStorageMemoryStore.cpp
 NetworkProcess/storage/CacheStorageManager.cpp

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -893,6 +893,7 @@
 		411B89C927B2B75D00F9EBD3 /* WKQueryPermissionResultCallback.h in Headers */ = {isa = PBXBuildFile; fileRef = 411B89C727B2B75C00F9EBD3 /* WKQueryPermissionResultCallback.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		411B89CC27B2B89800F9EBD3 /* QueryPermissionResultCallback.h in Headers */ = {isa = PBXBuildFile; fileRef = 411B89CB27B2B89600F9EBD3 /* QueryPermissionResultCallback.h */; };
 		41287D4E225D1ECB009A3E26 /* WebSocketTaskCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 41287D4B225C05C4009A3E26 /* WebSocketTaskCocoa.mm */; };
+		412915A129A8C7A300BE3091 /* BackgroundFetchStoreImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = 4129159F29A8C7A300BE3091 /* BackgroundFetchStoreImpl.h */; };
 		413075AC1DE85F370039EC69 /* NetworkRTCMonitor.h in Headers */ = {isa = PBXBuildFile; fileRef = 4130759B1DE84FB00039EC69 /* NetworkRTCMonitor.h */; };
 		413075AD1DE85F580039EC69 /* LibWebRTCSocket.h in Headers */ = {isa = PBXBuildFile; fileRef = 413075A01DE85EE70039EC69 /* LibWebRTCSocket.h */; };
 		413075B01DE85F580039EC69 /* WebRTCMonitor.h in Headers */ = {isa = PBXBuildFile; fileRef = 413075A31DE85EE70039EC69 /* WebRTCMonitor.h */; };
@@ -4422,6 +4423,8 @@
 		41287D4B225C05C4009A3E26 /* WebSocketTaskCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebSocketTaskCocoa.mm; sourceTree = "<group>"; };
 		41287D4C225C05C5009A3E26 /* WebSocketTaskCocoa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebSocketTaskCocoa.h; sourceTree = "<group>"; };
 		41287D4D225C161F009A3E26 /* WebSocketTask.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebSocketTask.h; sourceTree = "<group>"; };
+		4129159F29A8C7A300BE3091 /* BackgroundFetchStoreImpl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BackgroundFetchStoreImpl.h; sourceTree = "<group>"; };
+		412915A029A8C7A300BE3091 /* BackgroundFetchStoreImpl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BackgroundFetchStoreImpl.cpp; sourceTree = "<group>"; };
 		412FF91625373F9D001DF036 /* RemoteAudioSourceProvider.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteAudioSourceProvider.cpp; sourceTree = "<group>"; };
 		412FF91725373F9D001DF036 /* RemoteAudioSourceProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RemoteAudioSourceProvider.h; sourceTree = "<group>"; };
 		412FF92325382BD3001DF036 /* RemoteAudioSourceProviderManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteAudioSourceProviderManager.cpp; sourceTree = "<group>"; };
@@ -4541,6 +4544,8 @@
 		41E0A7C823B6397900561060 /* LibWebRTCCodecsProxy.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = LibWebRTCCodecsProxy.mm; sourceTree = "<group>"; };
 		41E242DE26E0C8D6009A8C64 /* NetworkRTCUtilitiesCocoa.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NetworkRTCUtilitiesCocoa.h; sourceTree = "<group>"; };
 		41E242DF26E0C904009A8C64 /* NetworkRTCUtilitiesCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = NetworkRTCUtilitiesCocoa.mm; sourceTree = "<group>"; };
+		41E4C3F429A3E38800EA6B3A /* BackgroundFetchLoad.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BackgroundFetchLoad.h; sourceTree = "<group>"; };
+		41E4C3F529A3E38900EA6B3A /* BackgroundFetchLoad.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = BackgroundFetchLoad.cpp; sourceTree = "<group>"; };
 		41E67A8C25D2CFD0007B0A4C /* RemoteRealtimeAudioSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteRealtimeAudioSource.h; sourceTree = "<group>"; };
 		41E67A8D25D2CFD0007B0A4C /* RemoteRealtimeAudioSource.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteRealtimeAudioSource.cpp; sourceTree = "<group>"; };
 		41EB4D3A274CE04500A9272B /* ServiceWorkerNavigationPreloader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ServiceWorkerNavigationPreloader.h; sourceTree = "<group>"; };
@@ -10423,6 +10428,8 @@
 				468386652763FA1B00CF9182 /* SharedWorker */,
 				93085DC226E1BB65000EC6A7 /* storage */,
 				413075971DE84ED70039EC69 /* webrtc */,
+				41E4C3F529A3E38900EA6B3A /* BackgroundFetchLoad.cpp */,
+				41E4C3F429A3E38800EA6B3A /* BackgroundFetchLoad.h */,
 				5C826D6E26D58A16008AEC91 /* DatabaseUtilities.cpp */,
 				5C826D6F26D58A16008AEC91 /* DatabaseUtilities.h */,
 				53F3CAA5206C443E0086490E /* NetworkActivityTracker.cpp */,
@@ -11458,6 +11465,8 @@
 		93085DC226E1BB65000EC6A7 /* storage */ = {
 			isa = PBXGroup;
 			children = (
+				412915A029A8C7A300BE3091 /* BackgroundFetchStoreImpl.cpp */,
+				4129159F29A8C7A300BE3091 /* BackgroundFetchStoreImpl.h */,
 				935BF7FB2936BF1A00B41326 /* CacheStorageCache.cpp */,
 				935BF7F22936BF1700B41326 /* CacheStorageCache.h */,
 				934CF814294B884B00304F7D /* CacheStorageDiskStore.cpp */,
@@ -14057,6 +14066,7 @@
 				E1513C67166EABB200149FCB /* AuxiliaryProcessProxy.h in Headers */,
 				290F4272172A0C7400939FF0 /* AuxiliaryProcessSupplement.h in Headers */,
 				CDA041F41ACE2105004A13EC /* BackBoardServicesSPI.h in Headers */,
+				412915A129A8C7A300BE3091 /* BackgroundFetchStoreImpl.h in Headers */,
 				46A2B6091E5676A600C3DEDA /* BackgroundProcessResponsivenessTimer.h in Headers */,
 				95C943912523C0D00054F3D5 /* BaseBoardSPI.h in Headers */,
 				E164A2F2191AF14E0010737D /* BlobDataFileReferenceWithSandboxExtension.h in Headers */,

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.h
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.h
@@ -37,6 +37,7 @@
 #include "WebPageProxyIdentifier.h"
 #include "WebPreferencesStore.h"
 #include "WorkQueueMessageReceiver.h"
+#include <WebCore/BackgroundFetchFailureReason.h>
 #include <WebCore/SWContextManager.h>
 #include <WebCore/ServiceWorkerClientData.h>
 #include <WebCore/ServiceWorkerTypes.h>
@@ -108,6 +109,7 @@ private:
     void fireActivateEvent(WebCore::ServiceWorkerIdentifier);
     void firePushEvent(WebCore::ServiceWorkerIdentifier, const std::optional<IPC::DataReference>&, CompletionHandler<void(bool)>&&);
     void fireNotificationEvent(WebCore::ServiceWorkerIdentifier, WebCore::NotificationData&&, WebCore::NotificationEventType, CompletionHandler<void(bool)>&&);
+    void fireBackgroundFetchEvent(WebCore::ServiceWorkerIdentifier, WebCore::BackgroundFetchInformation&&, CompletionHandler<void(bool)>&&);
     void terminateWorker(WebCore::ServiceWorkerIdentifier);
 #if ENABLE(SHAREABLE_RESOURCE) && PLATFORM(COCOA)
     void didSaveScriptsToDisk(WebCore::ServiceWorkerIdentifier, WebCore::ScriptBuffer&&, HashMap<URL, WebCore::ScriptBuffer>&& importedScripts);

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.messages.in
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.messages.in
@@ -33,6 +33,7 @@ messages -> WebSWContextManagerConnection {
     FireActivateEvent(WebCore::ServiceWorkerIdentifier identifier)
     FirePushEvent(WebCore::ServiceWorkerIdentifier identifier, std::optional<IPC::DataReference> data) -> (bool result)
     FireNotificationEvent(WebCore::ServiceWorkerIdentifier identifier, struct WebCore::NotificationData data, enum:bool WebCore::NotificationEventType type) -> (bool result)
+    FireBackgroundFetchEvent(WebCore::ServiceWorkerIdentifier identifier, struct WebCore::BackgroundFetchInformation info) -> (bool result)
 
     TerminateWorker(WebCore::ServiceWorkerIdentifier identifier)
 #if ENABLE(SHAREABLE_RESOURCE) && PLATFORM(COCOA)


### PR DESCRIPTION
#### 1767a09f5be8c26c8b4e95a11cfe9af937a0f114
<pre>
Add a functional background fetch backend
<a href="https://bugs.webkit.org/show_bug.cgi?id=252657">https://bugs.webkit.org/show_bug.cgi?id=252657</a>
rdar://problem/105720611

Reviewed by Chris Dumez and Sihui Liu.

Implement background fetch backend as follows:
- BackgroundFetchEngine is the class that is used by SWServer to implement the background fetch functionality
- BackgroundFetch represents a back ground fetch and has BackgroundFetch::Record(s).
- BackgroundFetchRecordLoader and its BackgroundFetchLoad implementation is about the actual network load.
- BackgroundFetchStore and its WebKit implementation BackgroundFetchStoreImpl allow storing background fetches.
BackgroundFetchStoreImpl is currently an empty shell.

Covered by rebased tests.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/background-fetch/abort.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/background-fetch/content-security-policy.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/background-fetch/fetch-uploads.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/background-fetch/fetch.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/background-fetch/get-ids.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/background-fetch/get.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/background-fetch/match.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/background-fetch/mixed-content-and-allowed-schemes.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/background-fetch/port-blocking.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/background-fetch/update-ui.https.window-expected.txt:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/workers/service/ServiceWorkerRegistrationKey.h:
* Source/WebCore/workers/service/background-fetch/BackgroundFetch.cpp: Added.
(WebCore::BackgroundFetch::BackgroundFetch):
(WebCore::BackgroundFetch::~BackgroundFetch):
(WebCore::BackgroundFetch::information const):
(WebCore::BackgroundFetch::match):
(WebCore::BackgroundFetch::abort):
(WebCore::BackgroundFetch::perform):
(WebCore::BackgroundFetch::storeResponse):
(WebCore::BackgroundFetch::storeResponseBodyChunk):
(WebCore::BackgroundFetch::didSendData):
(WebCore::BackgroundFetch::didFinishRecord):
(WebCore::BackgroundFetch::handleStoreResult):
(WebCore::BackgroundFetch::recordIsCompleted):
(WebCore::BackgroundFetch::updateBackgroundFetchStatus):
(WebCore::BackgroundFetch::unsetRecordsAvailableFlag):
(WebCore::BackgroundFetch::Record::Record):
(WebCore::BackgroundFetch::Record::~Record):
(WebCore::BackgroundFetch::Record::isMatching const):
(WebCore::BackgroundFetch::Record::information const):
(WebCore::BackgroundFetch::Record::complete):
(WebCore::BackgroundFetch::Record::abort):
(WebCore::BackgroundFetch::Record::didSendData):
(WebCore::BackgroundFetch::Record::didReceiveResponse):
(WebCore::BackgroundFetch::Record::didReceiveResponseBodyChunk):
(WebCore::BackgroundFetch::Record::didFinish):
(WebCore::BackgroundFetch::Record::retrieveResponse):
(WebCore::BackgroundFetch::Record::retrieveRecordResponseBody):
* Source/WebCore/workers/service/background-fetch/BackgroundFetch.h: Added.
(WebCore::BackgroundFetch::identifier const):
(WebCore::BackgroundFetch::Record::create):
(WebCore::BackgroundFetch::Record::setAsCompleted):
(WebCore::BackgroundFetch::Record::isCompleted const):
(WebCore::BackgroundFetch::Record::responseDataSize const):
(WebCore::BackgroundFetch::isActive const):
(WebCore::BackgroundFetch::origin const):
(WebCore::BackgroundFetch::downloadTotal const):
(WebCore::BackgroundFetch::uploadTotal const):
* Source/WebCore/workers/service/background-fetch/BackgroundFetchEngine.cpp: Added.
(WebCore::BackgroundFetchEngine::BackgroundFetchEngine):
(WebCore::BackgroundFetchEngine::startBackgroundFetch):
(WebCore::BackgroundFetchEngine::notifyBackgroundFetchUpdate):
(WebCore::BackgroundFetchEngine::backgroundFetchInformation):
(WebCore::BackgroundFetchEngine::backgroundFetchIdentifiers):
(WebCore::BackgroundFetchEngine::abortBackgroundFetch):
(WebCore::BackgroundFetchEngine::matchBackgroundFetch):
(WebCore::BackgroundFetchEngine::remove):
(WebCore::BackgroundFetchEngine::retrieveRecordResponse):
(WebCore::BackgroundFetchEngine::retrieveRecordResponseBody):
* Source/WebCore/workers/service/background-fetch/BackgroundFetchEngine.h: Added.
* Source/WebCore/workers/service/background-fetch/BackgroundFetchRecordLoader.h: Added.
* Source/WebCore/workers/service/background-fetch/BackgroundFetchStore.h: Added.
(WebCore::BackgroundFetchStore::clearRecords):
(WebCore::BackgroundFetchStore::clearAllRecords):
* Source/WebCore/workers/service/context/SWContextManager.cpp:
(WebCore::SWContextManager::fireBackgroundFetchEvent):
* Source/WebCore/workers/service/context/SWContextManager.h:
* Source/WebCore/workers/service/context/ServiceWorkerThread.cpp:
(WebCore::ServiceWorkerThread::queueTaskToFireBackgroundFetchEvent):
* Source/WebCore/workers/service/context/ServiceWorkerThread.h:
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp:
(WebCore::ServiceWorkerThreadProxy::fireBackgroundFetchEvent):
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h:
* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::removeRegistration):
(WebCore::SWServer::fireBackgroundFetchEvent):
(WebCore::SWServer::backgroundFetchEngine):
(WebCore::SWServer::Connection::startBackgroundFetch):
(WebCore::SWServer::Connection::backgroundFetchInformation):
(WebCore::SWServer::Connection::backgroundFetchIdentifiers):
(WebCore::SWServer::Connection::abortBackgroundFetch):
(WebCore::SWServer::Connection::matchBackgroundFetch):
(WebCore::SWServer::Connection::retrieveRecordResponse):
(WebCore::SWServer::Connection::retrieveRecordResponseBody):
* Source/WebCore/workers/service/server/SWServer.h:
(WebCore::SWServer::createBackgroundFetchRecordLoader):
(WebCore::SWServer::requestBackgroundFetchSpace):
(WebCore::SWServer::createBackgroundFetchStore):
* Source/WebCore/workers/service/server/SWServerDelegate.h:
* Source/WebCore/workers/service/server/SWServerToContextConnection.h:
* Source/WebKit/NetworkProcess/BackgroundFetchLoad.cpp: Added.
(WebKit::toSecurityOrigin):
(WebKit::BackgroundFetchLoad::BackgroundFetchLoad):
(WebKit::BackgroundFetchLoad::initialize):
(WebKit::BackgroundFetchLoad::~BackgroundFetchLoad):
(WebKit::BackgroundFetchLoad::abort):
(WebKit::BackgroundFetchLoad::didFinish):
(WebKit::BackgroundFetchLoad::loadRequest):
(WebKit::BackgroundFetchLoad::willPerformHTTPRedirection):
(WebKit::BackgroundFetchLoad::didReceiveChallenge):
(WebKit::BackgroundFetchLoad::didReceiveResponse):
(WebKit::BackgroundFetchLoad::didReceiveData):
(WebKit::BackgroundFetchLoad::didCompleteWithError):
(WebKit::BackgroundFetchLoad::didSendData):
(WebKit::BackgroundFetchLoad::wasBlocked):
(WebKit::BackgroundFetchLoad::cannotShowURL):
(WebKit::BackgroundFetchLoad::wasBlockedByRestrictions):
(WebKit::BackgroundFetchLoad::wasBlockedByDisabledFTP):
(WebKit::BackgroundFetchLoad::currentURL const):
* Source/WebKit/NetworkProcess/BackgroundFetchLoad.h: Added.
* Source/WebKit/NetworkProcess/NetworkLoadChecker.h:
(WebKit::NetworkLoadChecker::origin const):
(WebKit::NetworkLoadChecker::topOrigin const):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::NetworkSession::createBackgroundFetchRecordLoader):
(WebKit::NetworkSession::requestBackgroundFetchSpace):
(WebKit::NetworkSession::createBackgroundFetchStore):
* Source/WebKit/NetworkProcess/NetworkSession.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp:
(WebKit::WebSWServerToContextConnection::fireBackgroundFetchEvent):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h:
* Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.cpp: Added.
* Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.h: Added.
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::createBackgroundFetchStore):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/Sources.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp:
(WebKit::WebSWContextManagerConnection::fireBackgroundFetchEvent):
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.h:
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.messages.in:

Canonical link: <a href="https://commits.webkit.org/260928@main">https://commits.webkit.org/260928@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3142406670cd5eb2406247efc9e8b982256a2d13

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109991 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19092 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42674 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1435 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/119038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113945 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20557 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10285 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102249 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115738 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/43522 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/30173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/85345 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11794 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/31513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12417 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17785 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7578 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14212 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->