### PR TITLE
Rename PLATFORM(WIN_CAIRO) to PLATFORM(WIN)

### DIFF
--- a/Source/WTF/wtf/PlatformEnable.h
+++ b/Source/WTF/wtf/PlatformEnable.h
@@ -85,8 +85,8 @@
 #include <wtf/PlatformEnableCocoa.h>
 #endif
 
-/* --------- Windows CAIRO port --------- */
-#if PLATFORM(WIN_CAIRO)
+/* --------- Windows port --------- */
+#if PLATFORM(WIN)
 #include <wtf/PlatformEnableWinCairo.h>
 #endif
 

--- a/Source/WTF/wtf/PlatformEnableWinCairo.h
+++ b/Source/WTF/wtf/PlatformEnableWinCairo.h
@@ -32,16 +32,12 @@
 #error "Please #include <wtf/Platform.h> instead of this file directly."
 #endif
 
-#if !PLATFORM(WIN_CAIRO)
-#error "This file should only be included when building the Windows CAIRO port."
+#if !PLATFORM(WIN)
+#error "This file should only be included when building the Windows port."
 #endif
 
 
-/* --------- Windows CAIRO port --------- */
-
-/* PLATFORM(WIN_CAIRO) is a specialization of PLATFORM(WIN). */
-/* PLATFORM(WIN) is always enabled when PLATFORM(WIN_CAIRO) is enabled. */
-
+/* --------- Windows port --------- */
 
 #if !defined(ENABLE_WEB_ARCHIVE)
 #define ENABLE_WEB_ARCHIVE 1

--- a/Source/WTF/wtf/PlatformUse.h
+++ b/Source/WTF/wtf/PlatformUse.h
@@ -272,7 +272,7 @@
 #define USE_CFNETWORK_CONTENT_ENCODING_SNIFFING_OVERRIDE 1
 #endif
 
-#if PLATFORM(MAC) || PLATFORM(WPE) || PLATFORM(GTK) || PLATFORM(WIN_CAIRO)
+#if PLATFORM(MAC) || PLATFORM(WPE) || PLATFORM(GTK) || PLATFORM(WIN)
 /* FIXME: This really needs a descriptive name, this "new theme" was added in 2008. */
 #define USE_NEW_THEME 1
 #endif

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
@@ -127,7 +127,7 @@ String MediaControlsHost::layoutTraitsClassName() const
     return "IOSLayoutTraits"_s;
 #elif PLATFORM(WATCHOS)
     return "WatchOSLayoutTraits"_s;
-#elif PLATFORM(GTK) || PLATFORM(WPE) || PLATFORM(WIN_CAIRO)
+#elif PLATFORM(GTK) || PLATFORM(WPE) || PLATFORM(WIN)
     return "AdwaitaLayoutTraits"_s;
 #else
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/WebCorePrefix.h
+++ b/Source/WebCore/WebCorePrefix.h
@@ -114,7 +114,7 @@
 #endif
 #endif
 
