### PR TITLE
[build.webkit.org] Improve support for required changes for uat/dev instance

### DIFF
--- a/Tools/CISupport/build-webkit-org/master.cfg
+++ b/Tools/CISupport/build-webkit-org/master.cfg
@@ -1,5 +1,6 @@
 import json
 import os
+import socket
 import sys
 
 from buildbot.changes.pb import PBChangeSource
@@ -17,7 +18,7 @@ def load_password(name, default=None):
         passwords = json.load(open('passwords.json'))
         return passwords.get(name, default)
     except Exception as e:
-        print('Error in finding {} in passwords.json'.format(name))
+        print(f'Error in finding {name} in passwords.json')
         return default
 
 
@@ -27,6 +28,12 @@ BuildStep.warn_deprecated_if_oldstyle_subclass = lambda self, name: None
 
 
 is_test_mode_enabled = os.getenv('BUILDBOT_PRODUCTION') is None
+custom_suffix = ''
+hostname = socket.gethostname().strip()
+if 'dev' in hostname:
+    custom_suffix = '-dev'
+if 'uat' in hostname:
+    custom_suffix = '-uat'
 
 c = BuildmasterConfig = {}
 
@@ -64,13 +71,13 @@ if not is_test_mode_enabled:
     )
 
 c['protocols'] = {'pb': {'port': 17000}}
-c['projectName'] = 'WebKit'
+c['projectName'] = f'WebKit CI{custom_suffix}'
 c['projectURL'] = 'https://webkit.org'
 
 if is_test_mode_enabled:
     c['buildbotURL'] = 'http://localhost:8710/'
 else:
-    c['buildbotURL'] = 'https://build.webkit.org/'
+    c['buildbotURL'] = f'https://build.webkit{custom_suffix}.org/'
     db_url = load_password('DB_URL')
     db_name = load_password('DB_NAME')
     db_username = load_password('DB_USERNAME')


### PR DESCRIPTION
#### fc24cb6aa35fab30f64f21e16cfe90d466ee1775
<pre>
[build.webkit.org] Improve support for required changes for uat/dev instance
<a href="https://bugs.webkit.org/show_bug.cgi?id=252764">https://bugs.webkit.org/show_bug.cgi?id=252764</a>
&lt;rdar://problem/105793351&gt;

Reviewed by Ryan Haddad.

Auto-detect the uat/dev instance and make changes accordingly.

* Tools/CISupport/build-webkit-org/master.cfg:

Canonical link: <a href="https://commits.webkit.org/260701@main">https://commits.webkit.org/260701@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/012371d5ebbe14a2c97de33dea5f65974d332112

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109108 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18191 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/41930 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings); Archived built product (cancelled)") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/643 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/118366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112993 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/19649 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/9492 "Build was cancelled. Recent messages:Pull request contains relevant changes; Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings); Failed to upload built product") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101349 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114867 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/19649 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/41930 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings); Archived built product (cancelled)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/42900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/19649 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/41930 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings); Archived built product (cancelled)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/84633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10972 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/41930 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings); Archived built product (cancelled)") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/11709 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/9492 "Build was cancelled. Recent messages:Pull request contains relevant changes; Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings); Failed to upload built product") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/107867 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17078 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/41930 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings); Archived built product (cancelled)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13317 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4038 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->