### PR TITLE
[Wasm-GC] Use correct offsets when generating code for struct gets and sets in B3 and Air

### DIFF
--- a/JSTests/wasm/gc/bug252719.js
+++ b/JSTests/wasm/gc/bug252719.js
@@ -1,0 +1,68 @@
+//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true", "--webAssemblyBBQAirModeThreshold=20")
+
+// See the comments in `testIntFields()` for why we set --webAssemblyBBQAirModeThreshold=20
+
+import * as assert from "../assert.js";
+import { compile, instantiate } from "./wast-wrapper.js";
+
+function module(bytes, valid = true) {
+  let buffer = new ArrayBuffer(bytes.length);
+  let view = new Uint8Array(buffer);
+  for (let i = 0; i < bytes.length; ++i) {
+    view[i] = bytes.charCodeAt(i);
+  }
+  return new WebAssembly.Module(buffer);
+}
+
+let iterations = 10;
+
+function testIntFields() {
+
+  // size = 41
+  let m = instantiate(`
+    (module
+      (type $s (struct (field i32) (field i32)))
+
+      (func $new (export "new") (result (ref $s))
+         (struct.new_canon $s (i32.const 1) (i32.const 5)))
+
+      (func (export "len0") (result i32)
+         (struct.get $s 0 (call $new)))
+      (func (export "len1") (result i32)
+         (struct.get $s 1 (call $new))))`);
+
+    /*
+      Without the fix for bug 252719, the following assertions will fail
+      after the point when the $new function has been compiled but
+      $len0 and $len1 haven't been yet, so the value for the struct's 1st
+      field will be written to its 0th field.
+    */
+    for (var i = 0; i < iterations; i++) {
+        assert.eq(m.exports.len0(), 1);
+        assert.eq(m.exports.len1(), 5);
+    }
+
+    /*
+      If the bug is fixed in Air but not B3 (or vice versa), the following
+      assertion will fail in the wasm.b3 config because m2 is below the size
+      threshold and so it will be compiled with Air, while m is above the size
+      threshold and will be compiled with B3. The wrong result will be read
+      because the backends will disagree on struct field offsets.
+
+      This relies on setting --webAssemblyBBQAirModeThreshold=20, which is between
+      the size of m and the size of m2.
+     */
+
+    // size = 14
+    let m2 =  instantiate(`(module
+      (type $s (struct (field i32) (field i32)))
+
+      (import "m" "new" (func $new  (result (ref $s))))
+      (func (export "f") (result i32)
+         (call $new)
+         (struct.get $s 1)))`, { "m": { "new": m.exports["new"] }});
+
+    assert.eq(m2.exports.f(), 5);
+}
+
+testIntFields();

