### PR TITLE
[GStreamer][MediaStream] Unify stream collection handling with MSE

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1746,11 +1746,8 @@ webkit.org/b/235885 webrtc/vp8-then-h264.html [ Failure ]
 # this is not enough for the receiver webrtcbin to create its video source pad,
 # because on sender side we need at least a complete GOP... So the tests time
 # out, awaiting forever a remote mediastream.
-webkit.org/b/235885 webrtc/canvas-to-peer-connection.html [ Skip ]
 webkit.org/b/235885 webrtc/canvas-to-peer-connection-vp8-2d.html [ Skip ]
 webkit.org/b/235885 webrtc/canvas-to-peer-connection-vp8.html [ Skip ]
-webkit.org/b/235885 webrtc/canvas-to-peer-connection-2d.html [ Skip ]
-webkit.org/b/235885 webrtc/captureCanvas-webrtc.html [ Skip ]
 
 # This is actually a flaky timeout but skipping nonetheless. GStreamer logs
 # highlight a srtpenc protection error when the test times out. Might be

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.h
@@ -30,10 +30,6 @@ class MediaStreamPrivate;
 class MediaStreamTrackPrivate;
 }
 
-#define WEBKIT_MEDIA_TRACK_TAG_WIDTH "webkit-media-stream-width"
-#define WEBKIT_MEDIA_TRACK_TAG_HEIGHT "webkit-media-stream-height"
-#define WEBKIT_MEDIA_TRACK_TAG_KIND "webkit-media-stream-kind"
-
 #define WEBKIT_MEDIA_STREAM_SRC(o) (G_TYPE_CHECK_INSTANCE_CAST((o), WEBKIT_TYPE_MEDIA_STREAM_SRC, WebKitMediaStreamSrc))
 #define WEBKIT_IS_MEDIA_STREAM_SRC(o) (G_TYPE_CHECK_INSTANCE_TYPE((o), WEBKIT_TYPE_MEDIA_STREAM_SRC))
 #define WEBKIT_MEDIA_STREAM_SRC_CAST(o) ((WebKitMediaStreamSrc*) o)


### PR DESCRIPTION
#### f9e2e16a6e8d7899cefb934c5a33f98015be0bb2
<pre>
[GStreamer][MediaStream] Unify stream collection handling with MSE
<a href="https://bugs.webkit.org/show_bug.cgi?id=252815">https://bugs.webkit.org/show_bug.cgi?id=252815</a>

Reviewed by Xabier Rodriguez-Calvar.

Both the MSE and mediastream source elements now post their stream collection in a similar fashion.
The custom mediastream tags handling was removed too, I don&apos;t know why that was needed in the first
place.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::handleStreamCollectionMessage):
(WebCore::MediaPlayerPrivateGStreamer::naturalSize const):
(WebCore::MediaPlayerPrivateGStreamer::createGSTPlayBin):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp:
(mediaStreamTrackPrivateGetTags):
(webkitMediaStreamNew):
(WebKitMediaStreamObserver::didRemoveTrack):
(webkitMediaStreamSrcChangeState):
(webkitMediaStreamSrcChain):
(webkitMediaStreamSrcPostStreamCollection):
(webkitMediaStreamSrcEnsureStreamCollectionPosted):
(webkitMediaStreamSrcAddTrack):
(webkitMediaStreamSrcSetStream):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.h:

Canonical link: <a href="https://commits.webkit.org/260873@main">https://commits.webkit.org/260873@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/770d749a83b2bbb30ce86e805c0e1bfcfb0f2cb0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109603 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18727 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42355 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1091 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118734 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113501 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20193 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9924 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101874 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115359 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15030 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98264 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43244 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97004 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29917 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85020 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11462 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31259 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12120 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8191 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17485 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50868 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7540 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13860 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->