### PR TITLE
Add support for painting document markers using system colors

### DIFF
--- a/Source/WebCore/PAL/pal/spi/mac/NSSpellCheckerSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSSpellCheckerSPI.h
@@ -43,6 +43,13 @@ extern NSString *NSTextCheckingSuppressInitialCapitalizationKey;
 
 @end
 
+#endif // USE(APPLE_INTERNAL_SDK)
+
+#if HAVE(NSSPELLCHECKER_CORRECTION_INDICATOR_UNDERLINE_COLOR)
+// FIXME: rdar://105853874 Remove staging code.
+@interface NSSpellChecker (Staging_105286196)
++ (NSColor *)correctionIndicatorUnderlineColor;
+@end
 #endif
 
 #endif // PLATFORM(MAC)

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -1983,16 +1983,71 @@ Color RenderTheme::datePlaceholderTextColor(const Color& textColor, const Color&
     return convertColor<SRGBA<float>>(hsla);
 }
 
-Color RenderTheme::documentMarkerLineColor(DocumentMarkerLineStyleMode mode, OptionSet<StyleColorOptions>) const
+
+Color RenderTheme::spellingMarkerColor(OptionSet<StyleColorOptions> options) const
+{
+    auto& cache = colorCache(options);
+    if (!cache.spellingMarkerColor.isValid())
+        cache.spellingMarkerColor = platformSpellingMarkerColor(options);
+    return cache.spellingMarkerColor;
+}
+
+Color RenderTheme::platformSpellingMarkerColor(OptionSet<StyleColorOptions>) const
+{
+    return Color::red;
+}
+
+Color RenderTheme::dictationAlternativesMarkerColor(OptionSet<StyleColorOptions> options) const
+{
+    auto& cache = colorCache(options);
+    if (!cache.dictationAlternativesMarkerColor.isValid())
+        cache.dictationAlternativesMarkerColor = platformDictationAlternativesMarkerColor(options);
+    return cache.dictationAlternativesMarkerColor;
+}
+
+Color RenderTheme::platformDictationAlternativesMarkerColor(OptionSet<StyleColorOptions>) const
+{
+    return Color::green;
+}
+
+Color RenderTheme::autocorrectionReplacementMarkerColor(OptionSet<StyleColorOptions> options) const
+{
+    auto& cache = colorCache(options);
+    if (!cache.autocorrectionReplacementMarkerColor.isValid())
+        cache.autocorrectionReplacementMarkerColor = platformAutocorrectionReplacementMarkerColor(options);
+    return cache.autocorrectionReplacementMarkerColor;
+}
+
+Color RenderTheme::platformAutocorrectionReplacementMarkerColor(OptionSet<StyleColorOptions>) const
+{
+    return Color::green;
+}
+
+Color RenderTheme::grammarMarkerColor(OptionSet<StyleColorOptions> options) const
+{
+    auto& cache = colorCache(options);
+    if (!cache.grammarMarkerColor.isValid())
+        cache.grammarMarkerColor = platformGrammarMarkerColor(options);
+    return cache.grammarMarkerColor;
+}
+
+Color RenderTheme::platformGrammarMarkerColor(OptionSet<StyleColorOptions>) const
+{
+    return Color::green;
+}
+
+Color RenderTheme::documentMarkerLineColor(DocumentMarkerLineStyleMode mode, OptionSet<StyleColorOptions> options) const
 {
     switch (mode) {
     case DocumentMarkerLineStyleMode::Spelling:
-        return Color::red;
+        return spellingMarkerColor(options);
     case DocumentMarkerLineStyleMode::DictationAlternatives:
     case DocumentMarkerLineStyleMode::TextCheckingDictationPhraseWithAlternatives:
+        return dictationAlternativesMarkerColor(options);
     case DocumentMarkerLineStyleMode::AutocorrectionReplacement:
+        return autocorrectionReplacementMarkerColor(options);
     case DocumentMarkerLineStyleMode::Grammar:
-        return Color::green;
+        return grammarMarkerColor(options);
     }
 
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -184,7 +184,7 @@ public:
 
     Color datePlaceholderTextColor(const Color& textColor, const Color& backgroundColor) const;
 
-    virtual Color documentMarkerLineColor(DocumentMarkerLineStyleMode, OptionSet<StyleColorOptions>) const;
+    Color documentMarkerLineColor(DocumentMarkerLineStyleMode, OptionSet<StyleColorOptions>) const;
 
     WEBCORE_EXPORT Color focusRingColor(OptionSet<StyleColorOptions>) const;
     virtual Color platformFocusRingColor(OptionSet<StyleColorOptions>) const { return Color::black; }
@@ -281,6 +281,11 @@ protected:
     virtual Color platformAnnotationHighlightColor(OptionSet<StyleColorOptions>) const;
 
     virtual Color platformDefaultButtonTextColor(OptionSet<StyleColorOptions>) const;
+
+    virtual Color platformSpellingMarkerColor(OptionSet<StyleColorOptions>) const;
+    virtual Color platformDictationAlternativesMarkerColor(OptionSet<StyleColorOptions>) const;
+    virtual Color platformAutocorrectionReplacementMarkerColor(OptionSet<StyleColorOptions>) const;
+    virtual Color platformGrammarMarkerColor(OptionSet<StyleColorOptions>) const;
 
     virtual bool supportsSelectionForegroundColors(OptionSet<StyleColorOptions>) const { return true; }
     virtual bool supportsListBoxSelectionForegroundColors(OptionSet<StyleColorOptions>) const { return true; }
@@ -429,6 +434,11 @@ protected:
         Color annotationHighlightColor;
 
         Color defaultButtonTextColor;
+
+        Color spellingMarkerColor;
+        Color dictationAlternativesMarkerColor;
+        Color autocorrectionReplacementMarkerColor;
+        Color grammarMarkerColor;
     };
 
     virtual ColorCache& colorCache(OptionSet<StyleColorOptions>) const;
