### PR TITLE
Introduce AllowTestOnlyIPC in order to block "ForTesting" IPC endpoints

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6277,3 +6277,6 @@ imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text
 imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing [ Skip ]
 
 webkit.org/b/252942 imported/w3c/web-platform-tests/preload/modulepreload.html [ Pass Failure ]
+
+# This test is checking that WebContent is terminated when performing an invalid IPC operation
+ipc/no-test-only-ipc-expected-crash.html [ Crash ]

--- a/LayoutTests/fast/mediastream/keep-microphone-muted-on-uninterruption.html
+++ b/LayoutTests/fast/mediastream/keep-microphone-muted-on-uninterruption.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ allowTestOnlyIPC=true ] -->
 <html>
 <head>
     <meta charset="utf-8">

--- a/LayoutTests/fast/mediastream/video-created-while-interrupted.html
+++ b/LayoutTests/fast/mediastream/video-created-while-interrupted.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ allowTestOnlyIPC=true ] -->
 <html>
 <head>
     <meta charset="utf-8">

--- a/LayoutTests/ipc/no-test-only-ipc-expected-crash.html
+++ b/LayoutTests/ipc/no-test-only-ipc-expected-crash.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<title>Test that calling a message which should be blocked behind AllowTestOnlyIPC kills the calling process if AllowTestOnlyIPC isn't set</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<body>
+<script>
+
+promise_test(async t => {
+    if (!window.internals)
+        return;
+
+    internals.beginAudioSessionInterruption();
+}, "Send beginAudioSessionInterruption without AllowTestOnlyIPC being set");
+
+</script>
+</body>

--- a/LayoutTests/ipc/test-only-ipc-allowed-expected.txt
+++ b/LayoutTests/ipc/test-only-ipc-allowed-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Send beginAudioSessionInterruption with AllowTestOnlyIPC set
+

--- a/LayoutTests/ipc/test-only-ipc-allowed.html
+++ b/LayoutTests/ipc/test-only-ipc-allowed.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ allowTestOnlyIPC=true ] -->
+<title>Test that calling a message which should be blocked behind AllowTestOnlyIPC is allowed if AllowTestOnlyIPC is set</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<body>
+<script>
+
+promise_test(async t => {
+    if (!window.internals)
+        return;
+
+    internals.beginAudioSessionInterruption();
+}, "Send beginAudioSessionInterruption with AllowTestOnlyIPC set");
+
+</script>
+</body>

--- a/LayoutTests/media/audioSession/audioSessionState.html
+++ b/LayoutTests/media/audioSession/audioSessionState.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html> <!-- webkit-test-runner [ allowTestOnlyIPC=true ] -->
 <html>
     <head>
         <meta charset="utf-8">

--- a/LayoutTests/media/audioSession/ios/audioSessionState-getUserMedia.html
+++ b/LayoutTests/media/audioSession/ios/audioSessionState-getUserMedia.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html> <!-- webkit-test-runner [ allowTestOnlyIPC=true ] -->
 <html>
     <head>
         <meta charset="utf-8">

--- a/LayoutTests/media/media-source/media-source-istypesupported-vp8-without-vp9.html
+++ b/LayoutTests/media/media-source/media-source-istypesupported-vp8-without-vp9.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ allowTestOnlyIPC=true ] -->
 <html>
     <head>
         <script src="../video-test.js"></script>

--- a/LayoutTests/media/media-source/media-source-video-renders.html
+++ b/LayoutTests/media/media-source/media-source-video-renders.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ allowTestOnlyIPC=true ] -->
 <html>
     <head>
         <meta name="fuzzy" content="maxDifference=0-39; totalPixels=0-180000" />

--- a/LayoutTests/platform/ios/mediastream/getUserMedia-override-audio-session-interruption.html
+++ b/LayoutTests/platform/ios/mediastream/getUserMedia-override-audio-session-interruption.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ allowTestOnlyIPC=true ] -->
 <html>
     <head>
         <title>override interruption with getUserMedia</title>

--- a/LayoutTests/platform/mac/media/mediacapabilities/vp9-decodingInfo-sw.html
+++ b/LayoutTests/platform/mac/media/mediacapabilities/vp9-decodingInfo-sw.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ allowTestOnlyIPC=true ] -->
 <html>
 <head>
     <script src=../../../../media/video-test.js></script>

