### PR TITLE
Use RobinHoodHashMap for large style rule tables

### DIFF
--- a/Source/WebCore/style/RuleFeature.h
+++ b/Source/WebCore/style/RuleFeature.h
@@ -26,6 +26,7 @@
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
+#include <wtf/RobinHoodHashMap.h>
 #include <wtf/text/AtomString.h>
 #include <wtf/text/AtomStringHash.h>
 
@@ -107,8 +108,8 @@ struct RuleFeatureSet {
     Vector<RuleAndSelector> siblingRules;
     Vector<RuleAndSelector> uncommonAttributeRules;
 
-    HashMap<AtomString, std::unique_ptr<RuleFeatureVector>> idRules;
-    HashMap<AtomString, std::unique_ptr<RuleFeatureVector>> classRules;
+    FastRobinHoodHashMap<AtomString, std::unique_ptr<RuleFeatureVector>> idRules;
+    FastRobinHoodHashMap<AtomString, std::unique_ptr<RuleFeatureVector>> classRules;
     HashMap<AtomString, std::unique_ptr<Vector<RuleFeatureWithInvalidationSelector>>> attributeRules;
     HashMap<PseudoClassInvalidationKey, std::unique_ptr<RuleFeatureVector>> pseudoClassRules;
     HashMap<PseudoClassInvalidationKey, std::unique_ptr<Vector<RuleFeatureWithInvalidationSelector>>> hasPseudoClassRules;

--- a/Source/WebCore/style/RuleSet.h
+++ b/Source/WebCore/style/RuleSet.h
@@ -28,6 +28,7 @@
 #include "StyleRule.h"
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
+#include <wtf/RobinHoodHashMap.h>
 #include <wtf/VectorHash.h>
 #include <wtf/text/AtomString.h>
 #include <wtf/text/AtomStringHash.h>
@@ -73,7 +74,7 @@ public:
     ~RuleSet();
 
     typedef Vector<RuleData, 1> RuleDataVector;
-    typedef HashMap<AtomString, std::unique_ptr<RuleDataVector>> AtomRuleMap;
+    typedef FastRobinHoodHashMap<AtomString, std::unique_ptr<RuleDataVector>> AtomRuleMap;
 
     void addRule(const StyleRule&, unsigned selectorIndex, unsigned selectorListIndex);
     void addPageRule(StyleRulePage&);

--- a/Source/WebCore/style/StyleScopeRuleSets.cpp
+++ b/Source/WebCore/style/StyleScopeRuleSets.cpp
@@ -262,8 +262,8 @@ void ScopeRuleSets::collectFeatures() const
     m_features.shrinkToFit();
 }
 
