### PR TITLE
GraphicsContextCG should clip the paths via CGContext in GPUP mode

### DIFF
--- a/Source/WebCore/platform/graphics/cg/PathCG.h
+++ b/Source/WebCore/platform/graphics/cg/PathCG.h
@@ -32,6 +32,8 @@
 #include "WindRule.h"
 #include <wtf/Function.h>
 
+typedef struct CGContext* CGContextRef;
+
 namespace WebCore {
 
 class GraphicsContext;
@@ -87,6 +89,8 @@ private:
 
     RetainPtr<CGMutablePathRef> m_platformPath;
 };
+
+void addToCGContextPath(CGContextRef, const Path&);
 
 } // namespace WebCore
 


### PR DESCRIPTION
#### a8f57b13f2c7937bbd719183f5e60ff868433d87
<pre>
GraphicsContextCG should clip the paths via CGContext in GPUP mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=252833">https://bugs.webkit.org/show_bug.cgi?id=252833</a>
<a href="https://rdar.apple.com/105835901">rdar://105835901</a>

Reviewed by Said Abou-Hallawa.

Construct the clipped path directly into the CGContext.
Instead of creating a CGPath object, add the path info upon need to
the CGContext.

Removes some of CG work in GPUP receive side where time is spent
just copying the CGPath objects.

The implementation has now duplicated logic:
 - Add path segments to CGPath via PathCG
 - Add path segments to CGContext path

The implementation of both are stored next to each other so that
they keep in sync.

* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::setCGContextPath):
(WebCore::drawPathWithCGContext):
(WebCore::GraphicsContextCG::drawNativeImageInternal):
(WebCore::GraphicsContextCG::drawPattern):
(WebCore::GraphicsContextCG::drawPath):
(WebCore::GraphicsContextCG::fillPath):
(WebCore::GraphicsContextCG::strokePath):
(WebCore::GraphicsContextCG::fillRect):
(WebCore::GraphicsContextCG::fillRectWithRoundedHole):
(WebCore::GraphicsContextCG::clipOut):
(WebCore::GraphicsContextCG::clipPath):
(WebCore::GraphicsContextCG::beginTransparencyLayer):
(WebCore::GraphicsContextCG::drawLinesForText):
* Source/WebCore/platform/graphics/cg/PathCG.cpp:
(WebCore::addToContextPath):
(WebCore::copyClosingSubpathsApplierFunction):
(WebCore::addToCGContextPath):
* Source/WebCore/platform/graphics/cg/PathCG.h:

Canonical link: <a href="https://commits.webkit.org/271354@main">https://commits.webkit.org/271354@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03811ed1aa159eeb815a498e76768dea39e73882

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27878 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6517 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29153 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30409 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25445 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28372 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8493 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3911 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/25215 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28144 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5276 "Found 1 new test failure: editing/execCommand/insert-ordered-list-and-delete.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23931 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4546 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4735 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24946 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31097 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25482 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25389 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30935 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4742 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2897 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28798 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6263 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6738 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5188 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5210 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->