### PR TITLE
Content Blocker API ignores some CSS Selectors with uppercase letters.

### DIFF
--- a/LayoutTests/http/tests/contentextensions/css-display-none.html
+++ b/LayoutTests/http/tests/contentextensions/css-display-none.html
@@ -6,7 +6,9 @@
 <p class="hidden_global2">This text should not be visible once the global css selector is applied.</p>
 <p class="hidden">This text should not be visible once the particular css selector is applied.</p>
 <p class="hidden_Ž">This text should not be visible once the particular css selector with non-ascii characters is applied.</p>
-<div><p class="hidden_hasTestMatchingEverything">This text should not be visible once the global css selector with :has is applied.</p></div>
-<div><p class="hidden_hasTestNotMatchingEverything">This text should not be visible once the particular css selector with :has is applied.</p></div>
+<p class="hiDDen">This text should not be visible once the particular css selector is applied.</p>
+<p class="HiDDeN">This text should not be visible once the particular css selector is applied.</p>
+<div><p class="hidden_has_test_matching_everything">This text should not be visible once the global css selector with :has is applied.</p></div>
+<div><p class="hidden_has_test_not_matching_everything">This text should not be visible once the particular css selector with :has is applied.</p></div>
 <p class="not_hidden">This text should be visible.</p>
 </body>

--- a/LayoutTests/http/tests/contentextensions/css-display-none.html.json
+++ b/LayoutTests/http/tests/contentextensions/css-display-none.html.json
@@ -38,7 +38,7 @@
     {
         "action": {
             "type": "css-display-none",
-            "selector": "div:has(.hidden_hasTestNotMatchingEverything)"
+            "selector": "div:has(.hidden_has_test_not_matching_everything)"
         },
         "trigger": {
             "url-filter": ".*css-display-none.html"
@@ -47,7 +47,25 @@
     {
         "action": {
             "type": "css-display-none",
-            "selector": "div:has(.hidden_hasTestMatchingEverything)"
+            "selector": "div:has(.hidden_has_test_matching_everything)"
+        },
+        "trigger": {
+            "url-filter": ".*"
+        }
+    },
+    {
+        "action": {
+            "type": "css-display-none",
+            "selector": ".hiDDen"
+        },
+        "trigger": {
+            "url-filter": ".*css-display-none.html"
+        }
+    },
+    {
+        "action": {
+            "type": "css-display-none",
+            "selector": ".HiDDeN"
         },
         "trigger": {
             "url-filter": ".*"

--- a/Source/WebCore/contentextensions/ContentExtensionParser.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionParser.cpp
@@ -206,13 +206,19 @@ bool isValidCSSSelector(const String& selector)
 {
     ASSERT(isMainThread());
     ProcessWarming::initializeNames();
-    CSSParser parser(contentExtensionCSSParserContext());
+
+    // This explicitly does not use the CSSParserContext created in contentExtensionCSSParserContext because
+    // we want to use quirks mode in parsing, but automatic mode when actually applying the content blocker styles.
+    // FIXME: rdar://105733691 (Parse/apply content blocker style sheets in both standards and quirks mode lazily).
+    WebCore::CSSParserContext context(HTMLQuirksMode);
+    context.hasPseudoClassEnabled = true;
+    CSSParser parser(context);
     return !!parser.parseSelector(selector);
 }
 
 WebCore::CSSParserContext contentExtensionCSSParserContext()
 {
-    WebCore::CSSParserContext context(HTMLQuirksMode);
+    WebCore::CSSParserContext context(HTMLStandardMode);
     context.hasPseudoClassEnabled = true;
     return context;
 }


### PR DESCRIPTION
#### 6f913a33098ba2633d5cb251e002637e50fcffc7
<pre>
Content Blocker API ignores some CSS Selectors with uppercase letters.
<a href="https://bugs.webkit.org/show_bug.cgi?id=252677">https://bugs.webkit.org/show_bug.cgi?id=252677</a>
rdar://105648971

Reviewed by Antti Koivisto.

The fix for <a href="https://bugs.webkit.org/show_bug.cgi?id=250609">https://bugs.webkit.org/show_bug.cgi?id=250609</a> caused us to use Quirks mode when both
parsing content blocker rules and applying them.

That caused this regression, since rules like .SomeCLass stopped working in Quirks mode.

To fix this, make us use Quirks mode when actually parsing the rules, but standard mode when
applying them, to match how the behavior was before <a href="https://bugs.webkit.org/show_bug.cgi?id=250609.">https://bugs.webkit.org/show_bug.cgi?id=250609.</a>

* LayoutTests/http/tests/contentextensions/css-display-none.html:
* LayoutTests/http/tests/contentextensions/css-display-none.html.json:
* Source/WebCore/contentextensions/ContentExtensionParser.cpp:
(WebCore::ContentExtensions::isValidCSSSelector):
(WebCore::ContentExtensions::contentExtensionCSSParserContext):

Canonical link: <a href="https://commits.webkit.org/260638@main">https://commits.webkit.org/260638@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9e6e26fb962937bb1e742ee1380cb27a51717b2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-16-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wincairo ](https://ews-build.webkit.org/#/builders/WinCairo-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-16-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-9-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7349 "Built successfully and passed tests") | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-9-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | | | | 
<!--EWS-Status-Bubble-End-->