### PR TITLE
Implement Priority Hints

### DIFF
--- a/LayoutTests/http/tests/priority-hints/fetch-api-priority-expected.txt
+++ b/LayoutTests/http/tests/priority-hints/fetch-api-priority-expected.txt
@@ -1,0 +1,12 @@
+
+PASS fetch() with URL and request_init whose priority is "high" must be fetched with high load priority
+PASS fetch() with URL and request_init whose priority is "auto" must have no effect on resource load priority
+PASS fetch() with URL and request_init whose priority is missing must have no effect on resource load priority
+PASS fetch() with URL and request_init whose priority is "low" must be fetched with low resource load priority
+PASS fetch() with Request whose priority is "low" and request_init whose priority is "high" must have no effect on resource load priority
+PASS fetch() with Request whose priority is "high" and request_init whose priority is "low" must be fetched with low resource load priority
+PASS fetch() with Request whose priority is "high" and no request_init must be fetched with high resource load priority
+PASS fetch() with Request whose priority is "auto" and no request_init must have no effect on resource load priority
+PASS fetch() with Request whose priority is missing and no request_init must have no effect on resource load priority
+PASS fetch() with Request whose priority is "low" and no request_init must be fetched with low resource load priority
+

--- a/LayoutTests/http/tests/priority-hints/fetch-api-priority.html
+++ b/LayoutTests/http/tests/priority-hints/fetch-api-priority.html
@@ -1,0 +1,58 @@
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src="http://127.0.0.1:8000/resources/checkResourcePriority.js"></script>
+
+<script>
+  const resource_url = new URL('../resources/dummy.css', location);
+
+  const tests = [
+    // fetch("url", request_init) tests
+    {description: 'fetch() with URL and request_init whose priority is "high" must be fetched with high load priority', request_info: `${resource_url}?1`, request_init: {priority: 'high'}, expected_priority: "ResourceLoadPriorityHigh"},
+    {description: 'fetch() with URL and request_init whose priority is "auto" must have no effect on resource load priority', request_info: `${resource_url}?2`, request_init: {priority: 'auto'}, expected_priority: "ResourceLoadPriorityMedium"},
+    {description: 'fetch() with URL and request_init whose priority is missing must have no effect on resource load priority', request_info: `${resource_url}?3`, request_init: {}, expected_priority: "ResourceLoadPriorityMedium"},
+    {description: 'fetch() with URL and request_init whose priority is "low" must be fetched with low resource load priority', request_info: `${resource_url}?4`, request_init: {priority: 'low'}, expected_priority: "ResourceLoadPriorityLow"},
+    // fetch(Request, request_init) tests
+    {
+      description: 'fetch() with Request whose priority is "low" and request_init whose priority is "high" must have no effect on resource load priority',
+      request_info: new Request(`${resource_url}?5`, {priority: 'low'}),
+      request_init: {priority: 'high'},
+      expected_priority: "ResourceLoadPriorityHigh"
+    },
+    {
+      description: 'fetch() with Request whose priority is "high" and request_init whose priority is "low" must be fetched with low resource load priority',
+      request_info: new Request(`${resource_url}?6`, {priority: 'high'}),
+      request_init: {priority: 'low'},
+      expected_priority: "ResourceLoadPriorityLow"
+    },
+    // fetch(Request) tests
+    {
+      description: 'fetch() with Request whose priority is "high" and no request_init must be fetched with high resource load priority',
+      request_info: new Request(`${resource_url}?7`, {priority: 'high'}),
+      expected_priority: "ResourceLoadPriorityHigh"
+    },
+    {
+      description: 'fetch() with Request whose priority is "auto" and no request_init must have no effect on resource load priority',
+      request_info: new Request(`${resource_url}?8`, {priority: 'auto'}),
+      expected_priority: "ResourceLoadPriorityMedium"
+    },
+    {
+      description: 'fetch() with Request whose priority is missing and no request_init must have no effect on resource load priority',
+      request_info: new Request(`${resource_url}?9`),
+      expected_priority: "ResourceLoadPriorityMedium"
+    },
+    {
+      description: 'fetch() with Request whose priority is "low" and no request_init must be fetched with low resource load priority',
+      request_info: new Request(`${resource_url}?10`, {priority: 'low'}),
+      expected_priority: "ResourceLoadPriorityLow"
+    }
+  ];
+
+  for (const test of tests) {
+    promise_test(async () => {
+      const url = test.request_info instanceof Request ?
+                    test.request_info.url : test.request_info;
+      const response = await fetch(test.request_info, test.request_init);
+      checkResourcePriority(url, test.expected_priority);
+    }, test.description);
+  }
+</script>

--- a/LayoutTests/http/tests/priority-hints/image-dynamic-insertion-expected.txt
+++ b/LayoutTests/http/tests/priority-hints/image-dynamic-insertion-expected.txt
@@ -1,0 +1,7 @@
+
+PASS image-dynamic-insertion
+PASS image-dynamic-insertion 1
+PASS image-dynamic-insertion 2
+PASS image-dynamic-insertion 3
+PASS image-dynamic-insertion 4
+

--- a/LayoutTests/http/tests/priority-hints/image-dynamic-insertion.html
+++ b/LayoutTests/http/tests/priority-hints/image-dynamic-insertion.html
@@ -1,0 +1,24 @@
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="http://127.0.0.1:8000/resources/checkResourcePriority.js"></script>
+
+<script>
+  const tests = [
+    {description: 'high fetchpriority on <img>s not fetched by the preload scanner must translate to medium resource load priority', fetchPriority: 'high', expected_priority: "ResourceLoadPriorityMedium"},
+    {description: 'low fetchpriority on <img>s not fetched by the preload scanner must translate to very low resource load priority', fetchPriority: 'low', expected_priority: "ResourceLoadPriorityVeryLow"},
+    {description: 'auto fetchpriority on <img>s not fetched by the preload scanner must have no effect on resource load priority', fetchPriority: 'auto', expected_priority: "ResourceLoadPriorityLow"},
+    {description: 'invalid fetchpriority on <img>s not fetched by the preload scanner must have no effect on resource load priority', fetchPriority: 'xyz', expected_priority: "ResourceLoadPriorityLow"},
+    {description: 'missing fetchpriority on <img>s not fetched by the preload scanner must have no effect on resource load priority', expected_priority: "ResourceLoadPriorityLow"}
+  ];
+  let iteration = 0;
+  for (const test of tests) {
+    async_test(t => {
+      const img = document.createElement('img');
+      if (test.fetchPriority) img.fetchPriority = test.fetchPriority;
+
+      const url = new URL(`../resources/square100.png?${iteration++}`, location);
+      img.onload = t.step_func(() => { checkResourcePriority(url, test.expected_priority, test.description); t.done(); });
+      img.src = url;
+    });
+  }
+</script>

--- a/LayoutTests/http/tests/priority-hints/image-initial-load-expected.txt
+++ b/LayoutTests/http/tests/priority-hints/image-initial-load-expected.txt
@@ -1,0 +1,9 @@
+
+
+PASS all images must be fetched by the preload scanner
+PASS image-initial-load
+PASS image-initial-load 1
+PASS image-initial-load 2
+PASS image-initial-load 3
+PASS image-initial-load 4
+

--- a/LayoutTests/http/tests/priority-hints/image-initial-load.html
+++ b/LayoutTests/http/tests/priority-hints/image-initial-load.html
@@ -1,0 +1,63 @@
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src="http://127.0.0.1:8000/resources/slow-script.pl?delay=100"></script>
+<script src="http://127.0.0.1:8000/resources/checkResourcePriority.js"></script>
+
+<script>
+const priority_tests = [
+  {
+    url: new URL('../resources/square100.png', location),
+    expected_priority: "ResourceLoadPriorityMedium",
+    description: 'high fetchpriority on <img> must translate to medium resource load priority'
+  },
+  {
+    url: new URL('../resources/square100.png?1', location),
+    expected_priority: "ResourceLoadPriorityVeryLow",
+    description: 'low fetchpriority on <img> must translate to very low resource load priority'
+  },
+  {
+    url: new URL('../resources/square100.png?2', location),
+    expected_priority: "ResourceLoadPriorityLow",
+    description: 'auto fetchpriority on <img> must translate to low resource load priority'
+  },
+  {
+    url: new URL('../resources/square100.png?3', location),
+    expected_priority: "ResourceLoadPriorityLow",
+    description: 'invalid fetchpriority on <img> must translate to low resource load priority'
+  },
+  {
+    url: new URL('../resources/square100.png?4', location),
+    expected_priority: "ResourceLoadPriorityLow",
+    description: 'missing fetchpriority on <img> must translate to low resource load priority'
+  }
+];
+</script>
+
+<img id=img1 fetchpriority=high src=../resources/square100.png alt=img>
+<img id=img2 fetchpriority=low src=../resources/square100.png?1 alt=img>
+<img id=img3 fetchpriority=auto src=../resources/square100.png?2 alt=img>
+<img id=img4 fetchpriority=xyz src=../resources/square100.png?3 alt=img>
+<img id=img5 src=../resources/square100.png?4 alt=img>
+
+<script>
+  promise_test(async (t) => {
+    await new Promise(resolve => {
+      addEventListener('DOMContentLoaded', resolve);
+    });
+
+    const base_msg = " was fetched by the preload scanner";
+    assert_true(internals.isPreloaded(img1.src), img1.src + base_msg);
+    assert_true(internals.isPreloaded(img2.src), img2.src + base_msg);
+    assert_true(internals.isPreloaded(img3.src), img3.src + base_msg);
+    assert_true(internals.isPreloaded(img4.src), img4.src + base_msg);
+    assert_true(internals.isPreloaded(img5.src), img5.src + base_msg);
+  }, 'all images must be fetched by the preload scanner');
+
+  // Setup the tests described by |priority_tests|.
+  for (const test of priority_tests) {
+    async_test(t => {
+      checkResourcePriority(test.url, test.expected_priority, test.description);
+      t.done();
+    });
+  }
+</script>

--- a/LayoutTests/http/tests/priority-hints/link-dynamic-insertion-expected.txt
+++ b/LayoutTests/http/tests/priority-hints/link-dynamic-insertion-expected.txt
@@ -1,0 +1,7 @@
+
+PASS link-dynamic-insertion
+PASS link-dynamic-insertion 1
+PASS link-dynamic-insertion 2
+PASS link-dynamic-insertion 3
+PASS link-dynamic-insertion 4
+

--- a/LayoutTests/http/tests/priority-hints/link-dynamic-insertion.html
+++ b/LayoutTests/http/tests/priority-hints/link-dynamic-insertion.html
@@ -1,0 +1,26 @@
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="http://127.0.0.1:8000/resources/checkResourcePriority.js"></script>
+
+<script>
+  const tests = [
+    {description: 'high fetchpriority on <link rel=stylesheet>s not fetched by the preload scanner must load with very high priority', fetchPriority: 'high', expected_priority: "ResourceLoadPriorityVeryHigh"},
+    {description: 'low fetchpriority on <link rel=stylesheet>s not fetched by the preload scanner must load with medium priority', fetchPriority: 'low', expected_priority: "ResourceLoadPriorityMedium"},
+    {description: 'auto fetchpriority on <link rel=stylesheet>s not fetched by the preload scanner must have no effect on resource load priority', fetchPriority: 'auto', expected_priority: "ResourceLoadPriorityHigh"},
+    {description: 'invalid fetchpriority on <link rel=stylesheet>s not fetched by the preload scanner must have no effect on resource load priority', fetchPriority: 'xyz', expected_priority: "ResourceLoadPriorityHigh"},
+    {description: 'missing fetchpriority on <link rel=stylesheet>s not fetched by the preload scanner must have no effect on resource load priority', expected_priority: "ResourceLoadPriorityHigh"}
+  ];
+
+  let iteration = 0;
+  for (const test of tests) {
+    async_test(t => {
+      const link = document.createElement('link');
+      link.rel = 'stylesheet';
+      if (test.fetchPriority) link.fetchPriority = test.fetchPriority;
+      const url = new URL(`/resources/square100.png?${iteration++}`, location);
+      link.href = url;
+      link.onload = t.step_func(() => { checkResourcePriority(url, test.expected_priority, test.description); t.done(); });
+      document.head.appendChild(link);
+    });
+  }
+</script>

