### PR TITLE
Block level boxes with block-step-size other than none should establish an independent formatting context.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-establishes-block-formatting-context-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-establishes-block-formatting-context-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-establishes-block-formatting-context-list-item-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-establishes-block-formatting-context-list-item-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-establishes-block-formatting-context-list-item.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-establishes-block-formatting-context-list-item.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="block-step-size values other than none on a block box causes it to establish a block formatting context">
+<style>
+div {
+    width: 50px;
+    height: 100px;
+    background-color: green;
+}
+.floating {
+    float: left;
+}
+.block-step-size {
+    display: list-item;
+    list-style: none;
+    block-step-size: 1px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div class="floating"></div>
+<div class="block-step-size"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-establishes-block-formatting-context.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-establishes-block-formatting-context.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="block-step-size values other than none on a block box causes it to establish a block formatting context">
+<style>
+div {
+    width: 50px;
+    height: 100px;
+    background-color: green;
+}
+.floating {
+    float: left;
+}
+.block-step-size {
+    block-step-size: 1px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div class="floating"></div>
+<div class="block-step-size"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-none-does-not-establish-block-formatting-context-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-none-does-not-establish-block-formatting-context-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-none-does-not-establish-block-formatting-context.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-none-does-not-establish-block-formatting-context.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="block-step-size none should not establish a block formatting context for the block box">
+<style>
+div {
+    width: 100px;
+    height: 100px;
+    background-color: green;
+}
+.floating {
+    position: relative;
+    z-index: -1;
+    float: left;
+    background-color: red;
+}
+.block-step-size {
+    block-step-size: none;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div class="floating"></div>
+<div class="block-step-size"></div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -4986,7 +4986,7 @@ bool RenderBox::establishesBlockFormattingContext() const
     || isInlineBlockOrInlineTable() || isTableCell() || isTableCaption() || isBlockWithOverFlowOtherThanVisibleAndClip()
     || boxStyle.display() == DisplayType::FlowRoot || boxStyle.containsLayoutOrPaint()
     || isFlexItemIncludingDeprecated() || isGridItem() || boxStyle.specifiesColumns()
-    || boxStyle.columnSpan() == ColumnSpan::All;
+    || boxStyle.columnSpan() == ColumnSpan::All || style().blockStepSize();
 }
 
 bool RenderBox::avoidsFloats() const

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -2123,7 +2123,7 @@ bool RenderElement::createsNewFormattingContext() const
 
 bool RenderElement::establishesIndependentFormattingContext() const
 {
-    return isFloatingOrOutOfFlowPositioned() || hasPotentiallyScrollableOverflow() || style().containsLayout() || paintContainmentApplies();
+    return isFloatingOrOutOfFlowPositioned() || hasPotentiallyScrollableOverflow() || style().containsLayout() || paintContainmentApplies() || (style().isDisplayBlockLevel() && style().blockStepSize());
 }
 
 FloatRect RenderElement::referenceBoxRect(CSSBoxType boxType) const


### PR DESCRIPTION
#### 423f7933224ac4609944bf6e5a18932f2c337b37
<pre>
Block level boxes with block-step-size other than none should establish an independent formatting context.
<a href="https://bugs.webkit.org/show_bug.cgi?id=252358">https://bugs.webkit.org/show_bug.cgi?id=252358</a>
rdar://105519556

Reviewed by Tim Nguyen.

In order to determine whether this property would apply to a box we
first need to check its display type. According to the table from
css-display-3 (<a href="https://www.w3.org/TR/css-display-3/#the-display-properties)">https://www.w3.org/TR/css-display-3/#the-display-properties)</a>,
block level boxes are generated from the following display types:
block, flow-root, list-item, flex, grid, block ruby, and table. Of these,
flow-root, flex, grid, and table already establish an independent
formatting context. So we need to make sure that a new block formatting
context is generated for the remaining, which is what the tests cover.

Inside RenderBox::establishesBlockFormattingContext and
RenderElement::establishesIndependentFormattingContext we will call
into RenderElement::isBlockLevelElementWithBlockStepSizing which will
return true if the box has a block level display type and if it has
a valid value for block-step-sizing (other than none).

div {
    width: 50px;
    height: 100px;
    background-color: green;
}
.floating {
    float: left;
}
.block-step-size {
    block-step-size: 1px;
}
&lt;/style&gt;
&lt;div class=&quot;floating&quot;&gt;&lt;/div&gt;
&lt;div class=&quot;block-step-size&quot;&gt;&lt;/div&gt;

Since both of the conditions hold for the second div it will establish a
new block formatting context and will become aware of the float so that
it does not get positioned over it.

Spec reference: <a href="https://drafts.csswg.org/css-rhythm/#block-step-size">https://drafts.csswg.org/css-rhythm/#block-step-size</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-establishes-independent-formatting-context-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-establishes-independent-formatting-context-list-item-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-establishes-independent-formatting-context-list-item.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-establishes-independent-formatting-context.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-none-does-not-establish-indepdendent-formatting-context-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-none-does-not-establish-indepdendent-formatting-context.html: Added.
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::establishesBlockFormattingContext const):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::establishesIndependentFormattingContext const):
(WebCore::RenderElement::isBlockLevelElementWithBlockStepSizing const):
* Source/WebCore/rendering/RenderElement.h:

Canonical link: <a href="https://commits.webkit.org/261065@main">https://commits.webkit.org/261065@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f2bcfd49552aa47279d5ab5eaec22120b4a1239

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110351 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19441 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42966 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1742 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119288 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114299 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20884 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10608 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102597 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116095 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15556 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98752 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43772 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97517 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30417 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85627 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12109 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31755 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12700 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8721 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18065 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51370 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7663 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14545 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->