### PR TITLE
[Linux] DMABufObject modifiers should default to being not-present

### DIFF
--- a/Source/WebCore/platform/graphics/gbm/DMABufEGLUtilities.h
+++ b/Source/WebCore/platform/graphics/gbm/DMABufEGLUtilities.h
@@ -57,10 +57,10 @@ static inline Vector<EGLint> constructEGLCreateImageAttributes(const DMABufObjec
         EGL_DMA_BUF_PLANE0_PITCH_EXT, EGLint(object.stride[planeIndex]),
     }));
 
-    if (planeModifiersUsage == PlaneModifiersUsage::Use) {
+    if (planeModifiersUsage == PlaneModifiersUsage::Use && object.modifierPresent[planeIndex]) {
         attributes.uncheckedAppend(Span<const EGLint>({
-            EGL_DMA_BUF_PLANE0_MODIFIER_HI_EXT, EGLint(object.modifier[planeIndex] >> 32),
-            EGL_DMA_BUF_PLANE0_MODIFIER_LO_EXT, EGLint(object.modifier[planeIndex] & 0xffffffff),
+            EGL_DMA_BUF_PLANE0_MODIFIER_HI_EXT, EGLint(object.modifierValue[planeIndex] >> 32),
+            EGL_DMA_BUF_PLANE0_MODIFIER_LO_EXT, EGLint(object.modifierValue[planeIndex] & 0xffffffff),
         }));
     }
 

--- a/Source/WebCore/platform/graphics/gbm/DMABufObject.h
+++ b/Source/WebCore/platform/graphics/gbm/DMABufObject.h
@@ -63,7 +63,8 @@ struct DMABufObject {
     std::array<UnixFileDescriptor, DMABufFormat::c_maxPlanes> fd { };
     std::array<size_t, DMABufFormat::c_maxPlanes> offset { 0, 0, 0, 0 };
     std::array<uint32_t, DMABufFormat::c_maxPlanes> stride { 0, 0, 0, 0 };
-    std::array<uint64_t, DMABufFormat::c_maxPlanes> modifier { 0, 0, 0, 0 };
+    std::array<bool, DMABufFormat::c_maxPlanes> modifierPresent { false, false, false, false };
+    std::array<uint64_t, DMABufFormat::c_maxPlanes> modifierValue { 0, 0, 0, 0 };
 };
 
 template<class Encoder>
@@ -74,7 +75,7 @@ void DMABufObject::encode(Encoder& encoder) &&
 
     for (unsigned i = 0; i < DMABufFormat::c_maxPlanes; ++i) {
         encoder << WTFMove(fd[i]);
-        encoder << offset[i] << stride[i] << modifier[i];
+        encoder << offset[i] << stride[i] << modifierPresent[i] << modifierValue[i];
     }
 }
 
@@ -133,11 +134,17 @@ std::optional<DMABufObject> DMABufObject::decode(Decoder& decoder)
             return std::nullopt;
         dmabufObject.stride[i] = *stride;
 
-        std::optional<uint64_t> modifier;
-        decoder >> modifier;
-        if (!modifier)
+        std::optional<bool> modifierPresent;
+        decoder >> modifierPresent;
+        if (!modifierPresent)
             return std::nullopt;
-        dmabufObject.modifier[i] = *modifier;
+        dmabufObject.modifierPresent[i] = *modifierPresent;
+
+        std::optional<uint64_t> modifierValue;
+        decoder >> modifierValue;
+        if (!modifierValue)
+            return std::nullopt;
+        dmabufObject.modifierValue[i] = *modifierValue;
     }
 
     return dmabufObject;

--- a/Source/WebCore/platform/graphics/gbm/GBMBufferSwapchain.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GBMBufferSwapchain.cpp
@@ -163,7 +163,8 @@ DMABufObject GBMBufferSwapchain::Buffer::createDMABufObject(uintptr_t handle) co
         object.fd[i] = UnixFileDescriptor { gbm_bo_get_fd(m_planes[i].bo), UnixFileDescriptor::Adopt };
         object.offset[i] = 0;
         object.stride[i] = m_planes[i].stride;
