### PR TITLE
[JSC] Avoid saving top-level scope for non-module code

### DIFF
--- a/JSTests/stress/call-link-info-osrexit-repatch.js
+++ b/JSTests/stress/call-link-info-osrexit-repatch.js
@@ -14,5 +14,6 @@ function foo(a, b) {
     return foo(b / 1, a, 0);
     0 === 0
 }
+noInline(foo);
 
 foo(1, 5);

--- a/JSTests/stress/hoisted-eval-different-scope.js
+++ b/JSTests/stress/hoisted-eval-different-scope.js
@@ -1,0 +1,13 @@
+for (var i = 0; i < 1e5; ++i) {
+    eval(`
+    var x = 1;
+    with ({ g() { } }) {
+        if (true) {
+            function f() {
+            }
+        }
+        f();
+        g('here')
+    }
+    `)
+}

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
@@ -1236,7 +1236,6 @@ namespace JSC {
         RegisterID m_thisRegister;
         RegisterID m_calleeRegister;
         RegisterID* m_scopeRegister { nullptr };
-        RegisterID* m_topMostScope { nullptr };
         RegisterID* m_argumentsRegister { nullptr };
         RegisterID* m_lexicalEnvironmentRegister { nullptr };
         RegisterID* m_generatorRegister { nullptr };


### PR DESCRIPTION
#### 5fc313f94632beae308222510df47f48b9e6b866
<pre>
[JSC] Avoid saving top-level scope for non-module code
<a href="https://bugs.webkit.org/show_bug.cgi?id=252674">https://bugs.webkit.org/show_bug.cgi?id=252674</a>
rdar://105732218

Reviewed by Yusuke Suzuki.

Avoid allocating a local variable and moving the scope to save the top-level
scope. Re-loading the context is pretty cheap and this reduces the amount of
bytecode overhead for small functions. Notice that we still allocate a variable
for module code, which is necessary since we allocate a lexical environment,
which needs the scope for variable resolution.

* JSTests/stress/hoisted-eval-different-scope.js: Added.
(i.with.g):
(i.g.f):
(i.g):
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::BytecodeGenerator):
(JSC::BytecodeGenerator::emitResolveScopeForHoistingFuncDeclInEval):
(JSC::BytecodeGenerator::allocateAndEmitScope):
(JSC::BytecodeGenerator::restoreScopeRegister):

Canonical link: <a href="https://commits.webkit.org/260743@main">https://commits.webkit.org/260743@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9868e052ac83a7a44751a74ff3ab2f9e8246df20

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109200 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18284 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42014 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/728 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118431 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19743 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9585 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101444 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114957 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14797 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98027 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42969 "Found 4 new test failures: webgl/2.0.y/conformance/glsl/bugs/character-set.html, webgl/2.0.y/conformance/glsl/misc/fragcolor-fragdata-invariant.html, webgl/2.0.y/conformance/misc/expando-loss.html, webgl/2.0.y/conformance/misc/invalid-passed-params.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96769 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29681 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84712 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/98192 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11057 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31024 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/99098 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/9136 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11783 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7957 "Passed tests") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/31040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17152 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50627 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/107050 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7416 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13406 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26437 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->