### PR TITLE
[WebGL] Avoid using glReadPixels to paint WebGL canvas into 2D canvas

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsContextGL.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.cpp
@@ -685,6 +685,35 @@ void GraphicsContextGL::markLayerComposited()
         m_client->didComposite();
 }
 
+void GraphicsContextGL::paintToCanvas(NativeImage& image, const IntSize& canvasSize, GraphicsContext& context)
+{
+    if (canvasSize.isEmpty())
+        return;
+
+    auto imageSize = image.size();
+
+    // CSS styling may cause the canvas's content to be resized on
+    // the page. Go back to the Canvas to figure out the correct
+    // width and height to draw.
+    FloatRect canvasRect(FloatPoint(), canvasSize);
+    // We want to completely overwrite the previous frame's
+    // rendering results.
+
+    GraphicsContextStateSaver stateSaver(context);
+    context.scale(FloatSize(1, -1));
+    context.translate(0, -imageSize.height());
+    context.setImageInterpolationQuality(InterpolationQuality::DoNotInterpolate);
+    context.drawNativeImage(image, imageSize, canvasRect, FloatRect(FloatPoint(), imageSize), { CompositeOperator::Copy });
+}
+
+void GraphicsContextGL::paintToCanvas(const GraphicsContextGLAttributes& sourceContextAttributes, Ref<PixelBuffer>&& pixelBuffer, const IntSize& canvasSize, GraphicsContext& context)
+{
+    if (canvasSize.isEmpty())
+        return;
+
+    auto image = createNativeImageFromPixelBuffer(sourceContextAttributes, WTFMove(pixelBuffer));
+    paintToCanvas(*image, canvasSize, context);
+}
 
 void GraphicsContextGL::forceContextLost()
 {

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -1630,7 +1630,10 @@ public:
     // Returns true upon success.
     static bool packImageData(Image*, const void* pixels, GCGLenum format, GCGLenum type, bool flipY, AlphaOp, DataFormat sourceFormat, unsigned sourceImageWidth, unsigned sourceImageHeight, const IntRect& sourceImageSubRectangle, int depth, unsigned sourceUnpackAlignment, int unpackImageHeight, Vector<uint8_t>& data);
 
+    WEBCORE_EXPORT static RefPtr<NativeImage> createNativeImageFromPixelBuffer(const GraphicsContextGLAttributes&, Ref<PixelBuffer>&&);
+    WEBCORE_EXPORT static void paintToCanvas(NativeImage&, const IntSize& canvasSize, GraphicsContext&);
     WEBCORE_EXPORT static void paintToCanvas(const GraphicsContextGLAttributes&, Ref<PixelBuffer>&&, const IntSize& canvasSize, GraphicsContext&);
+
 protected:
     WEBCORE_EXPORT void forceContextLost();
     WEBCORE_EXPORT void dispatchContextChangedNotification();

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
@@ -350,12 +350,16 @@ public:
     void deleteShader(PlatformGLObject) final;
     void deleteTexture(PlatformGLObject) final;
     void simulateEventForTesting(SimulatedEventForTesting) override;
-    void paintRenderingResultsToCanvas(ImageBuffer&) final;
-    RefPtr<PixelBuffer> paintRenderingResultsToPixelBuffer() final;
-    void paintCompositedResultsToCanvas(ImageBuffer&) final;
+    void paintRenderingResultsToCanvas(ImageBuffer&) override;
+    RefPtr<PixelBuffer> paintRenderingResultsToPixelBuffer() override;
+    void paintCompositedResultsToCanvas(ImageBuffer&) override;
 
     RefPtr<PixelBuffer> readRenderingResultsForPainting();
     RefPtr<PixelBuffer> readCompositedResultsForPainting();
+
+    virtual void withDrawingBufferAsNativeImage(std::function<void(NativeImage&)>);
+    virtual void withDisplayBufferAsNativeImage(std::function<void(NativeImage&)>);
+
     // Returns true on success.
     bool readnPixelsWithStatus(GCGLint x, GCGLint y, GCGLsizei width, GCGLsizei height, GCGLenum format, GCGLenum type, GCGLSpan<GCGLvoid> data);
 

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextGLCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextGLCG.cpp
@@ -505,11 +505,9 @@ bool GraphicsContextGLImageExtractor::extractImage(bool premultiplyAlpha, bool i
     return true;
 }
 
-void GraphicsContextGL::paintToCanvas(const GraphicsContextGLAttributes& sourceContextAttributes, Ref<PixelBuffer>&& pixelBuffer, const IntSize& canvasSize, GraphicsContext& context)
+RefPtr<NativeImage> GraphicsContextGL::createNativeImageFromPixelBuffer(const GraphicsContextGLAttributes& sourceContextAttributes, Ref<PixelBuffer>&& pixelBuffer)
 {
     ASSERT(!pixelBuffer->size().isEmpty());
-    if (canvasSize.isEmpty())
-        return;
     // Input is GL_RGBA == kCGBitmapByteOrder32Big | kCGImageAlpha*Last.
     // GL_BGRA would be kCGBitmapByteOrder32Little | kCGImageAlpha*First.
     CGBitmapInfo bitmapInfo = kCGBitmapByteOrder32Big;
@@ -531,20 +529,7 @@ void GraphicsContextGL::paintToCanvas(const GraphicsContextGLAttributes& sourceC
     }));
 
     auto imageSize = pixelBuffer->size();
