### PR TITLE
Clarify WebPageProxy wheel event code for UI-side compositing

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -3038,44 +3038,72 @@ void WebPageProxy::flushPendingMouseEventCallbacks()
     m_callbackHandlersAfterProcessingPendingMouseEvents.clear();
 }
 
+#if PLATFORM(IOS_FAMILY)
 void WebPageProxy::dispatchWheelEventWithoutScrolling(const WebWheelEvent& event, CompletionHandler<void(bool)>&& completionHandler)
 {
     sendWithAsyncReply(Messages::WebPage::DispatchWheelEventWithoutScrolling(event), WTFMove(completionHandler));
 }
+#endif
 
 void WebPageProxy::handleWheelEvent(const NativeWebWheelEvent& event)
 {
-    WheelEventHandlingResult handlingResult;
-
-    auto rubberBandableEdges = rubberBandableEdgesRespectingHistorySwipe();
-
-#if ENABLE(ASYNC_SCROLLING) && PLATFORM(COCOA)
-    if (m_scrollingCoordinatorProxy) {
-        handlingResult = m_scrollingCoordinatorProxy->handleWheelEvent(platform(event), rubberBandableEdges);
-        if (!handlingResult.needsMainThreadProcessing()) {
-            if (!handlingResult.wasHandled)
-                wheelEventWasNotHandled(event);
-            return;
-        }
-    }
-#else
-    handlingResult.steps = WheelEventProcessingSteps::MainThreadForScrolling;
-#endif
     if (!hasRunningProcess())
         return;
 
     closeOverlayedViews();
 
+    auto handlingResult = WheelEventHandlingResult { WheelEventProcessingSteps::MainThreadForScrolling, false };
+    auto rubberBandableEdges = rubberBandableEdgesRespectingHistorySwipe();
+
+    if (drawingArea()->shouldSendWheelEventsToEventDispatcher()) {
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER)
-    // FIXME: We should not have to look this up repeatedly, but it can also change occasionally.
-    if (event.momentumPhase() == WebWheelEvent::PhaseBegan && preferences().momentumScrollingAnimatorEnabled())
-        m_scrollingAccelerationCurve = ScrollingAccelerationCurve::fromNativeWheelEvent(event);
+        // FIXME: We should not have to look this up repeatedly, but it can also change occasionally.
+        if (event.momentumPhase() == WebWheelEvent::PhaseBegan && preferences().momentumScrollingAnimatorEnabled())
+            m_scrollingAccelerationCurve = ScrollingAccelerationCurve::fromNativeWheelEvent(event);
 #endif
+    } else {
+#if ENABLE(ASYNC_SCROLLING) && PLATFORM(MAC)
+        if (m_scrollingCoordinatorProxy) {
+            handlingResult = m_scrollingCoordinatorProxy->handleWheelEvent(platform(event), rubberBandableEdges);
+            if (!handlingResult.needsMainThreadProcessing()) {
+                if (!handlingResult.wasHandled)
+                    wheelEventWasNotHandled(event);
+                return;
+            }
+        }
+#endif
+    }
 
     if (wheelEventCoalescer().shouldDispatchEvent(event, handlingResult.steps)) {
         auto eventAndSteps = wheelEventCoalescer().nextEventToDispatch();
         sendWheelEvent(eventAndSteps->event, eventAndSteps->processingSteps, rubberBandableEdges);
     }
+}
+
+void WebPageProxy::sendWheelEvent(const WebWheelEvent& event, OptionSet<WebCore::WheelEventProcessingSteps> processingSteps, RectEdges<bool> rubberBandableEdges)
+{
+#if HAVE(CVDISPLAYLINK)
+    m_wheelEventActivityHysteresis.impulse();
+#endif
+
+    auto* connection = messageSenderConnection();
+    if (!connection)
+        return;
+
+    if (drawingArea()->shouldSendWheelEventsToEventDispatcher()) {
+#if ENABLE(MOMENTUM_EVENT_DISPATCHER)
+        if (event.momentumPhase() == WebWheelEvent::PhaseBegan && m_scrollingAccelerationCurve != m_lastSentScrollingAccelerationCurve) {
+            connection->send(Messages::EventDispatcher::SetScrollingAccelerationCurve(m_webPageID, m_scrollingAccelerationCurve), 0, { }, Thread::QOS::UserInteractive);
+            m_lastSentScrollingAccelerationCurve = m_scrollingAccelerationCurve;
+        }
+#endif
+        connection->send(Messages::EventDispatcher::WheelEvent(m_webPageID, event, rubberBandableEdges), 0, { }, Thread::QOS::UserInteractive);
+    } else
+        send(Messages::WebPage::HandleWheelEvent(event, processingSteps));
+
+    // Manually ping the web process to check for responsiveness since our wheel
+    // event will dispatch to a non-main thread, which always responds.
+    m_process->isResponsiveWithLazyStop();
 }
 
 #if HAVE(CVDISPLAYLINK)
@@ -3102,33 +3130,6 @@ void WebPageProxy::updateWheelEventActivityAfterProcessSwap()
 #if HAVE(CVDISPLAYLINK)
     updateDisplayLinkFrequency();
 #endif
