### PR TITLE
Add functionality to find-feature-flags script to find defines that are only used once

### DIFF
--- a/Tools/Scripts/find-feature-flags
+++ b/Tools/Scripts/find-feature-flags
@@ -66,6 +66,7 @@ def _parse_args(argv):
     parser.add_argument("find", help="the code to search", choices=_CHOICES, nargs="*")
     parser.add_argument("--diff", choices=_CHOICES, action="append")
     parser.add_argument("--macro", choices=["ENABLE", "USE", "HAVE"], default="ENABLE")
+    parser.add_argument("--uncommon", action='store_true', help="returns defines only used once in the code, not to be used when --diff is defined")
     return parser.parse_args(argv)
 
 
@@ -85,24 +86,33 @@ def _choice_set(choices):
     return choices_set
 
 
-def _search_for(choices, macro):
+def _search_for(choices, macro, uncommon_flag):
     found = set()
+    found_single_use = set()
 
     for choice in _choice_set(choices):
         search_with = _search_with(choice)
         search_with.search(_ROOT, macro)
         found.update(search_with.definitions())
+    
+    if uncommon_flag:
+        for choice in {"native-code", "cmake-code", "idl-code"}:
+            search_with = _search_with(choice)
+            search_with.search(_ROOT, macro)
+            single_use = set()
+            single_use.update(search_with.single_use_definitions())
+            found_single_use = found.intersection(single_use)
 
-    return found
+    return found, found_single_use
 
 
 def main(argv):
     args = _parse_args(argv)
 
-    find_defines = _search_for(args.find, args.macro)
+    find_defines, find_defines_single_use = _search_for(args.find, args.macro, args.uncommon)
 
     if args.diff:
-        diff_defines = _search_for(args.diff, args.macro)
+        diff_defines, find_defines_single_use = _search_for(args.diff, args.macro, False)
 
         only_find = find_defines.difference(diff_defines)
 
@@ -114,6 +124,19 @@ def main(argv):
 
         print("Only in Diff (" + ",".join(args.diff) + ")")
         for item in sorted(only_diff):
+            print(item)
+    elif args.uncommon:
+        print("All defines:")
+        for item in sorted(find_defines):
+            print(item)
+        
+        print("\nDefines only used once:")
+        for item in sorted(find_defines_single_use):
+            print(item)
+
+        only_multi_use = find_defines.difference(find_defines_single_use)
+        print("\nDefines used more than once:")
+        for item in sorted(only_multi_use):
             print(item)
     else:
         for item in sorted(find_defines):

--- a/Tools/Scripts/find-feature-flags
+++ b/Tools/Scripts/find-feature-flags
@@ -47,100 +47,116 @@ _CHOICES = [
     "idl-code",
 ]
 
-
-def _search_with(choice):
+def _heuristic(self, choice):
     mapping = {
-        "platform": search.FeatureDefinesPlatform,
-        "perl": search.FeatureDefinesPerl,
-        "cmake": search.FeatureDefinesCMake,
-        "native-code": search.FeatureDefinesUsageNativeCode,
-        "cmake-code": search.FeatureDefinesUsageCMakeCode,
-        "idl-code": search.FeatureDefinesUsageIdlCode,
+        "count": FeatureDefinesCount,
     }
 
-    return mapping[choice]()
+    return mapping[choice]() if mapping[choice] else FeatureDefines()
 
+class FeatureDefines:
 
