### PR TITLE
[GPU Process][FormControls] Don't create a fake NSView if viewless cell drawing is supported

### DIFF
--- a/Source/WebCore/platform/graphics/mac/controls/ButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ButtonMac.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,7 +32,6 @@
 #import "ControlFactoryMac.h"
 #import "GraphicsContext.h"
 #import "LocalDefaultSystemAppearance.h"
-#import <wtf/BlockObjCExceptions.h>
 
 namespace WebCore {
 
@@ -114,8 +113,6 @@ FloatRect ButtonMac::rectForBounds(const FloatRect& bounds, const ControlStyle& 
 
 void ButtonMac::draw(GraphicsContext& context, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle& style)
 {
-    BEGIN_BLOCK_OBJC_EXCEPTIONS
-
     LocalDefaultSystemAppearance localAppearance(style.states.contains(ControlStyle::State::DarkAppearance), style.accentColor);
 
     GraphicsContextStateSaver stateSaver(context);
@@ -127,23 +124,7 @@ void ButtonMac::draw(GraphicsContext& context, const FloatRoundedRect& borderRec
         context.scale(style.zoomFactor);
     }
 
-    auto *view = m_controlFactory.drawingView(borderRect.rect(), style);
-    auto *window = [view window];
-    auto *previousDefaultButtonCell = [window defaultButtonCell];
-
-    // Setup the window default button cell.
-    if (style.states.contains(ControlStyle::State::Default))
-        [window setDefaultButtonCell:m_buttonCell.get()];
-    else if ([previousDefaultButtonCell isEqual:m_buttonCell.get()])
-        [window setDefaultButtonCell:nil];
-
-    drawCell(context, inflatedRect, deviceScaleFactor, style, m_buttonCell.get(), view, true);
-
-    // Restore the window default button cell.
-    if (![previousDefaultButtonCell isEqual:m_buttonCell.get()])
-        [window setDefaultButtonCell:previousDefaultButtonCell];
-
-    END_BLOCK_OBJC_EXCEPTIONS
+    drawCell(context, inflatedRect, deviceScaleFactor, style, m_buttonCell.get(), true);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/mac/controls/ColorWellMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ColorWellMac.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,8 +30,7 @@
 
 #import "ColorWellPart.h"
 #import "ControlFactoryMac.h"
-#import "LocalCurrentGraphicsContext.h"
-#import <wtf/BlockObjCExceptions.h>
+#import "LocalDefaultSystemAppearance.h"
 
 namespace WebCore {
 
@@ -48,28 +47,9 @@ void ColorWellMac::updateCellStates(const FloatRect& rect, const ControlStyle& s
 
 void ColorWellMac::draw(GraphicsContext& context, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle& style)
 {
-    BEGIN_BLOCK_OBJC_EXCEPTIONS
-
     LocalDefaultSystemAppearance localAppearance(style.states.contains(ControlStyle::State::DarkAppearance), style.accentColor);
 
-    GraphicsContextStateSaver stateSaver(context);
-    LocalCurrentGraphicsContext localContext(context);
-
-    auto *view = m_controlFactory.drawingView(borderRect.rect(), style);
-    auto *window = [view window];
-    auto *previousDefaultButtonCell = [window defaultButtonCell];
-
-    // The ColorWell can't be the window default button cell.
-    if ([previousDefaultButtonCell isEqual:m_buttonCell.get()])
-        [window setDefaultButtonCell:nil];
-
-    drawCell(context, borderRect.rect(), deviceScaleFactor, style, m_buttonCell.get(), view, true);
-
-    // Restore the window default button cell.
-    if (![previousDefaultButtonCell isEqual:m_buttonCell.get()])
-        [window setDefaultButtonCell:previousDefaultButtonCell];
-
-    END_BLOCK_OBJC_EXCEPTIONS
+    drawCell(context, borderRect.rect(), deviceScaleFactor, style, m_buttonCell.get(), true);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/mac/controls/ControlMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlMac.h
@@ -63,12 +63,18 @@ protected:
 
     void updateCellStates(const FloatRect&, const ControlStyle&) override;
 
-    void drawCell(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&, NSCell *, NSView *, bool drawCell = true);
-    void drawCellOrFocusRing(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&, NSCell *, NSView *, bool drawCell = true);
+    void drawCell(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&, NSCell *, bool drawCell = true);
 
 #if ENABLE(DATALIST_ELEMENT)
     void drawListButton(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&);
 #endif
+
+private:
+    void drawCellInternal(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&, NSCell *);
+    void drawCellFocusRingInternal(const FloatRect&, float deviceScaleFactor, const ControlStyle&, NSCell *);
+
+    void drawCellFocusRing(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&, NSCell *);
+    void drawCellOrFocusRing(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&, NSCell *, bool drawCell = true);
 
     ControlFactoryMac& m_controlFactory;
 };

--- a/Source/WebCore/platform/graphics/mac/controls/ImageControlsButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ImageControlsButtonMac.mm
@@ -32,9 +32,7 @@
 #import "FloatRoundedRect.h"
 #import "GraphicsContext.h"
 #import "ImageControlsButtonPart.h"
-#import "LocalCurrentGraphicsContext.h"
 #import <pal/spi/mac/NSServicesRolloverButtonCellSPI.h>
-#import <wtf/BlockObjCExceptions.h>
 
 namespace WebCore {
 
@@ -54,16 +52,9 @@ IntSize ImageControlsButtonMac::servicesRolloverButtonCellSize()
 
 void ImageControlsButtonMac::draw(GraphicsContext& context, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle& style)
 {
-    BEGIN_BLOCK_OBJC_EXCEPTIONS
+    LocalDefaultSystemAppearance localAppearance(style.states.contains(ControlStyle::State::DarkAppearance), style.accentColor);
 
-    LocalCurrentGraphicsContext localContext(context);
-    GraphicsContextStateSaver stateSaver(context);
-
-    auto *view = m_controlFactory.drawingView(borderRect.rect(), style);
-    
-    drawCell(context, borderRect.rect(), deviceScaleFactor, style, m_servicesRolloverButtonCell.get(), view, true);
-    
-    END_BLOCK_OBJC_EXCEPTIONS
+    drawCell(context, borderRect.rect(), deviceScaleFactor, style, m_servicesRolloverButtonCell.get(), true);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/mac/controls/InnerSpinButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/InnerSpinButtonMac.mm
@@ -31,7 +31,6 @@
 #import "FloatRoundedRect.h"
 #import "GraphicsContext.h"
 #import "InnerSpinButtonPart.h"
-#import "LocalCurrentGraphicsContext.h"
 #import "LocalDefaultSystemAppearance.h"
 #import <pal/spi/mac/CoreUISPI.h>
 #import <pal/spi/mac/NSAppearanceSPI.h>
@@ -90,8 +89,7 @@ void InnerSpinButtonMac::draw(GraphicsContext& context, const FloatRoundedRect& 
         context.scale(style.zoomFactor);
     }
 
-    LocalCurrentGraphicsContext localContext(context);
-    [[NSAppearance currentDrawingAppearance] _drawInRect:logicalRect context:localContext.cgContext() options:@{
+    [[NSAppearance currentDrawingAppearance] _drawInRect:logicalRect context:context.platformContext() options:@{
         (__bridge NSString *)kCUIWidgetKey: (__bridge NSString *)kCUIWidgetButtonLittleArrows,
         (__bridge NSString *)kCUISizeKey: coreUISize,
         (__bridge NSString *)kCUIStateKey: coreUIState,

--- a/Source/WebCore/platform/graphics/mac/controls/MenuListButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/MenuListButtonMac.mm
@@ -31,7 +31,6 @@
 #import "ColorSpaceCG.h"
 #import "FloatRoundedRect.h"
 #import "GraphicsContext.h"
-#import "LocalCurrentGraphicsContext.h"
 #import "MenuListButtonPart.h"
 
 namespace WebCore {

--- a/Source/WebCore/platform/graphics/mac/controls/MenuListMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/MenuListMac.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,10 +30,8 @@
 
 #import "ControlFactoryMac.h"
 #import "GraphicsContext.h"
-#import "LocalCurrentGraphicsContext.h"
 #import "LocalDefaultSystemAppearance.h"
 #import "MenuListPart.h"
-#import <wtf/BlockObjCExceptions.h>
 
 namespace WebCore {
 
@@ -105,26 +103,18 @@ FloatRect MenuListMac::rectForBounds(const FloatRect& bounds, const ControlStyle
 
 void MenuListMac::draw(GraphicsContext& context, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle& style)
 {
-    BEGIN_BLOCK_OBJC_EXCEPTIONS
-
-    LocalCurrentGraphicsContext localContext(context);
-
-    auto inflatedRect = rectForBounds(borderRect.rect(), style);
+    LocalDefaultSystemAppearance localAppearance(style.states.contains(ControlStyle::State::DarkAppearance), style.accentColor);
 
     GraphicsContextStateSaver stateSaver(context);
+
+    auto inflatedRect = rectForBounds(borderRect.rect(), style);
 
     if (style.zoomFactor != 1) {
         inflatedRect.scale(1 / style.zoomFactor);
         context.scale(style.zoomFactor);
     }
 
-    LocalDefaultSystemAppearance localAppearance(style.states.contains(ControlStyle::State::DarkAppearance), style.accentColor);
-
-    auto *view = m_controlFactory.drawingView(borderRect.rect(), style);
-
-    drawCell(context, inflatedRect, deviceScaleFactor, style, m_popUpButtonCell.get(), view, true);
-
-    END_BLOCK_OBJC_EXCEPTIONS
+    drawCell(context, inflatedRect, deviceScaleFactor, style, m_popUpButtonCell.get(), true);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/mac/controls/MeterMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/MeterMac.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,7 +30,6 @@
 
 #import "ControlFactoryMac.h"
 #import "GraphicsContext.h"
-#import "LocalCurrentGraphicsContext.h"
 #import "LocalDefaultSystemAppearance.h"
 #import "MeterPart.h"
 #import <wtf/BlockObjCExceptions.h>
@@ -92,9 +91,7 @@ void MeterMac::draw(GraphicsContext& context, const FloatRoundedRect& borderRect
 {
     LocalDefaultSystemAppearance localAppearance(style.states.contains(ControlStyle::State::DarkAppearance), style.accentColor);
 
-    auto *view = m_controlFactory.drawingView(borderRect.rect(), style);
-
-    drawCell(context, borderRect.rect(), deviceScaleFactor, style, m_levelIndicatorCell.get(), view);
+    drawCell(context, borderRect.rect(), deviceScaleFactor, style, m_levelIndicatorCell.get());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.mm
@@ -29,7 +29,6 @@
 #if PLATFORM(MAC)
 
 #import "GraphicsContext.h"
-#import "LocalCurrentGraphicsContext.h"
 #import "LocalDefaultSystemAppearance.h"
 #import "ProgressBarPart.h"
 #import <pal/spi/mac/CoreUISPI.h>

--- a/Source/WebCore/platform/graphics/mac/controls/SearchFieldCancelButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SearchFieldCancelButtonMac.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,7 +31,6 @@
 #import "ControlFactoryMac.h"
 #import "FloatRoundedRect.h"
 #import "GraphicsContext.h"
-#import "LocalCurrentGraphicsContext.h"
 #import "LocalDefaultSystemAppearance.h"
 #import "SearchFieldCancelButtonPart.h"
 
@@ -83,8 +82,6 @@ void SearchFieldCancelButtonMac::draw(GraphicsContext& context, const FloatRound
 {
     LocalDefaultSystemAppearance localAppearance(style.states.contains(ControlStyle::State::DarkAppearance), style.accentColor);
 
-    LocalCurrentGraphicsContext localContext(context);
-
     GraphicsContextStateSaver stateSaver(context);
 
     auto logicalRect = rectForBounds(borderRect.rect(), style);
@@ -97,9 +94,7 @@ void SearchFieldCancelButtonMac::draw(GraphicsContext& context, const FloatRound
     auto styleForDrawing = style;
     styleForDrawing.states.remove(ControlStyle::State::Focused);
 
-    auto *view = m_controlFactory.drawingView(borderRect.rect(), style);
-
-    drawCell(context, logicalRect, deviceScaleFactor, styleForDrawing, [m_searchFieldCell cancelButtonCell], view, true);
+    drawCell(context, logicalRect, deviceScaleFactor, styleForDrawing, [m_searchFieldCell cancelButtonCell], true);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/mac/controls/SearchFieldMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SearchFieldMac.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,7 +31,6 @@
 #import "ControlFactoryMac.h"
 #import "FloatRoundedRect.h"
 #import "GraphicsContext.h"
-#import "LocalCurrentGraphicsContext.h"
 #import "LocalDefaultSystemAppearance.h"
 #import "SearchFieldPart.h"
 
@@ -47,8 +46,6 @@ void SearchFieldMac::draw(GraphicsContext& context, const FloatRoundedRect& bord
 {
     LocalDefaultSystemAppearance localAppearance(style.states.contains(ControlStyle::State::DarkAppearance), style.accentColor);
 
-    LocalCurrentGraphicsContext localContext(context);
-
     GraphicsContextStateSaver stateSaver(context);
 
     auto logicalRect = borderRect.rect();
@@ -57,11 +54,9 @@ void SearchFieldMac::draw(GraphicsContext& context, const FloatRoundedRect& bord
         context.scale(style.zoomFactor);
     }
 
-    auto *view = m_controlFactory.drawingView(borderRect.rect(), style);
-
     [m_searchFieldCell setSearchButtonCell:nil];
 
-    drawCell(context, logicalRect, deviceScaleFactor, style, m_searchFieldCell.get(), view, true);
+    drawCell(context, logicalRect, deviceScaleFactor, style, m_searchFieldCell.get(), true);
 
     [m_searchFieldCell resetSearchButtonCell];
     

--- a/Source/WebCore/platform/graphics/mac/controls/SearchFieldResultsMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SearchFieldResultsMac.mm
@@ -31,10 +31,8 @@
 #import "ControlFactoryMac.h"
 #import "FloatRoundedRect.h"
 #import "GraphicsContext.h"
-#import "LocalCurrentGraphicsContext.h"
 #import "LocalDefaultSystemAppearance.h"
 #import "SearchFieldResultsPart.h"
-#import <wtf/BlockObjCExceptions.h>
 
 namespace WebCore {
 
@@ -57,12 +55,8 @@ void SearchFieldResultsMac::updateCellStates(const FloatRect& rect, const Contro
 
 void SearchFieldResultsMac::draw(GraphicsContext& context, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle& style)
 {
-    BEGIN_BLOCK_OBJC_EXCEPTIONS
-
     LocalDefaultSystemAppearance localAppearance(style.states.contains(ControlStyle::State::DarkAppearance), style.accentColor);
 
-    LocalCurrentGraphicsContext localContext(context);
-    
     GraphicsContextStateSaver stateSaver(context);
 
     auto logicalRect = borderRect.rect();
@@ -72,11 +66,7 @@ void SearchFieldResultsMac::draw(GraphicsContext& context, const FloatRoundedRec
         context.scale(style.zoomFactor);
     }
 
-    auto *view = m_controlFactory.drawingView(borderRect.rect(), style);
-
-    drawCell(context, logicalRect, deviceScaleFactor, style, [m_searchFieldCell searchButtonCell], view, true);
-
-    END_BLOCK_OBJC_EXCEPTIONS
+    drawCell(context, logicalRect, deviceScaleFactor, style, [m_searchFieldCell searchButtonCell], true);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/mac/controls/SliderThumbMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SliderThumbMac.mm
@@ -31,7 +31,6 @@
 #import "ControlFactoryMac.h"
 #import "FloatRoundedRect.h"
 #import "GraphicsContext.h"
-#import "LocalCurrentGraphicsContext.h"
 #import "LocalDefaultSystemAppearance.h"
 #import "SliderThumbPart.h"
 
@@ -50,13 +49,6 @@ void SliderThumbMac::updateCellStates(const FloatRect& rect, const ControlStyle&
 
     updateEnabledState(m_sliderCell.get(), style);
     updateFocusedState(m_sliderCell.get(), style);
-
-    auto *view = m_controlFactory.drawingView(rect, style);
-
-    if (style.states.contains(ControlStyle::State::Pressed))
-        [m_sliderCell startTrackingAt:NSPoint() inView:view];
-    else
-        [m_sliderCell stopTracking:NSPoint() at:NSPoint() inView:view mouseIsUp:YES];
 }
 
 FloatRect SliderThumbMac::rectForBounds(const FloatRect& bounds, const ControlStyle& style) const
@@ -72,11 +64,10 @@ FloatRect SliderThumbMac::rectForBounds(const FloatRect& bounds, const ControlSt
 void SliderThumbMac::draw(GraphicsContext& context, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle& style)
 {
     LocalDefaultSystemAppearance localAppearance(style.states.contains(ControlStyle::State::DarkAppearance), style.accentColor);
-    LocalCurrentGraphicsContext localContext(context);
-    
-    auto logicalRect = rectForBounds(borderRect.rect(), style);
 
     GraphicsContextStateSaver stateSaver(context);
+
+    auto logicalRect = rectForBounds(borderRect.rect(), style);
 
     if (style.zoomFactor != 1) {
         logicalRect.scale(1 / style.zoomFactor);
@@ -87,9 +78,7 @@ void SliderThumbMac::draw(GraphicsContext& context, const FloatRoundedRect& bord
     auto styleForDrawing = style;
     styleForDrawing.states.remove(ControlStyle::State::Focused);
 
-    auto *view = m_controlFactory.drawingView(borderRect.rect(), style);
-
-    drawCell(context, logicalRect, deviceScaleFactor, styleForDrawing, m_sliderCell.get(), view, true);
+    drawCell(context, logicalRect, deviceScaleFactor, styleForDrawing, m_sliderCell.get(), true);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/mac/controls/SliderTrackMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SliderTrackMac.mm
@@ -30,7 +30,6 @@
 
 #import "ColorSpaceCG.h"
 #import "FloatRoundedRect.h"
-#import "LocalCurrentGraphicsContext.h"
 
 namespace WebCore {
 
@@ -74,8 +73,7 @@ void SliderTrackMac::draw(GraphicsContext& context, const FloatRoundedRect& bord
     static constexpr int sliderTrackRadius = 2;
     static constexpr IntSize sliderRadius(sliderTrackRadius, sliderTrackRadius);
 
-    LocalCurrentGraphicsContext localContext(context);
-    CGContextRef cgContext = localContext.cgContext();
+    CGContextRef cgContext = context.platformContext();
     CGColorSpaceRef cspace = sRGBColorSpaceRef();
 
     auto& sliderTrackPart = owningSliderTrackPart();
@@ -98,7 +96,6 @@ void SliderTrackMac::draw(GraphicsContext& context, const FloatRoundedRect& bord
         mainShading = adoptCF(CGShadingCreateAxial(cspace, CGPointMake(logicalRect.x(),  logicalRect.y()), CGPointMake(logicalRect.x(), logicalRect.maxY()), mainFunction.get(), false, false));
 
     context.clipRoundedRect(FloatRoundedRect(logicalRect, sliderRadius, sliderRadius, sliderRadius, sliderRadius));
-    cgContext = localContext.cgContext();
     CGContextDrawShading(cgContext, mainShading.get());
 }
 

--- a/Source/WebCore/platform/graphics/mac/controls/TextAreaMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/TextAreaMac.mm
@@ -42,6 +42,8 @@ TextAreaMac::TextAreaMac(TextAreaPart& owningPart)
 
 void TextAreaMac::draw(GraphicsContext& context, const FloatRoundedRect& borderRect, float, const ControlStyle& style)
 {
+    LocalDefaultSystemAppearance localAppearance(style.states.contains(ControlStyle::State::DarkAppearance), style.accentColor);
+
     LocalCurrentGraphicsContext localContext(context);
 
     bool enabled = style.states.contains(ControlStyle::State::Enabled);

--- a/Source/WebCore/platform/graphics/mac/controls/TextFieldMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/TextFieldMac.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,9 +29,9 @@
 #if PLATFORM(MAC)
 
 #import "ControlFactoryMac.h"
-#import "LocalCurrentGraphicsContext.h"
+#import "GraphicsContext.h"
+#import "LocalDefaultSystemAppearance.h"
 #import "TextFieldPart.h"
-#import "WebControlView.h"
 
 namespace WebCore {
 
@@ -51,13 +51,14 @@ bool TextFieldMac::shouldPaintCustomTextField(const ControlStyle& style)
 
 void TextFieldMac::draw(GraphicsContext& context, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle& style)
 {
-    const auto& states = style.states;
-    auto enabled = states.contains(ControlStyle::State::Enabled) && !states.contains(ControlStyle::State::ReadOnly);
+    LocalDefaultSystemAppearance localAppearance(style.states.contains(ControlStyle::State::DarkAppearance), style.accentColor);
 
-    LocalCurrentGraphicsContext localContext(context);
     GraphicsContextStateSaver stateSaver(context);
 
     FloatRect paintRect(borderRect.rect());
+
+    const auto& states = style.states;
+    auto enabled = states.contains(ControlStyle::State::Enabled) && !states.contains(ControlStyle::State::ReadOnly);
 
     if (shouldPaintCustomTextField(style)) {
         constexpr int strokeThickness = 1;
@@ -78,11 +79,12 @@ void TextFieldMac::draw(GraphicsContext& context, const FloatRoundedRect& border
             paintRect.move(0, -1 / transform.yScale());
         }
         
-        auto *view = m_controlFactory.drawingView(borderRect.rect(), style);
-        
         [m_textFieldCell.get() setEnabled:enabled];
-        [m_textFieldCell.get() drawWithFrame:NSRect(paintRect) inView:view];
-        [m_textFieldCell.get() setControlView:nil];
+
+        auto styleForDrawing = style;
+        styleForDrawing.states.remove(ControlStyle::State::Focused);
+
+        drawCell(context, paintRect, deviceScaleFactor, styleForDrawing, m_textFieldCell.get(), true);
     }
 
 #if ENABLE(DATALIST_ELEMENT)

--- a/Source/WebCore/platform/graphics/mac/controls/ToggleButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ToggleButtonMac.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,7 +34,6 @@
 #import "LocalDefaultSystemAppearance.h"
 #import "ToggleButtonPart.h"
 #import <pal/spi/cocoa/NSButtonCellSPI.h>
-#import <wtf/BlockObjCExceptions.h>
 
 namespace WebCore {
 
@@ -98,7 +97,7 @@ IntOutsets ToggleButtonMac::cellOutsets(NSControlSize controlSize, const Control
 
 void ToggleButtonMac::draw(GraphicsContext& context, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle& style)
 {
-    BEGIN_BLOCK_OBJC_EXCEPTIONS
+    LocalDefaultSystemAppearance localAppearance(style.states.contains(ControlStyle::State::DarkAppearance), style.accentColor);
 
     GraphicsContextStateSaver stateSaver(context);
 
@@ -124,10 +123,6 @@ void ToggleButtonMac::draw(GraphicsContext& context, const FloatRoundedRect& bor
         context.scale(style.zoomFactor);
     }
 
-    LocalDefaultSystemAppearance localAppearance(style.states.contains(ControlStyle::State::DarkAppearance), style.accentColor);
-
-    auto *view = m_controlFactory.drawingView(borderRect.rect(), style);
-
     if ([m_buttonCell _stateAnimationRunning]) {
         context.translate(logicalRect.location());
         context.scale(FloatSize(1, -1));
@@ -136,11 +131,9 @@ void ToggleButtonMac::draw(GraphicsContext& context, const FloatRoundedRect& bor
         [m_buttonCell _renderCurrentAnimationFrameInContext:context.platformContext() atLocation:NSMakePoint(0, 0)];
 
         if (![m_buttonCell _stateAnimationRunning] && style.states.contains(ControlStyle::State::Focused))
-            drawCell(context, logicalRect, deviceScaleFactor, style, m_buttonCell.get(), view, false);
+            drawCell(context, logicalRect, deviceScaleFactor, style, m_buttonCell.get(), false);
     } else
-        drawCell(context, logicalRect, deviceScaleFactor, style, m_buttonCell.get(), view, true);
-
-    END_BLOCK_OBJC_EXCEPTIONS
+        drawCell(context, logicalRect, deviceScaleFactor, style, m_buttonCell.get(), true);
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### d9b43d246262ba0832806f7aa7dcb6e6fbc4806f
<pre>
[GPU Process][FormControls] Don&apos;t create a fake NSView if viewless cell drawing is supported
<a href="https://bugs.webkit.org/show_bug.cgi?id=252723">https://bugs.webkit.org/show_bug.cgi?id=252723</a>
rdar://105778966

Reviewed by Aditya Keerthi.

Currently, we create an NSView unconditionally which may or may not be used.
Creating the fake NSView should be restricted to the case when the viewless
drawing is not supported.

Because viewless cell drawing is still in progress, we are going to enable it if
GPUP is enabled on macOS only for now.

This will require moving the call to ControlFactoryMac::drawingView() from the
super classes `draw()` methods deeper inside the base class ControlMac methods
after we check `supportsViewlessCells()` and find it is false.

The call to `[window setDefaultButtonCell:buttonCell]` was removed from drawing
the default button. We call `[m_defaultButtonCell setKeyEquivalent:@&quot;\r&quot;]` when
creating the NSButtonCell for the default button. And this is sufficient to make
the drawing correct: the dark background and the white text.

The calls to [sliderCell startTrackingAt:] and [sliderCell stopTracking:] were
removed also. The methods seem to be related to interacting with NSSliderCell
and they do not affect the drawing. The interaction with the SliderThumb part is
managed by WebKit which decides where to display this control part.

ControlMac::drawCellOrFocusRing() should be responsible of creating an instance
of LocalCurrentGraphicsContext because the caller which is `ControlMac::drawCell()`
may change the drawing GraphicsContext to an intermediate ImageBuffer for scaling.

For clarity, make instantiating an instance of LocalDefaultSystemAppearance and
an instance of GraphicsContextStateSaver if needed be the responsibility of the
super classes `draw()` methods.

Another clean-up was added. The exception block controls can be moved from the
super classes `draw()` methods to ControlMac::drawCellOrFocusRing().

* Source/WebCore/platform/graphics/mac/controls/ButtonMac.mm:
(WebCore::ButtonMac::draw):
* Source/WebCore/platform/graphics/mac/controls/ColorWellMac.mm:
(WebCore::ColorWellMac::draw):
* Source/WebCore/platform/graphics/mac/controls/ControlMac.h:
* Source/WebCore/platform/graphics/mac/controls/ControlMac.mm:
(WebCore::supportsViewlessCells):
(WebCore::drawViewlessCell):
(WebCore::ControlMac::drawCellInternal):
(WebCore::drawViewlessCellFocusRing):
(WebCore::ControlMac::drawCellFocusRingInternal):
(WebCore::ControlMac::drawCellFocusRing):
(WebCore::ControlMac::drawCellOrFocusRing):
(WebCore::ControlMac::drawCell):
(WebCore::ControlMac::drawListButton):
(WebCore::drawCellFocusRing): Deleted.
* Source/WebCore/platform/graphics/mac/controls/ImageControlsButtonMac.mm:
(WebCore::ImageControlsButtonMac::draw):
* Source/WebCore/platform/graphics/mac/controls/MenuListMac.mm:
(WebCore::MenuListMac::draw):
* Source/WebCore/platform/graphics/mac/controls/MeterMac.mm:
(WebCore::MeterMac::draw):
* Source/WebCore/platform/graphics/mac/controls/SearchFieldCancelButtonMac.mm:
(WebCore::SearchFieldCancelButtonMac::draw):
* Source/WebCore/platform/graphics/mac/controls/SearchFieldMac.mm:
(WebCore::SearchFieldMac::draw):
* Source/WebCore/platform/graphics/mac/controls/SearchFieldResultsMac.mm:
(WebCore::SearchFieldResultsMac::draw):
* Source/WebCore/platform/graphics/mac/controls/SliderThumbMac.mm:
(WebCore::SliderThumbMac::updateCellStates):
(WebCore::SliderThumbMac::draw):
* Source/WebCore/platform/graphics/mac/controls/SliderTrackMac.mm:
(WebCore::SliderTrackMac::draw):
* Source/WebCore/platform/graphics/mac/controls/TextFieldMac.mm:
(WebCore::TextFieldMac::draw):
* Source/WebCore/platform/graphics/mac/controls/ToggleButtonMac.mm:
(WebCore::ToggleButtonMac::draw):

Canonical link: <a href="https://commits.webkit.org/260726@main">https://commits.webkit.org/260726@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3673add295a5a259cc259bcc96006f8629f5b61

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109164 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18243 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41977 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/691 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118405 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113046 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19702 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9545 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101404 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114922 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14773 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98004 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/42955 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29658 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84677 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11022 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31001 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11751 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7934 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17120 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50604 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7400 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13369 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->