### PR TITLE
[WGSL] Move type checking into the validation stage

### DIFF
--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -45,7 +45,7 @@ class TypeChecker : public AST::Visitor, public ContextProvider<Type*> {
 public:
     TypeChecker(ShaderModule&);
 
-    void check();
+    std::optional<FailedCheck> check();
 
     // Declarations
     void visit(AST::Structure&) override;
@@ -122,7 +122,7 @@ TypeChecker::TypeChecker(ShaderModule& shaderModule)
 #include "TypeDeclarations.h" // NOLINT
 }
 
-void TypeChecker::check()
+std::optional<FailedCheck> TypeChecker::check()
 {
     // FIXME: fill in struct fields in a second pass since declarations might be
     // out of order
@@ -145,6 +145,14 @@ void TypeChecker::check()
         for (auto& error : m_errors)
             dataLogLn(error);
     }
+
+    if (m_errors.isEmpty())
+        return std::nullopt;
+
+
+    // FIXME: add support for warnings
+    Vector<Warning> warnings { };
+    return FailedCheck { WTFMove(m_errors), WTFMove(warnings) };
 }
 
 // Declarations
@@ -563,9 +571,9 @@ void TypeChecker::typeError(InferBottom inferBottom, const SourceSpan& span, Arg
         inferred(m_types.bottomType());
 }
 
-void typeCheck(ShaderModule& shaderModule)
+std::optional<FailedCheck> typeCheck(ShaderModule& shaderModule)
 {
-    TypeChecker(shaderModule).check();
+    return TypeChecker(shaderModule).check();
 }
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/TypeCheck.h
+++ b/Source/WebGPU/WGSL/TypeCheck.h
@@ -25,10 +25,12 @@
 
 #pragma once
 
+#include "WGSL.h"
+
 namespace WGSL {
 
 class ShaderModule;
 
-void typeCheck(ShaderModule&);
+std::optional<FailedCheck> typeCheck(ShaderModule&);
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/TypeDeclarations.js
+++ b/Source/WebGPU/WGSL/TypeDeclarations.js
@@ -4,3 +4,6 @@ type('+', [Number(T), N], [Vector(T, N), T], T)
 type('+', [Number(T), N], [T, Vector(T, N)], Vector(T, N))
 type('+', [Number(T), N], [Vector(T, N), Vector(T, N)], Vector(T, N))
 type('+', [Float(T), C, R], [Matrix(T, C, R), Matrix(T, C, R)], Matrix(T, C, R))
+
+type('*', [Float(T), C, R], [Matrix(T, C, R), Vector(T, C)], Vector(T, R))
+type('*', [Float(T), C, R], [Vector(T, R), Matrix(T, C, R)], Vector(T, C))

--- a/Source/WebGPU/WGSL/WGSL.cpp
+++ b/Source/WebGPU/WGSL/WGSL.cpp
@@ -75,8 +75,12 @@ std::variant<SuccessfulCheck, FailedCheck> staticCheck(const String& wgsl, const
         return FailedCheck { { *error }, { /* warnings */ } };
     }
 
+    // FIXME: add more validation
+    auto maybeFailure = typeCheck(shaderModule);
+    if (maybeFailure.has_value())
+        return *maybeFailure;
+
     Vector<Warning> warnings { };
-    // FIXME: add validation
     return std::variant<SuccessfulCheck, FailedCheck>(std::in_place_type<SuccessfulCheck>, WTFMove(warnings), WTFMove(shaderModule));
 }
 
@@ -98,8 +102,6 @@ inline PrepareResult prepareImpl(ShaderModule& ast, const HashMap<String, Pipeli
     {
         PhaseTimer phaseTimer("prepare total", phaseTimes);
 
-        // FIXME: this should run as part of staticCheck
-        RUN_PASS(typeCheck, ast);
         RUN_PASS_WITH_RESULT(callGraph, buildCallGraph, ast);
         RUN_PASS(resolveTypeReferences, ast);
         RUN_PASS(rewriteEntryPoints, callGraph, result);


### PR DESCRIPTION
#### 0c0a78158493361033491779b9ec813d6da84fbf
<pre>
[WGSL] Move type checking into the validation stage
<a href="https://bugs.webkit.org/show_bug.cgi?id=252760">https://bugs.webkit.org/show_bug.cgi?id=252760</a>
rdar://105788936

Reviewed by Myles C. Maxfield.

At first, since there was very little of the type checking implemented, it was
only run right before generating and the errors behind a compiler-time flag.
While the type checker is still far from complete, it can now correctly check
the examples we&apos;ve been using for development, so we can move it into the
validation phase.

* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::check):
(WGSL::typeCheck):
* Source/WebGPU/WGSL/TypeCheck.h:
* Source/WebGPU/WGSL/TypeDeclarations.js:
* Source/WebGPU/WGSL/WGSL.cpp:
(WGSL::staticCheck):
(WGSL::prepareImpl):

Canonical link: <a href="https://commits.webkit.org/260735@main">https://commits.webkit.org/260735@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5ba147e3d01d6ce23fba237408f0b5f500258cd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109093 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18175 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41915 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/628 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118356 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19634 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9477 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101334 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114853 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14719 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97954 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42882 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96691 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29608 "Found 1 new test failure: imported/w3c/web-platform-tests/preload/onerror-event.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84615 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10957 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30953 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11694 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7881 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17066 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50553 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7406 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13302 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->