### PR TITLE
[fetch] Implement the `Response.json` static method

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/response/response-static-json.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/response/response-static-json.any-expected.txt
@@ -1,19 +1,15 @@
 
-FAIL Check response returned by static json() with init undefined promise_test: Unhandled rejection with value: object "TypeError: Response.json is not a function. (In 'Response.json("hello world", init)', 'Response.json' is undefined)"
-FAIL Check response returned by static json() with init {"status":400} promise_test: Unhandled rejection with value: object "TypeError: Response.json is not a function. (In 'Response.json("hello world", init)', 'Response.json' is undefined)"
-FAIL Check response returned by static json() with init {"statusText":"foo"} promise_test: Unhandled rejection with value: object "TypeError: Response.json is not a function. (In 'Response.json("hello world", init)', 'Response.json' is undefined)"
-FAIL Check response returned by static json() with init {"headers":{}} promise_test: Unhandled rejection with value: object "TypeError: Response.json is not a function. (In 'Response.json("hello world", init)', 'Response.json' is undefined)"
-FAIL Check response returned by static json() with init {"headers":{"content-type":"foo/bar"}} promise_test: Unhandled rejection with value: object "TypeError: Response.json is not a function. (In 'Response.json("hello world", init)', 'Response.json' is undefined)"
-FAIL Check response returned by static json() with init {"headers":{"x-foo":"bar"}} promise_test: Unhandled rejection with value: object "TypeError: Response.json is not a function. (In 'Response.json("hello world", init)', 'Response.json' is undefined)"
+PASS Check response returned by static json() with init undefined
+PASS Check response returned by static json() with init {"status":400}
+PASS Check response returned by static json() with init {"statusText":"foo"}
+PASS Check response returned by static json() with init {"headers":{}}
+PASS Check response returned by static json() with init {"headers":{"content-type":"foo/bar"}}
+PASS Check response returned by static json() with init {"headers":{"x-foo":"bar"}}
 PASS Throws TypeError when calling static json() with a status of 204
 PASS Throws TypeError when calling static json() with a status of 205
 PASS Throws TypeError when calling static json() with a status of 304
-FAIL Check static json() encodes JSON objects correctly promise_test: Unhandled rejection with value: object "TypeError: Response.json is not a function. (In 'Response.json({ foo: "bar" })', 'Response.json' is undefined)"
+PASS Check static json() encodes JSON objects correctly
 PASS Check static json() throws when data is not encodable
 PASS Check static json() throws when data is circular
-FAIL Check static json() propagates JSON serializer errors assert_throws_js: function "function () {
-      Response.json({ get foo() { throw new CustomError("bar") }});
-    }" threw object "TypeError: Response.json is not a function. (In 'Response.json({ get foo() { throw new CustomError("bar") }})', 'Response.json' is undefined)" ("TypeError") expected instance of function "class CustomError extends Error {
-    name = "CustomError";
-  }" ("CustomError")
+PASS Check static json() propagates JSON serializer errors
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/response/response-static-json.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/response/response-static-json.any.serviceworker-expected.txt
@@ -1,19 +1,15 @@
 
-FAIL Check response returned by static json() with init undefined promise_test: Unhandled rejection with value: object "TypeError: Response.json is not a function. (In 'Response.json("hello world", init)', 'Response.json' is undefined)"
-FAIL Check response returned by static json() with init {"status":400} promise_test: Unhandled rejection with value: object "TypeError: Response.json is not a function. (In 'Response.json("hello world", init)', 'Response.json' is undefined)"
-FAIL Check response returned by static json() with init {"statusText":"foo"} promise_test: Unhandled rejection with value: object "TypeError: Response.json is not a function. (In 'Response.json("hello world", init)', 'Response.json' is undefined)"
-FAIL Check response returned by static json() with init {"headers":{}} promise_test: Unhandled rejection with value: object "TypeError: Response.json is not a function. (In 'Response.json("hello world", init)', 'Response.json' is undefined)"
-FAIL Check response returned by static json() with init {"headers":{"content-type":"foo/bar"}} promise_test: Unhandled rejection with value: object "TypeError: Response.json is not a function. (In 'Response.json("hello world", init)', 'Response.json' is undefined)"
-FAIL Check response returned by static json() with init {"headers":{"x-foo":"bar"}} promise_test: Unhandled rejection with value: object "TypeError: Response.json is not a function. (In 'Response.json("hello world", init)', 'Response.json' is undefined)"
+PASS Check response returned by static json() with init undefined
+PASS Check response returned by static json() with init {"status":400}
+PASS Check response returned by static json() with init {"statusText":"foo"}
+PASS Check response returned by static json() with init {"headers":{}}
+PASS Check response returned by static json() with init {"headers":{"content-type":"foo/bar"}}
+PASS Check response returned by static json() with init {"headers":{"x-foo":"bar"}}
 PASS Throws TypeError when calling static json() with a status of 204
 PASS Throws TypeError when calling static json() with a status of 205
 PASS Throws TypeError when calling static json() with a status of 304
