### PR TITLE
webgl/webgl-metal-disabled.html and webgl/webgl-via-metal-flag-off.html trigger GPU process crash

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -3774,6 +3774,11 @@ imported/w3c/web-platform-tests/css/css-fonts/font-weight-bolder-001.xht [ Image
 imported/w3c/web-platform-tests/css/css-fonts/font-weight-lighter-001.xht [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-fonts/font-weight-normal-001.xht [ ImageOnlyFailure ]
 
+# These tests are currently only relevant on older OSes. They should be removed once Metal is
+# the only backend on Cocoa WebKit.
+webgl/webgl-metal-disabled.html [ Skip ]
+webgl/webgl-via-metal-flag-off.html [ Skip ]
+
 # webkit.org/b/203763 2019 WebGL test gardening: These tests pass in Safari and the conformance suite, but timeout in TestRunner and MiniBrowser.
 webgl/1.0.3/conformance/glsl/bugs/complex-glsl-does-not-crash.html [ Skip ]
 webgl/1.0.3/conformance/glsl/constructors/glsl-construct-bvec3.html [ Skip ]

--- a/LayoutTests/platform/mac-bigsur/TestExpectations
+++ b/LayoutTests/platform/mac-bigsur/TestExpectations
@@ -1,0 +1,2 @@
+webgl/webgl-metal-disabled.html [ Pass ]
+webgl/webgl-via-metal-flag-off.html [ Pass ]


### PR DESCRIPTION
#### ea59040a79b363bf516f610a5868025dfdc4e800
<pre>
webgl/webgl-metal-disabled.html and webgl/webgl-via-metal-flag-off.html trigger GPU process crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=252659">https://bugs.webkit.org/show_bug.cgi?id=252659</a>
rdar://102072583

Reviewed by Antti Koivisto.

Disable the tests that test running Cocoa WebGL without Metal.
Enable the tests only on BigSur, as that is the only platform that
ships devices that use WebGL with ANGLE/OpenGL.

The reason for the crash is:

    if (( &quot;${TARGET_MAC_OS_X_VERSION_MAJOR}&quot; &gt;= 130000 ))
        then
            plistbuddy Add :com.apple.private.gpu-restricted bool YES
        fi

E.g. the new OSes have an entitlement disabling the GPU access needed
for the OpenGL and this is applied to all processes.

* LayoutTests/TestExpectations:
* LayoutTests/platform/mac-bigsur/TestExpectations: Added.

Canonical link: <a href="https://commits.webkit.org/260668@main">https://commits.webkit.org/260668@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e4ce2e0b1d021bf05b91b27e84e747c96209839b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108854 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17957 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41690 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/392 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118186 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19415 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9236 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101091 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114624 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14569 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97773 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42642 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96541 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29416 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84393 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10732 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30763 "Found 1 new test failure: media/video-object-fit.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11487 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7709 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16876 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50364 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7361 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13074 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->