### PR TITLE
Add support for retrieving background fetch response bodies

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -517,7 +517,6 @@ imported/w3c/web-platform-tests/x-frame-options/sameorigin.sub.html [ DumpJSCons
 
 # Timing out tests.
 imported/w3c/web-platform-tests/background-fetch/fetch-uploads.https.window.html [ Skip ]
-imported/w3c/web-platform-tests/background-fetch/match.https.window.html [ Skip ]
 imported/w3c/web-platform-tests/background-fetch/update-ui.https.window.html [ Skip ]
 imported/w3c/web-platform-tests/background-fetch/fetch.https.window.html [ Skip ]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/background-fetch/match.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/background-fetch/match.https.window-expected.txt
@@ -1,9 +1,7 @@
 
-Harness Error (TIMEOUT), message = null
-
-FAIL Matching to a single request should work assert_equals: expected "Background Fetch" but got ""
-TIMEOUT Matching to a non-existing request should work Test timed out
-NOTRUN Matching multiple times on the same request works as expected.
-NOTRUN Access to active fetches is supported.
-NOTRUN Match with query options.
+PASS Matching to a single request should work
+FAIL Matching to a non-existing request should work assert_equals: expected (string) "matchmissingrequest" but got (undefined) undefined
+PASS Matching multiple times on the same request works as expected.
+PASS Access to active fetches is supported.
+FAIL Match with query options. assert_equals: expected 2 but got 3
 

--- a/LayoutTests/imported/w3c/web-platform-tests/background-fetch/service_workers/sw.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/background-fetch/service_workers/sw.js
@@ -52,6 +52,10 @@ function handleBackgroundFetchEvent(event) {
         const registrationCopy = cloneRegistration(event.registration);
         sendMessageToDocument(
           { type: event.type, eventRegistration: registrationCopy, results })
+      })
+      .catch(error => {
+        sendMessageToDocument(
+          { type: event.type, eventRegistration:{}, results:[], error:true })
       }));
 }
 

--- a/Source/WebCore/Modules/fetch/FetchBody.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBody.cpp
@@ -173,7 +173,7 @@ void FetchBody::consume(FetchBodyOwner& owner, Ref<DeferredPromise>&& promise)
         return;
     }
 
-    m_consumer.resolve(WTFMove(promise), owner.contentType(), m_readableStream.get());
+    m_consumer.resolve(WTFMove(promise), owner.contentType(), &owner, m_readableStream.get());
 }
 
 void FetchBody::consumeAsStream(FetchBodyOwner& owner, FetchBodySource& source)

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
@@ -331,7 +331,7 @@ void FetchBodyConsumer::extract(ReadableStream& stream, ReadableStreamToSharedBu
     m_sink->pipeFrom(stream);
 }
 
