### PR TITLE
[CMake] Update WebKitFindPackages wrapper

### DIFF
--- a/Source/cmake/WebKitFindPackage.cmake
+++ b/Source/cmake/WebKitFindPackage.cmake
@@ -10,16 +10,8 @@
 
 # CMake provided targets. Remove wrappers whenever the minimum version is bumped.
 #
-# CURL::libcurl : since 3.12
-# ICU::<C> : since 3.7
-# Freetype::Freetype: since 3.10
-# LibXml2::LibXml2: since 3.12
-# LibXslt::LibXslt: since never
-# JPEG::JPEG: since 3.12
-# OpenSSL::SSL: Since 3.4
-# PNG::PNG : since 3.4
-# Threads::Threads: since 3.1
-# ZLIB::ZLIB: Since 3.1
+# ICU::<C> : need to be kept for Apple ICU
+# LibXslt::LibXslt: since 3.18
 
 macro(find_package package)
     set(_found_package OFF)
@@ -45,15 +37,7 @@ macro(find_package package)
     endif ()
 
     # Create targets that are present in later versions of CMake or are referenced above
-    if ("${package}" STREQUAL "CURL")
-        if (CURL_FOUND AND NOT TARGET CURL::libcurl)
-            add_library(CURL::libcurl UNKNOWN IMPORTED)
-            set_target_properties(CURL::libcurl PROPERTIES
-                IMPORTED_LOCATION "${CURL_LIBRARIES}"
-                INTERFACE_INCLUDE_DIRECTORIES "${CURL_INCLUDE_DIRS}"
-            )
-        endif ()
-    elseif ("${package}" STREQUAL "ICU")
+    if ("${package}" STREQUAL "ICU")
         if (ICU_FOUND AND NOT TARGET ICU::data)
             add_library(ICU::data UNKNOWN IMPORTED)
             set_target_properties(ICU::data PROPERTIES
@@ -76,15 +60,6 @@ macro(find_package package)
                 IMPORTED_LINK_INTERFACE_LANGUAGES "CXX"
             )
         endif ()
-    elseif ("${package}" STREQUAL "LibXml2")
-        if (LIBXML2_FOUND AND NOT TARGET LibXml2::LibXml2)
-            add_library(LibXml2::LibXml2 UNKNOWN IMPORTED)
-            set_target_properties(LibXml2::LibXml2 PROPERTIES
-                IMPORTED_LOCATION "${LIBXML2_LIBRARIES}"
-                INTERFACE_INCLUDE_DIRECTORIES "${LIBXML2_INCLUDE_DIRS}"
-                INTERFACE_COMPILE_OPTIONS "${LIBXML2_DEFINITIONS}"
-            )
-        endif ()
     elseif ("${package}" STREQUAL "LibXslt")
         if (LIBXSLT_FOUND AND NOT TARGET LibXslt::LibXslt)
             add_library(LibXslt::LibXslt UNKNOWN IMPORTED)
@@ -99,22 +74,6 @@ macro(find_package package)
             set_target_properties(LibXslt::LibExslt PROPERTIES
                 IMPORTED_LOCATION "${LIBXSLT_EXSLT_LIBRARY}"
                 INTERFACE_INCLUDE_DIRECTORIES "${LIBXSLT_INCLUDE_DIR}"
-            )
-        endif ()
-    elseif ("${package}" STREQUAL "JPEG")
-        if (JPEG_FOUND AND NOT TARGET JPEG::JPEG)
-            add_library(JPEG::JPEG UNKNOWN IMPORTED)
-            set_target_properties(JPEG::JPEG PROPERTIES
-                IMPORTED_LOCATION "${JPEG_LIBRARIES}"
-                INTERFACE_INCLUDE_DIRECTORIES "${JPEG_INCLUDE_DIR}"
-            )
-        endif ()
-    elseif ("${package}" STREQUAL "ZLIB")
-        if (ZLIB_FOUND AND NOT TARGET ZLIB::ZLIB)
-            add_library(ZLIB::ZLIB UNKNOWN IMPORTED)
-            set_target_properties(ZLIB::ZLIB PROPERTIES
-                IMPORTED_LOCATION "${ZLIB_LIBRARY}"
-                INTERFACE_INCLUDE_DIRECTORIES "${ZLIB_INCLUDE_DIRS}"
             )
         endif ()
     endif ()


### PR DESCRIPTION
#### 5d7824d83862568b7e98796d18c2c5a8189e4ab9
<pre>
[CMake] Update WebKitFindPackages wrapper
<a href="https://bugs.webkit.org/show_bug.cgi?id=252854">https://bugs.webkit.org/show_bug.cgi?id=252854</a>

Reviewed by Michael Catanzaro.

Remove redundant target creation based on a `cmake_minimum_required` of
3.16. Now only `ICU::&lt;C&gt;` and `LibXslt::LibXslt` targets are created in
the `find_package` wrapper.

* Source/cmake/WebKitFindPackage.cmake:

Canonical link: <a href="https://commits.webkit.org/260783@main">https://commits.webkit.org/260783@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c606e9bb91f12aa1deaadee20a89c30ac1fbed96

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109333 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18412 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42141 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/874 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118539 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19851 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9692 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101570 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115089 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14876 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98110 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43062 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96848 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29763 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84812 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/98299 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11179 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31106 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/38/builds/99194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/9248 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11915 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8034 "Passed tests") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/38/builds/99194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/17282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50709 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/107159 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7463 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13536 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26456 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->