### PR TITLE
Adopt new subclass for InteractionRegion layers

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm
@@ -37,6 +37,7 @@
 #if USE(APPLE_INTERNAL_SDK)
 #import <WebKitAdditions/RemoteLayerTreePropertyApplierInteractionRegionAdditions.mm>
 #else
+static Class interactionRegionLayerClass() { return [CALayer class]; }
 static void configureLayerForInteractionRegion(CALayer *, NSString *) { }
 #endif
 
@@ -176,7 +177,7 @@ void updateLayersForInteractionRegions(CALayer *layer, RemoteLayerTreeHost& host
                 interactionRegionLayer = layerIterator->value;
                 interactionLayers.remove(layerIterator);
             } else {
-                interactionRegionLayer = adoptNS([[CALayer alloc] init]);
+                interactionRegionLayer = adoptNS([[interactionRegionLayerClass() alloc] init]);
                 [interactionRegionLayer setFrame:rect];
                 [interactionRegionLayer setHitTestsAsOpaque:YES];
 
@@ -197,7 +198,7 @@ void updateLayersForInteractionRegions(CALayer *layer, RemoteLayerTreeHost& host
             }
 
             setInteractionRegion(interactionRegionLayer.get(), region);
-            configureLayerForInteractionRegion(interactionRegionLayer.get(), makeString("WKInteractionRegion-"_s, String::number(region.elementIdentifier.toUInt64())));
+            configureLayerForInteractionRegion(interactionRegionLayer.get(), makeString("WKInteractionRegion-"_s, region.elementIdentifier.toUInt64()));
             [interactionRegionLayer setCornerRadius:std::max(region.borderRadius, minimumBorderRadius)];
         }
     }


### PR DESCRIPTION
#### b3bdeda02fd5995a5ac0f90d8dfb3d52904ae337
<pre>
Adopt new subclass for InteractionRegion layers
<a href="https://bugs.webkit.org/show_bug.cgi?id=252743">https://bugs.webkit.org/show_bug.cgi?id=252743</a>
&lt;rdar://105616856&gt;

Reviewed by Darin Adler.

Use the new extension point to get the InteractionRegion layer subclass.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm:
(interactionRegionLayerClass):
(WebKit::updateLayersForInteractionRegions):
Remove the explicit string conversion for the element identifier.

Canonical link: <a href="https://commits.webkit.org/260892@main">https://commits.webkit.org/260892@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a4b81761b67262051d0f1822801d34a83d3aabe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109502 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18624 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42261 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1000 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118680 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20092 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9823 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101779 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115257 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14969 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98198 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43185 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96941 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29851 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84935 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11365 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31194 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12028 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8120 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17394 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50798 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13761 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4097 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->