### PR TITLE
Add support for fading out document markers

### DIFF
--- a/Source/WebCore/dom/DocumentMarkerController.h
+++ b/Source/WebCore/dom/DocumentMarkerController.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "DocumentMarker.h"
+#include "Timer.h"
 #include <memory>
 #include <wtf/HashMap.h>
 #include <wtf/Vector.h>
@@ -73,6 +74,8 @@ public:
     void repaintMarkers(OptionSet<DocumentMarker::MarkerType> = DocumentMarker::allMarkers());
     void shiftMarkers(Node&, unsigned startOffset, int delta);
 
+    void dismissMarkers(OptionSet<DocumentMarker::MarkerType> = DocumentMarker::allMarkers());
+
     WEBCORE_EXPORT Vector<RenderedDocumentMarker*> markersFor(Node&, OptionSet<DocumentMarker::MarkerType> = DocumentMarker::allMarkers());
     WEBCORE_EXPORT Vector<RenderedDocumentMarker*> markersInRange(const SimpleRange&, OptionSet<DocumentMarker::MarkerType>);
     void clearDescriptionOnMarkersIntersectingRange(const SimpleRange&, OptionSet<DocumentMarker::MarkerType>);
@@ -99,16 +102,22 @@ private:
     Vector<TextRange> collectTextRanges(const SimpleRange&);
 
     void forEach(const SimpleRange&, OptionSet<DocumentMarker::MarkerType>, const Function<bool(RenderedDocumentMarker&)>);
+    void forEachOfTypes(OptionSet<DocumentMarker::MarkerType>, const Function<bool(Node&, RenderedDocumentMarker&)>);
 
     using MarkerMap = HashMap<RefPtr<Node>, std::unique_ptr<Vector<RenderedDocumentMarker>>>;
 
     bool possiblyHasMarkers(OptionSet<DocumentMarker::MarkerType>);
-    void removeMarkersFromList(MarkerMap::iterator, OptionSet<DocumentMarker::MarkerType>);
+    void removeMarkers(OptionSet<DocumentMarker::MarkerType>, const Function<FilterMarkerResult(const RenderedDocumentMarker&)>& filterFunction);
+    void removeMarkersFromList(MarkerMap::iterator, OptionSet<DocumentMarker::MarkerType>, const Function<FilterMarkerResult(const RenderedDocumentMarker&)>& filterFunction = nullptr);
+
+    void fadeAnimationTimerFired();
 
     MarkerMap m_markers;
     // Provide a quick way to determine whether a particular marker type is absent without going through the map.
     OptionSet<DocumentMarker::MarkerType> m_possiblyExistingMarkerTypes;
     Document& m_document;
+
+    Timer m_fadeAnimationTimer;
 };
 
 void addMarker(const SimpleRange&, DocumentMarker::MarkerType, const DocumentMarker::Data& = { });

--- a/Source/WebCore/dom/RenderedDocumentMarker.h
+++ b/Source/WebCore/dom/RenderedDocumentMarker.h
@@ -27,7 +27,9 @@
 #pragma once
 
 #include "DocumentMarker.h"
+#include <wtf/Markable.h>
 #include <wtf/Vector.h>
+#include <wtf/WallTime.h>
 
 namespace WebCore {
 
@@ -68,9 +70,32 @@ public:
 
     bool isValid() const { return m_isValid; }
 
+    float opacity() const { return m_opacity; }
+    void setOpacity(float opacity) { m_opacity = opacity; }
+
+    bool isBeingDismissed() const { return m_isBeingDismissed; }
+
+    void setBeingDismissed(bool beingDismissed)
+    {
+        if (m_isBeingDismissed == beingDismissed)
+            return;
+
+        m_isBeingDismissed = beingDismissed;
+        if (m_isBeingDismissed)
+            m_animationStartTime = WallTime::now();
+        else
+            m_animationStartTime.reset();
+    }
+
+    Markable<WallTime> animationStartTime() const { return m_animationStartTime; }
+
 private:
     Vector<FloatRect, 1> m_rects;
     bool m_isValid { false };
+    bool m_isBeingDismissed { false };
+
+    float m_opacity { 1.0 };
+    Markable<WallTime> m_animationStartTime;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -41,6 +41,7 @@
 #include "RenderText.h"
 #include "RenderTheme.h"
 #include "RenderView.h"
+#include "RenderedDocumentMarker.h"
 #include "ShadowData.h"
 #include "StyledMarkedText.h"
 #include "TextPaintStyle.h"
@@ -825,7 +826,10 @@ void TextBoxPainter<TextBoxPath>::paintPlatformDocumentMarker(const MarkedText& 
             return DocumentMarkerLineStyleMode::Spelling;
         }
     }();
