### PR TITLE
Port out-of-line display list items to the new serialization format

### DIFF
--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
@@ -237,7 +237,7 @@ void DrawLine::apply(GraphicsContext& context) const
     context.drawLine(m_point1, m_point2);
 }
 
-DrawLinesForText::DrawLinesForText(const FloatPoint& blockLocation, const FloatSize& localAnchor, float thickness, const DashArray& widths, bool printing, bool doubleLines, StrokeStyle style)
+DrawLinesForText::DrawLinesForText(const FloatPoint& blockLocation, const FloatSize& localAnchor, const DashArray& widths, float thickness, bool printing, bool doubleLines, StrokeStyle style)
     : m_blockLocation(blockLocation)
     , m_localAnchor(localAnchor)
     , m_widths(widths)
@@ -291,6 +291,12 @@ void FillRectWithColor::apply(GraphicsContext& context) const
 FillRectWithGradient::FillRectWithGradient(const FloatRect& rect, Gradient& gradient)
     : m_rect(rect)
     , m_gradient(gradient)
+{
+}
+
+FillRectWithGradient::FillRectWithGradient(FloatRect&& rect, Ref<Gradient>&& gradient)
+    : m_rect(WTFMove(rect))
+    , m_gradient(WTFMove(gradient))
 {
 }
 

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
@@ -259,31 +259,11 @@ public:
 
     const GraphicsContextState& state() const { return m_state; }
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<SetState> decode(Decoder&);
-
     WEBCORE_EXPORT void apply(GraphicsContext&);
 
 private:
     GraphicsContextState m_state;
 };
-
-template<class Encoder>
-void SetState::encode(Encoder& encoder) const
-{
-    encoder << m_state;
-}
-
-template<class Decoder>
-std::optional<SetState> SetState::decode(Decoder& decoder)
-{
-    std::optional<GraphicsContextState> state;
-    decoder >> state;
-    if (!state)
-        return std::nullopt;
-
-    return SetState(*state);
-}
 
 class SetLineCap {
 public:
@@ -321,36 +301,10 @@ public:
 
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<SetLineDash> decode(Decoder&);
-
 private:
     DashArray m_dashArray;
     float m_dashOffset;
 };
-
-template<class Encoder>
-void SetLineDash::encode(Encoder& encoder) const
-{
-    encoder << m_dashArray;
-    encoder << m_dashOffset;
-}
-
-template<class Decoder>
-std::optional<SetLineDash> SetLineDash::decode(Decoder& decoder)
-{
-    std::optional<DashArray> dashArray;
-    decoder >> dashArray;
-    if (!dashArray)
-        return std::nullopt;
-
-    std::optional<float> dashOffset;
-    decoder >> dashOffset;
-    if (!dashOffset)
-        return std::nullopt;
-
-    return {{ *dashArray, *dashOffset }};
-}
 
 class SetLineJoin {
 public:
@@ -479,31 +433,11 @@ public:
 
     const Path& path() const { return m_path; }
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<ClipOutToPath> decode(Decoder&);
-
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
 
 private:
     Path m_path;
 };
-
-template<class Encoder>
-void ClipOutToPath::encode(Encoder& encoder) const
-{
-    encoder << m_path;
-}
-
-template<class Decoder>
-std::optional<ClipOutToPath> ClipOutToPath::decode(Decoder& decoder)
-{
-    std::optional<Path> path;
-    decoder >> path;
-    if (!path)
-        return std::nullopt;
-
-    return {{ WTFMove(*path) }};
-}
 
 class ClipPath {
 public:
@@ -528,36 +462,10 @@ public:
 
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<ClipPath> decode(Decoder&);
-
 private:
     Path m_path;
     WindRule m_windRule;
 };
