### PR TITLE
[Win] Reimplement LocalizedStrings.cpp without CF

### DIFF
--- a/Source/WebCore/platform/LocalizedStrings.cpp
+++ b/Source/WebCore/platform/LocalizedStrings.cpp
@@ -33,10 +33,7 @@
 #include <wtf/text/TextBreakIterator.h>
 #include <wtf/unicode/CharacterNames.h>
 
-#if USE(CF)
-#if PLATFORM(WIN)
-#include "WebCoreBundleWin.h"
-#endif
+#if PLATFORM(COCOA)
 #include <wtf/RetainPtr.h>
 #endif
 
@@ -46,7 +43,7 @@
 
 namespace WebCore {
 
-#if USE(CF) && !PLATFORM(WIN)
+#if PLATFORM(COCOA)
 String formatLocalizedString(CFStringRef format, ...)
 {
     va_list arguments;
@@ -61,20 +58,23 @@ ALLOW_NONLITERAL_FORMAT_END
     va_end(arguments);
     return result.get();
 }
+#elif PLATFORM(WIN)
+String formatLocalizedString(const wchar_t* format, ...)
+{
+    va_list arguments;
+    va_start(arguments, format);
+    int len = _vscwprintf(format, arguments);
+    Vector<wchar_t> buffer(len + 1);
+    _vsnwprintf(buffer.data(), len + 1, format, arguments);
+    va_end(arguments);
+    return { buffer.data() };
+}
 #else
 // Because |format| is used as the second parameter to va_start, it cannot be a reference
 // type according to section 18.7/3 of the C++ N1905 standard.
 String formatLocalizedString(const char* format, ...)
 {
-#if USE(CF) && PLATFORM(WIN)
-    auto cfFormat = adoptCF(CFStringCreateWithCStringNoCopy(nullptr, format, kCFStringEncodingUTF8, kCFAllocatorNull));
-    va_list arguments;
-    va_start(arguments, format);
-    auto localizedFormat = copyLocalizedString(cfFormat.get());
-    auto result = adoptCF(CFStringCreateWithFormatAndArguments(0, 0, localizedFormat.get(), arguments));
-    va_end(arguments);
-    return result.get();
-#elif USE(GLIB)
+#if USE(GLIB)
     va_list arguments;
     va_start(arguments, format);
     GUniquePtr<gchar> result(g_strdup_vprintf(format, arguments));
@@ -87,15 +87,13 @@ String formatLocalizedString(const char* format, ...)
 }
 #endif
 
-#if USE(CF)
-#if !PLATFORM(WIN)
+#if PLATFORM(COCOA)
 static CFBundleRef webCoreBundle()
 {
     static NeverDestroyed<RetainPtr<CFBundleRef>> bundle = CFBundleGetBundleWithIdentifier(CFSTR("com.apple.WebCore"));
     ASSERT(bundle.get());
     return bundle.get().get();
 }
-#endif
 
 RetainPtr<CFStringRef> copyLocalizedString(CFStringRef key)
 {
@@ -107,12 +105,7 @@ RetainPtr<CFStringRef> copyLocalizedString(CFStringRef key)
 
     static CFStringRef notFound = CFSTR("localized string not found");
 
-#if PLATFORM(WIN)
-    CFBundleRef bundle = webKitBundle();
-#else
-    CFBundleRef bundle = webCoreBundle();
-#endif
-    auto result = adoptCF(CFBundleCopyLocalizedString(bundle, key, notFound, nullptr));
+    auto result = adoptCF(CFBundleCopyLocalizedString(webCoreBundle(), key, notFound, nullptr));
 
 #if ASSERT_ENABLED
     if (result.get() == notFound) {
@@ -126,24 +119,24 @@ RetainPtr<CFStringRef> copyLocalizedString(CFStringRef key)
 }
 #endif
 
-#if USE(CF) && !PLATFORM(WIN)
+#if PLATFORM(COCOA)
 String localizedString(CFStringRef key)
 {
     return copyLocalizedString(key).get();
 }
+#elif PLATFORM(WIN)
+String localizedString(const wchar_t* key)
+{
+    return key;
+}
 #else
 String localizedString(const char* key)
 {
-#if USE(CF)
-    auto keyString = adoptCF(CFStringCreateWithCStringNoCopy(nullptr, key, kCFStringEncodingUTF8, kCFAllocatorNull));
-    return copyLocalizedString(keyString.get()).get();
-#else
     return String::fromUTF8(key, strlen(key));
-#endif
 }
 #endif
 
-#if ENABLE(CONTEXT_MENUS)
+#if ENABLE(CONTEXT_MENUS) && PLATFORM(COCOA)
 
 static String truncatedStringForMenuItem(const String& original)
 {
@@ -301,17 +294,13 @@ String contextMenuItemTagSearchWeb()
 }
 #endif
 
+#if PLATFORM(COCOA)
 String contextMenuItemTagLookUpInDictionary(const String& selectedString)
 {
-#if USE(CF)
     auto selectedCFString = truncatedStringForMenuItem(selectedString).createCFString();
     return WEB_UI_FORMAT_CFSTRING("Look Up “%@”", "Look Up context menu item with selected word", selectedCFString.get());
-#elif USE(GLIB)
-    return WEB_UI_FORMAT_STRING("Look Up “%s”", "Look Up context menu item with selected word", truncatedStringForMenuItem(selectedString).utf8().data());
-#else
-    return makeStringByReplacingAll(WEB_UI_STRING("Look Up “<selection>”", "Look Up context menu item with selected word"), "<selection>"_s, truncatedStringForMenuItem(selectedString));
-#endif
 }
+#endif
 
 String contextMenuItemTagOpenLink()
 {
@@ -988,7 +977,7 @@ String unknownFileSizeText()
 
 String imageTitle(const String& filename, const IntSize& size)
 {
-#if USE(CF)
+#if PLATFORM(COCOA)
     auto locale = adoptCF(CFLocaleCopyCurrent());
     auto formatter = adoptCF(CFNumberFormatterCreate(0, locale.get(), kCFNumberFormatterDecimalStyle));
 
@@ -1001,6 +990,8 @@ String imageTitle(const String& filename, const IntSize& size)
     auto heightString = adoptCF(CFNumberFormatterCreateStringWithNumber(0, formatter.get(), height.get()));
 
     return WEB_UI_FORMAT_CFSTRING("%@ %@×%@ pixels", "window title for a standalone image (uses multiplication symbol, not x)", filename.createCFString().get(), widthString.get(), heightString.get());
+#elif PLATFORM(WIN)
+    return WEB_UI_FORMAT_STRING("%s %d×%d pixels", "window title for a standalone image (uses multiplication symbol, not x)", filename.wideCharacters().data(), size.width(), size.height());
 #elif USE(GLIB)
     return WEB_UI_FORMAT_STRING("%s %d×%d pixels", "window title for a standalone image (uses multiplication symbol, not x)", filename.utf8().data(), size.width(), size.height());
 #else
@@ -1205,7 +1196,7 @@ String validationMessageTooLongText(int, int maxLength)
 
 String validationMessageRangeUnderflowText(const String& minimum)
 {
-#if USE(CF)
+#if PLATFORM(COCOA)
     return WEB_UI_FORMAT_CFSTRING("Value must be greater than or equal to %@", "Validation message for input form controls with value lower than allowed minimum", minimum.createCFString().get());
 #elif USE(GLIB)
     return WEB_UI_FORMAT_STRING("Value must be greater than or equal to %s", "Validation message for input form controls with value lower than allowed minimum", minimum.utf8().data());
@@ -1217,7 +1208,7 @@ String validationMessageRangeUnderflowText(const String& minimum)
 
 String validationMessageRangeOverflowText(const String& maximum)
 {
-#if USE(CF)
+#if PLATFORM(COCOA)
     return WEB_UI_FORMAT_CFSTRING("Value must be less than or equal to %@", "Validation message for input form controls with value higher than allowed maximum", maximum.createCFString().get());
 #elif USE(GLIB)
     return WEB_UI_FORMAT_STRING("Value must be less than or equal to %s", "Validation message for input form controls with value higher than allowed maximum", maximum.utf8().data());
@@ -1259,7 +1250,7 @@ String textTrackAutomaticMenuItemText()
     return WEB_UI_STRING_KEY("Auto (Recommended)", "Auto (Recommended) (text track)", "Menu item label for automatic track selection behavior.");
 }
 
-#if USE(CF)
+#if PLATFORM(COCOA)
 
 String addTrackLabelAsSuffix(const String& text, const String& label)
 {
@@ -1386,7 +1377,7 @@ String addAudioTrackKindCommentarySuffix(const String& text)
     return WEB_UI_FORMAT_CFSTRING_KEY("%@ Commentary", "%@ Commentary (audio track)", "Commentary audio track display name format that includes the language and/or locale (e.g. 'English Commentary').", text.createCFString().get());
 }
 
-#endif // USE(CF)
+#endif // PLATFORM(COCOA)
 
 String contextMenuItemTagShowMediaStats()
 {
@@ -1410,11 +1401,11 @@ String useBlockedPlugInContextMenuTitle()
     return WEB_UI_STRING("Show in blocked plug-in", "Title of the context menu item to show when PDFPlugin was used instead of a blocked plugin");
 }
 
-#if ENABLE(WEB_CRYPTO)
+#if ENABLE(WEB_CRYPTO) && PLATFORM(COCOA)
 
 String webCryptoMasterKeyKeychainLabel(const String& localizedApplicationName)
 {
-#if USE(CF)
+#if PLATFORM(COCOA)
     return WEB_UI_FORMAT_CFSTRING("%@ WebCrypto Master Key", "Name of application's single WebCrypto master key in Keychain", localizedApplicationName.createCFString().get());
 #elif USE(GLIB)
     return WEB_UI_FORMAT_STRING("%s WebCrypto Master Key", "Name of application's single WebCrypto master key in Keychain", localizedApplicationName.utf8().data());

--- a/Source/WebCore/platform/LocalizedStrings.h
+++ b/Source/WebCore/platform/LocalizedStrings.h
@@ -99,7 +99,9 @@ namespace WebCore {
     String contextMenuItemTagIgnoreSpelling();
     String contextMenuItemTagLearnSpelling();
     String contextMenuItemTagSearchWeb();
+#if PLATFORM(COCOA)
     String contextMenuItemTagLookUpInDictionary(const String& selectedString);
+#endif
     WEBCORE_EXPORT String contextMenuItemTagOpenLink();
     WEBCORE_EXPORT String contextMenuItemTagIgnoreGrammar();
     WEBCORE_EXPORT String contextMenuItemTagSpellingMenu();
@@ -332,7 +334,7 @@ namespace WebCore {
     String trackNoLabelText();
     String textTrackOffMenuItemText();
     String textTrackAutomaticMenuItemText();
-#if USE(CF)
+#if PLATFORM(COCOA)
     String addTrackLabelAsSuffix(const String&, const String&);
     String textTrackKindClosedCaptionsDisplayName();
     String addTextTrackKindClosedCaptionsSuffix(const String&);
@@ -354,7 +356,7 @@ namespace WebCore {
     String addAudioTrackKindDescriptionsSuffix(const String&);
     String audioTrackKindCommentaryDisplayName();
     String addAudioTrackKindCommentarySuffix(const String&);
-#endif // USE(CF)
+#endif // PLATFORM(COCOA)
     String contextMenuItemTagShowMediaStats();
 #endif // ENABLE(VIDEO)
 
@@ -363,7 +365,7 @@ namespace WebCore {
 
     WEBCORE_EXPORT String useBlockedPlugInContextMenuTitle();
 
-#if ENABLE(WEB_CRYPTO)
+#if ENABLE(WEB_CRYPTO) && PLATFORM(COCOA)
     String webCryptoMasterKeyKeychainLabel(const String& localizedApplicationName);
     String webCryptoMasterKeyKeychainComment();
 #endif
@@ -404,60 +406,56 @@ namespace WebCore {
     WEBCORE_EXPORT String contextMenuItemTitleRemoveBackground();
 #endif
 
-#if USE(CF) && !PLATFORM(WIN)
+#if PLATFORM(COCOA)
 #define WEB_UI_STRING(string, description) WebCore::localizedString(CFSTR(string))
 #define WEB_UI_STRING_KEY(string, key, description) WebCore::localizedString(CFSTR(key))
 #define WEB_UI_STRING_WITH_MNEMONIC(string, mnemonic, description) WebCore::localizedString(CFSTR(string))
+#elif PLATFORM(WIN)
+#define WEB_UI_STRING(string, description) WebCore::localizedString(L##string)
+#define WEB_UI_STRING_KEY(string, key, description) WebCore::localizedString(L##string)
+#define WEB_UI_STRING_WITH_MNEMONIC(string, mnemonic, description) WebCore::localizedString(L##string)
 #elif USE(GLIB) && defined(GETTEXT_PACKAGE)
 #define WEB_UI_STRING(string, description) WebCore::localizedString(_(string))
 #define WEB_UI_STRING_KEY(string, key, description) WebCore::localizedString(C_(key, string))
 #define WEB_UI_STRING_WITH_MNEMONIC(string, mnemonic, description) WebCore::localizedString(_(mnemonic))
 #else
-// Work around default Mac Roman encoding of CFSTR() for Apple Windows port.
 #define WEB_UI_STRING(string, description) WebCore::localizedString(string)
 #define WEB_UI_STRING_KEY(string, key, description) WebCore::localizedString(key)
 #define WEB_UI_STRING_WITH_MNEMONIC(string, mnemonic, description) WebCore::localizedString(string)
 #endif
 
-#if USE(CF)
+#if PLATFORM(COCOA)
 // This is exactly as WEB_UI_STRING, but renamed to ensure the string is not scanned by non-CF ports.
-#if PLATFORM(WIN)
-// Work around default Mac Roman encoding of CFSTR() for Apple Windows port.
-#define WEB_UI_CFSTRING(string, description) WebCore::localizedString(string)
-#define WEB_UI_CFSTRING_KEY(string, key, description) WebCore::localizedString(key)
-#else
 #define WEB_UI_CFSTRING(string, description) WebCore::localizedString(CFSTR(string))
 #define WEB_UI_CFSTRING_KEY(string, key, description) WebCore::localizedString(CFSTR(key))
-#endif
 
     WEBCORE_EXPORT RetainPtr<CFStringRef> copyLocalizedString(CFStringRef key);
 #endif
 
-#if USE(CF) && !PLATFORM(WIN)
+#if PLATFORM(COCOA)
     WEBCORE_EXPORT String localizedString(CFStringRef key);
+#elif PLATFORM(WIN)
+    WEBCORE_EXPORT String localizedString(const wchar_t* key);
 #else
     WEBCORE_EXPORT String localizedString(const char* key);
 #endif
 
-#if USE(CF)
-#if PLATFORM(WIN)
-// Work around default Mac Roman encoding of CFSTR() for Apple Windows port.
-#define WEB_UI_FORMAT_CFSTRING(string, description, ...) WebCore::formatLocalizedString(string, __VA_ARGS__)
-#define WEB_UI_FORMAT_CFSTRING_KEY(string, key, description, ...) WebCore::formatLocalizedString(key, __VA_ARGS__)
-#define WEB_UI_FORMAT_STRING(string, description, ...) WebCore::formatLocalizedString(string, __VA_ARGS__)
-#else
+#if PLATFORM(COCOA)
 #define WEB_UI_FORMAT_CFSTRING(string, description, ...) WebCore::formatLocalizedString(CFSTR(string), __VA_ARGS__)
 #define WEB_UI_FORMAT_CFSTRING_KEY(string, key, description, ...) WebCore::formatLocalizedString(CFSTR(key), __VA_ARGS__)
 #define WEB_UI_FORMAT_STRING(string, description, ...) WebCore::formatLocalizedString(CFSTR(string), __VA_ARGS__)
-#endif // PLATFORM(WIN)
+#elif PLATFORM(WIN)
+#define WEB_UI_FORMAT_STRING(string, description, ...) WebCore::formatLocalizedString(L##string, __VA_ARGS__)
 #elif USE(GLIB) && defined(GETTEXT_PACKAGE)
 #define WEB_UI_FORMAT_STRING(string, description, ...) WebCore::formatLocalizedString(_(string), __VA_ARGS__)
 #else
 #define WEB_UI_FORMAT_STRING(string, description, ...) WebCore::formatLocalizedString(string, __VA_ARGS__)
 #endif
 
-#if USE(CF) && !PLATFORM(WIN)
+#if PLATFORM(COCOA)
     WEBCORE_EXPORT String formatLocalizedString(CFStringRef format, ...) CF_FORMAT_FUNCTION(1, 2);
+#elif PLATFORM(WIN)
+    WEBCORE_EXPORT String formatLocalizedString(const wchar_t* format, ...) WTF_ATTRIBUTE_PRINTF(1, 2);
 #else
     WEBCORE_EXPORT String formatLocalizedString(const char* format, ...) WTF_ATTRIBUTE_PRINTF(1, 2);
 #endif


### PR DESCRIPTION
#### 62c199983aead46a9bcef25c66a41071713ceddd
<pre>
[Win] Reimplement LocalizedStrings.cpp without CF
<a href="https://bugs.webkit.org/show_bug.cgi?id=252728">https://bugs.webkit.org/show_bug.cgi?id=252728</a>

Reviewed by Alex Christensen.

Implement formatLocalizedString with _vsnwprintf. Some functions are
called only by Cocoa ports. Conditioned out them with #if
PLATFORM(COCOA).

* Source/WebCore/platform/LocalizedStrings.cpp:
(WebCore::formatLocalizedString):
(WebCore::webCoreBundle):
(WebCore::copyLocalizedString):
(WebCore::localizedString):
(WebCore::imageTitle):
(WebCore::validationMessageRangeUnderflowText):
(WebCore::validationMessageRangeOverflowText):
* Source/WebCore/platform/LocalizedStrings.h:

Canonical link: <a href="https://commits.webkit.org/260705@main">https://commits.webkit.org/260705@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da6f224c0cd51423a1827a135d2667e9598f8254

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109106 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18189 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41928 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/641 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118365 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112991 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19647 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9490 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101347 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114865 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97966 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42898 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/29620 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/84631 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10970 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30963 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11707 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/7893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17076 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50566 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7387 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13315 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->