### PR TITLE
Change the default iPadOS simulator to one with a larger screen size

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests_integrationtest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests_integrationtest.py
@@ -1037,7 +1037,7 @@ class RunTest(unittest.TestCase, StreamTestingMixin):
         for line in logging.getvalue():
             if str(DeviceType.from_string('iPhone SE')) in line:
                 self.assertTrue('Skipping 2 tests' in line)
-            elif str(DeviceType.from_string('iPad (10th generation)')) in line:
+            elif str(DeviceType.from_string('iPad (9th generation)')) in line:
                 self.assertTrue('Skipping 1 test' in line)
             elif str(DeviceType.from_string('iPhone 7')) in line:
                 self.assertTrue('Skipping 0 tests' in line)
@@ -1067,7 +1067,7 @@ class RunTest(unittest.TestCase, StreamTestingMixin):
 
         self.assertEqual(3, len(by_type.keys()))
         self.assertEqual(2, len(by_type[DeviceType.from_string('iPhone 12')]))
-        self.assertEqual(1, len(by_type[DeviceType.from_string('iPad (10th generation)')]))
+        self.assertEqual(1, len(by_type[DeviceType.from_string('iPad (9th generation)')]))
         self.assertEqual(0, len(by_type[DeviceType.from_string('iPhone 7')]))
 
     def test_ipad_test_division(self):
@@ -1085,7 +1085,7 @@ class RunTest(unittest.TestCase, StreamTestingMixin):
             run_webkit_tests.run(port, run_webkit_tests.parse_args(['--debug-rwt-logging', '-n', '--no-build', '--root', '/build'])[0], [], logging_stream=logging)
 
         for line in logging.getvalue():
-            if str(DeviceType.from_string('iPad (10th generation)')) in line:
+            if str(DeviceType.from_string('iPad (9th generation)')) in line:
                 self.assertTrue('Skipping 3 test' in line)
 
     def test_ipad_listing(self):
@@ -1113,7 +1113,7 @@ class RunTest(unittest.TestCase, StreamTestingMixin):
             by_type[current_type].append(line)
 
         self.assertEqual(1, len(by_type.keys()))
-        self.assertEqual(3, len(by_type[DeviceType.from_string('iPad (10th generation)')]))
+        self.assertEqual(3, len(by_type[DeviceType.from_string('iPad (9th generation)')]))
 
 
 class RebaselineTest(unittest.TestCase, StreamTestingMixin):

--- a/Tools/Scripts/webkitpy/port/ios_simulator.py
+++ b/Tools/Scripts/webkitpy/port/ios_simulator.py
@@ -45,7 +45,7 @@ class IOSSimulatorPort(IOSPort):
 
     DEFAULT_DEVICE_TYPES = [
         DeviceType(hardware_family='iPhone', hardware_type='12'),
-        DeviceType(hardware_family='iPad', hardware_type='(10th generation)'),
+        DeviceType(hardware_family='iPad', hardware_type='(9th generation)'),
         DeviceType(hardware_family='iPhone', hardware_type='7'),
     ]
     SDK = apple_additions().get_sdk('iphonesimulator') if apple_additions() else 'iphonesimulator'
@@ -126,7 +126,7 @@ class IPadSimulatorPort(IOSSimulatorPort):
     port_name = 'ipad-simulator'
 
     DEVICE_TYPE = DeviceType(hardware_family='iPad')
-    DEFAULT_DEVICE_TYPES = [DeviceType(hardware_family='iPad', hardware_type='(10th generation)')]
+    DEFAULT_DEVICE_TYPES = [DeviceType(hardware_family='iPad', hardware_type='(9th generation)')]
 
     def __init__(self, *args, **kwargs):
         super(IPadSimulatorPort, self).__init__(*args, **kwargs)

--- a/Tools/Scripts/webkitpy/xcode/simulated_device_unittest.py
+++ b/Tools/Scripts/webkitpy/xcode/simulated_device_unittest.py
@@ -106,8 +106,8 @@ simctl_json_output = """{
      "identifier" : "com.apple.CoreSimulator.SimDeviceType.iPad-Air-2"
    },
    {
-     "name" : "iPad (10th generation)",
-     "identifier" : "com.apple.CoreSimulator.SimDeviceType.iPad--10th-generation-"
+     "name" : "iPad (9th generation)",
+     "identifier" : "com.apple.CoreSimulator.SimDeviceType.iPad--9th-generation-"
    },
    {
      "name" : "iPad Pro (9.7-inch)",
@@ -408,7 +408,7 @@ simctl_json_output = """{
      {
        "state" : "Shutdown",
        "availability" : "(available)",
-       "name" : "iPad (10th generation)",
+       "name" : "iPad (9th generation)",
        "udid" : "1805162F-861B-40CA-8468-8B7DC0922D62"
      },
      {


### PR DESCRIPTION
#### 1ce84dcfeba0b213fa64c47104c8e87295f4a4ba
<pre>
Change the default iPadOS simulator to one with a larger screen size
<a href="https://bugs.webkit.org/show_bug.cgi?id=251458">https://bugs.webkit.org/show_bug.cgi?id=251458</a>
rdar://104886115

Reviewed by Ryan Haddad.

* Tools/Scripts/webkitpy/layout_tests/run_webkit_tests_integrationtest.py:
(RunTest.test_device_type_test_division):
(RunTest.test_device_type_specific_listing):
(RunTest.test_ipad_test_division):
(RunTest.test_ipad_listing):
* Tools/Scripts/webkitpy/port/ios_simulator.py:
(IOSSimulatorPort):
(IPadSimulatorPort):
* Tools/Scripts/webkitpy/xcode/simulated_device_unittest.py:

Canonical link: <a href="https://commits.webkit.org/260904@main">https://commits.webkit.org/260904@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48a37c2a95d35d3e94a3ceb6307e214539af9dfb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109510 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18633 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42267 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1007 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118665 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113394 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20100 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9831 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101786 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115265 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14973 "Found 4 new test failures: platform/ipad/fast/viewport/empty-meta.html, platform/ipad/fast/viewport/meta-viewport-ignored.html, platform/ipad/fast/viewport/width-is-device-width.html, platform/ipad/media/controls/close-page-with-picture-in-picture-video-assertion-failure.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98195 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43179 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/112983 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96945 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29848 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84951 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11372 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31191 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12034 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8127 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/api/basic/mediasource.window.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17400 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50795 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7561 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13769 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->