-
-template<class Encoder>
-void ClipPath::encode(Encoder& encoder) const
-{
-    encoder << m_path;
-    encoder << m_windRule;
-}
-
-template<class Decoder>
-std::optional<ClipPath> ClipPath::decode(Decoder& decoder)
-{
-    std::optional<Path> path;
-    decoder >> path;
-    if (!path)
-        return std::nullopt;
-
-    std::optional<WindRule> windRule;
-    decoder >> windRule;
-    if (!windRule)
-        return std::nullopt;
-
-    return {{ WTFMove(*path), *windRule }};
-}
 
 class DrawFilteredImageBuffer {
 public:
@@ -584,14 +492,12 @@ public:
     static constexpr bool isInlineItem = false;
     static constexpr bool isDrawingItem = true;
 
-    RenderingResourceIdentifier fontIdentifier() { return m_fontIdentifier; }
+    RenderingResourceIdentifier fontIdentifier() const { return m_fontIdentifier; }
+    PositionedGlyphs positionedGlyphs() const { return m_positionedGlyphs; }
     const FloatPoint& localAnchor() const { return m_positionedGlyphs.localAnchor; }
     FloatPoint anchorPoint() const { return m_positionedGlyphs.localAnchor; }
     FontSmoothingMode fontSmoothingMode() const { return m_positionedGlyphs.smoothingMode; }
     const Vector<GlyphBufferGlyph>& glyphs() const { return m_positionedGlyphs.glyphs; }
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<DrawGlyphs> decode(Decoder&);
 
     WEBCORE_EXPORT DrawGlyphs(const Font&, const GlyphBufferGlyph*, const GlyphBufferAdvance*, unsigned count, const FloatPoint& localAnchor, FontSmoothingMode);
     WEBCORE_EXPORT DrawGlyphs(RenderingResourceIdentifier, PositionedGlyphs&&);
@@ -602,29 +508,6 @@ private:
     RenderingResourceIdentifier m_fontIdentifier;
     PositionedGlyphs m_positionedGlyphs;
 };
-
-template<class Encoder>
-void DrawGlyphs::encode(Encoder& encoder) const
-{
-    encoder << m_fontIdentifier;
-    encoder << m_positionedGlyphs;
-}
-
-template<class Decoder>
-std::optional<DrawGlyphs> DrawGlyphs::decode(Decoder& decoder)
-{
-    std::optional<RenderingResourceIdentifier> fontIdentifier;
-    decoder >> fontIdentifier;
-    if (!fontIdentifier)
-        return std::nullopt;
-
-    std::optional<PositionedGlyphs> positionedGlyphs;
-    decoder >> positionedGlyphs;
-    if (!positionedGlyphs)
-        return std::nullopt;
-
-    return { { *fontIdentifier, WTFMove(*positionedGlyphs) } };
-}
 
 class DrawDecomposedGlyphs {
 public:
@@ -726,40 +609,10 @@ public:
 
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<DrawSystemImage> decode(Decoder&);
-
 private:
     Ref<SystemImage> m_systemImage;
     FloatRect m_destinationRect;
 };
-
-template<class Encoder>
-void DrawSystemImage::encode(Encoder& encoder) const
-{
-    encoder << m_systemImage;
-    encoder << m_destinationRect;
-}
-
-template<class Decoder>
-std::optional<DrawSystemImage> DrawSystemImage::decode(Decoder& decoder)
-{
-#define DECODE(name, type) \
-    std::optional<type> name; \
-    decoder >> name; \
-    if (!name) \
-        return std::nullopt; \
-
-    DECODE(systemImage, Ref<SystemImage>)
-    DECODE(destinationRect, FloatRect)
-
-#undef DECODE
-
-    return { {
-        WTFMove(*systemImage),
-        WTFMove(*destinationRect),
-    } };
-}
 
 class DrawPattern {
 public:
@@ -868,7 +721,7 @@ public:
     static constexpr bool isInlineItem = false;
     static constexpr bool isDrawingItem = true;
 
-    WEBCORE_EXPORT DrawLinesForText(const FloatPoint& blockLocation, const FloatSize& localAnchor, float thickness, const DashArray& widths, bool printing, bool doubleLines, StrokeStyle);
+    WEBCORE_EXPORT DrawLinesForText(const FloatPoint& blockLocation, const FloatSize& localAnchor, const DashArray& widths, float thickness, bool printing, bool doubleLines, StrokeStyle);
 
     void setBlockLocation(const FloatPoint& blockLocation) { m_blockLocation = blockLocation; }
     const FloatPoint& blockLocation() const { return m_blockLocation; }
@@ -882,9 +735,6 @@ public:
 
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<DrawLinesForText> decode(Decoder&);
-
 private:
     FloatPoint m_blockLocation;
     FloatSize m_localAnchor;
@@ -894,59 +744,6 @@ private:
     bool m_doubleLines;
     StrokeStyle m_style;
 };
