### PR TITLE
[popover] Implement toggle event task

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic-expected.txt
@@ -208,9 +208,9 @@ PASS IDL attribute reflection
 FAIL Popover attribute value should be case insensitive Element has unexpected visibility state
 FAIL Changing attribute values for popover should work Element has unexpected visibility state
 PASS Changing attribute values should close open popovers
-FAIL Removing a visible popover=auto element from the document should close the popover assert_false: expected false got true
+PASS Removing a visible popover=auto element from the document should close the popover
 PASS A showing popover=auto does not match :modal
-FAIL Removing a visible popover=manual element from the document should close the popover assert_false: expected false got true
+PASS Removing a visible popover=manual element from the document should close the popover
 PASS A showing popover=manual does not match :modal
 FAIL Changing the popover type in a "beforetoggle" event handler should throw an exception (during showPopover()) assert_throws_dom: function "() => popover.showPopover()" did not throw
 FAIL Changing the popover type in a "beforetoggle" event handler should throw an exception (during hidePopover()) assert_throws_dom: function "() => popover.hidePopover()" did not throw

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-document-open-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-document-open-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL document.open should not break popovers assert_false: popover1 should have been hidden when it was removed from the document expected false got true
+PASS document.open should not break popovers
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-events-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-events-expected.txt
@@ -1,8 +1,7 @@
-Popover
 
