### PR TITLE
[web-animations] rewrite tests under LayoutTests/webanimations to use promise_test instead of async_test

### DIFF
--- a/LayoutTests/webanimations/accelerated-animation-removal-upon-transition-completion.html
+++ b/LayoutTests/webanimations/accelerated-animation-removal-upon-transition-completion.html
@@ -15,32 +15,21 @@
 <body>
 <script src="../resources/testharness.js"></script>
 <script src="../resources/testharnessreport.js"></script>
+<script src="resources/rendering-frames.js"></script>
 <div id="target"></div>
 
 <script>
 
-function waitNFrames(numberOfFrames, continuation)
-{
-    let elapsedFrames = 0;
-    (function rAFCallback() {
-        if (elapsedFrames++ >= numberOfFrames)
-            continuation();
-        else
-            requestAnimationFrame(rAFCallback);
-    })();
-}
+promise_test(async () => {
+    await renderingFrames(1);
 
-async_test(t => {
-    requestAnimationFrame(() => {
-        const target = document.getElementById("target");
-        target.style.transform = "translate3d(100px, 0, 0)";
-        target.getAnimations()[0].finished.then(() => {
-            waitNFrames(2, () => {
-                assert_equals(internals.acceleratedAnimationsForElement(target).length, 0, "There should be no accelerated animation after the animation completed.");
-                t.done();
-            });
-        });
-    });
+    const target = document.getElementById("target");
+    target.style.transform = "translate3d(100px, 0, 0)";
+
+    await target.getAnimations()[0].finished;
+    await renderingFrames(2);
+
+    assert_equals(internals.acceleratedAnimationsForElement(target).length, 0, "There should be no accelerated animation after the animation completed.");
 }, "An accelerated CSS transition should remove its animation upon completion.");
 
 </script>

--- a/LayoutTests/webanimations/accelerated-animation-suspension.html
+++ b/LayoutTests/webanimations/accelerated-animation-suspension.html
@@ -14,42 +14,33 @@
 <body>
 <script src="../resources/testharness.js"></script>
 <script src="../resources/testharnessreport.js"></script>
+<script src="resources/rendering-frames.js"></script>
 <div id="target"></div>
 
 <script>
 
-function waitNFrames(numberOfFrames, continuation)
-{
-    let elapsedFrames = 0;
-    (function rAFCallback() {
-        if (elapsedFrames++ >= numberOfFrames)
-            continuation();
-        else
-            requestAnimationFrame(rAFCallback);
-    })();
-}
-
-async_test(t => {
+promise_test(async () => {
     const target = document.getElementById("target");
     target.animate({ transform: ["translateX(100px)", "none"] }, 1000 * 1000);
 
-    waitNFrames(3, () => {
-        const initialAnimations = internals.acceleratedAnimationsForElement(target);
-        assert_equals(initialAnimations.length, 1, "There should be a single accelerated animation before suspension.");
-        assert_object_equals(initialAnimations[0], { property: "transform", speed: 1 },
-                             'The single accelerated animation before suspension should be running and targeting the "transform" property.');
+    await renderingFrames(3);
 
-        internals.suspendAnimations();
+    const initialAnimations = internals.acceleratedAnimationsForElement(target);
+    assert_equals(initialAnimations.length, 1, "There should be a single accelerated animation before suspension.");
+    assert_object_equals(initialAnimations[0], { property: "transform", speed: 1 },
+                         'The single accelerated animation before suspension should be running and targeting the "transform" property.');
 
-        waitNFrames(2, () => {
-            const suspendedAnimations = internals.acceleratedAnimationsForElement(target);
-            assert_equals(suspendedAnimations.length, 1, "There should be a single accelerated animation after suspension.");
-            assert_object_equals(suspendedAnimations[0], { property: "transform", speed: 0 },
-                                 'The single accelerated animation after suspension should be paused and targeting the "transform" property.');
-            internals.resumeAnimations();
-            setTimeout(() => t.done());
-        });
-    });
+    internals.suspendAnimations();
+
+    await renderingFrames(2);
+
+    const suspendedAnimations = internals.acceleratedAnimationsForElement(target);
+    assert_equals(suspendedAnimations.length, 1, "There should be a single accelerated animation after suspension.");
+    assert_object_equals(suspendedAnimations[0], { property: "transform", speed: 0 },
+                         'The single accelerated animation after suspension should be paused and targeting the "transform" property.');
+    internals.resumeAnimations();
+
+    await new Promise(setTimeout);
 }, "Suspending animations should pause running accelerated animations.");
 
 </script>

--- a/LayoutTests/webanimations/css-animation-dynamic-duration-change.html
+++ b/LayoutTests/webanimations/css-animation-dynamic-duration-change.html
@@ -36,25 +36,25 @@
 
 <script>
 
-    async_test(t => {
+promise_test(async () => {
+    return new Promise(resolve => {
+        const once = { once: true };
+        const target = document.getElementById("target");
 
-    const once = { once: true };
-    const target = document.getElementById("target");
-
-    // Start the animation.
-    target.classList.add("animated");
-    target.addEventListener("animationstart", event => {
-        // Now we can cancel this animation.
-        target.classList.remove("animated");
-        target.addEventListener("animationend", event => {
-            // We wait a frame, resume the animation and check it's the same animation.
-            requestAnimationFrame(() => {
-                target.classList.add("animated");
-                target.addEventListener("animationstart", event => t.done(), once);
-            });
+        // Start the animation.
+        target.classList.add("animated");
+        target.addEventListener("animationstart", event => {
+            // Now we can cancel this animation.
+            target.classList.remove("animated");
+            target.addEventListener("animationend", event => {
+                // We wait a frame, resume the animation and check it's the same animation.
+                requestAnimationFrame(() => {
+                    target.classList.add("animated");
+                    target.addEventListener("animationstart", resolve, once);
+                });
+            }, once);
         }, once);
-    }, once);
-
+    });
 }, "A CSS Animation can be canceled and resumed by modifying its animation-duration.");
 
 </script>

--- a/LayoutTests/webanimations/css-transition-in-flight-reversal-accelerated.html
+++ b/LayoutTests/webanimations/css-transition-in-flight-reversal-accelerated.html
@@ -29,39 +29,41 @@
 
 function targetTest(propertyName)
 {
-    async_test(test => {
-        const target = document.body.appendChild(document.createElement("div"));
-        target.classList.add("target");
-        target.classList.add(propertyName);
+    promise_test(async() => {
+        return new Promise(resolve => {
+            const target = document.body.appendChild(document.createElement("div"));
+            target.classList.add("target");
+            target.classList.add(propertyName);
 
-        let initialTransition;
-        let reversedTransition;
+            let initialTransition;
+            let reversedTransition;
 
-        // Start the initial transition.
-        requestAnimationFrame(() => {
-            target.classList.add("in-flight");
-            const animations = target.getAnimations();
-            assert_equals(animations.length, 1, "There is one animation applied to the target after starting the initial transition.");
+            // Start the initial transition.
+            requestAnimationFrame(() => {
+                target.classList.add("in-flight");
+                const animations = target.getAnimations();
+                assert_equals(animations.length, 1, "There is one animation applied to the target after starting the initial transition.");
 
-            initialTransition = animations[0];
-            assert_true(initialTransition instanceof CSSTransition, "There is one animation applied to the target after starting the initial transition.");
+                initialTransition = animations[0];
+                assert_true(initialTransition instanceof CSSTransition, "There is one animation applied to the target after starting the initial transition.");
 
-            // Wait for the initial transition to start and then two frames before reversing the transition, to be certain that the animation did start.
-            // Indeed, the "transitionstart" event will be fired right before the next rAF callback is called, as the animation starts in that very same
-            // frame, and so progress will be 0 and the transition wouldn't be reversable until the next frame when the animation has progress > 0.
-            target.addEventListener("transitionstart", event => {
-                requestAnimationFrame(() => {
+                // Wait for the initial transition to start and then two frames before reversing the transition, to be certain that the animation did start.
+                // Indeed, the "transitionstart" event will be fired right before the next rAF callback is called, as the animation starts in that very same
+                // frame, and so progress will be 0 and the transition wouldn't be reversable until the next frame when the animation has progress > 0.
+                target.addEventListener("transitionstart", event => {
                     requestAnimationFrame(() => {
-                        target.classList.remove("in-flight");
-                        const animations = target.getAnimations();
-                        assert_equals(animations.length, 1, "There is one animation applied to the target after reversing the initial transition.");
+                        requestAnimationFrame(() => {
+                            target.classList.remove("in-flight");
+                            const animations = target.getAnimations();
+                            assert_equals(animations.length, 1, "There is one animation applied to the target after reversing the initial transition.");
 
-                        reversedTransition = animations[0];
-                        assert_true(reversedTransition instanceof CSSTransition, "There is one animation applied to the target after reversing the initial transition.");
-                        assert_not_equals(initialTransition, reversedTransition, "The animation applied to the target after reversing the initial transition is different than the original transition.");
+                            reversedTransition = animations[0];
+                            assert_true(reversedTransition instanceof CSSTransition, "There is one animation applied to the target after reversing the initial transition.");
+                            assert_not_equals(initialTransition, reversedTransition, "The animation applied to the target after reversing the initial transition is different than the original transition.");
 
-                        target.remove();
-                        test.done();
+                            target.remove();
+                            resolve();
+                        });
                     });
                 });
             });

--- a/LayoutTests/webanimations/no-scheduling-while-filling-accelerated.html
+++ b/LayoutTests/webanimations/no-scheduling-while-filling-accelerated.html
@@ -14,30 +14,19 @@
 <body>
 <script src="../resources/testharness.js"></script>
 <script src="../resources/testharnessreport.js"></script>
+<script src="resources/rendering-frames.js"></script>
 <div id="target"></div>
 <script>
 
-function waitNFrames(numberOfFrames, continuation)
-{
-    let elapsedFrames = 0;
-    (function rAFCallback() {
-        if (elapsedFrames++ >= numberOfFrames)
-            continuation();
-        else
-            requestAnimationFrame(rAFCallback);
-    })();
-}
-
-async_test(t => {
+promise_test(async () => {
     const keyframes = { transform: ["translateX(50px)", "translateX(100px)"] };
     const timing = { duration: 50, fill: "forwards" };
-    document.getElementById("target").animate(keyframes, timing).addEventListener("finish", event => {
-        const numberOfTimelineInvalidationsWhenFinished = internals.numberOfAnimationTimelineInvalidations();
-        waitNFrames(3, () => {
-            assert_equals(internals.numberOfAnimationTimelineInvalidations(), numberOfTimelineInvalidationsWhenFinished + 1);
-            t.done();
-        });
-    });
+
+    await document.getElementById("target").animate(keyframes, timing).finished;
+
+    const numberOfTimelineInvalidationsWhenFinished = internals.numberOfAnimationTimelineInvalidations();
+    await renderingFrames(3);
+    assert_equals(internals.numberOfAnimationTimelineInvalidations(), numberOfTimelineInvalidationsWhenFinished + 1);
 }, "There should not be more than one update made to the timeline after a forward-filling accelerated animation completes.");
 
 </script>

--- a/LayoutTests/webanimations/no-scheduling-while-filling-non-accelerated.html
+++ b/LayoutTests/webanimations/no-scheduling-while-filling-non-accelerated.html
@@ -14,30 +14,19 @@
 <body>
 <script src="../resources/testharness.js"></script>
 <script src="../resources/testharnessreport.js"></script>
+<script src="resources/rendering-frames.js"></script>
 <div id="target"></div>
 <script>
 
-function waitNFrames(numberOfFrames, continuation)
-{
-    let elapsedFrames = 0;
-    (function rAFCallback() {
-        if (elapsedFrames++ >= numberOfFrames)
-            continuation();
-        else
-            requestAnimationFrame(rAFCallback);
-    })();
-}
-
-async_test(t => {
+promise_test(async () => {
     const keyframes = { marginLeft: ["50px", "100px"] };
     const timing = { duration: 50, fill: "forwards" };
-    document.getElementById("target").animate(keyframes, timing).addEventListener("finish", event => {
-        const numberOfTimelineInvalidationsWhenFinished = internals.numberOfAnimationTimelineInvalidations();
-        waitNFrames(2, () => {
-            assert_equals(internals.numberOfAnimationTimelineInvalidations(), numberOfTimelineInvalidationsWhenFinished);
-            t.done();
-        });
-    });
+
+    await document.getElementById("target").animate(keyframes, timing).finished;
+
+    const numberOfTimelineInvalidationsWhenFinished = internals.numberOfAnimationTimelineInvalidations();
+    await renderingFrames(2);
+    assert_equals(internals.numberOfAnimationTimelineInvalidations(), numberOfTimelineInvalidationsWhenFinished);
 }, "There should not be any updates made to the timeline after a forward-filling animation completes.");
 
 </script>

--- a/LayoutTests/webanimations/resources/rendering-frames.js
+++ b/LayoutTests/webanimations/resources/rendering-frames.js
@@ -1,0 +1,12 @@
+
+const renderingFrames = async numberOfFrames => {
+    return new Promise(resolve => {
+        let elapsedFrames = 0;
+        (function rAFCallback() {
+            if (elapsedFrames++ >= numberOfFrames)
+                resolve();
+            else
+                requestAnimationFrame(rAFCallback);
+        })();
+    });
+}

--- a/LayoutTests/webanimations/transform-animation-with-steps-timing-function-not-accelerated.html
+++ b/LayoutTests/webanimations/transform-animation-with-steps-timing-function-not-accelerated.html
@@ -1,10 +1,10 @@
 <script src="../resources/testharness.js"></script>
 <script src="../resources/testharnessreport.js"></script>
+<script src="resources/rendering-frames.js"></script>
 <div style="position: absolute; top: 0; left: 0; width: 100px; height: 100px; background-color: black;"></div>
 <script>
 
-async_test(t => {
-
+promise_test(async () => {
     const target = document.querySelector("div");
     const animation = target.animate([
         { transform: "translateY(0px)", easing: "step-start" },
@@ -12,16 +12,11 @@ async_test(t => {
         { transform: "translateY(0px)" }
     ], 60 * 1000);
 
-    animation.ready.then(() => {
-        // We wait for two frames to ensure an accelerated animation would have been committed.
-        requestAnimationFrame(() => {
-            requestAnimationFrame(() => {
-                assert_equals(internals.acceleratedAnimationsForElement(target).length, 0, "The animation's target has no accelerated animation.");
-                t.done();
-            });
-        });
-    });
+    await animation.ready;
 
+    // We wait for two frames to ensure an accelerated animation would have been committed.
+    await renderingFrames(2);
+    assert_equals(internals.acceleratedAnimationsForElement(target).length, 0, "The animation's target has no accelerated animation.");
 }, "An animation targeting an accelerated property should not be accelerated if it uses a steps timing function in one of its keyframes.");
 
 </script>


### PR DESCRIPTION
#### 08509e730a888f16b662c2eede9b6f10d5b28604
<pre>
[web-animations] rewrite tests under LayoutTests/webanimations to use promise_test instead of async_test
<a href="https://bugs.webkit.org/show_bug.cgi?id=252806">https://bugs.webkit.org/show_bug.cgi?id=252806</a>

Reviewed by Dean Jackson.

We should stay clear of async_test() which will cause timeouts in case of assertion failures
while promise_test() just ends the test.

* LayoutTests/webanimations/accelerated-animation-removal-upon-transition-completion.html:
* LayoutTests/webanimations/accelerated-animation-suspension.html:
* LayoutTests/webanimations/css-animation-dynamic-duration-change.html:
* LayoutTests/webanimations/css-transition-in-flight-reversal-accelerated.html:
* LayoutTests/webanimations/no-scheduling-while-filling-accelerated.html:
* LayoutTests/webanimations/no-scheduling-while-filling-non-accelerated.html:
* LayoutTests/webanimations/resources/rendering-frames.js: Added.
(const.renderingFrames.async numberOfFrames.return.new.Promise):
(const.renderingFrames.async numberOfFrames):
* LayoutTests/webanimations/transform-animation-with-steps-timing-function-not-accelerated.html:

Canonical link: <a href="https://commits.webkit.org/260758@main">https://commits.webkit.org/260758@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a40dbd0f90b14fbac8a18f62d8937d9e9a680d9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109205 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18289 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42019 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/733 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118436 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19748 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9590 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101449 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114962 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14803 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98033 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42971 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96775 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29687 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84706 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11062 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31030 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11788 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7962 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17157 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50633 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13411 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4059 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->