-
-template<class Encoder>
-void DrawLinesForText::encode(Encoder& encoder) const
-{
-    encoder << m_blockLocation;
-    encoder << m_localAnchor;
-    encoder << m_widths;
-    encoder << m_thickness;
-    encoder << m_printing;
-    encoder << m_doubleLines;
-    encoder << m_style;
-}
-
-template<class Decoder>
-std::optional<DrawLinesForText> DrawLinesForText::decode(Decoder& decoder)
-{
-    std::optional<FloatPoint> blockLocation;
-    decoder >> blockLocation;
-    if (!blockLocation)
-        return std::nullopt;
-
-    std::optional<FloatSize> localAnchor;
-    decoder >> localAnchor;
-    if (!localAnchor)
-        return std::nullopt;
-
-    std::optional<DashArray> widths;
-    decoder >> widths;
-    if (!widths)
-        return std::nullopt;
-
-    std::optional<float> thickness;
-    decoder >> thickness;
-    if (!thickness)
-        return std::nullopt;
-
-    std::optional<bool> printing;
-    decoder >> printing;
-    if (!printing)
-        return std::nullopt;
-
-    std::optional<bool> doubleLines;
-    decoder >> doubleLines;
-    if (!doubleLines)
-        return std::nullopt;
-
-    std::optional<StrokeStyle> style;
-    decoder >> style;
-    if (!style)
-        return std::nullopt;
-
-    return { { *blockLocation, *localAnchor, *thickness, *widths, *printing, *doubleLines, *style } };
-}
 
 class DrawDotsForDocumentMarker {
 public:
@@ -1007,31 +804,11 @@ public:
 
     const Path& path() const { return m_path; }
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<DrawPath> decode(Decoder&);
-
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
 
 private:
     Path m_path;
 };
-
-template<class Encoder>
-void DrawPath::encode(Encoder& encoder) const
-{
-    encoder << m_path;
-}
-
-template<class Decoder>
-std::optional<DrawPath> DrawPath::decode(Decoder& decoder)
-{
-    std::optional<Path> path;
-    decoder >> path;
-    if (!path)
-        return std::nullopt;
-
-    return {{ WTFMove(*path) }};
-}
 
 class DrawFocusRingPath {
 public:
@@ -1057,9 +834,6 @@ public:
     float outlineWidth() const { return m_outlineWidth; }
     const Color& color() const { return m_color; }
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<DrawFocusRingPath> decode(Decoder&);
-
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
 
 private:
@@ -1067,35 +841,6 @@ private:
     float m_outlineWidth;
     Color m_color;
 };
-
-template<class Encoder>
-void DrawFocusRingPath::encode(Encoder& encoder) const
-{
-    encoder << m_path;
-    encoder << m_outlineWidth;
-    encoder << m_color;
-}
-
-template<class Decoder>
-std::optional<DrawFocusRingPath> DrawFocusRingPath::decode(Decoder& decoder)
-{
-    std::optional<Path> path;
-    decoder >> path;
-    if (!path)
-        return std::nullopt;
-
-    std::optional<float> outlineWidth;
-    decoder >> outlineWidth;
-    if (!outlineWidth)
-        return std::nullopt;
-
-    std::optional<Color> color;
-    decoder >> color;
-    if (!color)
-        return std::nullopt;
-
-    return { { WTFMove(*path), *outlineWidth, *color } };
-}
 
 class DrawFocusRingRects {
 public:
@@ -1124,9 +869,6 @@ public:
     float outlineWidth() const { return m_outlineWidth; }
     const Color& color() const { return m_color; }
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<DrawFocusRingRects> decode(Decoder&);
-
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
 
 private:
@@ -1135,41 +877,6 @@ private:
     float m_outlineWidth;
     Color m_color;
 };
