### PR TITLE
[IFC][Integration][Multicol] Allow column spanners

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2467,7 +2467,6 @@ imported/w3c/web-platform-tests/css/css-multicol/multicol-width-005.html
 imported/w3c/web-platform-tests/css/css-multicol/multicol-width-ch-001.xht [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-multicol/orthogonal-writing-mode-shrink-to-fit.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-multicol/with-custom-layout-on-same-element.https.html
-imported/w3c/web-platform-tests/css/css-multicol/zero-column-width-layout.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-multicol/multicol-span-all-children-height-003.html [ Skip ] # times out
 
 webkit.org/b/148884 imported/w3c/web-platform-tests/html/semantics/forms/textfieldselection/selection.html [ Pass Failure ]

--- a/LayoutTests/platform/ios/fast/multicol/client-rects-spanners-complex-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/client-rects-spanners-complex-expected.txt
@@ -82,7 +82,7 @@ layer at (136,72) size 48x115
     RenderMultiColumnSpannerPlaceholder at (0,10) size 0x0
     RenderBlock (anonymous) at (0,10) size 48x105
       RenderBR {BR} at (0,0) size 0x25
-      RenderInline {SPAN} at (0,0) size 25x80
+      RenderInline {SPAN} at (0,0) size 25x75
         RenderText {#text} at (0,25) size 25x80
           text run at (0,25) width 25: "x"
           text run at (0,55) width 25: "y"

--- a/LayoutTests/platform/mac/fast/multicol/client-rects-spanners-complex-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/client-rects-spanners-complex-expected.txt
@@ -82,7 +82,7 @@ layer at (136,71) size 48x115
     RenderMultiColumnSpannerPlaceholder at (0,10) size 0x0
     RenderBlock (anonymous) at (0,10) size 48x105
       RenderBR {BR} at (0,0) size 0x25
-      RenderInline {SPAN} at (0,0) size 25x80
+      RenderInline {SPAN} at (0,0) size 25x75
         RenderText {#text} at (0,25) size 25x80
           text run at (0,25) width 25: "x"
           text run at (0,55) width 25: "y"

--- a/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
@@ -88,9 +88,6 @@ namespace LayoutIntegration {
 static void printReason(AvoidanceReason reason, TextStream& stream)
 {
     switch (reason) {
-    case AvoidanceReason::FlowIsInsideANonMultiColumnThread:
-        stream << "flow is inside a non-multicolumn container";
-        break;
     case AvoidanceReason::ContentIsRuby:
         stream << "ruby";
         break;
@@ -117,9 +114,6 @@ static void printReason(AvoidanceReason reason, TextStream& stream)
         break;
     case AvoidanceReason::MultiColumnFlowHasVerticalWritingMode:
         stream << "column has vertical writing mode";
-        break;
-    case AvoidanceReason::MultiColumnFlowHasColumnSpanner:
-        stream << "column has spanner";
         break;
     case AvoidanceReason::MultiColumnFlowVerticalAlign:
         stream << "column with vertical-align != baseline";
@@ -430,15 +424,9 @@ OptionSet<AvoidanceReason> canUseForLineLayoutWithReason(const RenderBlockFlow& 
     if (!establishesInlineFormattingContext())
         SET_REASON_AND_RETURN_IF_NEEDED(FlowDoesNotEstablishInlineFormattingContext, reasons, includeReasons);
     if (flow.fragmentedFlowState() != RenderObject::NotInsideFragmentedFlow) {
-        auto* fragmentedFlow = flow.enclosingFragmentedFlow();
-        if (!is<RenderMultiColumnFlow>(fragmentedFlow))
-            SET_REASON_AND_RETURN_IF_NEEDED(FlowIsInsideANonMultiColumnThread, reasons, includeReasons);
-        auto& columnThread = downcast<RenderMultiColumnFlow>(*fragmentedFlow);
-        if (!flow.style().isHorizontalWritingMode())
-            SET_REASON_AND_RETURN_IF_NEEDED(MultiColumnFlowHasVerticalWritingMode, reasons, includeReasons);
-        if (columnThread.hasColumnSpanner())
-            SET_REASON_AND_RETURN_IF_NEEDED(MultiColumnFlowHasColumnSpanner, reasons, includeReasons);
         auto& style = flow.style();
+        if (!style.isHorizontalWritingMode())
+            SET_REASON_AND_RETURN_IF_NEEDED(MultiColumnFlowHasVerticalWritingMode, reasons, includeReasons);
         if (style.verticalAlign() != VerticalAlign::Baseline)
             SET_REASON_AND_RETURN_IF_NEEDED(MultiColumnFlowVerticalAlign, reasons, includeReasons);
         if (style.isFloating())

--- a/Source/WebCore/layout/integration/LayoutIntegrationCoverage.h
+++ b/Source/WebCore/layout/integration/LayoutIntegrationCoverage.h
@@ -39,7 +39,7 @@ namespace LayoutIntegration {
 class LineLayout;
 
 enum class AvoidanceReason : uint64_t {
-    FlowIsInsideANonMultiColumnThread            = 1LLU  << 0,
+    // Unused                                    = 1LLU  << 0,
     // Unused                                    = 1LLU  << 1,
     // Unused                                    = 1LLU  << 2,
     ContentIsRuby                                = 1LLU  << 3,
@@ -87,7 +87,7 @@ enum class AvoidanceReason : uint64_t {
     // Unused                                    = 1LLU  << 45,
     // Unused                                    = 1LLU  << 46,
     MultiColumnFlowHasVerticalWritingMode        = 1LLU  << 47,
-    MultiColumnFlowHasColumnSpanner              = 1LLU  << 48,
+    // Unused                                    = 1LLU  << 48,
     MultiColumnFlowVerticalAlign                 = 1LLU  << 49,
     MultiColumnFlowIsFloating                    = 1LLU  << 50,
     // Unused                                    = 1LLU  << 51,


### PR DESCRIPTION
#### b54541caa80c2ea7ade8d8f963a28250cbabf2fa
<pre>
[IFC][Integration][Multicol] Allow column spanners
<a href="https://bugs.webkit.org/show_bug.cgi?id=252667">https://bugs.webkit.org/show_bug.cgi?id=252667</a>
rdar://105727516

Reviewed by Alan Baradlay.

* LayoutTests/TestExpectations:
* LayoutTests/platform/ios/fast/multicol/client-rects-spanners-complex-expected.txt:
* LayoutTests/platform/mac/fast/multicol/client-rects-spanners-complex-expected.txt:
* Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp:

Also remove the is&lt;RenderMultiColumnFlow&gt; test, there is no other type of fragmentedFlow anymore
and the null case shouldn&apos;t happen.

(WebCore::LayoutIntegration::printReason):
(WebCore::LayoutIntegration::canUseForLineLayoutWithReason):
* Source/WebCore/layout/integration/LayoutIntegrationCoverage.h:

Canonical link: <a href="https://commits.webkit.org/260622@main">https://commits.webkit.org/260622@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/625515e00bb1549cf03925013ba4ec11980e7efe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/108887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/17992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/41730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/431 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/118206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/112768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/19449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/9274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101131 "Built successfully") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/114657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/19449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/41730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/42694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/19449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/41730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/84428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/10765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/41730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/11520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/9274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/16910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/41730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7338 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13108 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->