@@ -436,6 +446,11 @@ protected:
 private:
     StyleAppearance autoAppearanceForElement(RenderStyle&, const Element*) const;
     StyleAppearance adjustAppearanceForElement(RenderStyle&, const Element*, StyleAppearance) const;
+
+    Color spellingMarkerColor(OptionSet<StyleColorOptions>) const;
+    Color dictationAlternativesMarkerColor(OptionSet<StyleColorOptions>) const;
+    Color autocorrectionReplacementMarkerColor(OptionSet<StyleColorOptions>) const;
+    Color grammarMarkerColor(OptionSet<StyleColorOptions>) const;
 
     mutable HashMap<uint8_t, ColorCache, DefaultHash<uint8_t>, WTF::UnsignedWithZeroKeyHashTraits<uint8_t>> m_colorCacheMap;
 };

--- a/Source/WebCore/rendering/RenderThemeCocoa.h
+++ b/Source/WebCore/rendering/RenderThemeCocoa.h
@@ -45,6 +45,11 @@ protected:
     void paintAttachmentText(GraphicsContext&, AttachmentLayout*) final;
 #endif
 
+    Color platformSpellingMarkerColor(OptionSet<StyleColorOptions>) const override;
+    Color platformDictationAlternativesMarkerColor(OptionSet<StyleColorOptions>) const override;
+    Color platformAutocorrectionReplacementMarkerColor(OptionSet<StyleColorOptions>) const override;
+    Color platformGrammarMarkerColor(OptionSet<StyleColorOptions>) const override;
+
 private:
     void purgeCaches() override;
 
@@ -55,8 +60,6 @@ private:
 #if ENABLE(APPLE_PAY)
     void adjustApplePayButtonStyle(RenderStyle&, const Element*) const override;
 #endif
-
-    Color documentMarkerLineColor(DocumentMarkerLineStyleMode, OptionSet<StyleColorOptions>) const final;
 
 #if ENABLE(VIDEO) && ENABLE(MODERN_MEDIA_CONTROLS)
     String mediaControlsStyleSheet() override;