-    auto image = NativeImage::create(adoptCF(CGImageCreate(imageSize.width(), imageSize.height(), 8, 32, 4 * imageSize.width(), pixelBuffer->format().colorSpace.platformColorSpace(), bitmapInfo, dataProvider.get(), 0, false, kCGRenderingIntentDefault)));
-
-    // CSS styling may cause the canvas's content to be resized on
-    // the page. Go back to the Canvas to figure out the correct
-    // width and height to draw.
-    FloatRect canvasRect(FloatPoint(), canvasSize);
-    // We want to completely overwrite the previous frame's
-    // rendering results.
-
-    GraphicsContextStateSaver stateSaver(context);
-    context.scale(FloatSize(1, -1));
-    context.translate(0, -imageSize.height());
-    context.setImageInterpolationQuality(InterpolationQuality::DoNotInterpolate);
-    context.drawNativeImage(*image, imageSize, canvasRect, FloatRect(FloatPoint(), imageSize), { CompositeOperator::Copy });
+    return NativeImage::create(adoptCF(CGImageCreate(imageSize.width(), imageSize.height(), 8, 32, 4 * imageSize.width(), pixelBuffer->format().colorSpace.platformColorSpace(), bitmapInfo, dataProvider.get(), 0, false, kCGRenderingIntentDefault)));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h
@@ -75,6 +75,8 @@ public:
     void clientWaitSyncWithFlush(void* sync, uint64_t timeout);
 #endif
 
+    void waitUntilWorkScheduled();
+
     // GraphicsContextGLANGLE overrides.
     RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate() override;
 #if ENABLE(VIDEO)
@@ -89,6 +91,9 @@ public:
     void setContextVisibility(bool) final;
     void setDrawingBufferColorSpace(const DestinationColorSpace&) final;
     void prepareForDisplay() override;
+
+    void withDrawingBufferAsNativeImage(std::function<void(NativeImage&)>) override;
+    void withDisplayBufferAsNativeImage(std::function<void(NativeImage&)>) override;
 
 #if PLATFORM(MAC)
     void updateContextOnDisplayReconfiguration();

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLIOSurfaceSwapChain.h
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLIOSurfaceSwapChain.h
@@ -46,7 +46,7 @@ public:
     virtual ~GraphicsContextGLIOSurfaceSwapChain();
     struct Buffer {
         // The actual contents. Client transfers the ownership of the IOSurface.
-        std::unique_ptr<WebCore::IOSurface> surface;
+        std::unique_ptr<IOSurface> surface;
         // Producer specific metadata handle (such as EGLSurface). Client does not transfer the ownership.
         void* handle { nullptr };
     };

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
@@ -148,7 +148,7 @@ protected:
 private:
     void paintRenderingResultsToCanvasWithQualifiedIdentifier(QualifiedRenderingResourceIdentifier, CompletionHandler<void()>&&);
     void paintCompositedResultsToCanvasWithQualifiedIdentifier(QualifiedRenderingResourceIdentifier, CompletionHandler<void()>&&);
-    void paintPixelBufferToImageBuffer(RefPtr<WebCore::PixelBuffer>&&, QualifiedRenderingResourceIdentifier, CompletionHandler<void()>&&);
+    void paintNativeImageToImageBuffer(WebCore::NativeImage&, QualifiedRenderingResourceIdentifier, CompletionHandler<void()>&&);
 
 protected:
     WeakPtr<GPUConnectionToWebProcess> m_gpuConnectionToWebProcess;


