### PR TITLE
Implement text-representation for CounterStyle

### DIFF
--- a/Source/WebCore/css/CSSCounterStyle.h
+++ b/Source/WebCore/css/CSSCounterStyle.h
@@ -84,21 +84,22 @@ private:
     bool isInRange(int) const;
     // https://www.w3.org/TR/css-counter-styles-3/#counter-style-negative
     bool usesNegativeSign();
-    bool shouldApplyNegativeSymbols(int);
+    bool shouldApplyNegativeSymbols(int) const;
     // https://www.w3.org/TR/css-counter-styles-3/#counter-style-fallback
-    Ref<CSSCounterStyle> fallback();
+    WeakPtr<CSSCounterStyle> fallback() const { return m_fallbackReference; };
+    String fallbackText(int);
     // Generates a CSSCounterStyle object as it was defined by a 'decimal' descriptor. It is used as a last-resource in case we can't resolve fallback references.
-    void applyPadSymbols(String&);
-    void applyNegativeSymbols(String&);
+    void applyPadSymbols(String&, int) const;
+    void applyNegativeSymbols(String&) const;
     // Initial text representation for the counter, before applying pad and/or negative symbols. Suffix and Prefix are also not considered as described by https://www.w3.org/TR/css-counter-styles-3/#counter-styles.
-    String initialRepresentation(int);
+    String initialRepresentation(int) const;
 
-    String counterForSystemCyclic(int);
-    String counterForSystemFixed(int);
-    String counterForSystemSymbolic(int);
-    String counterForSystemAlphabetic(int);
-    String counterForSystemNumeric(int);
-    String counterForSystemAdditive(int);
+    String counterForSystemCyclic(int) const;
+    String counterForSystemFixed(int) const;
+    String counterForSystemSymbolic(int) const;
+    String counterForSystemAlphabetic(int) const;
+    String counterForSystemNumeric(int) const;
+    String counterForSystemAdditive(int) const;
 
     bool isPredefinedCounterStyle() const { return m_predefinedCounterStyle; }
     bool isAutoRange() const { return ranges().isEmpty(); }

--- a/Source/WebCore/css/CSSCounterStyleRegistry.cpp
+++ b/Source/WebCore/css/CSSCounterStyleRegistry.cpp
@@ -98,7 +98,7 @@ void CSSCounterStyleRegistry::addCounterStyle(const CSSCounterStyleDescriptors& 
     m_authorCounterStyles.set(descriptors.m_name, CSSCounterStyle::create(descriptors, false));
 }
 
-RefPtr<CSSCounterStyle> CSSCounterStyleRegistry::decimalCounter() const
+RefPtr<CSSCounterStyle> CSSCounterStyleRegistry::decimalCounter()
 {
     auto& userAgentCounters = userAgentCounterStyles();
     auto iterator = userAgentCounters.find("decimal"_s);
@@ -137,14 +137,7 @@ RefPtr<CSSCounterStyle> CSSCounterStyleRegistry::resolvedCounterStyle(const Atom
 
 CounterStyleMap& CSSCounterStyleRegistry::userAgentCounterStyles()
 {
-    // FIXME: counter-style should get pre-defined counters from UA stylesheet rdar://103021161.
-    auto initialStyles = []() {
-        CounterStyleMap map;
-        map.add("decimal"_s, CSSCounterStyle::createCounterStyleDecimal());
-        return map;
-    };
-
-    static NeverDestroyed<CounterStyleMap> counters = initialStyles();
+    static NeverDestroyed<CounterStyleMap> counters;
     return counters;
 }
 

--- a/Source/WebCore/css/CSSCounterStyleRegistry.h
+++ b/Source/WebCore/css/CSSCounterStyleRegistry.h
@@ -39,7 +39,7 @@ class CSSCounterStyleRegistry {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     RefPtr<CSSCounterStyle> resolvedCounterStyle(const AtomString&);
-    RefPtr<CSSCounterStyle> decimalCounter() const;
+    static RefPtr<CSSCounterStyle> decimalCounter();
     void addCounterStyle(const CSSCounterStyleDescriptors&);
     void resolveReferencesIfNeeded();
     bool operator==(const CSSCounterStyleRegistry& other) const;


### PR DESCRIPTION
#### 6aaf9c99077bb6f1cc0856d5380a5bca6f6cfeaf
<pre>
Implement text-representation for CounterStyle
<a href="https://bugs.webkit.org/show_bug.cgi?id=249804">https://bugs.webkit.org/show_bug.cgi?id=249804</a>
rdar://103648354

Reviewed by Tim Nguyen.

Implementing the text representation for the integer counter value
for a defined counter-style.

The text representation is specified at <a href="https://www.w3.org/TR/css-counter-styles-3/#counter-styles">https://www.w3.org/TR/css-counter-styles-3/#counter-styles</a>

A key point of the text representation is the algorithm used, which is
defined by the counter-style system. Each algorithm
is defined at <a href="https://www.w3.org/TR/css-counter-styles-3/#counter-style-system">https://www.w3.org/TR/css-counter-styles-3/#counter-style-system</a>

* Source/WebCore/css/CSSCounterStyle.cpp:
(WebCore::CSSCounterStyle::counterForSystemCyclic):
(WebCore::CSSCounterStyle::counterForSystemFixed):
(WebCore::CSSCounterStyle::counterForSystemSymbolic):
(WebCore::CSSCounterStyle::counterForSystemAlphabetic):
(WebCore::CSSCounterStyle::counterForSystemNumeric):
(WebCore::CSSCounterStyle::counterForSystemAdditive):
(WebCore::CSSCounterStyle::initialRepresentation):
(WebCore::CSSCounterStyle::fallbackText):
(WebCore::CSSCounterStyle::text):
(WebCore::CSSCounterStyle::shouldApplyNegativeSymbols const):
(WebCore::CSSCounterStyle::applyNegativeSymbols const):
(WebCore::CSSCounterStyle::applyPadSymbols const):
(WebCore::CSSCounterStyle::createCounterStyleDecimal):
* Source/WebCore/css/CSSCounterStyle.h:
(WebCore::CSSCounterStyle::fallback const):
* Source/WebCore/css/CSSCounterStyleRegistry.cpp:
(WebCore::CSSCounterStyleRegistry::decimalCounter):
(WebCore::CSSCounterStyleRegistry::decimalCounter const): Deleted.
* Source/WebCore/css/CSSCounterStyleRegistry.h:

Canonical link: <a href="https://commits.webkit.org/260792@main">https://commits.webkit.org/260792@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f55e4e0e5ca1d09a7e262594cfcd65622849cd22

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109444 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18568 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42206 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/942 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118608 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113329 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20034 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9765 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101720 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115200 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98150 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43126 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29803 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84883 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11312 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31146 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11976 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8081 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17342 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50750 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7476 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13707 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->