--- a/LayoutTests/http/tests/priority-hints/link-header-fetch-priority-expected.txt
+++ b/LayoutTests/http/tests/priority-hints/link-header-fetch-priority-expected.txt
@@ -1,0 +1,15 @@
+
+PASS all preloads must be fetched by the preload scanner
+PASS link-header-fetch-priority
+PASS link-header-fetch-priority 1
+PASS link-header-fetch-priority 2
+PASS link-header-fetch-priority 3
+PASS link-header-fetch-priority 4
+PASS link-header-fetch-priority 5
+PASS link-header-fetch-priority 6
+PASS link-header-fetch-priority 7
+PASS link-header-fetch-priority 8
+PASS link-header-fetch-priority 9
+PASS link-header-fetch-priority 10
+PASS link-header-fetch-priority 11
+

--- a/LayoutTests/http/tests/priority-hints/link-header-fetch-priority.py
+++ b/LayoutTests/http/tests/priority-hints/link-header-fetch-priority.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+
+import sys
+
+sys.stdout.write(
+    'Link: <../resources/dummy.css>; rel=preload; as=style; fetchpriority=low;\r\n'
+    'Link: <../resources/dummy.css?1>; rel=preload; as=style;\r\n'
+    'Link: <../resources/dummy.css?2>; rel=preload; as=style; fetchpriority=high;\r\n'
+    'Link: <../resources/dummy.js>; rel=preload; as=script; fetchpriority=low;\r\n'
+    'Link: <../resources/dummy.js?1>; rel=preload; as=script;\r\n'
+    'Link: <../resources/dummy.js?2>; rel=preload; as=script; fetchpriority=high;\r\n'
+    'Link: <../resources/dummy.txt>; rel=preload; as=fetch; fetchpriority=low;\r\n'
+    'Link: <../resources/dummy.txt?1>; rel=preload; as=fetch;\r\n'
+    'Link: <../resources/dummy.txt?2>; rel=preload; as=fetch; fetchpriority=high;\r\n'
+    'Link: <../resources/square.png>; rel=preload; as=image; fetchpriority=low;\r\n'
+    'Link: <../resources/square.png?1>; rel=preload; as=image;\r\n'
+    'Link: <../resources/square.png?2>; rel=preload; as=image; fetchpriority=high;\r\n'
+    'Content-Type: text/html\r\n\r\n'
+)
+
+print('''<!DOCTYPE html>
+<meta charset="utf-8">
+<script src=../resources/testharness.js></script>
+<script src=../resources/testharnessreport.js></script>
+<script src="http://127.0.0.1:8000/resources/slow-script.pl?delay=100"></script>
+<script src="http://127.0.0.1:8000/resources/checkResourcePriority.js"></script>
+
+<script>
+const priority_tests = [
+  {
+    url: new URL('../resources/dummy.css', location), expected_priority: "ResourceLoadPriorityMedium",
+    description: 'low fetchpriority on <link rel=preload as=style> must be fetched with medium resource load priority'
+  },
+  {
+    url: new URL('../resources/dummy.css?1', location), expected_priority: "ResourceLoadPriorityHigh",
+    description: 'missing fetchpriority on <link rel=preload as=style> must have no effect on resource load priority'
+  },
+  {
+    url: new URL('../resources/dummy.css?2', location), expected_priority: "ResourceLoadPriorityVeryHigh",
+    description: 'high fetchpriority on <link rel=preload as=style> must be fetched with very high resource load priority'
+  },
+  {
+    url: new URL('../resources/dummy.css', location), expected_priority: "ResourceLoadPriorityMedium",
+    description: 'low fetchpriority on <link rel=preload as=script> must be fetched with medium resource load priority'
+  },
+  {
+    url: new URL('../resources/dummy.css?1', location), expected_priority: "ResourceLoadPriorityHigh",
+    description: 'missing fetchpriority on <link rel=preload as=script> must have no effect on resource load priority'
+  },
+  {
+    url: new URL('../resources/dummy.css?2', location), expected_priority: "ResourceLoadPriorityVeryHigh",
+    description: 'high fetchpriority on <link rel=preload as=script> must be fetched with very high resource load priority'
+  },
+  {
+    url: new URL('../resources/dummy.css', location), expected_priority: "ResourceLoadPriorityMedium",
+    description: 'low fetchpriority on <link rel=preload as=fetch> must be fetched with medium resource load priority'
+  },
+  {
+    url: new URL('../resources/dummy.css?1', location), expected_priority: "ResourceLoadPriorityHigh",
+    description: 'missing fetchpriority on <link rel=preload as=fetch> must have no effect on resource load priority'
+  },
+  {
+    url: new URL('../resources/dummy.css?2', location), expected_priority: "ResourceLoadPriorityVeryHigh",
+    description: 'high fetchpriority on <link rel=preload as=fetch> must be fetched with very high resource load priority'
+  },
+  {
+    url: new URL('../resources/square.png', location), expected_priority: "ResourceLoadPriorityVeryLow",
+    description: 'low fetchpriority on <link rel=preload as=image> must be fetched with very low resource load priority'
+  },
+  {
+    url: new URL('../resources/square.png?1', location), expected_priority: "ResourceLoadPriorityLow",
+    description: 'missing fetchpriority on <link rel=preload as=image> must have no effect on resource load priority'
+  },
+  {
+    url: new URL('../resources/square.png?2', location), expected_priority: "ResourceLoadPriorityMedium",
+    description: 'high fetchpriority on <link rel=preload as=image> must be fetched with medium resource load priority'
+  }
+];
+</script>
+
+<script>
+  promise_test(async (t) => {
+    await new Promise(resolve => {
+      addEventListener('DOMContentLoaded', resolve);
+    });
+
+    const base_msg = ' was fetched by the preload scanner';
+    for (const test of priority_tests) {
+      assert_true(internals.isPreloaded(test.url), test.url + base_msg);
+    }
+  }, 'all preloads must be fetched by the preload scanner');
+
+ // Setup the tests described by |priority_tests|.
+  for (const test of priority_tests) {
+    async_test(t => {
+      checkResourcePriority(test.url, test.expected_priority, test.description);
+      t.done();
+    });
+  }
+</script>''')

--- a/LayoutTests/http/tests/priority-hints/link-preload-dynamic-insertion-expected.txt
+++ b/LayoutTests/http/tests/priority-hints/link-preload-dynamic-insertion-expected.txt
@@ -1,0 +1,14 @@
+
+PASS link-preload-dynamic-insertion
+PASS link-preload-dynamic-insertion 1
+PASS link-preload-dynamic-insertion 2
+PASS link-preload-dynamic-insertion 3
+PASS link-preload-dynamic-insertion 4
+PASS link-preload-dynamic-insertion 5
+PASS link-preload-dynamic-insertion 6
+PASS link-preload-dynamic-insertion 7
+PASS link-preload-dynamic-insertion 8
+PASS link-preload-dynamic-insertion 9
+PASS link-preload-dynamic-insertion 10
+PASS link-preload-dynamic-insertion 11
+

--- a/LayoutTests/http/tests/priority-hints/link-preload-dynamic-insertion.html
+++ b/LayoutTests/http/tests/priority-hints/link-preload-dynamic-insertion.html
@@ -1,0 +1,107 @@
+<script src=../resources/testharness.js></script>
+<script src=../resources/testharnessreport.js></script>
+<script src="http://127.0.0.1:8000/resources/checkResourcePriority.js"></script>
+
+<script>
+  const tests = [
+    // rel=style
+    {
+      description: 'low fetchPriority on <link rel=preload as=style> not loaded by the preload scanner must be fetched with medium resource load priority',
+      as: 'style',
+      fetchPriority: 'low',
+      resource: 'dummy.css',
+      expected_priority: "ResourceLoadPriorityMedium"
+    },
+    {
+      description: 'missing fetchPriority on <link rel=preload as=style> not loaded by the preload scanner must be fetched with high resource load priority',
+      as: 'style',
+      resource: 'dummy.css',
+      expected_priority: "ResourceLoadPriorityHigh"
+    },
+    {
+      description: 'high fetchPriority on <link rel=preload as=style> not loaded by the preload scanner must be fetched with very high resource load priority',
+      as: 'style',
+      fetchPriority: 'high',
+      resource: 'dummy.css',
+      expected_priority: "ResourceLoadPriorityVeryHigh"
+    },
+    // rel=script
+    {
+      description: 'low fetchPriority on <link rel=preload as=script> not loaded by the preload scanner must be fetched with medium resource load priority',
+      as: 'script',
+      fetchPriority: 'low',
+      resource: 'dummy.js',
+      expected_priority: "ResourceLoadPriorityMedium"
+    },
+    {
+      description: 'missing fetchPriority on <link rel=preload as=script> not loaded by the preload scanner must be fetched with high resource load priority',
+      as: 'script',
+      resource: 'dummy.js',
+      expected_priority: "ResourceLoadPriorityHigh"
+    },
+    {
+      description: 'high fetchPriority on <link rel=preload as=script> not loaded by the preload scanner must be fetched with very high resource load priority',
+      as: 'script',
+      fetchPriority: 'high',
+      resource: 'dummy.js',
+      expected_priority: "ResourceLoadPriorityVeryHigh"
+    },
+    // rel=fetch
+    {
+      description: 'low fetchPriority on <link rel=preload as=fetch> not loaded by the preload scanner must be fetched with low resource load priority',
+      as: 'fetch',
+      fetchPriority: 'low',
+      resource: 'dummy.css',
+      expected_priority: "ResourceLoadPriorityLow"
+    },
+    {
+      description: 'missing fetchPriority on <link rel=preload as=fetch> not loaded by the preload scanner must be fetched with medium resource load priority',
+      as: 'fetch',
+      resource: 'dummy.css',
+      expected_priority: "ResourceLoadPriorityMedium"
+    },
+    {
+      description: 'high fetchPriority on <link rel=preload as=fetch> not loaded by the preload scanner must be fetched with high resource load priority',
+      as: 'fetch',
+      fetchPriority: 'high',
+      resource: 'dummy.css',
+      expected_priority: "ResourceLoadPriorityHigh"
+    },
+    // rel=image
+    {
+      description: 'low fetchPriority on <link rel=preload as=image> not loaded by the preload scanner must be fetched with very low resource load priority',
+      as: 'image',
+      fetchPriority: 'low',
+      resource: 'square100.png',
+      expected_priority: "ResourceLoadPriorityVeryLow"
+    },
+    {
+      description: 'missing fetchPriority on <link rel=preload as=image> not loaded by the preload scanner must be fetched with low resource load priority',
+      as: 'image',
+      resource: 'square100.png',
+      expected_priority: "ResourceLoadPriorityLow"
+    },
+    {
+      description: 'high fetchPriority on <link rel=preload as=image> not loaded by the preload scanner must be fetched with medium resource load priority',
+      as: 'image',
+      fetchPriority: 'high',
+      resource: 'square100.png',
+      expected_priority: "ResourceLoadPriorityMedium"
+    }
+  ];
+
+  let iteration = 0;
+  for (const test of tests) {
+    async_test(t => {
+      const link = document.createElement('link');
+      link.rel = 'preload';
+      link.as = test.as;
+      if (test.fetchPriority) link.fetchPriority = test.fetchPriority;
+
+      const url = new URL(`../resources/${test.resource}?${iteration++}`, location);
+      link.href = url;
+      link.onload = t.step_func(() => { checkResourcePriority(url, test.expected_priority, test.description); t.done(); });
+      document.head.appendChild(link);
+    });
+  }
+</script>

