### PR TITLE
Implement Login with GitHub on build.webkit.org

### DIFF
--- a/Tools/CISupport/build-webkit-org/master.cfg
+++ b/Tools/CISupport/build-webkit-org/master.cfg
@@ -49,16 +49,19 @@ c['www']['ui_default_config'] = {
 }
 
 if not is_test_mode_enabled:
-    credentials = load_password('BUILD_WEBKIT_CREDENTIALS')
-    if not credentials:
-        print('BUILD_WEBKIT credentials not found. Please ensure BUILD_WEBKIT_CREDENTIALS is configured either in env variables or in passwords.json')
+    GITHUB_CLIENT_ID = load_password('GITHUB_CLIENT_ID')
+    GITHUB_CLIENT_SECRET = load_password('GITHUB_CLIENT_SECRET')
+    if (not GITHUB_CLIENT_ID) or (not GITHUB_CLIENT_SECRET):
+        print('ERROR: Credentials not found. Please ensure GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET are configured either in env variables or in passwords.json')
         sys.exit(1)
     # See https://docs.buildbot.net/2.10.0/manual/configuration/www.html#example-configs
     authz = util.Authz(
-        allowRules=[util.AnyControlEndpointMatcher(role="admin")],
-        roleMatchers=[util.RolesFromEmails(admin=list(credentials.keys()))]
+        allowRules=[util.AnyEndpointMatcher(role='Buildbot-Administrators', defaultDeny=False),
+            util.ForceBuildEndpointMatcher(role='Reviewers'),
+            util.AnyControlEndpointMatcher(role='Buildbot-Administrators')],
+        roleMatchers=[util.RolesFromGroups(groupPrefix='WebKit/')]
     )
-    auth = util.UserPasswordAuth(credentials)
+    auth = util.GitHubAuth(GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET, apiVersion=4, getTeamsMembership=True, debug=True)
     c['www']['auth'] = auth
     c['www']['authz'] = authz
 


### PR DESCRIPTION
#### 7be92ea7008d99047bd075d5f758ab9487cbc197
<pre>
Implement Login with GitHub on build.webkit.org
<a href="https://bugs.webkit.org/show_bug.cgi?id=252778">https://bugs.webkit.org/show_bug.cgi?id=252778</a>

Reviewed by Ryan Haddad.

References:
<a href="https://docs.buildbot.net/latest/developer/auth.html">https://docs.buildbot.net/latest/developer/auth.html</a>
<a href="https://docs.buildbot.net/current/manual/configuration/www.html#authorization-rules">https://docs.buildbot.net/current/manual/configuration/www.html#authorization-rules</a>

* Tools/CISupport/build-webkit-org/master.cfg:

Canonical link: <a href="https://commits.webkit.org/260763@main">https://commits.webkit.org/260763@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/27100e240440a0d664c18f6123b02ccffaa4c976

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109302 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/18381 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/42098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/118519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113184 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/19830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/9671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/101543 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115057 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/19830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/42098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/101543 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/19830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/42098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/101543 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/11155 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/42098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/11873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/9671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/108066 "Passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/17264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/42098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/13507 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4062 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->