### PR TITLE
AX: input[type=date] individual fields are announced as "group"

### DIFF
--- a/LayoutTests/accessibility/date-input-aria-label-and-value-expected.txt
+++ b/LayoutTests/accessibility/date-input-aria-label-and-value-expected.txt
@@ -1,0 +1,56 @@
+Tests that aria-label and aria-valuenow update correctly for date inputs.
+
+
+Checking ARIA Labels for sub-fields
+PASS: platformValueForW3CName(axDateFieldWrapper.childAtIndex(0)) === "month"
+PASS: platformValueForW3CName(axDateFieldWrapper.childAtIndex(1)) === "day"
+PASS: platformValueForW3CName(axDateFieldWrapper.childAtIndex(2)) === "year"
+
+Focusing date element and pressing up arrow to increment the first field.
+PASS: axDateFieldWrapper.childAtIndex(0).intValue === 3
+PASS: axDateFieldWrapper.childAtIndex(0).valueDescription === "AXValueDescription: 3"
+
+Simulating down arrow press to decrement the first field. (x2)
+PASS: axDateFieldWrapper.childAtIndex(0).intValue === 1
+PASS: axDateFieldWrapper.childAtIndex(0).valueDescription === "AXValueDescription: 1"
+
+Simulating tab key to move to the next field in the date input.
+PASS: axDateFieldWrapper.childAtIndex(1).intValue === 2
+PASS: axDateFieldWrapper.childAtIndex(1).valueDescription === "AXValueDescription: 2"
+
+Simulating typing "10" in the second input field.
+PASS: axDateFieldWrapper.childAtIndex(1).intValue === 10
+PASS: axDateFieldWrapper.childAtIndex(1).valueDescription === "AXValueDescription: 10"
+
+Simulating down arrow press to decrement the second field value.
+PASS: axDateFieldWrapper.childAtIndex(1).intValue === 9
+PASS: axDateFieldWrapper.childAtIndex(1).valueDescription === "AXValueDescription: 9"
+
+Simulating up arrow press to increment the second field value. (x2)
+PASS: axDateFieldWrapper.childAtIndex(1).intValue === 11
+PASS: axDateFieldWrapper.childAtIndex(1).valueDescription === "AXValueDescription: 11"
+
+Simulating tab key to move to the next field in the date input.
+PASS: axDateFieldWrapper.childAtIndex(2).intValue === 2022
+PASS: axDateFieldWrapper.childAtIndex(2).valueDescription === "AXValueDescription: 2022"
+
+Simulating down arrow press to decrement the third field value. (x10)
+PASS: axDateFieldWrapper.childAtIndex(2).intValue === 2012
+PASS: axDateFieldWrapper.childAtIndex(2).valueDescription === "AXValueDescription: 2012"
+
+Simulating up arrow press to increment the third field value.
+PASS: axDateFieldWrapper.childAtIndex(2).intValue === 2013
+PASS: axDateFieldWrapper.childAtIndex(2).valueDescription === "AXValueDescription: 2013"
+
+Manually setting the date input's value via JavaScript.
+PASS: axDateFieldWrapper.childAtIndex(0).intValue === 12
+PASS: axDateFieldWrapper.childAtIndex(0).valueDescription === "AXValueDescription: 12"
+PASS: axDateFieldWrapper.childAtIndex(1).intValue === 30
+PASS: axDateFieldWrapper.childAtIndex(1).valueDescription === "AXValueDescription: 30"
+PASS: axDateFieldWrapper.childAtIndex(2).intValue === 2023
+PASS: axDateFieldWrapper.childAtIndex(2).valueDescription === "AXValueDescription: 2023"
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/date-input-aria-label-and-value.html
+++ b/LayoutTests/accessibility/date-input-aria-label-and-value.html
@@ -1,0 +1,100 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<input id="date-input" type="date" value="2022-02-02" />
+
+<script>
+var testOutput = "Tests that aria-label and aria-valuenow update correctly for date inputs.\n\n";
+
+function outputString(message) {
+    testOutput += (`\n${message}\n`);
+}
+
+function keyDown(key, repeat = 1, message = "") {
+    if (message) 
+        outputString(message + ` (x${repeat})`);
+
+    for (let i = 0 ; i < repeat ; i++) 
+        eventSender.keyDown(key);
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+    var axDateFieldWrapper = accessibilityController.accessibleElementById("date-input")
+            .childAtIndex(0)
+            .childAtIndex(0);
+
+    setTimeout(async function() {
+        async function expectChildToHaveARIAValueAttributes(childIndex, description) {
+            let result = await expectAsync(`axDateFieldWrapper.childAtIndex(${childIndex}).intValue`, `${description}`);
+
+            result += await expectAsync(`axDateFieldWrapper.childAtIndex(${childIndex}).valueDescription`, `"AXValueDescription: ${description}"`);
+
+            return result;
+        }
+        
+        function expectChildToHaveARIALabel(childIndex, labelText) {
+            return expect(`platformValueForW3CName(axDateFieldWrapper.childAtIndex(${childIndex}))`, labelText);
+        }
+        
+        const dateInput = document.getElementById("date-input");
+
+        outputString("Checking ARIA Labels for sub-fields");
+        testOutput += expectChildToHaveARIALabel(0, `"month"`);
+        testOutput += expectChildToHaveARIALabel(1, `"day"`);
+        testOutput += expectChildToHaveARIALabel(2, `"year"`);
+        
+        outputString("Focusing date element and pressing up arrow to increment the first field.");
+        dateInput.focus();
+        keyDown("upArrow");
+
+        testOutput += await expectChildToHaveARIAValueAttributes(0, 3);
+
+        keyDown("downArrow", 2, "Simulating down arrow press to decrement the first field.");
+        testOutput += await expectChildToHaveARIAValueAttributes(0, 1);
+
+        outputString("Simulating tab key to move to the next field in the date input.");
+        keyDown("\t");
+        testOutput += await expectChildToHaveARIAValueAttributes(1, 2);
+
+        outputString("Simulating typing \"10\" in the second input field.");
+        keyDown("1");
+        keyDown("0")
+        testOutput += await expectChildToHaveARIAValueAttributes(1, 10);
+
+        outputString("Simulating down arrow press to decrement the second field value.")
+        keyDown("downArrow");
+        testOutput += await expectChildToHaveARIAValueAttributes(1, 9);
+
+        keyDown("upArrow", 2, "Simulating up arrow press to increment the second field value.");
+        testOutput += await expectChildToHaveARIAValueAttributes(1, 11);
+
+        outputString("Simulating tab key to move to the next field in the date input.");
+        keyDown("\t");
+        testOutput += await expectChildToHaveARIAValueAttributes(2, 2022);
+
+        keyDown("downArrow", 10, "Simulating down arrow press to decrement the third field value.");
+        testOutput += await expectChildToHaveARIAValueAttributes(2, 2012);
+
+        outputString("Simulating up arrow press to increment the third field value.")
+        keyDown("upArrow");
+        testOutput += await expectChildToHaveARIAValueAttributes(2, 2013);
+
+        outputString("Manually setting the date input's value via JavaScript.")
+        dateInput.value = "2023-12-30";
+        testOutput += await expectChildToHaveARIAValueAttributes(0, 12);
+        testOutput += await expectChildToHaveARIAValueAttributes(1, 30);
+        testOutput += await expectChildToHaveARIAValueAttributes(2, 2023);
+
+        debug(testOutput);
+        finishJSTest();
+    });
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -519,6 +519,8 @@ accessibility/element-reflection-ariadescribedby.html [ Timeout ]
 
 webkit.org/b/212805 accessibility/svg-text.html [ Failure ]
 
+webkit.org/b/251544 accessibility/date-input-aria-label-and-value.html [ Skip ]
+
 # Added in r263823. Both tests are timing out.
 webkit.org/b/213874 accessibility/keyevents-for-increment-actions-with-node-removal.html [ Skip ]
 webkit.org/b/213874 accessibility/keyevents-posted-for-increment-actions.html [ Skip ]

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1871,6 +1871,7 @@ webkit.org/b/210079 [ Debug ] inspector/debugger/evaluateOnCallFrame-errors.html
 webkit.org/b/230072 [ Release ] inspector/dom/shadow-and-non-shadow-children.html [ Pass Failure ]
 
 webkit.org/b/208477 accessibility/mac/text-marker-for-index.html [ Skip ]
+webkit.org/b/251544 accessibility/date-input-aria-label-and-value.html [ Skip ]
 accessibility/mac/textmarker-range-for-range.html [ Skip ]
 accessibility/mac/isolated-tree-mode-on-off.html [ Skip ]
 accessibility/aria-current-state-changed-notification.html [ Skip ]

--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -1516,6 +1516,15 @@
 /* accessibility role description for a date field. */
 "date field" = "date field";
 
+/* accessibility label for a date field month input. */
+"month" = "month";
+
+/* accessibility label for a date field day input. */
+"day" = "day";
+
+/* accessibility label for a date field year input. */
+"year" = "year";
+
 /* role description of ARIA definition role */
 "definition" = "definition";
 

--- a/Source/WebCore/html/shadow/DateTimeFieldElements.cpp
+++ b/Source/WebCore/html/shadow/DateTimeFieldElements.cpp
@@ -31,6 +31,8 @@
 
 #include "DateComponents.h"
 #include "DateTimeFieldsState.h"
+#include "HTMLNames.h"
+#include "LocalizedStrings.h"
 #include "ScriptDisallowedScope.h"
 #include <wtf/IsoMallocInlines.h>
 
@@ -49,6 +51,8 @@ Ref<DateTimeDayFieldElement> DateTimeDayFieldElement::create(Document& document,
     static MainThreadNeverDestroyed<const AtomString> dayPseudoId("-webkit-datetime-edit-day-field"_s);
     ScriptDisallowedScope::EventAllowedScope eventAllowedScope { element };
     element->initialize(dayPseudoId);
+    element->setAttributeWithoutSynchronization(HTMLNames::aria_labelAttr, AtomString { AXDateFieldDayText() });
+    element->setAttributeWithoutSynchronization(HTMLNames::roleAttr, AtomString { "spinbutton"_s });
     return element;
 }
 
@@ -223,6 +227,8 @@ Ref<DateTimeMonthFieldElement> DateTimeMonthFieldElement::create(Document& docum
     static MainThreadNeverDestroyed<const AtomString> monthPseudoId("-webkit-datetime-edit-month-field"_s);
     ScriptDisallowedScope::EventAllowedScope eventAllowedScope { element };
     element->initialize(monthPseudoId);
+    element->setAttributeWithoutSynchronization(HTMLNames::aria_labelAttr, AtomString { AXDateFieldMonthText() });
+    element->setAttributeWithoutSynchronization(HTMLNames::roleAttr, AtomString { "spinbutton"_s });
     return element;
 }
 
@@ -278,6 +284,8 @@ Ref<DateTimeSymbolicMonthFieldElement> DateTimeSymbolicMonthFieldElement::create
     static MainThreadNeverDestroyed<const AtomString> monthPseudoId("-webkit-datetime-edit-month-field"_s);
     ScriptDisallowedScope::EventAllowedScope eventAllowedScope { element };
     element->initialize(monthPseudoId);
+    element->setAttributeWithoutSynchronization(HTMLNames::aria_labelAttr, AtomString { AXDateFieldMonthText() });
+    element->setAttributeWithoutSynchronization(HTMLNames::roleAttr, AtomString { "spinbutton"_s });
     return element;
 }
 
