### PR TITLE
Some SystemPreview actions are not being detected

### DIFF
--- a/Source/WebKit/Platform/Logging.h
+++ b/Source/WebKit/Platform/Logging.h
@@ -103,6 +103,7 @@ extern "C" {
     M(SharedWorker) \
     M(Storage) \
     M(StorageAPI) \
+    M(SystemPreview) \
     M(TextInput) \
     M(TextInteraction) \
     M(Translation) \

--- a/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
@@ -283,6 +283,8 @@ void SystemPreviewController::start(URL originatingPageURL, const String& mimeTy
 #endif
 
     m_originatingPageURL = originatingPageURL;
+
+    RELEASE_LOG(SystemPreview, "SystemPreview began on %lld", m_systemPreviewInfo.element.elementIdentifier.toUInt64());
 }
 
 void SystemPreviewController::setDestinationURL(URL url)
@@ -321,6 +323,8 @@ void SystemPreviewController::finish(URL url)
 #else
     if (m_qlPreviewControllerDataSource)
         [m_qlPreviewControllerDataSource finish:url];
+
+    RELEASE_LOG(SystemPreview, "SystemPreview load has finished on %lld", m_systemPreviewInfo.element.elementIdentifier.toUInt64());
 #endif
 }
 
@@ -333,6 +337,8 @@ void SystemPreviewController::cancel()
     m_qlPreviewControllerDelegate = nullptr;
     m_qlPreviewControllerDataSource = nullptr;
     m_qlPreviewController = nullptr;
+
+    RELEASE_LOG(SystemPreview, "SystemPreview ended/cancelled on %lld", m_systemPreviewInfo.element.elementIdentifier.toUInt64());
 #endif
 }
 
@@ -346,6 +352,8 @@ void SystemPreviewController::fail(const WebCore::ResourceError& error)
 
 void SystemPreviewController::triggerSystemPreviewAction()
 {
+    RELEASE_LOG(SystemPreview, "SystemPreview action was triggered on %lld", m_systemPreviewInfo.element.elementIdentifier.toUInt64());
+
     page().systemPreviewActionTriggered(m_systemPreviewInfo, "_apple_ar_quicklook_button_tapped"_s);
 }
 


### PR DESCRIPTION
#### 17ea4508cabe787a84cfca694baec246a43e6393
<pre>
Some SystemPreview actions are not being detected
<a href="https://bugs.webkit.org/show_bug.cgi?id=252780">https://bugs.webkit.org/show_bug.cgi?id=252780</a>
rdar://105800886

Reviewed by Darin Adler.

We&apos;re getting reports of some SystemPreviews not detecting the user action.
We&apos;ve been unable to reproduce, so this is adding some release logging to help
us narrow down the problem.

* Source/WebKit/Platform/Logging.h:
* Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm: Add logging when a user
taps on a link, it finishes loading, the user clicks, and the preview ends.

Canonical link: <a href="https://commits.webkit.org/260727@main">https://commits.webkit.org/260727@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22038fbb405a9f493582982a3501909cc467d471

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109132 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18214 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41953 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/666 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118382 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19673 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9516 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101402 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114890 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14752 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97984 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42945 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96724 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29638 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84678 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10994 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30981 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11727 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7915 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17096 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50584 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7401 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13341 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->