--- a/Source/WebCore/rendering/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/RenderThemeCocoa.mm
@@ -243,8 +243,27 @@ void RenderThemeCocoa::paintAttachmentText(GraphicsContext& context, AttachmentL
 
 #endif
 
-static Color grammarColor(bool useDarkMode)
+Color RenderThemeCocoa::platformSpellingMarkerColor(OptionSet<StyleColorOptions> options) const
 {
+    auto useDarkMode = options.contains(StyleColorOptions::UseDarkAppearance);
+    return useDarkMode ? SRGBA<uint8_t> { 255, 140, 140, 217 } : SRGBA<uint8_t> { 255, 59, 48, 191 };
+}
+
+Color RenderThemeCocoa::platformDictationAlternativesMarkerColor(OptionSet<StyleColorOptions> options) const
+{
+    auto useDarkMode = options.contains(StyleColorOptions::UseDarkAppearance);
+    return useDarkMode ? SRGBA<uint8_t> { 40, 145, 255, 217 } : SRGBA<uint8_t> { 0, 122, 255, 191 };
+}
+
+Color RenderThemeCocoa::platformAutocorrectionReplacementMarkerColor(OptionSet<StyleColorOptions> options) const
+{
+    auto useDarkMode = options.contains(StyleColorOptions::UseDarkAppearance);
+    return useDarkMode ? SRGBA<uint8_t> { 40, 145, 255, 217 } : SRGBA<uint8_t> { 0, 122, 255, 191 };
+}
+
+Color RenderThemeCocoa::platformGrammarMarkerColor(OptionSet<StyleColorOptions> options) const
+{
+    auto useDarkMode = options.contains(StyleColorOptions::UseDarkAppearance);
 #if ENABLE(POST_EDITING_GRAMMAR_CHECKING)
     static bool useBlueForGrammar = false;
     static std::once_flag flag;
@@ -256,23 +275,6 @@ static Color grammarColor(bool useDarkMode)
         return useDarkMode ? SRGBA<uint8_t> { 40, 145, 255, 217 } : SRGBA<uint8_t> { 0, 122, 255, 191 };
 #endif
     return useDarkMode ? SRGBA<uint8_t> { 50, 215, 75, 217 } : SRGBA<uint8_t> { 25, 175, 50, 191 };
-}
-
-Color RenderThemeCocoa::documentMarkerLineColor(DocumentMarkerLineStyleMode mode, OptionSet<StyleColorOptions> options) const
-{
-    bool useDarkMode = options.contains(StyleColorOptions::UseDarkAppearance);
-    switch (mode) {
-    // Red
-    case DocumentMarkerLineStyleMode::Spelling:
-        return useDarkMode ? SRGBA<uint8_t> { 255, 140, 140, 217 } : SRGBA<uint8_t> { 255, 59, 48, 191 };
-    // Blue
-    case DocumentMarkerLineStyleMode::DictationAlternatives:
-    case DocumentMarkerLineStyleMode::TextCheckingDictationPhraseWithAlternatives:
-    case DocumentMarkerLineStyleMode::AutocorrectionReplacement:
-        return useDarkMode ? SRGBA<uint8_t> { 40, 145, 255, 217 } : SRGBA<uint8_t> { 0, 122, 255, 191 };
-    case DocumentMarkerLineStyleMode::Grammar:
-        return grammarColor(useDarkMode);
-    }
 }
 
 }

--- a/Source/WebCore/rendering/RenderThemeMac.h
+++ b/Source/WebCore/rendering/RenderThemeMac.h
@@ -62,6 +62,7 @@ public:
     Color platformTextSearchHighlightColor(OptionSet<StyleColorOptions>) const final;
     Color platformAnnotationHighlightColor(OptionSet<StyleColorOptions>) const final;
     Color platformDefaultButtonTextColor(OptionSet<StyleColorOptions>) const final;
+    Color platformAutocorrectionReplacementMarkerColor(OptionSet<StyleColorOptions>) const final;
 
     ScrollbarControlSize scrollbarControlSizeForPart(StyleAppearance) final { return ScrollbarControlSize::Small; }
 

--- a/Source/WebCore/rendering/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/RenderThemeMac.mm
@@ -72,6 +72,7 @@
 #import <pal/spi/mac/NSColorSPI.h>
 #import <pal/spi/mac/NSImageSPI.h>
 #import <pal/spi/mac/NSSharingServicePickerSPI.h>
+#import <pal/spi/mac/NSSpellCheckerSPI.h>
 #import <wtf/MathExtras.h>
 #import <wtf/ObjCRuntimeExtras.h>
 #import <wtf/RetainPtr.h>
