### PR TITLE
Let's call it "displayDidRefresh" everywhere consistently

### DIFF
--- a/Source/WebCore/platform/graphics/DisplayRefreshMonitor.cpp
+++ b/Source/WebCore/platform/graphics/DisplayRefreshMonitor.cpp
@@ -223,7 +223,7 @@ void DisplayRefreshMonitor::displayDidRefresh(const DisplayUpdate& displayUpdate
         setIsPreviousFrameDone(true);
     }
 
-    DisplayRefreshMonitorManager::sharedManager().displayDidRefresh(*this);
+    DisplayRefreshMonitorManager::sharedManager().displayMonitorDisplayDidRefresh(*this);
 }
 
 }

--- a/Source/WebCore/platform/graphics/DisplayRefreshMonitorManager.cpp
+++ b/Source/WebCore/platform/graphics/DisplayRefreshMonitorManager.cpp
@@ -85,7 +85,7 @@ bool DisplayRefreshMonitorManager::scheduleAnimation(DisplayRefreshMonitorClient
     return false;
 }
 
-void DisplayRefreshMonitorManager::displayDidRefresh(DisplayRefreshMonitor&)
+void DisplayRefreshMonitorManager::displayMonitorDisplayDidRefresh(DisplayRefreshMonitor&)
 {
     // Maybe we should remove monitors that haven't been active for some time.
 }
@@ -110,7 +110,7 @@ std::optional<FramesPerSecond> DisplayRefreshMonitorManager::nominalFramesPerSec
     return std::nullopt;
 }
 
