### PR TITLE
yasm: fix deprecation warnings for sprint()

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/third_party/yasm/frontends/yasm/yasm-options.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/yasm/frontends/yasm/yasm-options.c
@@ -174,30 +174,30 @@ help_msg(const char *msg, const char *tail, opt_option *options, size_t nopts)
 
         if (options[i].takes_param) {
             if (options[i].sopt) {
-                sprintf(optbuf, "-%c <%s>", options[i].sopt,
+                snprintf(optbuf, 100, "-%c <%s>", options[i].sopt,
                         options[i].param_desc ? options[i].
                         param_desc : _("param"));
                 shortopt_len = strlen(optbuf);
             }
             if (options[i].sopt && options[i].lopt)
-                strcat(optbuf, ", ");
+                strlcat(optbuf, ", ", 100);
             if (options[i].lopt) {
-                sprintf(optopt, "--%s=<%s>", options[i].lopt,
+                snprintf(optopt, 100, "--%s=<%s>", options[i].lopt,
                         options[i].param_desc ? options[i].
                         param_desc : _("param"));
-                strcat(optbuf, optopt);
+                strlcat(optbuf, optopt, 100);
                 longopt_len = strlen(optbuf);
             }
         } else {
             if (options[i].sopt) {
-                sprintf(optbuf, "-%c", options[i].sopt);
+                snprintf(optbuf, 100, "-%c", options[i].sopt);
                 shortopt_len = strlen(optbuf);
             }
             if (options[i].sopt && options[i].lopt)
-                strcat(optbuf, ", ");
+                strlcat(optbuf, ", ", 100);
             if (options[i].lopt) {
-                sprintf(optopt, "--%s", options[i].lopt);
-                strcat(optbuf, optopt);
+                snprintf(optopt, 100, "--%s", options[i].lopt);
+                strlcat(optbuf, optopt, 100);
                 longopt_len = strlen(optbuf);
             }
         }

--- a/Source/ThirdParty/libwebrtc/Source/third_party/yasm/modules/arch/x86/x86arch.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/yasm/modules/arch/x86/x86arch.c
@@ -166,7 +166,7 @@ x86_dir_cpu(yasm_object *object, yasm_valparamhead *valparams,
                                N_("invalid argument to [%s]"), "CPU");
             else {
                 char strcpu[16];
-                sprintf(strcpu, "%lu", yasm_intnum_get_uint(intcpu));
+                snprintf(strcpu, 16, "%lu", yasm_intnum_get_uint(intcpu));
                 yasm_x86__parse_cpu(arch_x86, strcpu, strlen(strcpu));
             }
         } else


### PR DESCRIPTION
#### d8e149964798f5b84ea9fd2887f0c69f56efe8bd
<pre>
yasm: fix deprecation warnings for sprint()
<a href="https://bugs.webkit.org/show_bug.cgi?id=252725">https://bugs.webkit.org/show_bug.cgi?id=252725</a>
&lt;rdar://105763698&gt;

Unreviewed build fix for deprecation warnings as errors.

Replace sprintf() with snprintf().  Replace strcat() with
strlcat() while we&apos;re here.

* Source/ThirdParty/libwebrtc/Source/third_party/yasm/frontends/yasm/yasm-options.c:
(help_msg):
- Switch to snprintf() and strlcat().
* Source/ThirdParty/libwebrtc/Source/third_party/yasm/modules/arch/x86/x86arch.c:
(x86_dir_cpu):
- Switch to snprintf().

Canonical link: <a href="https://commits.webkit.org/260657@main">https://commits.webkit.org/260657@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d33f0904be6b1541d02332b98c827c1732e8235

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108998 "Failed to checkout and rebase branch from PR 10496") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/18077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41819 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/533 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/118277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19532 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9376 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/101234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114756 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/97883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/101234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/29524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/101234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/10862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/30872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/11606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/7805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/16985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/50470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/13205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4021 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->