### PR TITLE
[IFC][Integration][Multicol] Allow vertical-align

### DIFF
--- a/LayoutTests/platform/ios/fast/multicol/table-vertical-align-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/table-vertical-align-expected.txt
@@ -269,7 +269,7 @@ layer at (8,376) size 384x1293 backgroundClip at (0,0) size 1992x1010 clip at (0
               text run at (11,1199) width 46: "of text."
             RenderBR {BR} at (56,1199) size 1x19
           RenderTableCell {TD} at (145,529) size 238x232 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
-            RenderInline {SPAN} at (0,0) size 146x147
+            RenderInline {SPAN} at (0,0) size 146x148
               RenderText {#text} at (11,70) size 146x148
                 text run at (11,71) width 146: "Other"
                 text run at (11,146) width 109: "cell."
@@ -405,7 +405,7 @@ layer at (8,702) size 384x1288 backgroundClip at (0,0) size 1992x1010 clip at (0
               text run at (11,1199) width 46: "of text."
             RenderBR {BR} at (56,1199) size 1x19
           RenderTableCell {TD} at (145,1059) size 238x227 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
-            RenderInline {SPAN} at (0,0) size 146x201
+            RenderInline {SPAN} at (0,0) size 146x147
               RenderText {#text} at (11,12) size 146x201
                 text run at (11,12) width 146: "Other"
                 text run at (11,141) width 109: "cell."

--- a/LayoutTests/platform/mac/fast/multicol/table-vertical-align-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/table-vertical-align-expected.txt
@@ -269,7 +269,7 @@ layer at (8,376) size 377x1166 backgroundClip at (0,0) size 1562x1010 clip at (0
               text run at (11,1097) width 46: "of text."
             RenderBR {BR} at (56,1097) size 1x18
           RenderTableCell {TD} at (142,478) size 233x207 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
-            RenderInline {SPAN} at (0,0) size 146x184
+            RenderInline {SPAN} at (0,0) size 146x149
               RenderText {#text} at (11,10) size 146x185
                 text run at (11,11) width 146: "Other"
                 text run at (11,121) width 109: "cell."

--- a/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
@@ -115,9 +115,6 @@ static void printReason(AvoidanceReason reason, TextStream& stream)
     case AvoidanceReason::MultiColumnFlowHasVerticalWritingMode:
         stream << "column has vertical writing mode";
         break;
-    case AvoidanceReason::MultiColumnFlowVerticalAlign:
-        stream << "column with vertical-align != baseline";
-        break;
     case AvoidanceReason::MultiColumnFlowIsFloating:
         stream << "column with floating objects";
         break;
@@ -427,8 +424,6 @@ OptionSet<AvoidanceReason> canUseForLineLayoutWithReason(const RenderBlockFlow& 
         auto& style = flow.style();
         if (!style.isHorizontalWritingMode())
             SET_REASON_AND_RETURN_IF_NEEDED(MultiColumnFlowHasVerticalWritingMode, reasons, includeReasons);
-        if (style.verticalAlign() != VerticalAlign::Baseline)
-            SET_REASON_AND_RETURN_IF_NEEDED(MultiColumnFlowVerticalAlign, reasons, includeReasons);
         if (style.isFloating())
             SET_REASON_AND_RETURN_IF_NEEDED(MultiColumnFlowIsFloating, reasons, includeReasons);
     }

--- a/Source/WebCore/layout/integration/LayoutIntegrationCoverage.h
+++ b/Source/WebCore/layout/integration/LayoutIntegrationCoverage.h
@@ -88,7 +88,7 @@ enum class AvoidanceReason : uint64_t {
     // Unused                                    = 1LLU  << 46,
     MultiColumnFlowHasVerticalWritingMode        = 1LLU  << 47,
     // Unused                                    = 1LLU  << 48,
-    MultiColumnFlowVerticalAlign                 = 1LLU  << 49,
+    // Unused                                    = 1LLU  << 49,
     MultiColumnFlowIsFloating                    = 1LLU  << 50,
     // Unused                                    = 1LLU  << 51,
     // Unused                                    = 1LLU  << 52,


### PR DESCRIPTION
#### ca13d2a5e4eb8f57ed2eb13109aab43f50473b5a
<pre>
[IFC][Integration][Multicol] Allow vertical-align
<a href="https://bugs.webkit.org/show_bug.cgi?id=252680">https://bugs.webkit.org/show_bug.cgi?id=252680</a>
rdar://105734719

Reviewed by Alan Baradlay.

* LayoutTests/platform/mac/fast/multicol/table-vertical-align-expected.txt:
* Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp:
(WebCore::LayoutIntegration::canUseForLineLayoutWithReason):

Enable.

Canonical link: <a href="https://commits.webkit.org/260665@main">https://commits.webkit.org/260665@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa65ad369378042b3e556a7d2f3113e259d930e0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109012 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18091 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41833 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/547 "Reverted pull request changes (failure)") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/118289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112894 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19547 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9391 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101249 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114770 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/97891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/42785 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29533 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/84532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10876 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/30881 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11620 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/7818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17000 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50479 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7365 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13219 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->