### PR TITLE
Fix inefficient uses of Vector::fill()

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGraphColoring.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGraphColoring.cpp
@@ -61,6 +61,7 @@ public:
     AbstractColoringAllocator(Code& code, const Vector<Reg>& regsInPriorityOrder, IndexType lastPrecoloredRegisterIndex, unsigned tmpArraySize, const BitVector& unspillableTmps, const UseCounts& useCounts)
         : m_regsInPriorityOrder(regsInPriorityOrder)
         , m_lastPrecoloredRegisterIndex(lastPrecoloredRegisterIndex)
+        , m_coalescedTmps(tmpArraySize, 0)
         , m_unspillableTmps(unspillableTmps)
         , m_useCounts(useCounts)
         , m_code(code)
@@ -76,7 +77,6 @@ public:
         
         m_adjacencyList.resize(tmpArraySize);
         m_moveList.resize(tmpArraySize);
-        m_coalescedTmps.fill(0, tmpArraySize);
         m_isOnSelectStack.ensureSize(tmpArraySize);
         m_spillWorklist.ensureSize(tmpArraySize);
     }
@@ -1896,8 +1896,7 @@ private:
         unsigned numTmps = m_code.numTmps(bank);
         unsigned arraySize = AbsoluteTmpMapper<bank>::absoluteIndex(numTmps);
 
-        Vector<Range, 0, UnsafeVectorOverflow> ranges;
-        ranges.fill(Range(), arraySize);
+        Vector<Range, 0, UnsafeVectorOverflow> ranges(arraySize, Range());
 
         unsigned globalIndex = 0;
         for (BasicBlock* block : m_code) {

--- a/Source/JavaScriptCore/b3/air/AirUseCounts.h
+++ b/Source/JavaScriptCore/b3/air/AirUseCounts.h
@@ -56,12 +56,10 @@ public:
         }
 
         unsigned gpArraySize = AbsoluteTmpMapper<GP>::absoluteIndex(code.numTmps(GP));
-        m_gpNumWarmUsesAndDefs = FixedVector<float>(gpArraySize);
-        m_gpNumWarmUsesAndDefs.fill(0);
+        m_gpNumWarmUsesAndDefs = FixedVector<float>(gpArraySize, 0);
         m_gpConstDefs.ensureSize(gpArraySize);
         unsigned fpArraySize = AbsoluteTmpMapper<FP>::absoluteIndex(code.numTmps(FP));
-        m_fpNumWarmUsesAndDefs = FixedVector<float>(fpArraySize);
-        m_fpNumWarmUsesAndDefs.fill(0);
+        m_fpNumWarmUsesAndDefs = FixedVector<float>(fpArraySize, 0);
         m_fpConstDefs.ensureSize(fpArraySize);
 
         for (BasicBlock* block : code) {

--- a/Source/JavaScriptCore/bytecode/Operands.h
+++ b/Source/JavaScriptCore/bytecode/Operands.h
@@ -158,20 +158,18 @@ public:
     }
 
     explicit Operands(size_t numArguments, size_t numLocals, size_t numTmps, const T& initialValue)
-        : m_values(numArguments + numLocals + numTmps)
+        : m_values(numArguments + numLocals + numTmps, initialValue)
         , m_numArguments(numArguments)
         , m_numLocals(numLocals)
     {
-        m_values.fill(initialValue);
     }
     
     template<typename U, typename V>
     explicit Operands(OperandsLikeTag, const Operands<U, V>& other, const T& initialValue = T())
-        : m_values(other.size())
+        : m_values(other.size(), initialValue)
         , m_numArguments(other.numberOfArguments())
         , m_numLocals(other.numberOfLocals())
     {
-        m_values.fill(initialValue);
     }
 
     template<typename U>