-
-template<class Encoder>
-void DrawFocusRingRects::encode(Encoder& encoder) const
-{
-    encoder << m_rects;
-    encoder << m_outlineOffset;
-    encoder << m_outlineWidth;
-    encoder << m_color;
-}
-
-template<class Decoder>
-std::optional<DrawFocusRingRects> DrawFocusRingRects::decode(Decoder& decoder)
-{
-    std::optional<Vector<FloatRect>> rects;
-    decoder >> rects;
-    if (!rects)
-        return std::nullopt;
-
-    std::optional<float> outlineOffset;
-    decoder >> outlineOffset;
-    if (!outlineOffset)
-        return std::nullopt;
-
-    std::optional<float> outlineWidth;
-    decoder >> outlineWidth;
-    if (!outlineWidth)
-        return std::nullopt;
-
-    std::optional<Color> color;
-    decoder >> color;
-    if (!color)
-        return std::nullopt;
-
-    return { { WTFMove(*rects), *outlineOffset, *outlineWidth, *color } };
-}
 
 class FillRect {
 public:
@@ -1207,36 +914,10 @@ public:
 
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<FillRectWithColor> decode(Decoder&);
-
 private:
     FloatRect m_rect;
     Color m_color;
 };
-
-template<class Encoder>
-void FillRectWithColor::encode(Encoder& encoder) const
-{
-    encoder << m_rect;
-    encoder << m_color;
-}
-
-template<class Decoder>
-std::optional<FillRectWithColor> FillRectWithColor::decode(Decoder& decoder)
-{
-    std::optional<FloatRect> rect;
-    decoder >> rect;
-    if (!rect)
-        return std::nullopt;
-
-    std::optional<Color> color;
-    decoder >> color;
-    if (!color)
-        return std::nullopt;
-
-    return {{ *rect, *color }};
-}
 
 class FillRectWithGradient {
 public:
@@ -1245,42 +926,17 @@ public:
     static constexpr bool isDrawingItem = true;
 
     WEBCORE_EXPORT FillRectWithGradient(const FloatRect&, Gradient&);
+    WEBCORE_EXPORT FillRectWithGradient(FloatRect&&, Ref<Gradient>&&);
 
     const FloatRect& rect() const { return m_rect; }
-    const Gradient& gradient() const { return m_gradient.get(); }
+    const Ref<Gradient>& gradient() const { return m_gradient; }
 
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<FillRectWithGradient> decode(Decoder&);
 
 private:
     FloatRect m_rect;
     mutable Ref<Gradient> m_gradient; // FIXME: Make this not mutable
 };
-
-template<class Encoder>
-void FillRectWithGradient::encode(Encoder& encoder) const
-{
-    encoder << m_rect;
-    encoder << m_gradient.get();
-}
-
-template<class Decoder>
-std::optional<FillRectWithGradient> FillRectWithGradient::decode(Decoder& decoder)
-{
-    std::optional<FloatRect> rect;
-    decoder >> rect;
-    if (!rect)
-        return std::nullopt;
-    
-    std::optional<Ref<Gradient>> gradient;
-    decoder >> gradient;
-    if (!gradient)
-        return std::nullopt;
-
-    return { { *rect, WTFMove(*gradient) } };
-}
 
 class FillCompositedRect {
 public:
@@ -1303,50 +959,12 @@ public:
 
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<FillCompositedRect> decode(Decoder&);
-
 private:
     FloatRect m_rect;
     Color m_color;
     CompositeOperator m_op;
     BlendMode m_blendMode;
 };
-
-template<class Encoder>
-void FillCompositedRect::encode(Encoder& encoder) const
-{
-    encoder << m_rect;
-    encoder << m_color;
-    encoder << m_op;
-    encoder << m_blendMode;
-}
-
-template<class Decoder>
-std::optional<FillCompositedRect> FillCompositedRect::decode(Decoder& decoder)
-{
-    std::optional<FloatRect> rect;
-    decoder >> rect;
-    if (!rect)
-        return std::nullopt;
-
-    std::optional<Color> color;
-    decoder >> color;
-    if (!color)
-        return std::nullopt;
-
-    std::optional<CompositeOperator> op;
-    decoder >> op;
-    if (!op)
-        return std::nullopt;
-
-    std::optional<BlendMode> blendMode;
-    decoder >> blendMode;
-    if (!blendMode)
-        return std::nullopt;
-
-    return {{ *rect, *color, *op, *blendMode }};
-}
 
 class FillRoundedRect {
 public:
@@ -1365,9 +983,6 @@ public:
     const Color& color() const { return m_color; }
     BlendMode blendMode() const { return m_blendMode; }
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<FillRoundedRect> decode(Decoder&);
-
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
 
 private:
@@ -1375,35 +990,6 @@ private:
     Color m_color;
     BlendMode m_blendMode;
 };