--- a/LayoutTests/http/tests/priority-hints/link-preload-initial-load-expected.txt
+++ b/LayoutTests/http/tests/priority-hints/link-preload-initial-load-expected.txt
@@ -1,0 +1,15 @@
+
+PASS all preloads must be fetched by the preload scanner
+PASS link-preload-initial-load
+PASS link-preload-initial-load 1
+PASS link-preload-initial-load 2
+PASS link-preload-initial-load 3
+PASS link-preload-initial-load 4
+PASS link-preload-initial-load 5
+PASS link-preload-initial-load 6
+PASS link-preload-initial-load 7
+PASS link-preload-initial-load 8
+PASS link-preload-initial-load 9
+PASS link-preload-initial-load 10
+PASS link-preload-initial-load 11
+

--- a/LayoutTests/http/tests/priority-hints/link-preload-initial-load.html
+++ b/LayoutTests/http/tests/priority-hints/link-preload-initial-load.html
@@ -1,0 +1,108 @@
+<script src=../resources/testharness.js></script>
+<script src=../resources/testharnessreport.js></script>
+<script src="http://127.0.0.1:8000/resources/slow-script.pl?delay=100"></script>
+<script src="http://127.0.0.1:8000/resources/checkResourcePriority.js"></script>
+
+<script>
+const priority_tests = [
+  {
+    url: new URL('../resources/dummy.css', location), expected_priority: "ResourceLoadPriorityMedium",
+    description: 'low fetchpriority on <link rel=preload as=style> must be fetched with medium resource load priority'
+  },
+  {
+    url: new URL('../resources/dummy.css?1', location), expected_priority: "ResourceLoadPriorityHigh",
+    description: 'missing fetchpriority on <link rel=preload as=style> must have no effect on resource load priority'
+  },
+  {
+    url: new URL('../resources/dummy.css?2', location), expected_priority: "ResourceLoadPriorityVeryHigh",
+    description: 'high fetchpriority on <link rel=preload as=style> must be fetched with very high resource load priority'
+  },
+  {
+    url: new URL('../resources/dummy.js', location), expected_priority: "ResourceLoadPriorityMedium",
+    description: 'low fetchpriority on <link rel=preload as=script> must be fetched with medium resource load priority'
+  },
+  {
+    url: new URL('../resources/dummy.js?1', location), expected_priority: "ResourceLoadPriorityHigh",
+    description: 'missing fetchpriority on <link rel=preload as=script> must have no effect on resource load priority'
+  },
+  {
+    url: new URL('../resources/dummy.js?2', location), expected_priority: "ResourceLoadPriorityVeryHigh",
+    description: 'high fetchpriority on <link rel=preload as=script> must be fetched with very high resource load priority'
+  },
+  {
+    url: new URL('../resources/dummy.txt', location), expected_priority: "ResourceLoadPriorityLow",
+    description: 'low fetchpriority on <link rel=preload as=fetch> must be fetched with low resource load priority'
+  },
+  {
+    url: new URL('../resources/dummy.txt?1', location), expected_priority: "ResourceLoadPriorityMedium",
+    description: 'missing fetchpriority on <link rel=preload as=fetch> must have no effect on resource load priority'
+  },
+  {
+    url: new URL('../resources/dummy.txt?2', location), expected_priority: "ResourceLoadPriorityHigh",
+    description: 'high fetchpriority on <link rel=preload as=fetch> must be fetched with high resource load priority'
+  },
+  {
+    url: new URL('../resources/square.png', location), expected_priority: "ResourceLoadPriorityVeryLow",
+    description: 'low fetchpriority on <link rel=preload as=image> must be fetched with very low resource load priority'
+  },
+  {
+    url: new URL('../resources/square.png?1', location), expected_priority: "ResourceLoadPriorityLow",
+    description: 'missing fetchpriority on <link rel=preload as=image> must have no effect on resource load priority'
+  },
+  {
+    url: new URL('../resources/square.png?2', location), expected_priority: "ResourceLoadPriorityMedium",
+    description: 'high fetchpriority on <link rel=preload as=image> must be fetched with medium resource load priority'
+  }
+];
+</script>
+
+<!-- as=style -->
+<!-- don't need to test for invalid and explicit auto fetchpriority here, since we already do that in the other link test -->
+<link id=link1 fetchpriority=low rel=preload as=style href=../resources/dummy.css>
+<link id=link2 rel=preload as=style href=../resources/dummy.css?1>
+<link id=link3 fetchpriority=high rel=preload as=style href=../resources/dummy.css?2>
+
+<!-- as=script-->
+<link id=link4 fetchpriority=low rel=preload as=script href=../resources/dummy.js>
+<link id=link5 rel=preload as=script href=../resources/dummy.js?1>
+<link id=link6 fetchpriority=high rel=preload as=script href=../resources/dummy.js?2>
+
+<!-- as=fetch-->
+<link id=link7 fetchpriority=low rel=preload as=fetch href=../resources/dummy.txt>
+<link id=link8 rel=preload as=fetch href=../resources/dummy.txt?1>
+<link id=link9 fetchpriority=high rel=preload as=fetch href=../resources/dummy.txt?2>
+
+<!-- as=image-->
+<link id=link10 fetchpriority=low rel=preload as=image href=../resources/square.png>
+<link id=link11 rel=preload as=image href=../resources/square.png?1>
+<link id=link12 fetchpriority=high rel=preload as=image href=../resources/square.png?2>
+
+<script>
+  promise_test(async (t) => {
+    await new Promise(resolve => {
+      addEventListener('DOMContentLoaded', resolve);
+    });
+
+    const base_msg = ' was fetched by the preload scanner';
+    assert_true(internals.isPreloaded(link1.href), link1.href + base_msg);
+    assert_true(internals.isPreloaded(link2.href), link2.href + base_msg);
+    assert_true(internals.isPreloaded(link3.href), link3.href + base_msg);
+    assert_true(internals.isPreloaded(link4.href), link4.href + base_msg);
+    assert_true(internals.isPreloaded(link5.href), link5.href + base_msg);
+    assert_true(internals.isPreloaded(link6.href), link6.href + base_msg);
+    assert_true(internals.isPreloaded(link7.href), link7.href + base_msg);
+    assert_true(internals.isPreloaded(link8.href), link8.href + base_msg);
+    assert_true(internals.isPreloaded(link9.href), link9.href + base_msg);
+    assert_true(internals.isPreloaded(link10.href), link10.href + base_msg);
+    assert_true(internals.isPreloaded(link11.href), link11.href + base_msg);
+    assert_true(internals.isPreloaded(link12.href), link12.href + base_msg);
+  }, 'all preloads must be fetched by the preload scanner');
+
+  // Setup the tests described by |priority_tests|.
+  for (const test of priority_tests) {
+    async_test(t => {
+      checkResourcePriority(test.url, test.expected_priority, test.description);
+      t.done();
+    });
+  }
+</script>

--- a/LayoutTests/http/tests/priority-hints/link-stylesheet-initial-load-expected.txt
+++ b/LayoutTests/http/tests/priority-hints/link-stylesheet-initial-load-expected.txt
@@ -1,0 +1,8 @@
+
+PASS all stylesheets must be fetched by the preload scanner
+PASS link-stylesheet-initial-load
+PASS link-stylesheet-initial-load 1
+PASS link-stylesheet-initial-load 2
+PASS link-stylesheet-initial-load 3
+PASS link-stylesheet-initial-load 4
+

--- a/LayoutTests/http/tests/priority-hints/link-stylesheet-initial-load.html
+++ b/LayoutTests/http/tests/priority-hints/link-stylesheet-initial-load.html
@@ -1,0 +1,63 @@
+<script src=../resources/testharness.js></script>
+<script src=../resources/testharnessreport.js></script>
+<script src="http://127.0.0.1:8000/resources/slow-script.pl?delay=100"></script>
+<script src="http://127.0.0.1:8000/resources/checkResourcePriority.js"></script>
+
+<script>
+const priority_tests = [
+  {
+    url: new URL('../resources/dummy.css', location),
+    expected_priority: "ResourceLoadPriorityMedium",
+    description: 'low fetchpriority on <link rel=stylesheet> must load with medium priority'
+  },
+  {
+    url: new URL('../resources/dummy.css?1', location),
+    expected_priority: "ResourceLoadPriorityVeryHigh",
+    description: 'high fetchpriority on <link rel=stylesheet> must load with very high priority'
+  },
+  {
+    url: new URL('../resources/dummy.css?2', location),
+    expected_priority: "ResourceLoadPriorityHigh",
+    description: 'auto fetchpriority on <link rel=stylesheet> must have no effect on resource load priority'
+  },
+  {
+    url: new URL('../resources/dummy.css?3', location),
+    expected_priority: "ResourceLoadPriorityHigh",
+    description: 'invalid fetchpriority on <link rel=stylesheet> must have no effect on resource load priority'
+  },
+  {
+    url: new URL('../resources/dummy.css?4', location),
+    expected_priority: "ResourceLoadPriorityHigh",
+    description: 'missing fetchpriority on <link rel=stylesheet> must have no effect on resource load priority'
+  }
+];
+</script>
+
+<link id=link1 fetchpriority=low rel=stylesheet href=../resources/dummy.css>
+<link id=link2 fetchpriority=high rel=stylesheet href=../resources/dummy.css?1>
+<link id=link3 fetchpriority=auto rel=stylesheet href=../resources/dummy.css?2>
+<link id=link4 fetchpriority=xyz rel=stylesheet href=../resources/dummy.css?3>
+<link id=link5 rel=stylesheet href=../resources/dummy.css?4>
+
+<script>
+  promise_test(async (t) => {
+    await new Promise(resolve => {
+      addEventListener('DOMContentLoaded', resolve);
+    });
+
+    const base_msg = ' was fetched by the preload scanner';
+    assert_true(internals.isPreloaded(link1.href), link1.href + base_msg);
+    assert_true(internals.isPreloaded(link2.href), link2.href + base_msg);
+    assert_true(internals.isPreloaded(link3.href), link3.href + base_msg);
+    assert_true(internals.isPreloaded(link4.href), link4.href + base_msg);
+    assert_true(internals.isPreloaded(link5.href), link5.href + base_msg);
+  }, 'all stylesheets must be fetched by the preload scanner');
+
+  // Setup the tests described by |priority_tests|.
+  for (const test of priority_tests) {
+    async_test(t => {
+      checkResourcePriority(test.url, test.expected_priority, test.description);
+      t.done();
+    });
+  }
+</script>

--- a/LayoutTests/http/tests/priority-hints/script-async-initial-load-expected.txt
+++ b/LayoutTests/http/tests/priority-hints/script-async-initial-load-expected.txt
@@ -1,0 +1,8 @@
+
+PASS all scripts must be fetched by the preload scanner
+PASS script-async-initial-load
+PASS script-async-initial-load 1
+PASS script-async-initial-load 2
+PASS script-async-initial-load 3
+PASS script-async-initial-load 4
+

