### PR TITLE
link rel=modulepreload should always use CORS preflight for cross-origin requests

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/preload/modulepreload-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/preload/modulepreload-expected.txt
@@ -2,10 +2,10 @@
 PASS link rel=modulepreload
 PASS same-origin link rel=modulepreload crossorigin=anonymous
 PASS same-origin link rel=modulepreload crossorigin=use-credentials
-FAIL cross-origin link rel=modulepreload promise_test: Unhandled rejection with value: object "[object Event]"
-FAIL cross-origin link rel=modulepreload crossorigin=anonymous promise_test: Unhandled rejection with value: object "[object Event]"
-FAIL cross-origin link rel=modulepreload crossorigin=use-credentials promise_test: Unhandled rejection with value: object "[object Event]"
-FAIL link rel=modulepreload with submodules assert_equals: resources/module1.js expected 1 but got 0
+PASS cross-origin link rel=modulepreload
+PASS cross-origin link rel=modulepreload crossorigin=anonymous
+PASS cross-origin link rel=modulepreload crossorigin=use-credentials
+PASS link rel=modulepreload with submodules
 PASS link rel=modulepreload for a module with syntax error
 PASS link rel=modulepreload for a module with network error
 PASS link rel=modulepreload with bad href attribute

--- a/LayoutTests/imported/w3c/web-platform-tests/preload/modulepreload.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/preload/modulepreload.html
@@ -6,11 +6,11 @@
 <script>
 host_info = get_host_info();
 
