### PR TITLE
[content-visibility] Do no create renderers for skipped content

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4766,13 +4766,14 @@ webanimations/translate-property-and-translate-animation-with-delay-on-forced-la
 
 # CSS containment tests that fail
 imported/w3c/web-platform-tests/css/css-contain/contain-inline-size-bfc-floats-001.html [ ImageOnlyFailure ]
-# forced layout
-imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-035.html [ Skip ]
+# can't work since scroll offset is stored in renderer
+imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-081.html [ Skip ]
+# problematic test crbug.com/1247844
+imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-input-image.html [ Skip ]
 # c-v: auto
 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-075.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-076.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-state-changed.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-fieldset-size.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-video.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-contain/counter-scoping-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-contain/counter-scoping-002.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-035.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-035.html
@@ -10,7 +10,7 @@
 <body style="margin: 0">
 
 <div id="host">
-  <input id="slotted" type="text">
+  <input id="slotted" type="button">
 </div>
 
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-044-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-044-expected.txt
@@ -1,4 +1,3 @@
 
-
 PASS Content Visibility: slot moved after container is hidden
 

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -362,6 +362,15 @@ private:
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
 };
 
+class ContentVisibilityForceLayoutScope {
+public:
+    ContentVisibilityForceLayoutScope(Element&);
+    ~ContentVisibilityForceLayoutScope();
+
+private:
+    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
+};
+
 class Document
     : public ContainerNode
     , public TreeScope
@@ -1772,6 +1781,9 @@ public:
     DOMAudioSessionType audioSessionType() const { return m_audioSessionType; }
 #endif
 
+    void ignoreSkippedContent(bool ignore) { m_ignoreSkippedContent = ignore; }
+    bool isSkippedContentIgnored() const { return m_ignoreSkippedContent; }
+
 protected:
     enum ConstructionFlags { Synthesized = 1, NonRenderedPlaceholder = 1 << 1 };
     WEBCORE_EXPORT Document(LocalFrame*, const Settings&, const URL&, DocumentClasses = { }, unsigned constructionFlags = 0, ScriptExecutionContextIdentifier = { });
@@ -2397,6 +2409,7 @@ private:
     bool m_didDispatchViewportPropertiesChanged { false };
 #endif
     bool m_isDirAttributeDirty { false };
+    bool m_ignoreSkippedContent { false };
 
     static bool hasEverCreatedAnAXObjectCache;
 

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -693,6 +693,9 @@ public:
     void storeDisplayContentsStyle(std::unique_ptr<RenderStyle>);
     void clearDisplayContentsStyle();
 
