### PR TITLE
[WebGPU] "bgra8unorm-storage" is missing from GPUFeatureName

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUFeatureName.h
+++ b/Source/WebCore/Modules/WebGPU/GPUFeatureName.h
@@ -38,6 +38,9 @@ enum class GPUFeatureName : uint8_t {
     TextureCompressionAstc,
     TimestampQuery,
     IndirectFirstInstance,
+    ShaderF16,
+    Rg11b10ufloatRenderable,
+    Bgra8unormStorage,
 };
 
 inline PAL::WebGPU::FeatureName convertToBacking(GPUFeatureName featureName)
@@ -57,6 +60,12 @@ inline PAL::WebGPU::FeatureName convertToBacking(GPUFeatureName featureName)
         return PAL::WebGPU::FeatureName::TimestampQuery;
     case GPUFeatureName::IndirectFirstInstance:
         return PAL::WebGPU::FeatureName::IndirectFirstInstance;
+    case GPUFeatureName::Bgra8unormStorage:
+        return PAL::WebGPU::FeatureName::Bgra8unormStorage;
+    case GPUFeatureName::ShaderF16:
+        return PAL::WebGPU::FeatureName::ShaderF16;
+    case GPUFeatureName::Rg11b10ufloatRenderable:
+        return PAL::WebGPU::FeatureName::Rg11b10ufloatRenderable;
     }
     RELEASE_ASSERT_NOT_REACHED();
 }

--- a/Source/WebCore/Modules/WebGPU/GPUFeatureName.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUFeatureName.idl
@@ -35,5 +35,8 @@ enum GPUFeatureName {
     "texture-compression-etc2",
     "texture-compression-astc",
     "timestamp-query",
-    "indirect-first-instance"
+    "indirect-first-instance",
+    "shader-f16",
+    "rg11b10ufloat-renderable",
+    "bgra8unorm-storage",
 };

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUAdapterImpl.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUAdapterImpl.cpp
@@ -87,6 +87,7 @@ static Ref<SupportedFeatures> supportedFeatures(WGPUAdapter adapter)
             result.append("bgra8unorm-storage"_s);
             break;
         case WGPUFeatureName_Force32:
+            ASSERT_NOT_REACHED();
             continue;
         }
     }

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUConvertToBackingContext.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUConvertToBackingContext.cpp
@@ -216,6 +216,12 @@ WGPUFeatureName ConvertToBackingContext::convertToBacking(FeatureName featureNam
         return WGPUFeatureName_TimestampQuery;
     case FeatureName::IndirectFirstInstance:
         return static_cast<WGPUFeatureName>(WGPUFeatureName_IndirectFirstInstance);
+    case FeatureName::Bgra8unormStorage:
+        return static_cast<WGPUFeatureName>(WGPUFeatureName_BGRA8UnormStorage);
+    case FeatureName::ShaderF16:
+        return static_cast<WGPUFeatureName>(WGPUFeatureName_ShaderF16);
+    case FeatureName::Rg11b10ufloatRenderable:
+        return static_cast<WGPUFeatureName>(WGPUFeatureName_RG11B10UfloatRenderable);
     }
 }
 

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUFeatureName.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUFeatureName.h
@@ -38,6 +38,9 @@ enum class FeatureName : uint8_t {
     TextureCompressionAstc,
     TimestampQuery,
     IndirectFirstInstance,
+    ShaderF16,
+    Rg11b10ufloatRenderable,
+    Bgra8unormStorage,
 };
 
 } // namespace PAL::WebGPU

--- a/Source/WebGPU/WebGPU/HardwareCapabilities.mm
+++ b/Source/WebGPU/WebGPU/HardwareCapabilities.mm
@@ -100,6 +100,8 @@ static Vector<WGPUFeatureName> baseFeatures(id<MTLDevice> device, const Hardware
 
     features.append(WGPUFeatureName_IndirectFirstInstance);
     features.append(WGPUFeatureName_RG11B10UfloatRenderable);
+    features.append(WGPUFeatureName_ShaderF16);
+    features.append(static_cast<WGPUFeatureName>(WGPUFeatureName_BGRA8UnormStorage));
 
     return features;
 }

--- a/Source/WebKit/Shared/WebGPU/WebGPUFeatureName.serialization.in
+++ b/Source/WebKit/Shared/WebGPU/WebGPUFeatureName.serialization.in
@@ -29,5 +29,8 @@ enum class PAL::WebGPU::FeatureName : uint8_t {
     TextureCompressionAstc,
     TimestampQuery,
     IndirectFirstInstance,
+    ShaderF16,
+    Rg11b10ufloatRenderable,
+    Bgra8unormStorage,
 };
 #endif


### PR DESCRIPTION
#### f5c8208c8ddbf14ae5c9edc948eec1de511e3383
<pre>
[WebGPU] &quot;bgra8unorm-storage&quot; is missing from GPUFeatureName
<a href="https://bugs.webkit.org/show_bug.cgi?id=252731">https://bugs.webkit.org/show_bug.cgi?id=252731</a>
&lt;radar://105767446&gt;

Reviewed by Myles C. Maxfield.

Add missing feature names and related enum values.

* Source/WebCore/Modules/WebGPU/GPUFeatureName.idl:
* Source/WebCore/Modules/WebGPU/GPUFeatureName.h:
(WebCore::convertToBacking):
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUAdapterImpl.cpp:
(PAL::WebGPU::supportedFeatures):
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUConvertToBackingContext.cpp:
(PAL::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUFeatureName.h:
* Source/WebGPU/WebGPU/HardwareCapabilities.mm:
(WebGPU::baseFeatures):
* Source/WebKit/Shared/WebGPU/WebGPUFeatureName.serialization.in:

Canonical link: <a href="https://commits.webkit.org/260785@main">https://commits.webkit.org/260785@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d74fcba51d1542386258f65773f42bab386daf2a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109417 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18541 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42186 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/921 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/118588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113304 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20011 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9744 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101693 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115173 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/43106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/29787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/84859 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11290 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/31130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/11956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/17323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/50733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7464 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13681 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->