### PR TITLE
ImageBufferIOSurfaceBackend context setup and teardown functions are redundant and error-prone

### DIFF
--- a/Source/WebCore/platform/graphics/ImageBufferBackend.cpp
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.cpp
@@ -174,11 +174,4 @@ AffineTransform ImageBufferBackend::calculateBaseTransform(const Parameters& par
     return baseTransform;
 }
 
-void ImageBufferBackend::applyBaseTransformToContext() const
-{
-    auto& context = this->context();
-    context.applyDeviceScaleFactor(m_parameters.resolutionScale);
-    context.setCTM(calculateBaseTransform(m_parameters, originAtBottomLeftCorner()));
-}
-
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.h
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.h
@@ -145,8 +145,6 @@ public:
 
     virtual std::unique_ptr<ThreadSafeImageBufferFlusher> createFlusher() { return nullptr; }
 
-    void applyBaseTransformToContext() const;
-
     static constexpr bool isOriginAtBottomLeftCorner = false;
     virtual bool originAtBottomLeftCorner() const { return isOriginAtBottomLeftCorner; }
 

--- a/Source/WebCore/platform/graphics/cg/IOSurfacePool.cpp
+++ b/Source/WebCore/platform/graphics/cg/IOSurfacePool.cpp
@@ -89,7 +89,7 @@ void IOSurfacePool::willAddSurface(IOSurface& surface, bool inUse)
     CachedSurfaceDetails& details = m_surfaceDetails.add(&surface, CachedSurfaceDetails()).iterator->value;
     details.resetLastUseTime();
 
-    surface.releaseGraphicsContext();
+    surface.releasePlatformContext();
 
     size_t surfaceBytes = surface.totalBytes();
 

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.cpp
@@ -84,9 +84,17 @@ std::unique_ptr<ThreadSafeImageBufferFlusher> ImageBufferCGBackend::createFlushe
     return makeUnique<ThreadSafeImageBufferFlusherCG>(context().platformContext());
 }
 