--- a/LayoutTests/http/tests/priority-hints/script-async-initial-load.html
+++ b/LayoutTests/http/tests/priority-hints/script-async-initial-load.html
@@ -1,0 +1,63 @@
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src="http://127.0.0.1:8000/resources/slow-script.pl?delay=100"></script>
+<script src="http://127.0.0.1:8000/resources/checkResourcePriority.js"></script>
+
+<script>
+const priority_tests = [
+  {
+    url: new URL('../resources/dummy.js', location),
+    expected_priority: "ResourceLoadPriorityHigh",
+    description: 'high fetchpriority on async <script> raises the priority to high'
+  },
+  {
+    url: new URL('../resources/dummy.js?1', location),
+    expected_priority: "ResourceLoadPriorityLow",
+    description: 'low fetchpriority on async <script> lowers the priority to low'
+  },
+  {
+    url: new URL('../resources/dummy.js?2', location),
+    expected_priority: "ResourceLoadPriorityMedium",
+    description: 'auto fetchpriority on async <script> has no effect'
+  },
+  {
+    url: new URL('../resources/dummy.js?3', location),
+    expected_priority: "ResourceLoadPriorityMedium",
+    description: 'invalid fetchpriority on async <script> has no effect'
+  },
+  {
+    url: new URL('../resources/dummy.js?4', location),
+    expected_priority: "ResourceLoadPriorityMedium",
+    description: 'missing fetchpriority on async <script> has no effect'
+  },
+];
+
+</script>
+
+<script id=script1 async fetchpriority=high src=../resources/dummy.js></script>
+<script id=script2 async fetchpriority=low src=../resources/dummy.js?1></script>
+<script id=script3 async fetchpriority=auto src=../resources/dummy.js?2></script>
+<script id=script4 async fetchpriority=xyz src=../resources/dummy.js?3></script>
+<script id=script5 async src=../resources/dummy.js?4></script>
+
+<script>
+  promise_test(async (t) => {
+    await new Promise(resolve => {
+      addEventListener('DOMContentLoaded', resolve);
+    });
+    const base_msg = " was fetched by the preload scanner";
+    assert_true(internals.isPreloaded(script1.src), script1.src + base_msg);
+    assert_true(internals.isPreloaded(script2.src), script2.src + base_msg);
+    assert_true(internals.isPreloaded(script3.src), script3.src + base_msg);
+    assert_true(internals.isPreloaded(script4.src), script4.src + base_msg);
+    assert_true(internals.isPreloaded(script5.src), script5.src + base_msg);
+  }, 'all scripts must be fetched by the preload scanner');
+
+  // Setup the tests described by |priority_tests|.
+  for (const test of priority_tests) {
+    async_test(t => {
+      checkResourcePriority(test.url, test.expected_priority, test.description);
+      t.done();
+    });
+  }
+</script>

--- a/LayoutTests/http/tests/priority-hints/script-dynamic-insertion-expected.txt
+++ b/LayoutTests/http/tests/priority-hints/script-dynamic-insertion-expected.txt
@@ -1,0 +1,12 @@
+
+PASS script-dynamic-insertion
+PASS script-dynamic-insertion 1
+PASS script-dynamic-insertion 2
+PASS script-dynamic-insertion 3
+PASS script-dynamic-insertion 4
+PASS script-dynamic-insertion 5
+PASS script-dynamic-insertion 6
+PASS script-dynamic-insertion 7
+PASS script-dynamic-insertion 8
+PASS script-dynamic-insertion 9
+

--- a/LayoutTests/http/tests/priority-hints/script-dynamic-insertion.html
+++ b/LayoutTests/http/tests/priority-hints/script-dynamic-insertion.html
@@ -1,0 +1,35 @@
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src="http://127.0.0.1:8000/resources/checkResourcePriority.js"></script>
+
+<script>
+  const tests = [
+    // Dynamically-inserted <script> tests.
+    {description: 'high fetchPriority on dynamically-inserted <script>s translates to very high resource load priority', fetchPriority: 'high', expected_priority: "ResourceLoadPriorityVeryHigh"},
+    {description: 'low fetchPriority on dynamically-inserted <script>s  translates to medium resource load priority', fetchPriority: 'low', expected_priority: "ResourceLoadPriorityMedium"},
+    {description: 'auto fetchPriority on dynamically-inserted <script>s has no effect on resource load priority', fetchPriority: 'auto', expected_priority: "ResourceLoadPriorityHigh"},
+    {description: 'invalid fetchPriority on dynamically-inserted <script>s has no effect on resource load priority', fetchPriority: 'xyz', expected_priority: "ResourceLoadPriorityHigh"},
+    {description: 'missing fetchPriority on dynamically-inserted <script>s has no effect on resource load priority', expected_priority: "ResourceLoadPriorityHigh"},
+
+    // Dynamically-inserted <script type=module> tests.
+    {description: 'high fetchPriority on dynamically-inserted module <script>s translates to very high resource load priority', fetchPriority: 'high', module: true, expected_priority: "ResourceLoadPriorityVeryHigh"},
+    {description: 'low fetchPriority on dynamically-inserted module <script>s translates to medium resource load priority', fetchPriority: 'low', module: true, expected_priority: "ResourceLoadPriorityMedium"},
+    {description: 'auto fetchPriority on dynamically-inserted module <script>s has no effect on resource load priority', fetchPriority: 'auto', module: true, expected_priority: "ResourceLoadPriorityHigh"},
+    {description: 'invalid fetchPriority on dynamically-inserted module <script>s has no effect on resource load priority', fetchPriority: 'xyz', module: true, expected_priority: "ResourceLoadPriorityHigh"},
+    {description: 'missing fetchPriority on dynamically-inserted module <script>s has no effect on resource load priority', module: true, expected_priority: "ResourceLoadPriorityHigh"}
+  ];
+
+  let iteration = 0;
+  for (const test of tests) {
+    async_test(t => {
+      const script = document.createElement('script');
+      if (test.fetchPriority) script.fetchPriority = test.fetchPriority;
+      if (test.module) script.type = "module";
+
+      const url = new URL(`../resources/dummy.js?${iteration++}`, location);
+      script.src = url;
+      script.onload = t.step_func(() => { checkResourcePriority(url, test.expected_priority, test.description); t.done(); });
+      document.head.appendChild(script);
+    });
+  }
+</script>

--- a/LayoutTests/http/tests/priority-hints/script-initial-load-expected.txt
+++ b/LayoutTests/http/tests/priority-hints/script-initial-load-expected.txt
@@ -1,0 +1,14 @@
+
+
+PASS all scripts must be fetched by the preload scanner
+PASS script-initial-load
+PASS script-initial-load 1
+PASS script-initial-load 2
+PASS script-initial-load 3
+PASS script-initial-load 4
+PASS script-initial-load 5
+PASS script-initial-load 6
+PASS script-initial-load 7
+PASS script-initial-load 8
+PASS script-initial-load 9
+

--- a/LayoutTests/http/tests/priority-hints/script-initial-load.html
+++ b/LayoutTests/http/tests/priority-hints/script-initial-load.html
@@ -1,0 +1,91 @@
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src="http://127.0.0.1:8000/resources/slow-script.pl?delay=100"></script>
+<script src="http://127.0.0.1:8000/resources/checkResourcePriority.js"></script>
+
+<script>
+const priority_tests = [
+  {
+    url: new URL('../resources/dummy.js', location), expected_priority: "ResourceLoadPriorityVeryHigh",
+    description: 'high fetchpriority on <script> must translate to very high resource load priority'
+  },
+  {
+    url: new URL('../resources/dummy.js?1', location), expected_priority: "ResourceLoadPriorityMedium",
+    description: 'low fetchpriority on <script> must translate to medium resource load priority'
+  },
+  {
+    url: new URL('../resources/dummy.js?2', location), expected_priority: "ResourceLoadPriorityHigh",
+    description: 'auto fetchpriority on <script> must translate to high resource load priority'
+  },
+  {
+    url: new URL('../resources/dummy.js?3', location), expected_priority: "ResourceLoadPriorityHigh",
+    description: 'invalid fetchpriority on <script> must translate to high resource load priority'
+  },
+  {
+    url: new URL('../resources/dummy.js?4', location), expected_priority: "ResourceLoadPriorityHigh",
+    description: 'missing fetchpriority on <script> must translate to high resource load priority'
+  },
+  {
+    url: new URL('../resources/dummy.js?6', location), expected_priority: "ResourceLoadPriorityVeryHigh",
+    description: 'high fetchpriority on late-body <script> raises priority to very high'
+  },
+  {
+    url: new URL('../resources/dummy.js?7', location), expected_priority: "ResourceLoadPriorityMedium",
+    description: 'low fetchpriority on late-body <script> lowers priority to medium'
+  },
+  {
+    url: new URL('../resources/dummy.js?8', location), expected_priority: "ResourceLoadPriorityHigh",
+    description: 'auto fetchpriority on late-body <script> has no effect (high)'
+  },
+  {
+    url: new URL('../resources/dummy.js?9', location), expected_priority: "ResourceLoadPriorityHigh",
+    description: 'invalid fetchpriority on late-body <script> has no effect (high)'
+  },
+  {
+    url: new URL('../resources/dummy.js?10', location), expected_priority: "ResourceLoadPriorityHigh",
+    description: 'missing fetchpriority on late-body <script> has no effect (high)'
+  }
+];
+
+</script>
+
+<script id=script1 fetchpriority=high src=../resources/dummy.js></script>
+<script id=script2 fetchpriority=low src=../resources/dummy.js?1></script>
+<script id=script3 fetchpriority=auto src=../resources/dummy.js?2></script>
+<script id=script4 fetchpriority=xyz src=../resources/dummy.js?3></script>
+<script id=script5 src=../resources/dummy.js?4></script>
+
+<script>
+  promise_test(async (t) => {
+    await new Promise(resolve => {
+      addEventListener('DOMContentLoaded', resolve);
+    });
+
+    const base_msg = " was fetched by the preload scanner";
+    assert_true(internals.isPreloaded(script1.src), script1.src + base_msg);
+    assert_true(internals.isPreloaded(script2.src), script2.src + base_msg);
+    assert_true(internals.isPreloaded(script3.src), script3.src + base_msg);
+    assert_true(internals.isPreloaded(script4.src), script4.src + base_msg);
+    assert_true(internals.isPreloaded(script5.src), script5.src + base_msg);
+  }, 'all scripts must be fetched by the preload scanner');
+
+  // Setup the tests described by |priority_tests|.
+  for (const test of priority_tests) {
+    async_test(t => {
+      checkResourcePriority(test.url, test.expected_priority, test.description);
+      t.done();
+    });
+  }
+</script>
+
+<body>
+<!-- Dummy Image to delineate late-body -->
+<img src="../resources/square.png">
+
+<script id=script6 fetchpriority=high src=../resources/dummy.js?6></script>
+<script id=script7 fetchpriority=low src=../resources/dummy.js?7></script>
+<script id=script8 fetchpriority=auto src=../resources/dummy.js?8></script>
+<script id=script9 fetchpriority=xyz src=../resources/dummy.js?9></script>
+<script id=script10 src=../resources/dummy.js?10></script>
+
+</body>

--- a/LayoutTests/http/tests/priority-hints/script-module-initial-load-expected.txt
+++ b/LayoutTests/http/tests/priority-hints/script-module-initial-load-expected.txt
@@ -1,0 +1,8 @@
+
+PASS all scripts were fetched by the preload scanner
+PASS script-module-initial-load
+PASS script-module-initial-load 1
+PASS script-module-initial-load 2
+PASS script-module-initial-load 3
+PASS script-module-initial-load 4
+

