### PR TITLE
Allow use-after-move to verify nullness in TestWTF.WTF_CheckedPtr.CheckedRef API test

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WTF/CheckedPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CheckedPtr.cpp
@@ -161,6 +161,9 @@ TEST(WTF_CheckedPtr, CheckedRef)
             EXPECT_EQ(ref->someFunction(), -7);
             EXPECT_EQ(checkedObject.ptrCount(), 1u);
             CheckedPtr ptr { WTFMove(ref) };
+#if ASAN_ENABLED
+            __asan_unpoison_memory_region(&ref, sizeof(ref));
+#endif
             EXPECT_EQ(ref.ptr(), nullptr);
             EXPECT_EQ(ptr.get(), &checkedObject);
             EXPECT_EQ(ptr->someFunction(), -7);
@@ -178,6 +181,9 @@ TEST(WTF_CheckedPtr, CheckedRef)
             EXPECT_EQ(ref->someFunction(), -7);
             EXPECT_EQ(checkedObject.ptrCount(), 1u);
             CheckedPtr<CheckedObject> ptr { WTFMove(ref) };
+#if ASAN_ENABLED
+            __asan_unpoison_memory_region(&ref, sizeof(ref));
+#endif
             EXPECT_EQ(ref.ptr(), nullptr);
             EXPECT_EQ(ptr.get(), &checkedObject);
             EXPECT_EQ(ptr->someFunction(), -7);


### PR DESCRIPTION
#### edebcc5417a6ea19448825879a08b8925c3431e6
<pre>
Allow use-after-move to verify nullness in TestWTF.WTF_CheckedPtr.CheckedRef API test
<a href="https://bugs.webkit.org/show_bug.cgi?id=252771">https://bugs.webkit.org/show_bug.cgi?id=252771</a>

Reviewed by Ryosuke Niwa.

When you move from a CheckedRef, we call __asan_poison_memory_region to indicate you shouldn&apos;t use it,
and you shouldn&apos;t.  This test verifies that if you do call CheckedRef::ptr() you get null, which is
fine for the test to do.  We don&apos;t want to unpoison the memory in the production code, so I just call
__asan_unpoison_memory_region to allow the test to verify the use-after-move value.

* Tools/TestWebKitAPI/Tests/WTF/CheckedPtr.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/260711@main">https://commits.webkit.org/260711@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39beb16a39591b496666bd4f688ca030ea42c785

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109119 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18201 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41942 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/653 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118375 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113003 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19660 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9503 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101362 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114877 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97974 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42912 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29628 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84642 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10983 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30971 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11719 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/7904 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17088 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50574 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13328 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4044 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->