### PR TITLE
Introduce RemoteLayerTreeEventDispatcher for threaded UI-side scrolling

### DIFF
--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -550,6 +550,7 @@ UIProcess/Network/CustomProtocols/LegacyCustomProtocolManagerProxy.cpp
 UIProcess/RemoteLayerTree/cocoa/RemoteLayerTreeLayers.mm
 
 UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
+UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
 UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
 UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
 UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.cpp

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -45,6 +45,8 @@ public:
     RemoteLayerTreeDrawingAreaProxy(WebPageProxy&, WebProcessProxy&);
     virtual ~RemoteLayerTreeDrawingAreaProxy();
 
+    virtual bool isRemoteLayerTreeDrawingAreaProxyMac() const { return false; }
+
     const RemoteLayerTreeHost& remoteLayerTreeHost() const { return *m_remoteLayerTreeHost; }
     std::unique_ptr<RemoteLayerTreeHost> detachRemoteLayerTreeHost();
     

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -128,6 +128,8 @@ public:
     void deferWheelEventTestCompletionForReason(WebCore::ScrollingNodeID, WebCore::WheelEventTestMonitor::DeferReason);
     void removeWheelEventTestCompletionDeferralForReason(WebCore::ScrollingNodeID, WebCore::WheelEventTestMonitor::DeferReason);
 
+    virtual void windowScreenDidChange(WebCore::PlatformDisplayID, std::optional<WebCore::FramesPerSecond>) { }
+
 protected:
     RemoteScrollingTree* scrollingTree() const { return m_scrollingTree.get(); }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h
@@ -48,9 +48,13 @@ public:
 
     void didRefreshDisplay() override;
 
+    DisplayLink& displayLink();
+
 private:
     WebCore::DelegatedScrollingMode delegatedScrollingMode() const override;
     std::unique_ptr<RemoteScrollingCoordinatorProxy> createScrollingCoordinatorProxy() const override;
+
+    bool isRemoteLayerTreeDrawingAreaProxyMac() const override { return true; }
 
     void didCommitLayerTree(IPC::Connection&, const RemoteLayerTreeTransaction&, const RemoteScrollingCoordinatorTransaction&) override;
 
@@ -73,7 +77,6 @@ private:
     void removeObserver(std::optional<DisplayLinkObserverID>&);
 
     DisplayLink* exisingDisplayLink();
-    DisplayLink& ensureDisplayLink();
 
     WTF::MachSendRight createFence() override;
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
@@ -108,7 +108,7 @@ DisplayLink* RemoteLayerTreeDrawingAreaProxyMac::exisingDisplayLink()
     return m_webPageProxy.process().processPool().displayLinks().existingDisplayLinkForDisplay(*m_displayID);
 }
 
-DisplayLink& RemoteLayerTreeDrawingAreaProxyMac::ensureDisplayLink()
+DisplayLink& RemoteLayerTreeDrawingAreaProxyMac::displayLink()
 {
     ASSERT(m_displayID);
 
@@ -251,7 +251,7 @@ void RemoteLayerTreeDrawingAreaProxyMac::scheduleDisplayRefreshCallbacks()
         return;
     }
 
-    auto& displayLink = ensureDisplayLink();
+    auto& displayLink = this->displayLink();
     m_displayRefreshObserverID = DisplayLinkObserverID::generate();
     displayLink.addObserver(*m_displayLinkClient, *m_displayRefreshObserverID, m_clientPreferredFramesPerSecond);
 }