-void DisplayRefreshMonitorManager::displayWasUpdated(PlatformDisplayID displayID, const DisplayUpdate& displayUpdate)
+void DisplayRefreshMonitorManager::displayDidRefresh(PlatformDisplayID displayID, const DisplayUpdate& displayUpdate)
 {
     auto* monitor = monitorForDisplayID(displayID);
     if (monitor)

--- a/Source/WebCore/platform/graphics/DisplayRefreshMonitorManager.h
+++ b/Source/WebCore/platform/graphics/DisplayRefreshMonitorManager.h
@@ -51,13 +51,13 @@ public:
 
     void clientPreferredFramesPerSecondChanged(DisplayRefreshMonitorClient&);
 
-    WEBCORE_EXPORT void displayWasUpdated(PlatformDisplayID, const DisplayUpdate&);
+    WEBCORE_EXPORT void displayDidRefresh(PlatformDisplayID, const DisplayUpdate&);
 
 private:
     DisplayRefreshMonitorManager() = default;
     virtual ~DisplayRefreshMonitorManager();
 
-    void displayDidRefresh(DisplayRefreshMonitor&);
+    void displayMonitorDisplayDidRefresh(DisplayRefreshMonitor&);
 
     size_t findMonitorForDisplayID(PlatformDisplayID) const;
     DisplayRefreshMonitor* monitorForDisplayID(PlatformDisplayID) const;

--- a/Source/WebKit/UIProcess/mac/DisplayLink.cpp
+++ b/Source/WebKit/UIProcess/mac/DisplayLink.cpp
@@ -213,11 +213,11 @@ void DisplayLink::setObserverPreferredFramesPerSecond(Client& client, DisplayLin
 
 CVReturn DisplayLink::displayLinkCallback(CVDisplayLinkRef displayLinkRef, const CVTimeStamp*, const CVTimeStamp*, CVOptionFlags, CVOptionFlags*, void* data)
 {
-    static_cast<DisplayLink*>(data)->notifyObserversDisplayWasRefreshed();
+    static_cast<DisplayLink*>(data)->notifyObserversDisplayDidRefresh();
     return kCVReturnSuccess;
 }
 
-void DisplayLink::notifyObserversDisplayWasRefreshed()
+void DisplayLink::notifyObserversDisplayDidRefresh()
 {
     ASSERT(!RunLoop::isMain());
 

--- a/Source/WebKit/UIProcess/mac/DisplayLink.h
+++ b/Source/WebKit/UIProcess/mac/DisplayLink.h
@@ -71,7 +71,7 @@ public:
 
 private:
     static CVReturn displayLinkCallback(CVDisplayLinkRef, const CVTimeStamp*, const CVTimeStamp*, CVOptionFlags, CVOptionFlags*, void* data);
-    void notifyObserversDisplayWasRefreshed();
+    void notifyObserversDisplayDidRefresh();
 
     bool removeInfoForClientIfUnused(Client&) WTF_REQUIRES_LOCK(m_clientsLock);
 

--- a/Source/WebKit/UIProcess/mac/DisplayLinkProcessProxyClient.cpp
+++ b/Source/WebKit/UIProcess/mac/DisplayLinkProcessProxyClient.cpp
@@ -54,9 +54,9 @@ void DisplayLinkProcessProxyClient::displayLinkFired(WebCore::PlatformDisplayID 
         return;
 
     if (wantsFullSpeedUpdates)
-        connection->send(Messages::EventDispatcher::DisplayWasRefreshed(displayID, displayUpdate, anyObserverWantsCallback), 0, { }, Thread::QOS::UserInteractive);
+        connection->send(Messages::EventDispatcher::DisplayDidRefresh(displayID, displayUpdate, anyObserverWantsCallback), 0, { }, Thread::QOS::UserInteractive);
     else if (anyObserverWantsCallback)
-        connection->send(Messages::WebProcess::DisplayWasRefreshed(displayID, displayUpdate), 0, { }, Thread::QOS::UserInteractive);
+        connection->send(Messages::WebProcess::DisplayDidRefresh(displayID, displayUpdate), 0, { }, Thread::QOS::UserInteractive);
 }
 
 }

--- a/Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp
+++ b/Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp
@@ -295,7 +295,7 @@ void EventDispatcher::sendDidReceiveEvent(PageIdentifier pageID, WebEventType ev
     WebProcess::singleton().parentProcessConnection()->send(Messages::WebPageProxy::DidReceiveEvent(eventType, didHandleEvent), pageID);
 }
 
-void EventDispatcher::notifyScrollingTreesDisplayWasRefreshed(PlatformDisplayID displayID)
+void EventDispatcher::notifyScrollingTreesDisplayDidRefresh(PlatformDisplayID displayID)
 {
 #if ENABLE(ASYNC_SCROLLING) && ENABLE(SCROLLING_THREAD)
     Locker locker { m_scrollingTreesLock };
@@ -305,23 +305,23 @@ void EventDispatcher::notifyScrollingTreesDisplayWasRefreshed(PlatformDisplayID 
 }
 
 #if HAVE(CVDISPLAYLINK)
-void EventDispatcher::displayWasRefreshed(PlatformDisplayID displayID, const DisplayUpdate& displayUpdate, bool sendToMainThread)
+void EventDispatcher::displayDidRefresh(PlatformDisplayID displayID, const DisplayUpdate& displayUpdate, bool sendToMainThread)
 {
     tracePoint(DisplayRefreshDispatchingToMainThread, displayID, sendToMainThread);
 
     ASSERT(!RunLoop::isMain());
 
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER)
-    m_momentumEventDispatcher->displayWasRefreshed(displayID);
+    m_momentumEventDispatcher->displayDidRefresh(displayID);
 #endif
 
-    notifyScrollingTreesDisplayWasRefreshed(displayID);
+    notifyScrollingTreesDisplayDidRefresh(displayID);
 
     if (!sendToMainThread)
         return;
 
     RunLoop::main().dispatch([displayID, displayUpdate]() {
-        DisplayRefreshMonitorManager::sharedManager().displayWasUpdated(displayID, displayUpdate);
+        DisplayRefreshMonitorManager::sharedManager().displayDidRefresh(displayID, displayUpdate);
     });
 }
 #endif
@@ -347,12 +347,12 @@ void EventDispatcher::handleSyntheticWheelEvent(WebCore::PageIdentifier pageIden
     internalWheelEvent(pageIdentifier, event, rubberBandableEdges, WheelEventOrigin::MomentumEventDispatcher);
 }
 
-void EventDispatcher::startDisplayWasRefreshedCallbacks(WebCore::PlatformDisplayID displayID)
+void EventDispatcher::startDisplayDidRefreshCallbacks(WebCore::PlatformDisplayID displayID)
 {
     WebProcess::singleton().parentProcessConnection()->send(Messages::WebProcessProxy::StartDisplayLink(m_observerID, displayID, WebCore::FullSpeedFramesPerSecond), 0);
 }
 
-void EventDispatcher::stopDisplayWasRefreshedCallbacks(WebCore::PlatformDisplayID displayID)
+void EventDispatcher::stopDisplayDidRefreshCallbacks(WebCore::PlatformDisplayID displayID)
 {
     WebProcess::singleton().parentProcessConnection()->send(Messages::WebProcessProxy::StopDisplayLink(m_observerID, displayID), 0);
 }

--- a/Source/WebKit/WebProcess/WebPage/EventDispatcher.h
+++ b/Source/WebKit/WebProcess/WebPage/EventDispatcher.h
@@ -88,7 +88,7 @@ public:
 
     void initializeConnection(IPC::Connection&);
 
-    void notifyScrollingTreesDisplayWasRefreshed(WebCore::PlatformDisplayID);
+    void notifyScrollingTreesDisplayDidRefresh(WebCore::PlatformDisplayID);
 
 private:
     // IPC::MessageReceiver overrides.
@@ -123,7 +123,7 @@ private:
     static void sendDidReceiveEvent(WebCore::PageIdentifier, WebEventType, bool didHandleEvent);
 
 #if PLATFORM(MAC)
-    void displayWasRefreshed(WebCore::PlatformDisplayID, const WebCore::DisplayUpdate&, bool sendToMainThread);
+    void displayDidRefresh(WebCore::PlatformDisplayID, const WebCore::DisplayUpdate&, bool sendToMainThread);
 #endif
 
 #if ENABLE(SCROLLING_THREAD)
@@ -133,8 +133,8 @@ private:
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER)
     // EventDispatcher::Client
     void handleSyntheticWheelEvent(WebCore::PageIdentifier, const WebWheelEvent&, WebCore::RectEdges<bool> rubberBandableEdges) override;
-    void startDisplayWasRefreshedCallbacks(WebCore::PlatformDisplayID) override;
-    void stopDisplayWasRefreshedCallbacks(WebCore::PlatformDisplayID) override;
+    void startDisplayDidRefreshCallbacks(WebCore::PlatformDisplayID) override;
+    void stopDisplayDidRefreshCallbacks(WebCore::PlatformDisplayID) override;
 
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER_TEMPORARY_LOGGING)
     void flushMomentumEventLoggingSoon() override;