-}
-
-void WebPageProxy::sendWheelEvent(const WebWheelEvent& event, OptionSet<WebCore::WheelEventProcessingSteps> processingSteps, RectEdges<bool> rubberBandableEdges)
-{
-#if HAVE(CVDISPLAYLINK)
-    m_wheelEventActivityHysteresis.impulse();
-#endif
-
-    auto* connection = messageSenderConnection();
-    if (!connection)
-        return;
-
-#if ENABLE(MOMENTUM_EVENT_DISPATCHER)
-    if (event.momentumPhase() == WebWheelEvent::PhaseBegan && m_scrollingAccelerationCurve != m_lastSentScrollingAccelerationCurve) {
-        connection->send(Messages::EventDispatcher::SetScrollingAccelerationCurve(m_webPageID, m_scrollingAccelerationCurve), 0, { }, Thread::QOS::UserInteractive);
-        m_lastSentScrollingAccelerationCurve = m_scrollingAccelerationCurve;
-    }
-#endif
-
-    if (drawingArea()->shouldSendWheelEventsToEventDispatcher())
-        connection->send(Messages::EventDispatcher::WheelEvent(m_webPageID, event, rubberBandableEdges), 0, { }, Thread::QOS::UserInteractive);
-    else
-        send(Messages::WebPage::HandleWheelEvent(event, processingSteps));
-
-    // Manually ping the web process to check for responsiveness since our wheel
-    // event will dispatch to a non-main thread, which always responds.
-    m_process->isResponsiveWithLazyStop();
 }
 
 void WebPageProxy::wheelEventWasNotHandled(const NativeWebWheelEvent& event)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2087,7 +2087,9 @@ public:
     bool isServiceWorkerPage() const { return false; }
 #endif
 
+#if PLATFORM(IOS_FAMILY)
     void dispatchWheelEventWithoutScrolling(const WebWheelEvent&, CompletionHandler<void(bool)>&&);
+#endif
 
 #if ENABLE(CONTEXT_MENUS)
 #if ENABLE(IMAGE_ANALYSIS)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -3255,6 +3255,7 @@ bool WebPage::wheelEvent(const WebWheelEvent& wheelEvent, OptionSet<WheelEventPr
     return handled;
 }
 
+#if PLATFORM(IOS_FAMILY)
 void WebPage::dispatchWheelEventWithoutScrolling(const WebWheelEvent& wheelEvent, CompletionHandler<void(bool)>&& completionHandler)
 {
 #if ENABLE(KINETIC_SCROLLING)
@@ -3268,6 +3269,7 @@ void WebPage::dispatchWheelEventWithoutScrolling(const WebWheelEvent& wheelEvent
     // The caller of dispatchWheelEventWithoutScrolling never cares about DidReceiveEvent being sent back.
     completionHandler(handled);
 }
+#endif
 
 static bool handleKeyEvent(const WebKeyboardEvent& keyboardEvent, Page* page)
 {

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1542,7 +1542,9 @@ public:
     void setAppHighlightsVisibility(const WebCore::HighlightVisibility);
 #endif
 
+#if PLATFORM(IOS_FAMILY)
     void dispatchWheelEventWithoutScrolling(const WebWheelEvent&, CompletionHandler<void(bool)>&&);
+#endif
 
 #if ENABLE(PDFKIT_PLUGIN)
     bool shouldUsePDFPlugin(const String& contentType, StringView path) const;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -676,7 +676,9 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
 #endif
 
     HandleWheelEvent(WebKit::WebWheelEvent event, OptionSet<WebCore::WheelEventProcessingSteps> processingSteps)
+#if PLATFORM(IOS_FAMILY)
     DispatchWheelEventWithoutScrolling(WebKit::WebWheelEvent event) -> (bool handled)
+#endif
 
     LastNavigationWasAppInitiated() -> (bool wasAppBound)
 


### PR DESCRIPTION
#### 380e2f6bed60dc8af9193a12c8945b8bf1904796
<pre>
Clarify WebPageProxy wheel event code for UI-side compositing
<a href="https://bugs.webkit.org/show_bug.cgi?id=252703">https://bugs.webkit.org/show_bug.cgi?id=252703</a>
rdar://105752960

Reviewed by Tim Horton.

Make use of DrawingAreaProxy::shouldSendWheelEventsToEventDispatcher() to conditionalize
code in WebPageProxy, making it clear that we only call into m_scrollingCoordinatorProxy if we&apos;re
not sending events to the EventDispatcher, and that we don&apos;t need to send ScrollingAccelerationCurves
to the web process with UI-side compositing.

Also dispatchWheelEventWithoutScrolling() is only used on iOS, so #ifdef it for clarity.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::handleWheelEvent):
(WebKit::WebPageProxy::sendWheelEvent):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

Canonical link: <a href="https://commits.webkit.org/260752@main">https://commits.webkit.org/260752@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8fb61618657bf74ff6fc0250ea83c15731189fd4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108955 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18035 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41779 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/483 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118246 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19491 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9330 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101186 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114711 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14623 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97847 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42743 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96595 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29488 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84485 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10817 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30837 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11565 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7776 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16953 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50433 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7422 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13161 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->