### PR TITLE
Port over remaining ServiceWorker types to the new serialization format

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2029,6 +2029,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     rendering/BreakLines.h
     rendering/CaretRectComputation.h
     rendering/CSSFilter.h
+    rendering/CSSValueKey.h
     rendering/ClipRect.h
     rendering/EventRegion.h
     rendering/FloatingObjects.h
@@ -2234,6 +2235,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     workers/service/ServiceWorkerContextData.h
     workers/service/ServiceWorkerData.h
     workers/service/ServiceWorkerIdentifier.h
+    workers/service/ServiceWorkerImportedScript.h
     workers/service/ServiceWorkerJob.h
     workers/service/ServiceWorkerJobClient.h
     workers/service/ServiceWorkerJobData.h

--- a/Source/WebCore/html/LinkIconType.h
+++ b/Source/WebCore/html/LinkIconType.h
@@ -40,16 +40,3 @@ enum class LinkIconType : uint8_t {
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::LinkIconType> {
-    using values = EnumValues<
-        WebCore::LinkIconType,
-        WebCore::LinkIconType::Favicon,
-        WebCore::LinkIconType::TouchIcon,
-        WebCore::LinkIconType::TouchPrecomposedIcon
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/platform/PasteboardItemInfo.h
+++ b/Source/WebCore/platform/PasteboardItemInfo.h
@@ -30,7 +30,7 @@
 
 namespace WebCore {
 
-enum class PasteboardItemPresentationStyle {
+enum class PasteboardItemPresentationStyle : uint8_t {
     Unspecified,
     Inline,
     Attachment
@@ -39,29 +39,7 @@ enum class PasteboardItemPresentationStyle {
 struct PresentationSize {
     std::optional<double> width;
     std::optional<double> height;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<PresentationSize> decode(Decoder&);
 };
-
-template<class Encoder>
-void PresentationSize::encode(Encoder& encoder) const
-{
-    encoder << width << height;
-}
-
-template<class Decoder>
-std::optional<PresentationSize> PresentationSize::decode(Decoder& decoder)
-{
-    PresentationSize result;
-    if (!decoder.decode(result.width))
-        return std::nullopt;
-
-    if (!decoder.decode(result.height))
-        return std::nullopt;
-
-    return result;
-}
 
 struct PasteboardItemInfo {
     Vector<String> pathsForFileUpload;
@@ -117,63 +95,6 @@ struct PasteboardItemInfo {
 
         return pathsForFileUpload.first();
     }
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<PasteboardItemInfo> decode(Decoder&);
 };
 
-template<class Encoder>
-void PasteboardItemInfo::encode(Encoder& encoder) const
-{
-    encoder << pathsForFileUpload << platformTypesForFileUpload << platformTypesByFidelity << suggestedFileName << preferredPresentationSize << isNonTextType << containsFileURLAndFileUploadContent << webSafeTypesByFidelity;
-    encoder << preferredPresentationStyle;
 }
-
-template<class Decoder>
-std::optional<PasteboardItemInfo> PasteboardItemInfo::decode(Decoder& decoder)
-{
-    PasteboardItemInfo result;
-    if (!decoder.decode(result.pathsForFileUpload))
-        return std::nullopt;
-
-    if (!decoder.decode(result.platformTypesForFileUpload))
-        return std::nullopt;
-
-    if (!decoder.decode(result.platformTypesByFidelity))
-        return std::nullopt;
-
-    if (!decoder.decode(result.suggestedFileName))
-        return std::nullopt;
-
-    if (!decoder.decode(result.preferredPresentationSize))
-        return std::nullopt;
-
-    if (!decoder.decode(result.isNonTextType))
-        return std::nullopt;
-
-    if (!decoder.decode(result.containsFileURLAndFileUploadContent))
-        return std::nullopt;
-
-    if (!decoder.decode(result.webSafeTypesByFidelity))
-        return std::nullopt;
-
-    if (!decoder.decode(result.preferredPresentationStyle))
-        return std::nullopt;
-
-    return result;
-}
-
-}
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::PasteboardItemPresentationStyle> {
-    using values = EnumValues<
-        WebCore::PasteboardItemPresentationStyle,
-        WebCore::PasteboardItemPresentationStyle::Unspecified,
-        WebCore::PasteboardItemPresentationStyle::Inline,
-        WebCore::PasteboardItemPresentationStyle::Attachment
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/platform/ScreenProperties.h
+++ b/Source/WebCore/platform/ScreenProperties.h
@@ -54,9 +54,6 @@ struct ScreenData {
 #if PLATFORM(MAC) || PLATFORM(IOS_FAMILY)
     float scaleFactor { 1 };
 #endif
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<ScreenData> decode(Decoder&);
 };
 
 using ScreenDataMap = HashMap<PlatformDisplayID, ScreenData>;
@@ -64,9 +61,6 @@ using ScreenDataMap = HashMap<PlatformDisplayID, ScreenData>;
 struct ScreenProperties {
     PlatformDisplayID primaryDisplayID { 0 };
     ScreenDataMap screenDataMap;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<ScreenProperties> decode(Decoder&);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/VideoFrameTimeMetadata.h
+++ b/Source/WebCore/platform/VideoFrameTimeMetadata.h
@@ -36,41 +36,6 @@ struct VideoFrameTimeMetadata {
     std::optional<Seconds> captureTime;
     std::optional<Seconds> receiveTime;
     std::optional<unsigned> rtpTimestamp;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<VideoFrameTimeMetadata> decode(Decoder&);
 };
-
-template<class Encoder>
-inline void VideoFrameTimeMetadata::encode(Encoder& encoder) const
-{
-    encoder << processingDuration << captureTime << receiveTime << rtpTimestamp;
-}
-
-template<class Decoder>
-inline std::optional<VideoFrameTimeMetadata> VideoFrameTimeMetadata::decode(Decoder& decoder)
-{
-    std::optional<std::optional<double>> processingDuration;
-    decoder >> processingDuration;
-    if (!processingDuration)
-        return std::nullopt;
-
-    std::optional<std::optional<Seconds>> captureTime;
-    decoder >> captureTime;
-    if (!captureTime)
-        return std::nullopt;
-
-    std::optional<std::optional<Seconds>> receiveTime;
-    decoder >> receiveTime;
-    if (!receiveTime)
-        return std::nullopt;
-
-    std::optional<std::optional<unsigned>> rtpTimestamp;
-    decoder >> rtpTimestamp;
-    if (!rtpTimestamp)
-        return std::nullopt;
-
-    return VideoFrameTimeMetadata { *processingDuration, *captureTime, *receiveTime, *rtpTimestamp };
-}
 
 }

--- a/Source/WebCore/platform/graphics/PositionedGlyphs.h
+++ b/Source/WebCore/platform/graphics/PositionedGlyphs.h
@@ -44,9 +44,6 @@ struct PositionedGlyphs {
     FontSmoothingMode smoothingMode;
 
     FloatRect computeBounds(const Font&) const;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<PositionedGlyphs> decode(Decoder&);
 };
 
 inline PositionedGlyphs::PositionedGlyphs(Vector<GlyphBufferGlyph>&& glyphs, Vector<GlyphBufferAdvance>&& advances, const FloatPoint& localAnchor, FontSmoothingMode smoothingMode)
@@ -56,43 +53,4 @@ inline PositionedGlyphs::PositionedGlyphs(Vector<GlyphBufferGlyph>&& glyphs, Vec
     , smoothingMode(smoothingMode)
 {
 }
-
-template<class Encoder>
-void PositionedGlyphs::encode(Encoder& encoder) const
-{
-    encoder << glyphs;
-    encoder << advances;
-    encoder << localAnchor;
-    encoder << smoothingMode;
-}
-
-template<class Decoder>
-std::optional<PositionedGlyphs> PositionedGlyphs::decode(Decoder& decoder)
-{
-    std::optional<Vector<GlyphBufferGlyph>> glyphs;
-    decoder >> glyphs;
-    if (!glyphs)
-        return std::nullopt;
-
-    std::optional<Vector<GlyphBufferAdvance>> advances;
-    decoder >> advances;
-    if (!advances)
-        return std::nullopt;
-
-    if (glyphs->size() != advances->size())
-        return std::nullopt;
-
-    std::optional<FloatPoint> localAnchor;
-    decoder >> localAnchor;
-    if (!localAnchor)
-        return std::nullopt;
-
-    std::optional<FontSmoothingMode> smoothingMode;
-    decoder >> smoothingMode;
-    if (!smoothingMode)
-        return std::nullopt;
-
-    return { { WTFMove(*glyphs), WTFMove(*advances), *localAnchor, *smoothingMode } };
-}
-
 } // namespace WebCore

--- a/Source/WebCore/plugins/PluginData.h
+++ b/Source/WebCore/plugins/PluginData.h
@@ -87,9 +87,6 @@ inline bool operator==(PluginInfo& a, PluginInfo& b)
 struct SupportedPluginIdentifier {
     String matchingDomain;
     String pluginIdentifier;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<SupportedPluginIdentifier> decode(Decoder&);
 };
 
 // FIXME: merge with PluginDatabase in the future
@@ -139,40 +136,4 @@ inline bool isSupportedPlugin(const Vector<SupportedPluginIdentifier>& pluginIde
     }) != notFound;
 }
 
-template<class Decoder> inline std::optional<SupportedPluginIdentifier> SupportedPluginIdentifier::decode(Decoder& decoder)
-{
-    std::optional<String> matchingDomain;
-    decoder >> matchingDomain;
-    if (!matchingDomain)
-        return std::nullopt;
-
-    std::optional<String> pluginIdentifier;
-    decoder >> pluginIdentifier;
-    if (!pluginIdentifier)
-        return std::nullopt;
-
-    return SupportedPluginIdentifier { WTFMove(matchingDomain.value()), WTFMove(pluginIdentifier.value()) };
-}
-
-template<class Encoder> inline void SupportedPluginIdentifier::encode(Encoder& encoder) const
-{
-    encoder << matchingDomain;
-    encoder << pluginIdentifier;
-}
-
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::PluginLoadClientPolicy> {
-    using values = EnumValues<
-        WebCore::PluginLoadClientPolicy,
-        WebCore::PluginLoadClientPolicy::Undefined,
-        WebCore::PluginLoadClientPolicy::Block,
-        WebCore::PluginLoadClientPolicy::Ask,
-        WebCore::PluginLoadClientPolicy::Allow,
-        WebCore::PluginLoadClientPolicy::AllowAlways
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/rendering/CSSValueKey.h
+++ b/Source/WebCore/rendering/CSSValueKey.h
@@ -33,9 +33,6 @@ struct CSSValueKey {
 
     unsigned hash() const;
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<CSSValueKey> decode(Decoder&);
-
     unsigned cssValueID;
     bool useDarkAppearance;
     bool useElevatedUserInterfaceLevel;
@@ -44,32 +41,6 @@ struct CSSValueKey {
 inline bool operator==(const CSSValueKey& a, const CSSValueKey& b)
 {
     return a.cssValueID == b.cssValueID && a.useDarkAppearance == b.useDarkAppearance && a.useElevatedUserInterfaceLevel == b.useElevatedUserInterfaceLevel;
-}
-
-template<class Encoder>
-void CSSValueKey::encode(Encoder& encoder) const
-{
-    encoder << cssValueID;
-    encoder << useDarkAppearance;
-    encoder << useElevatedUserInterfaceLevel;
-}
-
-template<class Decoder>
-std::optional<CSSValueKey> CSSValueKey::decode(Decoder& decoder)
-{
-    std::optional<unsigned> cssValueID;
-    decoder >> cssValueID;
-    if (!cssValueID)
-        return std::nullopt;
-    std::optional<bool> useDarkAppearance;
-    decoder >> useDarkAppearance;
-    if (!useDarkAppearance)
-        return std::nullopt;
-    std::optional<bool> useElevatedUserInterfaceLevel;
-    decoder >> useElevatedUserInterfaceLevel;
-    if (!useElevatedUserInterfaceLevel)
-        return std::nullopt;
-    return { { WTFMove(*cssValueID), WTFMove(*useDarkAppearance), WTFMove(*useElevatedUserInterfaceLevel) } };
 }
 
 inline unsigned CSSValueKey::hash() const

--- a/Source/WebCore/rendering/EventRegion.cpp
+++ b/Source/WebCore/rendering/EventRegion.cpp
@@ -139,6 +139,38 @@ void EventRegionContext::copyInteractionRegionsToEventRegion()
 
 EventRegion::EventRegion() = default;
 
+EventRegion::EventRegion(Region&& region
+#if ENABLE(TOUCH_ACTION_REGIONS)
+    , Vector<WebCore::Region> touchActionRegions
+#endif
+#if ENABLE(WHEEL_EVENT_REGIONS)
+    , WebCore::Region wheelEventListenerRegion
+    , WebCore::Region nonPassiveWheelEventListenerRegion
+#endif
+#if ENABLE(EDITABLE_REGION)
+    , std::optional<WebCore::Region> editableRegion
+#endif
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    , Vector<WebCore::InteractionRegion> interactionRegions
+#endif
+    )
+    : m_region(WTFMove(region))
+#if ENABLE(TOUCH_ACTION_REGIONS)
+    , m_touchActionRegions(WTFMove(touchActionRegions))
+#endif
+#if ENABLE(WHEEL_EVENT_REGIONS)
+    , m_wheelEventListenerRegion(WTFMove(wheelEventListenerRegion))
+    , m_nonPassiveWheelEventListenerRegion(WTFMove(nonPassiveWheelEventListenerRegion))
+#endif
+#if ENABLE(EDITABLE_REGION)
+    , m_editableRegion(WTFMove(editableRegion))
+#endif
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    , m_interactionRegions(WTFMove(interactionRegions))
+#endif
+{
+}
+
 bool EventRegion::operator==(const EventRegion& other) const
 {
 #if ENABLE(TOUCH_ACTION_REGIONS)

--- a/Source/WebCore/workers/WorkerFetchResult.h
+++ b/Source/WebCore/workers/WorkerFetchResult.h
@@ -43,45 +43,10 @@ struct WorkerFetchResult {
     ResourceError error;
 
     WorkerFetchResult isolatedCopy() const { return { script.isolatedCopy(), responseURL.isolatedCopy(), certificateInfo.isolatedCopy(), contentSecurityPolicy.isolatedCopy(), crossOriginEmbedderPolicy.isolatedCopy(), referrerPolicy.isolatedCopy(), error.isolatedCopy() }; }
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static WARN_UNUSED_RETURN bool decode(Decoder&, WorkerFetchResult&);
 };
 
 inline WorkerFetchResult workerFetchError(const ResourceError& error)
 {
     return { { }, { }, { }, { }, { }, { }, error };
 }
-
-template<class Encoder>
-void WorkerFetchResult::encode(Encoder& encoder) const
-{
-    encoder << script << responseURL << contentSecurityPolicy << crossOriginEmbedderPolicy << referrerPolicy << error << certificateInfo;
-}
-
-template<class Decoder>
-bool WorkerFetchResult::decode(Decoder& decoder, WorkerFetchResult& result)
-{
-    if (!decoder.decode(result.script))
-        return false;
-    if (!decoder.decode(result.responseURL))
-        return false;
-    if (!decoder.decode(result.contentSecurityPolicy))
-        return false;
-    if (!decoder.decode(result.crossOriginEmbedderPolicy))
-        return false;
-    if (!decoder.decode(result.referrerPolicy))
-        return false;
-    if (!decoder.decode(result.error))
-        return false;
-
-    std::optional<CertificateInfo> certificateInfo;
-    decoder >> certificateInfo;
-    if (!certificateInfo)
-        return false;
-    result.certificateInfo = WTFMove(*certificateInfo);
-
-    return true;
-}
-
 } // namespace WebCore

--- a/Source/WebCore/workers/WorkerInitializationData.h
+++ b/Source/WebCore/workers/WorkerInitializationData.h
@@ -40,9 +40,6 @@ struct WorkerInitializationData {
     String userAgent;
 
     WorkerInitializationData isolatedCopy() const;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<WorkerInitializationData> decode(Decoder&);
 };
 
 inline WorkerInitializationData WorkerInitializationData::isolatedCopy() const
@@ -53,45 +50,6 @@ inline WorkerInitializationData WorkerInitializationData::isolatedCopy() const
 #endif
         clientIdentifier,
         userAgent.isolatedCopy()
-    };
-}
-
-
-template<class Encoder>
-void WorkerInitializationData::encode(Encoder& encoder) const
-{
-#if ENABLE(SERVICE_WORKER)
-    encoder << serviceWorkerData;
-#endif
-    encoder << clientIdentifier << userAgent;
-}
-
-template<class Decoder>
-std::optional<WorkerInitializationData> WorkerInitializationData::decode(Decoder& decoder)
-{
-#if ENABLE(SERVICE_WORKER)
-    std::optional<std::optional<ServiceWorkerData>> serviceWorkerData;
-    decoder >> serviceWorkerData;
-    if (!serviceWorkerData)
-        return { };
-#endif
-
-    std::optional<std::optional<ScriptExecutionContextIdentifier>> clientIdentifier;
-    decoder >> clientIdentifier;
-    if (!clientIdentifier)
-        return { };
-
-    std::optional<String> userAgent;
-    decoder >> userAgent;
-    if (!userAgent)
-        return { };
-
-    return WorkerInitializationData {
-#if ENABLE(SERVICE_WORKER)
-        WTFMove(*serviceWorkerData),
-#endif
-        WTFMove(*clientIdentifier),
-        WTFMove(*userAgent)
     };
 }
 

--- a/Source/WebCore/workers/WorkerOptions.h
+++ b/Source/WebCore/workers/WorkerOptions.h
@@ -34,36 +34,6 @@ struct WorkerOptions {
     WorkerType type { WorkerType::Classic };
     FetchRequestCredentials credentials { FetchRequestCredentials::SameOrigin };
     String name;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<WorkerOptions> decode(Decoder&);
 };
-
-template<class Encoder>
-void WorkerOptions::encode(Encoder& encoder) const
-{
-    encoder << type << credentials << name;
-}
-
-template<class Decoder>
-std::optional<WorkerOptions> WorkerOptions::decode(Decoder& decoder)
-{
-    std::optional<WorkerType> workerType;
-    decoder >> workerType;
-    if (!workerType)
-        return std::nullopt;
-
-    std::optional<FetchRequestCredentials> credentials;
-    decoder >> credentials;
-    if (!credentials)
-        return std::nullopt;
-
-    std::optional<String> name;
-    decoder >> name;
-    if (!name)
-        return std::nullopt;
-
-    return { { *workerType, *credentials, WTFMove(*name) } };
-}
 
 } // namespace WebCore

--- a/Source/WebCore/workers/service/ServiceWorkerImportedScript.h
+++ b/Source/WebCore/workers/service/ServiceWorkerImportedScript.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,19 +25,21 @@
 
 #pragma once
 
-#include "LinkIconType.h"
-#include <wtf/HashMap.h>
-#include <wtf/URL.h>
-#include <wtf/text/WTFString.h>
+#include "ScriptBuffer.h"
+#include <wtf/URLHash.h>
+
+#if ENABLE(SERVICE_WORKER)
 
 namespace WebCore {
 
-struct LinkIcon {
-    URL url;
-    LinkIconType type;
+struct ServiceWorkerImportedScript {
+    ScriptBuffer script;
+    URL responseURL;
     String mimeType;
-    std::optional<unsigned> size;
-    Vector<std::pair<String, String>> attributes;
-};
 
+    ServiceWorkerImportedScript isolatedCopy() const & { return { script.isolatedCopy(), responseURL.isolatedCopy(), mimeType.isolatedCopy() }; }
+    ServiceWorkerImportedScript isolatedCopy() && { return { WTFMove(script).isolatedCopy(), WTFMove(responseURL).isolatedCopy(), WTFMove(mimeType).isolatedCopy() }; }
+};
 } // namespace WebCore
+
+#endif // ENABLE(SERVICE_WORKER)

--- a/Source/WebCore/workers/service/ServiceWorkerJobDataIdentifier.h
+++ b/Source/WebCore/workers/service/ServiceWorkerJobDataIdentifier.h
@@ -39,36 +39,11 @@ struct ServiceWorkerJobDataIdentifier {
     {
         return connectionIdentifier.loggingString() + "-" + jobIdentifier.loggingString();
     }
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<ServiceWorkerJobDataIdentifier> decode(Decoder&);
 };
 
 inline bool operator==(const ServiceWorkerJobDataIdentifier& a, const ServiceWorkerJobDataIdentifier& b)
 {
     return a.connectionIdentifier == b.connectionIdentifier && a.jobIdentifier == b.jobIdentifier;
-}
-
-template<class Encoder>
-void ServiceWorkerJobDataIdentifier::encode(Encoder& encoder) const
-{
-    encoder << connectionIdentifier << jobIdentifier;
-}
-
-template<class Decoder>
-std::optional<ServiceWorkerJobDataIdentifier> ServiceWorkerJobDataIdentifier::decode(Decoder& decoder)
-{
-    std::optional<SWServerConnectionIdentifier> connectionIdentifier;
-    decoder >> connectionIdentifier;
-    if (!connectionIdentifier)
-        return std::nullopt;
-
-    std::optional<ServiceWorkerJobIdentifier> jobIdentifier;
-    decoder >> jobIdentifier;
-    if (!jobIdentifier)
-        return std::nullopt;
-
-    return { { WTFMove(*connectionIdentifier), WTFMove(*jobIdentifier) } };
 }
 
 } // namespace WebCore

--- a/Source/WebCore/workers/service/ServiceWorkerRegistrationData.h
+++ b/Source/WebCore/workers/service/ServiceWorkerRegistrationData.h
@@ -53,63 +53,7 @@ struct ServiceWorkerRegistrationData {
 
     ServiceWorkerRegistrationData isolatedCopy() const &;
     ServiceWorkerRegistrationData isolatedCopy() &&;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<ServiceWorkerRegistrationData> decode(Decoder&);
 };
-
-
-template<class Encoder>
-void ServiceWorkerRegistrationData::encode(Encoder& encoder) const
-{
-    encoder << key << identifier << scopeURL << updateViaCache << lastUpdateTime.secondsSinceEpoch().value() << installingWorker << waitingWorker << activeWorker;
-}
-
-template<class Decoder>
-std::optional<ServiceWorkerRegistrationData> ServiceWorkerRegistrationData::decode(Decoder& decoder)
-{
-    std::optional<ServiceWorkerRegistrationKey> key;
-    decoder >> key;
-    if (!key)
-        return std::nullopt;
-    
-    std::optional<ServiceWorkerRegistrationIdentifier> identifier;
-    decoder >> identifier;
-    if (!identifier)
-        return std::nullopt;
-
-    std::optional<URL> scopeURL;
-    decoder >> scopeURL;
-    if (!scopeURL)
-        return std::nullopt;
-
-    std::optional<ServiceWorkerUpdateViaCache> updateViaCache;
-    decoder >> updateViaCache;
-    if (!updateViaCache)
-        return std::nullopt;
-
-    std::optional<double> rawWallTime;
-    decoder >> rawWallTime;
-    if (!rawWallTime)
-        return std::nullopt;
-
-    std::optional<std::optional<ServiceWorkerData>> installingWorker;
-    decoder >> installingWorker;
-    if (!installingWorker)
-        return std::nullopt;
-
-    std::optional<std::optional<ServiceWorkerData>> waitingWorker;
-    decoder >> waitingWorker;
-    if (!waitingWorker)
-        return std::nullopt;
-
-    std::optional<std::optional<ServiceWorkerData>> activeWorker;
-    decoder >> activeWorker;
-    if (!activeWorker)
-        return std::nullopt;
-
-    return { { WTFMove(*key), WTFMove(*identifier), WTFMove(*scopeURL), WTFMove(*updateViaCache), WallTime::fromRawSeconds(*rawWallTime), WTFMove(*installingWorker), WTFMove(*waitingWorker), WTFMove(*activeWorker) } };
-}
 
 } // namespace WTF
 

--- a/Source/WebCore/workers/service/ServiceWorkerRegistrationKey.h
+++ b/Source/WebCore/workers/service/ServiceWorkerRegistrationKey.h
@@ -59,9 +59,6 @@ public:
     ServiceWorkerRegistrationKey isolatedCopy() const &;
     ServiceWorkerRegistrationKey isolatedCopy() &&;
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<ServiceWorkerRegistrationKey> decode(Decoder&);
-
     String toDatabaseKey() const;
     WEBCORE_EXPORT static std::optional<ServiceWorkerRegistrationKey> fromDatabaseKey(const String&);
 
@@ -75,29 +72,6 @@ private:
     SecurityOriginData m_topOrigin;
     URL m_scope;
 };
-
-template<class Encoder>
-void ServiceWorkerRegistrationKey::encode(Encoder& encoder) const
-{
-    RELEASE_ASSERT(!m_topOrigin.isNull());
-    RELEASE_ASSERT(!m_scope.isNull());
-    encoder << m_topOrigin << m_scope;
-}
-
-template<class Decoder>
-std::optional<ServiceWorkerRegistrationKey> ServiceWorkerRegistrationKey::decode(Decoder& decoder)
-{
-    std::optional<SecurityOriginData> topOrigin;
-    decoder >> topOrigin;
-    if (!topOrigin)
-        return std::nullopt;
-
-    URL scope;
-    if (!decoder.decode(scope))
-        return std::nullopt;
-
-    return ServiceWorkerRegistrationKey { WTFMove(*topOrigin), WTFMove(scope) };
-}
 
 inline void add(Hasher& hasher, const ServiceWorkerRegistrationKey& key)
 {

--- a/Source/WebCore/workers/service/ServiceWorkerRegistrationOptions.h
+++ b/Source/WebCore/workers/service/ServiceWorkerRegistrationOptions.h
@@ -41,37 +41,7 @@ struct ServiceWorkerRegistrationOptions {
 
     ServiceWorkerRegistrationOptions isolatedCopy() const &;
     ServiceWorkerRegistrationOptions isolatedCopy() &&;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<ServiceWorkerRegistrationOptions> decode(Decoder&);
 };
-
-template<class Encoder>
-void ServiceWorkerRegistrationOptions::encode(Encoder& encoder) const
-{
-    encoder << scope << type << updateViaCache;
-}
-
-template<class Decoder>
-std::optional<ServiceWorkerRegistrationOptions> ServiceWorkerRegistrationOptions::decode(Decoder& decoder)
-{
-    std::optional<String> scope;
-    decoder >> scope;
-    if (!scope)
-        return std::nullopt;
-
-    std::optional<WorkerType> type;
-    decoder >> type;
-    if (!type)
-        return std::nullopt;
-
-    std::optional<ServiceWorkerUpdateViaCache> updateViaCache;
-    decoder >> updateViaCache;
-    if (!updateViaCache)
-        return std::nullopt;
-
-    return ServiceWorkerRegistrationOptions { WTFMove(*scope), WTFMove(*type), WTFMove(*updateViaCache) };
-}
 
 } // namespace WebCore
 

--- a/Source/WebCore/workers/shared/SharedWorkerKey.h
+++ b/Source/WebCore/workers/shared/SharedWorkerKey.h
@@ -33,41 +33,11 @@ struct SharedWorkerKey {
     ClientOrigin origin;
     URL url;
     String name;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<SharedWorkerKey> decode(Decoder&);
 };
 
 inline void add(Hasher& hasher, const SharedWorkerKey& key)
 {
     add(hasher, key.origin, key.url, key.name);
-}
-
-template<class Encoder>
-void SharedWorkerKey::encode(Encoder& encoder) const
-{
-    encoder << origin << url << name;
-}
-
-template<class Decoder>
-std::optional<SharedWorkerKey> SharedWorkerKey::decode(Decoder& decoder)
-{
-    std::optional<ClientOrigin> origin;
-    decoder >> origin;
-    if (!origin)
-        return std::nullopt;
-
-    std::optional<URL> url;
-    decoder >> url;
-    if (!url)
-        return std::nullopt;
-
-    std::optional<String> name;
-    decoder >> name;
-    if (!name)
-        return std::nullopt;
-
-    return { { WTFMove(*origin), WTFMove(*url), WTFMove(*name) } };
 }
 
 inline bool operator==(const SharedWorkerKey& a, const SharedWorkerKey& b)

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.messages.in
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.messages.in
@@ -37,7 +37,7 @@ messages -> WebSWServerToContextConnection NotRefCounted {
     Claim(WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier) -> (std::optional<WebCore::ExceptionData> result)
     Focus(WebCore::ScriptExecutionContextIdentifier serviceWorkerClientIdentifier) -> (std::optional<WebCore::ServiceWorkerClientData> result)
     Navigate(WebCore::ScriptExecutionContextIdentifier clientIdentifier, WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, URL url) -> (Expected<std::optional<WebCore::ServiceWorkerClientData>, WebCore::ExceptionData> result)
-    SetScriptResource(WebCore::ServiceWorkerIdentifier identifier, URL scriptURL, WebCore::ServiceWorkerContextData::ImportedScript script)
+    SetScriptResource(WebCore::ServiceWorkerIdentifier identifier, URL scriptURL, struct WebCore::ServiceWorkerImportedScript script)
     PostMessageToServiceWorkerClient(WebCore::ScriptExecutionContextIdentifier destination, struct WebCore::MessageWithMessagePorts message, WebCore::ServiceWorkerIdentifier source, String sourceOrigin)
     DidFailHeartBeatCheck(WebCore::ServiceWorkerIdentifier identifier)
     SetAsInspected(WebCore::ServiceWorkerIdentifier identifier, bool isInspected)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4387,3 +4387,177 @@ enum class WebCore::COEPDisposition : bool;
 [AdditionalEncoder=StreamConnectionEncoder] class WebCore::SourceImage {
     WebCore::RenderingResourceIdentifier imageIdentifier();
 }
+
+enum class WebCore::LinkIconType : uint8_t {
+    Favicon,
+    TouchIcon,
+    TouchPrecomposedIcon
+};
+
+struct WebCore::LinkIcon {
+    URL url;
+    WebCore::LinkIconType type;
+    String mimeType;
+    std::optional<unsigned> size;
+    Vector<std::pair<String, String>> attributes;
+};
+
+header: <WebCore/PluginData.h>
+[CustomHeader] struct WebCore::SupportedPluginIdentifier {
+    String matchingDomain;
+    String pluginIdentifier;
+};
+
+enum class WebCore::PluginLoadClientPolicy : uint8_t {
+    Undefined,
+    Block,
+    Ask,
+    Allow,
+    AllowAlways,
+};
+
+struct WebCore::CSSValueKey {
+    unsigned cssValueID;
+    bool useDarkAppearance;
+    bool useElevatedUserInterfaceLevel;
+};
+
+struct WebCore::VideoFrameTimeMetadata {
+    std::optional<double> processingDuration;
+    std::optional<Seconds> captureTime;
+    std::optional<Seconds> receiveTime;
+    std::optional<unsigned> rtpTimestamp;
+};
+
+[AdditionalEncoder=StreamConnectionEncoder] struct WebCore::PositionedGlyphs {
+    Vector<WebCore::GlyphBufferGlyph> glyphs;
+    [Validator='glyphs->size() == advances->size()'] Vector<WebCore::GlyphBufferAdvance> advances;
+    WebCore::FloatPoint localAnchor;
+    WebCore::FontSmoothingMode smoothingMode;
+};
+
+class WebCore::EventRegion {
+    WebCore::Region m_region;
+#if ENABLE(TOUCH_ACTION_REGIONS)
+    Vector<WebCore::Region> m_touchActionRegions;
+#endif
+#if ENABLE(WHEEL_EVENT_REGIONS)
+    WebCore::Region m_wheelEventListenerRegion;
+    WebCore::Region m_nonPassiveWheelEventListenerRegion;
+#endif
+#if ENABLE(EDITABLE_REGION)
+    std::optional<WebCore::Region> m_editableRegion;
+#endif
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    Vector<WebCore::InteractionRegion> m_interactionRegions;
+#endif
+};
+
+enum class WebCore::PasteboardItemPresentationStyle : uint8_t {
+    Unspecified,
+    Inline,
+    Attachment
+};
+
+[CustomHeader] struct WebCore::PresentationSize {
+    std::optional<double> width;
+    std::optional<double> height;
+};
+
+struct WebCore::PasteboardItemInfo {
+    Vector<String> pathsForFileUpload;
+    Vector<String> platformTypesForFileUpload;
+    Vector<String> platformTypesByFidelity;
+    String suggestedFileName;
+    WebCore::PresentationSize preferredPresentationSize;
+    bool isNonTextType;
+    bool containsFileURLAndFileUploadContent;
+    Vector<String> webSafeTypesByFidelity;
+    WebCore::PasteboardItemPresentationStyle preferredPresentationStyle;
+};
+
+struct WebCore::WorkerOptions {
+    WebCore::WorkerType type;
+    WebCore::FetchRequestCredentials credentials;
+    String name;
+};
+
+struct WebCore::WorkerInitializationData {
+#if ENABLE(SERVICE_WORKER)
+    std::optional<WebCore::ServiceWorkerData> serviceWorkerData;
+#endif
+    std::optional<WebCore::ScriptExecutionContextIdentifier> clientIdentifier;
+    String userAgent;
+};
+
+struct WebCore::WorkerFetchResult {
+    WebCore::ScriptBuffer script;
+    URL responseURL;
+    WebCore::CertificateInfo certificateInfo;
+    WebCore::ContentSecurityPolicyResponseHeaders contentSecurityPolicy;
+    WebCore::CrossOriginEmbedderPolicy crossOriginEmbedderPolicy;
+    String referrerPolicy;
+    WebCore::ResourceError error;
+};
+
+struct WebCore::SharedWorkerKey {
+    WebCore::ClientOrigin origin;
+    URL url;
+    String name;
+};
+
+#if ENABLE(SERVICE_WORKER)
+
+struct WebCore::ServiceWorkerRegistrationOptions {
+    String scope;
+    WebCore::WorkerType type;
+    WebCore::ServiceWorkerUpdateViaCache updateViaCache;
+};
+
+class WebCore::ServiceWorkerRegistrationKey {
+    WebCore::SecurityOriginData topOrigin();
+    URL scope();
+};
+
+struct WebCore::ServiceWorkerRegistrationData {
+    WebCore::ServiceWorkerRegistrationKey key;
+    WebCore::ServiceWorkerRegistrationIdentifier identifier;
+    URL scopeURL;
+    WebCore::ServiceWorkerUpdateViaCache updateViaCache;
+    WallTime lastUpdateTime;
+    std::optional<WebCore::ServiceWorkerData> installingWorker;
+    std::optional<WebCore::ServiceWorkerData> waitingWorker;
+    std::optional<WebCore::ServiceWorkerData> activeWorker;
+};
+
+struct WebCore::ServiceWorkerJobDataIdentifier {
+    WebCore::SWServerConnectionIdentifier connectionIdentifier;
+    WebCore::ServiceWorkerJobIdentifier jobIdentifier;
+};
+
+struct WebCore::ServiceWorkerImportedScript {
+    WebCore::ScriptBuffer script;
+    URL responseURL;
+    String mimeType;
+};
+
+header: <wtf/RobinHoodHashTable.h>
+struct WebCore::ServiceWorkerContextData {
+    std::optional<WebCore::ServiceWorkerJobDataIdentifier> jobDataIdentifier;
+    WebCore::ServiceWorkerRegistrationData registration;
+    WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier;
+    WebCore::ScriptBuffer script;
+    WebCore::CertificateInfo certificateInfo;
+    WebCore::ContentSecurityPolicyResponseHeaders contentSecurityPolicy;
+    WebCore::CrossOriginEmbedderPolicy crossOriginEmbedderPolicy;
+    String referrerPolicy;
+    URL scriptURL;
+    WebCore::WorkerType workerType;
+    bool loadedFromDisk;
+    std::optional<WebCore::LastNavigationWasAppInitiated> lastNavigationWasAppInitiated;
+    MemoryCompactRobinHoodHashMap<URL, WebCore::ServiceWorkerImportedScript> scriptResourceMap;
+    std::optional<WebCore::ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier;
+    WebCore::NavigationPreloadState navigationPreloadState;
+};
+
+#endif

--- a/Source/WebKit/Shared/WebEvent.h
+++ b/Source/WebKit/Shared/WebEvent.h
@@ -99,9 +99,6 @@ public:
 protected:
     WebEvent();
 
-    void encode(IPC::Encoder&) const;
-    static WARN_UNUSED_RETURN bool decode(IPC::Decoder&, WebEvent&);
-
 private:
     WebEventType m_type;
     OptionSet<WebEventModifier> m_modifiers;

--- a/Source/WebKit/Shared/WebKeyboardEvent.h
+++ b/Source/WebKit/Shared/WebKeyboardEvent.h
@@ -77,9 +77,6 @@ public:
     bool isKeypad() const { return m_isKeypad; }
     bool isSystemKey() const { return m_isSystemKey; }
 
-    void encode(IPC::Encoder&) const;
-    static WARN_UNUSED_RETURN bool decode(IPC::Decoder&, WebKeyboardEvent&);
-
     static bool isKeyboardEventType(WebEventType);
 
 private:


### PR DESCRIPTION
#### a3a9a226e40c6a7a89d4ab2f4346b72631450238
<pre>
Port over remaining ServiceWorker types to the new serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=252748">https://bugs.webkit.org/show_bug.cgi?id=252748</a>
rdar://105782903

Reviewed by Alex Christensen.

This change ports the following types to the new IPC serialization
format:
    - LinkIconType
    - LinkIcon
    - SupportedPluginIdentifier
    - CSSValueKey
    - VideoFrameTimeMetadata
    - PositionedGlyphs
    - EventRegion
    - PasteboardItemPresentationStyle
    - PresentationSize
    - PasteboardItemInfo
    - WorkerOptions
    - WorkerInitializationData
    - WorkerFetchResult
    - SharedWorkerKey
    - ServiceWorkerRegistrationOptions
    - ServiceWorkerRegistrationKey
    - ServiceWorkerRegistrationData
    - ServiceWorkerJobDataIdentifier
    - ServiceWorkerImportedScript
    - ServiceWorkerContextData

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/LinkIconType.h:
* Source/WebCore/platform/LinkIcon.h:
(WebCore::LinkIcon::encode const): Deleted.
(WebCore::LinkIcon::decode): Deleted.
* Source/WebCore/platform/PasteboardItemInfo.h:
(WebCore::PasteboardItemInfo::pathForHighestFidelityItem const):
(WebCore::PresentationSize::encode const): Deleted.
(WebCore::PresentationSize::decode): Deleted.
(WebCore::PasteboardItemInfo::encode const): Deleted.
(WebCore::PasteboardItemInfo::decode): Deleted.
* Source/WebCore/platform/ScreenProperties.h:
* Source/WebCore/platform/VideoFrameTimeMetadata.h:
(WebCore::VideoFrameTimeMetadata::encode const): Deleted.
(WebCore::VideoFrameTimeMetadata::decode): Deleted.
* Source/WebCore/platform/graphics/PositionedGlyphs.h:
(WebCore::PositionedGlyphs::PositionedGlyphs):
(WebCore::PositionedGlyphs::encode const): Deleted.
(WebCore::PositionedGlyphs::decode): Deleted.
* Source/WebCore/plugins/PluginData.h:
(WebCore::SupportedPluginIdentifier::decode): Deleted.
(WebCore::SupportedPluginIdentifier::encode const): Deleted.
* Source/WebCore/rendering/CSSValueKey.h:
(WebCore::CSSValueKey::encode const): Deleted.
(WebCore::CSSValueKey::decode): Deleted.
* Source/WebCore/rendering/EventRegion.cpp:
(WebCore::EventRegion::EventRegion):
* Source/WebCore/rendering/EventRegion.h:
(WebCore::EventRegion::encode const): Deleted.
(WebCore::EventRegion::decode): Deleted.
* Source/WebCore/workers/WorkerFetchResult.h:
(WebCore::WorkerFetchResult::isolatedCopy const):
(WebCore::workerFetchError):
(WebCore::WorkerFetchResult::encode const): Deleted.
(WebCore::WorkerFetchResult::decode): Deleted.
* Source/WebCore/workers/WorkerInitializationData.h:
(WebCore::WorkerInitializationData::encode const): Deleted.
(WebCore::WorkerInitializationData::decode): Deleted.
* Source/WebCore/workers/WorkerOptions.h:
(WebCore::WorkerOptions::encode const): Deleted.
(WebCore::WorkerOptions::decode): Deleted.
* Source/WebCore/workers/service/ServiceWorkerContextData.h:
(WebCore::ServiceWorkerContextData::ImportedScript::encode const): Deleted.
(WebCore::ServiceWorkerContextData::ImportedScript::decode): Deleted.
(WebCore::ServiceWorkerContextData::ImportedScript::isolatedCopy const): Deleted.
(WebCore::ServiceWorkerContextData::ImportedScript::isolatedCopy): Deleted.
(WebCore::ServiceWorkerContextData::encode const): Deleted.
(WebCore::ServiceWorkerContextData::decode): Deleted.
* Source/WebCore/workers/service/ServiceWorkerImportedScript.h: Copied from Source/WebCore/html/LinkIconType.h.
(WebCore::ServiceWorkerImportedScript::isolatedCopy const):
(WebCore::ServiceWorkerImportedScript::isolatedCopy):
* Source/WebCore/workers/service/ServiceWorkerJobDataIdentifier.h:
(WebCore::ServiceWorkerJobDataIdentifier::loggingString const):
(WebCore::ServiceWorkerJobDataIdentifier::encode const): Deleted.
(WebCore::ServiceWorkerJobDataIdentifier::decode): Deleted.
* Source/WebCore/workers/service/ServiceWorkerRegistrationData.h:
(WebCore::ServiceWorkerRegistrationData::encode const): Deleted.
(WebCore::ServiceWorkerRegistrationData::decode): Deleted.
* Source/WebCore/workers/service/ServiceWorkerRegistrationKey.h:
(WebCore::ServiceWorkerRegistrationKey::encode const): Deleted.
(WebCore::ServiceWorkerRegistrationKey::decode): Deleted.
* Source/WebCore/workers/service/ServiceWorkerRegistrationOptions.h:
(WebCore::ServiceWorkerRegistrationOptions::encode const): Deleted.
(WebCore::ServiceWorkerRegistrationOptions::decode): Deleted.
* Source/WebCore/workers/shared/SharedWorkerKey.h:
(WebCore::SharedWorkerKey::encode const): Deleted.
(WebCore::SharedWorkerKey::decode): Deleted.
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.messages.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebEvent.h:
* Source/WebKit/Shared/WebKeyboardEvent.h:

Canonical link: <a href="https://commits.webkit.org/260747@main">https://commits.webkit.org/260747@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f2e68a3e3cd0fe8b428247d68916dbafe943278

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109209 "7 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18293 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42022 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/736 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118439 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113091 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19752 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9594 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101452 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114965 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14805 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98035 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42978 "Found 1 new test failure: webgl/2.0.y/conformance/programs/program-test.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96777 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29689 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84714 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11066 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31032 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11792 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7965 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17160 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50635 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7417 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13415 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->