@@ -305,6 +313,8 @@ Ref<DateTimeYearFieldElement> DateTimeYearFieldElement::create(Document& documen
     static MainThreadNeverDestroyed<const AtomString> yearPseudoId("-webkit-datetime-edit-year-field"_s);
     ScriptDisallowedScope::EventAllowedScope eventAllowedScope { element };
     element->initialize(yearPseudoId);
+    element->setAttributeWithoutSynchronization(HTMLNames::aria_labelAttr, AtomString { AXDateFieldYearText() });
+    element->setAttributeWithoutSynchronization(HTMLNames::roleAttr, AtomString { "spinbutton"_s });
     return element;
 }
 

--- a/Source/WebCore/html/shadow/DateTimeNumericFieldElement.cpp
+++ b/Source/WebCore/html/shadow/DateTimeNumericFieldElement.cpp
@@ -31,6 +31,7 @@
 
 #include "EventNames.h"
 #include "FontCascade.h"
+#include "HTMLNames.h"
 #include "KeyboardEvent.h"
 #include "PlatformLocale.h"
 #include "RenderBlock.h"
@@ -117,6 +118,7 @@ void DateTimeNumericFieldElement::setEmptyValue(EventBehavior eventBehavior)
     m_hasValue = false;
     m_typeAheadBuffer.clear();
     updateVisibleValue(eventBehavior);