-void FetchBodyConsumer::resolve(Ref<DeferredPromise>&& promise, const String& contentType, ReadableStream* stream)
+void FetchBodyConsumer::resolve(Ref<DeferredPromise>&& promise, const String& contentType, FetchBodyOwner* owner, ReadableStream* stream)
 {
     if (stream) {
         ASSERT(!m_sink);
@@ -353,6 +353,8 @@ void FetchBodyConsumer::resolve(Ref<DeferredPromise>&& promise, const String& co
     }
 
     if (m_isLoading) {
+        if (owner)
+            owner->loadBody();
         setConsumePromise(WTFMove(promise));
         return;
     }
@@ -473,10 +475,10 @@ void FetchBodyConsumer::loadingSucceeded(const String& contentType)
 
     if (m_consumePromise) {
         if (!m_userGestureToken || m_userGestureToken->hasExpired(UserGestureToken::maximumIntervalForUserGestureForwardingForFetch()) || !m_userGestureToken->processingUserGesture())
-            resolve(m_consumePromise.releaseNonNull(), contentType, nullptr);
+            resolve(m_consumePromise.releaseNonNull(), contentType, nullptr, nullptr);
         else {
             UserGestureIndicator gestureIndicator(m_userGestureToken, UserGestureToken::GestureScope::MediaOnly, UserGestureToken::IsPropagatedFromFetch::Yes);
-            resolve(m_consumePromise.releaseNonNull(), contentType, nullptr);
+            resolve(m_consumePromise.releaseNonNull(), contentType, nullptr, nullptr);
         }
     }
     if (m_source) {

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.h
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.h
@@ -40,6 +40,7 @@ namespace WebCore {
 
 class Blob;
 class DOMFormData;
+class FetchBodyOwner;
 class FetchBodySource;
 class FormData;
 class ReadableStream;
@@ -71,7 +72,7 @@ public:
     void clean();
 
     void extract(ReadableStream&, ReadableStreamToSharedBufferSink::Callback&&);
-    void resolve(Ref<DeferredPromise>&&, const String& contentType, ReadableStream*);
+    void resolve(Ref<DeferredPromise>&&, const String& contentType, FetchBodyOwner*, ReadableStream*);
     void resolveWithData(Ref<DeferredPromise>&&, const String& contentType, const unsigned char*, unsigned);
     void resolveWithFormData(Ref<DeferredPromise>&&, const String& contentType, const FormData&, ScriptExecutionContext*);
     void consumeFormDataAsStream(const FormData&, FetchBodySource&, ScriptExecutionContext*);

--- a/Source/WebCore/Modules/fetch/FetchBodyOwner.h
+++ b/Source/WebCore/Modules/fetch/FetchBodyOwner.h
@@ -69,6 +69,7 @@ public:
     virtual void consumeBodyAsStream();
     virtual void feedStream() { }
     virtual void cancel() { }
+    virtual void loadBody() { }
 
     bool hasLoadingError() const;
     ResourceError loadingError() const;

--- a/Source/WebCore/Modules/fetch/FetchResponseBodyLoader.h
+++ b/Source/WebCore/Modules/fetch/FetchResponseBodyLoader.h
@@ -1,72 +1,50 @@
 /*
- * Copyright (C) 2016 Canon Inc.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
- * modification, are permitted, provided that the following conditions
- * are required to be met:
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
  *
- * 1.  Redistributions of source code must retain the above copyright
- *     notice, this list of conditions and the following disclaimer.
- * 2.  Redistributions in binary form must reproduce the above copyright
- *     notice, this list of conditions and the following disclaimer in the
- *     documentation and/or other materials provided with the distribution.
- * 3.  Neither the name of Canon Inc. nor the names of
- *     its contributors may be used to endorse or promote products derived
- *     from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY CANON INC. AND ITS CONTRIBUTORS "AS IS" AND ANY
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL CANON INC. AND ITS CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #pragma once
 
-#include "ExceptionOr.h"
-#include "SharedBuffer.h"
-#include <wtf/Function.h>
-#include <wtf/Span.h>
-
 namespace WebCore {
 
-class FragmentedSharedBuffer;
+class FetchResponse;
 
 class FetchResponseBodyLoader {
     WTF_MAKE_FAST_ALLOCATED;
 public:
+    explicit FetchResponseBodyLoader(FetchResponse&);
     virtual ~FetchResponseBodyLoader() = default;
 
+    virtual void start() = 0;
     virtual void stop() = 0;
-    virtual bool isActive() const = 0;
-    virtual RefPtr<FragmentedSharedBuffer> startStreaming() = 0;
 
-    using ConsumeDataByChunkCallback = Function<void(ExceptionOr<Span<const uint8_t>*>&&)>;
-    void consumeDataByChunk(ConsumeDataByChunkCallback&&);
-    ConsumeDataByChunkCallback takeConsumeDataCallback() { return WTFMove(m_consumeDataCallback); }
-    bool hasConsumeDataCallback() const { return !!m_consumeDataCallback; }
-    ConsumeDataByChunkCallback& consumeDataCallback() { return m_consumeDataCallback; }
-
-private:
-    ConsumeDataByChunkCallback m_consumeDataCallback;
+protected:
+    WeakPtr<FetchResponse> m_response;
 };
 
-inline void FetchResponseBodyLoader::consumeDataByChunk(ConsumeDataByChunkCallback&& callback)
+inline FetchResponseBodyLoader::FetchResponseBodyLoader(FetchResponse& response)
+    : m_response(response)
 {
-    ASSERT(!m_consumeDataCallback);
-    m_consumeDataCallback = WTFMove(callback);
-    auto data = startStreaming();
-    if (!data)
-        return;
-
-    auto contiguousBuffer = data->makeContiguous();
-    Span chunk { contiguousBuffer->data(), data->size() };
-    m_consumeDataCallback(&chunk);
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 9800cc8170bb90a97ddad70cf13bdf595acf7703
<pre>
Add support for retrieving background fetch response bodies
<a href="https://bugs.webkit.org/show_bug.cgi?id=252738">https://bugs.webkit.org/show_bug.cgi?id=252738</a>
rdar://problem/105770593

Reviewed by Chris Dumez.

Add infrastructure in FetchResponse to asynchronously trigger fetch response bodies when actually needed.
Pipe this infra to BackgroundFetch responses which will call SWClientConnection::retrieveRecordResponseBody.

Covered by rebased and updated test.
Test is updated to no longer be timing out.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/background-fetch/match.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/background-fetch/service_workers/sw.js:
* Source/WebCore/Modules/fetch/FetchBody.cpp:
(WebCore::FetchBody::consume):
* Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp:
(WebCore::FetchBodyConsumer::resolve):
(WebCore::FetchBodyConsumer::loadingSucceeded):
* Source/WebCore/Modules/fetch/FetchBodyConsumer.h:
* Source/WebCore/Modules/fetch/FetchBodyOwner.cpp:
(WebCore::FetchBodyOwner::text):
* Source/WebCore/Modules/fetch/FetchBodyOwner.h:
(WebCore::FetchBodyOwner::loadBody):
* Source/WebCore/Modules/fetch/FetchResponse.cpp:
(WebCore::FetchResponse::addAbortSteps):
(WebCore::FetchResponse::createFetchResponse):
(WebCore::FetchResponse::startLoader):
(WebCore::FetchResponse::Loader::didSucceed):
(WebCore::FetchResponse::Loader::didFail):
(WebCore::FetchResponse::Loader::Loader):
(WebCore::FetchResponse::Loader::~Loader):
(WebCore::FetchResponse::Loader::didReceiveResponse):
(WebCore::FetchResponse::Loader::didReceiveData):
(WebCore::FetchResponse::Loader::start):
(WebCore::FetchResponse::Loader::stop):
(WebCore::FetchResponse::Loader::consumeDataByChunk):
(WebCore::FetchResponse::consumeBodyReceivedByChunk):
(WebCore::FetchResponse::consumeBodyAsStream):
(WebCore::FetchResponse::feedStream):
(WebCore::FetchResponse::Loader::startStreaming):
(WebCore::FetchResponse::stop):
(WebCore::FetchResponse::loadBody):
(WebCore::FetchResponse::setBodyLoader):
(WebCore::FetchResponse::receivedError):
(WebCore::FetchResponse::processReceivedError):
(WebCore::FetchResponse::didSucceed):
(WebCore::FetchResponse::receivedData):
(WebCore::FetchResponse::BodyLoader::didSucceed): Deleted.
(WebCore::FetchResponse::BodyLoader::didFail): Deleted.
(WebCore::FetchResponse::BodyLoader::BodyLoader): Deleted.
(WebCore::FetchResponse::BodyLoader::~BodyLoader): Deleted.
(WebCore::FetchResponse::BodyLoader::didReceiveResponse): Deleted.
(WebCore::FetchResponse::BodyLoader::didReceiveData): Deleted.
(WebCore::FetchResponse::BodyLoader::start): Deleted.
(WebCore::FetchResponse::BodyLoader::stop): Deleted.
(WebCore::FetchResponse::BodyLoader::consumeDataByChunk): Deleted.
(WebCore::FetchResponse::BodyLoader::startStreaming): Deleted.
* Source/WebCore/Modules/fetch/FetchResponse.h:
* Source/WebCore/Modules/fetch/FetchResponseBodyLoader.h:
(WebCore::FetchResponseBodyLoader::FetchResponseBodyLoader):
(WebCore::FetchResponseBodyLoader::takeConsumeDataCallback): Deleted.
(WebCore::FetchResponseBodyLoader::hasConsumeDataCallback const): Deleted.
(WebCore::FetchResponseBodyLoader::consumeDataCallback): Deleted.
(WebCore::FetchResponseBodyLoader::consumeDataByChunk): Deleted.
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/workers/service/background-fetch/BackgroundFetchRegistration.cpp:
(WebCore::BackgroundFetchResponseBodyLoader::BackgroundFetchResponseBodyLoader):
(WebCore::createRecord):

Canonical link: <a href="https://commits.webkit.org/261047@main">https://commits.webkit.org/261047@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e09c442bf9766960482870d554278c5502faf5c8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110210 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19307 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42868 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1629 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119200 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114161 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20768 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10498 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102468 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115955 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15461 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98670 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43677 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97422 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30334 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85521 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11997 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31671 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12609 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8634 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17975 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51288 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7649 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14418 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->