--- a/Source/WebKit/WebProcess/WebPage/EventDispatcher.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/EventDispatcher.messages.in
@@ -30,7 +30,7 @@ messages -> EventDispatcher NotRefCounted {
     GestureEvent(WebCore::PageIdentifier pageID, WebKit::WebGestureEvent event)
 #endif
 #if HAVE(CVDISPLAYLINK)
-    DisplayWasRefreshed(uint32_t displayID, struct WebCore::DisplayUpdate update, bool sendToMainThread)
+    DisplayDidRefresh(uint32_t displayID, struct WebCore::DisplayUpdate update, bool sendToMainThread)
 #endif
 
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER)

--- a/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp
+++ b/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp
@@ -286,7 +286,7 @@ void MomentumEventDispatcher::startDisplayLink()
     }
 
     // FIXME: Switch down to lower-than-full-speed frame rates for the tail end of the curve.
-    m_client.startDisplayWasRefreshedCallbacks(displayProperties->displayID);
+    m_client.startDisplayDidRefreshCallbacks(displayProperties->displayID);
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER_TEMPORARY_LOGGING)
     RELEASE_LOG(ScrollAnimations, "MomentumEventDispatcher starting display link for display %d", displayProperties->displayID);
 #endif
@@ -300,7 +300,7 @@ void MomentumEventDispatcher::stopDisplayLink()
         return;
     }
 