-def _parse_args(argv):
-    parser = argparse.ArgumentParser(description=_DESCRIPTION, formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("find", help="the code to search", choices=_CHOICES, nargs="*")
-    parser.add_argument("--diff", choices=_CHOICES, action="append")
-    parser.add_argument("--macro", choices=["ENABLE", "USE", "HAVE"], default="ENABLE")
-    parser.add_argument("--uncommon", action='store_true', help="returns defines only used once in the code, not to be used when --diff is defined")
-    return parser.parse_args(argv)
+    def search_for(self, choices, macro):
+        found = set()
 
-
-def _choice_set(choices):
-    choices_set = set(choices)
-
-    if "definitions" in choices_set:
-        choices_set.remove("definitions")
-
-        choices_set.update(["platform", "perl", "cmake"])
-
-    if "all-code" in choices_set:
-        choices_set.remove("all-code")
-
-        choices_set.update(["native-code", "cmake-code", "idl-code"])
-
-    return choices_set
-
-
-def _search_for(choices, macro, uncommon_flag):
-    found = set()
-    found_single_use = set()
-
-    for choice in _choice_set(choices):
-        search_with = _search_with(choice)
-        search_with.search(_ROOT, macro)
-        found.update(search_with.definitions())
-    
-    if uncommon_flag:
-        for choice in {"native-code", "cmake-code", "idl-code"}:
-            search_with = _search_with(choice)
+        for choice in self._choice_set(choices):
+            search_with = self._search_with(choice)
             search_with.search(_ROOT, macro)
-            single_use = set()
-            single_use.update(search_with.single_use_definitions())
-            found_single_use = found.intersection(single_use)
+            found.update(search_with.definitions())
 
-    return found, found_single_use
+        return found
+
+    def _search_with(self, choice):
+        mapping = {
+            "platform": search.FeatureDefinesPlatform,
+            "perl": search.FeatureDefinesPerl,
+            "cmake": search.FeatureDefinesCMake,
+            "native-code": search.FeatureDefinesUsageNativeCode,
+            "cmake-code": search.FeatureDefinesUsageCMakeCode,
+            "idl-code": search.FeatureDefinesUsageIdlCode,
+        }
+
+        return mapping[choice]()
+
+
+    def _parse_args(self, argv):
+        parser = argparse.ArgumentParser(description=_DESCRIPTION, formatter_class=argparse.RawDescriptionHelpFormatter)
+        parser.add_argument("find", help="the code to search", choices=_CHOICES, nargs="*")
+        parser.add_argument("--diff", choices=_CHOICES, action="append")
+        parser.add_argument("--macro", choices=["ENABLE", "USE", "HAVE"], default="ENABLE")
+        parser.add_argument("-c", "--count", action='store_true', help="returns the number of files each define shows up in")
+        return parser.parse_args(argv)
+
+
+    def _choice_set(self, choices):
+        choices_set = set(choices)
+
+        if "definitions" in choices_set:
+            choices_set.remove("definitions")
+
+            choices_set.update(["platform", "perl", "cmake"])
+
+        if "all-code" in choices_set:
+            choices_set.remove("all-code")
+
+            choices_set.update(["native-code", "cmake-code", "idl-code"])
+
+        return choices_set
+
+
+class FeatureDefinesCount(FeatureDefines):
+
+    def __init__(self):
+        self._defines_count = {}
+
+    def get_defines_count(self):
+        return self._defines_count
+
+    def search_for(self, choices, macro):
+        found = super().search_for(choices, macro)
+
+        for choice in {"platform", "perl", "cmake", "native-code", "cmake-code", "idl-code"}:
+            search_with = self._search_with(choice)
+            search_with.search(_ROOT, macro)
+            self._defines_count.update(search_with.definitions_count())
+        
+        return found
 
 
 def main(argv):
-    args = _parse_args(argv)
+    feature_defines = FeatureDefines()
+    args = feature_defines._parse_args(argv)
 
-    find_defines, find_defines_single_use = _search_for(args.find, args.macro, args.uncommon)
+    if args.count:
+        feature_defines = FeatureDefinesCount()
+
+    find_defines = feature_defines.search_for(args.find, args.macro)
 
     if args.diff:
-        diff_defines, find_defines_single_use = _search_for(args.diff, args.macro, False)
+        diff_defines = feature_defines.search_for(args.diff, args.macro)
+
+        if args.count:
+            defines_count = feature_defines.get_defines_count()
 
         only_find = find_defines.difference(diff_defines)
 
         print("Only in Source (" + ",".join(args.find) + ")")
         for item in sorted(only_find):
-            print(item)
+            output = item if not args.count else item + ": " + str(defines_count[item])
+            print(output)
 
         only_diff = diff_defines.difference(find_defines)
 
         print("Only in Diff (" + ",".join(args.diff) + ")")
         for item in sorted(only_diff):
-            print(item)
-    elif args.uncommon:
-        print("All defines:")
-        for item in sorted(find_defines):
-            print(item)
-        
-        print("\nDefines only used once:")
-        for item in sorted(find_defines_single_use):
-            print(item)
-
-        only_multi_use = find_defines.difference(find_defines_single_use)
-        print("\nDefines used more than once:")
-        for item in sorted(only_multi_use):
-            print(item)
+            output = item if not args.count else item + ": " + str(defines_count[item])
+            print(output)
     else:
+        if args.count:
+            defines_count = feature_defines.get_defines_count()
         for item in sorted(find_defines):
-            print(item)
+            output = item if not args.count else item + ": " + str(defines_count[item])
+            print(output)
 
 
 if __name__ == "__main__":

--- a/Tools/Scripts/webkitpy/featuredefines/search.py
+++ b/Tools/Scripts/webkitpy/featuredefines/search.py
@@ -51,6 +51,14 @@ class FeatureDefinesSearch(object):
         """ Retrieves any references to the define found. """
         return self._defines[define]
 
+    def single_use_definitions(self):
+        definitions = set()
+        for k, v in self._defines.items():
+            if len(v) == 1:
+                definitions.add(k)
+        
+        return definitions
+
     @abstractmethod
     def search(self, root, macro):
         """ Search for feature defines within the root """
@@ -71,8 +79,8 @@ class FeatureDefinesSearch(object):
     def _search_directory(self, matcher, path, patterns):
         for root, __, files in os.walk(path):
             for file in files:
-                for patten in patterns:
-                    if fnmatch.fnmatch(file, patten):
+                for pattern in patterns:
+                    if fnmatch.fnmatch(file, pattern):
                         self._search_file(matcher, os.path.join(root, file))
 
     @classmethod

--- a/Tools/Scripts/webkitpy/featuredefines/search.py
+++ b/Tools/Scripts/webkitpy/featuredefines/search.py
@@ -51,12 +51,14 @@ class FeatureDefinesSearch(object):
         """ Retrieves any references to the define found. """
         return self._defines[define]
 
-    def single_use_definitions(self):
-        definitions = set()
+    def definitions_count(self):
+        definitions = {}
         for k, v in self._defines.items():
-            if len(v) == 1:
-                definitions.add(k)
-        
+            if k not in definitions:
+                definitions[k] = len(v)
+            
+            definitions[k] = definitions[k] + len(v)
+
         return definitions
 
     @abstractmethod


### PR DESCRIPTION
#### f0a1be091b779a7d1477127cea731e1764a51779
<pre>
Add functionality to find-feature-flags script to find defines that are only used once
<a href="https://bugs.webkit.org/show_bug.cgi?id=252763">https://bugs.webkit.org/show_bug.cgi?id=252763</a>

Reviewed by NOBODY (OOPS!).

It might be useful to know which defines are only used in one file. Knowing such may help us clean up the code and remove any underutilized defines. This PR adds the functionality of printing out single use defines to the find-feature-flags script.

-Tools/Scripts/find-feature-flags
-Tools/Scripts/webkitpy/featuredefines/search.py
</pre>
----------------------------------------------------------------------
#### ac7c707b38a221fa23b2af33c71ea6356aac854a
<pre>
Add functionality to find-feature-flags script to find defines that are only used once
<a href="https://bugs.webkit.org/show_bug.cgi?id=252763">https://bugs.webkit.org/show_bug.cgi?id=252763</a>

Reviewed by NOBODY (OOPS!).

It might be useful to know which defines are only used in one file. Knowing such may help us clean up the code and remove any underutilized defines. This PR adds the functionality of printing out single use defines to the find-feature-flags script.

-Tools/Scripts/find-feature-flags
-Tools/Scripts/webkitpy/featuredefines/search.py
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0a1be091b779a7d1477127cea731e1764a51779

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110090 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19192 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42763 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1526 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119106 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114042 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20654 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10383 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102349 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115836 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15376 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98584 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43597 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/113529 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97337 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30244 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85429 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11889 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31582 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12508 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8544 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17873 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51197 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14307 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->