### PR TITLE
Remove old GCC workarounds

### DIFF
--- a/Source/JavaScriptCore/bytecode/InlineAccess.h
+++ b/Source/JavaScriptCore/bytecode/InlineAccess.h
@@ -81,11 +81,8 @@ public:
 #endif
     }
 
-    // FIXME: Make this constexpr when GCC is able to compile std::max() inside a constexpr function.
-    // https://bugs.webkit.org/show_bug.cgi?id=159436
-    //
     // This is the maximum between array length, string length, and regular self access sizes.
-    ALWAYS_INLINE static size_t sizeForLengthAccess()
+    ALWAYS_INLINE static constexpr size_t sizeForLengthAccess()
     {
 #if CPU(X86_64)
         size_t size = 43;

--- a/Source/WebCore/PAL/pal/text/TextCodecSingleByte.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecSingleByte.cpp
@@ -174,8 +174,7 @@ static constexpr SingleByteDecodeTable ibm866 {
 template<const SingleByteDecodeTable& decodeTable> SingleByteEncodeTable tableForEncoding()
 {
     // Allocate this at runtime because building it at compile time would make the binary much larger and this is often not used.
-    // FIXME: With the C++20 version of std::count, we should be able to change this from const to constexpr and compute the size at compile time.
-    static const auto size = std::size(decodeTable) - std::count(std::begin(decodeTable), std::end(decodeTable), replacementCharacter);
+    static constexpr auto size = std::size(decodeTable) - std::count(std::begin(decodeTable), std::end(decodeTable), replacementCharacter);
     static const SingleByteEncodeTableEntry* entries;
     static std::once_flag once;
     std::call_once(once, [&] {

--- a/Source/WebCore/bridge/objc/WebScriptObject.mm
+++ b/Source/WebCore/bridge/objc/WebScriptObject.mm
@@ -496,10 +496,8 @@ static void getListFromNSArray(JSC::JSGlobalObject* lexicalGlobalObject, NSArray
 
 - (NSString *)stringRepresentation
 {
-    if (![self _isSafeScript]) {
-        // This is a workaround for a gcc 3.3 internal compiler error.
-        return @"Undefined";
-    }
+    if (![self _isSafeScript])
+        return nil;
 
     JSC::JSGlobalObject* lexicalGlobalObject = [self _rootObject]->globalObject();
     JSLockHolder lock(lexicalGlobalObject);

--- a/Source/WebCore/bridge/objc/objc_instance.mm
+++ b/Source/WebCore/bridge/objc/objc_instance.mm
@@ -340,9 +340,7 @@ JSC::JSValue ObjcInstance::invokeObjcMethod(JSGlobalObject* lexicalGlobalObject,
 }
     moveGlobalExceptionToExecState(lexicalGlobalObject);
 
-    // Work around problem in some versions of GCC where result gets marked volatile and
-    // it can't handle copying from a volatile to non-volatile.
-    return const_cast<JSValue&>(result);
+    return result;
 }
 
 JSC::JSValue ObjcInstance::invokeDefaultMethod(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame)
@@ -391,9 +389,7 @@ JSC::JSValue ObjcInstance::invokeDefaultMethod(JSGlobalObject* lexicalGlobalObje
 }
     moveGlobalExceptionToExecState(lexicalGlobalObject);
 
-    // Work around problem in some versions of GCC where result gets marked volatile and
-    // it can't handle copying from a volatile to non-volatile.
-    return const_cast<JSValue&>(result);
+    return result;
 }
 
 bool ObjcInstance::setValueOfUndefinedField(JSGlobalObject* lexicalGlobalObject, PropertyName propertyName, JSValue aValue)
@@ -456,9 +452,7 @@ JSC::JSValue ObjcInstance::getValueOfUndefinedField(JSGlobalObject* lexicalGloba
         moveGlobalExceptionToExecState(lexicalGlobalObject);
     }
 
-    // Work around problem in some versions of GCC where result gets marked volatile and
-    // it can't handle copying from a volatile to non-volatile.
-    return const_cast<JSValue&>(result);
+    return result;
 }
 
 JSC::JSValue ObjcInstance::defaultValue(JSGlobalObject* lexicalGlobalObject, PreferredPrimitiveType hint) const

--- a/Source/WebCore/bridge/objc/objc_runtime.mm
+++ b/Source/WebCore/bridge/objc/objc_runtime.mm
@@ -119,9 +119,7 @@ JSValue ObjcField::valueFromInstance(JSGlobalObject* lexicalGlobalObject, const 
         throwError(lexicalGlobalObject, scope, [localException reason]);
     }
 
-    // Work around problem in some versions of GCC where result gets marked volatile and
-    // it can't handle copying from a volatile to non-volatile.
-    return const_cast<JSValue&>(result);
+    return result;
 }
 
 static id convertValueToObjcObject(JSGlobalObject* lexicalGlobalObject, JSValue value)


### PR DESCRIPTION
#### d139619c4a1e761411647d6c27b646e81c80c1b7
<pre>
Remove old GCC workarounds
<a href="https://bugs.webkit.org/show_bug.cgi?id=252898">https://bugs.webkit.org/show_bug.cgi?id=252898</a>

Reviewed by Michael Catanzaro.

GCC is not used to compile Objective-C anymore, and GCC now supports
std::max() inside a constexpr function.

Source/JavaScriptCore/bytecode/InlineAccess.h: Make sizeForLengthAccess constexpr
Source/WebCore/PAL/pal/text/TextCodecSingleByte.cpp: Make size constexpr
Source/WebCore/bridge/objc/WebScriptObject.mm:(getListFromNSArray:) Remove gcc 3.3 workaround
Source/WebCore/bridge/objc/objc_instance.mm: Remove const workarounds
Source/WebCore/bridge/objc/objc_runtime.mm: Remove const workaround

Canonical link: <a href="https://commits.webkit.org/260883@main">https://commits.webkit.org/260883@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ffc40bfd8caa67b0d15578b40002c84c23b4fd58

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109790 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18903 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42524 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1255 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118902 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113742 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20371 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10101 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102058 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115538 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15165 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/43389 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/30052 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85186 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/98651 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11628 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/31394 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/99533 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/9660 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12275 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8332 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31127 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17646 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51003 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/107551 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7549 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14030 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26542 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->