--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -531,6 +531,7 @@ set(WebKit_SERIALIZATION_IN_FILES
     Shared/FocusedElementInformation.serialization.in
     Shared/FrameInfoData.serialization.in
     Shared/FrameTreeNodeData.serialization.in
+    Shared/GPUProcessConnectionParameters.serialization.in
     Shared/LayerTreeContext.serialization.in
     Shared/Model.serialization.in
     Shared/NavigationActionData.serialization.in

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -177,6 +177,7 @@ $(PROJECT_DIR)/Shared/FocusedElementInformation.serialization.in
 $(PROJECT_DIR)/Shared/FrameInfoData.serialization.in
 $(PROJECT_DIR)/Shared/FrameTreeNodeData.serialization.in
 $(PROJECT_DIR)/Shared/Gamepad/GamepadData.serialization.in
+$(PROJECT_DIR)/Shared/GPUProcessConnectionParameters.serialization.in
 $(PROJECT_DIR)/Shared/HTTPSUpgrade/HTTPSUpgradeList.txt
 $(PROJECT_DIR)/Shared/IPCConnectionTester.messages.in
 $(PROJECT_DIR)/Shared/IPCStreamTester.messages.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -485,6 +485,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/FrameInfoData.serialization.in \
 	Shared/FrameTreeNodeData.serialization.in \
 	Shared/Gamepad/GamepadData.serialization.in \
+	Shared/GPUProcessConnectionParameters.serialization.in \
 	Shared/ios/InteractionInformationAtPosition.serialization.in \
 	Shared/ios/WebAutocorrectionContext.serialization.in \
 	Shared/ios/WebAutocorrectionData.serialization.in \

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -263,6 +263,7 @@ GPUConnectionToWebProcess::GPUConnectionToWebProcess(GPUProcess& gpuProcess, Web
     , m_presentingApplicationAuditToken(WTFMove(parameters.presentingApplicationAuditToken))
 #endif
     , m_isLockdownModeEnabled(parameters.isLockdownModeEnabled)
+    , m_allowTestOnlyIPC(parameters.allowTestOnlyIPC)
 #if ENABLE(ROUTING_ARBITRATION) && HAVE(AVAUDIO_ROUTING_ARBITER)
     , m_routingArbitrator(LocalAudioSessionRoutingArbitrator::create(*this))
 #endif
@@ -733,6 +734,8 @@ void GPUConnectionToWebProcess::releaseRemoteCommandListener(RemoteRemoteCommand
 
 void GPUConnectionToWebProcess::setMediaOverridesForTesting(MediaOverridesForTesting overrides)
 {
+    MESSAGE_CHECK(allowTestOnlyIPC());
+
 #if ENABLE(VP9) && PLATFORM(COCOA)
     VP9TestingOverrides::singleton().setHardwareDecoderDisabled(WTFMove(overrides.vp9HardwareDecoderDisabled));
     VP9TestingOverrides::singleton().setVP9DecoderDisabled(WTFMove(overrides.vp9DecoderDisabled));

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -145,6 +145,7 @@ public:
     PAL::SessionID sessionID() const { return m_sessionID; }
 
     bool isLockdownModeEnabled() const { return m_isLockdownModeEnabled; }
+    bool allowTestOnlyIPC() const { return m_allowTestOnlyIPC; }
 
     Logger& logger();
 
@@ -385,6 +386,7 @@ private:
     RefPtr<RemoteRemoteCommandListenerProxy> m_remoteRemoteCommandListener;
     bool m_isActiveNowPlayingProcess { false };
     bool m_isLockdownModeEnabled { false };
+    bool m_allowTestOnlyIPC { false };
 
 #if ENABLE(ROUTING_ARBITRATION) && HAVE(AVAUDIO_ROUTING_ARBITER)
     UniqueRef<LocalAudioSessionRoutingArbitrator> m_routingArbitrator;

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
@@ -30,10 +30,13 @@
 
 #include "GPUConnectionToWebProcess.h"
 #include "GPUProcess.h"
+#include "Logging.h"
 #include "RemoteAudioSessionMessages.h"
 #include "RemoteAudioSessionProxyManager.h"
 #include "RemoteAudioSessionProxyMessages.h"
 #include <WebCore/AudioSession.h>
+
+#define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, (&connection()))
 
 namespace WebKit {
 
@@ -136,11 +139,13 @@ IPC::Connection& RemoteAudioSessionProxy::connection()
 
 void RemoteAudioSessionProxy::triggerBeginInterruptionForTesting()
 {
+    MESSAGE_CHECK(m_gpuConnection.allowTestOnlyIPC());
     AudioSession::sharedSession().beginInterruptionForTesting();
 }
 
 void RemoteAudioSessionProxy::triggerEndInterruptionForTesting()
 {
+    MESSAGE_CHECK(m_gpuConnection.allowTestOnlyIPC());
     AudioSession::sharedSession().endInterruptionForTesting();
 }
 

--- a/Source/WebKit/Shared/GPUProcessConnectionParameters.h
+++ b/Source/WebKit/Shared/GPUProcessConnectionParameters.h
@@ -40,6 +40,7 @@ struct GPUProcessConnectionParameters {
 #if ENABLE(IPC_TESTING_API)
     bool ignoreInvalidMessageForTesting { false };
 #endif
+    bool allowTestOnlyIPC { false };
 #if HAVE(AUDIT_TOKEN)
     std::optional<audit_token_t> presentingApplicationAuditToken;
 #endif
@@ -47,60 +48,8 @@ struct GPUProcessConnectionParameters {
     std::optional<bool> hasVP9HardwareDecoder;
     std::optional<bool> hasVP9ExtensionSupport;
 #endif
-
-    void encode(IPC::Encoder& encoder) const
-    {
-        encoder << webProcessIdentity;
-        encoder << overrideLanguages;
-        encoder << isLockdownModeEnabled;
-#if ENABLE(IPC_TESTING_API)
-        encoder << ignoreInvalidMessageForTesting;
-#endif
-#if HAVE(AUDIT_TOKEN)
-        encoder << presentingApplicationAuditToken;
-#endif
-#if ENABLE(VP9)
-        encoder << hasVP9HardwareDecoder;
-        encoder << hasVP9ExtensionSupport;
-#endif
-    }
-
-    static std::optional<GPUProcessConnectionParameters> decode(IPC::Decoder& decoder)
-    {
-        auto webProcessIdentity = decoder.decode<WebCore::ProcessIdentity>();
-        auto overrideLanguages = decoder.decode<Vector<String>>();
-        auto isLockdownModeEnabled = decoder.decode<bool>();
-#if ENABLE(IPC_TESTING_API)
-        auto ignoreInvalidMessageForTesting = decoder.decode<bool>();
-#endif
-#if HAVE(AUDIT_TOKEN)
-        auto presentingApplicationAuditToken = decoder.decode<std::optional<audit_token_t>>();
-#endif
-#if ENABLE(VP9)
-        auto hasVP9HardwareDecoder = decoder.decode<std::optional<bool>>();
-        auto hasVP9ExtensionSupport = decoder.decode<std::optional<bool>>();
-#endif
-        if (!decoder.isValid())
-            return std::nullopt;
-
-        return GPUProcessConnectionParameters {
-            WTFMove(*webProcessIdentity),
-            WTFMove(*overrideLanguages),
-            *isLockdownModeEnabled,
-#if ENABLE(IPC_TESTING_API)
-            *ignoreInvalidMessageForTesting,
-#endif
-#if HAVE(AUDIT_TOKEN)
-            WTFMove(*presentingApplicationAuditToken),
-#endif
-#if ENABLE(VP9)
-            WTFMove(*hasVP9HardwareDecoder),
-            WTFMove(*hasVP9ExtensionSupport),
-#endif
-        };
-    }
 };
 
-} // namespace WebKit
+}; // namespace WebKit
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/Shared/GPUProcessConnectionParameters.serialization.in
+++ b/Source/WebKit/Shared/GPUProcessConnectionParameters.serialization.in
@@ -1,0 +1,42 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE(GPU_PROCESS)
+
+struct WebKit::GPUProcessConnectionParameters {
+    WebCore::ProcessIdentity webProcessIdentity;
+    Vector<String> overrideLanguages;
+    bool isLockdownModeEnabled;
+#if ENABLE(IPC_TESTING_API)
+    bool ignoreInvalidMessageForTesting;
+#endif
+    bool allowTestOnlyIPC;
+#if HAVE(AUDIT_TOKEN)
+    std::optional<audit_token_t> presentingApplicationAuditToken;
+#endif
+#if ENABLE(VP9)
+    std::optional<bool> hasVP9HardwareDecoder;
+    std::optional<bool> hasVP9ExtensionSupport;
+#endif
+};
+
+#endif

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
@@ -111,6 +111,8 @@ Ref<PageConfiguration> PageConfiguration::copy() const
 #if HAVE(TOUCH_BAR)
     copy->m_requiresUserActionForEditingControlsManager = this->m_requiresUserActionForEditingControlsManager;
 #endif
+    
+    copy->m_allowTestOnlyIPC = this->m_allowTestOnlyIPC;
 
     copy->m_contentSecurityPolicyModeForExtension = this->m_contentSecurityPolicyModeForExtension;
 

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -210,6 +210,9 @@ public:
 
     bool isLockdownModeExplicitlySet() const;
     bool lockdownModeEnabled() const;
+    
+    void setAllowTestOnlyIPC(bool enabled) { m_allowTestOnlyIPC = enabled; }
+    bool allowTestOnlyIPC() const { return m_allowTestOnlyIPC; }
 
     void setContentSecurityPolicyModeForExtension(WebCore::ContentSecurityPolicyModeForExtension mode) { m_contentSecurityPolicyModeForExtension = mode; }
     WebCore::ContentSecurityPolicyModeForExtension contentSecurityPolicyModeForExtension() const { return m_contentSecurityPolicyModeForExtension; }
@@ -240,6 +243,7 @@ private:
     bool m_waitsForPaintAfterViewDidMoveToWindow { true };
     bool m_drawsBackground { true };
     bool m_controlledByAutomation { false };
+    bool m_allowTestOnlyIPC { false };
     std::optional<double> m_cpuLimit;
 
     WTF::String m_overrideContentSecurityPolicy;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
@@ -1396,6 +1396,16 @@ static WebKit::AttributionOverrideTesting toAttributionOverrideTesting(_WKAttrib
 #endif
 }
 
+- (BOOL)_allowTestOnlyIPC
+{
+    return _pageConfiguration->allowTestOnlyIPC();
+}
+
+- (void)_setAllowTestOnlyIPC:(BOOL)allowTestOnlyIPC
+{
+    _pageConfiguration->setAllowTestOnlyIPC(allowTestOnlyIPC);
+}
+
 - (BOOL)_shouldRelaxThirdPartyCookieBlocking
 {
     return _pageConfiguration->shouldRelaxThirdPartyCookieBlocking() == WebCore::ShouldRelaxThirdPartyCookieBlocking::Yes;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h
@@ -144,6 +144,8 @@ typedef NS_ENUM(NSUInteger, _WKContentSecurityPolicyModeForExtension) {
 
 @property (nonatomic, setter=_setAppHighlightsEnabled:) BOOL _appHighlightsEnabled WK_API_AVAILABLE(macos(12.0), ios(15.0));
 
+@property (nonatomic, setter=_setAllowTestOnlyIPC:) BOOL _allowTestOnlyIPC WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
 // The maximum Lab color difference allowed between two consecutive page top snapshots.
 // Expects 0 (disables page top color sampling entirely) or any positive number.
 @property (nonatomic, setter=_setSampledPageTopColorMaxDifference:) double _sampledPageTopColorMaxDifference WK_API_AVAILABLE(macos(12.0), ios(15.0));

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -893,6 +893,9 @@ void WebPageProxy::launchProcess(const RegistrableDomain& registrableDomain, Pro
     if (m_preferences->store().getBoolValueForKey(WebPreferencesKey::ipcTestingAPIEnabledKey()))
         m_process->setIgnoreInvalidMessageForTesting();
 #endif
+    
+    if (m_configuration->allowTestOnlyIPC())
+        m_process->setAllowTestOnlyIPC(true);
 
     finishAttachingToWebProcess(reason);
 

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -502,6 +502,9 @@ void WebProcessPool::createGPUProcessConnection(WebProcessProxy& webProcessProxy
 #endif
 
     parameters.isLockdownModeEnabled = webProcessProxy.lockdownMode() == WebProcessProxy::LockdownMode::Enabled;
+    
+    parameters.allowTestOnlyIPC = webProcessProxy.allowTestOnlyIPC();
+    
     ensureGPUProcess().createGPUProcessConnection(webProcessProxy, WTFMove(connectionIdentifier), WTFMove(parameters));
 }
 #endif
@@ -1117,6 +1120,8 @@ Ref<WebPageProxy> WebProcessPool::createWebPage(PageClient& pageClient, Ref<API:
     RefPtr<WebUserContentControllerProxy> userContentController = pageConfiguration->userContentController();
     
     ASSERT(process);
+    
+    process->setAllowTestOnlyIPC(pageConfiguration->allowTestOnlyIPC());
 
     auto page = process->createWebPage(pageClient, WTFMove(pageConfiguration));
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -434,6 +434,9 @@ public:
     bool ignoreInvalidMessageForTesting() const { return m_ignoreInvalidMessageForTesting; }
     void setIgnoreInvalidMessageForTesting();
 #endif
+    
+    bool allowTestOnlyIPC() const { return m_allowTestOnlyIPC; }
+    void setAllowTestOnlyIPC(bool allowTestOnlyIPC) { m_allowTestOnlyIPC = allowTestOnlyIPC; }
 
 #if ENABLE(MEDIA_STREAM)
     static void muteCaptureInPagesExcept(WebCore::PageIdentifier);
@@ -732,6 +735,8 @@ private:
 #if ENABLE(IPC_TESTING_API)
     bool m_ignoreInvalidMessageForTesting { false };
 #endif
+    
+    bool m_allowTestOnlyIPC { false };
 
     using SpeechRecognitionServerMap = HashMap<SpeechRecognitionServerIdentifier, std::unique_ptr<SpeechRecognitionServer>>;
     SpeechRecognitionServerMap m_speechRecognitionServerMap;

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -5844,6 +5844,7 @@
 		86D1968329A517A20083B077 /* TouchBarMenuItemData.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = TouchBarMenuItemData.serialization.in; sourceTree = "<group>"; };
 		86D1968429A51D070083B077 /* WebsiteDataType.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WebsiteDataType.serialization.in; sourceTree = "<group>"; };
 		86D196CE29A8D0D60083B077 /* DisplayListArgumentCoders.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = DisplayListArgumentCoders.serialization.in; sourceTree = "<group>"; };
+		86D196BF29A7890F0083B077 /* GPUProcessConnectionParameters.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = GPUProcessConnectionParameters.serialization.in; sourceTree = "<group>"; };
 		86DA60C628EAE9C00044FE4D /* FocusedElementInformation.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = FocusedElementInformation.serialization.in; sourceTree = "<group>"; };
 		86DA60CA28EB11830044FE4D /* InteractionInformationAtPosition.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; name = InteractionInformationAtPosition.serialization.in; path = ios/InteractionInformationAtPosition.serialization.in; sourceTree = "<group>"; };
 		86DD518B28EF028500DF2A58 /* TextFlags.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = TextFlags.serialization.in; sourceTree = "<group>"; };
@@ -7862,6 +7863,7 @@
 				5C121E8324101F7000486F9B /* FrameTreeNodeData.h */,
 				5C4AB4B128BD6FED0059E6CD /* FrameTreeNodeData.serialization.in */,
 				46AC532425DED81E003B57EC /* GPUProcessConnectionParameters.h */,
+				86D196BF29A7890F0083B077 /* GPUProcessConnectionParameters.serialization.in */,
 				1AC75A1A1B3368270056745B /* HangDetectionDisabler.h */,
 				0FD2CB2526CDD7A30008B11C /* IdentifierTypes.h */,
 				BCCF6B2312C93E7A008F9C35 /* ImageOptions.h */,

--- a/Tools/WebKitTestRunner/TestOptions.cpp
+++ b/Tools/WebKitTestRunner/TestOptions.cpp
@@ -155,6 +155,7 @@ const TestFeatures& TestOptions::defaults()
         };
         features.boolTestRunnerFeatures = {
             { "allowsLinkPreview", true },
+            { "allowTestOnlyIPC", false },
             { "appHighlightsEnabled", false },
             { "dumpJSConsoleLogInStdErr", false },
             { "editable", false },
@@ -214,6 +215,7 @@ const std::unordered_map<std::string, TestHeaderKeyType>& TestOptions::keyTypeMa
 
         { "allowsLinkPreview", TestHeaderKeyType::BoolTestRunner },
         { "appHighlightsEnabled", TestHeaderKeyType::BoolTestRunner },
+        { "allowTestOnlyIPC", TestHeaderKeyType::BoolTestRunner },
         { "dumpJSConsoleLogInStdErr", TestHeaderKeyType::BoolTestRunner },
         { "editable", TestHeaderKeyType::BoolTestRunner },
         { "enableInAppBrowserPrivacy", TestHeaderKeyType::BoolTestRunner },

--- a/Tools/WebKitTestRunner/TestOptions.h
+++ b/Tools/WebKitTestRunner/TestOptions.h
@@ -52,6 +52,7 @@ public:
 
     bool allowsLinkPreview() const { return boolTestRunnerFeatureValue("allowsLinkPreview"); }
     bool appHighlightsEnabled() const { return boolTestRunnerFeatureValue("appHighlightsEnabled"); }
+    bool allowTestOnlyIPC() const { return boolTestRunnerFeatureValue("allowTestOnlyIPC"); }
     bool dumpJSConsoleLogInStdErr() const { return boolTestRunnerFeatureValue("dumpJSConsoleLogInStdErr"); }
     bool editable() const { return boolTestRunnerFeatureValue("editable"); }
     bool enableInAppBrowserPrivacy() const { return boolTestRunnerFeatureValue("enableInAppBrowserPrivacy"); }

--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -206,6 +206,8 @@ void TestController::platformCreateWebView(WKPageConfigurationRef, const TestOpt
         NSString *text = [NSString stringWithContentsOfFile:manifestPath usedEncoding:nullptr error:nullptr];
         [copiedConfiguration _setApplicationManifest:[_WKApplicationManifest applicationManifestFromJSON:text manifestURL:nil documentURL:nil]];
     }
+    
+    [copiedConfiguration _setAllowTestOnlyIPC:options.allowTestOnlyIPC()];
 
     m_mainWebView = makeUnique<PlatformWebView>(copiedConfiguration.get(), options);
     finishCreatingPlatformWebView(m_mainWebView.get(), options);


### PR DESCRIPTION
#### 106f2630430967aba20df89a91f093284a7f4362
<pre>
Introduce AllowTestOnlyIPC in order to block &quot;ForTesting&quot; IPC endpoints
<a href="https://bugs.webkit.org/show_bug.cgi?id=252829">https://bugs.webkit.org/show_bug.cgi?id=252829</a>
rdar://105837347

Reviewed by Alex Christensen.

Starts to block unneeded &quot;ForTesting&quot; IPC endpoints by adding a default
deny to those messages and then allowing them only when a preference is
specified. The new preference exposed is AllowTestOnlyIPC.

* LayoutTests/TestExpectations:
* LayoutTests/fast/mediastream/keep-microphone-muted-on-uninterruption.html:
* LayoutTests/fast/mediastream/video-created-while-interrupted.html:
* LayoutTests/ipc/no-test-only-ipc-expected-crash.html: Added.
* LayoutTests/ipc/test-only-ipc-allowed-expected.txt: Added.
* LayoutTests/ipc/test-only-ipc-allowed.html: Added.
* LayoutTests/media/audioSession/audioSessionState.html:
* LayoutTests/media/audioSession/ios/audioSessionState-getUserMedia.html:
* LayoutTests/platform/ios/mediastream/getUserMedia-override-audio-session-interruption.html:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::setMediaOverridesForTesting):
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
(WebKit::GPUConnectionToWebProcess::allowTestOnlyIPC const):
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp:
(WebKit::RemoteAudioSessionProxy::triggerBeginInterruptionForTesting):
(WebKit::RemoteAudioSessionProxy::triggerEndInterruptionForTesting):
* Source/WebKit/Shared/GPUProcessConnectionParameters.h:
(WebKit::GPUProcessConnectionParameters::encode const): Deleted.
(WebKit::GPUProcessConnectionParameters::decode): Deleted.
* Source/WebKit/Shared/GPUProcessConnectionParameters.serialization.in: Added.
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _setupPageConfiguration:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(-[WKWebViewConfiguration init]):
(-[WKWebViewConfiguration copyWithZone:]):
(-[WKWebViewConfiguration _allowTestOnlyIPC]):
(-[WKWebViewConfiguration _setAllowTestOnlyIPC:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::launchProcess):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::createGPUProcessConnection):
(WebKit::WebProcessPool::createWebPage):
* Source/WebKit/UIProcess/WebProcessProxy.h:
(WebKit::WebProcessProxy::allowTestOnlyIPC const):
(WebKit::WebProcessProxy::setAllowTestOnlyIPC):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/WebKitTestRunner/TestOptions.cpp:
(WTR::TestOptions::defaults):
(WTR::TestOptions::keyTypeMapping):
* Tools/WebKitTestRunner/TestOptions.h:
(WTR::TestOptions::allowTestOnlyIPC const):
* Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm:
(WTR::TestController::platformCreateWebView):

Canonical link: <a href="https://commits.webkit.org/260935@main">https://commits.webkit.org/260935@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ece1e3a7dcc72fe8b8aa8a8f41eb8f2ef2e327d7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109989 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19090 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42672 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1433 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119036 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113941 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20555 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10283 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102247 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115736 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43520 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30176 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85343 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11792 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31516 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12415 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17783 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51127 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7581 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14210 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->