### PR TITLE
[GTK][WPE] Wrong WebKit version recorded on the MiniBrowser of the built-products generated on the bots.

### DIFF
--- a/Tools/glib/apply-build-revision-to-files.py
+++ b/Tools/glib/apply-build-revision-to-files.py
@@ -31,7 +31,7 @@ WEBKIT_TOP_LEVEL = Path(__file__).parent.parent.parent.resolve()
 def get_revision_from_most_recent_git_commit():
     with open(os.devnull, 'w') as devnull:
         try:
-            commit_message = subprocess.check_output(("git", "log", "-1", "--pretty=%B", "origin/HEAD"), stderr=devnull)
+            commit_message = subprocess.check_output(("git", "log", "-1", "--pretty=%B", "HEAD"), stderr=devnull)
         except subprocess.CalledProcessError:
             # This may happen with shallow checkouts whose HEAD has been
             # modified; there is no origin reference anymore, and git


### PR DESCRIPTION
#### 8e68aca2bb75ec8265a76b2681f10d2c5107b126
<pre>
[GTK][WPE] Wrong WebKit version recorded on the MiniBrowser of the built-products generated on the bots.
<a href="https://bugs.webkit.org/show_bug.cgi?id=252720">https://bugs.webkit.org/show_bug.cgi?id=252720</a>

Reviewed by Carlos Garcia Campos.

The bots don&apos;t update the git repository by doing a standard pull.
They checkout a specific commit (FETCH_HEAD) after fetching the repo.

So instead of looking for the commit at origin/HEAD we should look
at HEAD which matches what is currently checked out.

* Tools/glib/apply-build-revision-to-files.py:
(get_revision_from_most_recent_git_commit):

Canonical link: <a href="https://commits.webkit.org/260673@main">https://commits.webkit.org/260673@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a05bef72bc375585ea395b09f5bdc83b96a15f2c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108981 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18059 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41801 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/513 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118266 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112863 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19513 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9357 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101214 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114738 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14632 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97866 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42761 "Found 3 new test failures: webgl/2.0.0/conformance2/textures/image_bitmap_from_video/tex-2d-r8ui-red_integer-unsigned_byte.html, webgl/2.0.y/conformance2/renderbuffers/multisampled-depth-renderbuffer-initialization.html, webgl/2.0.y/conformance2/vertex_arrays/vertex-array-object.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96604 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29507 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84508 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10844 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30856 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11591 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7796 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16973 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50453 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13188 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4028 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->