### PR TITLE
Have RemoteLayerTreeEventDispatcher start and stop a DisplayLink callback

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
@@ -27,6 +27,7 @@
 
 #if PLATFORM(MAC) && ENABLE(SCROLLING_THREAD)
 
+#include "DisplayLinkObserverID.h"
 #include <wtf/FastMalloc.h>
 #include <wtf/HashMap.h>
 #include <wtf/Lock.h>
@@ -40,6 +41,7 @@ struct WheelEventHandlingResult;
 
 namespace WebKit {
 
+class DisplayLink;
 class NativeWebWheelEvent;
 class RemoteScrollingCoordinatorProxyMac;
 class RemoteScrollingTree;
@@ -71,6 +73,13 @@ private:
     WebCore::WheelEventHandlingResult scrollingTreeHandleWheelEvent(RemoteScrollingTree&, const PlatformWheelEvent&);
     PlatformWheelEvent filteredWheelEvent(const PlatformWheelEvent&);
 
+    DisplayLink* displayLink() const;
+
+    void startDisplayLinkObserver();
+    void stopDisplayLinkObserver();
+
+    void startOrStopDisplayLink();
+
     RefPtr<RemoteScrollingTree> scrollingTree();
 
     Lock m_scrollingTreeLock;
@@ -80,6 +89,8 @@ private:
     WebCore::PageIdentifier m_pageIdentifier;
 
     std::unique_ptr<WebCore::WheelEventDeltaFilter> m_wheelEventDeltaFilter;
+    std::unique_ptr<RemoteLayerTreeEventDispatcherDisplayLinkClient> m_displayLinkClient;
+    std::optional<DisplayLinkObserverID> m_displayRefreshObserverID;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### eac81f7d7c8d4eb9040ee21a0c94530228ef30ac
<pre>
Have RemoteLayerTreeEventDispatcher start and stop a DisplayLink callback
<a href="https://bugs.webkit.org/show_bug.cgi?id=252796">https://bugs.webkit.org/show_bug.cgi?id=252796</a>
&lt;rdar://problem/105815711&gt;

Reviewed by Myles C. Maxfield.

RemoteLayerTreeEventDispatcher needs its own DisplayLink::Client because it
needs to bounce the callbacks to the scrolling thread. So have RemoteLayerTreeEventDispatcher
create a RemoteLayerTreeEventDispatcherDisplayLinkClient which receives the callback,
taking care to make the invalidation code path thread safe.

We start and stop the callback currently just for scroll animations; future patches
will actually hook this up, and add more reasons to run a callback.

* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp:
(WebKit::m_displayLinkClient):
(WebKit::RemoteLayerTreeEventDispatcher::invalidate):
(WebKit::RemoteLayerTreeEventDispatcher::displayLink const):
(WebKit::RemoteLayerTreeEventDispatcher::startOrStopDisplayLink):
(WebKit::RemoteLayerTreeEventDispatcher::startDisplayLinkObserver):
(WebKit::RemoteLayerTreeEventDispatcher::stopDisplayLinkObserver):
(WebKit::m_wheelEventDeltaFilter): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h:

Canonical link: <a href="https://commits.webkit.org/260762@main">https://commits.webkit.org/260762@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbc5eb43ebf9589e05f785f0df48228d96007692

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109290 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18371 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/42088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/805 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118509 "Built successfully") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/19820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/9661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101531 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115045 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/19820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/42088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/43035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/19820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/42088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/84780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11145 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/42088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11863 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/9661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/17256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/42088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7424 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13496 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->