### PR TITLE
[GStreamer][GL] Enable DMABuf sink

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp
@@ -27,6 +27,10 @@
 #include <mutex>
 #include <wtf/glib/WTFGType.h>
 
+#if USE(LIBGBM)
+#include "GBMDevice.h"
+#endif
+
 using namespace WebCore;
 
 enum {
@@ -130,13 +134,12 @@ static void webKitDMABufVideoSinkGetProperty(GObject* object, guint propertyId, 
     WebKitDMABufVideoSink* sink = WEBKIT_DMABUF_VIDEO_SINK(object);
 
     switch (propertyId) {
-    case PROP_STATS:
-        if (webkitGstCheckVersion(1, 18, 0)) {
-            GUniqueOutPtr<GstStructure> stats;
-            g_object_get(sink->priv->appSink.get(), "stats", &stats.outPtr(), nullptr);
-            gst_value_set_structure(value, stats.get());
-        }
+    case PROP_STATS: {
+        GUniqueOutPtr<GstStructure> stats;
+        g_object_get(sink->priv->appSink.get(), "stats", &stats.outPtr(), nullptr);
+        gst_value_set_structure(value, stats.get());
         break;
+    }
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propertyId, paramSpec);
         RELEASE_ASSERT_NOT_REACHED();
@@ -162,19 +165,29 @@ static void webkit_dmabuf_video_sink_class_init(WebKitDMABufVideoSinkClass* klas
 
 bool webKitDMABufVideoSinkIsEnabled()
 {
-    static bool s_enabled = false;
+    static bool s_disabled = false;
+#if USE(LIBGBM)
     static std::once_flag s_flag;
-    std::call_once(s_flag,
-        [&] {
-            const char* value = g_getenv("WEBKIT_GST_DMABUF_SINK_ENABLED");
-            s_enabled = value && (equalLettersIgnoringASCIICase(value, "true"_s) || equalLettersIgnoringASCIICase(value, "1"_s));
-        });
-    return s_enabled;
+    std::call_once(s_flag, [&] {
+        const char* value = g_getenv("WEBKIT_GST_DMABUF_SINK_DISABLED");
+        s_disabled = value && (equalLettersIgnoringASCIICase(value, "true"_s) || equalLettersIgnoringASCIICase(value, "1"_s));
+        if (!s_disabled) {
+            auto& gbmDevice = GBMDevice::singleton();
+            if (!gbmDevice.device()) {
+                WTFLogAlways("Unable to access the GBM device, disabling DMABuf video sink.");
+                s_disabled = true;
+            }
+        }
+    });
+#else
+    s_disabled = true;
+#endif
+    return !s_disabled;
 }
 
 bool webKitDMABufVideoSinkProbePlatform()
 {
-    return isGStreamerPluginAvailable("app");
+    return webkitGstCheckVersion(1, 22, 0) && isGStreamerPluginAvailable("app");
 }
 
 void webKitDMABufVideoSinkSetMediaPlayerPrivate(WebKitDMABufVideoSink* sink, MediaPlayerPrivateGStreamer* player)

--- a/Tools/Scripts/webkitpy/port/glib.py
+++ b/Tools/Scripts/webkitpy/port/glib.py
@@ -96,6 +96,7 @@ class GLibPort(Port):
         self._copy_value_from_environ_if_set(environment, 'WEBKIT_JHBUILD')
         self._copy_value_from_environ_if_set(environment, 'WEBKIT_TOP_LEVEL')
         self._copy_value_from_environ_if_set(environment, 'WEBKIT_DEBUG')
+        self._copy_value_from_environ_if_set(environment, 'WEBKIT_GST_DMABUF_SINK_DISABLED')
         self._copy_value_from_environ_if_set(environment, 'WEBKIT_GST_HARNESS_DUMP_DIR')
         self._copy_value_from_environ_if_set(environment, 'WEBKIT_GST_USE_PLAYBIN3')
         self._copy_value_from_environ_if_set(environment, 'AT_SPI_BUS_ADDRESS')


### PR DESCRIPTION
#### e962336d3261fc58317d3a0e90032e5c900a79e4
<pre>
[GStreamer][GL] Enable DMABuf sink
<a href="https://bugs.webkit.org/show_bug.cgi?id=252826">https://bugs.webkit.org/show_bug.cgi?id=252826</a>

Reviewed by Žan Doberšek and Xabier Rodriguez-Calvar.

Unconditionally enable the DMABuf sink when running with GStreamer 1.22 and newer. The
WEBKIT_GST_DMABUF_SINK_DISABLED environment variable can be set to fallback to the GL sink.

* Source/WebCore/platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp:
(webKitDMABufVideoSinkGetProperty):
(webKitDMABufVideoSinkIsEnabled):
(webKitDMABufVideoSinkProbePlatform):
* Tools/Scripts/webkitpy/port/glib.py:
(GLibPort.setup_environ_for_server):

Canonical link: <a href="https://commits.webkit.org/260881@main">https://commits.webkit.org/260881@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd1b6f228121330cf146d28cdbdbbd2667074dba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109605 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18729 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42357 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1093 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118736 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113503 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20195 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9926 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101876 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115361 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15032 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98266 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43247 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/113074 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97006 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29919 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85026 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11464 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31261 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12122 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8193 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17487 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50870 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7548 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13862 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->