### PR TITLE
Add EWS Infrastructure to support Monterey (252579)

### DIFF
--- a/Tools/CISupport/ews-build/config.json
+++ b/Tools/CISupport/ews-build/config.json
@@ -40,35 +40,35 @@
     { "name": "wincairo-ews-002", "platform": "wincairo" },
     { "name": "wincairo-ews-003", "platform": "wincairo" },
     { "name": "wincairo-ews-004", "platform": "wincairo" },
-    { "name": "ews100", "platform": "mac-bigsur" },
-    { "name": "ews101", "platform": "mac-bigsur" },
-    { "name": "ews102", "platform": "mac-bigsur" },
-    { "name": "ews103", "platform": "mac-bigsur" },
-    { "name": "ews104", "platform": "mac-bigsur" },
-    { "name": "ews105", "platform": "mac-bigsur" },
-    { "name": "ews106", "platform": "mac-bigsur" },
-    { "name": "ews107", "platform": "mac-bigsur" },
+    { "name": "ews100", "platform": "mac-monterey" },
+    { "name": "ews101", "platform": "mac-monterey" },
+    { "name": "ews102", "platform": "mac-monterey" },
+    { "name": "ews103", "platform": "mac-monterey" },
+    { "name": "ews104", "platform": "mac-monterey" },
+    { "name": "ews105", "platform": "mac-monterey" },
+    { "name": "ews106", "platform": "mac-monterey" },
+    { "name": "ews107", "platform": "mac-monterey" },
     { "name": "ews108", "platform": "*" },
     { "name": "ews109", "platform": "ios-16" },
-    { "name": "ews112", "platform": "mac-bigsur" },
-    { "name": "ews113", "platform": "mac-bigsur" },
+    { "name": "ews112", "platform": "mac-monterey" },
+    { "name": "ews113", "platform": "mac-monterey" },
     { "name": "ews114", "platform": "*" },
-    { "name": "ews115", "platform": "mac-bigsur" },
-    { "name": "ews116", "platform": "mac-bigsur" },
-    { "name": "ews117", "platform": "mac-bigsur" },
-    { "name": "ews118", "platform": "mac-bigsur" },
-    { "name": "ews119", "platform": "mac-bigsur" },
-    { "name": "ews120", "platform": "mac-bigsur" },
-    { "name": "ews129", "platform": "mac-bigsur" },
-    { "name": "ews169", "platform": "mac-bigsur" },
+    { "name": "ews115", "platform": "mac-monterey" },
+    { "name": "ews116", "platform": "mac-monterey" },
+    { "name": "ews117", "platform": "mac-monterey" },
+    { "name": "ews118", "platform": "mac-monterey" },
+    { "name": "ews119", "platform": "mac-monterey" },
+    { "name": "ews120", "platform": "mac-monterey" },
+    { "name": "ews129", "platform": "mac-monterey" },
+    { "name": "ews169", "platform": "mac-monterey" },
     { "name": "ews121", "platform": "ios-simulator-16" },
     { "name": "ews122", "platform": "ios-simulator-16" },
     { "name": "ews123", "platform": "ios-simulator-16" },
     { "name": "ews124", "platform": "ios-simulator-16" },
     { "name": "ews125", "platform": "ios-simulator-16" },
     { "name": "ews126", "platform": "ios-simulator-16" },
-    { "name": "ews127", "platform": "mac-bigsur" },
-    { "name": "ews128", "platform": "mac-bigsur" },
+    { "name": "ews127", "platform": "mac-monterey" },
+    { "name": "ews128", "platform": "mac-monterey" },
     { "name": "ews130", "platform": "*" },
     { "name": "ews131", "platform": "ios-16" },
     { "name": "ews132", "platform": "*" },
@@ -91,8 +91,8 @@
     { "name": "ews158", "platform": "*" },
     { "name": "ews159", "platform": "*" },
     { "name": "ews160", "platform": "*" },
-    { "name": "ews161", "platform": "mac-bigsur" },
-    { "name": "ews162", "platform": "mac-bigsur" },
+    { "name": "ews161", "platform": "mac-monterey" },
+    { "name": "ews162", "platform": "mac-monterey" },
     { "name": "ews163", "platform": "*" },
     { "name": "ews164", "platform": "*" },
     { "name": "ews165", "platform": "*" },