@@ -369,6 +370,28 @@ Color RenderThemeMac::platformDefaultButtonTextColor(OptionSet<StyleColorOptions
 {
     LocalDefaultSystemAppearance localAppearance(options.contains(StyleColorOptions::UseDarkAppearance));
     return colorFromCocoaColor([NSColor alternateSelectedControlTextColor]);
+}
+
+#if USE(APPLE_INTERNAL_SDK)
+#include <WebKitAdditions/RenderThemeMacAdditions.mm>
+#else
+#if HAVE(NSSPELLCHECKER_CORRECTION_INDICATOR_UNDERLINE_COLOR)
+static inline bool usePlatformColorForAutocorrectionReplacementMarker()
+{
+    return false;
+}
+#endif
+#endif
+
+Color RenderThemeMac::platformAutocorrectionReplacementMarkerColor(OptionSet<StyleColorOptions> options) const
+{
+#if HAVE(NSSPELLCHECKER_CORRECTION_INDICATOR_UNDERLINE_COLOR)
+    if (usePlatformColorForAutocorrectionReplacementMarker() && [NSSpellChecker respondsToSelector:@selector(correctionIndicatorUnderlineColor)]) {
+        LocalDefaultSystemAppearance localAppearance(options.contains(StyleColorOptions::UseDarkAppearance));
+        return colorFromCocoaColor([NSSpellChecker correctionIndicatorUnderlineColor]);
+    }
+#endif
+    return RenderThemeCocoa::platformAutocorrectionReplacementMarkerColor(options);
 }
 
 static Color activeButtonTextColor()


### PR DESCRIPTION
#### 68ae85e5b18813ea881d0f18312e848a9389366e
<pre>
Add support for painting document markers using system colors
<a href="https://bugs.webkit.org/show_bug.cgi?id=252791">https://bugs.webkit.org/show_bug.cgi?id=252791</a>
rdar://105796291

Reviewed by Wenson Hsieh and Megan Gardner.

Use system colors for painting document markers when possible. To support this
functionality, new `RenderTheme` methods are added to control platform-specific
marker colors and the color cache is expanded for the new colors. This approach
matches the implementation of existing system colors.

* Source/WebCore/PAL/pal/spi/mac/NSSpellCheckerSPI.h:
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::spellingMarkerColor const):
(WebCore::RenderTheme::platformSpellingMarkerColor const):
(WebCore::RenderTheme::dictationAlternativesMarkerColor const):
(WebCore::RenderTheme::platformDictationAlternativesMarkerColor const):
(WebCore::RenderTheme::autocorrectionReplacementMarkerColor const):
(WebCore::RenderTheme::platformAutocorrectionReplacementMarkerColor const):
(WebCore::RenderTheme::grammarMarkerColor const):
(WebCore::RenderTheme::platformGrammarMarkerColor const):
(WebCore::RenderTheme::documentMarkerLineColor const):
* Source/WebCore/rendering/RenderTheme.h:
* Source/WebCore/rendering/RenderThemeCocoa.h:
* Source/WebCore/rendering/RenderThemeCocoa.mm:
(WebCore::RenderThemeCocoa::platformSpellingMarkerColor const):
(WebCore::RenderThemeCocoa::platformDictationAlternativesMarkerColor const):
(WebCore::RenderThemeCocoa::platformAutocorrectionReplacementMarkerColor const):
(WebCore::RenderThemeCocoa::platformGrammarMarkerColor const):
(WebCore::grammarColor): Deleted.
(WebCore::RenderThemeCocoa::documentMarkerLineColor const): Deleted.
* Source/WebCore/rendering/RenderThemeMac.h:
* Source/WebCore/rendering/RenderThemeMac.mm:
(WebCore::usePlatformColorForAutocorrectionReplacementMarker):
(WebCore::RenderThemeMac::platformAutocorrectionReplacementMarkerColor const):

Canonical link: <a href="https://commits.webkit.org/260779@main">https://commits.webkit.org/260779@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1173f0ede85d675eb9d274b187362a007abb43b9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109372 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18504 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/42159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/118561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113255 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19984 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/9717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101656 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115128 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/42159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/43082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/42159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/84834 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11263 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/42159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/11931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/9717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/17298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/42159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13645 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4075 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->