-    m_client.stopDisplayWasRefreshedCallbacks(displayProperties->displayID);
+    m_client.stopDisplayDidRefreshCallbacks(displayProperties->displayID);
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER_TEMPORARY_LOGGING)
     RELEASE_LOG(ScrollAnimations, "MomentumEventDispatcher stopping display link for display %d", displayProperties->displayID);
 #endif
@@ -344,7 +344,7 @@ std::optional<WebCore::FloatSize> MomentumEventDispatcher::consumeDeltaForCurren
     return delta;
 }
 
-void MomentumEventDispatcher::displayWasRefreshed(WebCore::PlatformDisplayID displayID)
+void MomentumEventDispatcher::displayDidRefresh(WebCore::PlatformDisplayID displayID)
 {
     if (!m_currentGesture.active)
         return;

--- a/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.h
+++ b/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.h
@@ -59,8 +59,8 @@ public:
     private:
         virtual void handleSyntheticWheelEvent(WebCore::PageIdentifier, const WebWheelEvent&, WebCore::RectEdges<bool> rubberBandableEdges) = 0;
         
-        virtual void startDisplayWasRefreshedCallbacks(WebCore::PlatformDisplayID) = 0;
-        virtual void stopDisplayWasRefreshedCallbacks(WebCore::PlatformDisplayID) = 0;
+        virtual void startDisplayDidRefreshCallbacks(WebCore::PlatformDisplayID) = 0;
+        virtual void stopDisplayDidRefreshCallbacks(WebCore::PlatformDisplayID) = 0;
 
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER_TEMPORARY_LOGGING)
         virtual void flushMomentumEventLoggingSoon() = 0;
@@ -74,7 +74,7 @@ public:
 
     void setScrollingAccelerationCurve(WebCore::PageIdentifier, std::optional<ScrollingAccelerationCurve>);
 
-    void displayWasRefreshed(WebCore::PlatformDisplayID);
+    void displayDidRefresh(WebCore::PlatformDisplayID);
 
     void pageScreenDidChange(WebCore::PageIdentifier, WebCore::PlatformDisplayID, std::optional<unsigned> nominalFramesPerSecond);
 

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -2064,11 +2064,11 @@ void WebProcess::setClientBadge(WebPageProxyIdentifier pageIdentifier, const Web
 }
 
 #if HAVE(CVDISPLAYLINK)
-void WebProcess::displayWasRefreshed(uint32_t displayID, const DisplayUpdate& displayUpdate)
+void WebProcess::displayDidRefresh(uint32_t displayID, const DisplayUpdate& displayUpdate)
 {
     ASSERT(RunLoop::isMain());
-    m_eventDispatcher.notifyScrollingTreesDisplayWasRefreshed(displayID);
-    DisplayRefreshMonitorManager::sharedManager().displayWasUpdated(displayID, displayUpdate);
+    m_eventDispatcher.notifyScrollingTreesDisplayDidRefresh(displayID);
+    DisplayRefreshMonitorManager::sharedManager().displayDidRefresh(displayID, displayUpdate);
 }
 #endif
 

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -528,7 +528,7 @@ private:
 #endif
 
 #if HAVE(CVDISPLAYLINK)
-    void displayWasRefreshed(uint32_t displayID, const WebCore::DisplayUpdate&);
+    void displayDidRefresh(uint32_t displayID, const WebCore::DisplayUpdate&);
 #endif
 
 #if PLATFORM(MAC)

