### PR TITLE
[JSC] Stop eagerly emitting wide32 opcodes

### DIFF
--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
@@ -255,7 +255,7 @@ namespace JSC {
         WTF_MAKE_FAST_ALLOCATED;
         WTF_MAKE_NONCOPYABLE(ForInContext);
     public:
-        using GetInst = std::tuple<unsigned, int>;
+        using GetInst = std::tuple<unsigned, int, unsigned>;
         using InInst = GetInst;
         using HasOwnPropertyJumpInst = std::tuple<unsigned, unsigned>;
 
@@ -269,14 +269,14 @@ namespace JSC {
         RegisterID* mode() const { return m_mode.get(); }
         const std::optional<Variable>& baseVariable() const { return m_baseVariable; }
 
-        void addGetInst(unsigned instIndex, int propertyRegIndex)
+        void addGetInst(unsigned instIndex, int propertyRegIndex, unsigned metadataID)
         {
-            m_getInsts.append(GetInst { instIndex, propertyRegIndex });
+            m_getInsts.append(GetInst { instIndex, propertyRegIndex, metadataID });
         }
 
-        void addInInst(unsigned instIndex, int propertyRegIndex)
+        void addInInst(unsigned instIndex, int propertyRegIndex, unsigned metadataID)
         {
-            m_inInsts.append(InInst { instIndex, propertyRegIndex });
+            m_inInsts.append(InInst { instIndex, propertyRegIndex, metadataID });
         }
 
         void addHasOwnPropertyJump(unsigned branchInstIndex, unsigned genericPathTarget)
@@ -850,7 +850,7 @@ namespace JSC {
         void emitJumpIfNotFunctionApply(RegisterID* cond, Label& target);
         void emitJumpIfEmptyPropertyNameEnumerator(RegisterID* cond, Label& target);
         void emitJumpIfSentinelString(RegisterID* cond, Label& target);
-        unsigned emitWideJumpIfNotFunctionHasOwnProperty(RegisterID* cond, Label& target);
+        unsigned emitJumpIfNotFunctionHasOwnProperty(RegisterID* cond, Label& target);
         void recordHasOwnPropertyInForInLoop(ForInContext&, unsigned branchOffset, Label& genericPath);
 
         template<typename BinOp, typename JmpOp>

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -2297,7 +2297,7 @@ RegisterID* HasOwnPropertyFunctionCallDotNode::emitBytecode(BytecodeGenerator& g
         Ref<Label> realCall = generator.newLabel();
         Ref<Label> end = generator.newLabel();
 
-        unsigned branchInsnOffset = generator.emitWideJumpIfNotFunctionHasOwnProperty(function.get(), realCall.get());
+        unsigned branchInsnOffset = generator.emitJumpIfNotFunctionHasOwnProperty(function.get(), realCall.get());
         generator.emitEnumeratorHasOwnProperty(returnValue.get(), base.get(), context->mode(), generator.emitNode(argument), context->propertyOffset(), context->enumerator());
         generator.emitJump(end.get());
 


### PR DESCRIPTION
#### 53e0cdd7040794989e4e7b87617e53b5e1c5b97e
<pre>
[JSC] Stop eagerly emitting wide32 opcodes
<a href="https://bugs.webkit.org/show_bug.cgi?id=252891">https://bugs.webkit.org/show_bug.cgi?id=252891</a>
rdar://105876002

Reviewed by Yusuke Suzuki.

There were 3 cases where we emitted 32-bit wide opcodes:
- OpEnumeratorGetByVal and OpEnumeratorInByVal: we might need to de-optimize these
into OpGetByVal and OpInByVal respectively, and although the take the same arguments,
the metadata ID might overflow whatever size we picked when emitting the original
opcode. To address this, we allocate the metadataID upfront and ensure we emit a
size that will fit the metadataID. These operators are not super common, and worst
case scenario we&apos;ll get one extra wide OpGetByVal due to the eagerly allocated metadata.
- OpJneqPtr: similar optimization, we can optimize `o.hasOwnProperty(p)` to a no-op
if we can guarantee that the iterator hasn&apos;t been modified. Here we can guarantee that
will always be able to emit a narrow jump, since the jump is only over a OpEnumeratorHasOwnProperty +
the value we&apos;re iterating over, which is guaranteed to be a variable.

Additionally, make the deoptimization a little more precise by not deoptimizing
everything in the loop body if we assign to the iterator, but instead only the
operations after the assignment. We are still conservative with regards to loops,
and if there&apos;s any reassignment we&apos;ll deoptimize everything after the first
loop_hint we encountered.

* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::emitWideJumpIfNotFunctionHasOwnProperty):
(JSC::BytecodeGenerator::emitInByVal):
(JSC::BytecodeGenerator::emitGetByVal):
(JSC::rewriteOp):
(JSC::ForInContext::finalize):
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h:
(JSC::ForInContext::addGetInst):
(JSC::ForInContext::addInInst):

Canonical link: <a href="https://commits.webkit.org/261125@main">https://commits.webkit.org/261125@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74dd1f0e2060a22184d7d8a53cd1fbeb61414184

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110508 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19592 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43170 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1878 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119396 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21022 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10740 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102743 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116250 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15665 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98893 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43895 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97629 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30560 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85778 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/99197 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12246 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31898 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/100241 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/10304 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12823 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8815 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31284 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18186 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51514 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/108262 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7709 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14690 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26692 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->