### PR TITLE
ASSERTION FAILED: !visualMetricsValues.isEmpty() in WebCore::SVGTextLayoutEngine::layoutTextOnLineOrPath

### DIFF
--- a/LayoutTests/svg/text/white-space-pre-wrap-whitespace-only-crash-expected.txt
+++ b/LayoutTests/svg/text/white-space-pre-wrap-whitespace-only-crash-expected.txt
@@ -1,0 +1,5 @@
+PASS if no crash.
+
+
+
+

--- a/LayoutTests/svg/text/white-space-pre-wrap-whitespace-only-crash.html
+++ b/LayoutTests/svg/text/white-space-pre-wrap-whitespace-only-crash.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+</script>
+<p>PASS if no crash.</p>
+<svg>
+  <text style='white-space: normal'> </text>
+  <text style='white-space: nowrap'> </text>
+  <text style='white-space: pre'> </text>
+  <text style='white-space: pre-wrap'> </text>
+  <text style='white-space: pre-line'> </text>
+</svg>

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -443,6 +443,8 @@ bool RenderTreeUpdater::textRendererIsNeeded(const Text& textNode)
         return true;
     // This text node has nothing but white space. We may still need a renderer in some cases.
     if (parentRenderer.isTable() || parentRenderer.isTableRow() || parentRenderer.isTableSection() || parentRenderer.isRenderTableCol() || parentRenderer.isFrameSet() || parentRenderer.isRenderGrid() || (parentRenderer.isFlexibleBox() && !parentRenderer.isRenderButton()))
+        return false;
+    if (parentRenderer.style().whiteSpace() == WhiteSpace::PreWrap && parentRenderer.isSVGRoot())
         return false;
     if (parentRenderer.style().preserveNewline()) // pre/pre-wrap/pre-line always make renderers.
         return true;


### PR DESCRIPTION
<pre>
ASSERTION FAILED: !visualMetricsValues.isEmpty() in WebCore::SVGTextLayoutEngine::layoutTextOnLineOrPath
<a href="https://bugs.webkit.org/show_bug.cgi?id=136941">https://bugs.webkit.org/show_bug.cgi?id=136941</a>
rdar://problem/27689544

Reviewed by NOBODY (OOPS!).

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/cfed17d1b14f9cff420321fca6eac89bca504492">https://chromium.googlesource.com/chromium/blink/+/cfed17d1b14f9cff420321fca6eac89bca504492</a>

SVGTextMetricsBuilder only knows how to handle 'white-space: pre' with regards to whitespace
preservation, meaning it will collapse the spaces in the node, and hence not generate any
SVGTextMetrics for it. Filter this case out to avoid even creating the text layout object in
the first place.

* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(RenderTreeUpdater::textRendererIsNeeded): Added "SVG" text cases with "PreWrap" whitespace handling
* LayoutTests/svg/text/white-space-pre-wrap-whitespace-only-crash.html: Added Test Case
* LayoutTests/svg/text/white-space-pre-wrap-whitespace-only-crash-expected.txt: Added Test Case Expectation
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47a319c7c7f35c2c5f51c4b5a8568aa4d34b7495

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109252 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18349 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42063 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/778 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118482 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113142 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19794 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9636 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/384 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115007 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14841 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98077 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101496 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96813 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29728 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43014 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11110 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31071 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84762 "Found 2 new API test failures: /TestWebKit:WebKit.OnDeviceChangeCrash, /TestWebKit:WebKit.PrivateBrowsingPushStateNoHistoryCallback (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11835 "Built successfully") | [💥 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10186 "An unexpected error occured. Recent messages:OS: Ventura (13.2), Xcode: 14.2; Skipping applying patch since patch_id isn't provided; Checked out pull request") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17201 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50674 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13460 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->