### PR TITLE
Produce 8 bit function toString() strings when possible

### DIFF
--- a/Source/JavaScriptCore/runtime/FunctionExecutable.cpp
+++ b/Source/JavaScriptCore/runtime/FunctionExecutable.cpp
@@ -231,6 +231,9 @@ JSString* FunctionExecutable::toStringSlow(JSGlobalObject* globalObject)
     auto name = this->name().string();
     if (name == vm.propertyNames->starDefaultPrivateName.string())
         name = emptyAtom();
+
+    if (!src.is8Bit() && src.isAllASCII())
+        return cacheIfNoException(jsMakeNontrivialString(globalObject, functionHeader, WTFMove(name), String::make8Bit(src.characters16(), src.length())));
     return cacheIfNoException(jsMakeNontrivialString(globalObject, functionHeader, WTFMove(name), src));
 }
 


### PR DESCRIPTION
#### 1bae0f66782d0c3366fde5faa0455e5df0a80ff6
<pre>
Produce 8 bit function toString() strings when possible
<a href="https://bugs.webkit.org/show_bug.cgi?id=252790">https://bugs.webkit.org/show_bug.cgi?id=252790</a>
&lt;rdar://problem/105810084&gt;

Reviewed by NOBODY (OOPS!).

Some pages call Function.prototype.toString() on a function whose resulting
string contains only 8 bit characters, but results in a 16 bit WTF::String due
to the script source being stored in a 16 bit string, which can end up wasting
memory.

* Source/JavaScriptCore/runtime/FunctionExecutable.cpp:
(JSC::FunctionExecutable::toStringSlow):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1bae0f66782d0c3366fde5faa0455e5df0a80ff6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109168 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18247 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41980 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/694 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118407 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19706 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9549 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101408 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114926 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14776 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98002 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42947 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96748 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29656 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84680 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed (failure)") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/98170 "Found 5 new JSC stress test failures: slowMicrobenchmarks.yaml/slowMicrobenchmarks/function-constructor-with-huge-strings.js.default, slowMicrobenchmarks.yaml/slowMicrobenchmarks/function-constructor-with-huge-strings.js.ftl-no-cjit-validate-sampling-profiler, slowMicrobenchmarks.yaml/slowMicrobenchmarks/function-constructor-with-huge-strings.js.no-cjit, slowMicrobenchmarks.yaml/slowMicrobenchmarks/function-constructor-with-huge-strings.js.no-ftl, stress/string-substring-oom.js.default (failure)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11025 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30999 "Found 1 new test failure: media/video-playback-quality.html (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/98963 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/9109 "Found 5 new JSC stress test failures: slowMicrobenchmarks.yaml/slowMicrobenchmarks/function-constructor-with-huge-strings.js.default, slowMicrobenchmarks.yaml/slowMicrobenchmarks/function-constructor-with-huge-strings.js.ftl-no-cjit-validate-sampling-profiler, slowMicrobenchmarks.yaml/slowMicrobenchmarks/function-constructor-with-huge-strings.js.no-cjit, slowMicrobenchmarks.yaml/slowMicrobenchmarks/function-constructor-with-huge-strings.js.no-ftl, stress/string-substring-oom.js.default (failure)") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11754 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7935 "Passed tests") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31034 "Found 1 jsc stress test failure: stress/string-substring-oom.js.default") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17123 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50602 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/106652 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13373 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26427 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->