### PR TITLE
[GStreamer][WebRTC] replaceTrack support

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1007,7 +1007,6 @@ webkit.org/b/213699 http/wpt/mediarecorder/MediaRecorder-AV-audio-video-dataavai
 # https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/1017
 
 webkit.org/b/230415 fast/mediastream/RTCPeerConnection-iceconnectionstatechange-event.html [ Timeout ]
-webkit.org/b/79203 fast/mediastream/RTCRtpSender-replaceTrack.html [ Failure ]
 webkit.org/b/187603 fast/mediastream/media-stream-track-source-failure.html [ Timeout Failure Pass ]
 
 fast/mediastream/mediastreamtrack-configurationchange.html [ Failure ]
@@ -1691,13 +1690,7 @@ webrtc/video-sframe.html [ Skip ]
 webkit.org/b/219825 webrtc/sframe-keys.html [ Skip ]
 webkit.org/b/229055 http/wpt/webrtc/sframe-transform-error.html [ Skip ]
 
-# On-the-fly track switching not supported yet.
-webkit.org/b/235885 webrtc/audio-replace-track.html [ Skip ]
-webkit.org/b/235885 webrtc/video-replace-track-to-null.html [ Skip ]
-webkit.org/b/235885 webrtc/video-replace-track.html [ Skip ]
-webkit.org/b/235885 webrtc/video-replace-muted-track.html
-webkit.org/b/216538 webrtc/captureCanvas-webrtc-software-h264-baseline.html [ Skip ]
-webkit.org/b/216763 webkit.org/b/235885 webrtc/captureCanvas-webrtc-software-h264-high.html [ Skip ]
+# GStreamerRtpReceiverBackend::getSynchronizationSources() unimplemented and also hitting srtpenc errors.
 webkit.org/b/235885 webrtc/video-addTransceiver.html [ Skip ]
 
 # GstWebRTC doesn't support transceiver direction changes.
@@ -1707,6 +1700,10 @@ webkit.org/b/235885 webrtc/direction-change.html [ Skip ]
 # Specific to LibWebRTC:
 webkit.org/b/235885 webrtc/disable-encryption.html [ Skip ]
 webkit.org/b/235885 webrtc/libwebrtc/release-while-getting-stats.html [ Skip ]
+
+# This test is flaky because sometimes the onnegotiationneeded event is not fired fast enough after
+# the addTrack() call.
+webrtc/video-replace-track.html [ Pass Failure ]
 
 # Pending investigation.
 webkit.org/b/235885 fast/mediastream/RTCPeerConnection-addIceCandidate.html [ Failure ]

--- a/LayoutTests/webrtc/video-replace-track.html
+++ b/LayoutTests/webrtc/video-replace-track.html
@@ -5,6 +5,7 @@
         <title>Testing basic video exchange from offerer to receiver</title>
         <script src="../resources/testharness.js"></script>
         <script src="../resources/testharnessreport.js"></script>
+        <script src="../media/utilities.js"></script>
         <script src="routines.js"></script>
     </head>
     <body>
@@ -29,6 +30,7 @@ async function testFrontCameraImage(counter)
     if (!counter)
         counter = 0;
 
+    await waitForVideoFrame(video);
     if (isVideoBlack(canvas, video, 20, 20, 2 ,2))
         return;
 
@@ -49,6 +51,7 @@ async function testBackCameraImage(counter)
     if (!counter)
         counter = 0;
 
+    await waitForVideoFrame(video);
     data = grabImagePixels();
 
     var pixel = getImageDataPixel(data, [0, 0]);
@@ -56,7 +59,7 @@ async function testBackCameraImage(counter)
     if(isBetween100And200(pixel[0]) && isBetween100And200(pixel[1]) && isBetween100And200(pixel[2]))
         return;
 
-    if (counter >= 20)
+    if (counter >= 30)
         return Promise.reject("testBackCameraImage timed out");
 
     await waitFor(50);
@@ -139,6 +142,8 @@ promise_test((test) => {
         didReplaceTrack = true;
         return sender.replaceTrack(backStream.getVideoTracks()[0]);
     }).then(() => {
+        return waitForVideoSize(video, 320, 240);
+    }).then(() => {
         return testBackCameraImage();
     });
 }, "Switching from front to back camera, with lower resolution");
