### PR TITLE
OpenTypeMathData should depend on ENABLE(MATHML)

### DIFF
--- a/Source/WebCore/platform/graphics/Font.cpp
+++ b/Source/WebCore/platform/graphics/Font.cpp
@@ -39,7 +39,6 @@
 #include "FontCache.h"
 #include "FontCascade.h"
 #include "FontCustomPlatformData.h"
-#include "OpenTypeMathData.h"
 #include "SharedBuffer.h"
 #include <wtf/MathExtras.h>
 #include <wtf/NeverDestroyed.h>
@@ -530,6 +529,7 @@ String Font::description() const
 }
 #endif
 
+#if ENABLE(MATHML)
 const OpenTypeMathData* Font::mathData() const
 {
     if (isInterstitial())
@@ -541,6 +541,7 @@ const OpenTypeMathData* Font::mathData() const
     }
     return m_mathData.get();
 }
+#endif
 
 RefPtr<Font> Font::createScaledFont(const FontDescription& fontDescription, float scaleFactor) const
 {

--- a/Source/WebCore/platform/graphics/Font.h
+++ b/Source/WebCore/platform/graphics/Font.h
@@ -29,7 +29,6 @@
 #include "GlyphBuffer.h"
 #include "GlyphMetricsMap.h"
 #include "GlyphPage.h"
-#include "OpenTypeMathData.h"
 #include "RenderingResourceIdentifier.h"
 #include <wtf/BitVector.h>
 #include <wtf/Hasher.h>
@@ -39,6 +38,10 @@
 #include <CoreFoundation/CoreFoundation.h>
 #include <pal/cf/OTSVGTable.h>
 #include <wtf/RetainPtr.h>
+#endif
+
+#if ENABLE(MATHML)
+#include "OpenTypeMathData.h"
 #endif
 
 #if ENABLE(OPENTYPE_VERTICAL)
@@ -88,7 +91,9 @@ public:
     static const Font* systemFallback() { return reinterpret_cast<const Font*>(-1); }
 
     const FontPlatformData& platformData() const { return m_platformData; }
+#if ENABLE(MATHML)
     const OpenTypeMathData* mathData() const;
+#endif
 #if ENABLE(OPENTYPE_VERTICAL)
     const OpenTypeVerticalData* verticalData() const { return m_verticalData.get(); }
 #endif
@@ -288,7 +293,9 @@ private:
     mutable std::unique_ptr<GlyphMetricsMap<std::optional<Path>>> m_glyphPathMap;
     mutable BitVector m_codePointSupport;
 
+#if ENABLE(MATHML)
     mutable RefPtr<OpenTypeMathData> m_mathData;
+#endif
 #if ENABLE(OPENTYPE_VERTICAL)
     RefPtr<OpenTypeVerticalData> m_verticalData;
 #endif

--- a/Source/WebCore/platform/graphics/FontPlatformData.h
+++ b/Source/WebCore/platform/graphics/FontPlatformData.h
@@ -43,9 +43,12 @@
 
 #if USE(FREETYPE)
 #include "FcUniquePtr.h"
-#include "HbUniquePtr.h"
 #include "RefPtrFontconfig.h"
 #include <memory>
+
+#if ENABLE(MATHML) && USE(HARFBUZZ)
+#include "HbUniquePtr.h"
+#endif
 #endif
 
 #if USE(APPKIT)
@@ -169,7 +172,7 @@ public:
 #endif
 
 #if USE(FREETYPE)
-#if USE(HARFBUZZ)
+#if ENABLE(MATHML) && USE(HARFBUZZ)
     HbUniquePtr<hb_font_t> createOpenTypeMathHarfBuzzFont() const;
 #endif
     bool hasCompatibleCharmap() const;

--- a/Source/WebCore/platform/graphics/freetype/FontPlatformDataFreeType.cpp
+++ b/Source/WebCore/platform/graphics/freetype/FontPlatformDataFreeType.cpp
@@ -35,10 +35,13 @@
 #include <ft2build.h>
 #include FT_FREETYPE_H
 #include FT_TRUETYPE_TABLES_H
-#include <hb-ft.h>
-#include <hb-ot.h>
 #include <wtf/MathExtras.h>
 #include <wtf/text/WTFString.h>
+
+#if ENABLE(MATHML) && USE(HARFBUZZ)
+#include <hb-ft.h>
+#include <hb-ot.h>
+#endif
 
 namespace WebCore {
 
@@ -302,7 +305,7 @@ RefPtr<SharedBuffer> FontPlatformData::openTypeTable(uint32_t table) const
     return SharedBuffer::create(WTFMove(data));
 }
 
-#if USE(HARFBUZZ)
+#if ENABLE(MATHML) && USE(HARFBUZZ)
 HbUniquePtr<hb_font_t> FontPlatformData::createOpenTypeMathHarfBuzzFont() const
 {
     CairoFtFaceLocker cairoFtFaceLocker(m_scaledFont.get());

--- a/Source/WebCore/platform/graphics/opentype/OpenTypeMathData.cpp
+++ b/Source/WebCore/platform/graphics/opentype/OpenTypeMathData.cpp
@@ -27,6 +27,8 @@
 #include "config.h"
 #include "OpenTypeMathData.h"
 
+#if ENABLE(MATHML)
+
 #include "Font.h"
 #include "FontPlatformData.h"
 #if ENABLE(OPENTYPE_MATH)
@@ -387,3 +389,5 @@ void OpenTypeMathData::getMathVariants(Glyph, bool, Vector<Glyph>&, Vector<Assem
 }
 
 } // namespace WebCore
+
+#endif // ENABLE(MATHML)

--- a/Source/WebCore/platform/graphics/opentype/OpenTypeMathData.h
+++ b/Source/WebCore/platform/graphics/opentype/OpenTypeMathData.h
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#if ENABLE(MATHML)
+
 #include "Glyph.h"
 #include <wtf/Forward.h>
 #include <wtf/Ref.h>
@@ -140,3 +142,5 @@ private:
 };
 
 } // namespace WebCore
+
+#endif // ENABLE(MATHML)


### PR DESCRIPTION
#### 5a42b144278f6e999087354b9c9e08f77b24fe30
<pre>
OpenTypeMathData should depend on ENABLE(MATHML)
<a href="https://bugs.webkit.org/show_bug.cgi?id=252851">https://bugs.webkit.org/show_bug.cgi?id=252851</a>

Reviewed by Michael Catanzaro.

All the uses of `OpenTypeMathData` are within code guarded by
`ENABLE(MATHML)` so add the guard to it and its references in Font
classes.

Fixes PlayStation build after 260744@main.

* Source/WebCore/platform/graphics/Font.cpp:
* Source/WebCore/platform/graphics/Font.h:
* Source/WebCore/platform/graphics/FontPlatformData.h:
* Source/WebCore/platform/graphics/freetype/FontPlatformDataFreeType.cpp:
* Source/WebCore/platform/graphics/opentype/OpenTypeMathData.cpp:
* Source/WebCore/platform/graphics/opentype/OpenTypeMathData.h:

Canonical link: <a href="https://commits.webkit.org/260778@main">https://commits.webkit.org/260778@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5fdef29ec1cc5906a2b94dc786d2dfff48bb031

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109317 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18397 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42138 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/826 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118530 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113200 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19842 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9683 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101555 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115072 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98106 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43055 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96847 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29759 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84804 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11168 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31102 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11906 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8028 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/17273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50705 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7456 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13522 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->