### PR TITLE
Remove _webkit_fixedCarbonPOSIXPath

### DIFF
--- a/Source/WebKitLegacy/mac/Misc/WebKitNSStringExtras.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebKitNSStringExtras.mm
@@ -163,17 +163,6 @@ static bool canUseFastRenderer(const UniChar* buffer, unsigned length)
     return trimmed.autorelease();
 }
 
-#if PLATFORM(MAC)
-
-// FIXME: This is here only for binary compatibility with Safari 8 and earlier.
-// Remove it once we don't have to support that any more.
--(NSString *)_webkit_fixedCarbonPOSIXPath
-{
-    return self;
-}
-
-#endif
-
 + (NSString *)_webkit_localCacheDirectoryWithBundleIdentifier:(NSString*)bundleIdentifier
 {
     NSString *cacheDirectory = [[NSUserDefaults standardUserDefaults] objectForKey:WebKitLocalCacheDefaultsKey];

--- a/Source/WebKitLegacy/mac/WebKit.order
+++ b/Source/WebKitLegacy/mac/WebKit.order
@@ -1154,7 +1154,6 @@ _WKHTTPCookiesForURL
 _WKGetPreferredExtensionForMIMEType
 +[WebView(WebPrivate) _decodeData:]
 +[NSPasteboard(WebExtras) _web_setFindPasteboardString:withOwner:]
--[NSString(WebKitExtras) _webkit_fixedCarbonPOSIXPath]
 +[WebCoreStatistics statistics]
 +[WebCache statistics]
 +[WebCoreStatistics javaScriptObjectsCount]


### PR DESCRIPTION
#### 27185f9bee793bfd09452c651b83385d488c3dea
<pre>
Remove _webkit_fixedCarbonPOSIXPath
<a href="https://bugs.webkit.org/show_bug.cgi?id=252818">https://bugs.webkit.org/show_bug.cgi?id=252818</a>

Reviewed by Alexey Proskuryakov.

Safari 8 is long gone and no longer supported. We can remove this
function/method.

Canonical link: <a href="https://commits.webkit.org/262457@main">https://commits.webkit.org/262457@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0d673775dd57945dd41b552557f2bae9b73c850

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109230 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18315 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42044 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/758 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118461 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19774 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9616 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/371 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114985 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14822 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98058 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101474 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96794 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29712 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42996 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11088 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31055 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84744 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11813 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7984 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17182 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50658 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/388 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13437 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->