### PR TITLE
[Win] The generic URL::fileSystemPath has to remove a leading slash

### DIFF
--- a/Source/WTF/wtf/URL.cpp
+++ b/Source/WTF/wtf/URL.cpp
@@ -269,7 +269,7 @@ URL URL::truncatedForUseAsBase() const
     return URL(m_string.left(m_pathAfterLastSlash));
 }
 
-#if !USE(CF)
+#if !USE(CF) || PLATFORM(WIN)
 
 String URL::fileSystemPath() const
 {
@@ -278,7 +278,8 @@ String URL::fileSystemPath() const
 
     auto result = decodeEscapeSequencesFromParsedURL(path());
 #if PLATFORM(WIN)
-    result = FileSystem::fileSystemRepresentation(result);
+    if (result.startsWith('/'))
+        result = result.substring(1);
 #endif
     return result;
 }

--- a/Source/WTF/wtf/cf/URLCF.cpp
+++ b/Source/WTF/wtf/cf/URLCF.cpp
@@ -73,18 +73,15 @@ RetainPtr<CFURLRef> URL::createCFURL() const
     return result;
 }
 
+#if !PLATFORM(WIN)
 String URL::fileSystemPath() const
 {
     auto cfURL = createCFURL();
     if (!cfURL)
         return String();
 
-#if PLATFORM(WIN)
-    CFURLPathStyle pathStyle = kCFURLWindowsPathStyle;
-#else
-    CFURLPathStyle pathStyle = kCFURLPOSIXPathStyle;
-#endif
-    return adoptCF(CFURLCopyFileSystemPath(cfURL.get(), pathStyle)).get();
+    return adoptCF(CFURLCopyFileSystemPath(cfURL.get(), kCFURLPOSIXPathStyle)).get();
 }
+#endif
 
 }


### PR DESCRIPTION
#### 5e1c8e09258cfc87c6907b65a5f7c72b08e295af
<pre>
[Win] The generic URL::fileSystemPath has to remove a leading slash
<a href="https://bugs.webkit.org/show_bug.cgi?id=252367">https://bugs.webkit.org/show_bug.cgi?id=252367</a>

Reviewed by Darin Adler and Ross Kirsling.

Switched Windows port to use the generic URL::fileSystemPath rather
than one using CF.

URL::fileSystemPath has to remove a leading slash for Windows.
Otherwise it returns a path &quot;/C:/x.txt&quot; for a URL
&quot;file:///C:/x.txt&quot;.

* Source/WTF/wtf/URL.cpp:
(WTF::URL::fileSystemPath const):
* Source/WTF/wtf/cf/URLCF.cpp:
(WTF::URL::fileSystemPath const):

Canonical link: <a href="https://commits.webkit.org/260739@main">https://commits.webkit.org/260739@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5eba3aad6ed600437c2a54a482a2fee0f37243df

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108984 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18062 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41804 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/516 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118268 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19516 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9360 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101217 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114741 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14635 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97871 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42763 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96607 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29512 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84511 "Found 1 new API test failure: /WebKitGTK/TestDownloads:/webkit/Downloads/local-file-error (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/98043 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10847 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30860 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/98834 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/8957 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11593 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31013 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16975 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50458 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/106486 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7409 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13191 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26392 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->