### PR TITLE
Remove deleteFromInput

### DIFF
--- a/Source/WebKitLegacy/ios/DefaultDelegates/WebDefaultUIKitDelegate.m
+++ b/Source/WebKitLegacy/ios/DefaultDelegates/WebDefaultUIKitDelegate.m
@@ -176,11 +176,6 @@ static WebDefaultUIKitDelegate *sharedDelegate = nil;
 {
 }
 
-// FIXME: to be removed when UIKit implements the new one below.
-- (void)deleteFromInput
-{
-}
-
 - (void)deleteFromInputWithFlags:(NSUInteger)flags
 {
 }

--- a/Source/WebKitLegacy/ios/WebView/WebUIKitDelegate.h
+++ b/Source/WebKitLegacy/ios/WebView/WebUIKitDelegate.h
@@ -96,8 +96,6 @@ typedef NS_ENUM(NSInteger, WebMediaCaptureType) {
 - (void)addInputString:(NSString *)str withFlags:(NSUInteger)flags;
 - (BOOL)handleKeyTextCommandForCurrentEvent;
 - (BOOL)handleKeyAppCommandForCurrentEvent;
-// FIXME: remove deleteFromInput when UIKit implements deleteFromInputWithFlags.
-- (void)deleteFromInput;
 - (void)deleteFromInputWithFlags:(NSUInteger)flags;
 
 // Accelerated compositing


### PR DESCRIPTION
#### 556b4e5ace61922197e5b00e65c454bf68ba8cfe
<pre>
Remove deleteFromInput
<a href="https://bugs.webkit.org/show_bug.cgi?id=252821">https://bugs.webkit.org/show_bug.cgi?id=252821</a>

Reviewed by NOBODY (OOPS!).

deleteFromInputWithFlags is now used instead, so as per the FIXME:
deleteFromInput can be removed.

*Source\WebKitLegacy\ios\DefaultDelegates\WebDefaultUIKitDelegate.m:
*Source\WebKitLegacy\ios\WebView\WebUIKitDelegate.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/556b4e5ace61922197e5b00e65c454bf68ba8cfe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109238 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18323 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42051 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/766 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118468 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19782 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9624 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101482 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114993 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14831 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98063 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43003 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96803 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29717 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84745 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11096 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31060 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11821 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7991 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17189 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50663 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13445 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->