### PR TITLE
Pass length as parameter with non-literal expected buffers in FragmentedSharedBufferTest

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebCore/SharedBuffer.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/SharedBuffer.cpp
@@ -195,13 +195,18 @@ TEST_F(FragmentedSharedBufferTest, builder)
     EXPECT_TRUE(builder2.isEmpty());
 }
 
+static void checkBufferWithLength(const uint8_t* buffer, size_t bufferLength, const char* expected, size_t length)
+{
+    ASSERT_EQ(length, bufferLength);
+    for (size_t i = 0; i < length; ++i)
+        EXPECT_EQ(buffer[i], expected[i]);
+}
+
 static void checkBuffer(const uint8_t* buffer, size_t bufferLength, const char* expected)
 {
     // expected is null terminated, buffer is not.
     size_t length = strlen(expected);
-    ASSERT_EQ(length, bufferLength);
-    for (size_t i = 0; i < length; ++i)
-        EXPECT_EQ(buffer[i], expected[i]);
+    checkBufferWithLength(buffer, bufferLength, expected, length);
 }
 
 TEST_F(FragmentedSharedBufferTest, getSomeData)
@@ -235,7 +240,7 @@ TEST_F(FragmentedSharedBufferTest, getSomeData)
     checkBuffer(gh2.data(), gh2.size(), "gh");
     checkBuffer(ghijkl.data(), ghijkl.size(), "ghijkl");
     EXPECT_EQ(gh1.size(), gh2.size());
-    checkBuffer(gh1.data(), gh1.size(), gh2.dataAsCharPtr());
+    checkBufferWithLength(gh1.data(), gh1.size(), gh2.dataAsCharPtr(), gh2.size());
     checkBuffer(l.data(), l.size(), "l");
 }
 


### PR DESCRIPTION
#### fb9f9ec928c1647d057c02995aaf194df601d512
<pre>
Pass length as parameter with non-literal expected buffers in FragmentedSharedBufferTest
<a href="https://bugs.webkit.org/show_bug.cgi?id=252707">https://bugs.webkit.org/show_bug.cgi?id=252707</a>

Reviewed by Chris Dumez.

Using strlen on a non-null-terminated buffer isn&apos;t great.

* Tools/TestWebKitAPI/Tests/WebCore/SharedBuffer.cpp:
(TestWebKitAPI::checkBufferWithLength):
(TestWebKitAPI::checkBuffer):
(TestWebKitAPI::TEST_F):

Canonical link: <a href="https://commits.webkit.org/260647@main">https://commits.webkit.org/260647@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9046904602480919b4d5d2023f4993ddcb66887

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108960 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/18040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41784 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/492 "Reverted pull request changes (failure)") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/118251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112843 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/19496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9335 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101191 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114716 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/19496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/97855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/42745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/19496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/29496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/84487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10822 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/30845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11570 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/7780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/16958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/50441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13166 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4012 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->