-FAIL Check static json() encodes JSON objects correctly promise_test: Unhandled rejection with value: object "TypeError: Response.json is not a function. (In 'Response.json({ foo: "bar" })', 'Response.json' is undefined)"
+PASS Check static json() encodes JSON objects correctly
 PASS Check static json() throws when data is not encodable
 PASS Check static json() throws when data is circular
-FAIL Check static json() propagates JSON serializer errors assert_throws_js: function "function () {
-      Response.json({ get foo() { throw new CustomError("bar") }});
-    }" threw object "TypeError: Response.json is not a function. (In 'Response.json({ get foo() { throw new CustomError("bar") }})', 'Response.json' is undefined)" ("TypeError") expected instance of function "class CustomError extends Error {
-    name = "CustomError";
-  }" ("CustomError")
+PASS Check static json() propagates JSON serializer errors
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/response/response-static-json.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/response/response-static-json.any.sharedworker-expected.txt
@@ -1,19 +1,15 @@
 
-FAIL Check response returned by static json() with init undefined promise_test: Unhandled rejection with value: object "TypeError: Response.json is not a function. (In 'Response.json("hello world", init)', 'Response.json' is undefined)"
-FAIL Check response returned by static json() with init {"status":400} promise_test: Unhandled rejection with value: object "TypeError: Response.json is not a function. (In 'Response.json("hello world", init)', 'Response.json' is undefined)"
-FAIL Check response returned by static json() with init {"statusText":"foo"} promise_test: Unhandled rejection with value: object "TypeError: Response.json is not a function. (In 'Response.json("hello world", init)', 'Response.json' is undefined)"
-FAIL Check response returned by static json() with init {"headers":{}} promise_test: Unhandled rejection with value: object "TypeError: Response.json is not a function. (In 'Response.json("hello world", init)', 'Response.json' is undefined)"
-FAIL Check response returned by static json() with init {"headers":{"content-type":"foo/bar"}} promise_test: Unhandled rejection with value: object "TypeError: Response.json is not a function. (In 'Response.json("hello world", init)', 'Response.json' is undefined)"
-FAIL Check response returned by static json() with init {"headers":{"x-foo":"bar"}} promise_test: Unhandled rejection with value: object "TypeError: Response.json is not a function. (In 'Response.json("hello world", init)', 'Response.json' is undefined)"
+PASS Check response returned by static json() with init undefined
+PASS Check response returned by static json() with init {"status":400}
+PASS Check response returned by static json() with init {"statusText":"foo"}
+PASS Check response returned by static json() with init {"headers":{}}
+PASS Check response returned by static json() with init {"headers":{"content-type":"foo/bar"}}
+PASS Check response returned by static json() with init {"headers":{"x-foo":"bar"}}
 PASS Throws TypeError when calling static json() with a status of 204
 PASS Throws TypeError when calling static json() with a status of 205
 PASS Throws TypeError when calling static json() with a status of 304
-FAIL Check static json() encodes JSON objects correctly promise_test: Unhandled rejection with value: object "TypeError: Response.json is not a function. (In 'Response.json({ foo: "bar" })', 'Response.json' is undefined)"
+PASS Check static json() encodes JSON objects correctly
 PASS Check static json() throws when data is not encodable
 PASS Check static json() throws when data is circular