--- a/Source/WebKit/WebProcess/WebProcess.messages.in
+++ b/Source/WebKit/WebProcess/WebProcess.messages.in
@@ -189,7 +189,7 @@ messages -> WebProcess LegacyReceiver NotRefCounted {
 #endif
 
 #if HAVE(CVDISPLAYLINK)
-    DisplayWasRefreshed(uint32_t displayID, struct WebCore::DisplayUpdate update)
+    DisplayDidRefresh(uint32_t displayID, struct WebCore::DisplayUpdate update)
 #endif
 
 #if PLATFORM(MAC)


### PR DESCRIPTION
#### 62b307c7fef7c479de44aadd7c3ba6a6f4a5586f
<pre>
Let&apos;s call it &quot;displayDidRefresh&quot; everywhere consistently
<a href="https://bugs.webkit.org/show_bug.cgi?id=252713">https://bugs.webkit.org/show_bug.cgi?id=252713</a>
rdar://105755550

Reviewed by Myles C. Maxfield.

Use &quot;displayDidRefresh&quot; consistently in WebKit, rather than &quot;displayWasRefreshed&quot;.

Rename one private function on DisplayRefreshMonitorManager to disambiguate
internal calls from the monitor.

* Source/WebCore/platform/graphics/DisplayRefreshMonitor.cpp:
(WebCore::DisplayRefreshMonitor::displayDidRefresh):
* Source/WebCore/platform/graphics/DisplayRefreshMonitorManager.cpp:
(WebCore::DisplayRefreshMonitorManager::displayMonitorDisplayDidRefresh):
(WebCore::DisplayRefreshMonitorManager::displayDidRefresh):
(WebCore::DisplayRefreshMonitorManager::displayWasUpdated): Deleted.
* Source/WebCore/platform/graphics/DisplayRefreshMonitorManager.h:
* Source/WebKit/UIProcess/mac/DisplayLink.cpp:
(WebKit::DisplayLink::displayLinkCallback):
(WebKit::DisplayLink::notifyObserversDisplayDidRefresh):
(WebKit::DisplayLink::notifyObserversDisplayWasRefreshed): Deleted.
* Source/WebKit/UIProcess/mac/DisplayLink.h:
* Source/WebKit/UIProcess/mac/DisplayLinkProcessProxyClient.cpp:
(WebKit::DisplayLinkProcessProxyClient::displayLinkFired):
* Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp:
(WebKit::EventDispatcher::notifyScrollingTreesDisplayDidRefresh):
(WebKit::EventDispatcher::displayDidRefresh):
(WebKit::EventDispatcher::startDisplayDidRefreshCallbacks):
(WebKit::EventDispatcher::stopDisplayDidRefreshCallbacks):
(WebKit::EventDispatcher::notifyScrollingTreesDisplayWasRefreshed): Deleted.
(WebKit::EventDispatcher::displayWasRefreshed): Deleted.
(WebKit::EventDispatcher::startDisplayWasRefreshedCallbacks): Deleted.
(WebKit::EventDispatcher::stopDisplayWasRefreshedCallbacks): Deleted.
* Source/WebKit/WebProcess/WebPage/EventDispatcher.h:
* Source/WebKit/WebProcess/WebPage/EventDispatcher.messages.in:
* Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp:
(WebKit::MomentumEventDispatcher::startDisplayLink):
(WebKit::MomentumEventDispatcher::stopDisplayLink):
(WebKit::MomentumEventDispatcher::displayDidRefresh):
(WebKit::MomentumEventDispatcher::displayWasRefreshed): Deleted.
* Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::displayDidRefresh):
(WebKit::WebProcess::displayWasRefreshed): Deleted.
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/WebProcess.messages.in:

Canonical link: <a href="https://commits.webkit.org/260684@main">https://commits.webkit.org/260684@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3433f600c48cfa1a8357e5c32d1a2eeeb968fff7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108966 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18045 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41789 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/496 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118256 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112848 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19501 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9341 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101197 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114722 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14628 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97854 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42748 "Found 1 new test failure: webgl/2.0.y/conformance2/vertex_arrays/vertex-array-object.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96600 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29495 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84490 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10828 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30844 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11575 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7785 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16963 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50440 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7373 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13172 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->