@@ -176,6 +181,8 @@ promise_test((test) => {
         backStream = stream;
         assert_true(backStream.getVideoTracks()[0].getSettings().height === 480, "back stream should be big");
         return sender.replaceTrack(backStream.getVideoTracks()[0]);
+    }).then(() => {
+        return waitForVideoSize(video, 640, 480);
     }).then(() => {
         return testBackCameraImage();
     });

--- a/Source/WebCore/Modules/mediastream/RTCRtpTransceiverBackend.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpTransceiverBackend.h
@@ -26,6 +26,7 @@
 
 #if ENABLE(WEB_RTC)
 
+#include "ExceptionOr.h"
 #include "RTCRtpTransceiverDirection.h"
 #include <wtf/Forward.h>
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h
@@ -78,7 +78,7 @@ public:
     void gatherDecoderImplementationName(Function<void(String&&)>&&);
     bool isNegotiationNeeded(uint32_t eventId) const { return eventId == m_negotiationNeededEventId; }
 
-    void configureAndLinkSource(RealtimeOutgoingMediaSourceGStreamer&);
+    void configureAndLinkSource(RealtimeOutgoingMediaSourceGStreamer&, bool shouldLookForUnusedPads = false);
 
     bool addTrack(GStreamerRtpSenderBackend&, MediaStreamTrack&, const FixedVector<String>&);
     void removeTrack(GStreamerRtpSenderBackend&);
@@ -92,7 +92,7 @@ public:
     std::optional<Backends> addTransceiver(MediaStreamTrack&, const RTCRtpTransceiverInit&);
     std::unique_ptr<GStreamerRtpTransceiverBackend> transceiverBackendFromSender(GStreamerRtpSenderBackend&);
 
-    void setSenderSourceFromTrack(GStreamerRtpSenderBackend&, MediaStreamTrack&);
+    GStreamerRtpSenderBackend::Source createLinkedSourceForTrack(MediaStreamTrack&);
 
     void collectTransceivers();
 
@@ -146,7 +146,7 @@ private:
 
     void processSDPMessage(const GstSDPMessage*, Function<void(unsigned index, const char* mid, const GstSDPMedia*)>);
 
-    GRefPtr<GstPad> requestPad(unsigned mlineIndex, const GRefPtr<GstCaps>&, const String& mediaStreamID);
+    GRefPtr<GstPad> requestPad(std::optional<unsigned> mlineIndex, const GRefPtr<GstCaps>&, const String& mediaStreamID);
 
 #if !RELEASE_LOG_DISABLED
     void gatherStatsForLogging();

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
@@ -293,9 +293,9 @@ ExceptionOr<Ref<RTCRtpTransceiver>> GStreamerPeerConnectionBackend::addTransceiv
     return addTransceiverFromTrackOrKind(WTFMove(track), init);
 }
 
-void GStreamerPeerConnectionBackend::setSenderSourceFromTrack(GStreamerRtpSenderBackend& sender, MediaStreamTrack& track)
+GStreamerRtpSenderBackend::Source GStreamerPeerConnectionBackend::createLinkedSourceForTrack(MediaStreamTrack& track)
 {
-    m_endpoint->setSenderSourceFromTrack(sender, track);
+    return m_endpoint->createLinkedSourceForTrack(track);
 }
 
 static inline GStreamerRtpTransceiverBackend& backendFromRTPTransceiver(RTCRtpTransceiver& transceiver)

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.h
@@ -21,8 +21,10 @@
 
 #if USE(GSTREAMER_WEBRTC)
 
+#include "GStreamerRtpSenderBackend.h"
 #include "PeerConnectionBackend.h"
 #include "RealtimeMediaSource.h"
+
 #include <gst/gst.h>
 #include <wtf/HashMap.h>
 
