### PR TITLE
Disable body to root background propagation when `content:paint` is set on body or the root

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-color-body-propagation-008-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-color-body-propagation-008-expected.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<title>CSS Reftest Reference</title>
+<div style="background-color:green">This text should have a green background.</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-color-body-propagation-008.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-color-body-propagation-008.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Backgrounds and Borders Test: Do not propagate body background when html root is contained</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds/#special-backgrounds">
+<link rel="match" href="background-color-no-body-propagation-ref.html">
+<style>
+  html { contain: paint; }
+  body { background: green; }
+</style>
+<body>This text should have a green background.</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-color-body-propagation-009-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-color-body-propagation-009-expected.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<title>CSS Reftest Reference</title>
+<div style="background-color:green">This text should have a green background.</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-color-body-propagation-009.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-color-body-propagation-009.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Backgrounds and Borders Test: Do not propagate body background when body is contained</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds/#special-backgrounds">
+<link rel="match" href="background-color-no-body-propagation-ref.html">
+<style>
+  body { contain: paint; background: green; }
+</style>
+<body>This text should have a green background.</body>

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -102,10 +102,12 @@ bool BackgroundPainter::paintsOwnBackground(const RenderBoxModelObject& renderer
 {
     if (!renderer.isBody())
         return true;
+    if (renderer.shouldApplyAnyContainment())
+        return true;
     // The <body> only paints its background if the root element has defined a background independent of the body,
     // or if the <body>'s parent is not the document element's renderer (e.g. inside SVG foreignObject).
     auto documentElementRenderer = renderer.document().documentElement()->renderer();
-    return !documentElementRenderer || documentElementRenderer->hasBackground() || documentElementRenderer != renderer.parent();
+    return !documentElementRenderer || documentElementRenderer->shouldApplyAnyContainment() || documentElementRenderer->hasBackground() || documentElementRenderer != renderer.parent();
 }
 
 void BackgroundPainter::paintFillLayers(const Color& color, const FillLayer& fillLayer, const LayoutRect& rect, BackgroundBleedAvoidance bleedAvoidance, CompositeOperator op, RenderElement* backgroundObject)


### PR DESCRIPTION
#### 2a4bd98a580e6517634eb4f04dc6f4d7f695212c
<pre>
Disable body to root background propagation when `content:paint` is set on body or the root
<a href="https://bugs.webkit.org/show_bug.cgi?id=252733">https://bugs.webkit.org/show_bug.cgi?id=252733</a>

Reviewed by Tim Nguyen.

Disable body to root background propagation when `content:paint` is set on body or the root [1].

[1] <a href="https://drafts.csswg.org/css-contain-1/#contain-property">https://drafts.csswg.org/css-contain-1/#contain-property</a> (proposed correction 3)

* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-color-body-propagation-008-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-color-body-propagation-008.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-color-body-propagation-009-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-color-body-propagation-009.html: Added.
* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::BackgroundPainter::paintsOwnBackground):

Canonical link: <a href="https://commits.webkit.org/260766@main">https://commits.webkit.org/260766@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5ab7cf8302fbc97e00e3606d7f8d06327d32277

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109212 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18296 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42025 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/739 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118442 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113094 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19755 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9597 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101455 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114968 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14808 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98044 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42979 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96780 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29698 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84721 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11069 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31041 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11795 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7969 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17164 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50644 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7433 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13418 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->