### PR TITLE
Add half of block-step-size (rounded up) space to each block margin for non-orthogonal in flow elements with display: block no margin collapsing

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-0-disables-rounding-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-0-disables-rounding-expected.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<p>There should be a green square below and no red.</p>
+<div style="width: 100px; height: 100px; background-color: green"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-0-disables-rounding.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-0-disables-rounding.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="Specifying 0 for block-step-size should not change the size of the box">
+<style>
+.red {
+    display: flow-root;
+    inline-size: 100px;
+    background-color: red;
+}
+.block-step {
+    block-step-size: 0px;
+    block-size: 100px;
+    background-color: green;
+}
+</style>
+</head>
+<body>
+<p>There should be a green square below and no red.</p>
+<div class="red">
+    <div class="block-step"></div>
+</div>
+</head>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-adjustment-block-replaced-element-round-up-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-adjustment-block-replaced-element-round-up-expected.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<p>There should be a green square below and no red.</p>
+<div style="width: 100px; height: 100px; background-color: green"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-adjustment-block-replaced-element-round-up.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-adjustment-block-replaced-element-round-up.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<link rel="match" href="block-step-size-adjustment-block-replaced-element-round-up-ref.html">
+<meta name="assert" content="Replaced element with display block should add margins according to block-step-size">
+<style>
+.red {
+    inline-size: 100px;
+    block-size: 100px;
+    background-color: red;
+}
+.block-step {
+    display: block;
+    inline-size: 100px;
+    aspect-ratio: 2/1;
+    block-step-size: 70px; 
+}
+.cover {
+    background-color: green;
+    block-size: 25px;
+}
+</style>
+</head>
+<body>
+<p>There should be a green square below and no red.</p>
+<div class="red">
+    <div class="cover" style="margin-block-end: -10px"></div>
+    <img src="/css/support/60x60-green.png" class="block-step">
+    <div class="cover" style="margin-block-start: -10px"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-adjustment-round-up-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-adjustment-round-up-expected.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<p>There should be a green square below and no red.</p>
+<div style="width: 100px; height: 100px; background-color: green"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-adjustment-round-up-relative-unit-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-adjustment-round-up-relative-unit-expected.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<p>There should be a green square below and no red.</p>
+<div style="width: 100px; height: 100px; background-color: green"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-adjustment-round-up-relative-unit.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-adjustment-round-up-relative-unit.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<link rel="match" href="block-step-size-adjustment-round-up-relative-unit-ref.html">
+<meta name="assert" content="Item's margin box block size gets rounded up to the nearested multiple of block-step-size using font relative unit">
+<style>
+.red {
+    inline-size: 100px;
+    block-size: 100px;
+    background-color: red;
+}
+.block-step {
+    font-size: 5px;
+    block-size: 50px;
+    background-color: green;
+    block-step-size: 7em; 
+}
+.cover {
+    background-color: green;
+    block-size: 25px;
+}
+</style>
+</head>
+<body>
+<p>There should be a green square below and no red.</p>
+<div class="red">
+    <div class="cover" style="margin-block-end: -10px;"></div>
+    <div class="block-step"></div>
+    <div class="cover" style="margin-block-start: -10px"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-adjustment-round-up-vert-lr-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-adjustment-round-up-vert-lr-expected.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<style>
+body {
+    writing-mode: vertical-lr;
+}
+</style>
+<p>There should be a green square below and no red.</p>
+<div style="width: 100px; height: 100px; background-color: green"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-adjustment-round-up-vert-lr.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-adjustment-round-up-vert-lr.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<link rel="match" href="block-step-size-adjustment-round-up-ref.html">
+<meta name="assert" content="Item's margin box block size gets rounded up to the nearested multiple of block-step-size in vertical-lr writing mode">
+<style>
+body {
+    writing-mode: vertical-lr;
+}
+.red {
+    inline-size: 100px;
+    block-size: 100px;
+    background-color: red;
+}
+.block-step {
+    block-size: 50px;
+    background-color: green;
+    block-step-size: 35px; 
+}
+.cover {
+    background-color: green;
+    block-size: 25px;
+}
+</style>
+</head>
+<body>
+<p>There should be a green square below and no red.</p>
+<div class="red">
+    <div class="cover" style="margin-block-end: -10px;"></div>
+    <div class="block-step"></div>
+    <div class="cover" style="margin-block-start: -10px;"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-adjustment-round-up.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-adjustment-round-up.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<link rel="match" href="block-step-size-adjustment-round-up-ref.html">
+<meta name="assert" content="Item's margin box block size gets rounded up to the nearested multiple of block-step-size">
+<style>
+.red {
+    inline-size: 100px;
+    block-size: 100px;
+    background-color: red;
+}
+.block-step {
+    block-size: 50px;
+    background-color: green;
+    block-step-size: 35px; 
+}
+.cover {
+    background-color: green;
+    block-size: 25px;
+}
+</style>
+</head>
+<body>
+<p>There should be a green square below and no red.</p>
+<div class="red">
+    <div class="cover" style="margin-block-end: -10px;"></div>
+    <div class="block-step"></div>
+    <div class="cover" style="margin-block-start: -10px;"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-larger-than-item-margin-box-round-up-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-larger-than-item-margin-box-round-up-expected.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<p>There should be a green square below and no red.</p>
+<div style="width: 100px; height: 100px; background-color: green"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-larger-than-item-margin-box-round-up.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-larger-than-item-margin-box-round-up.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<link rel="match" href="block-step-size-larger-than-item-margin-box-ref.html">
+<meta name="assert" content="Element's margin box size should just get set to the specified block-step-size if it is smaller">
+<style>
+.red {
+    inline-size: 100px;
+    block-size: 100px;
+    background-color: red;
+}
+.block-step {
+    block-size: 50px;
+    background-color: green;
+    block-step-size: 70px; 
+}
+.cover {
+    background-color: green;
+    block-size: 25px;
+}
+</style>
+</head>
+<body>
+<p>There should be a green square below and no red.</p>
+<div class="red">
+    <div class="cover" style="margin-block-end: -10px;"></div>
+    <div class="block-step"></div>
+    <div class="cover" style="margin-block-start: -10px"></div>
+</div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderBlockFlow.h
+++ b/Source/WebCore/rendering/RenderBlockFlow.h
@@ -237,6 +237,10 @@ public:
     void adjustPositionedBlock(RenderBox& child, const MarginInfo&);
     void adjustFloatingBlock(const MarginInfo&);
 