--- a/LayoutTests/http/tests/priority-hints/script-module-initial-load.html
+++ b/LayoutTests/http/tests/priority-hints/script-module-initial-load.html
@@ -1,0 +1,60 @@
+<script src=../resources/testharness.js></script>
+<script src=../resources/testharnessreport.js></script>
+<script src="http://127.0.0.1:8000/resources/slow-script.pl?delay=100"></script>
+<script src="http://127.0.0.1:8000/resources/checkResourcePriority.js"></script>
+
+<script>
+const priority_tests = [
+  {
+    url: new URL('../resources/dummy.js', location),
+    expected_priority: "ResourceLoadPriorityVeryHigh",
+    description: 'high fetchpriority on module <script> raises the priority to very high'
+  },
+  {
+    url: new URL('../resources/dummy.js?1', location),
+    expected_priority: "ResourceLoadPriorityMedium",
+    description: 'low fetchpriority on module <script> lowers the priority to medium'
+  },
+  {
+    url: new URL('../resources/dummy.js?2', location),
+    expected_priority: "ResourceLoadPriorityHigh",
+    description: 'auto fetchpriority on module <script> has no effect'
+  },
+  {
+    url: new URL('../resources/dummy.js?3', location),
+    expected_priority: "ResourceLoadPriorityHigh",
+    description: 'invalid fetchpriority on module <script> has no effect'
+  },
+  {
+    url: new URL('../resources/dummy.js?4', location),
+    expected_priority: "ResourceLoadPriorityHigh",
+    description: 'missing fetchpriority on module <script> has no effect'
+  },
+];
+
+</script>
+
+<script id=script1 type=module fetchpriority=high src=../resources/dummy.js></script>
+<script id=script2 type=module fetchpriority=low src=../resources/dummy.js?1></script>
+<script id=script3 type=module fetchpriority=auto src=../resources/dummy.js?2></script>
+<script id=script4 type=module fetchpriority=xyz src=../resources/dummy.js?3></script>
+<script id=script5 type=module src=../resources/dummy.js?4></script>
+
+<script>
+  promise_test(async (t) => {
+    const base_msg = ' was fetched by the preload scanner';
+    assert_true(internals.isPreloaded(script1.src), script1.src + base_msg);
+    assert_true(internals.isPreloaded(script2.src), script2.src + base_msg);
+    assert_true(internals.isPreloaded(script3.src), script3.src + base_msg);
+    assert_true(internals.isPreloaded(script4.src), script4.src + base_msg);
+    assert_true(internals.isPreloaded(script5.src), script5.src + base_msg);
+  }, 'all scripts were fetched by the preload scanner');
+
+  // Setup the tests described by |priority_tests|.
+  for (const test of priority_tests) {
+    async_test(t => {
+      checkResourcePriority(test.url, test.expected_priority, test.description);
+      t.done();
+    });
+  }
+</script>

--- a/LayoutTests/http/tests/resources/checkResourcePriority.js
+++ b/LayoutTests/http/tests/resources/checkResourcePriority.js
@@ -1,0 +1,3 @@
+function checkResourcePriority(url, value, desciption) {
+  assert_equals(internals.getResourcePriority(url), value, desciption);
+}

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -184,6 +184,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/fetch/FetchLoader.h
     Modules/fetch/FetchLoaderClient.h
     Modules/fetch/FetchRequestCredentials.h
+    Modules/fetch/RequestPriority.h
 
     Modules/filesystemaccess/FileSystemDirectoryHandle.h
     Modules/filesystemaccess/FileSystemFileHandle.h

