### PR TITLE
Move "subtitle" attribute from HTMLNames to HTMLAttachmentElement.cpp

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityAttachment.cpp
+++ b/Source/WebCore/accessibility/AccessibilityAttachment.cpp
@@ -91,7 +91,7 @@ void AccessibilityAttachment::accessibilityText(Vector<AccessibilityText>& textO
         return;
     
     auto title = attachmentElement->attachmentTitle();
-    auto& subtitle = getAttribute(subtitleAttr);
+    auto& subtitle = attachmentElement->attachmentSubtitle();
     auto& action = getAttribute(actionAttr);
     
     if (action.length())

--- a/Source/WebCore/html/HTMLAttachmentElement.cpp
+++ b/Source/WebCore/html/HTMLAttachmentElement.cpp
@@ -131,6 +131,11 @@ static const AtomString& attachmentSaveButtonIdentifier()
     return identifier;
 }
 
+static QualifiedName subtitleAttr()
+{
+    return QualifiedName { nullAtom(), "subtitle"_s, nullAtom() };
+}
+
 static QualifiedName saveAttr()
 {
     return QualifiedName { nullAtom(), "save"_s, nullAtom() };
@@ -300,11 +305,11 @@ void HTMLAttachmentElement::setFile(RefPtr<File>&& file, UpdateDisplayAttributes
     if (updateAttributes == UpdateDisplayAttributes::Yes) {
         if (m_file) {
             setAttributeWithoutSynchronization(HTMLNames::titleAttr, AtomString { m_file->name() });
-            setAttributeWithoutSynchronization(HTMLNames::subtitleAttr, PAL::fileSizeDescription(m_file->size()));
+            setAttributeWithoutSynchronization(subtitleAttr(), PAL::fileSizeDescription(m_file->size()));
             setAttributeWithoutSynchronization(HTMLNames::typeAttr, AtomString { m_file->type() });
         } else {
             removeAttribute(HTMLNames::titleAttr);
-            removeAttribute(HTMLNames::subtitleAttr);
+            removeAttribute(subtitleAttr());
             removeAttribute(HTMLNames::typeAttr);
         }
     }
@@ -355,7 +360,7 @@ RefPtr<HTMLImageElement> HTMLAttachmentElement::enclosingImageElement() const
 
 void HTMLAttachmentElement::parseAttribute(const QualifiedName& name, const AtomString& value)
 {
-    if (name == actionAttr || name == progressAttr || name == subtitleAttr || name == titleAttr || name == typeAttr)
+    if (name == actionAttr || name == progressAttr || name == subtitleAttr() || name == titleAttr || name == typeAttr)
         invalidateRendering();
 
     HTMLElement::parseAttribute(name, value);
@@ -366,7 +371,7 @@ void HTMLAttachmentElement::parseAttribute(const QualifiedName& name, const Atom
     } else if (name == titleAttr) {
         if (m_titleElement)
             m_titleElement->setTextContent(String(value.string()));
-    } else if (name == subtitleAttr) {
+    } else if (name == subtitleAttr()) {
         if (m_subtitleElement)
             m_subtitleElement->setTextContent(String(value.string()));
     } else if (name == saveAttr())
@@ -389,6 +394,11 @@ String HTMLAttachmentElement::attachmentTitle() const
     if (!title.isEmpty())
         return title;
     return m_file ? m_file->name() : String();
+}
+
+const AtomString& HTMLAttachmentElement::attachmentSubtitle() const
+{
+    return attributeWithoutSynchronization(subtitleAttr());
 }
 
 const AtomString& HTMLAttachmentElement::attachmentActionForDisplay() const
@@ -418,12 +428,12 @@ String HTMLAttachmentElement::attachmentTitleForDisplay() const
     );
 }
 
-String HTMLAttachmentElement::attachmentSubtitleForDisplay() const
+const AtomString& HTMLAttachmentElement::attachmentSubtitleForDisplay() const
 {
     if (m_implementation == Implementation::ImageOnly)
-        return { };
+        return nullAtom();
 
-    return attributeWithoutSynchronization(subtitleAttr);
+    return attachmentSubtitle();
 }
 
 String HTMLAttachmentElement::attachmentType() const
@@ -454,9 +464,9 @@ void HTMLAttachmentElement::updateAttributes(std::optional<uint64_t>&& newFileSi
         removeAttribute(HTMLNames::typeAttr);
 
     if (newFileSize)
-        setAttributeWithoutSynchronization(HTMLNames::subtitleAttr, PAL::fileSizeDescription(*newFileSize));
+        setAttributeWithoutSynchronization(subtitleAttr(), PAL::fileSizeDescription(*newFileSize));
     else
-        removeAttribute(HTMLNames::subtitleAttr);
+        removeAttribute(subtitleAttr());
 
     invalidateRendering();
 }

--- a/Source/WebCore/html/HTMLAttachmentElement.h
+++ b/Source/WebCore/html/HTMLAttachmentElement.h
@@ -69,9 +69,10 @@ public:
     RefPtr<HTMLImageElement> enclosingImageElement() const;
 
     WEBCORE_EXPORT String attachmentTitle() const;
+    const AtomString& attachmentSubtitle() const;
     const AtomString& attachmentActionForDisplay() const;
     String attachmentTitleForDisplay() const;
-    String attachmentSubtitleForDisplay() const;
+    const AtomString& attachmentSubtitleForDisplay() const;
     WEBCORE_EXPORT String attachmentType() const;
     String attachmentPath() const;
     RefPtr<Image> thumbnail() const { return m_thumbnail; }

--- a/Source/WebCore/html/HTMLAttributeNames.in
+++ b/Source/WebCore/html/HTMLAttributeNames.in
@@ -408,7 +408,6 @@ standby
 start
 step
 style
-subtitle
 summary
 tabindex
 tableborder


### PR DESCRIPTION
#### 87c8ca6824e54bbd244c7368b4ea41ed60de4c26
<pre>
Move &quot;subtitle&quot; attribute from HTMLNames to HTMLAttachmentElement.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=252730">https://bugs.webkit.org/show_bug.cgi?id=252730</a>
rdar://105697448

Reviewed by Tim Nguyen.

Because the &quot;subtitle&quot; attribute is only used in the non-standard Attachment element, it shouldn&apos;t be part of the list of standard HTML attribute names.

* Source/WebCore/accessibility/AccessibilityAttachment.cpp:
(WebCore::AccessibilityAttachment::accessibilityText const):
* Source/WebCore/html/HTMLAttachmentElement.cpp:
(WebCore::subtitleAttr):
(WebCore::HTMLAttachmentElement::setFile):
(WebCore::HTMLAttachmentElement::parseAttribute):
(WebCore::HTMLAttachmentElement::attachmentSubtitle const):
(WebCore::HTMLAttachmentElement::attachmentSubtitleForDisplay const):
(WebCore::HTMLAttachmentElement::updateAttributes):
* Source/WebCore/html/HTMLAttachmentElement.h:
* Source/WebCore/html/HTMLAttributeNames.in:

Canonical link: <a href="https://commits.webkit.org/260696@main">https://commits.webkit.org/260696@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d819fa4c68900b6b87b732853f446864344e8ed

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109014 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18093 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41835 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/549 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118290 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112896 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19549 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9393 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101251 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114772 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14658 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97894 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42792 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96630 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29536 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84543 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10878 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30884 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11622 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7819 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17002 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50482 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7383 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13221 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->