-FAIL Check static json() propagates JSON serializer errors assert_throws_js: function "function () {
-      Response.json({ get foo() { throw new CustomError("bar") }});
-    }" threw object "TypeError: Response.json is not a function. (In 'Response.json({ get foo() { throw new CustomError("bar") }})', 'Response.json' is undefined)" ("TypeError") expected instance of function "class CustomError extends Error {
-    name = "CustomError";
-  }" ("CustomError")
+PASS Check static json() propagates JSON serializer errors
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/response/response-static-json.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/response/response-static-json.any.worker-expected.txt
@@ -1,19 +1,15 @@
 
-FAIL Check response returned by static json() with init undefined promise_test: Unhandled rejection with value: object "TypeError: Response.json is not a function. (In 'Response.json("hello world", init)', 'Response.json' is undefined)"
-FAIL Check response returned by static json() with init {"status":400} promise_test: Unhandled rejection with value: object "TypeError: Response.json is not a function. (In 'Response.json("hello world", init)', 'Response.json' is undefined)"
-FAIL Check response returned by static json() with init {"statusText":"foo"} promise_test: Unhandled rejection with value: object "TypeError: Response.json is not a function. (In 'Response.json("hello world", init)', 'Response.json' is undefined)"
-FAIL Check response returned by static json() with init {"headers":{}} promise_test: Unhandled rejection with value: object "TypeError: Response.json is not a function. (In 'Response.json("hello world", init)', 'Response.json' is undefined)"
-FAIL Check response returned by static json() with init {"headers":{"content-type":"foo/bar"}} promise_test: Unhandled rejection with value: object "TypeError: Response.json is not a function. (In 'Response.json("hello world", init)', 'Response.json' is undefined)"
-FAIL Check response returned by static json() with init {"headers":{"x-foo":"bar"}} promise_test: Unhandled rejection with value: object "TypeError: Response.json is not a function. (In 'Response.json("hello world", init)', 'Response.json' is undefined)"
+PASS Check response returned by static json() with init undefined
+PASS Check response returned by static json() with init {"status":400}
+PASS Check response returned by static json() with init {"statusText":"foo"}
+PASS Check response returned by static json() with init {"headers":{}}
+PASS Check response returned by static json() with init {"headers":{"content-type":"foo/bar"}}
+PASS Check response returned by static json() with init {"headers":{"x-foo":"bar"}}
 PASS Throws TypeError when calling static json() with a status of 204
 PASS Throws TypeError when calling static json() with a status of 205
 PASS Throws TypeError when calling static json() with a status of 304
-FAIL Check static json() encodes JSON objects correctly promise_test: Unhandled rejection with value: object "TypeError: Response.json is not a function. (In 'Response.json({ foo: "bar" })', 'Response.json' is undefined)"
+PASS Check static json() encodes JSON objects correctly
 PASS Check static json() throws when data is not encodable
 PASS Check static json() throws when data is circular
-FAIL Check static json() propagates JSON serializer errors assert_throws_js: function "function () {
-      Response.json({ get foo() { throw new CustomError("bar") }});
-    }" threw object "TypeError: Response.json is not a function. (In 'Response.json({ get foo() { throw new CustomError("bar") }})', 'Response.json' is undefined)" ("TypeError") expected instance of function "class CustomError extends Error {
-    name = "CustomError";
-  }" ("CustomError")
+PASS Check static json() propagates JSON serializer errors
 

--- a/Source/WebCore/Modules/fetch/FetchBody.h
+++ b/Source/WebCore/Modules/fetch/FetchBody.h
@@ -60,6 +60,11 @@ public:
     WEBCORE_EXPORT ~FetchBody();
     FetchBody& operator=(FetchBody&&) = default;
 
+    explicit FetchBody(String&& data)
+        : m_data(WTFMove(data))
+    {
+    }
+
     WEBCORE_EXPORT static std::optional<FetchBody> fromFormData(ScriptExecutionContext&, Ref<FormData>&&);
 
     void loadingFailed(const Exception&);
@@ -96,7 +101,6 @@ private:
     explicit FetchBody(Ref<const ArrayBuffer>&& data) : m_data(WTFMove(data)) { }
     explicit FetchBody(Ref<const ArrayBufferView>&& data) : m_data(WTFMove(data)) { }
     explicit FetchBody(Ref<FormData>&& data) : m_data(WTFMove(data)) { }
