### PR TITLE
[WPE] built-product-archive should not unconditionally include the Tools and Source directories

### DIFF
--- a/Tools/CISupport/built-product-archive
+++ b/Tools/CISupport/built-product-archive
@@ -133,11 +133,14 @@ def createZipFromList(listToZip, configuration, excludePatterns=None):
             raise
 
     if sys.platform.startswith('linux'):
-        zipCommand = ['zip', '-y', '-r', archiveFile] + listToZip
+        zipCommand = ['zip', '-y', '-r', archiveFile, '-@']
         if excludePatterns:
             for excludePattern in excludePatterns:
                 zipCommand += ['-x', excludePattern]
-        return subprocess.call(zipCommand, cwd=_configurationBuildDirectory)
+        # listToZip can be very large, so we pass it via stdin (see zip manpage)
+        # to avoid a potential issue hitting the ARG_MAX limit.
+        zipSubprocess = subprocess.run(zipCommand, cwd=_configurationBuildDirectory, input='\n'.join(listToZip).encode())
+        return zipSubprocess.returncode
 
     raise NotImplementedError('Unsupported platform: {platform}'.format(platform=sys.platform))
 
@@ -212,14 +215,15 @@ def createZip(directoryToZip, configuration, excludePatterns=None, embedParentDi
                 zipCommand += ['-x', excludePattern]
         return subprocess.call(zipCommand, cwd=directoryToZip)
 
-
-def dirContainsdwo(directory):
-    sourcedir = os.path.join(_configurationBuildDirectory, directory)
-    for root, dirs, files in os.walk(sourcedir, topdown=False):
-        for name in files:
-            if name.endswith(".dwo"):
-                return True
-    return False
+def listRecursiveFilesInDirWithSuffix(directory, suffix):
+    listFiles = []
+    for root, dirs, files in os.walk(directory):
+        for file in files:
+            if file.endswith(suffix):
+                realAbsolutePath = os.path.join(root, file)
+                realRelativePath = realAbsolutePath[len(directory)+1:]
+                listFiles.append(realRelativePath)
+    return listFiles
 
 MINIFIED_EXCLUDED_PATTERNS = ('*.a', '*.dSYM', 'DerivedSources')
 
@@ -311,14 +315,10 @@ def archiveBuiltProduct(configuration, platform, fullPlatform, minify=False):
         if platform == 'gtk':
             contents.extend([os.path.join('install', directory) for directory in ['include', os.path.join('lib', 'pkgconfig')]])
 
-        # When debug fission is enabled the directories below contain dwo files
-        # with the debug information needed to generate backtraces with GDB.
-        for objectDir in ['Tools', 'Source']:
-            if dirContainsdwo(objectDir):
-                contents.append(objectDir)
+        # When debug fission is enabled the dwo files have information needed to generate backtraces with GDB.
+        contents.extend(listRecursiveFilesInDirWithSuffix(_configurationBuildDirectory, '.dwo'))
 
-        if createZipFromList(contents, configuration, excludePatterns=['*.o', '*.a']):
-            return 1
+        return createZipFromList(contents, configuration, excludePatterns=['*.o', '*.a'])
 
 def unzipArchive(directoryToExtractTo, configuration):
     archiveDir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "WebKitBuild"))


### PR DESCRIPTION
#### 7093ddf8f1346d351fbd14b04a089ed1c52940ec
<pre>
[WPE] built-product-archive should not unconditionally include the Tools and Source directories
<a href="https://bugs.webkit.org/show_bug.cgi?id=252711">https://bugs.webkit.org/show_bug.cgi?id=252711</a>

Reviewed by Carlos Garcia Campos.

The built products generated for WPE were including some stamp files
from the Cog build that they shouldn&apos;t. Like all the ones inside the
sub-directory `Tools/cog-prefix/src/cog-stamp`

This was causing an error when downloading a built-product and then
trying to do a build without cleaning the downloaded built-product
(basically what bots do). The error is caused because CMake was
tricked to think that it has already executed the steps to download
Cog (because the stamp files were present) when it still hasn&apos;t.

This stamp files were included in the first place by mistake when
trying to include the debug fission files (`.dwo`), because the
current code was adding the main top-level directories of `Tools`
and `Source` without further considerations (adding everything
inside this directories instead of just the `.dwo` files)

This patch changes the code to explicitly add each individual
`.dwo` file instead of adding the whole directories.

Since this list can be quite large, we pass it to the zip
command via stdin, to avoid issues with the ARG_MAX limit.

* Tools/CISupport/built-product-archive:

Canonical link: <a href="https://commits.webkit.org/260672@main">https://commits.webkit.org/260672@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa07f79a0b7ab8e112c22d25cbf97c97d9fc09d3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108971 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18050 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41794 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/504 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118261 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112853 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19506 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9346 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101202 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114727 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14625 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97859 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42753 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96597 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29500 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84498 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10833 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30849 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11580 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7789 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16968 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50445 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13177 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4027 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->