-        object.modifier[i] = gbm_bo_get_modifier(m_planes[i].bo);
+        object.modifierPresent[i] = true;
+        object.modifierValue[i] = gbm_bo_get_modifier(m_planes[i].bo);
     }
 
     return object;

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -3246,6 +3246,9 @@ void MediaPlayerPrivateGStreamer::pushDMABufToCompositor()
                 // but left for later.
                 object.releaseFlag = DMABufReleaseFlag { };
 
+                // No way (yet) to retrieve the modifier information. Until then, no modifiers are specified
+                // for this DMABufObject (via the modifierPresent and modifierValue member variables).
+
                 // For each plane, the relevant data (stride, offset, skip, dmabuf fd) is retrieved and assigned
                 // as appropriate. Modifier values are zeroed out for now, since GStreamer doesn't yet provide
                 // the information.
@@ -3265,7 +3268,6 @@ void MediaPlayerPrivateGStreamer::pushDMABufToCompositor()
                     gst_video_format_info_component(videoInfo.finfo, i, comp);
                     object.offset[i] = offset;
                     object.stride[i] = GST_VIDEO_INFO_PLANE_STRIDE(&videoInfo, i);
-                    object.modifier[i] = 0;
                 }
                 return WTFMove(object);
             });


### PR DESCRIPTION
#### 71065ff83269f32d9b25ae7ec79f900d3cd46e6c
<pre>
[Linux] DMABufObject modifiers should default to being not-present
<a href="https://bugs.webkit.org/show_bug.cgi?id=252744">https://bugs.webkit.org/show_bug.cgi?id=252744</a>

Reviewed by Carlos Garcia Campos.

Until now, the modifier values on the DMABufObject instances defaulted to 0,
which is equivalent to DRM_FORMAT_MOD_LINEAR. These values were then used in
the constructEGLCreateImageAttributes() helper, specifying the modifier value
for the EGLImage import as long as the driver supported the relevant extension.

DRM_FORMAT_MOD_LINEAR enforces the linear format, but that is not the same as
leaving the modifier unspecified. The latter step is necessary when the
modifier value has not been specified otherwise, since it allows the driver to
detect the corresponding modifier through internal logic.

This problem has been exhibited with some GStreamer decoders that yield DMABufs
without any modifier specified (perhaps because a specified modifier isn&apos;t
required, but mostly because the GStreamer pipeline doesn&apos;t relay that
information yet). When the linear modifier was specified, sampling of the
DMABuf-backed EGLImage was incorrect.

To fix this, modifier presence is now tracked alongside the per-plane modifier
value. Only when the modifier usage is enabled and the modifier is actually
present, the relevant EGL attributes are set during the EGLImage import.

GStreamer sink, when operating on DMABufs, leaves the modifiers unspecified,
since for now there&apos;s no information to work with. In GBMBufferSwapchain, when
creating a DMABufObject for a given buffer, that information is retrievable
through libgbm API, and the modifier for a given plane is marked as present.

* Source/WebCore/platform/graphics/gbm/DMABufEGLUtilities.h:
(WebCore::DMABufEGLUtilities::constructEGLCreateImageAttributes):
* Source/WebCore/platform/graphics/gbm/DMABufObject.h:
(WebCore::DMABufObject::encode):
(WebCore::DMABufObject::decode):
* Source/WebCore/platform/graphics/gbm/GBMBufferSwapchain.cpp:
(WebCore::GBMBufferSwapchain::Buffer::createDMABufObject const):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::pushDMABufToCompositor):

Canonical link: <a href="https://commits.webkit.org/260790@main">https://commits.webkit.org/260790@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/773cf8a6d9168ce5288486091bb4bdb86f60187c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109055 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18135 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41875 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/588 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118321 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112940 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19594 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9437 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101293 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114814 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14686 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97920 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42826 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96658 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29570 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84578 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10918 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30917 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11658 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7850 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17033 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50515 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7471 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13262 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->