### PR TITLE
Fix some bounds issues in API tests

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WTF/CompactRefPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CompactRefPtr.cpp
@@ -432,13 +432,13 @@ struct alignas(16) ConstRefCounted
 
 static const ConstRefCounted& returnConstRefCountedRef()
 {
-    static NeverDestroyed<ConstRefCounted> instance;
-    return instance.get();
+    static NeverDestroyed<Ref<ConstRefCounted>> instance { ConstRefCounted::create() };
+    return instance.get().get();
 }
 static ConstRefCounted& returnRefCountedRef()
 {
-    static NeverDestroyed<ConstRefCounted> instance;
-    return instance.get();
+    static NeverDestroyed<Ref<ConstRefCounted>> instance { ConstRefCounted::create() };
+    return instance.get().get();
 }
 
 TEST(WTF_CompactRefPtr, Const)

--- a/Tools/TestWebKitAPI/Tests/WTF/FixedBitVector.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/FixedBitVector.cpp
@@ -53,8 +53,17 @@ static constexpr bool expectedBits[size] = {
     false, false, true,  false,  true,  true,  true,  true,
 };
 
-static constexpr bool expectedSmallBits[smallSize] = {
+static constexpr bool expectedSmallBits[65] = {
     false, true, true,  false,  true,  false, false, true, true,
+
+    // Additional unused booleans to make testFixedBitVectorFindBit not read out of bounds.
+    false, false, false, false, false, false, false, false,
+    false, false, false, false, false, false, false, false,
+    false, false, false, false, false, false, false, false,
+    false, false, false, false, false, false, false, false,
+    false, false, false, false, false, false, false, false,
+    false, false, false, false, false, false, false, false,
+    false, false, false, false, false, false, false, false,
 };
 
 constexpr size_t countBits(const bool boolArray[], size_t size)

--- a/Tools/TestWebKitAPI/Tests/WTF/PackedRefPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/PackedRefPtr.cpp
@@ -418,13 +418,13 @@ struct ConstRefCounted : RefCounted<ConstRefCounted> {
 
 static const ConstRefCounted& returnConstRefCountedRef()
 {
-    static NeverDestroyed<ConstRefCounted> instance;
-    return instance.get();
+    static NeverDestroyed<Ref<ConstRefCounted>> instance { ConstRefCounted::create() };
+    return instance.get().get();
 }
 static ConstRefCounted& returnRefCountedRef()
 {
-    static NeverDestroyed<ConstRefCounted> instance;
-    return instance.get();
+    static NeverDestroyed<Ref<ConstRefCounted>> instance { ConstRefCounted::create() };
+    return instance.get().get();
 }
 
 TEST(WTF_PackedRefPtr, Const)

--- a/Tools/TestWebKitAPI/Tests/WTF/RefPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/RefPtr.cpp
@@ -417,13 +417,13 @@ struct ConstRefCounted : RefCounted<ConstRefCounted> {
 
 static const ConstRefCounted& returnConstRefCountedRef()
 {
-    static NeverDestroyed<ConstRefCounted> instance;
-    return instance.get();
+    static NeverDestroyed<Ref<ConstRefCounted>> instance { ConstRefCounted::create() };
+    return instance.get().get();
 }
 static ConstRefCounted& returnRefCountedRef()
 {
-    static NeverDestroyed<ConstRefCounted> instance;
-    return instance.get();
+    static NeverDestroyed<Ref<ConstRefCounted>> instance { ConstRefCounted::create() };
+    return instance.get().get();
 }
 
 TEST(WTF_RefPtr, Const)


### PR DESCRIPTION
#### d5d4adedf8268ecf3e454dad02981a9cbcd9b07e
<pre>
Fix some bounds issues in API tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=252779">https://bugs.webkit.org/show_bug.cgi?id=252779</a>
rdar://105784168

Reviewed by Darin Adler.

Asan found some out of bounds operations because of how we wrote our tests.

* Tools/TestWebKitAPI/Tests/WTF/CompactRefPtr.cpp:
(TestWebKitAPI::returnConstRefCountedRef):
(TestWebKitAPI::returnRefCountedRef):
* Tools/TestWebKitAPI/Tests/WTF/FixedBitVector.cpp:
(TestWebKitAPI::testFixedBitVectorFindBit):
* Tools/TestWebKitAPI/Tests/WTF/PackedRefPtr.cpp:
(TestWebKitAPI::returnConstRefCountedRef):
(TestWebKitAPI::returnRefCountedRef):
* Tools/TestWebKitAPI/Tests/WTF/RefPtr.cpp:
(TestWebKitAPI::returnConstRefCountedRef):
(TestWebKitAPI::returnRefCountedRef):

Canonical link: <a href="https://commits.webkit.org/260746@main">https://commits.webkit.org/260746@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a72f09b57b771e29eb62bd9b0d794e91dfda8f33

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109146 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18228 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41965 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/678 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118393 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113029 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19687 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9530 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101387 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114904 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14762 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97990 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42933 "Found 1 new test failure: webgl/2.0.0/conformance2/textures/misc/copy-texture-image.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96734 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29644 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84664 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11008 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30987 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11739 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7924 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17108 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50590 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13355 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4054 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->