+    setARIAValueAttributesWithInteger(0);
 }
 
 void DateTimeNumericFieldElement::setValueAsInteger(int value, EventBehavior eventBehavior)
@@ -124,12 +126,19 @@ void DateTimeNumericFieldElement::setValueAsInteger(int value, EventBehavior eve
     m_value = m_range.clampValue(value);
     m_hasValue = true;
     updateVisibleValue(eventBehavior);
+    setARIAValueAttributesWithInteger(value);
 }
 
 void DateTimeNumericFieldElement::setValueAsIntegerByStepping(int value)
 {
     m_typeAheadBuffer.clear();
     setValueAsInteger(value, DispatchInputAndChangeEvents);
+}
+
+void DateTimeNumericFieldElement::setARIAValueAttributesWithInteger(int value)
+{
+    setAttributeWithoutSynchronization(HTMLNames::aria_valuenowAttr, AtomString::number(value));
+    setAttributeWithoutSynchronization(HTMLNames::aria_valuetextAttr, AtomString::number(value));
 }
 
 void DateTimeNumericFieldElement::stepDown()

--- a/Source/WebCore/html/shadow/DateTimeNumericFieldElement.h
+++ b/Source/WebCore/html/shadow/DateTimeNumericFieldElement.h
@@ -71,6 +71,7 @@ private:
 
     String formatValue(int) const;
     void setValueAsIntegerByStepping(int);