@@ -281,7 +281,7 @@ void RemoteLayerTreeDrawingAreaProxyMac::setDisplayLinkWantsFullSpeedUpdates(boo
     if (!m_displayID)
         return;
 
-    auto& displayLink = ensureDisplayLink();
+    auto& displayLink = this->displayLink();
 
     // Use a second observer for full-speed updates (used to drive scroll animations).
     if (wantsFullSpeedUpdates) {
@@ -307,6 +307,8 @@ void RemoteLayerTreeDrawingAreaProxyMac::windowScreenDidChange(PlatformDisplayID
 
     m_displayID = displayID;
     m_displayNominalFramesPerSecond = nominalFramesPerSecond;
+
+    m_webPageProxy.scrollingCoordinatorProxy()->windowScreenDidChange(displayID, nominalFramesPerSecond);
 
     scheduleDisplayRefreshCallbacks();
     if (hadFullSpeedOberver) {

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "RemoteLayerTreeEventDispatcher.h"
+
+#if PLATFORM(MAC) && ENABLE(SCROLLING_THREAD)
+
+#include "DisplayLink.h"
+#include "Logging.h"
+#include "NativeWebWheelEvent.h"
+#include "RemoteLayerTreeDrawingAreaProxyMac.h"
+#include "RemoteScrollingCoordinatorProxyMac.h"
+#include "RemoteScrollingTree.h"
+#include "WebEventConversion.h"
+#include "WebPageProxy.h"
+#include <WebCore/PlatformWheelEvent.h>
+#include <WebCore/ScrollingCoordinatorTypes.h>
+#include <WebCore/ScrollingThread.h>
+#include <WebCore/WheelEventDeltaFilter.h>
+
+namespace WebKit {
+using namespace WebCore;
+
+Ref<RemoteLayerTreeEventDispatcher> RemoteLayerTreeEventDispatcher::create(RemoteScrollingCoordinatorProxyMac& scrollingCoordinator, WebCore::PageIdentifier pageIdentifier)
+{
+    return adoptRef(*new RemoteLayerTreeEventDispatcher(scrollingCoordinator, pageIdentifier));
+}
+
+static const Seconds wheelEventHysteresisDuration { 1_s };
+
+RemoteLayerTreeEventDispatcher::RemoteLayerTreeEventDispatcher(RemoteScrollingCoordinatorProxyMac& scrollingCoordinator, WebCore::PageIdentifier pageIdentifier)
+    : m_scrollingCoordinator(WeakPtr { scrollingCoordinator })
+    , m_pageIdentifier(pageIdentifier)
+    , m_wheelEventDeltaFilter(WheelEventDeltaFilter::create())
+{
+}
+
+RemoteLayerTreeEventDispatcher::~RemoteLayerTreeEventDispatcher() = default;
+
+void RemoteLayerTreeEventDispatcher::invalidate()
+{
+    // Will be used to break ref cycles.
+}
+
+void RemoteLayerTreeEventDispatcher::setScrollingTree(RefPtr<RemoteScrollingTree>&& scrollingTree)
+{
+    ASSERT(isMainRunLoop());
+
+    Locker locker { m_scrollingTreeLock };
+    m_scrollingTree = WTFMove(scrollingTree);
+}
+
+RefPtr<RemoteScrollingTree> RemoteLayerTreeEventDispatcher::scrollingTree()
+{
+    RefPtr<RemoteScrollingTree> result;
+    {
+        Locker locker { m_scrollingTreeLock };
+        result = m_scrollingTree;
+    }
+    
+    return result;
+}
+
+void RemoteLayerTreeEventDispatcher::willHandleWheelEvent(const NativeWebWheelEvent&)
+{
+    ASSERT(isMainRunLoop());
+}
+
+// FIXME: This should return void and send its response back to the main thread.
+WheelEventHandlingResult RemoteLayerTreeEventDispatcher::handleWheelEvent(const WebWheelEvent& wheelEvent, RectEdges<bool> rubberBandableEdges)
+{
+    ASSERT(ScrollingThread::isCurrentThread());
+
+    return internalHandleWheelEvent(platform(wheelEvent), rubberBandableEdges);
+}
+
+WheelEventHandlingResult RemoteLayerTreeEventDispatcher::internalHandleWheelEvent(const PlatformWheelEvent& wheelEvent, RectEdges<bool> rubberBandableEdges)
+{
+    ASSERT(ScrollingThread::isCurrentThread());
+
+    auto scrollingTree = this->scrollingTree();
+    if (!scrollingTree)
+        return WheelEventHandlingResult::unhandled();
+
+    // Replicate the hack in EventDispatcher::internalWheelEvent(). We could pass rubberBandableEdges all the way through the
+    // WebProcess and back via the ScrollingTree, but we only ever need to consult it here.
+    if (wheelEvent.phase() == PlatformWheelEventPhase::Began)
+        scrollingTree->setMainFrameCanRubberBand(rubberBandableEdges);
+
+    auto processingSteps = scrollingTree->determineWheelEventProcessing(wheelEvent);
+    LOG_WITH_STREAM(Scrolling, stream << "RemoteLayerTreeEventDispatcher::handleWheelEvent " << wheelEvent << " - steps " << processingSteps);
+    if (!processingSteps.contains(WheelEventProcessingSteps::ScrollingThread))
+        return WheelEventHandlingResult::unhandled(processingSteps);
+
+    scrollingTree->willProcessWheelEvent();
+
+    auto filteredEvent = filteredWheelEvent(wheelEvent);
+    auto result = scrollingTree->handleWheelEvent(filteredEvent, processingSteps);
+
+    scrollingTree->applyLayerPositions();
+
+    return result;
+}
+
+PlatformWheelEvent RemoteLayerTreeEventDispatcher::filteredWheelEvent(const PlatformWheelEvent& wheelEvent)
+{
+    m_wheelEventDeltaFilter->updateFromEvent(wheelEvent);
+
+    auto filteredEvent = wheelEvent;
+    if (WheelEventDeltaFilter::shouldApplyFilteringForEvent(wheelEvent))
+        filteredEvent = m_wheelEventDeltaFilter->eventCopyWithFilteredDeltas(wheelEvent);
+    else if (WheelEventDeltaFilter::shouldIncludeVelocityForEvent(wheelEvent))
+        filteredEvent = m_wheelEventDeltaFilter->eventCopyWithVelocity(wheelEvent);
+
+    return filteredEvent;
+}
+
+void RemoteLayerTreeEventDispatcher::didRefreshDisplay(PlatformDisplayID displayID)
+{
+    ASSERT(ScrollingThread::isCurrentThread());
+
+    auto scrollingTree = this->scrollingTree();
+    if (!scrollingTree)
+        return;
+
+    scrollingTree->displayDidRefresh(displayID);
+}
+
+void RemoteLayerTreeEventDispatcher::windowScreenDidChange(WebCore::PlatformDisplayID displayID, std::optional<WebCore::FramesPerSecond> nominalFramesPerSecond)
+{
+}
+
+} // namespace WebKit
+
+#endif // PLATFORM(MAC) && ENABLE(SCROLLING_THREAD)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(MAC) && ENABLE(SCROLLING_THREAD)
+
+#include <wtf/FastMalloc.h>
+#include <wtf/HashMap.h>
+#include <wtf/Lock.h>
+#include <wtf/ThreadSafeRefCounted.h>
+
+namespace WebCore {
+class PlatformWheelEvent;
+class WheelEventDeltaFilter;
+struct WheelEventHandlingResult;
+};
+
+namespace WebKit {
+
+class NativeWebWheelEvent;
+class RemoteScrollingCoordinatorProxyMac;
+class RemoteScrollingTree;
+class RemoteLayerTreeEventDispatcherDisplayLinkClient;
+
+// This class exists to act as a threadsafe DisplayLink::Client client, allowing RemoteScrollingCoordinatorProxyMac to
+// be main-thread only. It's the UI-process analogue of WebPage/EventDispatcher.
+class RemoteLayerTreeEventDispatcher : public ThreadSafeRefCounted<RemoteLayerTreeEventDispatcher> {
+    WTF_MAKE_FAST_ALLOCATED();
+    friend class RemoteLayerTreeEventDispatcherDisplayLinkClient;
+public:
+    static Ref<RemoteLayerTreeEventDispatcher> create(RemoteScrollingCoordinatorProxyMac&, WebCore::PageIdentifier);
+
+    explicit RemoteLayerTreeEventDispatcher(RemoteScrollingCoordinatorProxyMac&, WebCore::PageIdentifier);
+    ~RemoteLayerTreeEventDispatcher();
+    
+    void invalidate();
+
+    void willHandleWheelEvent(const NativeWebWheelEvent&);
+    WebCore::WheelEventHandlingResult handleWheelEvent(const WebWheelEvent&, RectEdges<bool> rubberBandableEdges);
+
+    void setScrollingTree(RefPtr<RemoteScrollingTree>&&);
+
+    void didRefreshDisplay(WebCore::PlatformDisplayID);
+    void windowScreenDidChange(WebCore::PlatformDisplayID, std::optional<WebCore::FramesPerSecond>);
+
+private:
+    WebCore::WheelEventHandlingResult internalHandleWheelEvent(const PlatformWheelEvent&, RectEdges<bool> rubberBandableEdges);
+    WebCore::WheelEventHandlingResult scrollingTreeHandleWheelEvent(RemoteScrollingTree&, const PlatformWheelEvent&);
+    PlatformWheelEvent filteredWheelEvent(const PlatformWheelEvent&);
+
+    RefPtr<RemoteScrollingTree> scrollingTree();
+
+    Lock m_scrollingTreeLock;
+    RefPtr<RemoteScrollingTree> m_scrollingTree WTF_GUARDED_BY_LOCK(m_scrollingTreeLock);
+
+    WeakPtr<RemoteScrollingCoordinatorProxyMac> m_scrollingCoordinator;
+    WebCore::PageIdentifier m_pageIdentifier;
+
+    std::unique_ptr<WebCore::WheelEventDeltaFilter> m_wheelEventDeltaFilter;
+};
+
+} // namespace WebKit
+
+#endif // PLATFORM(MAC) && ENABLE(SCROLLING_THREAD)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
@@ -32,9 +32,14 @@
 
 namespace WebKit {
 
+#if ENABLE(SCROLLING_THREAD)
+class RemoteLayerTreeEventDispatcher;
+#endif
+
 class RemoteScrollingCoordinatorProxyMac final : public RemoteScrollingCoordinatorProxy {
 public:
     explicit RemoteScrollingCoordinatorProxyMac(WebPageProxy&);
+    ~RemoteScrollingCoordinatorProxyMac();
 
 private:
     WebCore::PlatformWheelEvent filteredWheelEvent(const WebCore::PlatformWheelEvent&) override;
@@ -47,7 +52,13 @@ private:
     void connectStateNodeLayers(WebCore::ScrollingStateTree&, const RemoteLayerTreeHost&) override;
     void establishLayerTreeScrollingRelations(const RemoteLayerTreeHost&) override;
 
+    void windowScreenDidChange(WebCore::PlatformDisplayID, std::optional<WebCore::FramesPerSecond>) override;
+
     std::unique_ptr<WebCore::WheelEventDeltaFilter> m_recentWheelEventDeltaFilter;
+
+#if ENABLE(SCROLLING_THREAD)
+    RefPtr<RemoteLayerTreeEventDispatcher> m_wheelEventDispatcher;
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2818,6 +2818,8 @@
 		0F174AA2142A4CB60039250F /* APIGeometry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APIGeometry.h; sourceTree = "<group>"; };
 		0F174AA6142AAC610039250F /* WKGeometry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WKGeometry.cpp; sourceTree = "<group>"; };
 		0F189CAB24749F2F00E58D81 /* DisplayLinkObserverID.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DisplayLinkObserverID.h; sourceTree = "<group>"; };
+		0F25C49F29A5DF8E00D2CF5A /* RemoteLayerTreeEventDispatcher.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteLayerTreeEventDispatcher.cpp; sourceTree = "<group>"; };
+		0F25C4A029A5DF8E00D2CF5A /* RemoteLayerTreeEventDispatcher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteLayerTreeEventDispatcher.h; sourceTree = "<group>"; };
 		0F2E0DF628F0CD35006B9079 /* RemoteScrollingCoordinatorProxyMac.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = RemoteScrollingCoordinatorProxyMac.mm; sourceTree = "<group>"; };
 		0F2E0DF728F0CD35006B9079 /* RemoteScrollingCoordinatorProxyMac.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteScrollingCoordinatorProxyMac.h; sourceTree = "<group>"; };
 		0F2E0DF828F0D04D006B9079 /* RemoteLayerTreeDrawingAreaProxyMac.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = RemoteLayerTreeDrawingAreaProxyMac.mm; sourceTree = "<group>"; };
@@ -13649,6 +13651,8 @@
 			children = (
 				0F2E0DF928F0D04E006B9079 /* RemoteLayerTreeDrawingAreaProxyMac.h */,
 				0F2E0DF828F0D04D006B9079 /* RemoteLayerTreeDrawingAreaProxyMac.mm */,
+				0F25C49F29A5DF8E00D2CF5A /* RemoteLayerTreeEventDispatcher.cpp */,
+				0F25C4A029A5DF8E00D2CF5A /* RemoteLayerTreeEventDispatcher.h */,
 				0F2E0DF728F0CD35006B9079 /* RemoteScrollingCoordinatorProxyMac.h */,
 				0F2E0DF628F0CD35006B9079 /* RemoteScrollingCoordinatorProxyMac.mm */,
 				0FF7CE8A2901FDAC00EA62D6 /* RemoteScrollingTreeMac.h */,


### PR DESCRIPTION
#### 41dd555e7e49b0765636e06be569d29ce1355d4d
<pre>
Introduce RemoteLayerTreeEventDispatcher for threaded UI-side scrolling
<a href="https://bugs.webkit.org/show_bug.cgi?id=252724">https://bugs.webkit.org/show_bug.cgi?id=252724</a>
rdar://105763050

Reviewed by Tim Horton.

Introduce RemoteLayerTreeEventDispatcher for threaded scrolling in the UI Process. This
class needs to be thread safe both for interactions with the scrolling thread, and for
`displayDidRefresh` notifications coming from a display link. RemoteScrollingCoordinatorProxy
isn&apos;t refcounted, so it&apos;s cleaner to have a new thread safe refcounted class for these
between-thread interactions. RemoteScrollingCoordinatorProxy code will only run on the
main-thread.

RemoteLayerTreeEventDispatcher is roughly analogous to WebPage/EventDispatcher.

The responsibilities of RemoteLayerTreeEventDispatcher will be as follow:
1. Dispatch wheel events and `displayDidRefresh` to the scrolling tree.
2. Dispatch messages from the scrolling tree back to RemoteScrollingCoordinatorProxy on the main thread.
3. Use a DisplayLink::Client to bounce `displayDidRefresh` from the CVDisplayLink thread
   to the scrolling thread.
4. Own the WheelEventDeltaFilter
5. Own a MomentumEventGenerator
6. Start and stop high-frequency display link callbacks for scroll animations and momentum

This functionality will be fleshed out in future PRs.

* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
(WebKit::RemoteLayerTreeDrawingAreaProxy::isRemoteLayerTreeDrawingAreaProxyMac const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
(WebKit::RemoteScrollingCoordinatorProxy::windowScreenDidChange):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::displayLink):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::scheduleDisplayRefreshCallbacks):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::setDisplayLinkWantsFullSpeedUpdates):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::windowScreenDidChange):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::ensureDisplayLink): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp: Added.
(WebKit::RemoteLayerTreeEventDispatcher::create):
(WebKit::RemoteLayerTreeEventDispatcher::RemoteLayerTreeEventDispatcher):
(WebKit::m_wheelEventDeltaFilter):
(WebKit::RemoteLayerTreeEventDispatcher::invalidate):
(WebKit::RemoteLayerTreeEventDispatcher::setScrollingTree):
(WebKit::RemoteLayerTreeEventDispatcher::scrollingTree):
(WebKit::RemoteLayerTreeEventDispatcher::willHandleWheelEvent):
(WebKit::RemoteLayerTreeEventDispatcher::handleWheelEvent):
(WebKit::RemoteLayerTreeEventDispatcher::internalHandleWheelEvent):
(WebKit::RemoteLayerTreeEventDispatcher::filteredWheelEvent):
(WebKit::RemoteLayerTreeEventDispatcher::didRefreshDisplay):
(WebKit::RemoteLayerTreeEventDispatcher::windowScreenDidChange):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h: Added.
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm:
(WebKit::RemoteScrollingCoordinatorProxyMac::RemoteScrollingCoordinatorProxyMac):
(WebKit::RemoteScrollingCoordinatorProxyMac::~RemoteScrollingCoordinatorProxyMac):
(WebKit::RemoteScrollingCoordinatorProxyMac::displayDidRefresh):
(WebKit::RemoteScrollingCoordinatorProxyMac::establishLayerTreeScrollingRelations):
(WebKit::RemoteScrollingCoordinatorProxyMac::windowScreenDidChange):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/260687@main">https://commits.webkit.org/260687@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/789e655dcf51904278f0084de2ce936f86996cd8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108994 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18073 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41815 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/529 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118276 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19528 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9372 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101230 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114752 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14642 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97881 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42771 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96614 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29522 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84519 "Found 2 new API test failures: /TestWebKit:WebKit.OnDeviceChangeCrash, /TestWebKit:WebKit.PrivateBrowsingPushStateNoHistoryCallback (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10858 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30870 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11602 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7804 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16983 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50468 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7380 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13201 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->