+    bool isSkippedContent() const;
+    void storeSkippedContentStyle(std::unique_ptr<RenderStyle>);
+
     using ContainerNode::setAttributeEventListener;
     void setAttributeEventListener(const AtomString& eventType, const QualifiedName& attributeName, const AtomString& value);
 

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -537,8 +537,11 @@ void HTMLImageElement::setPictureElement(HTMLPictureElement* pictureElement)
     
 unsigned HTMLImageElement::width()
 {
-    if (inRenderedDocument())
+    if (inRenderedDocument()) {
+        ContentVisibilityForceLayoutScope scope(*const_cast<HTMLImageElement*>(this));
+
         document().updateLayoutIgnorePendingStylesheets();
+    }
 
     if (!renderer()) {
         // check the attribute first for an explicit pixel value
@@ -560,8 +563,11 @@ unsigned HTMLImageElement::width()
 
 unsigned HTMLImageElement::height()
 {
-    if (inRenderedDocument())
+    if (inRenderedDocument()) {
+        ContentVisibilityForceLayoutScope scope(*const_cast<HTMLImageElement*>(this));
+
         document().updateLayoutIgnorePendingStylesheets();
+    }
 
     if (!renderer()) {
         // check the attribute first for an explicit pixel value
@@ -702,6 +708,8 @@ void HTMLImageElement::setWidth(unsigned value)
 
 int HTMLImageElement::x() const
 {
+    ContentVisibilityForceLayoutScope scope(*const_cast<HTMLImageElement*>(this));
+
     document().updateLayoutIgnorePendingStylesheets();
     auto renderer = this->renderer();
     if (!renderer)
@@ -713,6 +721,8 @@ int HTMLImageElement::x() const
 
 int HTMLImageElement::y() const
 {
+    ContentVisibilityForceLayoutScope scope(*const_cast<HTMLImageElement*>(this));
+
     document().updateLayoutIgnorePendingStylesheets();
     auto renderer = this->renderer();
     if (!renderer)

--- a/Source/WebCore/html/ImageInputType.cpp
+++ b/Source/WebCore/html/ImageInputType.cpp
@@ -175,6 +175,8 @@ unsigned ImageInputType::height() const
     ASSERT(element());
     Ref<HTMLInputElement> element(*this->element());
 
+    ContentVisibilityForceLayoutScope scope(element.get());
+
     element->document().updateLayout();
 
     if (auto* renderer = element->renderer())
@@ -196,6 +198,8 @@ unsigned ImageInputType::width() const
 {
     ASSERT(element());
     Ref<HTMLInputElement> element(*this->element());
+
+    ContentVisibilityForceLayoutScope scope(element.get());
 
     element->document().updateLayout();
 

--- a/Source/WebCore/page/ResizeObservation.cpp
+++ b/Source/WebCore/page/ResizeObservation.cpp
@@ -72,10 +72,10 @@ auto ResizeObservation::computeObservedSizes() const -> std::optional<BoxSizes>
         }
     }
 
+    if (m_target->isSkippedContent())
+        return std::nullopt;
     auto* box = m_target->renderBox();
     if (box) {
-        if (box->isSkippedContent())
-            return std::nullopt;
         return { {
             adjustLayoutSizeForAbsoluteZoom(box->contentSize(), *box),
             adjustLayoutSizeForAbsoluteZoom(box->contentLogicalSize(), *box),

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -2700,7 +2700,7 @@ bool RenderObject::isSkippedContent() const
 
 bool RenderObject::shouldSkipContent() const
 {
-    return style().contentVisibility() == ContentVisibility::Hidden;
+    return shouldApplySizeOrStyleContainment(style().contentVisibility() == ContentVisibility::Hidden);
 }
 
 TextStream& operator<<(TextStream& ts, const RenderObject& renderer)

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -834,6 +834,8 @@ protected:
 
     void issueRepaint(std::optional<LayoutRect> partialRepaintRect = std::nullopt, ClipRepaintToLayer = ClipRepaintToLayer::No, ForceRepaint = ForceRepaint::No, ClipRepaintToContainer = ClipRepaintToContainer::Yes) const;
 
+    bool shouldApplySizeOrStyleContainment(bool) const;
+
 private:
     void addAbsoluteRectForLayer(LayoutRect& result);
     void setLayerNeedsFullRepaint();

--- a/Source/WebCore/rendering/RenderObjectInlines.h
+++ b/Source/WebCore/rendering/RenderObjectInlines.h
@@ -28,5 +28,6 @@ inline bool RenderObject::hasTransformOrPerspective() const { return hasTransfor
 inline bool RenderObject::isAtomicInlineLevelBox() const { return style().isDisplayInlineType() && !(style().display() == DisplayType::Inline && !isReplacedOrInlineBlock()); }
 inline bool RenderObject::isTransformed() const { return hasTransformRelatedProperty() && (style().affectsTransform() || hasSVGTransform()); }
 inline bool RenderObject::preservesNewline() const { return !isSVGInlineText() && style().preserveNewline(); }
+inline bool RenderObject::shouldApplySizeOrStyleContainment(bool containsAccordingToStyle) const { return containsAccordingToStyle && (!isInline() || isAtomicInlineLevelBox()) && !isRubyText() && (!isTablePart() || isTableCaption()) && !isTable(); }
 
 } // namespace WebCore

--- a/Source/WebCore/style/StyleChange.cpp
+++ b/Source/WebCore/style/StyleChange.cpp
@@ -35,6 +35,8 @@ Change determineChange(const RenderStyle& s1, const RenderStyle& s2)
 {
     if (s1.display() != s2.display())
         return Change::Renderer;
+    if (s1.contentVisibility() != s2.contentVisibility())
+        return Change::Renderer;
     if (s1.hasPseudoStyle(PseudoId::FirstLetter) != s2.hasPseudoStyle(PseudoId::FirstLetter))
         return Change::Renderer;
     // We just detach if a renderer acquires or loses a column-span, since spanning elements

--- a/Source/WebCore/svg/SVGLocatable.cpp
+++ b/Source/WebCore/svg/SVGLocatable.cpp
@@ -67,8 +67,11 @@ SVGElement* SVGLocatable::farthestViewportElement(const SVGElement* element)
 FloatRect SVGLocatable::getBBox(SVGElement* element, StyleUpdateStrategy styleUpdateStrategy)
 {
     ASSERT(element);
-    if (styleUpdateStrategy == AllowStyleUpdate)
+    if (styleUpdateStrategy == AllowStyleUpdate) {
+        ContentVisibilityForceLayoutScope scope(*element);
+
         element->document().updateLayoutIgnorePendingStylesheets();
+    }
 
     // FIXME: Eventually we should support getBBox for detached elements.
     if (!element->renderer())

--- a/Source/WebCore/svg/SVGTextContentElement.cpp
+++ b/Source/WebCore/svg/SVGTextContentElement.cpp
@@ -56,12 +56,16 @@ SVGTextContentElement::SVGTextContentElement(const QualifiedName& tagName, Docum
 
 unsigned SVGTextContentElement::getNumberOfChars()
 {
+    ContentVisibilityForceLayoutScope scope(*this);
+
     document().updateLayoutIgnorePendingStylesheets();
     return SVGTextQuery(renderer()).numberOfCharacters();
 }
 
 float SVGTextContentElement::getComputedTextLength()
 {
+    ContentVisibilityForceLayoutScope scope(*this);
+
     document().updateLayoutIgnorePendingStylesheets();
     return SVGTextQuery(renderer()).textLength();
 }
@@ -110,6 +114,8 @@ ExceptionOr<float> SVGTextContentElement::getRotationOfChar(unsigned charnum)
 
 int SVGTextContentElement::getCharNumAtPosition(DOMPointInit&& pointInit)
 {
+    ContentVisibilityForceLayoutScope scope(*this);
+
     document().updateLayoutIgnorePendingStylesheets();
     FloatPoint transformPoint {static_cast<float>(pointInit.x), static_cast<float>(pointInit.y)};
     return SVGTextQuery(renderer()).characterNumberAtPosition(transformPoint);


### PR DESCRIPTION
#### d73b0dac4dd6f8ef37e56fecf5a7ef0abc5a0087
<pre>
[content-visibility] Do no create renderers for skipped content
<a href="https://bugs.webkit.org/show_bug.cgi?id=252658">https://bugs.webkit.org/show_bug.cgi?id=252658</a>

Reviewed by NOBODY (OOPS!).

Do no create renderers for skipped content unless we are using a DOM method
that measures layout, in this case we use ContentVisibilityForceLayoutScope.

Since in some places in DOM we need to check for skipped content, in the case
where there is no renderer store the style using storeSkippedContentStyle and
use that when isSkippedContent is called while there is no renderer.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-035.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-044-expected.txt:
* Source/WebCore/dom/Document.cpp: Add helper to force layout if there is a hidden content-visibility subtree.
(WebCore::ContentVisibilityForceLayoutScope::ContentVisibilityForceLayoutScope):
(WebCore::ContentVisibilityForceLayoutScope::~ContentVisibilityForceLayoutScope):
* Source/WebCore/dom/Document.h: keep track of whether we want to ignore skipped content.
(WebCore::Document::ignoreSkippedContent):
(WebCore::Document::isSkippedContentIgnored const):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::hasFocusableStyle const):
(WebCore::Element::isFocusable const): rely on Element.isSkippedContent.
(WebCore::Element::offsetLeftForBindings):
(WebCore::Element::offsetTopForBindings):
(WebCore::Element::scrollTop):
(WebCore::Element::getClientRects):
(WebCore::Element::boundingClientRect):
(WebCore::Element::isSkippedContent const): check for skipped content regardless whether there is a renderer.
(WebCore::Element::storeSkippedContentStyle):
(WebCore::Element::innerText): rely on Element.isSkippedContent.
* Source/WebCore/dom/Element.h:
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::width):
(WebCore::HTMLImageElement::height):
(WebCore::HTMLImageElement::x const):
(WebCore::HTMLImageElement::y const):
* Source/WebCore/html/ImageInputType.cpp:
(WebCore::ImageInputType::height const):
(WebCore::ImageInputType::width const):
* Source/WebCore/page/ResizeObservation.cpp:
(WebCore::ResizeObservation::computeObservedSizes const):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::shouldSkipContent const): only can apply if size containment applies
* Source/WebCore/rendering/RenderObject.h: move from RenderElement
* Source/WebCore/rendering/RenderObjectInlines.h:
(WebCore::RenderObject::shouldApplySizeOrStyleContainment const):
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::RenderTreeUpdater::updateRenderTree): always proceed processing skipped content to set style on element.
(WebCore::RenderTreeUpdater::updateElementRenderer): do not create renderers for skipped content.
(WebCore::RenderTreeUpdater::updateTextRenderer): do not create text renderers for skipped content.
* Source/WebCore/style/StyleChange.cpp:
(WebCore::Style::determineChange): a content-visibility change needs a renderer update.
* Source/WebCore/svg/SVGLocatable.cpp:
(WebCore::SVGLocatable::getBBox):
* Source/WebCore/svg/SVGTextContentElement.cpp:
(WebCore::SVGTextContentElement::getNumberOfChars):
(WebCore::SVGTextContentElement::getComputedTextLength):
(WebCore::SVGTextContentElement::getCharNumAtPosition):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d73b0dac4dd6f8ef37e56fecf5a7ef0abc5a0087

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5772 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5935 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6124 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7329 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6164 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5772 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6157 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5903 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/7938 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5877 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5924 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5216 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7383 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3401 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5200 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/12983 "4 flakes 158 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5269 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5277 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7440 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5721 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4694 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5166 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/5130 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9283 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5527 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->