-template<typename KeyType, typename RuleFeatureVectorType, typename Hash, typename HashTraits>
-static Vector<InvalidationRuleSet>* ensureInvalidationRuleSets(const KeyType& key, HashMap<KeyType, std::unique_ptr<Vector<InvalidationRuleSet>>, Hash, HashTraits>& ruleSetMap, const HashMap<KeyType, std::unique_ptr<RuleFeatureVectorType>, Hash, HashTraits>& ruleFeatures)
+template<typename KeyType, typename Hash, typename HashTraits, typename U>
+static Vector<InvalidationRuleSet>* ensureInvalidationRuleSets(const KeyType& key, HashMap<KeyType, std::unique_ptr<Vector<InvalidationRuleSet>>, Hash, HashTraits>& ruleSetMap, const U& ruleFeatures)
 {
     return ruleSetMap.ensure(key, [&] () -> std::unique_ptr<Vector<InvalidationRuleSet>> {
         auto* features = ruleFeatures.get(key);
@@ -286,7 +286,7 @@ static Vector<InvalidationRuleSet>* ensureInvalidationRuleSets(const KeyType& ke
 
             invalidationRuleSet.ruleSet->addRule(*feature.styleRule, feature.selectorIndex, feature.selectorListIndex);
 
-            if constexpr (std::is_same<typename RuleFeatureVectorType::ValueType, RuleFeatureWithInvalidationSelector>::value) {
+            if constexpr (std::is_same<typename U::MappedType, std::unique_ptr<Vector<InvalidationRuleSet>>>::value) {
                 if (feature.invalidationSelector)
                     invalidationRuleSet.invalidationSelectors.append(feature.invalidationSelector);
             }


### PR DESCRIPTION
#### 4e1a7529bdb07ecd49e16f5a5cefde691d4c4999
<pre>
Use RobinHoodHashMap for large style rule tables
<a href="https://bugs.webkit.org/show_bug.cgi?id=252883">https://bugs.webkit.org/show_bug.cgi?id=252883</a>
&lt;rdar://problem/105868369&gt;

Reviewed by NOBODY (OOPS!).

* Source/WebCore/style/RuleFeature.h:
* Source/WebCore/style/RuleSet.h:
* Source/WebCore/style/StyleScopeRuleSets.cpp:
(WebCore::Style::ensureInvalidationRuleSets):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e1a7529bdb07ecd49e16f5a5cefde691d4c4999

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109435 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18559 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42197 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/933 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118599 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113320 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20024 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9756 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101710 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115191 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14920 "Found 60 new test failures: compositing/reflections/mask-and-reflection.html, editing/selection/ios/change-selection-by-tapping.html, fast/canvas/image-pattern-rotate.html, fast/css/attribute-selector-begin-dynamic-no-elementstyle.html, fast/css/attribute-selector-contain-dynamic-no-elementstyle.html, fast/css/attribute-selector-dynamic.xml, fast/css/attribute-selector-end-dynamic-no-elementstyle.html, fast/css/attribute-selector-exact-dynamic-no-elementstyle.html, fast/css/attribute-selector-hyphen-dynamic-no-elementstyle.html, fast/css/attribute-selector-list-dynamic-no-elementstyle.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98142 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43115 "Found 55 new test failures: fast/css/attribute-selector-begin-dynamic-no-elementstyle.html, fast/css/attribute-selector-contain-dynamic-no-elementstyle.html, fast/css/attribute-selector-dynamic.xml, fast/css/attribute-selector-end-dynamic-no-elementstyle.html, fast/css/attribute-selector-exact-dynamic-no-elementstyle.html, fast/css/attribute-selector-hyphen-dynamic-no-elementstyle.html, fast/css/attribute-selector-list-dynamic-no-elementstyle.html, fast/css/attribute-selector-recursive-update-on-setAttribute.html, fast/css/attribute-selector-set-dynamic-no-elementstyle.html, fast/css/attribute-style-invalidation-optimization-html.html ... (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96892 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29795 "Found 60 new test failures: accessibility/dialog-showModal.html, fast/css/attribute-selector-begin-dynamic-no-elementstyle.html, fast/css/attribute-selector-contain-dynamic-no-elementstyle.html, fast/css/attribute-selector-dynamic.xml, fast/css/attribute-selector-end-dynamic-no-elementstyle.html, fast/css/attribute-selector-exact-dynamic-no-elementstyle.html, fast/css/attribute-selector-hyphen-dynamic-no-elementstyle.html, fast/css/attribute-selector-list-dynamic-no-elementstyle.html, fast/css/attribute-selector-recursive-update-on-setAttribute.html, fast/css/attribute-selector-set-dynamic-no-elementstyle.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84875 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11303 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31138 "Found 60 new test failures: accessibility/dialog-showModal.html, fast/css/attribute-selector-begin-dynamic-no-elementstyle.html, fast/css/attribute-selector-contain-dynamic-no-elementstyle.html, fast/css/attribute-selector-dynamic.xml, fast/css/attribute-selector-end-dynamic-no-elementstyle.html, fast/css/attribute-selector-exact-dynamic-no-elementstyle.html, fast/css/attribute-selector-hyphen-dynamic-no-elementstyle.html, fast/css/attribute-selector-list-dynamic-no-elementstyle.html, fast/css/attribute-selector-recursive-update-on-setAttribute.html, fast/css/attribute-selector-set-dynamic-no-elementstyle.html ... (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11967 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8073 "Found 60 new test failures: accessibility/dialog-showModal.html, animations/stop-animation-on-suspend.html, fast/css/attribute-selector-begin-dynamic-no-elementstyle.html, fast/css/attribute-selector-contain-dynamic-no-elementstyle.html, fast/css/attribute-selector-dynamic.xml, fast/css/attribute-selector-end-dynamic-no-elementstyle.html, fast/css/attribute-selector-exact-dynamic-no-elementstyle.html, fast/css/attribute-selector-hyphen-dynamic-no-elementstyle.html, fast/css/attribute-selector-list-dynamic-no-elementstyle.html, fast/css/attribute-selector-recursive-update-on-setAttribute.html ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17333 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50742 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13698 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->