--- a/Source/JavaScriptCore/dfg/DFGScoreBoard.h
+++ b/Source/JavaScriptCore/dfg/DFGScoreBoard.h
@@ -43,8 +43,8 @@ class ScoreBoard {
 public:
     ScoreBoard(unsigned nextMachineLocal)
         : m_highWatermark(nextMachineLocal + 1)
+        , m_used(nextMachineLocal, max())
     {
-        m_used.fill(max(), nextMachineLocal);
         m_free.reserveInitialCapacity(nextMachineLocal);
     }
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp
@@ -41,9 +41,8 @@ const ClassInfo JSWebAssemblyStruct::s_info = { "WebAssembly.Struct"_s, &Base::s
 JSWebAssemblyStruct::JSWebAssemblyStruct(VM& vm, Structure* structure, Ref<const Wasm::TypeDefinition>&& type)
     : Base(vm, structure)
     , m_type(WTFMove(type))
-    , m_payload(structType()->instancePayloadSize())
+    , m_payload(structType()->instancePayloadSize(), 0)
 {
-    m_payload.fill(0);
 }
 
 JSWebAssemblyStruct* JSWebAssemblyStruct::tryCreate(JSGlobalObject* globalObject, Structure* structure, JSWebAssemblyInstance* instance, uint32_t typeIndex)

--- a/Source/WTF/wtf/FastBitVector.h
+++ b/Source/WTF/wtf/FastBitVector.h
@@ -481,6 +481,12 @@ public:
     {
         grow(numBits);
     }
+
+    FastBitVector(size_t numBits, bool value)
+    {
+        grow(numBits);
+        fill(value);
+    }
     
     FastBitVector(const FastBitVector&) = default;
     FastBitVector& operator=(const FastBitVector&) = default;

--- a/Source/WTF/wtf/FixedVector.h
+++ b/Source/WTF/wtf/FixedVector.h
@@ -84,6 +84,12 @@ public:
         : m_storage(size ? Storage::create(size).moveToUniquePtr() : nullptr)
     { }
 
+    FixedVector(size_t size, const T& value)
+        : m_storage(size ? Storage::create(size).moveToUniquePtr() : nullptr)
+    {
+        fill(value);
+    }
+
     template<size_t inlineCapacity, typename OverflowHandler>
     explicit FixedVector(const Vector<T, inlineCapacity, OverflowHandler>& other)
         : m_storage(other.isEmpty() ? nullptr : Storage::createFromVector(other).moveToUniquePtr())

--- a/Source/WTF/wtf/IndexMap.h
+++ b/Source/WTF/wtf/IndexMap.h
@@ -46,8 +46,8 @@ public:
     
     template<typename... Args>
     explicit IndexMap(size_t size, Args&&... args)
+        : m_vector(size, Value(std::forward<Args>(args)...))
     {
-        m_vector.fill(Value(std::forward<Args>(args)...), size);
     }
 
     template<typename... Args>

--- a/Source/WebCore/platform/audio/IIRFilter.cpp
+++ b/Source/WebCore/platform/audio/IIRFilter.cpp
@@ -52,11 +52,11 @@ static std::complex<double> evaluatePolynomial(const double* coefficients, std::
 }
 
 IIRFilter::IIRFilter(const Vector<double>& feedforward, const Vector<double>& feedback)
-    : m_feedforward(feedforward)
+    : m_xBuffer(bufferLength, 0)
+    , m_yBuffer(bufferLength, 0)
+    , m_feedforward(feedforward)
     , m_feedback(feedback)
 {
-    m_xBuffer.fill(0, bufferLength);
-    m_yBuffer.fill(0, bufferLength);
 }
 
 void IIRFilter::reset()

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -3022,8 +3022,7 @@ GraphicsLayerCA::CloneID GraphicsLayerCA::ReplicaState::cloneID() const
     const size_t bitsPerUChar = sizeof(UChar) * 8;
     size_t vectorSize = (depth + bitsPerUChar - 1) / bitsPerUChar;
     
-    Vector<UChar> result(vectorSize);
-    result.fill(0);
+    Vector<UChar> result(vectorSize, 0);
 
     // Create a string from the bit sequence which we can use to identify the clone.
     // Note that the string may contain embedded nulls, but that's OK.

--- a/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
@@ -790,16 +790,14 @@ bool Font::platformSupportsCodePoint(UChar32 character, std::optional<UChar32> v
 static bool hasGlyphsForCharacterRange(CTFontRef font, UniChar firstCharacter, UniChar lastCharacter, bool expectValidGlyphsForAllCharacters)
 {
     const unsigned numberOfCharacters = lastCharacter - firstCharacter + 1;
-    Vector<CGGlyph> glyphs;
-    glyphs.fill(0, numberOfCharacters);
+    Vector<CGGlyph> glyphs(numberOfCharacters, 0);
     CTFontGetGlyphsForCharacterRange(font, glyphs.begin(), CFRangeMake(firstCharacter, numberOfCharacters));
     glyphs.removeAll(0);
 
     if (glyphs.isEmpty())
         return false;
 
-    Vector<CGRect> boundingRects;
-    boundingRects.fill(CGRectZero, glyphs.size());
+    Vector<CGRect> boundingRects(glyphs.size(), CGRectZero);
     CTFontGetBoundingRectsForGlyphs(font, kCTFontOrientationDefault, glyphs.begin(), boundingRects.begin(), glyphs.size());
 
     unsigned validGlyphsCount = 0;

--- a/Source/WebCore/rendering/RenderFrameSet.h
+++ b/Source/WebCore/rendering/RenderFrameSet.h
@@ -34,11 +34,9 @@ enum FrameEdge { LeftFrameEdge, RightFrameEdge, TopFrameEdge, BottomFrameEdge };
 
 struct FrameEdgeInfo {
     explicit FrameEdgeInfo(bool preventResize = false, bool allowBorder = true)
-        : m_preventResize(4)
-        , m_allowBorder(4)
+        : m_preventResize(4, preventResize)
+        , m_allowBorder(4, allowBorder)
     {
-        m_preventResize.fill(preventResize);
-        m_allowBorder.fill(allowBorder);
     }
 
     bool preventResize(FrameEdge edge) const { return m_preventResize[edge]; }

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -64,6 +64,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderTable);
 
 RenderTable::RenderTable(Element& element, RenderStyle&& style)
     : RenderBlock(element, WTFMove(style), 0)
+    , m_columnPos(1, 0)
     , m_currentBorder(nullptr)
     , m_collapsedBordersValid(false)
     , m_collapsedEmptyBorderIsPresent(false)
@@ -78,11 +79,11 @@ RenderTable::RenderTable(Element& element, RenderStyle&& style)
     , m_columnOffsetHeight(-1)
 {
     setChildrenInline(false);
-    m_columnPos.fill(0, 1);
 }
 
 RenderTable::RenderTable(Document& document, RenderStyle&& style)
     : RenderBlock(document, WTFMove(style), 0)
+    , m_columnPos(1, 0)
     , m_currentBorder(nullptr)
     , m_collapsedBordersValid(false)
     , m_collapsedEmptyBorderIsPresent(false)
@@ -95,7 +96,6 @@ RenderTable::RenderTable(Document& document, RenderStyle&& style)
     , m_borderEnd(0)
 {
     setChildrenInline(false);
-    m_columnPos.fill(0, 1);
 }
 
 RenderTable::~RenderTable() = default;


### PR DESCRIPTION
#### 01b10b7f0e65f07e683f779755f4818487def6b8
<pre>
Fix inefficient uses of Vector::fill()
<a href="https://bugs.webkit.org/show_bug.cgi?id=252784">https://bugs.webkit.org/show_bug.cgi?id=252784</a>

Reviewed by Darin Adler.

Fix inefficient uses of Vector::fill(). Vector::fill() does a few things that
are unnecessary for a newly created Vector. It is more efficient to call the
`Vector(size, initialValue)` constructor.

* Source/JavaScriptCore/b3/air/AirAllocateRegistersByGraphColoring.cpp:
* Source/JavaScriptCore/b3/air/AirUseCounts.h:
(JSC::B3::Air::UseCounts::UseCounts):
* Source/JavaScriptCore/bytecode/Operands.h:
(JSC::Operands::Operands):
* Source/JavaScriptCore/dfg/DFGScoreBoard.h:
(JSC::DFG::ScoreBoard::ScoreBoard):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp:
(JSC::JSWebAssemblyStruct::JSWebAssemblyStruct):
* Source/WTF/wtf/FastBitVector.h:
(WTF::FastBitVector::FastBitVector):
* Source/WTF/wtf/FixedVector.h:
(WTF::FixedVector::FixedVector):
* Source/WTF/wtf/IndexMap.h:
(WTF::IndexMap::IndexMap):
* Source/WebCore/platform/audio/IIRFilter.cpp:
(WebCore::IIRFilter::IIRFilter):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::ReplicaState::cloneID const):
* Source/WebCore/platform/graphics/coretext/FontCoreText.cpp:
(WebCore::hasGlyphsForCharacterRange):
* Source/WebCore/rendering/RenderFrameSet.h:
(WebCore::FrameEdgeInfo::FrameEdgeInfo):
* Source/WebCore/rendering/RenderTable.cpp:
(WebCore::RenderTable::RenderTable):

Canonical link: <a href="https://commits.webkit.org/260748@main">https://commits.webkit.org/260748@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a2c941a89ad90e563140ea7efc2769c18126d11

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109148 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18230 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41967 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/680 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118395 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113031 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19689 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9532 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101389 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114906 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14764 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97995 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42936 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96736 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29649 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84668 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/98157 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11010 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30992 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/98950 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/9096 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11741 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7926 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31030 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17110 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50595 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/106638 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7418 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13357 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26423 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->