-
-template<class Encoder>
-void FillRoundedRect::encode(Encoder& encoder) const
-{
-    encoder << m_rect;
-    encoder << m_color;
-    encoder << m_blendMode;
-}
-
-template<class Decoder>
-std::optional<FillRoundedRect> FillRoundedRect::decode(Decoder& decoder)
-{
-    std::optional<FloatRoundedRect> rect;
-    decoder >> rect;
-    if (!rect)
-        return std::nullopt;
-
-    std::optional<Color> color;
-    decoder >> color;
-    if (!color)
-        return std::nullopt;
-
-    std::optional<BlendMode> blendMode;
-    decoder >> blendMode;
-    if (!blendMode)
-        return std::nullopt;
-
-    return {{ *rect, *color, *blendMode }};
-}
 
 class FillRectWithRoundedHole {
 public:
@@ -1422,9 +1008,6 @@ public:
     const FloatRoundedRect& roundedHoleRect() const { return m_roundedHoleRect; }
     const Color& color() const { return m_color; }
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<FillRectWithRoundedHole> decode(Decoder&);
-
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
 
 private:
@@ -1432,35 +1015,6 @@ private:
     FloatRoundedRect m_roundedHoleRect;
     Color m_color;
 };
-
-template<class Encoder>
-void FillRectWithRoundedHole::encode(Encoder& encoder) const
-{
-    encoder << m_rect;
-    encoder << m_roundedHoleRect;
-    encoder << m_color;
-}
-
-template<class Decoder>
-std::optional<FillRectWithRoundedHole> FillRectWithRoundedHole::decode(Decoder& decoder)
-{
-    std::optional<FloatRect> rect;
-    decoder >> rect;
-    if (!rect)
-        return std::nullopt;
-
-    std::optional<FloatRoundedRect> roundedHoleRect;
-    decoder >> roundedHoleRect;
-    if (!roundedHoleRect)
-        return std::nullopt;
-
-    std::optional<Color> color;
-    decoder >> color;
-    if (!color)
-        return std::nullopt;
-
-    return {{ *rect, *roundedHoleRect, *color }};
-}
 
 #if ENABLE(INLINE_PATH_DATA)
 
@@ -1552,31 +1106,11 @@ public:
 
     const Path& path() const { return m_path; }
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<FillPath> decode(Decoder&);
-
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
 
 private:
     Path m_path;
 };
-
-template<class Encoder>
-void FillPath::encode(Encoder& encoder) const
-{
-    encoder << m_path;
-}
-
-template<class Decoder>
-std::optional<FillPath> FillPath::decode(Decoder& decoder)
-{
-    std::optional<Path> path;
-    decoder >> path;
-    if (!path)
-        return std::nullopt;
-
-    return {{ WTFMove(*path) }};
-}
 
 class FillEllipse {
 public:
@@ -1741,31 +1275,11 @@ public:
 
     const Path& path() const { return m_path; }
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<StrokePath> decode(Decoder&);
-
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
 
 private:
     Path m_path;
 };