+ImageBufferCGBackend::~ImageBufferCGBackend() = default;
+
 bool ImageBufferCGBackend::originAtBottomLeftCorner() const
 {
     return isOriginAtBottomLeftCorner;
+}
+
+void ImageBufferCGBackend::applyBaseTransform(GraphicsContextCG& context) const
+{
+    context.applyDeviceScaleFactor(m_parameters.resolutionScale);
+    context.setCTM(calculateBaseTransform(m_parameters, originAtBottomLeftCorner()));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.h
@@ -28,26 +28,29 @@
 #if USE(CG)
 
 #include "ImageBufferBackend.h"
+#include <memory>
 #include <wtf/Forward.h>
-
-typedef struct CGImage* CGImageRef;
 
 namespace WebCore {
 
+class GraphicsContextCG;
+
 class WEBCORE_EXPORT ImageBufferCGBackend : public ImageBufferBackend {
 public:
+    ~ImageBufferCGBackend() override;
     static unsigned calculateBytesPerRow(const IntSize& backendSize);
-
     static constexpr bool isOriginAtBottomLeftCorner = true;
 
 protected:
     using ImageBufferBackend::ImageBufferBackend;
+    void applyBaseTransform(GraphicsContextCG&) const;
 
     void clipToMask(GraphicsContext&, const FloatRect& destRect) override;
 
     std::unique_ptr<ThreadSafeImageBufferFlusher> createFlusher() override;
 
     bool originAtBottomLeftCorner() const override;
+    mutable std::unique_ptr<GraphicsContextCG> m_context;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp
@@ -94,16 +94,16 @@ std::unique_ptr<ImageBufferCGBitmapBackend> ImageBufferCGBitmapBackend::create(c
     return std::unique_ptr<ImageBufferCGBitmapBackend>(new ImageBufferCGBitmapBackend(parameters, data, WTFMove(dataProvider), WTFMove(context)));
 }
 
-ImageBufferCGBitmapBackend::ImageBufferCGBitmapBackend(const Parameters& parameters, void* data, RetainPtr<CGDataProviderRef>&& dataProvider, std::unique_ptr<GraphicsContext>&& context)
+ImageBufferCGBitmapBackend::ImageBufferCGBitmapBackend(const Parameters& parameters, void* data, RetainPtr<CGDataProviderRef>&& dataProvider, std::unique_ptr<GraphicsContextCG>&& context)
     : ImageBufferCGBackend(parameters)
     , m_data(data)
     , m_dataProvider(WTFMove(dataProvider))
-    , m_context(WTFMove(context))
 {
     ASSERT(m_data);
     ASSERT(m_dataProvider);
+    m_context = WTFMove(context);
     ASSERT(m_context);
-    applyBaseTransformToContext();
+    applyBaseTransform(*m_context);
 }
 
 ImageBufferCGBitmapBackend::~ImageBufferCGBitmapBackend() = default;

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.h
@@ -47,7 +47,7 @@ public:
     GraphicsContext& context() const final;
 
 private:
-    ImageBufferCGBitmapBackend(const Parameters&, void* data, RetainPtr<CGDataProviderRef>&&, std::unique_ptr<GraphicsContext>&&);
+    ImageBufferCGBitmapBackend(const Parameters&, void* data, RetainPtr<CGDataProviderRef>&&, std::unique_ptr<GraphicsContextCG>&&);
 
     IntSize backendSize() const final;
     unsigned bytesPerRow() const final;
@@ -59,7 +59,6 @@ private:
 
     void* m_data;
     RetainPtr<CGDataProviderRef> m_dataProvider;
-    std::unique_ptr<GraphicsContext> m_context;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h
@@ -85,7 +85,6 @@ protected:
 
     std::unique_ptr<IOSurface> m_surface;
     mutable bool m_mayHaveOutstandingBackingStoreReferences { false };
-    mutable bool m_needsSetupContext { false };
     VolatilityState m_volatilityState { VolatilityState::NonVolatile };
 
     RefPtr<IOSurfacePool> m_ioSurfacePool;

--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.h
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.h
@@ -45,7 +45,6 @@ class TextStream;
 
 namespace WebCore {
 
-class GraphicsContext;
 class IOSurfacePool;
 
 enum class PixelFormat : uint8_t;
@@ -130,8 +129,10 @@ public:
     id asLayerContents() const { return (__bridge id)m_surface.get(); }
 #endif
     IOSurfaceRef surface() const { return m_surface.get(); }
-    WEBCORE_EXPORT GraphicsContext& ensureGraphicsContext();
     WEBCORE_EXPORT CGContextRef ensurePlatformContext(PlatformDisplayID = 0);
+    // The graphics context cached on the surface counts as a "user", so to get
+    // an accurate result from isInUse(), it needs to be released.
+    WEBCORE_EXPORT void releasePlatformContext();
 
     // Querying volatility can be expensive, so in cases where the surface is
     // going to be used immediately, use the return value of setVolatile to
@@ -152,10 +153,6 @@ public:
     WEBCORE_EXPORT IOSurfaceSeed seed() const;
 
     WEBCORE_EXPORT bool isInUse() const;
-
-    // The graphics context cached on the surface counts as a "user", so to get
-    // an accurate result from isInUse(), it needs to be released.
-    WEBCORE_EXPORT void releaseGraphicsContext();
 
 #if HAVE(IOSURFACE_ACCELERATOR)
     WEBCORE_EXPORT static bool allowConversionFromFormatToFormat(Format, Format);
@@ -188,7 +185,6 @@ private:
     size_t m_totalBytes;
 
     ProcessIdentity m_resourceOwner;
-    std::unique_ptr<GraphicsContext> m_graphicsContext;
     RetainPtr<CGContextRef> m_cgContext;
 
     RetainPtr<IOSurfaceRef> m_surface;

--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
@@ -51,7 +51,7 @@ std::unique_ptr<IOSurface> IOSurface::create(IOSurfacePool* pool, IntSize size, 
 
     if (pool) {
         if (auto cachedSurface = pool->takeSurface(size, colorSpace, pixelFormat)) {
-            cachedSurface->releaseGraphicsContext();
+            cachedSurface->releasePlatformContext();
             LOG_WITH_STREAM(IOSurface, stream << "IOSurface::create took from pool: " << *cachedSurface);
             return cachedSurface;
         }
@@ -417,17 +417,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     return m_cgContext.get();
 }
 
-GraphicsContext& IOSurface::ensureGraphicsContext()
-{
-    if (m_graphicsContext)
-        return *m_graphicsContext;
-
-    m_graphicsContext = makeUnique<GraphicsContextCG>(ensurePlatformContext());
-    m_graphicsContext->setIsAcceleratedContext(true);
-
-    return *m_graphicsContext;
-}
-
 SetNonVolatileResult IOSurface::state() const
 {
     uint32_t previousState = 0;
@@ -488,9 +477,8 @@ bool IOSurface::isInUse() const
     return IOSurfaceIsInUse(m_surface.get());
 }
 
-void IOSurface::releaseGraphicsContext()
+void IOSurface::releasePlatformContext()
 {
-    m_graphicsContext = nullptr;
     m_cgContext = nullptr;
 }
 


### PR DESCRIPTION
#### 0072dcd9a13bfa4235b0184fe629e657a60c9b4a
<pre>
ImageBufferIOSurfaceBackend context setup and teardown functions are redundant and error-prone
<a href="https://bugs.webkit.org/show_bug.cgi?id=240452">https://bugs.webkit.org/show_bug.cgi?id=240452</a>
rdar://93412550

Reviewed by Simon Fraser.

Make all ImageBufferCGBackend hold the GraphicsContextCG.
Avoid holding GraphicsContext in IOSurface, as the only caller was
ImageBufferIOSurfaceBackend.

ImageBufferBackend::applyBaseTransformToContext() invoked a virtual
function context(). This was called from the middle of the inheritance
chain, from a constructor. If a class later in the inheritance chain
would override context(), the call would not be invoked correctly.
Currently no class suffered from this, but in future some might.

ImageBufferIOSurfaceBackend call to applyBaseTransformToContext() would
also recurse through context() back to applyBaseTransformToContext() in
non-intuitive way through overridden ::context() which would re-enter
applyBaseTransformToContext(). Based on current knowledge doubly
invoking the logic did not cause any harm.

* Source/WebCore/platform/graphics/ImageBufferBackend.cpp:
(WebCore::ImageBufferBackend::applyBaseTransformToContext const): Deleted.
* Source/WebCore/platform/graphics/ImageBufferBackend.h:
* Source/WebCore/platform/graphics/cg/IOSurfacePool.cpp:
(WebCore::IOSurfacePool::willAddSurface):
* Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.cpp:
(WebCore::ImageBufferCGBackend::applyBaseTransform const):
* Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.h:
* Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp:
(WebCore::ImageBufferCGBitmapBackend::ImageBufferCGBitmapBackend):
* Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.h:
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp:
(WebCore::ImageBufferIOSurfaceBackend::ImageBufferIOSurfaceBackend):
(WebCore::ImageBufferIOSurfaceBackend::context const):
(WebCore::ImageBufferIOSurfaceBackend::releaseGraphicsContext):
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h:
* Source/WebCore/platform/graphics/cocoa/IOSurface.h:
* Source/WebCore/platform/graphics/cocoa/IOSurface.mm:
(WebCore::IOSurface::create):
(WebCore::IOSurface::releasePlatformContext):
(WebCore::IOSurface::ensureGraphicsContext): Deleted.
(WebCore::IOSurface::releaseGraphicsContext): Deleted.

Canonical link: <a href="https://commits.webkit.org/260734@main">https://commits.webkit.org/260734@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07989602093f6ecc0d4ad9d096473ac4d2a8f6d4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109053 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18133 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41873 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/586 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118319 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112938 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19592 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9435 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101291 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114812 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14685 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97922 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42822 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96657 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29573 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84573 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10916 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30920 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11656 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7847 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17031 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50519 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7405 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13260 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->