-function verifyNumberOfDownloads(url, number) {
+function verifyNumberOfDownloads(url, number, allowTransferSizeOfZero = false) {
     var numDownloads = 0;
     let absoluteURL = new URL(url, location.href).href;
     performance.getEntriesByName(absoluteURL).forEach(entry => {
-        if (entry.transferSize > 0) {
+        if (entry.transferSize > 0 || allowTransferSizeOfZero) {
             numDownloads++;
         }
     });
@@ -107,7 +107,7 @@ promise_test(function(t) {
         link.href = `${host_info.HTTP_REMOTE_ORIGIN}/preload/resources/cross-origin-module.py?crossOriginNone`;
         return attachAndWaitForLoad(link);
     }).then(() => {
-        verifyNumberOfDownloads(`${host_info.HTTP_REMOTE_ORIGIN}/preload/resources/cross-origin-module.py?crossOriginNone`, 1);
+        verifyNumberOfDownloads(`${host_info.HTTP_REMOTE_ORIGIN}/preload/resources/cross-origin-module.py?crossOriginNone`, 1, true);
 
         // Verify that <script> doesn't fetch the module again.
         var script = document.createElement('script');
@@ -115,7 +115,7 @@ promise_test(function(t) {
         script.src = `${host_info.HTTP_REMOTE_ORIGIN}/preload/resources/cross-origin-module.py?crossOriginNone`;
         return attachAndWaitForLoad(script);
     }).then(() => {
-        verifyNumberOfDownloads(`${host_info.HTTP_REMOTE_ORIGIN}/preload/resources/cross-origin-module.py?crossOriginNone`, 1);
+        verifyNumberOfDownloads(`${host_info.HTTP_REMOTE_ORIGIN}/preload/resources/cross-origin-module.py?crossOriginNone`, 1, true);
     });
 }, 'cross-origin link rel=modulepreload');
 
@@ -125,7 +125,7 @@ promise_test(function(t) {
     link.crossorigin = 'anonymous';
     link.href = `${host_info.HTTP_REMOTE_ORIGIN}/preload/resources/cross-origin-module.py?crossOriginAnonymous`;
     return attachAndWaitForLoad(link).then(() => {
-        verifyNumberOfDownloads(`${host_info.HTTP_REMOTE_ORIGIN}/preload/resources/cross-origin-module.py?crossOriginAnonymous`, 1);
+        verifyNumberOfDownloads(`${host_info.HTTP_REMOTE_ORIGIN}/preload/resources/cross-origin-module.py?crossOriginAnonymous`, 1, true);
 
         // Verify that <script> doesn't fetch the module again.
         var script = document.createElement('script');
@@ -134,7 +134,7 @@ promise_test(function(t) {
         script.src = `${host_info.HTTP_REMOTE_ORIGIN}/preload/resources/cross-origin-module.py?crossOriginAnonymous`;
         return attachAndWaitForLoad(script);
     }).then(() => {
-        verifyNumberOfDownloads(`${host_info.HTTP_REMOTE_ORIGIN}/preload/resources/cross-origin-module.py?crossOriginAnonymous`, 1);
+        verifyNumberOfDownloads(`${host_info.HTTP_REMOTE_ORIGIN}/preload/resources/cross-origin-module.py?crossOriginAnonymous`, 1, true);
     });
 }, 'cross-origin link rel=modulepreload crossorigin=anonymous');
 
@@ -144,7 +144,7 @@ promise_test(function(t) {
     link.crossorigin = 'use-credentials';
     link.href = `${host_info.HTTP_REMOTE_ORIGIN}/preload/resources/cross-origin-module.py?crossOriginUseCredentials`;
     return attachAndWaitForLoad(link).then(() => {
-        verifyNumberOfDownloads(`${host_info.HTTP_REMOTE_ORIGIN}/preload/resources/cross-origin-module.py?crossOriginUseCredentials`, 1);
+        verifyNumberOfDownloads(`${host_info.HTTP_REMOTE_ORIGIN}/preload/resources/cross-origin-module.py?crossOriginUseCredentials`, 1, true);
 
         // Verify that <script> doesn't fetch the module again.
         var script = document.createElement('script');
@@ -153,7 +153,7 @@ promise_test(function(t) {
         script.src = `${host_info.HTTP_REMOTE_ORIGIN}/preload/resources/cross-origin-module.py?crossOriginUseCredentials`;
         return attachAndWaitForLoad(script);
     }).then(() => {
-        verifyNumberOfDownloads(`${host_info.HTTP_REMOTE_ORIGIN}/preload/resources/cross-origin-module.py?crossOriginUseCredentials`, 1);
+        verifyNumberOfDownloads(`${host_info.HTTP_REMOTE_ORIGIN}/preload/resources/cross-origin-module.py?crossOriginUseCredentials`, 1, true);
     });
 }, 'cross-origin link rel=modulepreload crossorigin=use-credentials');
 /**

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/preload/modulepreload-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/preload/modulepreload-expected.txt
@@ -1,3 +1,6 @@
+CONSOLE MESSAGE: Origin http://localhost:8800 is not allowed by Access-Control-Allow-Origin. Status code: 500
+CONSOLE MESSAGE: Origin http://localhost:8800 is not allowed by Access-Control-Allow-Origin. Status code: 500
+CONSOLE MESSAGE: Origin http://localhost:8800 is not allowed by Access-Control-Allow-Origin. Status code: 500
 
 PASS link rel=modulepreload
 PASS same-origin link rel=modulepreload crossorigin=anonymous


### PR DESCRIPTION
#### 2581333cdb03631d467c1538d6b7f7f0f8e1b1c8
<pre>
link rel=modulepreload should always use CORS preflight for cross-origin requests
<a href="https://bugs.webkit.org/show_bug.cgi?id=252734">https://bugs.webkit.org/show_bug.cgi?id=252734</a>

Reviewed by Yusuke Suzuki.

Implement the semantics for cross-origin modulepreload requests.

This patch also updates the relevant web platform test to count a resource timing entry
with 0-byte transfer size for cross-origin test cases since WebKit&apos;s resource timing
implementation returns 0 byte for all cross-origin requests.

* LayoutTests/imported/w3c/web-platform-tests/preload/modulepreload-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/preload/modulepreload.html:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/preload/modulepreload-expected.txt:
* Source/WebCore/loader/LinkLoader.cpp:
(WebCore::LinkLoader::preloadIfNeeded):

Canonical link: <a href="https://commits.webkit.org/260709@main">https://commits.webkit.org/260709@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a01b3e3e8852650c3f47af2e1abc49742ff88443

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109018 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18097 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41839 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/553 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118293 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112900 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19553 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9397 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101255 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114776 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14660 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97896 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42791 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96632 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29539 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84537 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10882 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30887 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11626 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7822 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17006 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50485 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13225 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4042 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->