@@ -30,7 +32,6 @@ namespace WebCore {
 
 class GStreamerMediaEndpoint;
 class GStreamerRtpReceiverBackend;
-class GStreamerRtpSenderBackend;
 class GStreamerRtpTransceiverBackend;
 class RTCRtpReceiver;
 class RTCRtpReceiverBackend;
@@ -89,7 +90,8 @@ private:
 
     ExceptionOr<Ref<RTCRtpTransceiver>> addTransceiver(const String&, const RTCRtpTransceiverInit&) final;
     ExceptionOr<Ref<RTCRtpTransceiver>> addTransceiver(Ref<MediaStreamTrack>&&, const RTCRtpTransceiverInit&) final;
-    void setSenderSourceFromTrack(GStreamerRtpSenderBackend&, MediaStreamTrack&);
+
+    GStreamerRtpSenderBackend::Source createLinkedSourceForTrack(MediaStreamTrack&);
 
     RTCRtpTransceiver* existingTransceiver(WTF::Function<bool(GStreamerRtpTransceiverBackend&)>&&);
     RTCRtpTransceiver& newRemoteTransceiver(std::unique_ptr<GStreamerRtpTransceiverBackend>&&, RealtimeMediaSource::Type);
@@ -99,7 +101,6 @@ private:
     void addPendingTrackEvent(PendingTrackEvent&&);
     void dispatchPendingTrackEvents(MediaStream&);
 
-private:
     bool isLocalDescriptionSet() const final { return m_isLocalDescriptionSet; }
 
     template<typename T>
@@ -110,6 +111,9 @@ private:
     void suspend() final;
     void resume() final;
 
+    void setReconfiguring(bool isReconfiguring) { m_isReconfiguring = isReconfiguring; }
+    bool isReconfiguring() const { return m_isReconfiguring; }
+
     Ref<GStreamerMediaEndpoint> m_endpoint;
     bool m_isLocalDescriptionSet { false };
     bool m_isRemoteDescriptionSet { false };
@@ -117,6 +121,8 @@ private:
     Vector<std::unique_ptr<GStreamerIceCandidate>> m_pendingCandidates;
     Vector<Ref<RTCRtpReceiver>> m_pendingReceivers;
     Vector<PendingTrackEvent> m_pendingTrackEvents;
+
+    bool m_isReconfiguring { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.h
@@ -21,7 +21,6 @@
 
 #if ENABLE(WEB_RTC) && USE(GSTREAMER_WEBRTC)
 
-#include "GStreamerPeerConnectionBackend.h"
 #include "GUniquePtrGStreamer.h"
 #include "RTCRtpSenderBackend.h"
 #include "RealtimeOutgoingAudioSourceGStreamer.h"
@@ -35,21 +34,9 @@ class GStreamerPeerConnectionBackend;
 class GStreamerRtpSenderBackend final : public RTCRtpSenderBackend {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    GStreamerRtpSenderBackend(GStreamerPeerConnectionBackend& backend, GRefPtr<GstWebRTCRTPSender>&& rtcSender, GUniquePtr<GstStructure>&& initData)
-        : m_peerConnectionBackend(WeakPtr { &backend })
-        , m_rtcSender(WTFMove(rtcSender))
-        , m_initData(WTFMove(initData))
-    {
-    }
-
+    GStreamerRtpSenderBackend(GStreamerPeerConnectionBackend&, GRefPtr<GstWebRTCRTPSender>&&, GUniquePtr<GstStructure>&& initData);
     using Source = std::variant<std::nullptr_t, Ref<RealtimeOutgoingAudioSourceGStreamer>, Ref<RealtimeOutgoingVideoSourceGStreamer>>;
-    GStreamerRtpSenderBackend(GStreamerPeerConnectionBackend& backend, GRefPtr<GstWebRTCRTPSender>&& rtcSender, Source&& source, GUniquePtr<GstStructure>&& initData)
-        : m_peerConnectionBackend(WeakPtr { &backend })
-        , m_rtcSender(WTFMove(rtcSender))
-        , m_source(WTFMove(source))
-        , m_initData(WTFMove(initData))
-    {
-    }
+    GStreamerRtpSenderBackend(GStreamerPeerConnectionBackend&, GRefPtr<GstWebRTCRTPSender>&&, Source&&, GUniquePtr<GstStructure>&& initData);
 
     void setRTCSender(GRefPtr<GstWebRTCRTPSender>&& rtcSender) { m_rtcSender = WTFMove(rtcSender); }
     GstWebRTCRTPSender* rtcSender() { return m_rtcSender.get(); }
@@ -97,7 +84,7 @@ public:
         setSource(WTFMove(backend.m_source));
     }
 
-    WARN_UNUSED_RETURN GRefPtr<GstElement> stopSource();
+    void stopSource();
 
 private:
     bool replaceTrack(RTCRtpSender&, MediaStreamTrack*) final;

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp
@@ -25,7 +25,6 @@
 #include "GStreamerRtpReceiverBackend.h"
 #include "GStreamerRtpSenderBackend.h"
 #include "GStreamerWebRTCUtils.h"
-#include "NotImplemented.h"
 #include "RTCRtpCodecCapability.h"
 #include <wtf/glib/GUniquePtr.h>
 
@@ -86,14 +85,14 @@ String GStreamerRtpTransceiverBackend::mid()
 
 void GStreamerRtpTransceiverBackend::stop()
 {
-    // FIXME: webrtcbin transceivers can't be stopped yet.
-    notImplemented();
+    // Ideally we should also stop webrtcbin transceivers but it's not supported yet.
+    m_isStopped = true;
 }
 
 bool GStreamerRtpTransceiverBackend::stopped() const
 {
-    // FIXME: webrtcbin transceivers can't be stopped yet.
-    return false;
+    // Ideally this should be queried on webrtcbin, but its transceivers can't be stopped yet.
+    return m_isStopped;
 }
 
 static inline WARN_UNUSED_RETURN ExceptionOr<GstCaps*> toRtpCodecCapability(const RTCRtpCodecCapability& codec, int payloadType)

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.h
@@ -50,6 +50,7 @@ private:
     ExceptionOr<void> setCodecPreferences(const Vector<RTCRtpCodecCapability>&) final;
 
     GRefPtr<GstWebRTCRTPTransceiver> m_rtcTransceiver;
+    bool m_isStopped { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp
@@ -22,6 +22,7 @@
 
 #if USE(GSTREAMER_WEBRTC)
 
+#include "GStreamerCommon.h"
 #include "GStreamerRegistryScanner.h"
 #include "MediaStreamTrack.h"
 
@@ -114,20 +115,20 @@ bool RealtimeOutgoingAudioSourceGStreamer::setPayloadType(const GRefPtr<GstCaps>
     gst_bin_add_many(GST_BIN_CAST(m_bin.get()), m_payloader.get(), m_encoder.get(), nullptr);
 
     auto preEncoderSinkPad = adoptGRef(gst_element_get_static_pad(m_preEncoderQueue.get(), "sink"));
-    if (!gst_pad_is_linked(preEncoderSinkPad.get()))
-        gst_element_link_many(m_outgoingSource.get(), m_audioconvert.get(), m_audioresample.get(), m_preEncoderQueue.get(), nullptr);
+    if (!gst_pad_is_linked(preEncoderSinkPad.get())) {
+        if (!gst_element_link_many(m_outgoingSource.get(), m_inputSelector.get(), m_audioconvert.get(), m_audioresample.get(), m_preEncoderQueue.get(), nullptr)) {
+            GST_ERROR_OBJECT(m_bin.get(), "Unable to link outgoing source to pre-encoder queue");
+            return false;
+        }
+    }
 
-    gst_element_link_many(m_preEncoderQueue.get(), m_encoder.get(), m_payloader.get(), m_postEncoderQueue.get(), nullptr);
-    gst_bin_sync_children_states(GST_BIN_CAST(m_bin.get()));
-    return true;
+    return gst_element_link_many(m_preEncoderQueue.get(), m_encoder.get(), m_payloader.get(), m_postEncoderQueue.get(), nullptr);
 }
 
 void RealtimeOutgoingAudioSourceGStreamer::codecPreferencesChanged(const GRefPtr<GstCaps>& codecPreferences)
 {
     gst_element_set_locked_state(m_bin.get(), TRUE);
     if (m_payloader) {
-        gst_element_set_locked_state(m_payloader.get(), TRUE);
-        gst_element_set_locked_state(m_encoder.get(), TRUE);
         gst_element_set_state(m_payloader.get(), GST_STATE_NULL);
         gst_element_set_state(m_encoder.get(), GST_STATE_NULL);
         gst_element_unlink_many(m_preEncoderQueue.get(), m_encoder.get(), m_payloader.get(), m_postEncoderQueue.get(), nullptr);
@@ -135,10 +136,59 @@ void RealtimeOutgoingAudioSourceGStreamer::codecPreferencesChanged(const GRefPtr
         m_payloader.clear();
         m_encoder.clear();
     }
-    setPayloadType(codecPreferences);
+    if (!setPayloadType(codecPreferences)) {
+        gst_element_set_locked_state(m_bin.get(), FALSE);
+        GST_ERROR_OBJECT(m_bin.get(), "Unable to link encoder to webrtcbin");
+        return;
+    }
+
     gst_element_set_locked_state(m_bin.get(), FALSE);
+    gst_bin_sync_children_states(GST_BIN_CAST(m_bin.get()));
     gst_element_sync_state_with_parent(m_bin.get());
     GST_DEBUG_BIN_TO_DOT_FILE_WITH_TS(GST_BIN_CAST(m_bin.get()), GST_DEBUG_GRAPH_SHOW_ALL, "outgoing-audio-new-codec-prefs");
+    m_isStopped = false;
+}
+
+void RealtimeOutgoingAudioSourceGStreamer::connectFallbackSource()
+{
+    if (!m_fallbackPad) {
+        m_fallbackSource = makeGStreamerElement("audiotestsrc", nullptr);
+        if (!m_fallbackSource) {
+            WTFLogAlways("Unable to connect fallback audiotestsrc element, expect broken behavior. Please install gst-plugins-base.");
+            return;
+        }
+
+        gst_util_set_object_arg(G_OBJECT(m_fallbackSource.get()), "wave", "silence");
+
+        gst_bin_add(GST_BIN_CAST(m_bin.get()), m_fallbackSource.get());
+
+        m_fallbackPad = adoptGRef(gst_element_request_pad_simple(m_inputSelector.get(), "sink_%u"));
+
+        auto srcPad = adoptGRef(gst_element_get_static_pad(m_fallbackSource.get(), "src"));
+        gst_pad_link(srcPad.get(), m_fallbackPad.get());
+        gst_element_sync_state_with_parent(m_fallbackSource.get());
+    }
+
+    g_object_set(m_inputSelector.get(), "active-pad", m_fallbackPad.get(), nullptr);
+}
+
+void RealtimeOutgoingAudioSourceGStreamer::unlinkOutgoingSource()
+{
+    auto srcPad = adoptGRef(gst_element_get_static_pad(m_outgoingSource.get(), "audio_src0"));
+    auto peerPad = adoptGRef(gst_pad_get_peer(srcPad.get()));
+    if (!peerPad)
+        return;
+
+    gst_pad_unlink(srcPad.get(), peerPad.get());
+    gst_element_release_request_pad(m_inputSelector.get(), peerPad.get());
+}
+
+void RealtimeOutgoingAudioSourceGStreamer::linkOutgoingSource()
+{
+    auto srcPad = adoptGRef(gst_element_get_static_pad(m_outgoingSource.get(), "audio_src0"));
+    auto sinkPad = adoptGRef(gst_element_request_pad_simple(m_inputSelector.get(), "sink_%u"));
+    gst_pad_link(srcPad.get(), sinkPad.get());
+    g_object_set(m_inputSelector.get(), "active-pad", sinkPad.get(), nullptr);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.h
@@ -38,6 +38,11 @@ private:
     void codecPreferencesChanged(const GRefPtr<GstCaps>&) final;
     RTCRtpCapabilities rtpCapabilities() const final;
 
+    void connectFallbackSource() final;
+    void unlinkOutgoingSource() final;
+    void linkOutgoingSource() final;
+
+    GRefPtr<GstElement> m_fallbackSource;
     GRefPtr<GstElement> m_audioconvert;
     GRefPtr<GstElement> m_audioresample;
 };

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.h
@@ -34,6 +34,7 @@ public:
 
     bool setPayloadType(const GRefPtr<GstCaps>&) final;
     void teardown() final;
+    void flush() final;
 
     const GstStructure* stats() const { return m_stats.get(); }
 
@@ -51,8 +52,13 @@ private:
     void startUpdatingStats();
     void stopUpdatingStats();
 
+    void connectFallbackSource() final;
+    void unlinkOutgoingSource() final;
+    void linkOutgoingSource() final;
+
     void updateStats(GstBuffer*);
 
+    GRefPtr<GstElement> m_fallbackSource;
     GRefPtr<GstElement> m_videoConvert;
     GRefPtr<GstElement> m_videoFlip;
     GUniquePtr<GstStructure> m_stats;


### PR DESCRIPTION
#### 5bd55e4bf534024c800d3823cde87ba2139cb3ff
<pre>
[GStreamer][WebRTC] replaceTrack support
<a href="https://bugs.webkit.org/show_bug.cgi?id=252820">https://bugs.webkit.org/show_bug.cgi?id=252820</a>

Reviewed by Xabier Rodriguez-Calvar.

In the GStreamer WebRTC backend `sender.replaceTrack()` is now supported. Under the hood, the
outgoing media source now has an input-selector just after the mediastreamsrc element. This allows
us to toggle between a mediastreamsrc and a fake source, eg, when replacing the track with null.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/webrtc/video-replace-track.html:
* Source/WebCore/Modules/mediastream/RTCRtpTransceiverBackend.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::setConfiguration):
(WebCore::GStreamerMediaEndpoint::configureAndLinkSource):
(WebCore::GStreamerMediaEndpoint::requestPad):
(WebCore::GStreamerMediaEndpoint::addTrack):
(WebCore::GStreamerMediaEndpoint::removeTrack):
(WebCore::GStreamerMediaEndpoint::addTransceiver):
(WebCore::GStreamerMediaEndpoint::createLinkedSourceForTrack):
(WebCore::GStreamerMediaEndpoint::createDataChannel):
(WebCore::GStreamerMediaEndpoint::onNegotiationNeeded):
(WebCore::GStreamerMediaEndpoint::setSenderSourceFromTrack): Deleted.
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp:
(WebCore::GStreamerPeerConnectionBackend::createLinkedSourceForTrack):
(WebCore::GStreamerPeerConnectionBackend::setSenderSourceFromTrack): Deleted.
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.cpp:
(WebCore::ensureDebugCategoryIsRegistered):
(WebCore::GStreamerRtpSenderBackend::GStreamerRtpSenderBackend):
(WebCore::m_initData):
(WebCore::GStreamerRtpSenderBackend::startSource):
(WebCore::GStreamerRtpSenderBackend::stopSource):
(WebCore::GStreamerRtpSenderBackend::replaceTrack):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp:
(WebCore::GStreamerRtpTransceiverBackend::stop):
(WebCore::GStreamerRtpTransceiverBackend::stopped const):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.h:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingAudioSourceGStreamer::setPayloadType):
(WebCore::RealtimeOutgoingAudioSourceGStreamer::codecPreferencesChanged):
(WebCore::RealtimeOutgoingAudioSourceGStreamer::connectFallbackSource):
(WebCore::RealtimeOutgoingAudioSourceGStreamer::unlinkOutgoingSource):
(WebCore::RealtimeOutgoingAudioSourceGStreamer::linkOutgoingSource):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.h:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingMediaSourceGStreamer::RealtimeOutgoingMediaSourceGStreamer):
(WebCore::RealtimeOutgoingMediaSourceGStreamer::~RealtimeOutgoingMediaSourceGStreamer):
(WebCore::RealtimeOutgoingMediaSourceGStreamer::setSource):
(WebCore::RealtimeOutgoingMediaSourceGStreamer::start):
(WebCore::RealtimeOutgoingMediaSourceGStreamer::stop):
(WebCore::RealtimeOutgoingMediaSourceGStreamer::flush):
(WebCore::RealtimeOutgoingMediaSourceGStreamer::stopOutgoingSource):
(WebCore::RealtimeOutgoingMediaSourceGStreamer::initializeFromTrack):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.h:
(WebCore::RealtimeOutgoingMediaSourceGStreamer::isStopped const):
(WebCore::RealtimeOutgoingMediaSourceGStreamer::connectFallbackSource):
(WebCore::RealtimeOutgoingMediaSourceGStreamer::unlinkOutgoingSource):
(WebCore::RealtimeOutgoingMediaSourceGStreamer::linkOutgoingSource):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingVideoSourceGStreamer::setPayloadType):
(WebCore::RealtimeOutgoingVideoSourceGStreamer::codecPreferencesChanged):
(WebCore::RealtimeOutgoingVideoSourceGStreamer::connectFallbackSource):
(WebCore::RealtimeOutgoingVideoSourceGStreamer::unlinkOutgoingSource):
(WebCore::RealtimeOutgoingVideoSourceGStreamer::linkOutgoingSource):
(WebCore::RealtimeOutgoingVideoSourceGStreamer::flush):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/260815@main">https://commits.webkit.org/260815@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2b66428de5078ab2b4a262844aaf2b357248b15

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109504 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18629 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42262 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1001 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118660 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113388 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20094 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9825 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101780 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115259 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98196 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43172 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29849 "Found 1 new test failure: imported/w3c/web-platform-tests/preload/onerror-event.html (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84936 "Found 2 new API test failures: /TestWebKit:WebKit.OnDeviceChangeCrash, /TestWebKit:WebKit.PrivateBrowsingPushStateNoHistoryCallback (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11366 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31192 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12029 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8123 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17395 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50796 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7493 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13763 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->