@@ -110,16 +110,16 @@
     { "name": "ews178", "platform": "mac-ventura" },
     { "name": "ews179", "platform": "mac-ventura" },
     { "name": "ews180", "platform": "mac-ventura" },
-    { "name": "ews181", "platform": "mac-bigsur" },
-    { "name": "ews182", "platform": "mac-bigsur" },
+    { "name": "ews181", "platform": "mac-monterey" },
+    { "name": "ews182", "platform": "mac-monterey" },
     { "name": "ews183", "platform": "*" },
     { "name": "ews184", "platform": "ios-simulator-16" },
     { "name": "ews185", "platform": "ios-simulator-16" },
-    { "name": "webkit-cq-01", "platform": "mac-bigsur" },
-    { "name": "webkit-cq-02", "platform": "mac-bigsur" },
-    { "name": "webkit-cq-03", "platform": "mac-bigsur" },
-    { "name": "webkit-cq-04", "platform": "mac-bigsur" },
-    { "name": "webkit-cq-05", "platform": "mac-bigsur" }
+    { "name": "webkit-cq-01", "platform": "mac-monterey" },
+    { "name": "webkit-cq-02", "platform": "mac-monterey" },
+    { "name": "webkit-cq-03", "platform": "mac-monterey" },
+    { "name": "webkit-cq-04", "platform": "mac-monterey" },
+    { "name": "webkit-cq-05", "platform": "mac-monterey" }
   ],
   "builders": [
     {
@@ -181,31 +181,31 @@
       "workernames": ["ews138", "ews139", "ews140", "ews175", "ews176", "ews177", "ews178", "ews179", "ews180"]
     },
     {
-      "name": "macOS-BigSur-Release-Build-EWS", "shortname": "mac", "icon": "buildOnly",
-      "factory": "macOSBuildFactory", "platform": "mac-bigsur",
+      "name": "macOS-Monterey-Release-Build-EWS", "shortname": "mac", "icon": "buildOnly",
+      "factory": "macOSBuildFactory", "platform": "mac-monterey",
       "configuration": "release", "architectures": ["x86_64"],
-      "triggers": ["api-tests-mac-ews", "macos-bigsur-release-wk1-tests-ews", "macos-bigsur-release-wk2-tests-ews", "macos-release-wk2-stress-tests-ews"],
+      "triggers": ["api-tests-mac-ews", "macos-monterey-release-wk1-tests-ews", "macos-monterey-release-wk2-tests-ews", "macos-release-wk2-stress-tests-ews"],
       "workernames": ["ews102", "ews118", "ews119", "ews120", "ews161", "ews162"]
     },
     {
-      "name": "macOS-BigSur-Release-WK1-Tests-EWS", "shortname": "mac-wk1", "icon": "testOnly",
-      "factory": "macOSWK1Factory", "platform": "mac-bigsur",
+      "name": "macOS-Monterey-Release-WK1-Tests-EWS", "shortname": "mac-wk1", "icon": "testOnly",
+      "factory": "macOSWK1Factory", "platform": "mac-monterey",
       "configuration": "release", "architectures": ["x86_64"],
-      "triggered_by": ["macos-bigsur-release-build-ews"],
+      "triggered_by": ["macos-monterey-release-build-ews"],
       "workernames": ["ews101", "ews103", "ews105", "ews116", "ews112", "ews117"]
     },
     {
-      "name": "macOS-BigSur-Release-WK2-Tests-EWS", "shortname": "mac-wk2", "icon": "testOnly",
-      "factory": "macOSWK2Factory", "platform": "mac-bigsur",
+      "name": "macOS-Monterey-Release-WK2-Tests-EWS", "shortname": "mac-wk2", "icon": "testOnly",
+      "factory": "macOSWK2Factory", "platform": "mac-monterey",
       "configuration": "release", "architectures": ["x86_64"],
-      "triggered_by": ["macos-bigsur-release-build-ews"],
+      "triggered_by": ["macos-monterey-release-build-ews"],
       "workernames": ["ews104", "ews106", "ews107", "ews113", "ews115", "ews169"]
     },
     {
       "name": "macOS-Release-WK2-Stress-Tests-EWS", "shortname": "mac-wk2-stress", "icon": "testOnly",
-      "factory": "StressTestFactory", "platform": "mac-bigsur",
+      "factory": "StressTestFactory", "platform": "mac-monterey",
       "configuration": "release", "architectures": ["x86_64"],
-      "triggered_by": ["macos-bigsur-release-build-ews"],
+      "triggered_by": ["macos-monterey-release-build-ews"],
       "workernames": ["ews181", "ews182"]
     },
     {
@@ -254,7 +254,7 @@
     },
     {
       "name": "JSC-Tests-EWS", "shortname": "jsc", "icon": "buildAndTest",
-      "factory": "JSCBuildAndTestsFactory", "platform": "mac-bigsur",
+      "factory": "JSCBuildAndTestsFactory", "platform": "mac-monterey",
       "configuration": "release", "runTests": "true",
       "workernames": ["ews127", "ews128"]
     },
@@ -323,7 +323,7 @@
     {
       "name": "API-Tests-macOS-EWS", "shortname": "api-mac", "icon": "testOnly",
       "factory": "APITestsFactory", "platform": "*",
-      "triggered_by": ["macos-bigsur-release-build-ews"],
+      "triggered_by": ["macos-monterey-release-build-ews"],
       "workernames": ["ews100", "ews129", "ews150", "ews153", "ews155"]
     },
     {
@@ -340,19 +340,19 @@
     },
     {
       "name": "Commit-Queue", "shortname": "commit", "icon": "buildAndTest",
-      "factory": "CommitQueueFactory", "platform": "mac-bigsur",
+      "factory": "CommitQueueFactory", "platform": "mac-monterey",
       "configuration": "release", "architectures": ["x86_64"],
       "workernames": ["webkit-cq-01", "webkit-cq-02", "webkit-cq-03", "webkit-cq-05"]
     },
     {
       "name": "Merge-Queue", "shortname": "merge", "icon": "buildAndTest",
-      "factory": "MergeQueueFactory", "platform": "mac-bigsur",
+      "factory": "MergeQueueFactory", "platform": "mac-monterey",
       "configuration": "release", "architectures": ["x86_64"],
       "workernames": ["webkit-cq-01", "webkit-cq-02", "webkit-cq-03", "webkit-cq-05"]
     },
     {
       "name": "Unsafe-Merge-Queue", "shortname": "unsafe-merge", "icon": "buildAndTest",
-      "factory": "UnsafeMergeQueueFactory", "platform": "mac-bigsur",
+      "factory": "UnsafeMergeQueueFactory", "platform": "mac-monterey",
       "configuration": "release", "architectures": ["arm64"],
       "workernames": ["webkit-cq-01", "webkit-cq-02", "webkit-cq-03", "webkit-cq-04", "webkit-cq-05"]
     }
@@ -363,7 +363,7 @@
       "builderNames": [
             "Apply-WatchList-EWS", "Bindings-Tests-EWS", "GTK-Build-EWS", "iOS-16-Build-EWS", "iOS-16-Simulator-Build-EWS",
             "JSC-ARMv7-32bits-Build-EWS", "JSC-i386-32bits-EWS", "JSC-MIPSEL-32bits-Build-EWS", "JSC-Tests-EWS", "JSC-Tests-arm64-EWS",
-            "macOS-AppleSilicon-Ventura-Debug-Build-EWS", "macOS-BigSur-Release-Build-EWS",
+            "macOS-AppleSilicon-Ventura-Debug-Build-EWS", "macOS-Monterey-Release-Build-EWS",
             "Services-EWS", "Style-EWS", "tvOS-16-Build-EWS", "tvOS-16-Simulator-Build-EWS", "watchOS-9-Build-EWS",
             "watchOS-9-Simulator-Build-EWS", "WPE-Build-EWS", "WebKitPerl-Tests-EWS", "WebKitPy-Tests-EWS", "WinCairo-EWS"
       ]
@@ -377,7 +377,7 @@
       "builderNames": [
             "Bindings-Tests-EWS", "GTK-Build-EWS", "iOS-16-Build-EWS", "iOS-16-Simulator-Build-EWS",
             "JSC-ARMv7-32bits-Build-EWS", "JSC-i386-32bits-EWS", "JSC-MIPSEL-32bits-Build-EWS", "JSC-Tests-EWS", "JSC-Tests-arm64-EWS",
-            "macOS-AppleSilicon-Ventura-Debug-Build-EWS", "macOS-BigSur-Release-Build-EWS",
+            "macOS-AppleSilicon-Ventura-Debug-Build-EWS", "macOS-Monterey-Release-Build-EWS",
             "Services-EWS", "Style-EWS", "Style-EWS", "tvOS-16-Build-EWS", "tvOS-16-Simulator-Build-EWS", "watchOS-9-Build-EWS",
             "watchOS-9-Simulator-Build-EWS", "WPE-Build-EWS", "WebKitPerl-Tests-EWS", "WebKitPy-Tests-EWS", "WinCairo-EWS"
       ]
@@ -391,16 +391,16 @@
       "builderNames": ["Unsafe-Merge-Queue"]
     },
     {
-      "type": "Triggerable", "name": "macos-bigsur-release-build-ews",
-      "builderNames": ["macOS-BigSur-Release-Build-EWS"]
+      "type": "Triggerable", "name": "macos-monterey-release-build-ews",
+      "builderNames": ["macOS-Monterey-Release-Build-EWS"]
     },
     {
-      "type": "Triggerable", "name": "macos-bigsur-release-wk1-tests-ews",
-      "builderNames": ["macOS-BigSur-Release-WK1-Tests-EWS"]
+      "type": "Triggerable", "name": "macos-monterey-release-wk1-tests-ews",
+      "builderNames": ["macOS-Monterey-Release-WK1-Tests-EWS"]
     },
     {
-      "type": "Triggerable", "name": "macos-bigsur-release-wk2-tests-ews",
-      "builderNames": ["macOS-BigSur-Release-WK2-Tests-EWS"]
+      "type": "Triggerable", "name": "macos-monterey-release-wk2-tests-ews",
+      "builderNames": ["macOS-Monterey-Release-WK2-Tests-EWS"]
     },
     {
       "type": "Triggerable", "name": "macos-release-wk2-stress-tests-ews",

--- a/Tools/CISupport/ews-build/factories_unittest.py
+++ b/Tools/CISupport/ews-build/factories_unittest.py
@@ -180,7 +180,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'trigger-crash-log-submission',
             'set-build-summary'
         ],
