### PR TITLE
[GStreamer][WebRTC] Renegotiation signalling improvement

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -1140,13 +1140,10 @@ void GStreamerMediaEndpoint::resume()
 
 void GStreamerMediaEndpoint::onNegotiationNeeded()
 {
-    m_isNegotiationNeeded = true;
-
+    ++m_negotiationNeededEventId;
     callOnMainThread([protectedThis = Ref(*this), this] {
-        if (isStopped())
-            return;
         GST_DEBUG_OBJECT(m_pipeline.get(), "Negotiation needed!");
-        m_peerConnectionBackend.markAsNeedingNegotiation(0);
+        m_peerConnectionBackend.markAsNeedingNegotiation(m_negotiationNeededEventId);
     });
 }
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h
@@ -76,7 +76,7 @@ public:
     void resume();
 
     void gatherDecoderImplementationName(Function<void(String&&)>&&);
-    bool isNegotiationNeeded() const { return m_isNegotiationNeeded; }
+    bool isNegotiationNeeded(uint32_t eventId) const { return eventId == m_negotiationNeededEventId; }
 
     void configureAndLinkSource(RealtimeOutgoingMediaSourceGStreamer&);
 
@@ -176,7 +176,7 @@ private:
     int m_ptCounter { 96 };
     unsigned m_pendingIncomingStreams { 0 };
     bool m_isInitiator { false };
-    bool m_isNegotiationNeeded { false };
+    uint32_t m_negotiationNeededEventId { 0 };
 
 #if !RELEASE_LOG_DISABLED
     Timer m_statsLogTimer;

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
@@ -365,9 +365,9 @@ void GStreamerPeerConnectionBackend::gatherDecoderImplementationName(Function<vo
     m_endpoint->gatherDecoderImplementationName(WTFMove(callback));
 }
 
-bool GStreamerPeerConnectionBackend::isNegotiationNeeded(uint32_t) const
+bool GStreamerPeerConnectionBackend::isNegotiationNeeded(uint32_t eventId) const
 {
-    return m_endpoint->isNegotiationNeeded();
+    return m_endpoint->isNegotiationNeeded(eventId);
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 74387c514701e9fc47ee32f5d9b68fd2d7913071
<pre>
[GStreamer][WebRTC] Renegotiation signalling improvement
<a href="https://bugs.webkit.org/show_bug.cgi?id=252756">https://bugs.webkit.org/show_bug.cgi?id=252756</a>

Reviewed by Xabier Rodriguez-Calvar.

When webrtcbin emits its on-negotiation-needed it has already made sure the negotiation is really
needed according to the spec, but our implementation wasn&apos;t resetting the corresponding flag
afterwards. We now match the event serial number, similarly to the libwebrtc implementation.

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::onNegotiationNeeded):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h:
(WebCore::GStreamerMediaEndpoint::isNegotiationNeeded const):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp:
(WebCore::GStreamerPeerConnectionBackend::isNegotiationNeeded const):

Canonical link: <a href="https://commits.webkit.org/260731@main">https://commits.webkit.org/260731@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/402e42b5aa9d2fe85565272bb48c0e3ae97dd778

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109073 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18155 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41895 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/608 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118339 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112958 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19614 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9457 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101314 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114833 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14703 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97934 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42850 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96675 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29587 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84594 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10937 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30933 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11675 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7864 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17049 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50532 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7404 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13282 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->