+
+    bool shouldApplyBlockStepSizingForChild(const RenderBox&) const;
+    void adjustChildMarginsForBlockStepSiing(RenderBox&);
+
     void setStaticInlinePositionForChild(RenderBox& child, LayoutUnit blockOffset, LayoutUnit inlinePosition);
     void updateStaticInlinePositionForChild(RenderBox& child, LayoutUnit logicalTop, IndentTextOrNot shouldIndentText);
 


### PR DESCRIPTION
#### d038547f8b9838fcac7de0a201e024df996f69ae
<pre>
Add half of block-step-size (rounded up) space to each block margin for non-orthogonal in flow elements with display: block no margin collapsing
<a href="https://bugs.webkit.org/show_bug.cgi?id=252672">https://bugs.webkit.org/show_bug.cgi?id=252672</a>
rdar://105731498

Reviewed by NOBODY (OOPS!).

Takes the initial step of implementing the layout logic necessary for
the block-step-size CSS property. Since this property can be influenced
by a few other properties, our first step uses the following values
for the properties to provide the simplest implementation:

block-step-insert: margin
block-step-align: center
block-step-round: up

Basically, this means that we will always round up to the next multiple
of block-step-size and we will add the extra space by splitting it and
half and adding it to the margins of the box. As these other properties
get implemented, we will need to come back and slightly tweak the
block-step-sizing algorithm to take into consideration the different
values.

We will check to see if we need to apply block step sizing inside of
RenderBlockFlow::layoutBlockChild once the child has gone through its
first layout. Then, we will compute and adjust the box&apos;s size by taking
into consideration the computed margin box block size as well as the
value specified in block-step-size. If the child&apos;s margin box block
size changes we will need to update its border box position by calling
setLogicalTopForChild.

div {
    inline-size: 50px;
    block-size: 50px;
    background-color: green;
}
div:first-child {
    block-step-size: 35px;
}
&lt;div&gt;&lt;/div&gt;
&lt;div&gt;&lt;/div&gt;

Here the first div initially has a block margin box size of 50px.
block-step-size is 35px, which means that the next multiple we will
round to is 70px. 70px - 50px gives us 20px of extra space, so we will
evenly split it onto the block-start and block-end margins of the box.

* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-0-disables-rounding-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-0-disables-rounding.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-adjustment-block-replaced-element-round-up-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-adjustment-block-replaced-element-round-up.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-adjustment-round-up-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-adjustment-round-up-relative-unit-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-adjustment-round-up-relative-unit.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-adjustment-round-up-vert-lr-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-adjustment-round-up-vert-lr.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-adjustment-round-up.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-larger-than-item-margin-box-round-up-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/block-step-size-larger-than-item-margin-box-round-up.html: Added.
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::layoutBlockChild):
(WebCore::computeBlockStepSizeRoundedUp):
(WebCore::RenderBlockFlow::shouldApplyBlockStepSizingForChild const):
(WebCore::RenderBlockFlow::adjustChildMarginsForBlockStepSiing):
* Source/WebCore/rendering/RenderBlockFlow.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d038547f8b9838fcac7de0a201e024df996f69ae

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111258 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20399 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43803 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2686 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120067 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115208 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21766 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11497 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2278 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117021 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16161 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99343 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103868 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98118 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/31000 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44730 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12902 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32337 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86584 "Found 1 new API test failure: /WebKitGTK/TestDownloads:/webkit/Downloads/local-file-error (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13421 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9328 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18857 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51924 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15377 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->