### PR TITLE
REGRESSION (257658@main): Maximize full screen button fails to minimize once in full screen on trailers.apple.com

### DIFF
--- a/LayoutTests/fullscreen/event-listener-prefixed-unprefixed-expected.html
+++ b/LayoutTests/fullscreen/event-listener-prefixed-unprefixed-expected.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<style>
+    #test {
+        background-color: green;
+        width: 100px;
+        height: 100px;
+    }
+</style>
+<div id="test"></div>
+</html>

--- a/LayoutTests/fullscreen/event-listener-prefixed-unprefixed.html
+++ b/LayoutTests/fullscreen/event-listener-prefixed-unprefixed.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<style>
+    #test {
+        background-color: green;
+        width: 100px;
+        height: 100px;
+    }
+</style>
+<div id="test"></div>
+<script>
+test.addEventListener("webkitfullscreenchange", () => {
+    test.style.backgroundColor = "red";
+});
+test.addEventListener("fullscreenchange", () => {
+    if (document.fullscreenElement)
+        document.exitFullscreen();
+    else
+        document.documentElement.classList.remove("reftest-wait");
+});
+if (window.internals) {
+    internals.withUserGesture(() => {
+        test.requestFullscreen();
+    });
+}
+</script>
+</html>

--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -597,7 +597,8 @@ void FullscreenManager::dispatchEventForNode(Node& node, EventType eventType)
     case EventType::Change:
         if (supportsUnprefixedAPI)
             node.dispatchEvent(Event::create(eventNames().fullscreenchangeEvent, Event::CanBubble::Yes, Event::IsCancelable::No, Event::IsComposed::Yes));
-        node.dispatchEvent(Event::create(eventNames().webkitfullscreenchangeEvent, Event::CanBubble::Yes, Event::IsCancelable::No, Event::IsComposed::Yes));
+        if (!supportsUnprefixedAPI || !node.hasEventListeners(eventNames().fullscreenchangeEvent))
+            node.dispatchEvent(Event::create(eventNames().webkitfullscreenchangeEvent, Event::CanBubble::Yes, Event::IsCancelable::No, Event::IsComposed::Yes));
         break;
     case EventType::Error:
         if (supportsUnprefixedAPI)


### PR DESCRIPTION
#### 3a3294dbf52d08e036a8e55928267bb778e250d6
<pre>
REGRESSION (257658@main): Maximize full screen button fails to minimize once in full screen on trailers.apple.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=252414">https://bugs.webkit.org/show_bug.cgi?id=252414</a>
rdar://105144719

Reviewed by Chris Dumez.

The website was broken because it listens for both unprefixed &amp; prefixed APIs to toggle between states, which ends up toggling the
wrong number of times.

To fix this, only emit unprefixed API when there is no listener for the prefixed API.

* LayoutTests/fullscreen/event-listener-prefixed-unprefixed-expected.html: Added.
* LayoutTests/fullscreen/event-listener-prefixed-unprefixed.html: Added.
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::dispatchEventForNode):

Canonical link: <a href="https://commits.webkit.org/260651@main">https://commits.webkit.org/260651@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1378d15d11a5ee644f1655e150f5781b3221bb89

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108972 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18051 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41795 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/505 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/118262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112854 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19507 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9347 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101203 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114728 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97862 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/42755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29503 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/84501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10834 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/30852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11581 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/7791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/16969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50448 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7358 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13178 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->