-FAIL The "beforetoggle" event (listener) get properly dispatched for popovers assert_equals: toggle show is fired asynchronously expected 0 but got 1
-FAIL The "beforetoggle" event (attribute) get properly dispatched for popovers assert_false: expected false got true
-FAIL The "beforetoggle" event is cancelable for the "opening" transition assert_false: expected false got true
-FAIL The "beforetoggle" event is not fired for element removal assert_false: expected false got true
-FAIL The "toggle" event is coalesced assert_false: expected false got true
+PASS The "beforetoggle" event (listener) get properly dispatched for popovers
+PASS The "beforetoggle" event (attribute) get properly dispatched for popovers
+PASS The "beforetoggle" event is cancelable for the "opening" transition
+PASS The "beforetoggle" event is not fired for element removal
+PASS The "toggle" event is coalesced
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-events.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-events.html
@@ -28,21 +28,27 @@ window.onload = () => {
       let hideCount = 0;
       let afterHideCount = 0;
       function listener(e) {
+        assert_false(e.bubbles,'toggle events should not bubble');
         if (e.type === "beforetoggle") {
           if (e.newState === "open") {
             ++showCount;
             assert_equals(e.oldState,"closed",'The "beforetoggle" event should be fired before the popover is open');
             assert_true(e.target.matches(':closed'),'The popover should be in the :closed state when the opening event fires.');
             assert_false(e.target.matches(':open'),'The popover should *not* be in the :open state when the opening event fires.');
+            assert_true(e.cancelable,'beforetoggle should be cancelable only for the "show" transition');
           } else {
             ++hideCount;
             assert_equals(e.newState,"closed",'Popover toggleevent states should be "open" and "closed"');
             assert_equals(e.oldState,"open",'The "beforetoggle" event should be fired before the popover is closed')
             assert_true(e.target.matches(':open'),'The popover should be in the :open state when the hiding event fires.');
             assert_false(e.target.matches(':closed'),'The popover should *not* be in the :closed state when the hiding event fires.');
+            assert_false(e.cancelable,'beforetoggle should be cancelable only for the "show" transition');
+            e.preventDefault(); // beforetoggle should be cancelable only for the "show" transition
           }
         } else {
           assert_equals(e.type,"toggle",'Popover events should be "beforetoggle" and "toggle"')
+          assert_false(e.cancelable,'toggle should never be cancelable');
+          e.preventDefault(); // toggle should never be cancelable
           if (e.newState === "open") {
             ++afterShowCount;
             if (document.body.contains(e.target)) {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-removal-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-removal-2-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL Moving popover between documents shouldn't cause issues assert_false: expected false got true
+PASS Moving popover between documents shouldn't cause issues
 

--- a/Source/WebCore/dom/GlobalEventHandlers.idl
+++ b/Source/WebCore/dom/GlobalEventHandlers.idl
@@ -33,6 +33,7 @@ interface mixin GlobalEventHandlers {
     attribute EventHandler onabort;
     // FIXME: Implement 'onauxclick'.
     // attribute EventHandler onauxclick;
+    attribute EventHandler onbeforetoggle;
     attribute EventHandler onblur;
     attribute EventHandler oncancel;
     attribute EventHandler oncanplay;

--- a/Source/WebCore/dom/PopoverData.h
+++ b/Source/WebCore/dom/PopoverData.h
@@ -35,12 +35,17 @@ enum class PopoverVisibilityState : bool {
     Showing,
 };
 
+struct PopoverToggleEventData {
+    PopoverVisibilityState oldState;
+    PopoverVisibilityState newState;
+};
+
 class PopoverData {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     PopoverData() = default;
 
-    PopoverState popoverState() { return m_popoverState; }
+    PopoverState popoverState() const { return m_popoverState; }
     void setPopoverState(PopoverState state) { m_popoverState = state; }
 
     PopoverVisibilityState visibilityState() const { return m_visibilityState; }
@@ -49,9 +54,14 @@ public:
     Element* previouslyFocusedElement() const { return m_previouslyFocusedElement.get(); }
     void setPreviouslyFocusedElement(Element* element) { m_previouslyFocusedElement = element; }
 
+    std::optional<PopoverToggleEventData> queuedToggleEventData() const { return m_queuedToggleEventData; }
+    void setQueuedToggleEventData(PopoverToggleEventData data) { m_queuedToggleEventData = data; }
+    void clearQueuedToggleEventData() { m_queuedToggleEventData = std::nullopt; }
+
 private:
     PopoverState m_popoverState;
     PopoverVisibilityState m_visibilityState;
+    std::optional<PopoverToggleEventData> m_queuedToggleEventData;
     WeakPtr<Element, WeakPtrImplWithEventTargetData> m_previouslyFocusedElement;
 };
 

--- a/Source/WebCore/html/HTMLAttributeNames.in
+++ b/Source/WebCore/html/HTMLAttributeNames.in
@@ -220,6 +220,7 @@ onbeforeinput
 onbeforeload
 onbeforepaste
 onbeforeprint
+onbeforetoggle
 onbeforeunload
 onblur
 oncancel

--- a/Source/WebCore/html/HTMLElement.h
+++ b/Source/WebCore/html/HTMLElement.h
@@ -42,8 +42,9 @@ class VisibleSelection;
 struct SimpleRange;
 struct TextRecognitionResult;
 
-enum class PageIsEditable : bool;
 enum class EnterKeyHint : uint8_t;
+enum class PageIsEditable : bool;
+enum class PopoverVisibilityState : bool;
 
 enum class PopoverState : uint8_t {
     None,
@@ -144,6 +145,7 @@ public:
 
     WEBCORE_EXPORT ExceptionOr<Ref<ElementInternals>> attachInternals();
 
+    void queuePopoverToggleEventTask(PopoverVisibilityState oldState, PopoverVisibilityState newState);
     ExceptionOr<void> showPopover();
     ExceptionOr<void> hidePopover();
     ExceptionOr<void> togglePopover(std::optional<bool> force);


### PR DESCRIPTION
#### 53fc7cf368d2b375ec52fe5c8b33492b785340a8
<pre>
[popover] Implement toggle event task
<a href="https://bugs.webkit.org/show_bug.cgi?id=252215">https://bugs.webkit.org/show_bug.cgi?id=252215</a>
rdar://105703645

Reviewed by Darin Adler.

<a href="https://html.spec.whatwg.org/multipage/popover.html#queue-a-popover-toggle-event-task">https://html.spec.whatwg.org/multipage/popover.html#queue-a-popover-toggle-event-task</a>

Called in hidePopover/showPopover. In order to ensure only one event is emitted, we store the last queued oldState/newState,
then the queued task checks if the newState up to date and that there is still a queued task. The oldest &quot;oldState&quot; is always
preserved since we&apos;re collapsing multiple toggle events in one.

Also do other fixes to make html/semantics/popovers/popover-events.html pass:
- Make onbeforetoggle attribute actually work by adding it to IDL and attribute names
- Hide popover without firing events if element is removed from tree

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-document-open-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-removal-2-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-events-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-events.html:
* Source/WebCore/dom/GlobalEventHandlers.idl:
* Source/WebCore/dom/PopoverData.h:
(WebCore::PopoverData::queuedToggleEventData):
(WebCore::PopoverData::setQueuedToggleEventData):
(WebCore::PopoverData::clearQueuedToggleEventData):
* Source/WebCore/html/HTMLAttributeNames.in:
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::removedFromAncestor):
(WebCore::HTMLElement::queuePopoverToggleEventTask):
(WebCore::HTMLElement::showPopover):
(WebCore::HTMLElement::hidePopoverInternal):
* Source/WebCore/html/HTMLElement.h:

Canonical link: <a href="https://commits.webkit.org/260728@main">https://commits.webkit.org/260728@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0aa6ad5a5d1dd3e8aca55214f2c268d5f1dff7be

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109182 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18262 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41993 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/709 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118417 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113064 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19721 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9564 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101423 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114939 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98014 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/42958 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29668 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84692 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11039 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/31011 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11766 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/7946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17134 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50614 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7399 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13386 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->