### PR TITLE
CG display lists stick around on layers even after backing store is removed

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/WebCoreCALayerExtras.h
+++ b/Source/WebCore/platform/graphics/cocoa/WebCoreCALayerExtras.h
@@ -39,6 +39,7 @@
 - (void)_web_setLayerTopLeftPosition:(CGPoint)position;
 - (BOOL)_web_maskContainsPoint:(CGPoint)point;
 - (BOOL)_web_maskMayIntersectRect:(CGRect)rect;
+- (void)_web_clearContents;
 
 @end
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
@@ -44,6 +44,7 @@
 #import <WebCore/IOSurfacePool.h>
 #import <WebCore/ImageBuffer.h>
 #import <WebCore/PlatformCALayerClient.h>
+#import <WebCore/WebCoreCALayerExtras.h>
 #import <WebCore/WebLayer.h>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
@@ -593,6 +594,11 @@ void RemoteLayerBackingStore::applyBackingStoreToLayer(CALayer *layer, LayerCont
     // m_bufferHandle can be unset here if IPC with the GPU process timed out.
     if (m_bufferHandle)
         contents = layerContentsBufferFromBackendHandle(WTFMove(*m_bufferHandle), contentsType);
+
+    if (!contents) {
+        [layer _web_clearContents];
+        return;
+    }
 
 #if ENABLE(CG_DISPLAY_LIST_BACKED_IMAGE_BUFFER)
     if (m_displayListBufferHandle) {

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -33,6 +33,7 @@
 #import <QuartzCore/QuartzCore.h>
 #import <WebCore/PlatformCAFilters.h>
 #import <WebCore/ScrollbarThemeMac.h>
+#import <WebCore/WebCoreCALayerExtras.h>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
 #import <wtf/BlockObjCExceptions.h>
 #import <wtf/cocoa/VectorCocoa.h>
@@ -257,10 +258,8 @@ void RemoteLayerTreePropertyApplier::applyPropertiesToLayer(CALayer *layer, Remo
         auto* backingStore = properties.backingStore.get();
         if (backingStore && properties.backingStoreAttached)
             backingStore->applyBackingStoreToLayer(layer, layerContentsType, layerTreeHost->replayCGDisplayListsIntoBackingStore());
-        else {
-            layer.contents = nil;
-            layer.contentsOpaque = NO;
-        }
+        else
+            [layer _web_clearContents];
     }
 
     if (properties.changedProperties & LayerChange::FiltersChanged)


### PR DESCRIPTION
#### 545623ba3da1f4867c26ed80feefec663f0e45c2
<pre>
CG display lists stick around on layers even after backing store is removed
<a href="https://bugs.webkit.org/show_bug.cgi?id=252777">https://bugs.webkit.org/show_bug.cgi?id=252777</a>
rdar://104935890

Reviewed by Dean Jackson.

When removing backing store from a layer (because e.g. it became `visibility: hidden`),
we need to also remove the CG display list blob.

* Source/WebCore/platform/graphics/cocoa/WebCoreCALayerExtras.h:
* Source/WebCore/platform/graphics/cocoa/WebCoreCALayerExtras.mm:
(-[CALayer _web_clearContents]):
Factor out &quot;clear contents and display list if installed&quot; code.

Work around a bug where it&apos;s currently not possible to reset the display list to nil
without causing the layer to create its own backing store, by assigning an empty display list instead.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::RemoteLayerBackingStore::applyBackingStoreToLayer):
If we don&apos;t have layer contents for some unexpected reason (e.g. IPC timeout),
clear both contents and display list.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::RemoteLayerTreePropertyApplier::applyPropertiesToLayer):
If we don&apos;t have backing store at all, clear both contents and display list.

Canonical link: <a href="https://commits.webkit.org/260720@main">https://commits.webkit.org/260720@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57e786696a4ca273eb3856580d4d5021ae393061

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109167 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18246 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41979 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/693 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/118406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113049 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19705 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9548 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101407 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114925 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/42946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29654 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/84679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11024 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/30997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/11753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/7936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/17122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50600 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7395 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13372 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->