### PR TITLE
WebContent crashes if GPUP WebGL remote context buffer cannot be allocated

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2390,6 +2390,7 @@ accessibility/ax-object-destroyed-on-reload.html [ Skip ]
 fast/mediastream/captureInGPUProcess.html [ Skip ]
 fast/mediastream/video-rotation-gpu-process-crash.html [ Skip ]
 http/wpt/mediarecorder/MediaRecorder-AV-audio-video-dataavailable-gpuprocess.html [ Skip ]
+webgl/webgl-fail-remote-context-ipc-buffer-allocation-no-crash.html [ Skip ]
 
 # Payment Request
 imported/w3c/web-platform-tests/payment-request [ Skip ]

--- a/LayoutTests/webgl/webgl-fail-remote-context-ipc-buffer-allocation-no-crash-expected.txt
+++ b/LayoutTests/webgl/webgl-fail-remote-context-ipc-buffer-allocation-no-crash-expected.txt
@@ -1,0 +1,15 @@
+This test tests that WebGL remote context creation can fail due to buffer allocation failure and it doesn't crash.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+TEST COMPLETE: 5 PASS, 0 FAIL
+
+
+PASS [object WebGLRenderingContext] is non-null.
+PASS "remoteIPCBufferSizeLog2ForTesting" in glWorks.getContextAttributes() is true
+PASS Context was not returned
+PASS glWorks.NO_ERROR is glWorks.getError()
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/webgl/webgl-fail-remote-context-ipc-buffer-allocation-no-crash.html
+++ b/LayoutTests/webgl/webgl-fail-remote-context-ipc-buffer-allocation-no-crash.html
@@ -6,6 +6,7 @@
 <link rel="stylesheet" href="resources/webgl_test_files/resources/js-test-style.css"/>
 <script src="resources/webgl_test_files/js/js-test-pre.js"></script>
 <script src="resources/webgl_test_files/js/webgl-test-utils.js"></script>
+<script src="resources/test-shader-implementation-language.js"></script>
 </head>
 <body>
 <div id="description"></div>
@@ -14,9 +15,8 @@
 <canvas id="canvasFails"></canvas>
 <script>
 "use strict";
-description("This test tests that WebGL platform context creation can fail and it doesn't crash.");
-// At the time of writing, the GPU process would crash if ANGLE was not present and
-// GraphicsContextGL creation would fail.
+description("This test tests that WebGL remote context creation can fail due to buffer allocation failure and it doesn't crash.");
+// At the time of writing, the WebContent process would crash if memory was running low.
 
 debug("");
 var glWorks;
