### PR TITLE
DocumentMarkerLineStyle should encode the marker color

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsTypes.h
+++ b/Source/WebCore/platform/graphics/GraphicsTypes.h
@@ -101,7 +101,7 @@ enum class DocumentMarkerLineStyleMode : uint8_t {
 
 struct DocumentMarkerLineStyle {
     DocumentMarkerLineStyleMode mode;
-    bool shouldUseDarkAppearance { false };
+    Color color;
 };
 
 // Legacy shadow blur radius is used for canvas, and -webkit-box-shadow.

--- a/Source/WebCore/platform/graphics/cairo/CairoOperations.cpp
+++ b/Source/WebCore/platform/graphics/cairo/CairoOperations.cpp
@@ -1057,10 +1057,8 @@ void drawDotsForDocumentMarker(GraphicsContextCairo& platformContext, const Floa
     cairo_t* cr = platformContext.cr();
     cairo_save(cr);
 
-    if (style.mode == DocumentMarkerLineStyleMode::Spelling)
-        cairo_set_source_rgb(cr, 1, 0, 0);
-    else if (style.mode == DocumentMarkerLineStyleMode::Grammar)
-        cairo_set_source_rgb(cr, 0, 1, 0);
+    auto [r, g, b, a] = style.color.toColorTypeLossy<SRGBA<uint8_t>>().resolved();
+    cairo_set_source_rgba(cr, r, g, b, a);
 
     drawErrorUnderline(cr, rect.x(), rect.y(), rect.width(), rect.height());
     cairo_restore(cr);

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextCocoa.mm
@@ -62,21 +62,6 @@ namespace WebCore {
 // NSColor, NSBezierPath, and NSGraphicsContext calls do not raise exceptions
 // so we don't block exceptions.
 
-static RetainPtr<CGColorRef> grammarColor(bool useDarkMode)
-{
-#if ENABLE(POST_EDITING_GRAMMAR_CHECKING)
-    static bool useBlueForGrammar = false;
-    static std::once_flag flag;
-    std::call_once(flag, [] {
-        useBlueForGrammar = os_feature_enabled(TextComposer, PostEditing) && os_feature_enabled(TextComposer, PostEditingUseBlueDots);
-    });
-
-    if (useBlueForGrammar)
-        return cachedCGColor(useDarkMode ? SRGBA<uint8_t> { 40, 145, 255, 217 } : SRGBA<uint8_t> { 0, 122, 255, 191 });
-#endif
-    return cachedCGColor(useDarkMode ? SRGBA<uint8_t> { 50, 215, 75, 217 } : SRGBA<uint8_t> { 25, 175, 50, 191 });
-}
-
 void GraphicsContextCG::drawFocusRing(const Path& path, float, const Color& color)
 {
     if (path.isNull())
@@ -132,22 +117,6 @@ static inline void setPatternPhaseInUserSpace(CGContextRef context, CGPoint phas
     CGContextSetPatternPhase(context, CGSizeMake(phase.x, phase.y));
 }
 
-static RetainPtr<CGColorRef> colorForMarkerLineStyle(DocumentMarkerLineStyleMode style, bool useDarkMode)
-{
-    switch (style) {
-    // Red
-    case DocumentMarkerLineStyleMode::Spelling:
-        return cachedCGColor(useDarkMode ? SRGBA<uint8_t> { 255, 140, 140, 217 } : SRGBA<uint8_t> { 255, 59, 48, 191 });
-    // Blue
-    case DocumentMarkerLineStyleMode::DictationAlternatives:
-    case DocumentMarkerLineStyleMode::TextCheckingDictationPhraseWithAlternatives:
-    case DocumentMarkerLineStyleMode::AutocorrectionReplacement:
-        return cachedCGColor(useDarkMode ? SRGBA<uint8_t> { 40, 145, 255, 217 } : SRGBA<uint8_t> { 0, 122, 255, 191 });
-    case DocumentMarkerLineStyleMode::Grammar:
-        return grammarColor(useDarkMode);
-    }
-}
-
 void GraphicsContextCG::drawDotsForDocumentMarker(const FloatRect& rect, DocumentMarkerLineStyle style)
 {
     // We want to find the number of full dots, so we're solving the equations:
@@ -166,11 +135,9 @@ void GraphicsContextCG::drawDotsForDocumentMarker(const FloatRect& rect, Documen
     // Center the dots
     auto offset = (width - (dotDiameter * numberOfWholeDots + dotGap * numberOfWholeGaps)) / 2;
 
-    auto circleColor = colorForMarkerLineStyle(style.mode, style.shouldUseDarkAppearance);
-
     CGContextRef platformContext = this->platformContext();
     CGContextStateSaver stateSaver { platformContext };
-    CGContextSetFillColorWithColor(platformContext, circleColor.get());
+    CGContextSetFillColorWithColor(platformContext, cachedCGColor(style.color).get());
     for (unsigned i = 0; i < numberOfWholeDots; ++i) {
         auto location = rect.location();
         location.move(offset + i * (dotDiameter + dotGap), 0);

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItemBuffer.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItemBuffer.cpp
@@ -276,6 +276,9 @@ void ItemHandle::destroy()
     case ItemType::DrawLinesForText:
         get<DrawLinesForText>().~DrawLinesForText();
         return;
+    case ItemType::DrawDotsForDocumentMarker:
+        get<DrawDotsForDocumentMarker>().~DrawDotsForDocumentMarker();
+        return;
     case ItemType::DrawPath:
         get<DrawPath>().~DrawPath();
         return;
@@ -337,9 +340,6 @@ void ItemHandle::destroy()
         return;
     case ItemType::ConcatenateCTM:
         static_assert(std::is_trivially_destructible<ConcatenateCTM>::value);
-        return;
-    case ItemType::DrawDotsForDocumentMarker:
-        static_assert(std::is_trivially_destructible<DrawDotsForDocumentMarker>::value);
         return;
     case ItemType::DrawEllipse:
         static_assert(std::is_trivially_destructible<DrawEllipse>::value);

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItemType.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItemType.cpp
@@ -287,6 +287,7 @@ bool isInlineItem(ItemType type)
     case ItemType::ClipOutToPath:
     case ItemType::ClipPath:
     case ItemType::DrawControlPart:
+    case ItemType::DrawDotsForDocumentMarker:
     case ItemType::DrawFocusRingPath:
     case ItemType::DrawFocusRingRects:
     case ItemType::DrawGlyphs:
@@ -315,7 +316,6 @@ bool isInlineItem(ItemType type)
     case ItemType::ClipOut:
     case ItemType::ClipToImageBuffer:
     case ItemType::ConcatenateCTM:
-    case ItemType::DrawDotsForDocumentMarker:
     case ItemType::DrawEllipse:
     case ItemType::DrawFilteredImageBuffer:
     case ItemType::DrawDecomposedGlyphs:

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
@@ -255,10 +255,7 @@ void DrawLinesForText::apply(GraphicsContext& context) const
 
 void DrawDotsForDocumentMarker::apply(GraphicsContext& context) const
 {
-    context.drawDotsForDocumentMarker(m_rect, {
-        static_cast<DocumentMarkerLineStyleMode>(m_styleMode),
-        m_styleShouldUseDarkAppearance,
-    });
+    context.drawDotsForDocumentMarker(m_rect, m_style);
 }
 
 void DrawEllipse::apply(GraphicsContext& context) const

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
@@ -951,34 +951,23 @@ std::optional<DrawLinesForText> DrawLinesForText::decode(Decoder& decoder)
 class DrawDotsForDocumentMarker {
 public:
     static constexpr ItemType itemType = ItemType::DrawDotsForDocumentMarker;
-    static constexpr bool isInlineItem = true;
+    static constexpr bool isInlineItem = false;
     static constexpr bool isDrawingItem = true;
-
-    using UnderlyingDocumentMarkerLineStyleType = std::underlying_type<DocumentMarkerLineStyleMode>::type;
 
     DrawDotsForDocumentMarker(const FloatRect& rect, const DocumentMarkerLineStyle& style)
         : m_rect(rect)
-        , m_styleMode(static_cast<UnderlyingDocumentMarkerLineStyleType>(style.mode))
-        , m_styleShouldUseDarkAppearance(style.shouldUseDarkAppearance)
-    {
-    }
-
-    DrawDotsForDocumentMarker(const FloatRect& rect, UnderlyingDocumentMarkerLineStyleType styleMode, bool styleShouldUseDarkAppearance)
-        : m_rect(rect)
-        , m_styleMode(styleMode)
-        , m_styleShouldUseDarkAppearance(styleShouldUseDarkAppearance)
+        , m_style(style)
     {
     }
     
     FloatRect rect() const { return m_rect; }
+    DocumentMarkerLineStyle style() const { return m_style; }
 
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
 
 private:
-    friend struct IPC::ArgumentCoder<DrawDotsForDocumentMarker, void>;
     FloatRect m_rect;
-    UnderlyingDocumentMarkerLineStyleType m_styleMode { 0 };
-    bool m_styleShouldUseDarkAppearance { false };
+    DocumentMarkerLineStyle m_style;
 };
 
 class DrawEllipse {

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -37,6 +37,7 @@
 #include "Frame.h"
 #include "FrameSelection.h"
 #include "GraphicsContext.h"
+#include "GraphicsTypes.h"
 #include "HTMLAttachmentElement.h"
 #include "HTMLButtonElement.h"
 #include "HTMLInputElement.h"
@@ -1980,6 +1981,22 @@ Color RenderTheme::datePlaceholderTextColor(const Color& textColor, const Color&
 
     // FIXME: Consider keeping color in LCHA (if that change is made) or converting back to the initial underlying color type to avoid unnecessarily clamping colors outside of sRGB.
     return convertColor<SRGBA<float>>(hsla);
+}
+
+Color RenderTheme::documentMarkerLineColor(DocumentMarkerLineStyleMode mode, OptionSet<StyleColorOptions>) const
+{
+    switch (mode) {
+    case DocumentMarkerLineStyleMode::Spelling:
+        return Color::red;
+    case DocumentMarkerLineStyleMode::DictationAlternatives:
+    case DocumentMarkerLineStyleMode::TextCheckingDictationPhraseWithAlternatives:
+    case DocumentMarkerLineStyleMode::AutocorrectionReplacement:
+    case DocumentMarkerLineStyleMode::Grammar:
+        return Color::green;
+    }
+
+    ASSERT_NOT_REACHED();
+    return Color::transparentBlack;
 }
 
 void RenderTheme::setCustomFocusRingColor(const Color& color)

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -32,6 +32,8 @@
 
 namespace WebCore {
 
+enum class DocumentMarkerLineStyleMode : uint8_t;
+
 struct AttachmentLayout;
 class BorderData;
 class Element;
@@ -181,6 +183,8 @@ public:
     Color defaultButtonTextColor(OptionSet<StyleColorOptions>) const;
 
     Color datePlaceholderTextColor(const Color& textColor, const Color& backgroundColor) const;
+
+    virtual Color documentMarkerLineColor(DocumentMarkerLineStyleMode, OptionSet<StyleColorOptions>) const;
 
     WEBCORE_EXPORT Color focusRingColor(OptionSet<StyleColorOptions>) const;
     virtual Color platformFocusRingColor(OptionSet<StyleColorOptions>) const { return Color::black; }

--- a/Source/WebCore/rendering/RenderThemeCocoa.h
+++ b/Source/WebCore/rendering/RenderThemeCocoa.h
@@ -56,6 +56,8 @@ private:
     void adjustApplePayButtonStyle(RenderStyle&, const Element*) const override;
 #endif
 
+    Color documentMarkerLineColor(DocumentMarkerLineStyleMode, OptionSet<StyleColorOptions>) const final;
+
 #if ENABLE(VIDEO) && ENABLE(MODERN_MEDIA_CONTROLS)
     String mediaControlsStyleSheet() override;
     Vector<String, 2> mediaControlsScripts() override;

--- a/Source/WebCore/rendering/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/RenderThemeCocoa.mm
@@ -40,6 +40,7 @@
 #import <CoreGraphics/CoreGraphics.h>
 #import <algorithm>
 #import <pal/spi/cf/CoreTextSPI.h>
+#import <pal/spi/cocoa/FeatureFlagsSPI.h>
 #import <wtf/Language.h>
 
 #if ENABLE(VIDEO)
@@ -241,5 +242,37 @@ void RenderThemeCocoa::paintAttachmentText(GraphicsContext& context, AttachmentL
 }
 
 #endif
+
+static Color grammarColor(bool useDarkMode)
+{
+#if ENABLE(POST_EDITING_GRAMMAR_CHECKING)
+    static bool useBlueForGrammar = false;
+    static std::once_flag flag;
+    std::call_once(flag, [] {
+        useBlueForGrammar = os_feature_enabled(TextComposer, PostEditing) && os_feature_enabled(TextComposer, PostEditingUseBlueDots);
+    });
+
+    if (useBlueForGrammar)
+        return useDarkMode ? SRGBA<uint8_t> { 40, 145, 255, 217 } : SRGBA<uint8_t> { 0, 122, 255, 191 };
+#endif
+    return useDarkMode ? SRGBA<uint8_t> { 50, 215, 75, 217 } : SRGBA<uint8_t> { 25, 175, 50, 191 };
+}
+
+Color RenderThemeCocoa::documentMarkerLineColor(DocumentMarkerLineStyleMode mode, OptionSet<StyleColorOptions> options) const
+{
+    bool useDarkMode = options.contains(StyleColorOptions::UseDarkAppearance);
+    switch (mode) {
+    // Red
+    case DocumentMarkerLineStyleMode::Spelling:
+        return useDarkMode ? SRGBA<uint8_t> { 255, 140, 140, 217 } : SRGBA<uint8_t> { 255, 59, 48, 191 };
+    // Blue
+    case DocumentMarkerLineStyleMode::DictationAlternatives:
+    case DocumentMarkerLineStyleMode::TextCheckingDictationPhraseWithAlternatives:
+    case DocumentMarkerLineStyleMode::AutocorrectionReplacement:
+        return useDarkMode ? SRGBA<uint8_t> { 40, 145, 255, 217 } : SRGBA<uint8_t> { 0, 122, 255, 191 };
+    case DocumentMarkerLineStyleMode::Grammar:
+        return grammarColor(useDarkMode);
+    }
+}
 
 }

--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -39,6 +39,7 @@
 #include "RenderBlock.h"
 #include "RenderCombineText.h"
 #include "RenderText.h"
+#include "RenderTheme.h"
 #include "RenderView.h"
 #include "ShadowData.h"
 #include "StyledMarkedText.h"
@@ -804,30 +805,30 @@ void TextBoxPainter<TextBoxPath>::paintPlatformDocumentMarker(const MarkedText& 
 
     auto bounds = calculateDocumentMarkerBounds(makeIterator(), markedText);
 
-    auto lineStyleForMarkedTextType = [&]() -> DocumentMarkerLineStyle {
-        bool shouldUseDarkAppearance = m_renderer.useDarkAppearance();
+    auto lineStyleMode = [&] {
         switch (markedText.type) {
         case MarkedText::SpellingError:
-            return { DocumentMarkerLineStyleMode::Spelling, shouldUseDarkAppearance };
+            return DocumentMarkerLineStyleMode::Spelling;
         case MarkedText::GrammarError:
-            return { DocumentMarkerLineStyleMode::Grammar, shouldUseDarkAppearance };
+            return DocumentMarkerLineStyleMode::Grammar;
         case MarkedText::Correction:
-            return { DocumentMarkerLineStyleMode::AutocorrectionReplacement, shouldUseDarkAppearance };
+            return DocumentMarkerLineStyleMode::AutocorrectionReplacement;
         case MarkedText::DictationAlternatives:
-            return { DocumentMarkerLineStyleMode::DictationAlternatives, shouldUseDarkAppearance };
+            return DocumentMarkerLineStyleMode::DictationAlternatives;
 #if PLATFORM(IOS_FAMILY)
         case MarkedText::DictationPhraseWithAlternatives:
             // FIXME: Rename DocumentMarkerLineStyle::TextCheckingDictationPhraseWithAlternatives and remove the PLATFORM(IOS_FAMILY)-guard.
-            return { DocumentMarkerLineStyleMode::TextCheckingDictationPhraseWithAlternatives, shouldUseDarkAppearance };
+            return DocumentMarkerLineStyleMode::TextCheckingDictationPhraseWithAlternatives;
 #endif
         default:
             ASSERT_NOT_REACHED();
-            return { DocumentMarkerLineStyleMode::Spelling, shouldUseDarkAppearance };
+            return DocumentMarkerLineStyleMode::Spelling;
         }
-    };
+    }();
+    auto lineStyleColor = RenderTheme::singleton().documentMarkerLineColor(lineStyleMode, m_renderer.styleColorOptions());
 
     bounds.moveBy(m_paintRect.location());
-    m_paintInfo.context().drawDotsForDocumentMarker(bounds, lineStyleForMarkedTextType());
+    m_paintInfo.context().drawDotsForDocumentMarker(bounds, { lineStyleMode, lineStyleColor });
 }
 
 template<typename TextBoxPath>

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3590,7 +3590,7 @@ header: <WebCore/GraphicsTypes.h>
 header: <WebCore/GraphicsTypes.h>
 [CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::DocumentMarkerLineStyle {
     WebCore::DocumentMarkerLineStyleMode mode;
-    bool shouldUseDarkAppearance;
+    WebCore::Color color;
 };
 
 [Nested, AdditionalEncoder=StreamConnectionEncoder]  enum class WebCore::ShadowRadiusMode : bool;
@@ -3646,9 +3646,8 @@ header: <WebCore/ImageDecoder.h>
 
 header: <WebCore/DisplayListItems.h>
 [CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::DrawDotsForDocumentMarker {
-    WebCore::FloatRect m_rect;
-    uint8_t m_styleMode;
-    bool m_styleShouldUseDarkAppearance;
+    WebCore::FloatRect rect();
+    WebCore::DocumentMarkerLineStyle style();
 };
 
 [Nested] enum class WebCore::ImageOrientation::Orientation : int {


### PR DESCRIPTION
#### 38b829c238b8b749bd68bf25b5715acb90bde295
<pre>
DocumentMarkerLineStyle should encode the marker color
<a href="https://bugs.webkit.org/show_bug.cgi?id=252669">https://bugs.webkit.org/show_bug.cgi?id=252669</a>
rdar://105729542

Reviewed by Wenson Hsieh.

Currently, document marker colors are determined at the GraphicsContext level.
To support the use of system colors for marker colors, the colors must be
resolved earlier, in the web process.

* Source/WebCore/platform/graphics/GraphicsTypes.h:

Add a `color` member to `DocumentMarkerLineStyle`, representing the marker
color. Drop the `shouldUseDarkAppearance` bit, as the `color` already takes
light/dark mode into account.

* Source/WebCore/platform/graphics/cairo/CairoOperations.cpp:
(WebCore::Cairo::drawDotsForDocumentMarker):
* Source/WebCore/platform/graphics/cocoa/GraphicsContextCocoa.mm:
(WebCore::GraphicsContextCG::drawDotsForDocumentMarker):
(WebCore::grammarColor): Deleted.
(WebCore::colorForMarkerLineStyle): Deleted.
* Source/WebCore/platform/graphics/displaylists/DisplayListItemBuffer.cpp:
(WebCore::DisplayList::ItemHandle::destroy):
* Source/WebCore/platform/graphics/displaylists/DisplayListItemType.cpp:
(WebCore::DisplayList::isInlineItem):
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp:
(WebCore::DisplayList::DrawDotsForDocumentMarker::apply const):
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.h:

`DrawDotsForDocumentMarker` can no longer be an inline item, since `Color` can
have out-of-line components.

(WebCore::DisplayList::DrawDotsForDocumentMarker::DrawDotsForDocumentMarker):
(WebCore::DisplayList::DrawDotsForDocumentMarker::style const):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::documentMarkerLineColor const):
* Source/WebCore/rendering/RenderTheme.h:
* Source/WebCore/rendering/RenderThemeCocoa.h:
* Source/WebCore/rendering/RenderThemeCocoa.mm:
(WebCore::grammarColor):
(WebCore::RenderThemeCocoa::documentMarkerLineColor const):
* Source/WebCore/rendering/TextBoxPainter.cpp:
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::paintPlatformDocumentMarker):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/260658@main">https://commits.webkit.org/260658@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ac3845f6cbaac174f414cb3a63fc919b90e74c8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108905 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18010 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41748 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/451 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118223 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112798 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19466 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9294 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101205 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114675 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14605 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97827 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42758 "Found 4 new test failures: webgl/2.0.y/conformance/glsl/bugs/character-set.html, webgl/2.0.y/conformance/glsl/misc/fragcolor-fragdata-invariant.html, webgl/2.0.y/conformance/misc/expando-loss.html, webgl/2.0.y/conformance2/extensions/promoted-extensions-in-shaders.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96577 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29468 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84505 "Found 1 new API test failure: /WebKitGTK/TestDownloads:/webkit/Downloads/local-file-error (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10784 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30817 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11538 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7749 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16928 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50413 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13128 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4022 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->