-#if PLATFORM(WIN_CAIRO)
+#if PLATFORM(WIN)
 #include <windows.h>
 #else
 

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -380,7 +380,7 @@ CanvasRenderingContext2D* HTMLCanvasElement::getContext2d(const String& type, Ca
 
 static bool requiresAcceleratedCompositingForWebGL()
 {
-#if PLATFORM(GTK) || PLATFORM(WIN_CAIRO)
+#if PLATFORM(GTK) || PLATFORM(WIN)
     return false;
 #else
     return true;

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -182,7 +182,7 @@ void OffscreenCanvas::setSize(const IntSize& newSize)
 #if ENABLE(WEBGL)
 static bool requiresAcceleratedCompositingForWebGL()
 {
-#if PLATFORM(GTK) || PLATFORM(WIN_CAIRO)
+#if PLATFORM(GTK) || PLATFORM(WIN)
     return false;
 #else
     return true;

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -4348,7 +4348,7 @@ bool EventHandler::defaultKeyboardScrollEventHandler(KeyboardEvent& event, Scrol
 
 void EventHandler::defaultPageUpDownEventHandler(KeyboardEvent& event)
 {
-#if PLATFORM(GTK) || PLATFORM(WPE) || PLATFORM(WIN_CAIRO) || PLATFORM(COCOA)
+#if PLATFORM(GTK) || PLATFORM(WPE) || PLATFORM(WIN) || PLATFORM(COCOA)
     ASSERT(event.type() == eventNames().keydownEvent);
 
     if (event.ctrlKey() || event.metaKey() || event.altKey() || event.altGraphKey() || event.shiftKey())
@@ -4364,7 +4364,7 @@ void EventHandler::defaultPageUpDownEventHandler(KeyboardEvent& event)
 
 void EventHandler::defaultHomeEndEventHandler(KeyboardEvent& event)
 {
-#if PLATFORM(GTK) || PLATFORM(WPE) || PLATFORM(WIN_CAIRO)
+#if PLATFORM(GTK) || PLATFORM(WPE) || PLATFORM(WIN)
     ASSERT(event.type() == eventNames().keydownEvent);
 
     if (event.ctrlKey() || event.metaKey() || event.altKey() || event.altGraphKey() || event.shiftKey())

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -193,7 +193,7 @@ public:
 
 #if USE(TEXTURE_MAPPER_GL)
     PlatformLayer* platformLayer() const override;
-#if PLATFORM(WIN_CAIRO)
+#if PLATFORM(WIN)
     // FIXME: Accelerated rendering has not been implemented for WinCairo yet.
     bool supportsAcceleratedRendering() const override { return false; }
 #else

--- a/Source/WebCore/platform/graphics/win/ImageWin.cpp
+++ b/Source/WebCore/platform/graphics/win/ImageWin.cpp
@@ -29,17 +29,6 @@
 #include "BitmapImage.h"
 #include "SharedBuffer.h"
 
-#if !PLATFORM(WIN_CAIRO)
-// This function loads resources from WebKit
-RefPtr<WebCore::FragmentedSharedBuffer> loadResourceIntoBuffer(const char*);
-#else
-// FIXME: https://bugs.webkit.org/show_bug.cgi?id=188175
-RefPtr<WebCore::FragmentedSharedBuffer> loadResourceIntoBuffer(const char*)
-{
-    return nullptr;
-}
-#endif
-
 namespace WebCore {
 
 void BitmapImage::invalidatePlatformData()
@@ -48,9 +37,7 @@ void BitmapImage::invalidatePlatformData()
 
 Ref<Image> Image::loadPlatformResource(const char *name)
 {
-    auto buffer = loadResourceIntoBuffer(name);
     auto img = BitmapImage::create();
-    img->setData(WTFMove(buffer), true);
     return img;
 }
 

--- a/Source/WebCore/testing/js/WebCoreTestSupportPrefix.h
+++ b/Source/WebCore/testing/js/WebCoreTestSupportPrefix.h
@@ -86,7 +86,7 @@
 #include <CoreFoundation/CoreFoundation.h>
 #endif
 
-#if PLATFORM(WIN_CAIRO)
+#if PLATFORM(WIN)
 #include <windows.h>
 #else
 

--- a/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.h
@@ -113,7 +113,7 @@ public:
     void updateWindowTitle(const CString&);
 #endif
 
-#if PLATFORM(WIN_CAIRO)
+#if PLATFORM(WIN)
     LRESULT sizeChange();
     LRESULT onClose();
 
@@ -185,7 +185,7 @@ private:
     GWeakPtr<GtkWidget> m_webView;
     GWeakPtr<GtkWidget> m_window;
 #endif
-#if PLATFORM(WIN_CAIRO)
+#if PLATFORM(WIN)
     HWND m_frontendHandle;
     RefPtr<WebView> m_webView;
 #endif

--- a/Source/cmake/OptionsWin.cmake
+++ b/Source/cmake/OptionsWin.cmake
@@ -1,6 +1,4 @@
 set(PORT Win)
-# FIXME: https://bugs.webkit.org/show_bug.cgi?id=251927
-set(WTF_PLATFORM_WIN_CAIRO 1)
 
 # Use Release DLL CRT even for Debug build
 set(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreadedDLL)
@@ -17,8 +15,6 @@ add_definitions(-D_WINDOWS -DWINVER=0x601 -D_WIN32_WINNT=0x601)
 
 add_definitions(-DNOMINMAX)
 add_definitions(-DUNICODE -D_UNICODE)
-
-add_definitions(-DWTF_PLATFORM_WIN_CAIRO=1)
 add_definitions(-DNOCRYPT)
 
 # If <winsock2.h> is not included before <windows.h> redefinition errors occur

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
@@ -58,7 +58,7 @@
 #include <wtf/text/cf/StringConcatenateCF.h>
 #endif
 
-#if USE(CF) && !PLATFORM(WIN_CAIRO)
+#if USE(CF) && !PLATFORM(WIN)
 #include "WebArchiveDumpSupport.h"
 #endif
 
@@ -747,7 +747,7 @@ void InjectedBundlePage::dumpAllFramesText(StringBuilder& stringBuilder)
 
 void InjectedBundlePage::dumpDOMAsWebArchive(WKBundleFrameRef frame, StringBuilder& stringBuilder)
 {
-#if USE(CF) && !PLATFORM(WIN_CAIRO)
+#if USE(CF) && !PLATFORM(WIN)
     auto wkData = adoptWK(WKBundleFrameCopyWebArchive(frame));
     auto cfData = adoptCF(CFDataCreate(0, WKDataGetBytes(wkData.get()), WKDataGetSize(wkData.get())));
     stringBuilder.append(WebCoreTestSupport::createXMLStringFromWebArchiveData(cfData.get()).get());


### PR DESCRIPTION
#### f27a3c01300181daed36860ffdacc23ee4f6458d
<pre>
Rename PLATFORM(WIN_CAIRO) to PLATFORM(WIN)
<a href="https://bugs.webkit.org/show_bug.cgi?id=252881">https://bugs.webkit.org/show_bug.cgi?id=252881</a>

Reviewed by Don Olmstead.

We no longer need to distinguish PLATFORM(WIN_CAIRO) and PLATFORM(WIN)
since AppleWin port was removed.

* Source/WTF/wtf/PlatformEnable.h:
* Source/WTF/wtf/PlatformEnableWinCairo.h:
* Source/WTF/wtf/PlatformUse.h:
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp:
(WebCore::MediaControlsHost::layoutTraitsClassName const):
* Source/WebCore/WebCorePrefix.h:
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::requiresAcceleratedCompositingForWebGL):
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::requiresAcceleratedCompositingForWebGL):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::defaultPageUpDownEventHandler):
(WebCore::EventHandler::defaultHomeEndEventHandler):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:
* Source/WebCore/platform/graphics/win/ImageWin.cpp:
(WebCore::Image::loadPlatformResource):
(loadResourceIntoBuffer): Deleted.
* Source/WebCore/testing/js/WebCoreTestSupportPrefix.h:
* Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.h:
* Source/cmake/OptionsWin.cmake:
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp:
(WTR::InjectedBundlePage::dumpDOMAsWebArchive):

Canonical link: <a href="https://commits.webkit.org/260808@main">https://commits.webkit.org/260808@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d08e3f36a11278f3a902892dc316fdc1d668339

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109405 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18529 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42178 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/913 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118580 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113288 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20003 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9736 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101681 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115161 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14906 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98132 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43099 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96878 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29785 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84851 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/98334 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11282 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31128 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/99227 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/9300 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11948 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8063 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31056 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17315 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50731 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/107198 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7487 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13670 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26461 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->