-
-template<class Encoder>
-void StrokePath::encode(Encoder& encoder) const
-{
-    encoder << m_path;
-}
-
-template<class Decoder>
-std::optional<StrokePath> StrokePath::decode(Decoder& decoder)
-{
-    std::optional<Path> path;
-    decoder >> path;
-    if (!path)
-        return std::nullopt;
-
-    return {{ WTFMove(*path) }};
-}
 
 class StrokeEllipse {
 public:

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
@@ -219,7 +219,7 @@ void RecorderImpl::recordDrawLine(const FloatPoint& point1, const FloatPoint& po
 
 void RecorderImpl::recordDrawLinesForText(const FloatPoint& blockLocation, const FloatSize& localAnchor, float thickness, const DashArray& widths, bool printing, bool doubleLines, StrokeStyle style)
 {
-    append<DrawLinesForText>(blockLocation, localAnchor, thickness, widths, printing, doubleLines, style);
+    append<DrawLinesForText>(blockLocation, localAnchor, widths, thickness, printing, doubleLines, style);
 }
 
 void RecorderImpl::recordDrawDotsForDocumentMarker(const FloatRect& rect, const DocumentMarkerLineStyle& style)

--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -525,6 +525,7 @@ set(WebKit_SERIALIZATION_IN_FILES
     NetworkProcess/NetworkResourceLoadParameters.serialization.in
 
     Shared/CallbackID.serialization.in
+    Shared/DisplayListArgumentCoders.serialization.in
     Shared/EditorState.serialization.in
     Shared/FileSystemSyncAccessHandleInfo.serialization.in
     Shared/FocusedElementInformation.serialization.in

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -168,6 +168,7 @@ $(PROJECT_DIR)/Shared/Cocoa/DataDetectionResult.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/RevealItem.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
 $(PROJECT_DIR)/Shared/Databases/IndexedDB/WebIDBResult.serialization.in
+$(PROJECT_DIR)/Shared/DisplayListArgumentCoders.serialization.in
 $(PROJECT_DIR)/Shared/CallbackID.serialization.in
 $(PROJECT_DIR)/Shared/EditorState.serialization.in
 $(PROJECT_DIR)/Shared/Extensions/WebExtensionEventListenerType.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -477,6 +477,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/Cocoa/RevealItem.serialization.in \
 	Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in \
 	Shared/CallbackID.serialization.in \
+	Shared/DisplayListArgumentCoders.serialization.in \
 	Shared/EditorState.serialization.in \
 	Shared/Extensions/WebExtensionEventListenerType.serialization.in \
 	Shared/FileSystemSyncAccessHandleInfo.serialization.in \

--- a/Source/WebKit/Shared/DisplayListArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/DisplayListArgumentCoders.serialization.in
@@ -1,0 +1,115 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+headers: <WebCore/DisplayListItems.h>
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::SetState {
+    WebCore::GraphicsContextState state();
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::SetLineDash {
+    WebCore::DashArray dashArray();
+    float dashOffset();
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::ClipOutToPath {
+    WebCore::Path path();
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::ClipPath {
+    WebCore::Path path();
+    WebCore::WindRule windRule();
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::DrawGlyphs {
+    WebCore::RenderingResourceIdentifier fontIdentifier();
+    WebCore::PositionedGlyphs positionedGlyphs();
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::DrawSystemImage {
+    Ref<WebCore::SystemImage> systemImage();
+    WebCore::FloatRect destinationRect();
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::DrawLinesForText {
+    WebCore::FloatPoint blockLocation();
+    WebCore::FloatSize localAnchor();
+    WebCore::DashArray widths();
+    float thickness();
+    bool isPrinting();
+    bool doubleLines();
+    WebCore::StrokeStyle style();
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::DrawPath {
+    WebCore::Path path();
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::DrawFocusRingPath {
+    WebCore::Path path();
+    float outlineWidth();
+    WebCore::Color color();
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::DrawFocusRingRects {
+    Vector<WebCore::FloatRect> rects();
+    float outlineOffset();
+    float outlineWidth();
+    WebCore::Color color();
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::FillRectWithColor {
+    WebCore::FloatRect rect();
+    WebCore::Color color();
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::FillRectWithGradient {
+    WebCore::FloatRect rect();
+    Ref<WebCore::Gradient> gradient();
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::FillCompositedRect {
+    WebCore::FloatRect rect();
+    WebCore::Color color();
+    WebCore::CompositeOperator compositeOperator();
+    WebCore::BlendMode blendMode();
+};
+
+[CustomHeader] class WebCore::DisplayList::FillRoundedRect {
+    WebCore::FloatRoundedRect roundedRect();
+    WebCore::Color color();
+    WebCore::BlendMode blendMode();
+};
+
+[CustomHeader] class WebCore::DisplayList::FillRectWithRoundedHole {
+    WebCore::FloatRect rect();
+    WebCore::FloatRoundedRect roundedHoleRect();
+    WebCore::Color color();
+};
+
+[CustomHeader] class WebCore::DisplayList::FillPath {
+    WebCore::Path path();
+};
+
+[CustomHeader] class WebCore::DisplayList::StrokePath {
+    WebCore::Path path();
+};

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -5838,6 +5838,7 @@
 		86D1968229A516270083B077 /* PlatformPopupMenuData.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = PlatformPopupMenuData.serialization.in; sourceTree = "<group>"; };
 		86D1968329A517A20083B077 /* TouchBarMenuItemData.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = TouchBarMenuItemData.serialization.in; sourceTree = "<group>"; };
 		86D1968429A51D070083B077 /* WebsiteDataType.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WebsiteDataType.serialization.in; sourceTree = "<group>"; };
+		86D196CE29A8D0D60083B077 /* DisplayListArgumentCoders.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = DisplayListArgumentCoders.serialization.in; sourceTree = "<group>"; };
 		86DA60C628EAE9C00044FE4D /* FocusedElementInformation.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = FocusedElementInformation.serialization.in; sourceTree = "<group>"; };
 		86DA60CA28EB11830044FE4D /* InteractionInformationAtPosition.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; name = InteractionInformationAtPosition.serialization.in; path = ios/InteractionInformationAtPosition.serialization.in; sourceTree = "<group>"; };
 		86DD518B28EF028500DF2A58 /* TextFlags.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = TextFlags.serialization.in; sourceTree = "<group>"; };
@@ -7835,6 +7836,7 @@
 				99036AE823A970870000B06A /* DebuggableInfoData.cpp */,
 				99036AE723A970870000B06A /* DebuggableInfoData.h */,
 				0F189CAB24749F2F00E58D81 /* DisplayLinkObserverID.h */,
+				86D196CE29A8D0D60083B077 /* DisplayListArgumentCoders.serialization.in */,
 				2D7FD190223C730F007887F1 /* DocumentEditingContext.h */,
 				2D7FD191223C7310007887F1 /* DocumentEditingContext.mm */,
 				C517388012DF8F4F00EE3F47 /* DragControllerAction.h */,

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
@@ -245,7 +245,7 @@ void RemoteDisplayListRecorderProxy::recordDrawLine(const FloatPoint& point1, co
 
 void RemoteDisplayListRecorderProxy::recordDrawLinesForText(const FloatPoint& blockLocation, const FloatSize& localAnchor, float thickness, const DashArray& widths, bool printing, bool doubleLines, StrokeStyle style)
 {
-    send(Messages::RemoteDisplayListRecorder::DrawLinesForText(DisplayList::DrawLinesForText { blockLocation, localAnchor, thickness, widths, printing, doubleLines, style }));
+    send(Messages::RemoteDisplayListRecorder::DrawLinesForText(DisplayList::DrawLinesForText { blockLocation, localAnchor, widths, thickness, printing, doubleLines, style }));
 }
 
 void RemoteDisplayListRecorderProxy::recordDrawDotsForDocumentMarker(const FloatRect& rect, const DocumentMarkerLineStyle& style)

--- a/Tools/TestWebKitAPI/Tests/WebCore/DisplayListTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/DisplayListTests.cpp
@@ -103,7 +103,7 @@ TEST(DisplayListTests, AppendItems)
             EXPECT_TRUE(handle.is<FillRectWithGradient>());
             auto& item = handle.get<FillRectWithGradient>();
             EXPECT_EQ(item.rect(), FloatRect(1., 1., 10., 10.));
-            EXPECT_EQ(&item.gradient(), gradient.ptr());
+            EXPECT_EQ(item.gradient().ptr(), gradient.ptr());
             break;
         }
         case ItemType::SetInlineFillColor: {


### PR DESCRIPTION
#### 9dbbb78ff5f144ced7c9091bc09262d84df511d3
<pre>
Port out-of-line display list items to the new serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=252895">https://bugs.webkit.org/show_bug.cgi?id=252895</a>
rdar://105881207

Reviewed by Alex Christensen.

Ports the out-of-line display list items to the new serialization format.
This includes:
    - SetState
    - SetLineDash
    - ClipOutToPath
    - ClipPath
    - ClipPath
    - DrawGlyphs
    - DrawSystemImage
    - DrawLinesForText
    - DrawPath
    - DrawFocusRingPath
    - DrawFocusRingRects
    - FillRectWithColor
    - FillRectWithGradient
    - FillCompositedRect
    - FillRoundedRect
    - FillRectWithRoundedHole
    - FillPath
    - StrokePath

* Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp:
(WebCore::DisplayList::DrawLinesForText::DrawLinesForText):
(WebCore::DisplayList::FillRectWithGradient::FillRectWithGradient):
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.h:
(WebCore::DisplayList::DrawGlyphs::fontIdentifier const):
(WebCore::DisplayList::DrawGlyphs::positionedGlyphs const):
(WebCore::DisplayList::FillRectWithGradient::gradient const):
(WebCore::DisplayList::SetState::encode const): Deleted.
(WebCore::DisplayList::SetState::decode): Deleted.
(WebCore::DisplayList::SetLineDash::encode const): Deleted.
(WebCore::DisplayList::SetLineDash::decode): Deleted.
(WebCore::DisplayList::ClipOutToPath::encode const): Deleted.
(WebCore::DisplayList::ClipOutToPath::decode): Deleted.
(WebCore::DisplayList::ClipPath::encode const): Deleted.
(WebCore::DisplayList::ClipPath::decode): Deleted.
(WebCore::DisplayList::DrawGlyphs::fontIdentifier): Deleted.
(WebCore::DisplayList::DrawGlyphs::encode const): Deleted.
(WebCore::DisplayList::DrawGlyphs::decode): Deleted.
(WebCore::DisplayList::DrawSystemImage::encode const): Deleted.
(WebCore::DisplayList::DrawSystemImage::decode): Deleted.
(WebCore::DisplayList::DrawLinesForText::encode const): Deleted.
(WebCore::DisplayList::DrawLinesForText::decode): Deleted.
(WebCore::DisplayList::DrawPath::encode const): Deleted.
(WebCore::DisplayList::DrawPath::decode): Deleted.
(WebCore::DisplayList::DrawFocusRingPath::encode const): Deleted.
(WebCore::DisplayList::DrawFocusRingPath::decode): Deleted.
(WebCore::DisplayList::DrawFocusRingRects::encode const): Deleted.
(WebCore::DisplayList::DrawFocusRingRects::decode): Deleted.
(WebCore::DisplayList::FillRectWithColor::encode const): Deleted.
(WebCore::DisplayList::FillRectWithColor::decode): Deleted.
(WebCore::DisplayList::FillRectWithGradient::encode const): Deleted.
(WebCore::DisplayList::FillRectWithGradient::decode): Deleted.
(WebCore::DisplayList::FillCompositedRect::encode const): Deleted.
(WebCore::DisplayList::FillCompositedRect::decode): Deleted.
(WebCore::DisplayList::FillRoundedRect::encode const): Deleted.
(WebCore::DisplayList::FillRoundedRect::decode): Deleted.
(WebCore::DisplayList::FillRectWithRoundedHole::encode const): Deleted.
(WebCore::DisplayList::FillRectWithRoundedHole::decode): Deleted.
(WebCore::DisplayList::FillPath::encode const): Deleted.
(WebCore::DisplayList::FillPath::decode): Deleted.
(WebCore::DisplayList::StrokePath::encode const): Deleted.
(WebCore::DisplayList::StrokePath::decode): Deleted.
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp:
(WebCore::DisplayList::RecorderImpl::recordDrawLinesForText):
* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp:
(WebKit::RemoteDisplayListRecorderProxy::recordDrawLinesForText):
* Tools/TestWebKitAPI/Tests/WebCore/DisplayListTests.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/260879@main">https://commits.webkit.org/260879@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5be11d25514cb0de9b0abd1332d0ce382f8796be

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109469 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18593 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42231 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/967 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118631 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113354 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20059 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9790 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101751 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115224 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14947 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98170 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43152 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96919 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29823 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84914 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11335 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31166 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/11998 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8097 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17364 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50770 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7546 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13730 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->