### PR TITLE
[web-animations] remove getPropertyAtIndex() and getNumProperties() in favor of an iterable on CSSPropertyAnimation

### DIFF
--- a/Source/WebCore/animation/CSSPropertyAnimation.h
+++ b/Source/WebCore/animation/CSSPropertyAnimation.h
@@ -40,6 +40,24 @@ class CSSPropertyBlendingClient;
 class Document;
 class RenderStyle;
 
+class AnimatableCSSProperty {
+    WTF_MAKE_NONCOPYABLE(AnimatableCSSProperty);
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    explicit AnimatableCSSProperty(CSSPropertyID property)
+        : m_property(property)
+    {
+    }
+
+    virtual ~AnimatableCSSProperty() = default;
+
+    CSSPropertyID property() const { return m_property; }
+    virtual bool isShorthand() const { return false; }
+
+private:
+    CSSPropertyID m_property;
+};
+
 class CSSPropertyAnimation {
 public:
     static bool isPropertyAnimatable(AnimatableProperty);
@@ -48,8 +66,7 @@ public:
     static bool animationOfPropertyIsAccelerated(AnimatableProperty);
     static bool propertiesEqual(AnimatableProperty, const RenderStyle& a, const RenderStyle& b, const Document&);
     static bool canPropertyBeInterpolated(AnimatableProperty, const RenderStyle& a, const RenderStyle& b, const Document&);
-    static CSSPropertyID getPropertyAtIndex(int, std::optional<bool>& isShorthand);
-    static int getNumProperties();
+    static const Vector<std::unique_ptr<AnimatableCSSProperty>>& animatableProperties();
 
     static void blendProperty(const CSSPropertyBlendingClient&, AnimatableProperty, RenderStyle& destination, const RenderStyle& from, const RenderStyle& to, double progress, CompositeOperation, IterationCompositeOperation = IterationCompositeOperation::Replace, double currentIteration = 0);
 };

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -675,13 +675,10 @@ void Styleable::updateCSSTransitions(const RenderStyle& currentStyle, const Rend
     compileTransitionPropertiesInStyle(newStyle, transitionProperties, transitionPropertiesContainAll);
 
     if (transitionPropertiesContainAll) {
-        auto numberOfProperties = CSSPropertyAnimation::getNumProperties();
-        for (int propertyIndex = 0; propertyIndex < numberOfProperties; ++propertyIndex) {
-            std::optional<bool> isShorthand;
-            auto property = CSSPropertyAnimation::getPropertyAtIndex(propertyIndex, isShorthand);
-            if (isShorthand && *isShorthand)
+        for (auto& animatableCSSProperty : CSSPropertyAnimation::animatableProperties()) {
+            if (animatableCSSProperty->isShorthand())
                 continue;
-            updateCSSTransitionsForStyleableAndProperty(*this, property, currentStyle, newStyle, generationTime);
+            updateCSSTransitionsForStyleableAndProperty(*this, animatableCSSProperty->property(), currentStyle, newStyle, generationTime);
         }
 
         HashSet<AtomString> animatableCustomProperties;


### PR DESCRIPTION
#### c97226a27e6a1ef079d789a32d4d3c50a6d1c71a
<pre>
[web-animations] remove getPropertyAtIndex() and getNumProperties() in favor of an iterable on CSSPropertyAnimation
<a href="https://bugs.webkit.org/show_bug.cgi?id=252807">https://bugs.webkit.org/show_bug.cgi?id=252807</a>

Reviewed by NOBODY (OOPS!).

The current way to iterate through animatable properties is pretty ugly. We remove the getPropertyAtIndex() and
getNumProperties() combo from CSSPropertyAnimation and replace it with a new animatbaleProperties() method returning
a `const Vector&lt;std::unique_ptr&lt;AnimatableCSSProperty&gt;&gt;&amp;` where AnimatableCSSProperty is a new minimal superclass
of AnimationPropertyWrapperBase that simply exposes the property and whether it&apos;s a shorthand.

In the future, we will be able to also expose whether the property is accelerated for the work on threaded animation
resolution.

* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::AnimationPropertyWrapperBase::AnimationPropertyWrapperBase):
(WebCore::AnimationPropertyWrapperBase::equals const):
(WebCore::AnimationPropertyWrapperBase::blend const):
(WebCore::AnimationPropertyWrapperBase::logBlend const):
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):
(WebCore::CSSPropertyAnimation::animatableProperties):
(WebCore::AnimationPropertyWrapperBase::isShorthandWrapper const): Deleted.
(WebCore::AnimationPropertyWrapperBase::property const): Deleted.
(WebCore::CSSPropertyAnimation::getPropertyAtIndex): Deleted.
(WebCore::CSSPropertyAnimation::getNumProperties): Deleted.
* Source/WebCore/animation/CSSPropertyAnimation.h:
(WebCore::AnimatableCSSProperty::AnimatableCSSProperty):
(WebCore::AnimatableCSSProperty::property const):
(WebCore::AnimatableCSSProperty::isShorthand const):
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::updateCSSTransitions const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c97226a27e6a1ef079d789a32d4d3c50a6d1c71a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109208 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18292 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42021 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/735 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118438 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113090 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19751 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9593 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101451 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114964 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14804 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98036 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42976 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96776 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29690 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84716 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11065 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31033 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11791 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7964 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17161 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50636 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13414 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->