### PR TITLE
[WPE][GTK] Allow to configure auto-deleting of coredumps after processing

### DIFF
--- a/Tools/Scripts/webkitpy/port/linux_get_crash_log.py
+++ b/Tools/Scripts/webkitpy/port/linux_get_crash_log.py
@@ -154,6 +154,8 @@ class GDBCrashLogGenerator(object):
                 coredump_path = list(reversed(sorted(dumps)))[0]
                 if not self.newer_than or self._filesystem.mtime(coredump_path) > self.newer_than:
                     crash_log, errors = self._get_gdb_output(coredump_path)
+                    if os.environ.get('WEBKIT_CORE_DUMPS_AUTODELETE', '0') == '1':
+                        os.remove(coredump_path)
         elif coredumpctl:
             crash_log, errors = self._get_trace_from_systemd(coredumpctl, pid_representation)
 


### PR DESCRIPTION
#### 59ff7ba2dbdbe514d9f2c0848d5edf7e2eaad9d6
<pre>
[WPE][GTK] Allow to configure auto-deleting of coredumps after processing
<a href="https://bugs.webkit.org/show_bug.cgi?id=252762">https://bugs.webkit.org/show_bug.cgi?id=252762</a>

Reviewed by Philippe Normand.

The EWS for layout tests for WPE and GTK repeat each failure 11 times
to discard flakies. When there a lot of crashes it can cause a lot of
coredumps generated in a sort amount of time. This may end causing the
bot to run out of space until the cronjob to clean cores is fired,
which runs hourly in the best case.

Introduce the environment variable `WEBKIT_CORE_DUMPS_AUTODELETE` that
if set to `1` will cause the coredump to be deleted just after processing
it.

This is only implemented currently when processing the cores without
coredumpctl (the current default on the GTK and WPE bots).

* Tools/Scripts/webkitpy/port/linux_get_crash_log.py:
(GDBCrashLogGenerator.generate_crash_log):

Canonical link: <a href="https://commits.webkit.org/260694@main">https://commits.webkit.org/260694@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ff28bf85a457cedee89016b64d94fc1136600e4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109095 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18177 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41917 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/630 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/118358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112980 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19636 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9479 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101336 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114855 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/97957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/42886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/112595 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29611 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/84621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10959 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/30956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11696 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/7885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/17068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50556 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13304 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4034 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->