+    void setARIAValueAttributesWithInteger(int);
 
     const Range m_range;
     const String m_placeholder;

--- a/Source/WebCore/platform/LocalizedStrings.cpp
+++ b/Source/WebCore/platform/LocalizedStrings.cpp
@@ -708,6 +708,21 @@ String AXTimeFieldText()
     return WEB_UI_STRING("time field", "accessibility role description for a time field.");
 }
 
+String AXDateFieldMonthText()
+{
+    return WEB_UI_STRING("month", "accessibility label for a date field month input.");
+}
+
+String AXDateFieldDayText()
+{
+    return WEB_UI_STRING("day", "accessibility label for a date field day input.");
+}
+
+String AXDateFieldYearText()
+{
+    return WEB_UI_STRING("year", "accessibility label for a date field year input.");
+}
+
 String AXDateTimeFieldText()
 {
     return WEB_UI_STRING("date and time field", "accessibility role description for a date and time field.");

--- a/Source/WebCore/platform/LocalizedStrings.h
+++ b/Source/WebCore/platform/LocalizedStrings.h
@@ -217,6 +217,9 @@ namespace WebCore {
     String AXURLFieldText();
     String AXDateFieldText();
     String AXTimeFieldText();
+    String AXDateFieldMonthText();
+    String AXDateFieldDayText();
+    String AXDateFieldYearText();
     String AXDateTimeFieldText();
     String AXMonthFieldText();
     String AXNumberFieldText();


### PR DESCRIPTION
#### d4f4aedd06563422f36fff424b3592646262e0f3
<pre>
AX: input[type=date] individual fields are announced as &quot;group&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=251544">https://bugs.webkit.org/show_bug.cgi?id=251544</a>
rdar://problem/104928713

Reviewed by Aditya Keerthi.

This fixes the bug by adding labels representing the &quot;day&quot;, &quot;month&quot;, and &quot;year&quot; inputs so that a screen reader has something to read,
instead of just &quot;group&quot; - it also switches the &quot;role&quot; attribute of the same divs to &quot;spinbutton&quot; to more accurately
reflect how they are used.

* LayoutTests/accessibility/date-input-aria-label-and-value-expected.txt: Added.
* LayoutTests/accessibility/date-input-aria-label-and-value.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebCore/en.lproj/Localizable.strings:
* Source/WebCore/html/shadow/DateTimeFieldElements.cpp:
(WebCore::DateTimeDayFieldElement::create):
(WebCore::DateTimeMonthFieldElement::create):
(WebCore::DateTimeSymbolicMonthFieldElement::create):
(WebCore::DateTimeYearFieldElement::create):
* Source/WebCore/html/shadow/DateTimeNumericFieldElement.cpp:
(WebCore::DateTimeNumericFieldElement::setEmptyValue):
(WebCore::DateTimeNumericFieldElement::setValueAsInteger):
(WebCore::DateTimeNumericFieldElement::setARIAValueAttributesWithInteger):
* Source/WebCore/html/shadow/DateTimeNumericFieldElement.h:
* Source/WebCore/platform/LocalizedStrings.cpp:
(WebCore::AXDateFieldMonthText):
(WebCore::AXDateFieldDayText):
(WebCore::AXDateFieldYearText):
* Source/WebCore/platform/LocalizedStrings.h:

Canonical link: <a href="https://commits.webkit.org/261123@main">https://commits.webkit.org/261123@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62ae5663fb8f8f8c405f63b5fb89bbe259d231bd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110578 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19658 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43157 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1934 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119446 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114534 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21083 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10790 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102874 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116320 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15703 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98884 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43995 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97663 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30551 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85909 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12311 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31889 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12873 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8853 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18237 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51505 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7707 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14755 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->