+
     auto lineStyleColor = RenderTheme::singleton().documentMarkerLineColor(lineStyleMode, m_renderer.styleColorOptions());
+    if (auto* marker = markedText.marker)
+        lineStyleColor = lineStyleColor.colorWithAlpha(marker->opacity());
 
     bounds.moveBy(m_paintRect.location());
     m_paintInfo.context().drawDotsForDocumentMarker(bounds, { lineStyleMode, lineStyleColor });


### PR DESCRIPTION
#### 5c3f5c350c623143a75e7b21c99695aeac53d2eb
<pre>
Add support for fading out document markers
<a href="https://bugs.webkit.org/show_bug.cgi?id=252870">https://bugs.webkit.org/show_bug.cgi?id=252870</a>
rdar://105857998

Reviewed by Megan Gardner.

Add the ability to fade out document markers, similar to DataDetector highlights
and PageOverlays.

* Source/WebCore/dom/DocumentMarkerController.cpp:
(WebCore::DocumentMarkerController::DocumentMarkerController):

Specify constants for the animation frame rate and duration. The frame rate
was selected to match other existing animations, such as fading out DataDetector
highlights and PageOverlays.

(WebCore::DocumentMarkerController::detach):
(WebCore::DocumentMarkerController::forEachOfTypes):

Add a helper method to iterate over all markers of a given type.

(WebCore::DocumentMarkerController::removeMarkers):
(WebCore::DocumentMarkerController::removeMarkersFromList):

Introduce a filter function, to avoid code duplication when it is time to
remove faded out markers.

(WebCore::DocumentMarkerController::dismissMarkers):

This method removes markers of a given type by fading them out, rather than
simply removing them from the list of rendered document markers.

Markers that are fading out, as marked as &quot;being dismissed&quot; and an animation
start time is recorded. If the animation timer is not already running, it is
started.

(WebCore::DocumentMarkerController::fadeAnimationTimerFired):

On each tick, update the opacity of markers being dismissed based on the
animation start time and the current time. Once the marker is fully faded out,
it is removed from the list of markers. If there are no more markers to animate,
the timer is stopped.

* Source/WebCore/dom/DocumentMarkerController.h:
* Source/WebCore/dom/RenderedDocumentMarker.h:

Add new properties to `RenderedDocumentMarker` to support animation.

(WebCore::RenderedDocumentMarker::opacity const):
(WebCore::RenderedDocumentMarker::setOpacity):
(WebCore::RenderedDocumentMarker::isBeingDismissed const):
(WebCore::RenderedDocumentMarker::setBeingDismissed):
(WebCore::RenderedDocumentMarker::animationStartTime const):
* Source/WebCore/rendering/TextBoxPainter.cpp:
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::paintPlatformDocumentMarker):

Adjust the alpha value of the marker color to perform the fade.

Canonical link: <a href="https://commits.webkit.org/260842@main">https://commits.webkit.org/260842@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/578d25b95feab7f77a6ec9215104086325dbb82a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109642 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18762 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42387 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1123 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118765 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113538 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20229 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9961 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101911 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115395 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15057 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98292 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43273 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97031 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/29944 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85053 "Found 1 new API test failure: /WebKitGTK/TestDownloads:/webkit/Downloads/local-file-error (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11493 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31286 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12149 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8223 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17515 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50895 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7517 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13893 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->