### PR TITLE
Allow overwrite for FileSystemHandle::move

### DIFF
--- a/LayoutTests/storage/filesystemaccess/handle-move-expected.txt
+++ b/LayoutTests/storage/filesystemaccess/handle-move-expected.txt
@@ -12,7 +12,7 @@ PASS fileHandle2.kind is "file"
 Test move to a file handle:
 PASS moveFileError.toString() is "TypeMismatchError: The type of an object was incompatible with the expected type of the parameter associated to the object."
 Test move to a destination with existing file:
-PASS moveFileError.toString() is "UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)."
+PASS fileHandle.name is "secondFile"
 Test move with an invalid name:
 PASS moveFileError.toString() is "TypeError: Name is invalid"
 PASS moveFileError.toString() is "TypeError: Name is invalid"

--- a/LayoutTests/storage/filesystemaccess/handle-move-worker-expected.txt
+++ b/LayoutTests/storage/filesystemaccess/handle-move-worker-expected.txt
@@ -13,7 +13,7 @@ PASS [Worker] fileHandle2.kind is "file"
 [Worker] Test move to a file handle:
 PASS [Worker] moveFileError.toString() is "TypeMismatchError: The type of an object was incompatible with the expected type of the parameter associated to the object."
 [Worker] Test move to a destination with existing file:
-PASS [Worker] moveFileError.toString() is "UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)."
+PASS [Worker] fileHandle.name is "secondFile"
 [Worker] Test move with an invalid name:
 PASS [Worker] moveFileError.toString() is "TypeError: Name is invalid"
 PASS [Worker] moveFileError.toString() is "TypeError: Name is invalid"

--- a/LayoutTests/storage/filesystemaccess/resources/handle-move.js
+++ b/LayoutTests/storage/filesystemaccess/resources/handle-move.js
@@ -56,10 +56,9 @@ async function test()
         debug("Test move to a destination with existing file:");
         testError = null;
         await fileHandle.move(dirHandle1, "secondFile").then(() => {
-            testError =  "Moved file to dirHandle1 unexpectedly";
+            shouldBeEqualToString("fileHandle.name", "secondFile");
         }, (error) => {
-            moveFileError = error;
-            shouldBeEqualToString("moveFileError.toString()", "UnknownError: The operation failed for an unknown transient reason (e.g. out of memory).");
+            testError = error;
         });
 
         if (testError) {
@@ -90,13 +89,12 @@ async function test()
             return finishTest(testError);
         }
 
-
         if (typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope) {
             debug("Test move with open access handle:");
             testError = null;
             accessHandle = await fileHandle.createSyncAccessHandle();
             await fileHandle.move(dirHandle1, "file").then(() => {
-                testError =  "Moved file back to dirHandle1 unexpectedly";
+                testError =  "Moved file with active SyncAccessHandle unexpectedly";
             }, (error) => {
                 moveFileError = error;
                 shouldBeEqualToString("moveFileError.toString()", "InvalidStateError: Some AccessHandle is active");

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp
@@ -260,9 +260,6 @@ std::optional<FileSystemStorageError> FileSystemStorageHandle::move(WebCore::Fil
         return FileSystemStorageError::InvalidName;
 
     auto destinationPath = FileSystem::pathByAppendingComponent(path, newName);
-    if (FileSystem::fileExists(destinationPath))
-        return FileSystemStorageError::Unknown;
-
     if (!FileSystem::moveFile(m_path, destinationPath))
         return FileSystemStorageError::Unknown;
 


### PR DESCRIPTION
#### 4b8a13149708a0cbcd626fcbda03a727e050755f
<pre>
Allow overwrite for FileSystemHandle::move
<a href="https://bugs.webkit.org/show_bug.cgi?id=252872">https://bugs.webkit.org/show_bug.cgi?id=252872</a>
rdar://105858983

Reviewed by Per Arne Vollan.

Based on <a href="https://github.com/whatwg/fs/pull/10/commits/e2526d0d6324c774936bc80278d67b1060151492.">https://github.com/whatwg/fs/pull/10/commits/e2526d0d6324c774936bc80278d67b1060151492.</a>

Updated test: LayoutTests/storage/filesystemaccess/handle-move-worker.html

* LayoutTests/storage/filesystemaccess/handle-move-expected.txt:
* LayoutTests/storage/filesystemaccess/handle-move-worker-expected.txt:
* LayoutTests/storage/filesystemaccess/resources/handle-move.js:
(async test):
* Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp:
(WebKit::FileSystemStorageHandle::move):

Canonical link: <a href="https://commits.webkit.org/260806@main">https://commits.webkit.org/260806@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7fe1a501a059957c8c17766c7335d6b2192a086f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109386 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18510 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42166 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/901 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118568 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/19991 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9724 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101661 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115142 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14895 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98124 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43087 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96867 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29777 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84839 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11270 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31120 "Found 1 new test failure: media/video-playback-quality.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11936 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8052 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17303 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50723 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7486 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13652 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->