### PR DESCRIPTION
#### 50ae4e81ccce7b0c1ebd530b24a88ed25ba82caf
<pre>
[WebGL] Avoid using glReadPixels to paint WebGL canvas into 2D canvas
<a href="https://bugs.webkit.org/show_bug.cgi?id=252795">https://bugs.webkit.org/show_bug.cgi?id=252795</a>
rdar://87173127

Reviewed by Kimmo Kinnunen.

Instead of reading pixels from the current drawing buffer using glReadPixels,
the IOSurface backing the drawing buffer is wrapped in a CGImage for the
duration of the synchronous call to paintRenderingResultsToCanvas.

To ensure that the WebGL rendering is present in the drawing buffer, any pending
GL operations are executed to update rendering before creating a CGImageRef
wrapper around WebGL&apos;s IOSurface.

* Source/WebCore/platform/graphics/GraphicsContextGL.cpp:
(WebCore::GraphicsContextGL::paintToCanvas):

Platform dependent code has been extracted into
createNativeImageFromPixelBuffer, allowing paintToCanvas implementations to be
unified.

* Source/WebCore/platform/graphics/GraphicsContextGL.h:

Split paintToCanvas(..., Ref&lt;PixelBuffer&gt;&amp;&amp;, ...) into
createNativeImageFromPixelBuffer(Ref&lt;PixelBufer&gt;&amp;&amp;, ...) and
paintToCanvas(NativeImage&amp;, ...). This allows the painting of any NativeImage to
canvas, not just PixelBuffer sources and provides a convenience function to
obtain a NativeImage from a PixelBuffer.

* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::prepareTexture):

Since we&apos;re now calling prepareTexture() in a difference context remove ASSERT
that layer isn&apos;t composited.

* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h:
* Source/WebCore/platform/graphics/cairo/GraphicsContextGLCairo.cpp:
(WebCore::GraphicsContextGL::createNativeImageFromPixelBuffer):

Helper function to create NativeImage from PixelBuffer.

(WebCore::GraphicsContextGL::paintToCanvas): Deleted.
* Source/WebCore/platform/graphics/cg/GraphicsContextGLCG.cpp:
(WebCore::GraphicsContextGL::createNativeImageFromPixelBuffer):

Helper function to create NativeImage from PixelBuffer.

(WebCore::GraphicsContextGL::paintToCanvas): Deleted.
 Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h:
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm:
(WebCore::GraphicsContextGLCocoa::paintRenderingResultsToCanvas):
(WebCore::GraphicsContextGLCocoa::paintCompositedResultsToCanvas):

Defer implementation using helper functions and paintToCanvas(NativeImage&amp;, ...)

(WebCore::GraphicsContextGLCocoa::withDrawingBufferAsNativeImage):
(WebCore::GraphicsContextGLCocoa::withDisplayBufferAsNativeImage):

Helper methods to aid borrowing WebGL&apos;s IOSurface-backed drawing and display
buffers as NativeImage, taking care of conversion, context creation, flushing,
etc. WebGL contexts not using premultiplied alpha still use the glReadPixels
path because IOSurfaces without premultipled alpha are unsupported by
CoreGraphics. The image is passed by reference to stop the function from hanging
onto the image.

* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLIOSurfaceSwapChain.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp:
(WebKit::RemoteGraphicsContextGL::paintRenderingResultsToCanvasWithQualifiedIdentifier):
(WebKit::RemoteGraphicsContextGL::paintCompositedResultsToCanvasWithQualifiedIdentifier):

Defer implementation using helper functions and paintNativeImageToImageBuffer()

(WebKit::RemoteGraphicsContextGL::paintNativeImageToImageBuffer):
(WebKit::RemoteGraphicsContextGL::paintPixelBufferToImageBuffer): Deleted.

Painting to ImageBuffer is only supported via NativeImage. To paint a pixel
buffer, first convert the PixelBuffer to NativeImage using
createNativeImageFromPixelBuffer().

* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h:

Canonical link: <a href="https://commits.webkit.org/262518@main">https://commits.webkit.org/262518@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/401516891037ccd92b1a64ed55f8af876be8632d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1654 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1685 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1743 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2577 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1777 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1635 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1752 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1749 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1553 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1669 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1496 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1490 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2413 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1493 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1476 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1394 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1514 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1518 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2579 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1547 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1378 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1465 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1483 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/432 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1611 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->