### PR TITLE
[MSE] Fix browser hang caused by recursive MediaSource::completeSeek

### DIFF
--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -245,7 +245,8 @@ void MediaSource::completeSeek()
     // 4. Resume the seek algorithm at the "Await a stable state" step.
     m_private->seekCompleted();
 
-    monitorSourceBuffers();
+    if (m_pendingSeekTime.isInvalid())
+        monitorSourceBuffers();
 }
 
 Ref<TimeRanges> MediaSource::seekable()


### PR DESCRIPTION
#### 33249bf5d7e0d97b4e8f85622b5ea4898d923c78
<pre>
[MSE] Fix browser hang caused by recursive MediaSource::completeSeek
<a href="https://bugs.webkit.org/show_bug.cgi?id=252828">https://bugs.webkit.org/show_bug.cgi?id=252828</a>

Reviewed by NOBODY (OOPS!).

This happens when current media time (reported by HTMLMediaElement) differs from the seek media time requested by the
media player private.

For example if MediaSource::monitorSourceBuffers() is invoked after
HTMLMediaElement::seekWithTolerance() has updated
HTMLMediaElement::m_lastSeekTime but before actuall
HTMLMediaElement::seekTask() is executed.

Patch by Eugene Mutavchi &lt;Ievgen_Mutavchi@comcast.com&gt;.

* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::completeSeek):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33249bf5d7e0d97b4e8f85622b5ea4898d923c78

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109260 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18343 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42069 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/784 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118488 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113148 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19800 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9642 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101504 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115015 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14842 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98080 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43018 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96814 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29733 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84761 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11118 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31076 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11841 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8006 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17207 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50679 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13468 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->