### PR TITLE
Lazily loaded frames should still get a contentWindow/contentDocument as soon as they get inserted into the document

### DIFF
--- a/LayoutTests/http/tests/lazyload/synchronous-frame-creation-expected.txt
+++ b/LayoutTests/http/tests/lazyload/synchronous-frame-creation-expected.txt
@@ -1,0 +1,12 @@
+Tests that a lazy loaded iframe gets a contentWindow / contentDocument as soon as it gets inserted in the document.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+document.body.append(iframe)
+PASS iframe.contentDocument.URL is "about:blank"
+PASS iframe.contentWindow.location.href is "about:blank"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/lazyload/synchronous-frame-creation.html
+++ b/LayoutTests/http/tests/lazyload/synchronous-frame-creation.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Tests that a lazy loaded iframe gets a contentWindow / contentDocument as soon as it gets inserted in the document.");
+
+let iframe = document.createElement("iframe");
+iframe.src = "../dom/resources/dummy.html";
+iframe.loading = "lazy";
+
+evalAndLog("document.body.append(iframe)");
+shouldBeEqualToString("iframe.contentDocument.URL", "about:blank");
+shouldBeEqualToString("iframe.contentWindow.location.href", "about:blank");
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/HTMLFrameElementBase.cpp
+++ b/Source/WebCore/html/HTMLFrameElementBase.cpp
@@ -91,21 +91,20 @@ void HTMLFrameElementBase::openURL(LockHistory lockHistory, LockBackForwardList 
     if (m_frameURL.isEmpty())
         m_frameURL = AtomString { aboutBlankURL().string() };
 
-    // FIXME: This should delay the navigation to m_frameURL but shouldn't delay the creation
-    // of the Frame object or the load of the intially empty document.
-    if (shouldLoadFrameLazily())
-        return;
-
     RefPtr<Frame> parentFrame = document().frame();
     if (!parentFrame)
         return;
-
-    document().willLoadFrameElement(document().completeURL(m_frameURL));
 
     auto frameName = getNameAttribute();
     if (frameName.isNull() && UNLIKELY(document().settings().needsFrameNameFallbackToIdQuirk()))
         frameName = getIdAttribute();
 
+    if (shouldLoadFrameLazily()) {
+        parentFrame->loader().subframeLoader().createFrameIfNecessary(*this, frameName);
+        return;
+    }
+
+    document().willLoadFrameElement(document().completeURL(m_frameURL));
     parentFrame->loader().subframeLoader().requestFrame(*this, m_frameURL, frameName, lockHistory, lockBackForwardList);
 }
 

--- a/Source/WebCore/loader/SubframeLoader.cpp
+++ b/Source/WebCore/loader/SubframeLoader.cpp
@@ -81,6 +81,18 @@ void FrameLoader::SubframeLoader::clear()
     m_containsPlugins = false;
 }
 
+void FrameLoader::SubframeLoader::createFrameIfNecessary(HTMLFrameOwnerElement& ownerElement, const AtomString& frameName)
+{
+    if (ownerElement.contentFrame())
+        return;
+    m_frame.loader().client().createFrame(frameName, ownerElement);
+    if (!ownerElement.contentFrame())
+        return;
+
+    if (auto* contentDocument = downcast<LocalFrame>(ownerElement.contentFrame())->document())
+        contentDocument->setReferrerPolicy(ownerElement.referrerPolicy());
+}
+
 bool FrameLoader::SubframeLoader::requestFrame(HTMLFrameOwnerElement& ownerElement, const String& urlString, const AtomString& frameName, LockHistory lockHistory, LockBackForwardList lockBackForwardList)
 {
     // Support for <frame src="javascript:string">

--- a/Source/WebCore/loader/SubframeLoader.h
+++ b/Source/WebCore/loader/SubframeLoader.h
@@ -51,6 +51,7 @@ public:
 
     void clear();
 
+    void createFrameIfNecessary(HTMLFrameOwnerElement&, const AtomString& frameName);
     bool requestFrame(HTMLFrameOwnerElement&, const String& url, const AtomString& frameName, LockHistory = LockHistory::Yes, LockBackForwardList = LockBackForwardList::Yes);
     bool requestObject(HTMLPlugInImageElement&, const String& url, const AtomString& frameName,
         const String& serviceType, const Vector<AtomString>& paramNames, const Vector<AtomString>& paramValues);


### PR DESCRIPTION
#### 96e0c1e9f533ea9b3e084baee49342c95b6f68b8
<pre>
Lazily loaded frames should still get a contentWindow/contentDocument as soon as they get inserted into the document
<a href="https://bugs.webkit.org/show_bug.cgi?id=252754">https://bugs.webkit.org/show_bug.cgi?id=252754</a>

Reviewed by Rob Buis.

Lazily loaded frames should still get a contentWindow/contentDocument as soon
as they get inserted into the document. Currently, we return null for these
until the iframe moves to the viewport and gets loaded. This behavior is
inconsistent with Chrome and recently caused breakage on
<a href="https://www.kongregate.com">https://www.kongregate.com</a> (Bug 252636).

* LayoutTests/http/tests/lazyload/synchronous-frame-creation-expected.txt: Added.
* LayoutTests/http/tests/lazyload/synchronous-frame-creation.html: Added.
* Source/WebCore/html/HTMLFrameElementBase.cpp:
(WebCore::HTMLFrameElementBase::openURL):
* Source/WebCore/loader/SubframeLoader.cpp:
(WebCore::FrameLoader::SubframeLoader::createFrameIfNecessary):
* Source/WebCore/loader/SubframeLoader.h:

Canonical link: <a href="https://commits.webkit.org/260713@main">https://commits.webkit.org/260713@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7522f70974d2de39a6680f6a7594320548db3b10

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109066 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18148 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41888 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/601 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118333 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112951 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19607 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9450 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101306 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114826 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14696 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97930 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42836 "Archived test results (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96668 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29583 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84586 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10930 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30929 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11669 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7862 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17044 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50528 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7391 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13275 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->