--- a/Source/WebCore/Modules/fetch/FetchLoader.cpp
+++ b/Source/WebCore/Modules/fetch/FetchLoader.cpp
@@ -96,6 +96,7 @@ void FetchLoader::start(ScriptExecutionContext& context, const FetchRequest& req
     options.sameOriginDataURLFlag = SameOriginDataURLFlag::Set;
     options.navigationPreloadIdentifier = request.navigationPreloadIdentifier();
     options.contentEncodingSniffingPolicy = ContentEncodingSniffingPolicy::Disable;
+    options.fetchPriorityHint = request.fetchPriorityHint();
 
     ResourceRequest fetchRequest = request.resourceRequest();
 

--- a/Source/WebCore/Modules/fetch/FetchRequest.h
+++ b/Source/WebCore/Modules/fetch/FetchRequest.h
@@ -87,6 +87,8 @@ public:
     FetchIdentifier navigationPreloadIdentifier() const { return m_navigationPreloadIdentifier; }
     void setNavigationPreloadIdentifier(FetchIdentifier identifier) { m_navigationPreloadIdentifier = identifier; }
 
+    RequestPriority fetchPriorityHint() const { return m_fetchPriorityHint; }
+
 private:
     FetchRequest(ScriptExecutionContext&, std::optional<FetchBody>&&, Ref<FetchHeaders>&&, ResourceRequest&&, FetchOptions&&, String&& referrer);
 
@@ -102,6 +104,7 @@ private:
     ResourceRequest m_request;
     URLKeepingBlobAlive m_requestURL;
     FetchOptions m_options;
+    RequestPriority m_fetchPriorityHint { RequestPriority::Auto };
     String m_referrer;
     Ref<AbortSignal> m_signal;
     FetchIdentifier m_navigationPreloadIdentifier;

--- a/Source/WebCore/Modules/fetch/RequestPriority.h
+++ b/Source/WebCore/Modules/fetch/RequestPriority.h
@@ -28,4 +28,6 @@ namespace WebCore {
 
 enum class RequestPriority : uint8_t { High, Low, Auto };
 
+static constexpr unsigned bitWidthOfFetchPriorityHint = 2;
+
 }

--- a/Source/WebCore/bindings/js/CachedScriptFetcher.cpp
+++ b/Source/WebCore/bindings/js/CachedScriptFetcher.cpp
@@ -58,6 +58,7 @@ CachedResourceHandle<CachedScript> CachedScriptFetcher::requestScriptWithCache(D
     options.sameOriginDataURLFlag = SameOriginDataURLFlag::Set;
     options.integrity = WTFMove(integrity);
     options.referrerPolicy = m_referrerPolicy;
+    options.fetchPriorityHint = m_fetchPriorityHint;
     options.nonce = m_nonce;
 
     auto request = createPotentialAccessControlRequest(sourceURL, WTFMove(options), document, crossOriginMode);

--- a/Source/WebCore/bindings/js/CachedScriptFetcher.h
+++ b/Source/WebCore/bindings/js/CachedScriptFetcher.h
@@ -27,6 +27,7 @@
 
 #include "CachedResourceHandle.h"
 #include "ReferrerPolicy.h"
+#include "RequestPriority.h"
 #include "ResourceLoadPriority.h"
 #include <JavaScriptCore/ScriptFetcher.h>
 #include <wtf/text/WTFString.h>
@@ -43,12 +44,13 @@ public:
     static Ref<CachedScriptFetcher> create(const String& charset);
 
 protected:
-    CachedScriptFetcher(const String& nonce, ReferrerPolicy referrerPolicy, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree)
+    CachedScriptFetcher(const String& nonce, ReferrerPolicy referrerPolicy, RequestPriority fetchPriorityHint, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree)
         : m_nonce(nonce)
         , m_charset(charset)
         , m_initiatorType(initiatorType)
         , m_isInUserAgentShadowTree(isInUserAgentShadowTree)
         , m_referrerPolicy(referrerPolicy)
+        , m_fetchPriorityHint(fetchPriorityHint)
     {
     }
 
@@ -65,6 +67,7 @@ private:
     AtomString m_initiatorType;
     bool m_isInUserAgentShadowTree { false };
     ReferrerPolicy m_referrerPolicy { ReferrerPolicy::EmptyString };
+    RequestPriority m_fetchPriorityHint { RequestPriority::Auto };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/InlineClassicScript.cpp
+++ b/Source/WebCore/dom/InlineClassicScript.cpp
@@ -44,7 +44,7 @@ Ref<InlineClassicScript> InlineClassicScript::create(ScriptElement& scriptElemen
 }
 
 InlineClassicScript::InlineClassicScript(const AtomString& nonce, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree)
-    : ScriptElementCachedScriptFetcher(nonce, ReferrerPolicy::EmptyString, crossOriginMode, charset, initiatorType, isInUserAgentShadowTree)
+    : ScriptElementCachedScriptFetcher(nonce, ReferrerPolicy::EmptyString, RequestPriority::Auto, crossOriginMode, charset, initiatorType, isInUserAgentShadowTree)
 {
 }
 

--- a/Source/WebCore/dom/LoadableClassicScript.cpp
+++ b/Source/WebCore/dom/LoadableClassicScript.cpp
@@ -38,8 +38,8 @@
 
 namespace WebCore {
 
-LoadableNonModuleScriptBase::LoadableNonModuleScriptBase(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy policy, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree, bool isAsync)
-    : LoadableScript(nonce, policy, crossOriginMode, charset, initiatorType, isInUserAgentShadowTree)
+LoadableNonModuleScriptBase::LoadableNonModuleScriptBase(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy policy, RequestPriority fetchPriorityHint,  const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree, bool isAsync)
+    : LoadableScript(nonce, policy, fetchPriorityHint, crossOriginMode, charset, initiatorType, isInUserAgentShadowTree)
     , m_integrity(integrity)
     , m_isAsync(isAsync)
 {
@@ -157,13 +157,13 @@ bool LoadableNonModuleScriptBase::load(Document& document, const URL& sourceURL)
     return true;
 }
 
-Ref<LoadableClassicScript> LoadableClassicScript::create(const AtomString& nonce, const AtomString& integrityMetadata, ReferrerPolicy policy, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree, bool isAsync)
+Ref<LoadableClassicScript> LoadableClassicScript::create(const AtomString& nonce, const AtomString& integrityMetadata, ReferrerPolicy policy, RequestPriority fetchPriorityHint, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree, bool isAsync)
 {
-    return adoptRef(*new LoadableClassicScript(nonce, integrityMetadata, policy, crossOriginMode, charset, initiatorType, isInUserAgentShadowTree, isAsync));
+    return adoptRef(*new LoadableClassicScript(nonce, integrityMetadata, policy, fetchPriorityHint, crossOriginMode, charset, initiatorType, isInUserAgentShadowTree, isAsync));
 }
 
-LoadableClassicScript::LoadableClassicScript(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy policy, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree, bool isAsync)
-    : LoadableNonModuleScriptBase(nonce, integrity, policy, crossOriginMode, charset, initiatorType, isInUserAgentShadowTree, isAsync)
+LoadableClassicScript::LoadableClassicScript(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy policy, RequestPriority fetchPriorityHint, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree, bool isAsync)
+    : LoadableNonModuleScriptBase(nonce, integrity, policy, fetchPriorityHint, crossOriginMode, charset, initiatorType, isInUserAgentShadowTree, isAsync)
 {
 }
 

--- a/Source/WebCore/dom/LoadableClassicScript.h
+++ b/Source/WebCore/dom/LoadableClassicScript.h
@@ -57,7 +57,7 @@ public:
     const AtomString& integrity() const { return m_integrity; }
 
 protected:
-    LoadableNonModuleScriptBase(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree, bool isAsync);
+    LoadableNonModuleScriptBase(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, RequestPriority, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree, bool isAsync);
 
 private:
     void notifyFinished(CachedResource&, const NetworkLoadMetrics&) final;
@@ -73,14 +73,14 @@ protected:
 
 class LoadableClassicScript final : public LoadableNonModuleScriptBase {
 public:
-    static Ref<LoadableClassicScript> create(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree, bool isAsync);
+    static Ref<LoadableClassicScript> create(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, RequestPriority, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree, bool isAsync);
 
     ScriptType scriptType() const final { return ScriptType::Classic; }
 
     void execute(ScriptElement&) final;
 
 private:
-    LoadableClassicScript(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree, bool isAsync);
+    LoadableClassicScript(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, RequestPriority, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree, bool isAsync);
 };
 
 }

--- a/Source/WebCore/dom/LoadableImportMap.cpp
+++ b/Source/WebCore/dom/LoadableImportMap.cpp
@@ -42,7 +42,7 @@ Ref<LoadableImportMap> LoadableImportMap::create(const AtomString& nonce, const 
 }
 
 LoadableImportMap::LoadableImportMap(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy policy, const AtomString& crossOriginMode, const AtomString& initiatorType, bool isInUserAgentShadowTree, bool isAsync)
-    : LoadableNonModuleScriptBase(nonce, integrity, policy, crossOriginMode, "utf-8"_s, initiatorType, isInUserAgentShadowTree, isAsync)
+    : LoadableNonModuleScriptBase(nonce, integrity, policy, RequestPriority::Auto, crossOriginMode, "utf-8"_s, initiatorType, isInUserAgentShadowTree, isAsync)
 {
 }
 

--- a/Source/WebCore/dom/LoadableModuleScript.cpp
+++ b/Source/WebCore/dom/LoadableModuleScript.cpp
@@ -34,13 +34,13 @@
 
 namespace WebCore {
 
-Ref<LoadableModuleScript> LoadableModuleScript::create(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy policy, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree)
+Ref<LoadableModuleScript> LoadableModuleScript::create(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy policy, RequestPriority fetchPriorityHint, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree)
 {
-    return adoptRef(*new LoadableModuleScript(nonce, integrity, policy, crossOriginMode, charset, initiatorType, isInUserAgentShadowTree));
+    return adoptRef(*new LoadableModuleScript(nonce, integrity, policy, fetchPriorityHint, crossOriginMode, charset, initiatorType, isInUserAgentShadowTree));
 }
 
-LoadableModuleScript::LoadableModuleScript(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy policy, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree)
-    : LoadableScript(nonce, policy, crossOriginMode, charset, initiatorType, isInUserAgentShadowTree)
+LoadableModuleScript::LoadableModuleScript(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy policy, RequestPriority fetchPriorityHint, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree)
+    : LoadableScript(nonce, policy, fetchPriorityHint, crossOriginMode, charset, initiatorType, isInUserAgentShadowTree)
     , m_parameters(ModuleFetchParameters::create(JSC::ScriptFetchParameters::Type::JavaScript, integrity, /* isTopLevelModule */ true))
 {
 }

--- a/Source/WebCore/dom/LoadableModuleScript.h
+++ b/Source/WebCore/dom/LoadableModuleScript.h
@@ -38,7 +38,7 @@ class LoadableModuleScript final : public LoadableScript {
 public:
     virtual ~LoadableModuleScript();
 
-    static Ref<LoadableModuleScript> create(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree);
+    static Ref<LoadableModuleScript> create(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, RequestPriority, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree);
 
     bool isLoaded() const final;
     bool hasError() const final;
@@ -58,7 +58,7 @@ public:
     ModuleFetchParameters& parameters() { return m_parameters.get(); }
 
 private:
-    LoadableModuleScript(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree);
+    LoadableModuleScript(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, RequestPriority, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree);
 
     Ref<ModuleFetchParameters> m_parameters;
     RefPtr<UniquedStringImpl> m_moduleKey;

--- a/Source/WebCore/dom/LoadableScript.h
+++ b/Source/WebCore/dom/LoadableScript.h
@@ -58,8 +58,8 @@ public:
     void removeClient(LoadableScriptClient&);
 
 protected:
-    LoadableScript(const AtomString& nonce, ReferrerPolicy policy, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree)
-        : ScriptElementCachedScriptFetcher(nonce, policy, crossOriginMode, charset, initiatorType, isInUserAgentShadowTree)
+    LoadableScript(const AtomString& nonce, ReferrerPolicy policy, RequestPriority fetchPriority, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree)
+        : ScriptElementCachedScriptFetcher(nonce, policy, fetchPriority, crossOriginMode, charset, initiatorType, isInUserAgentShadowTree)
     {
     }
 

--- a/Source/WebCore/dom/ScriptElement.cpp
+++ b/Source/WebCore/dom/ScriptElement.cpp
@@ -316,7 +316,7 @@ bool ScriptElement::requestClassicScript(const String& sourceURL)
     ASSERT(m_element.isConnected());
     ASSERT(!m_loadableScript);
     if (!stripLeadingAndTrailingHTMLSpaces(sourceURL).isEmpty()) {
-        auto script = LoadableClassicScript::create(m_element.nonce(), m_element.attributeWithoutSynchronization(HTMLNames::integrityAttr), referrerPolicy(),
+        auto script = LoadableClassicScript::create(m_element.nonce(), m_element.attributeWithoutSynchronization(HTMLNames::integrityAttr), referrerPolicy(), fetchPriorityHint(),
             m_element.attributeWithoutSynchronization(HTMLNames::crossoriginAttr), scriptCharset(), m_element.localName(), m_element.isInUserAgentShadowTree(), hasAsyncAttribute());
 
         auto scriptURL = m_element.document().completeURL(sourceURL);
@@ -366,7 +366,7 @@ bool ScriptElement::requestModuleScript(const TextPosition& scriptStartPosition)
         }
 
         m_isExternalScript = true;
-        auto script = LoadableModuleScript::create(nonce, m_element.attributeWithoutSynchronization(HTMLNames::integrityAttr), referrerPolicy(), crossOriginMode,
+        auto script = LoadableModuleScript::create(nonce, m_element.attributeWithoutSynchronization(HTMLNames::integrityAttr), referrerPolicy(), fetchPriorityHint(), crossOriginMode,
             scriptCharset(), m_element.localName(), m_element.isInUserAgentShadowTree());
         m_loadableScript = WTFMove(script);
         if (auto* frame = m_element.document().frame()) {
@@ -376,7 +376,7 @@ bool ScriptElement::requestModuleScript(const TextPosition& scriptStartPosition)
         return true;
     }
 
-    auto script = LoadableModuleScript::create(nonce, emptyAtom(), referrerPolicy(), crossOriginMode, scriptCharset(), m_element.localName(), m_element.isInUserAgentShadowTree());
+    auto script = LoadableModuleScript::create(nonce, emptyAtom(), referrerPolicy(), fetchPriorityHint(), crossOriginMode, scriptCharset(), m_element.localName(), m_element.isInUserAgentShadowTree());
 
     TextPosition position = m_element.document().isInDocumentWrite() ? TextPosition() : scriptStartPosition;
     ScriptSourceCode sourceCode(scriptContent(), URL(m_element.document().url()), position, JSC::SourceProviderSourceType::Module, script.copyRef());

--- a/Source/WebCore/dom/ScriptElement.h
+++ b/Source/WebCore/dom/ScriptElement.h
@@ -25,6 +25,7 @@
 #include "ContentSecurityPolicy.h"
 #include "LoadableScript.h"
 #include "ReferrerPolicy.h"
+#include "RequestPriority.h"
 #include "ScriptExecutionContextIdentifier.h"
 #include "ScriptType.h"
 #include "UserGestureIndicator.h"
@@ -121,6 +122,7 @@ private:
     virtual String forAttributeValue() const = 0;
     virtual String eventAttributeValue() const = 0;
     virtual ReferrerPolicy referrerPolicy() const = 0;
+    virtual RequestPriority fetchPriorityHint() const { return RequestPriority::Auto; }
 
     Element& m_element;
     OrdinalNumber m_startLineNumber { OrdinalNumber::beforeFirst() };

--- a/Source/WebCore/dom/ScriptElementCachedScriptFetcher.h
+++ b/Source/WebCore/dom/ScriptElementCachedScriptFetcher.h
@@ -44,8 +44,8 @@ public:
     const String& crossOriginMode() const { return m_crossOriginMode; }
 
 protected:
-    ScriptElementCachedScriptFetcher(const AtomString& nonce, ReferrerPolicy policy, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree)
-        : CachedScriptFetcher(nonce, policy, charset, initiatorType, isInUserAgentShadowTree)
+    ScriptElementCachedScriptFetcher(const AtomString& nonce, ReferrerPolicy policy, RequestPriority fetchPriority, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree)
+        : CachedScriptFetcher(nonce, policy, fetchPriority, charset, initiatorType, isInUserAgentShadowTree)
         , m_crossOriginMode(crossOriginMode)
     {
     }

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -1028,7 +1028,12 @@ void HTMLImageElement::setFetchPriorityForBindings(const AtomString& value)
 
 String HTMLImageElement::fetchPriorityForBindings() const
 {
-    return convertEnumerationToString(parseEnumerationFromString<RequestPriority>(attributeWithoutSynchronization(fetchpriorityAttr)).value_or(RequestPriority::Auto));
+    return convertEnumerationToString(fetchPriorityHint());
+}
+
+RequestPriority HTMLImageElement::fetchPriorityHint() const
+{
+    return parseEnumerationFromString<RequestPriority>(attributeWithoutSynchronization(fetchpriorityAttr)).value_or(RequestPriority::Auto);
 }
 
 }

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -45,6 +45,7 @@ struct ImageCandidate;
 
 enum class ReferrerPolicy : uint8_t;
 enum class RelevantMutation : bool;
+enum class RequestPriority : uint8_t;
 
 class HTMLImageElement : public HTMLElement, public FormAssociatedElement, public ActiveDOMObject {
     WTF_MAKE_ISO_ALLOCATED(HTMLImageElement);
@@ -169,6 +170,7 @@ public:
 
     void setFetchPriorityForBindings(const AtomString&);
     String fetchPriorityForBindings() const;
+    RequestPriority fetchPriorityHint() const;
 
 protected:
     constexpr static auto CreateHTMLImageElement = CreateHTMLElement | NodeFlag::HasCustomStyleResolveCallbacks;

--- a/Source/WebCore/html/HTMLLinkElement.cpp
+++ b/Source/WebCore/html/HTMLLinkElement.cpp
@@ -270,6 +270,7 @@ void HTMLLinkElement::process()
         attributeWithoutSynchronization(imagesizesAttr),
         nonce(),
         referrerPolicy(),
+        fetchPriorityHint(),
     };
 
     m_linkLoader.loadLink(params, document());
@@ -326,6 +327,7 @@ void HTMLLinkElement::process()
             options.contentSecurityPolicyImposition = ContentSecurityPolicyImposition::SkipPolicyCheck;
         options.integrity = m_integrityMetadataForPendingSheetRequest;
         options.referrerPolicy = params.referrerPolicy;
+        options.fetchPriorityHint = fetchPriorityHint();
 
         auto request = createPotentialAccessControlRequest(m_url, WTFMove(options), document(), crossOrigin());
         request.setPriority(WTFMove(priority));
@@ -686,7 +688,12 @@ void HTMLLinkElement::setFetchPriorityForBindings(const AtomString& value)
 
 String HTMLLinkElement::fetchPriorityForBindings() const
 {
-    return convertEnumerationToString(parseEnumerationFromString<RequestPriority>(attributeWithoutSynchronization(fetchpriorityAttr)).value_or(RequestPriority::Auto));
+    return convertEnumerationToString(fetchPriorityHint());
+}
+
+RequestPriority HTMLLinkElement::fetchPriorityHint() const
+{
+    return parseEnumerationFromString<RequestPriority>(attributeWithoutSynchronization(fetchpriorityAttr)).value_or(RequestPriority::Auto);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLLinkElement.h
+++ b/Source/WebCore/html/HTMLLinkElement.h
@@ -39,6 +39,8 @@ class HTMLLinkElement;
 class Page;
 struct MediaQueryParserContext;
 
+enum class RequestPriority : uint8_t;
+
 template<typename T, typename Counter> class EventSender;
 using LinkEventSender = EventSender<HTMLLinkElement, WeakPtrImplWithEventTargetData>;
 
@@ -93,6 +95,7 @@ public:
 
     void setFetchPriorityForBindings(const AtomString&);
     String fetchPriorityForBindings() const;
+    RequestPriority fetchPriorityHint() const;
 
 private:
     void parseAttribute(const QualifiedName&, const AtomString&) final;

--- a/Source/WebCore/html/HTMLScriptElement.cpp
+++ b/Source/WebCore/html/HTMLScriptElement.cpp
@@ -212,7 +212,12 @@ void HTMLScriptElement::setFetchPriorityForBindings(const AtomString& value)
 
 String HTMLScriptElement::fetchPriorityForBindings() const
 {
-    return convertEnumerationToString(parseEnumerationFromString<RequestPriority>(attributeWithoutSynchronization(fetchpriorityAttr)).value_or(RequestPriority::Auto));
+    return convertEnumerationToString(fetchPriorityHint());
+}
+
+RequestPriority HTMLScriptElement::fetchPriorityHint() const
+{
+    return parseEnumerationFromString<RequestPriority>(attributeWithoutSynchronization(fetchpriorityAttr)).value_or(RequestPriority::Auto);
 }
 
 }

--- a/Source/WebCore/html/HTMLScriptElement.h
+++ b/Source/WebCore/html/HTMLScriptElement.h
@@ -28,6 +28,8 @@
 
 namespace WebCore {
 
+enum class RequestPriority : uint8_t;
+
 class HTMLScriptElement final : public HTMLElement, public ScriptElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLScriptElement);
 public:
@@ -55,6 +57,7 @@ public:
 
     void setFetchPriorityForBindings(const AtomString&);
     String fetchPriorityForBindings() const;
+    RequestPriority fetchPriorityHint() const override;
 
 private:
     HTMLScriptElement(const QualifiedName&, Document&, bool wasInsertedByParser, bool alreadyStarted);

--- a/Source/WebCore/html/parser/HTMLResourcePreloader.cpp
+++ b/Source/WebCore/html/parser/HTMLResourcePreloader.cpp
@@ -64,6 +64,7 @@ CachedResourceRequest PreloadRequest::resourceRequest(Document& document)
     }
     if (m_resourceType == CachedResource::Type::Script || m_resourceType == CachedResource::Type::ImageResource)
         options.referrerPolicy = m_referrerPolicy;
+    options.fetchPriorityHint = m_fetchPriorityHint;
     auto request = createPotentialAccessControlRequest(completeURL(document), WTFMove(options), document, crossOriginMode);
     request.setInitiatorType(m_initiatorType);
 

--- a/Source/WebCore/html/parser/HTMLResourcePreloader.h
+++ b/Source/WebCore/html/parser/HTMLResourcePreloader.h
@@ -34,7 +34,7 @@ namespace WebCore {
 class PreloadRequest {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    PreloadRequest(ASCIILiteral initiatorType, const String& resourceURL, const URL& baseURL, CachedResource::Type resourceType, const String& mediaAttribute, ScriptType scriptType, const ReferrerPolicy& referrerPolicy)
+    PreloadRequest(ASCIILiteral initiatorType, const String& resourceURL, const URL& baseURL, CachedResource::Type resourceType, const String& mediaAttribute, ScriptType scriptType, const ReferrerPolicy& referrerPolicy, RequestPriority fetchPriorityHint = RequestPriority::Auto)
         : m_initiatorType(initiatorType)
         , m_resourceURL(resourceURL)
         , m_baseURL(baseURL.isolatedCopy())
@@ -42,6 +42,7 @@ public:
         , m_mediaAttribute(mediaAttribute)
         , m_scriptType(scriptType)
         , m_referrerPolicy(referrerPolicy)
+        , m_fetchPriorityHint(fetchPriorityHint)
     {
     }
 
@@ -69,6 +70,7 @@ private:
     bool m_scriptIsAsync { false };
     ScriptType m_scriptType;
     ReferrerPolicy m_referrerPolicy;
+    RequestPriority m_fetchPriorityHint;
 };
 
 typedef Vector<std::unique_ptr<PreloadRequest>> PreloadRequestStream;

--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -194,6 +194,7 @@ void ImageLoader::updateFromElement(RelevantMutation relevantMutation)
         if (isImageElement) {
             auto& imageElement = downcast<HTMLImageElement>(element());
             options.referrerPolicy = imageElement.referrerPolicy();
+            options.fetchPriorityHint = imageElement.fetchPriorityHint();
             if (imageElement.usesSrcsetOrPicture())
                 options.initiator = Initiator::Imageset;
         }

--- a/Source/WebCore/loader/LinkHeader.cpp
+++ b/Source/WebCore/loader/LinkHeader.cpp
@@ -160,7 +160,9 @@ static LinkHeader::LinkParameterName parameterNameFromString(StringView name)
     if (equalLettersIgnoringASCIICase(name, "nonce"_s))
         return LinkHeader::LinkParameterNonce;
     if (equalLettersIgnoringASCIICase(name, "referrerpolicy"_s))
-        return LinkHeader::LinkParameterReferrerPolicy;  
+        return LinkHeader::LinkParameterReferrerPolicy;
+    if (equalLettersIgnoringASCIICase(name, "fetchpriority"_s))
+        return LinkHeader::LinkParameterFetchPriority;
     return LinkHeader::LinkParameterUnknown;
 }
 
@@ -289,6 +291,9 @@ void LinkHeader::setValue(LinkParameterName name, String&& value)
         break;
     case LinkParameterReferrerPolicy:
         m_referrerPolicy = WTFMove(value);
+        break;
+    case LinkParameterFetchPriority:
+        m_fetchPriorityHint = WTFMove(value);
         break;
     case LinkParameterTitle:
     case LinkParameterRev:

--- a/Source/WebCore/loader/LinkHeader.h
+++ b/Source/WebCore/loader/LinkHeader.h
@@ -46,6 +46,7 @@ public:
     const String& imageSizes() const { return m_imageSizes; }
     const String& nonce() const { return m_nonce; }
     const String& referrerPolicy() const { return m_referrerPolicy; }
+    const String& fetchPriorityHint() const { return m_fetchPriorityHint; }
     bool valid() const { return m_isValid; }
     bool isViewportDependent() const { return !media().isEmpty() || !imageSrcSet().isEmpty() || !imageSizes().isEmpty(); }
 
@@ -65,6 +66,7 @@ public:
         LinkParameterImageSizes,
         LinkParameterNonce,
         LinkParameterReferrerPolicy,
+        LinkParameterFetchPriority,
     };
 
 private:
@@ -80,6 +82,7 @@ private:
     String m_imageSizes;
     String m_nonce;
     String m_referrerPolicy;
+    String m_fetchPriorityHint;
     bool m_isValid { true };
 };
 

--- a/Source/WebCore/loader/LinkLoader.cpp
+++ b/Source/WebCore/loader/LinkLoader.cpp
@@ -121,7 +121,8 @@ void LinkLoader::loadLinksFromHeader(const String& headerValue, const URL& baseU
             continue;
 
         LinkLoadParameters params { relAttribute, url, header.as(), header.media(), header.mimeType(), header.crossOrigin(), header.imageSrcSet(), header.imageSizes(), header.nonce(),
-            parseReferrerPolicy(header.referrerPolicy(), ReferrerPolicySource::ReferrerPolicyAttribute).value_or(ReferrerPolicy::EmptyString) };
+            parseReferrerPolicy(header.referrerPolicy(), ReferrerPolicySource::ReferrerPolicyAttribute).value_or(ReferrerPolicy::EmptyString),
+            parseEnumerationFromString<RequestPriority>(header.fetchPriorityHint()).value_or(RequestPriority::Auto) };
 
         preconnectIfNeeded(params, document);
         preloadIfNeeded(params, document, nullptr);
@@ -330,6 +331,7 @@ std::unique_ptr<LinkPreloadResourceClient> LinkLoader::preloadIfNeeded(const Lin
 
     auto options = CachedResourceLoader::defaultCachedResourceOptions();
     options.referrerPolicy = params.referrerPolicy;
+    options.fetchPriorityHint = params.fetchPriorityHint;
     options.nonce = params.nonce;
 
     auto linkRequest = [&]() {

--- a/Source/WebCore/loader/LinkLoader.h
+++ b/Source/WebCore/loader/LinkLoader.h
@@ -54,6 +54,7 @@ struct LinkLoadParameters {
     String imageSizes;
     String nonce;
     ReferrerPolicy referrerPolicy { ReferrerPolicy::EmptyString };
+    RequestPriority fetchPriorityHint { RequestPriority::Auto };
 };
 
 class LinkLoader : public CachedResourceClient {

--- a/Source/WebCore/loader/ResourceLoaderOptions.h
+++ b/Source/WebCore/loader/ResourceLoaderOptions.h
@@ -36,6 +36,7 @@
 #include "FetchIdentifier.h"
 #include "FetchOptions.h"
 #include "HTTPHeaderNames.h"
+#include "RequestPriority.h"
 #include "ServiceWorkerTypes.h"
 #include "StoredCredentialsPolicy.h"
 #include <wtf/EnumTraits.h>
@@ -190,6 +191,7 @@ struct ResourceLoaderOptions : public FetchOptions {
         , preflightPolicy(PreflightPolicy::Consider)
         , loadedFromOpaqueSource(LoadedFromOpaqueSource::No)
         , loadedFromPluginElement(LoadedFromPluginElement::No)
+        , fetchPriorityHint(RequestPriority::Auto)
     { }
 
     ResourceLoaderOptions(SendCallbackPolicy sendLoadCallbacks, ContentSniffingPolicy sniffContent, DataBufferingPolicy dataBufferingPolicy, StoredCredentialsPolicy storedCredentialsPolicy, ClientCredentialPolicy credentialPolicy, FetchOptions::Credentials credentials, SecurityCheckPolicy securityCheck, FetchOptions::Mode mode, CertificateInfoPolicy certificateInfoPolicy, ContentSecurityPolicyImposition contentSecurityPolicyImposition, DefersLoadingPolicy defersLoadingPolicy, CachingPolicy cachingPolicy)
@@ -212,7 +214,7 @@ struct ResourceLoaderOptions : public FetchOptions {
         , preflightPolicy(PreflightPolicy::Consider)
         , loadedFromOpaqueSource(LoadedFromOpaqueSource::No)
         , loadedFromPluginElement(LoadedFromPluginElement::No)
-
+        , fetchPriorityHint(RequestPriority::Auto)
     {
         this->credentials = credentials;
         this->mode = mode;
@@ -246,6 +248,7 @@ struct ResourceLoaderOptions : public FetchOptions {
     PreflightPolicy preflightPolicy : bitWidthOfPreflightPolicy;
     LoadedFromOpaqueSource loadedFromOpaqueSource : bitWidthOfLoadedFromOpaqueSource;
     LoadedFromPluginElement loadedFromPluginElement : bitWidthOfLoadedFromPluginElement;
+    RequestPriority fetchPriorityHint : bitWidthOfFetchPriorityHint;
 
     FetchIdentifier navigationPreloadIdentifier;
     String nonce;

--- a/Source/WebCore/loader/ThreadableLoader.cpp
+++ b/Source/WebCore/loader/ThreadableLoader.cpp
@@ -99,6 +99,7 @@ ThreadableLoaderOptions ThreadableLoaderOptions::isolatedCopy() const
     copy.maxRedirectCount = this->maxRedirectCount;
     copy.preflightPolicy = this->preflightPolicy;
     copy.navigationPreloadIdentifier = this->navigationPreloadIdentifier;
+    copy.fetchPriorityHint = this->fetchPriorityHint;
 
     // ThreadableLoaderOptions
     copy.contentSecurityPolicyEnforcement = this->contentSecurityPolicyEnforcement;

--- a/Source/WebCore/loader/cache/CachedResource.h
+++ b/Source/WebCore/loader/cache/CachedResource.h
@@ -139,7 +139,7 @@ public:
     static bool shouldUsePingLoad(Type type) { return type == Type::Beacon || type == Type::Ping; }
 
     ResourceLoadPriority loadPriority() const { return m_loadPriority; }
-    void setLoadPriority(const std::optional<ResourceLoadPriority>&);
+    void setLoadPriority(const std::optional<ResourceLoadPriority>&, RequestPriority);
 
     WEBCORE_EXPORT void addClient(CachedResourceClient&);
     WEBCORE_EXPORT void removeClient(CachedResourceClient&);

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -1167,7 +1167,7 @@ ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::requ
             }
 
             if (forPreload == ForPreload::No)
-                resource->setLoadPriority(request.priority());
+                resource->setLoadPriority(request.priority(), request.fetchPriorityHint());
         }
         break;
     }

--- a/Source/WebCore/loader/cache/CachedResourceRequest.h
+++ b/Source/WebCore/loader/cache/CachedResourceRequest.h
@@ -64,6 +64,8 @@ public:
     const std::optional<ResourceLoadPriority>& priority() const { return m_priority; }
     void setPriority(std::optional<ResourceLoadPriority>&& priority) { m_priority = WTFMove(priority); }
 
+    RequestPriority fetchPriorityHint() const { return m_options.fetchPriorityHint; }
+
     void setInitiator(Element&);
     void setInitiatorType(const AtomString&);
     const AtomString& initiatorType() const;

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -988,6 +988,34 @@ void Internals::setStrictRawResourceValidationPolicyDisabled(bool disabled)
     frame()->loader().setStrictRawResourceValidationPolicyDisabledForTesting(disabled);
 }
 
+static Internals::ResourceLoadPriority toInternalsResourceLoadPriority(ResourceLoadPriority priority)
+{
+    switch (priority) {
+    case ResourceLoadPriority::VeryLow:
+        return Internals::ResourceLoadPriority::ResourceLoadPriorityVeryLow;
+    case ResourceLoadPriority::Low:
+        return Internals::ResourceLoadPriority::ResourceLoadPriorityLow;
+    case ResourceLoadPriority::Medium:
+        return Internals::ResourceLoadPriority::ResourceLoadPriorityMedium;
+    case ResourceLoadPriority::High:
+        return Internals::ResourceLoadPriority::ResourceLoadPriorityHigh;
+    case ResourceLoadPriority::VeryHigh:
+        return Internals::ResourceLoadPriority::ResourceLoadPriorityVeryHigh;
+    }
+    ASSERT_NOT_REACHED();
+    return Internals::ResourceLoadPriority::ResourceLoadPriorityLow;
+}
+
+std::optional<Internals::ResourceLoadPriority> Internals::getResourcePriority(const String& url)
+{
+    auto* document = contextDocument();
+    if (!document)
+        return std::nullopt;
+    if (auto* resource = document->cachedResourceLoader().cachedResource(url))
+        return toInternalsResourceLoadPriority(resource->loadPriority());
+    return std::nullopt;
+}
+
 bool Internals::isFetchObjectContextStopped(const FetchObject& object)
 {
     return switchOn(object, [](const RefPtr<FetchRequest>& request) {

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -216,6 +216,7 @@ public:
     enum class ResourceLoadPriority { ResourceLoadPriorityVeryLow, ResourceLoadPriorityLow, ResourceLoadPriorityMedium, ResourceLoadPriorityHigh, ResourceLoadPriorityVeryHigh };
     void setOverrideResourceLoadPriority(ResourceLoadPriority);
     void setStrictRawResourceValidationPolicyDisabled(bool);
+    std::optional<ResourceLoadPriority> getResourcePriority(const String& url);
 
     using FetchObject = std::variant<RefPtr<FetchRequest>, RefPtr<FetchResponse>>;
     bool isFetchObjectContextStopped(const FetchObject&);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -386,6 +386,7 @@ typedef (FetchRequest or FetchResponse) FetchObject;
     undefined setOverrideCachePolicy(CachePolicy policy);
     undefined setOverrideResourceLoadPriority(ResourceLoadPriority priority);
     undefined setStrictRawResourceValidationPolicyDisabled(boolean disabled);
+    ResourceLoadPriority? getResourcePriority(DOMString url);
 
     boolean isFetchObjectContextStopped(FetchObject object);
 


### PR DESCRIPTION
#### 69a182bca140bcc4d604dd6eba4ea48a16e9d00a
<pre>
Implement Priority Hints
<a href="https://bugs.webkit.org/show_bug.cgi?id=252739">https://bugs.webkit.org/show_bug.cgi?id=252739</a>

Reviewed by Youenn Fablet.

Implement Priority Hints [1], specifically covering:
- processing the priority hint passed using fetch API [2]
- processing the priority hint for images
- processing the priority hint for scripts, both classic and module
- processing the priority hint for the link element
- processing the priority hint for the link HTTP header
- processing the priority hint in the html resource preloader

Tests are added covering this, including both dynamically inserting
elements (script/image/link) as well as static html.

The actual priority hint functionality consists of decreasing/increasing the
computed priority in the request for fetchpriority=low/high respectively, clamping
to the very low/very high limits.

[1] <a href="https://html.spec.whatwg.org/#fetch-and-process-the-linked-resource">https://html.spec.whatwg.org/#fetch-and-process-the-linked-resource</a>
[2] <a href="https://fetch.spec.whatwg.org/#dom-requestinit-priority">https://fetch.spec.whatwg.org/#dom-requestinit-priority</a>

* LayoutTests/http/tests/priority-hints/fetch-api-priority-expected.txt: Added.
* LayoutTests/http/tests/priority-hints/fetch-api-priority.html: Added.
* LayoutTests/http/tests/priority-hints/image-dynamic-insertion-expected.txt: Added.
* LayoutTests/http/tests/priority-hints/image-dynamic-insertion.html: Added.
* LayoutTests/http/tests/priority-hints/image-initial-load-expected.txt: Added.
* LayoutTests/http/tests/priority-hints/image-initial-load.html: Added.
* LayoutTests/http/tests/priority-hints/link-dynamic-insertion-expected.txt: Added.
* LayoutTests/http/tests/priority-hints/link-dynamic-insertion.html: Added.
* LayoutTests/http/tests/priority-hints/link-header-fetch-priority-expected.txt: Added.
* LayoutTests/http/tests/priority-hints/link-header-fetch-priority.py: Added.
* LayoutTests/http/tests/priority-hints/link-preload-dynamic-insertion-expected.txt: Added.
* LayoutTests/http/tests/priority-hints/link-preload-dynamic-insertion.html: Added.
* LayoutTests/http/tests/priority-hints/link-preload-initial-load-expected.txt: Added.
* LayoutTests/http/tests/priority-hints/link-preload-initial-load.html: Added.
* LayoutTests/http/tests/priority-hints/link-stylesheet-initial-load-expected.txt: Added.
* LayoutTests/http/tests/priority-hints/link-stylesheet-initial-load.html: Added.
* LayoutTests/http/tests/priority-hints/script-async-initial-load-expected.txt: Added.
* LayoutTests/http/tests/priority-hints/script-async-initial-load.html: Added.
* LayoutTests/http/tests/priority-hints/script-dynamic-insertion-expected.txt: Added.
* LayoutTests/http/tests/priority-hints/script-dynamic-insertion.html: Added.
* LayoutTests/http/tests/priority-hints/script-initial-load-expected.txt: Added.
* LayoutTests/http/tests/priority-hints/script-initial-load.html: Added.
* LayoutTests/http/tests/priority-hints/script-module-initial-load-expected.txt: Added.
* LayoutTests/http/tests/priority-hints/script-module-initial-load.html: Added.
* LayoutTests/http/tests/resources/checkResourcePriority.js: Added.
(checkResourcePriority):
* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/fetch/FetchLoader.cpp:
(WebCore::FetchLoader::start):
* Source/WebCore/Modules/fetch/FetchRequest.cpp:
(WebCore::buildOptions):
(WebCore::FetchRequest::initializeOptions):
(WebCore::FetchRequest::initializeWith):
* Source/WebCore/Modules/fetch/FetchRequest.h:
* Source/WebCore/Modules/fetch/RequestPriority.h:
* Source/WebCore/bindings/js/CachedScriptFetcher.cpp:
(WebCore::CachedScriptFetcher::requestScriptWithCache const): pass priority hint to the cached resource request
* Source/WebCore/bindings/js/CachedScriptFetcher.h:
(WebCore::CachedScriptFetcher::CachedScriptFetcher):
* Source/WebCore/dom/InlineClassicScript.cpp:
(WebCore::InlineClassicScript::InlineClassicScript):
* Source/WebCore/dom/LoadableClassicScript.cpp:
(WebCore::LoadableNonModuleScriptBase::LoadableNonModuleScriptBase):
(WebCore::LoadableClassicScript::create):
(WebCore::LoadableClassicScript::LoadableClassicScript):
* Source/WebCore/dom/LoadableClassicScript.h:
* Source/WebCore/dom/LoadableImportMap.cpp:
(WebCore::LoadableImportMap::LoadableImportMap):
* Source/WebCore/dom/LoadableModuleScript.cpp:
(WebCore::LoadableModuleScript::create):
(WebCore::LoadableModuleScript::LoadableModuleScript):
* Source/WebCore/dom/LoadableModuleScript.h:
* Source/WebCore/dom/LoadableScript.h:
(WebCore::LoadableScript::LoadableScript):
* Source/WebCore/dom/ScriptElement.cpp:
(WebCore::ScriptElement::requestClassicScript):
(WebCore::ScriptElement::requestModuleScript):
* Source/WebCore/dom/ScriptElement.h:
(WebCore::ScriptElement::fetchPriorityHint const):
* Source/WebCore/dom/ScriptElementCachedScriptFetcher.h:
(WebCore::ScriptElementCachedScriptFetcher::ScriptElementCachedScriptFetcher):
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::fetchPriorityForBindings const):
(WebCore::HTMLImageElement::fetchPriorityHint const):
* Source/WebCore/html/HTMLImageElement.h:
* Source/WebCore/html/HTMLLinkElement.cpp:
(WebCore::HTMLLinkElement::process): pass priority hint to the cached resource request
(WebCore::HTMLLinkElement::fetchPriorityForBindings const):
(WebCore::HTMLLinkElement::fetchPriorityHint const):
* Source/WebCore/html/HTMLLinkElement.h:
* Source/WebCore/html/HTMLScriptElement.cpp:
(WebCore::HTMLScriptElement::fetchPriorityForBindings const):
(WebCore::HTMLScriptElement::fetchPriorityHint const):
* Source/WebCore/html/HTMLScriptElement.h:
* Source/WebCore/html/parser/HTMLPreloadScanner.cpp:
(WebCore::TokenPreloadScanner::StartTagScanner::createPreloadRequest):
(WebCore::TokenPreloadScanner::StartTagScanner::processAttribute):
* Source/WebCore/html/parser/HTMLResourcePreloader.cpp: handle fetch priority in preloading for image/script/link
(WebCore::PreloadRequest::resourceRequest): pass priority hint to the cached resource request
* Source/WebCore/html/parser/HTMLResourcePreloader.h:
(WebCore::PreloadRequest::PreloadRequest):
* Source/WebCore/loader/ImageLoader.cpp:
(WebCore::ImageLoader::updateFromElement): pass priority hint to the cached resource request
* Source/WebCore/loader/LinkHeader.cpp: parse fetchpriority link header
(WebCore::parameterNameFromString):
(WebCore::LinkHeader::setValue):
* Source/WebCore/loader/LinkHeader.h:
(WebCore::LinkHeader::fetchPriorityHint const):
* Source/WebCore/loader/LinkLoader.cpp:
(WebCore::LinkLoader::loadLinksFromHeader):
(WebCore::LinkLoader::preloadIfNeeded): pass priority hint to the cached resource request
* Source/WebCore/loader/LinkLoader.h:
* Source/WebCore/loader/ResourceLoaderOptions.h:
(WebCore::ResourceLoaderOptions::fetchPriorityHint):
(WebCore::ResourceLoaderOptions::ResourceLoaderOptions):
(WebCore::ResourceLoaderOptions::loadedFromPluginElement): Deleted.
* Source/WebCore/loader/ThreadableLoader.cpp:
(WebCore::ThreadableLoaderOptions::isolatedCopy const):
* Source/WebCore/loader/cache/CachedResource.cpp:
(WebCore::CachedResource::CachedResource):
(WebCore::CachedResource::setLoadPriority): actually calculate final priority taking the hint into account
* Source/WebCore/loader/cache/CachedResource.h:
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::requestResource):
* Source/WebCore/loader/cache/CachedResourceRequest.h:
(WebCore::CachedResourceRequest::fetchPriorityHint const):
* Source/WebCore/testing/Internals.cpp: add API to get the priority used in the resource request
(WebCore::toInternalsResourceLoadPriority):
(WebCore::Internals::getResourcePriority):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/261689@main">https://commits.webkit.org/261689@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d163f99f35f7b9c1e0eda0011b8be6f3e220475

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112557 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21708 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1213 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4332 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121111 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116622 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23046 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12869 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5475 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118324 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100321 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105624 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99066 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/866 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46129 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14045 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/903 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/95224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14727 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20067 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52908 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8147 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16564 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->