### PR TITLE
Fix JPEGImageDecoder boolean enum and #define TRUE/FALSE mix

### DIFF
--- a/Source/WebCore/platform/image-decoders/jpeg/JPEGImageDecoder.h
+++ b/Source/WebCore/platform/image-decoders/jpeg/JPEGImageDecoder.h
@@ -32,13 +32,14 @@
 // ICU defines TRUE and FALSE macros, breaking libjpeg v9 headers
 #undef TRUE
 #undef FALSE
-extern "C" {
-#include "jpeglib.h"
-}
 
 #if USE(LCMS)
 #include "LCMSUniquePtr.h"
 #endif
+
+extern "C" {
+#include <jpeglib.h>
+}
 
 namespace WebCore {
 


### PR DESCRIPTION
<pre>
Fix JPEGImageDecoder boolean enum and #define TRUE/FALSE mix
<a href="https://bugs.webkit.org/show_bug.cgi?id=252666">https://bugs.webkit.org/show_bug.cgi?id=252666</a>

Reviewed by NOBODY (OOPS!).

jpeglib.h contains a typedef enum for boolean type but LCMSUniquePtr.h
include files that can contain #define TRUE/FALSE. This way build fails
with:
JPEGImageDecoder.cpp:343:43: error: invalid conversion from ‘int’ to ‘boolean’

This is because TRUE or FALSE should be an enum instead they get defined
as 1 or 0. To fix this move jpeglib.h inclusion after LCMSUniquePtr.h
inclusion. Let's also use angular paranthesis since jpeglib.h is a
system path header.

* Source/WebCore/platform/image-decoders/jpeg/JPEGImageDecoder.h:
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3588ed2eb35851fe423458d1240682841eca53d9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108882 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17986 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41725 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/426 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118202 "Failed to checkout and rebase branch from PR 10447") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112764 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19445 "Failed to checkout and rebase branch from PR 10447") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9269 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101125 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114652 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/76/builds/19445 "Failed to checkout and rebase branch from PR 10447") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97801 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42690 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/76/builds/19445 "Failed to checkout and rebase branch from PR 10447") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29442 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84424 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10760 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30791 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11515 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7728 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16905 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50387 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13103 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->