-        'macOS-BigSur-Release-Build-EWS': [
+        'macOS-Monterey-Release-Build-EWS': [
             'configure-build',
             'validate-change',
             'configuration',
@@ -195,7 +195,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'validate-change',
             'compile-webkit'
         ],
-        'macOS-BigSur-Release-WK1-Tests-EWS': [
+        'macOS-Monterey-Release-WK1-Tests-EWS': [
             'configure-build',
             'check-change-relevance',
             'validate-change',
@@ -217,7 +217,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'trigger-crash-log-submission',
             'set-build-summary'
         ],
-        'macOS-BigSur-Release-WK2-Tests-EWS': [
+        'macOS-Monterey-Release-WK2-Tests-EWS': [
             'configure-build',
             'validate-change',
             'configuration',

--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -1215,7 +1215,7 @@ class CheckChangeRelevance(AnalyzeChange):
         re.compile(rb'Tools', re.IGNORECASE),
     ]
 
-    big_sur_builder_path_regexes = [
+    monterey_builder_path_regexes = [
         re.compile(rb'Source/', re.IGNORECASE),
         re.compile(rb'Tools/', re.IGNORECASE),
     ]
@@ -1229,7 +1229,7 @@ class CheckChangeRelevance(AnalyzeChange):
 
     group_to_paths_mapping = {
         'bindings': bindings_path_regexes,
-        'bigsur-release-build': big_sur_builder_path_regexes,
+        'monterey-release-build': monterey_builder_path_regexes,
         'services-ews': services_path_regexes,
         'jsc': jsc_path_regexes,
         'webkitpy': webkitpy_path_regexes,
@@ -2656,17 +2656,6 @@ class CompileWebKit(shell.Compile, AddToLogMixin):
         self.setCommand(self.command + customBuildFlag(platform, self.getProperty('fullPlatform')))
 
         return shell.Compile.start(self)
-
-    def buildCommandKwargs(self, warnings):
-        kwargs = super().buildCommandKwargs(warnings)
-        # https://bugs.webkit.org/show_bug.cgi?id=239455: The timeout needs to be >20 min to
-        # work around log output delays on slower machines.
-        # https://bugs.webkit.org/show_bug.cgi?id=247506: Only applies to Xcode 12.x.
-        if self.getProperty('fullPlatform') == 'mac-bigsur':
-            kwargs['timeout'] = 60 * 60
-        else:
-            kwargs['timeout'] = 60 * 30
-        return kwargs
 
     def errorReceived(self, error):
         self._addToLog('errors', error + '\n')

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -1232,7 +1232,7 @@ class TestCompileWebKit(BuildStepMixinAdditions, unittest.TestCase):
         self.setProperty('configuration', 'release')
         self.expectRemoteCommands(
             ExpectShell(workdir='wkdir',
-                        timeout=1800,
+                        timeout=1200,
                         logEnviron=False,
                         command=['perl', 'Tools/Scripts/build-webkit', '--release'],
                         )
@@ -1248,7 +1248,7 @@ class TestCompileWebKit(BuildStepMixinAdditions, unittest.TestCase):
         self.setProperty('configuration', 'release')
         self.expectRemoteCommands(
             ExpectShell(workdir='wkdir',
-                        timeout=1800,
+                        timeout=1200,
                         logEnviron=False,
                         command=['perl', 'Tools/Scripts/build-webkit', '--release', '--prefix=/app/webkit/WebKitBuild/release/install', '--gtk'],
                         )
@@ -1264,7 +1264,7 @@ class TestCompileWebKit(BuildStepMixinAdditions, unittest.TestCase):
         self.setProperty('configuration', 'release')
         self.expectRemoteCommands(
             ExpectShell(workdir='wkdir',
-                        timeout=1800,
+                        timeout=1200,
                         logEnviron=False,
                         command=['perl', 'Tools/Scripts/build-webkit', '--release', '--wpe'],
                         )
@@ -1275,11 +1275,11 @@ class TestCompileWebKit(BuildStepMixinAdditions, unittest.TestCase):
 
     def test_failure(self):
         self.setupStep(CompileWebKit())
-        self.setProperty('fullPlatform', 'mac-bigsur')
+        self.setProperty('fullPlatform', 'mac-monterey')
         self.setProperty('configuration', 'debug')
         self.expectRemoteCommands(
             ExpectShell(workdir='wkdir',
-                        timeout=3600,  # only Big Sur uses an 3600 timeout
+                        timeout=1200,
                         logEnviron=False,
                         command=['perl', 'Tools/Scripts/build-webkit', '--debug'],
                         )
@@ -1312,7 +1312,7 @@ class TestCompileWebKitWithoutChange(BuildStepMixinAdditions, unittest.TestCase)
         self.setProperty('configuration', 'release')
         self.expectRemoteCommands(
             ExpectShell(workdir='wkdir',
-                        timeout=1800,
+                        timeout=1200,
                         logEnviron=False,
                         command=['perl', 'Tools/Scripts/build-webkit', '--release'],
                         )
@@ -1323,11 +1323,11 @@ class TestCompileWebKitWithoutChange(BuildStepMixinAdditions, unittest.TestCase)
 
     def test_failure(self):
         self.setupStep(CompileWebKitWithoutChange())
-        self.setProperty('fullPlatform', 'mac-bigsur')
+        self.setProperty('fullPlatform', 'mac-monterey')
         self.setProperty('configuration', 'debug')
         self.expectRemoteCommands(
             ExpectShell(workdir='wkdir',
-                        timeout=3600,  # only Big Sur uses an 3600 timeout
+                        timeout=1200,
                         logEnviron=False,
                         command=['perl', 'Tools/Scripts/build-webkit', '--debug'],
                         )
@@ -1450,7 +1450,7 @@ class TestCompileJSC(BuildStepMixinAdditions, unittest.TestCase):
         self.setProperty('configuration', 'release')
         self.expectRemoteCommands(
             ExpectShell(workdir='wkdir',
-                        timeout=1800,
+                        timeout=1200,
                         logEnviron=False,
                         command=['perl', 'Tools/Scripts/build-jsc', '--release'],
                         )
@@ -1465,7 +1465,7 @@ class TestCompileJSC(BuildStepMixinAdditions, unittest.TestCase):
         self.setProperty('configuration', 'debug')
         self.expectRemoteCommands(
             ExpectShell(workdir='wkdir',
-                        timeout=1800,
+                        timeout=1200,
                         logEnviron=False,
                         command=['perl', 'Tools/Scripts/build-jsc', '--debug'],
                         )
@@ -1490,7 +1490,7 @@ class TestCompileJSCWithoutChange(BuildStepMixinAdditions, unittest.TestCase):
         self.setProperty('configuration', 'release')
         self.expectRemoteCommands(
             ExpectShell(workdir='wkdir',
-                        timeout=1800,
+                        timeout=1200,
                         logEnviron=False,
                         command=['perl', 'Tools/Scripts/build-jsc', '--release'],
                         )
@@ -1505,7 +1505,7 @@ class TestCompileJSCWithoutChange(BuildStepMixinAdditions, unittest.TestCase):
         self.setProperty('configuration', 'debug')
         self.expectRemoteCommands(
             ExpectShell(workdir='wkdir',
-                        timeout=1800,
+                        timeout=1200,
                         logEnviron=False,
                         command=['perl', 'Tools/Scripts/build-jsc', '--debug'],
                         )
@@ -3950,10 +3950,10 @@ class TestCheckChangeRelevance(BuildStepMixinAdditions, unittest.TestCase):
             rc = self.runStep()
         return rc
 
-    def test_relevant_bigsur_builder_patch(self):
+    def test_relevant_monterey_builder_patch(self):
         file_names = ['Source/xyz', 'Tools/abc']
         self.setupStep(CheckChangeRelevance())
-        self.setProperty('buildername', 'macOS-BigSur-Release-Build-EWS')
+        self.setProperty('buildername', 'macOS-Monterey-Release-Build-EWS')
         for file_name in file_names:
             CheckChangeRelevance._get_patch = lambda x: f'Sample patch; file: {file_name}'
             self.expectOutcome(result=SUCCESS, state_string='Patch contains relevant changes')
@@ -3963,7 +3963,7 @@ class TestCheckChangeRelevance(BuildStepMixinAdditions, unittest.TestCase):
     def test_relevant_wk1_patch(self):
         CheckChangeRelevance._get_patch = lambda x: b'Sample patch; file: Source/WebKitLegacy'
         self.setupStep(CheckChangeRelevance())
-        self.setProperty('buildername', 'macOS-BigSur-Release-WK1-Tests-EWS')
+        self.setProperty('buildername', 'macOS-Monterey-Release-WK1-Tests-EWS')
         self.expectOutcome(result=SUCCESS, state_string='Patch contains relevant changes')
         return self.runStep()
 
@@ -4036,7 +4036,7 @@ class TestCheckChangeRelevance(BuildStepMixinAdditions, unittest.TestCase):
 
     def test_non_relevant_patch_on_various_queues(self):
         CheckChangeRelevance._get_patch = lambda x: 'Sample patch'
-        queues = ['Bindings-Tests-EWS', 'JSC-Tests-EWS', 'macOS-BigSur-Release-Build-EWS',
+        queues = ['Bindings-Tests-EWS', 'JSC-Tests-EWS', 'macOS-Monterey-Release-Build-EWS',
                   'macOS-Catalina-Debug-WK1-Tests-EWS', 'Services-EWS', 'WebKitPy-Tests-EWS']
         for queue in queues:
             self.setupStep(CheckChangeRelevance())
@@ -4047,7 +4047,7 @@ class TestCheckChangeRelevance(BuildStepMixinAdditions, unittest.TestCase):
 
     def test_non_relevant_pull_request_on_various_queues(self):
         CheckChangeRelevance._get_patch = lambda x: '\n'
-        queues = ['Bindings-Tests-EWS', 'JSC-Tests-EWS', 'macOS-BigSur-Release-Build-EWS',
+        queues = ['Bindings-Tests-EWS', 'JSC-Tests-EWS', 'macOS-Monterey-Release-Build-EWS',
                   'macOS-Catalina-Debug-WK1-Tests-EWS', 'Services-EWS', 'WebKitPy-Tests-EWS']
         for queue in queues:
             self.setupStep(CheckChangeRelevance())


### PR DESCRIPTION
#### eb60908303ab4874a8926527756e19b6ae6e4cdb
<pre>
Add EWS Infrastructure to support Monterey (252579)
<a href="https://bugs.webkit.org/show_bug.cgi?id=252579">https://bugs.webkit.org/show_bug.cgi?id=252579</a>
rdar://105684845

Reviewed by Ryan Haddad.

* Tools/CISupport/ews-build/config.json:
* Tools/CISupport/ews-build/factories_unittest.py:
(TestExpectedBuildSteps):

Canonical link: <a href="https://commits.webkit.org/261335@main">https://commits.webkit.org/261335@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd14c3e010f60cb5a3554f7c5a7bfb61faaa2fd6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109384 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18508 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42164 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/899 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118566 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113267 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19989 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9722 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/440 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115140 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14894 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98118 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101659 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96866 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29771 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43084 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11268 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31114 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84836 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11934 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8051 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/108150 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17301 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50717 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13650 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4302 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->