### PR TITLE
Fix use-after-move in CacheStorageDiskStore::writeRecords

### DIFF
--- a/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp
@@ -259,7 +259,7 @@ static std::optional<RecordHeader> decodeRecordHeader(Span<const uint8_t> header
         *insertionTime,
         *size,
         *requestHeadersGuard,
-        *request,
+        WTFMove(*request),
         WTFMove(options),
         WTFMove(*referrer),
         *responseHeadersGuard,
@@ -506,8 +506,9 @@ void CacheStorageDiskStore::writeRecords(Vector<CacheStorageRecord>&& records, W
         auto bodyData = encodeRecordBody(record);
         auto bodyHash = computeSHA1(bodyData.span(), m_salt);
         bool shouldCreateBlob = shouldStoreBodyAsBlob(bodyData);
+        auto recordInfoKey = record.info.key;
         auto headerData = encodeRecordHeader(WTFMove(record));
-        auto recordData = encodeRecord(record.info.key, headerData, !shouldCreateBlob, bodyData, bodyHash, m_salt);
+        auto recordData = encodeRecord(recordInfoKey, headerData, !shouldCreateBlob, bodyData, bodyHash, m_salt);
         recordDatas.append(WTFMove(recordData));
         if (!shouldCreateBlob)
             bodyData = { };


### PR DESCRIPTION
#### 7510aa30f01704cc269563c01011ba202edd3b70
<pre>
Fix use-after-move in CacheStorageDiskStore::writeRecords
<a href="https://bugs.webkit.org/show_bug.cgi?id=252673">https://bugs.webkit.org/show_bug.cgi?id=252673</a>
rdar://105731921

Reviewed by Youenn Fablet.

Also add WTFMove() at places that are possible to do move assignment.

* Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp:
(WebKit::CacheStorageCache::open):
(WebKit::CacheStorageCache::putRecordsInStore):
* Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp:
(WebKit::decodeRecordHeader):
(WebKit::CacheStorageDiskStore::writeRecords):

Canonical link: <a href="https://commits.webkit.org/260643@main">https://commits.webkit.org/260643@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b57482d1c7b40aa4a031478511c39436f41f2df

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-16-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wincairo ](https://ews-build.webkit.org/#/builders/WinCairo-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-16-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-9-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7353 "Built successfully and passed tests") | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-9-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | | | | 
<!--EWS-Status-Bubble-End-->