--- a/Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h
+++ b/Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h
@@ -2633,8 +2633,8 @@ auto AirIRGeneratorBase<Derived, ExpressionType>::addStructGet(ExpressionType st
     auto payload = self().gPtr();
     auto structBase = self().extractJSValuePointer(structReference);
     self().emitLoad(structBase, JSWebAssemblyStruct::offsetOfPayload(), payload);
+    uint32_t fieldOffset = fixupPointerPlusOffset(payload, *structType.offsetOfField(fieldIndex));
 
-    uint32_t fieldOffset = fixupPointerPlusOffset(payload, *structType.getFieldOffset(fieldIndex));
     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=246981
     ASSERT(structType.field(fieldIndex).type.is<Type>());
     Type fieldType = structType.field(fieldIndex).type.as<Type>();
@@ -2651,8 +2651,8 @@ auto AirIRGeneratorBase<Derived, ExpressionType>::addStructSet(ExpressionType st
     auto payload = self().gPtr();
     auto structBase = self().extractJSValuePointer(structReference);
     self().emitLoad(structBase, JSWebAssemblyStruct::offsetOfPayload(), payload);
+    uint32_t fieldOffset = fixupPointerPlusOffset(payload, *structType.offsetOfField(fieldIndex));
 
-    uint32_t fieldOffset = fixupPointerPlusOffset(payload, *structType.getFieldOffset(fieldIndex));
     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=246981
     ASSERT(structType.field(fieldIndex).type.is<Type>());
     Type fieldType = structType.field(fieldIndex).type.as<Type>();

--- a/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
@@ -2488,7 +2488,7 @@ Value* B3IRGenerator::emitAtomicCompareExchange(ExtAtomicOpType op, Type valueTy
 void B3IRGenerator::emitStructSet(Value* structValue, uint32_t fieldIndex, const StructType& structType, Value* argument)
 {
     Value* payloadBase = m_currentBlock->appendNew<MemoryValue>(m_proc, memoryKind(Load), Int64, origin(), structValue, JSWebAssemblyStruct::offsetOfPayload());
-    int32_t fieldOffset = fixupPointerPlusOffset(payloadBase, *structType.getFieldOffset(fieldIndex));
+    int32_t fieldOffset = fixupPointerPlusOffset(payloadBase, *structType.offsetOfField(fieldIndex));
 
     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=246981
     ASSERT(structType.field(fieldIndex).type.is<Type>());
@@ -3045,7 +3045,7 @@ auto B3IRGenerator::addStructGet(ExpressionType structReference, const StructTyp
     }
 
     Value* payloadBase = m_currentBlock->appendNew<MemoryValue>(m_proc, memoryKind(Load), pointerType(), origin(), get(structReference), JSWebAssemblyStruct::offsetOfPayload());
-    int32_t fieldOffset = fixupPointerPlusOffset(payloadBase, *structType.getFieldOffset(fieldIndex));
+    int32_t fieldOffset = fixupPointerPlusOffset(payloadBase, *structType.offsetOfField(fieldIndex));
 
     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=246981
     ASSERT(structType.field(fieldIndex).type.is<Type>());

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
@@ -108,12 +108,13 @@ StructType::StructType(FieldType* payload, StructFieldCount fieldCount, const Fi
     , m_hasRecursiveReference(false)
 {
     bool hasRecursiveReference = false;
-    unsigned currentFieldOffset = 0;
+    // Account for the internal header in m_payload.m_storage.data
+    unsigned currentFieldOffset = FixedVector<uint8_t>::Storage::offsetOfData();
     for (unsigned fieldIndex = 0; fieldIndex < m_fieldCount; ++fieldIndex) {
         const auto& fieldType = fieldTypes[fieldIndex];
         hasRecursiveReference |= isRefWithRecursiveReference(fieldType.type);
         getField(fieldIndex) = fieldType;
-        *getFieldOffset(fieldIndex) = currentFieldOffset;
+        *offsetOfField(fieldIndex) = currentFieldOffset;
         currentFieldOffset += typeSizeInBytes(field(fieldIndex).type);
     }
 

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
@@ -36,6 +36,7 @@
 #include "Width.h"
 #include "WriteBarrier.h"
 #include <wtf/CheckedArithmetic.h>
+#include <wtf/FixedVector.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/HashTraits.h>
@@ -508,9 +509,12 @@ public:
     FieldType* storage(StructFieldCount i) { return i + m_payload; }
     const FieldType* storage(StructFieldCount i) const { return const_cast<StructType*>(this)->storage(i); }
 
-    const unsigned* getFieldOffset(StructFieldCount i) const { ASSERT(i < fieldCount()); return bitwise_cast<const unsigned*>(m_payload + m_fieldCount) + i; }
-    unsigned* getFieldOffset(StructFieldCount i) { return const_cast<unsigned*>(const_cast<const StructType*>(this)->getFieldOffset(i)); }
+    // Returns the offset relative to `m_payload` (the internal vector of fields)
+    const unsigned* offsetOfField(StructFieldCount i) const { ASSERT(i < fieldCount()); return bitwise_cast<const unsigned*>(m_payload + m_fieldCount) + i; }
+    unsigned* offsetOfField(StructFieldCount i) { return const_cast<unsigned*>(const_cast<const StructType*>(this)->offsetOfField(i)); }
 
+    // Returns the offset relative to `m_payload.storage` (the internal storage for the internal vector of fields)
+    unsigned offsetOfFieldInternal(StructFieldCount i) const { ASSERT(i < fieldCount()); return(*offsetOfField(i) - FixedVector<uint8_t>::Storage::offsetOfData()); }
     size_t instancePayloadSize() const { return m_instancePayloadSize; }
 
 private:

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp
@@ -69,7 +69,7 @@ JSWebAssemblyStruct* JSWebAssemblyStruct::tryCreate(JSGlobalObject* globalObject
 
 const uint8_t* JSWebAssemblyStruct::fieldPointer(uint32_t fieldIndex) const
 {
-    return m_payload.data() + *structType()->getFieldOffset(fieldIndex);
+    return m_payload.data() + structType()->offsetOfFieldInternal(fieldIndex);
 }
 
 uint8_t* JSWebAssemblyStruct::fieldPointer(uint32_t fieldIndex)

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.h
@@ -65,6 +65,7 @@ public:
     const Wasm::StructType* structType() const { return m_type->as<Wasm::StructType>(); }
     Wasm::FieldType fieldType(uint32_t fieldIndex) const { return structType()->field(fieldIndex); }
 
+    // Returns the offset for m_payload.m_storage
     static ptrdiff_t offsetOfPayload() { return OBJECT_OFFSETOF(JSWebAssemblyStruct, m_payload) + FixedVector<uint8_t>::offsetOfStorage(); }
 
     const uint8_t* fieldPointer(uint32_t fieldIndex) const;


### PR DESCRIPTION
#### 2e2ee48591cd2f962f5554a4ab8831c9af2aa93f
<pre>
[Wasm-GC] Use correct offsets when generating code for struct gets and sets in B3 and Air
<a href="https://bugs.webkit.org/show_bug.cgi?id=252719">https://bugs.webkit.org/show_bug.cgi?id=252719</a>

Reviewed by Tadeu Zagallo and Justin Michaud.

The generated code for struct get and set operations was using the wrong offsets and overwriting
the header for the struct object&apos;s `m_payload.storage` field. Triggering the bug requires
a function call where the callee returns a struct and the caller performs a `struct.get` on the
result, and the callee is interpreted while the caller is compiled (or vice versa).

* JSTests/wasm/gc/bug252719.js: Added.
(module):
(testIntFields):
* Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h:
(JSC::Wasm::ExpressionType&gt;::addStructGet):
(JSC::Wasm::ExpressionType&gt;::addStructSet):
* Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp:
(JSC::Wasm::B3IRGenerator::emitStructSet):
(JSC::Wasm::B3IRGenerator::addStructGet):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp:
(JSC::Wasm::StructType::StructType):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.h:
(JSC::Wasm::StructType::offsetOfField const):
(JSC::Wasm::StructType::offsetOfField):
(JSC::Wasm::StructType::getFieldOffset const): Deleted.
(JSC::Wasm::StructType::getFieldOffset): Deleted.
* Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp:
(JSC::JSWebAssemblyStruct::fieldPointer const):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.h:

Canonical link: <a href="https://commits.webkit.org/261899@main">https://commits.webkit.org/261899@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/848946b45c9a05ac391bb3a37932451a45dc5d8b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112812 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/22000 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1517 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4622 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121346 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23345 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13167 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5794 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118581 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17346 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100596 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105931 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99305 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1133 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46361 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/101110 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14300 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1173 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/12443 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/15002 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10518 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/102635 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20317 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53166 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/32027 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8315 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16851 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/110680 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/27331 "Passed tests") | 
<!--EWS-Status-Bubble-End-->