### PR TITLE
[build.webkit.org] Build and run JSC tests if changes in LayoutTests/js

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -1261,6 +1261,11 @@ class CheckChangeRelevance(AnalyzeChange):
             self.finished(SUCCESS)
             return None
 
+        architecture = self.getProperty('architecture')
+        if architecture in ['mipsel', 'armv7']:
+            self.jsc_path_regexes.append(re.compile(rb'LayoutTests/js', re.IGNORECASE))
+            self.group_to_paths_mapping = self.jsc_path_regexes
+
         if self._patch_is_relevant(patch, self.getProperty('buildername', '')):
             self._addToLog('stdio', 'This {} contains relevant changes.'.format(self.change_type.lower()))
             self.finished(SUCCESS)


### PR DESCRIPTION
#### b21c8dba1b328cc4ddfa89d519107b1759b211fe
<pre>
[build.webkit.org] Build and run JSC tests if changes in LayoutTests/js

Reviewed by NOBODY (OOPS!).

WIP

* Tools/CISupport/ews-build/steps.py:
(CheckChangeRelevance.start):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b21c8dba1b328cc4ddfa89d519107b1759b211fe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109176 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18255 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41988 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/702 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118412 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113058 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19714 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9557 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101416 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114933 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14782 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98012 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42952 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96754 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29666 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84685 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11032 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31009 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11760 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7939 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/107934 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17129 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50612 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13380 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->