@@ -24,8 +24,8 @@ var glFails;
 function runTest() {
     glWorks = canvasWorks.getContext("webgl");
     shouldBeNonNull(glWorks);
-    shouldBeTrue('"failPlatformContextCreationForTesting" in glWorks.getContextAttributes()'); // Expects support for "DOM Testing APIs Enabled internal setting"
-    glFails = canvasFails.getContext("webgl", { failPlatformContextCreationForTesting: true });
+    shouldBeTrue('"remoteIPCBufferSizeLog2ForTesting" in glWorks.getContextAttributes()'); // Expects support for "DOM Testing APIs Enabled internal setting"
+    glFails = canvasFails.getContext("webgl", { remoteIPCBufferSizeLog2ForTesting: 50 });
     if (!glFails) {
         testPassed("Context was not returned");
         shouldBe("glWorks.NO_ERROR", "glWorks.getError()" );

--- a/Source/WebCore/html/canvas/WebGLContextAttributes.idl
+++ b/Source/WebCore/html/canvas/WebGLContextAttributes.idl
@@ -45,6 +45,8 @@ enum WebGLPowerPreference {
     GLboolean preserveDrawingBuffer = false;
     WebGLPowerPreference powerPreference = "default";
     GLboolean failIfMajorPerformanceCaveat = false;
-    [EnabledBySetting=DOMTestingAPIsEnabled] GLboolean failPlatformContextCreationForTesting = false;
     [Conditional=WEBXR, EnabledBySetting=WebXREnabled] boolean xrCompatible = false;
+    [EnabledBySetting=DOMTestingAPIsEnabled] GLboolean failPlatformContextCreationForTesting = false;
+    [EnabledBySetting=DOMTestingAPIsEnabled] unsigned long remoteIPCBufferSizeLog2ForTesting = 0;
+
 };

--- a/Source/WebCore/platform/graphics/GraphicsContextGLAttributes.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGLAttributes.h
@@ -57,7 +57,6 @@ struct GraphicsContextGLAttributes {
     bool failIfMajorPerformanceCaveat { false };
     using PowerPreference = GraphicsContextGLPowerPreference;
     PowerPreference powerPreference { PowerPreference::Default };
-    bool failPlatformContextCreationForTesting { false };
 
     // Additional attributes.
     bool shareResources { true };
@@ -76,6 +75,8 @@ struct GraphicsContextGLAttributes {
 #if ENABLE(WEBXR)
     bool xrCompatible { false };
 #endif
+    bool failPlatformContextCreationForTesting { false };
+    unsigned remoteIPCBufferSizeLog2ForTesting { 0 }; // Not serialized.
 
     PowerPreference effectivePowerPreference() const
     {

--- a/Source/WebKit/Platform/IPC/StreamClientConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.h
@@ -91,7 +91,7 @@ public:
     Connection& connectionForTesting();
 
 private:
-    StreamClientConnection(Ref<Connection>, unsigned bufferSizeLog2);
+    StreamClientConnection(Ref<Connection>, StreamClientConnectionBuffer&&);
 
     template<typename T, typename... AdditionalData>
     bool trySendStream(Span<uint8_t>&, T& message, AdditionalData&&...);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2011,7 +2011,6 @@ struct WebCore::GraphicsContextGLAttributes {
     bool preserveDrawingBuffer;
     bool failIfMajorPerformanceCaveat;
     WebCore::GraphicsContextGLPowerPreference powerPreference;
-    bool failPlatformContextCreationForTesting;
     bool shareResources;
     bool noExtensions;
     float devicePixelRatio;
@@ -2027,6 +2026,7 @@ struct WebCore::GraphicsContextGLAttributes {
 #if ENABLE(WEBXR)
     bool xrCompatible;
 #endif
+    bool failPlatformContextCreationForTesting;
 };
 #endif // ENABLE(GPU_PROCESS) && ENABLE(WEBGL)
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
@@ -364,11 +364,12 @@ public:
     // End of list used by generate-gpup-webgl script.
 
     static bool handleMessageToRemovedDestination(IPC::Connection&, IPC::Decoder&);
+
 protected:
 #if ENABLE(VIDEO)
-    RemoteGraphicsContextGLProxy(IPC::Connection&, SerialFunctionDispatcher&, const WebCore::GraphicsContextGLAttributes&, RenderingBackendIdentifier, Ref<RemoteVideoFrameObjectHeapProxy>&&);
+    RemoteGraphicsContextGLProxy(IPC::Connection&, RefPtr<IPC::StreamClientConnection>, const WebCore::GraphicsContextGLAttributes&, Ref<RemoteVideoFrameObjectHeapProxy>&&);
 #else
-    RemoteGraphicsContextGLProxy(IPC::Connection&, SerialFunctionDispatcher&, const WebCore::GraphicsContextGLAttributes&, RenderingBackendIdentifier);
+    RemoteGraphicsContextGLProxy(IPC::Connection&, RefPtr<IPC::StreamClientConnection>, const WebCore::GraphicsContextGLAttributes&);
 #endif
 
     bool isContextLost() const { return !m_connection; }
@@ -388,6 +389,12 @@ protected:
 
     GraphicsContextGLIdentifier m_graphicsContextGLIdentifier { GraphicsContextGLIdentifier::generate() };
 private:
+#if ENABLE(VIDEO)
+    static Ref<RemoteGraphicsContextGLProxy> platformCreate(IPC::Connection&, Ref<IPC::StreamClientConnection>, const WebCore::GraphicsContextGLAttributes&, Ref<RemoteVideoFrameObjectHeapProxy>&&);
+#else 
+    static Ref<RemoteGraphicsContextGLProxy> platformCreate(IPC::Connection&, Ref<IPC::StreamClientConnection>, const WebCore::GraphicsContextGLAttributes&);
+#endif
+    void initializeIPC(IPC::StreamServerConnection::Handle&&, RemoteRenderingBackendProxy&);
     // Messages to be received.
     void wasCreated(bool didSucceed, IPC::Semaphore&&, IPC::Semaphore&&, String&& availableExtensions, String&& requestedExtensions);
     void wasLost();

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -82,6 +82,8 @@ void RemoteRenderingBackendProxy::ensureGPUProcessConnection()
     if (!m_streamConnection) {
         static constexpr auto connectionBufferSizeLog2 = 21;
         auto [streamConnection, serverHandle] = IPC::StreamClientConnection::create(connectionBufferSizeLog2);
+        if (!streamConnection)
+            CRASH();
         m_streamConnection = WTFMove(streamConnection);
         m_streamConnection->open(*this, m_dispatcher);
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h
@@ -49,10 +49,7 @@ class DowncastConvertToBackingContext;
 class RemoteGPUProxy final : public PAL::WebGPU::GPU, private IPC::Connection::Client, private GPUProcessConnection::Client {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<RemoteGPUProxy> create(GPUProcessConnection& gpuProcessConnection, WebGPU::ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier, RenderingBackendIdentifier renderingBackend)
-    {
-        return adoptRef(*new RemoteGPUProxy(gpuProcessConnection, convertToBackingContext, identifier, renderingBackend));
-    }
+    static RefPtr<RemoteGPUProxy> create(GPUProcessConnection&, WebGPU::ConvertToBackingContext&, WebGPUIdentifier, RenderingBackendIdentifier);
 
     virtual ~RemoteGPUProxy();
 
@@ -63,7 +60,8 @@ public:
 private:
     friend class WebGPU::DowncastConvertToBackingContext;
 
-    RemoteGPUProxy(GPUProcessConnection&, WebGPU::ConvertToBackingContext&, WebGPUIdentifier, RenderingBackendIdentifier);
+    RemoteGPUProxy(GPUProcessConnection&, Ref<IPC::StreamClientConnection>, WebGPU::ConvertToBackingContext&, WebGPUIdentifier);
+    void initializeIPC(IPC::StreamServerConnection::Handle&&, RenderingBackendIdentifier);
 
     RemoteGPUProxy(const RemoteGPUProxy&) = delete;
     RemoteGPUProxy(RemoteGPUProxy&&) = delete;

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/RemoteGraphicsContextGLProxyCocoa.mm
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/RemoteGraphicsContextGLProxyCocoa.mm
@@ -101,8 +101,8 @@ public:
     WebCore::GraphicsContextGLCV* asCV() final { return nullptr; }
 #endif
 private:
-    RemoteGraphicsContextGLProxyCocoa(IPC::Connection& connection, SerialFunctionDispatcher& dispatcher, const WebCore::GraphicsContextGLAttributes& attributes, RenderingBackendIdentifier renderingBackend, Ref<RemoteVideoFrameObjectHeapProxy>&& videoFrameObjectHeapProxy)
-        : RemoteGraphicsContextGLProxy(connection, dispatcher, attributes, renderingBackend, WTFMove(videoFrameObjectHeapProxy))
+    RemoteGraphicsContextGLProxyCocoa(IPC::Connection& connection,  Ref<IPC::StreamClientConnection> streamConnection, const WebCore::GraphicsContextGLAttributes& attributes, Ref<RemoteVideoFrameObjectHeapProxy>&& videoFrameObjectHeapProxy)
+        : RemoteGraphicsContextGLProxy(connection, WTFMove(streamConnection), attributes, WTFMove(videoFrameObjectHeapProxy))
         , m_layerContentsDisplayDelegate(DisplayBufferDisplayDelegate::create(!attributes.alpha, attributes.devicePixelRatio))
     {
     }
@@ -131,9 +131,9 @@ void RemoteGraphicsContextGLProxyCocoa::prepareForDisplay()
 
 }
 
-RefPtr<RemoteGraphicsContextGLProxy> RemoteGraphicsContextGLProxy::create(IPC::Connection& connection, const WebCore::GraphicsContextGLAttributes& attributes, RemoteRenderingBackendProxy& renderingBackend, Ref<RemoteVideoFrameObjectHeapProxy>&& videoFrameObjectHeapProxy)
+Ref<RemoteGraphicsContextGLProxy> RemoteGraphicsContextGLProxy::platformCreate(IPC::Connection& connection,  Ref<IPC::StreamClientConnection> streamConnection, const WebCore::GraphicsContextGLAttributes& attributes, Ref<RemoteVideoFrameObjectHeapProxy>&& videoFrameObjectHeapProxy)
 {
-    return adoptRef(new RemoteGraphicsContextGLProxyCocoa(connection, renderingBackend.dispatcher(), attributes, renderingBackend.ensureBackendCreated(), WTFMove(videoFrameObjectHeapProxy)));
+    return adoptRef(*new RemoteGraphicsContextGLProxyCocoa(connection, WTFMove(streamConnection), attributes, WTFMove(videoFrameObjectHeapProxy)));
 }
 
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/wc/RemoteGraphicsContextGLProxyWC.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/wc/RemoteGraphicsContextGLProxyWC.cpp
@@ -71,15 +71,15 @@ public:
     RefPtr<WebCore::VideoFrame> paintCompositedResultsToVideoFrame() final { return nullptr; }
 #endif
 private:
-    RemoteGraphicsContextGLProxyWC(IPC::Connection& connection, SerialFunctionDispatcher& dispatcher, const WebCore::GraphicsContextGLAttributes& attributes, RenderingBackendIdentifier renderingBackend
+    RemoteGraphicsContextGLProxyWC(IPC::Connection& connection, Ref<IPC::StreamClientConnection> streamConnection, const WebCore::GraphicsContextGLAttributes& attributes
 #if ENABLE(VIDEO)
     , Ref<RemoteVideoFrameObjectHeapProxy>&& videoFrameObjectHeapProxy
 #endif
     )
 #if ENABLE(VIDEO)
-        : RemoteGraphicsContextGLProxy(connection, dispatcher, attributes, renderingBackend, WTFMove(videoFrameObjectHeapProxy))
+        : RemoteGraphicsContextGLProxy(connection, WTFMove(streamConnection), attributes, WTFMove(videoFrameObjectHeapProxy))
 #else
-        : RemoteGraphicsContextGLProxy(connection, dispatcher, attributes, renderingBackend)
+        : RemoteGraphicsContextGLProxy(connection, WTFMove(streamConnection), attributes)
 #endif
         , m_layerContentsDisplayDelegate(PlatformLayerDisplayDelegate::create(makeUnique<WCPlatformLayerGCGL>()))
     {
@@ -106,13 +106,13 @@ void RemoteGraphicsContextGLProxyWC::prepareForDisplay()
 
 }
 
-RefPtr<RemoteGraphicsContextGLProxy> RemoteGraphicsContextGLProxy::create(IPC::Connection& connection, const WebCore::GraphicsContextGLAttributes& attributes, RemoteRenderingBackendProxy& renderingBackend
+Ref<RemoteGraphicsContextGLProxy> RemoteGraphicsContextGLProxy::platformCreate(IPC::Connection& connection, Ref<IPC::StreamClientConnection> streamConnection, const WebCore::GraphicsContextGLAttributes& attributes
 #if ENABLE(VIDEO)
     , Ref<RemoteVideoFrameObjectHeapProxy>&& videoFrameObjectHeapProxy
 #endif
     )
 {
-    return adoptRef(new RemoteGraphicsContextGLProxyWC(connection, renderingBackend.dispatcher(), attributes, renderingBackend.ensureBackendCreated()
+    return adoptRef(*new RemoteGraphicsContextGLProxyWC(connection, WTFMove(streamConnection), attributes
 #if ENABLE(VIDEO)
         , WTFMove(videoFrameObjectHeapProxy)
 #endif

--- a/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionBufferTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionBufferTests.cpp
@@ -33,7 +33,9 @@ namespace TestWebKitAPI {
 
 TEST(StreamConnectionBufferTests, CreateWorks)
 {
-    IPC::StreamClientConnectionBuffer b(8);
+    auto buffer = IPC::StreamClientConnectionBuffer::create(8);
+    ASSERT_TRUE(buffer.has_value());
+    auto& b = *buffer;
     EXPECT_NE(b.data(), nullptr);
     EXPECT_EQ(b.dataSize(), 256u);
     {
@@ -41,7 +43,9 @@ TEST(StreamConnectionBufferTests, CreateWorks)
         ASSERT_TRUE(server.has_value());
         EXPECT_EQ(b.dataSize(), server->dataSize());
     }
-    IPC::StreamClientConnectionBuffer b2(24);
+    auto buffer2 = IPC::StreamClientConnectionBuffer::create(24);
+    ASSERT_TRUE(buffer2.has_value());
+    auto& b2 = *buffer2;
     EXPECT_NE(b2.data(), nullptr);
     EXPECT_EQ(b2.dataSize(), 16777216u);
     {
@@ -60,7 +64,8 @@ public:
 
     void SetUp() override
     {
-        m_client.emplace(bufferSizeLog2());
+        m_client = IPC::StreamClientConnectionBuffer::create(bufferSizeLog2());
+        ASSERT(m_client);
         m_maybeServer = IPC::StreamServerConnectionBuffer::map(m_client->createHandle());
     }
 

--- a/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp
@@ -214,6 +214,7 @@ TEST_F(StreamConnectionTest, OpenConnections)
 {
     auto cleanup = localReferenceBarrier();
     auto [clientConnection, serverConnectionHandle] = IPC::StreamClientConnection::create(defaultBufferSizeLog2);
+    ASSERT_TRUE(clientConnection);
     auto serverConnection = IPC::StreamServerConnection::create(WTFMove(serverConnectionHandle), serverQueue());
     MockMessageReceiver mockClientReceiver;
     clientConnection->open(mockClientReceiver);
@@ -230,6 +231,7 @@ TEST_F(StreamConnectionTest, InvalidateUnopened)
 {
     auto cleanup = localReferenceBarrier();
     auto [clientConnection, serverConnectionHandle] = IPC::StreamClientConnection::create(defaultBufferSizeLog2);
+    ASSERT_TRUE(clientConnection);
     auto serverConnection = IPC::StreamServerConnection::create(WTFMove(serverConnectionHandle), serverQueue());
     serverQueue().dispatch([this, serverConnection] {
         assertIsCurrent(serverQueue());
@@ -249,6 +251,7 @@ public:
     {
         setupBase();
         auto [clientConnection, serverConnectionHandle] = IPC::StreamClientConnection::create(bufferSizeLog2());
+        ASSERT(clientConnection);
         auto serverConnection = IPC::StreamServerConnection::create(WTFMove(serverConnectionHandle), serverQueue());
         m_clientConnection = WTFMove(clientConnection);
         m_clientConnection->setSemaphores(copyViaEncoder(serverQueue().wakeUpSemaphore()).value(), copyViaEncoder(serverConnection->clientWaitSemaphore()).value());


### PR DESCRIPTION
#### 8e47c0fabb97ea07aa6d12bea0c47b791be19250
<pre>
WebContent crashes if GPUP WebGL remote context buffer cannot be allocated
<a href="https://bugs.webkit.org/show_bug.cgi?id=252732">https://bugs.webkit.org/show_bug.cgi?id=252732</a>
rdar://105612611

Reviewed by Geoffrey Garen.

Change RemoteGraphicsContextGLProxy and RemoteGPUProxy creation to be
nullable. If the IPC stream connection buffer allocation fails,
return gracefully instead of previous inteded CRASH().

Preserves the CRASH() in RemoteRenderingBackendProxy as current code
structure is such that it is expected always to be succesfully created.

* LayoutTests/webgl/webgl-fail-platform-context-creation-no-crash.html:
Remove a unneeded &lt;script&gt; from a similar test as below.
* LayoutTests/webgl/webgl-fail-remote-context-ipc-buffer-allocation-no-crash-expected.txt: Added.
* LayoutTests/webgl/webgl-fail-remote-context-ipc-buffer-allocation-no-crash.html: Copied from LayoutTests/webgl/webgl-fail-platform-context-creation-no-crash.html.
Add the test.
* Source/WebCore/html/canvas/WebGLContextAttributes.idl:
* Source/WebCore/platform/graphics/GraphicsContextGLAttributes.h:
* Source/WebKit/Platform/IPC/StreamClientConnection.cpp:
(IPC::StreamClientConnection::create):
(IPC::StreamClientConnection::StreamClientConnection):
* Source/WebKit/Platform/IPC/StreamClientConnection.h:
* Source/WebKit/Platform/IPC/StreamClientConnectionBuffer.h:
(IPC::StreamClientConnectionBuffer::create):
(IPC::StreamClientConnectionBuffer::StreamClientConnectionBuffer):
(IPC::StreamClientConnectionBuffer::createMemory): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp:
(WebKit::RemoteGraphicsContextGLProxy::create):
(WebKit::RemoteGraphicsContextGLProxy::RemoteGraphicsContextGLProxy):
(WebKit::RemoteGraphicsContextGLProxy::initializeIPC):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::ensureGPUProcessConnection):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp:
(WebKit::RemoteGPUProxy::create):
(WebKit::RemoteGPUProxy::RemoteGPUProxy):
(WebKit::RemoteGPUProxy::initializeIPC):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/cocoa/RemoteGraphicsContextGLProxyCocoa.mm:
(WebKit::RemoteGraphicsContextGLProxy::platformCreate):
(WebKit::RemoteGraphicsContextGLProxy::create): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/wc/RemoteGraphicsContextGLProxyWC.cpp:
(WebKit::RemoteGraphicsContextGLProxy::platformCreate):
(WebKit::RemoteGraphicsContextGLProxy::create): Deleted.
* Tools/TestWebKitAPI/Tests/IPC/StreamConnectionBufferTests.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp:
(TestWebKitAPI::TEST_F):

Canonical link: <a href="https://commits.webkit.org/260738@main">https://commits.webkit.org/260738@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29ea73b63ea2e6251a89dba23453473611820a93

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109088 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18170 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41910 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/623 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118352 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112973 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19629 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9472 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101329 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114848 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14718 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97949 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42880 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96690 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29603 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84612 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10952 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30948 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11689 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7879 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17062 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50548 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7408 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13297 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->