-    explicit FetchBody(String&& data) : m_data(WTFMove(data)) { }
     explicit FetchBody(Ref<const URLSearchParams>&& data) : m_data(WTFMove(data)) { }
     explicit FetchBody(Ref<ReadableStream>&& stream) : m_data(stream) { m_readableStream = WTFMove(stream); }
     explicit FetchBody(FetchBodyConsumer&& consumer) : m_consumer(WTFMove(consumer)) { }
@@ -128,6 +132,11 @@ private:
 
     FetchBodyConsumer m_consumer { FetchBodyConsumer::Type::None };
     RefPtr<ReadableStream> m_readableStream;
+};
+
+struct FetchBodyWithType {
+    FetchBody body;
+    String type;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/fetch/FetchResponse.h
+++ b/Source/WebCore/Modules/fetch/FetchResponse.h
@@ -61,8 +61,10 @@ public:
     WEBCORE_EXPORT static Ref<FetchResponse> create(ScriptExecutionContext*, std::optional<FetchBody>&&, FetchHeaders::Guard, ResourceResponse&&);
 
     static ExceptionOr<Ref<FetchResponse>> create(ScriptExecutionContext&, std::optional<FetchBody::Init>&&, Init&&);
+    static ExceptionOr<Ref<FetchResponse>> create(ScriptExecutionContext&, std::optional<FetchBodyWithType>&&, Init&&);
     static Ref<FetchResponse> error(ScriptExecutionContext&);
     static ExceptionOr<Ref<FetchResponse>> redirect(ScriptExecutionContext&, const String& url, int status);
+    static ExceptionOr<Ref<FetchResponse>> jsonForBindings(ScriptExecutionContext&, JSC::JSValue data, Init&&);
 
     using NotificationCallback = Function<void(ExceptionOr<Ref<FetchResponse>>&&)>;
     static void fetch(ScriptExecutionContext&, FetchRequest&, NotificationCallback&&, const String& initiator);

--- a/Source/WebCore/Modules/fetch/FetchResponse.idl
+++ b/Source/WebCore/Modules/fetch/FetchResponse.idl
@@ -48,6 +48,7 @@ dictionary FetchResponseInit {
 
     [CallWith=CurrentScriptExecutionContext, NewObject] static FetchResponse error();
     [CallWith=CurrentScriptExecutionContext, NewObject] static FetchResponse redirect(USVString url, optional unsigned short status = 302);
+    [CallWith=CurrentScriptExecutionContext, NewObject, ImplementedAs=jsonForBindings] static FetchResponse json(any data, optional FetchResponseInit init);
 
     readonly attribute FetchResponseType type;
 


### PR DESCRIPTION
#### 206817f17f39b6de35ea63268b74b750030d574f
<pre>
[fetch] Implement the `Response.json` static method
<a href="https://bugs.webkit.org/show_bug.cgi?id=240375">https://bugs.webkit.org/show_bug.cgi?id=240375</a>

Reviewed by Youenn Fablet.

This implements the `Response.json` static method, added to the fetch
spec in <a href="https://github.com/whatwg/fetch/pull/1392.">https://github.com/whatwg/fetch/pull/1392.</a>

* LayoutTests/imported/w3c/web-platform-tests/fetch/api/response/response-static-json.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/response/response-static-json.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/response/response-static-json.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/response/response-static-json.any.worker-expected.txt:
* Source/WebCore/Modules/fetch/FetchBody.h:
* Source/WebCore/Modules/fetch/FetchResponse.cpp:
(WebCore::FetchResponse::create):
  Added this method overload to implement the spec&apos;s &quot;initialize a
  response&quot; algorithm. This algortihm used to be combined with the
  regular Response creation algorithm which extracts the body, but
  Response.json cannot use that directly.
(WebCore::FetchResponse::staticJson):
* Source/WebCore/Modules/fetch/FetchResponse.h:
* Source/WebCore/Modules/fetch/FetchResponse.idl:

Canonical link: <a href="https://commits.webkit.org/261960@main">https://commits.webkit.org/261960@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5fcd50d6371618768f60a163e5d9f70e429c7782

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/113237 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/22370 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1910 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/5012 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121691 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/117370 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23740 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13543 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/6237 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/119024 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17636 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100900 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/106332 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99589 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1441 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46682 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14669 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1480 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/98943 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/15379 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10804 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20671 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53471 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/17231 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->