### PR TITLE
Restored WebGL context is not visible until layout

### DIFF
--- a/LayoutTests/webgl/webgl-visible-after-context-restore-expected.html
+++ b/LayoutTests/webgl/webgl-visible-after-context-restore-expected.html
@@ -1,0 +1,3 @@
+<body style="margin:0">
+<div style="display:block; width:300px; height: 150px; background: lime" ></div>
+</body>

--- a/LayoutTests/webgl/webgl-visible-after-context-restore.html
+++ b/LayoutTests/webgl/webgl-visible-after-context-restore.html
@@ -1,0 +1,24 @@
+<body style="margin:0">
+<canvas style="display:block;" id="canvas"></canvas>
+<script>
+if (window.testRunner)
+    testRunner.waitUntilDone();
+canvas.addEventListener('webglcontextlost', e => {
+    e.preventDefault();
+    setTimeout((e) => {
+        ext.restoreContext();
+    }, 100);
+});
+canvas.addEventListener('webglcontextrestored', e => {
+    gl.clearColor(0, 1, 0, 1);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+let gl = canvas.getContext("webgl");
+let ext = gl.getExtension("WEBGL_lose_context");
+window.requestAnimationFrame(() => {
+    ext.loseContext();
+});
+</script>
+</body>

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -5563,8 +5563,12 @@ void WebGLRenderingContextBase::maybeRestoreContext()
     if (!canvas)
         return;
 
-    if (!isContextLost())
+    if (!isContextLost()) {
         canvas->dispatchEvent(WebGLContextEvent::create(eventNames().webglcontextrestoredEvent, Event::CanBubble::No, Event::IsCancelable::Yes, emptyString()));
+        // Notify the render layer to reconfigure the structure of the backing. This causes the backing to
+        // start using the new layer contents display delegate from the new context.
+        notifyCanvasContentChanged();
+    }
 }
 
 void WebGLRenderingContextBase::simulateEventForTesting(SimulatedEventForTesting event)


### PR DESCRIPTION
#### 3a7c3a3c6ad39d3723704d8d5568c35475c4db7b
<pre>
Restored WebGL context is not visible until layout
<a href="https://bugs.webkit.org/show_bug.cgi?id=252737">https://bugs.webkit.org/show_bug.cgi?id=252737</a>
rdar://104084385

Reviewed by Antti Koivisto.

Force reconfiguration of the layer backing store for WebGL element after
successful restore. The layerContentsDisplayDelegate is per
GraphicsContextGL context, and losing and restoring the context means
the delegate needs to be changed too.

* LayoutTests/webgl/webgl-visible-after-context-restore-expected.html: Added.
* LayoutTests/webgl/webgl-visible-after-context-restore.html: Added.
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::maybeRestoreContext):

Canonical link: <a href="https://commits.webkit.org/260693@main">https://commits.webkit.org/260693@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4ed3ee6691aeb9bd00538841263d0580c22b3cc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109030 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18109 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41851 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/564 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118300 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112913 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19567 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9411 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101267 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114789 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14670 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97905 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42805 "Found 1 new test failure: webgl/2.0.0/conformance2/textures/misc/copy-texture-image.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96642 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29550 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84554 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10895 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30897 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11635 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7830 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17013 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50495 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7379 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13237 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->