### PR TITLE
References resolution for UA counter-styles

### DIFF
--- a/LayoutTests/webexposed/counter-style-image-symbols-not-exposed-expected.txt
+++ b/LayoutTests/webexposed/counter-style-image-symbols-not-exposed-expected.txt
@@ -1,3 +1,3 @@
 
-PASS @counter-style image symbols are not exposed
+FAIL @counter-style image symbols are not exposed assert_equals: Should've been able to parse @counter-style. expected 1 but got 0
 

--- a/Source/WebCore/css/CSSCounterStyleDescriptors.cpp
+++ b/Source/WebCore/css/CSSCounterStyleDescriptors.cpp
@@ -162,7 +162,7 @@ static std::pair<CSSCounterStyleDescriptors::Name, int> extractDataFromSystemDes
     if (!systemValue)
         return { "decimal"_s, 1 };
 
-    std::pair<CSSCounterStyleDescriptors::Name, int> result;
+    std::pair<CSSCounterStyleDescriptors::Name, int> result { "decimal"_s, 1 };
     ASSERT(systemValue->isValueID() || systemValue->isPair());
     if (systemValue->isPair()) {
         // This value must be `fixed` or `extends`, both of which can or must have an additional component.
@@ -227,6 +227,31 @@ CSSCounterStyleDescriptors CSSCounterStyleDescriptors::create(AtomString name, c
     };
     descriptors.setExplicitlySetDescriptors(properties);
     return descriptors;
+}
+
+bool CSSCounterStyleDescriptors::areSymbolsValidForSystem() const
+{
+    switch (m_system) {
+    case System::Cyclic:
+    case System::Fixed:
+    case System::Symbolic:
+        return m_symbols.size();
+    case System::Alphabetic:
+    case System::Numeric:
+        return m_symbols.size() >= 2u;
+    case System::Additive:
+        return m_additiveSymbols.size();
+    case System::Extends:
+        return !m_symbols.size() && !m_additiveSymbols.size();
+    default:
+        ASSERT_NOT_REACHED();
+        return false;
+    }
+}
+
+bool CSSCounterStyleDescriptors::isValid() const
+{
+    return areSymbolsValidForSystem();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSCounterStyleDescriptors.h
+++ b/Source/WebCore/css/CSSCounterStyleDescriptors.h
@@ -59,7 +59,7 @@ struct CSSCounterStyleDescriptors {
     };
     struct Pad {
         unsigned m_padMinimumLength = 0;
-        Symbol m_padSymbol = "-"_s;
+        Symbol m_padSymbol;
         bool operator==(const Pad& other) const { return m_padMinimumLength == other.m_padMinimumLength && m_padSymbol == other.m_padSymbol; }
         bool operator!=(const Pad& other) const { return !(*this == other); }
     };
@@ -103,6 +103,8 @@ struct CSSCounterStyleDescriptors {
     }
     bool operator!=(const CSSCounterStyleDescriptors& other) const { return !(*this == other); }
     void setExplicitlySetDescriptors(const StyleProperties&);
+    bool isValid() const;
+    bool areSymbolsValidForSystem() const;
 
     Name m_name;
     System m_system;

--- a/Source/WebCore/css/CSSCounterStyleRegistry.h
+++ b/Source/WebCore/css/CSSCounterStyleRegistry.h
@@ -42,16 +42,18 @@ public:
     static RefPtr<CSSCounterStyle> decimalCounter();
     static void addUserAgentCounterStyle(const CSSCounterStyleDescriptors&);
     void addCounterStyle(const CSSCounterStyleDescriptors&);
+    static void resolveUserAgentReferences();
     void resolveReferencesIfNeeded();
     bool operator==(const CSSCounterStyleRegistry& other) const;
     CSSCounterStyleRegistry() = default;
 
 private:
     static CounterStyleMap& userAgentCounterStyles();
-    void resolveFallbackReference(CSSCounterStyle&);
-    void resolveExtendsReference(CSSCounterStyle&);
-    void resolveExtendsReference(CSSCounterStyle&, HashSet<CSSCounterStyle*>&);
-    RefPtr<CSSCounterStyle> counterStyle(const AtomString&);
+    // If no map is passed on, user-agent counter styles map will be used
+    static void resolveFallbackReference(CSSCounterStyle&, CounterStyleMap* = nullptr);
+    static void resolveExtendsReference(CSSCounterStyle&, CounterStyleMap* = nullptr);
+    static void resolveExtendsReference(CSSCounterStyle&, HashSet<CSSCounterStyle*>&, CounterStyleMap* = nullptr);
+    static RefPtr<CSSCounterStyle> counterStyle(const AtomString&, CounterStyleMap* = nullptr);
 
     CounterStyleMap m_authorCounterStyles;
     bool hasUnresolvedReferences { true };

--- a/Source/WebCore/css/CSSCounterStyleRule.cpp
+++ b/Source/WebCore/css/CSSCounterStyleRule.cpp
@@ -46,9 +46,8 @@ StyleRuleCounterStyle::StyleRuleCounterStyle(const AtomString& name, Ref<StylePr
 {
 }
 
-Ref<StyleRuleCounterStyle> StyleRuleCounterStyle::create(const AtomString& name, Ref<StyleProperties>&& properties)
+Ref<StyleRuleCounterStyle> StyleRuleCounterStyle::create(const AtomString& name, Ref<StyleProperties>&& properties, CSSCounterStyleDescriptors&& descriptors)
 {
-    auto descriptors = CSSCounterStyleDescriptors::create(name, properties);
     return adoptRef(*new StyleRuleCounterStyle(name, WTFMove(properties), WTFMove(descriptors)));
 }
 

--- a/Source/WebCore/css/CSSCounterStyleRule.h
+++ b/Source/WebCore/css/CSSCounterStyleRule.h
@@ -34,7 +34,7 @@
 namespace WebCore {
 class StyleRuleCounterStyle final : public StyleRuleBase {
 public:
-    static Ref<StyleRuleCounterStyle> create(const AtomString& name, Ref<StyleProperties>&&);
+    static Ref<StyleRuleCounterStyle> create(const AtomString&, Ref<StyleProperties>&&, CSSCounterStyleDescriptors&&);
     ~StyleRuleCounterStyle();
 
     Ref<StyleRuleCounterStyle> copy() const { RELEASE_ASSERT_NOT_REACHED(); }

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -888,7 +888,7 @@ RefPtr<StyleRuleCounterStyle> CSSParserImpl::consumeCounterStyleRule(CSSParserTo
         return nullptr;
 
     auto rangeCopy = prelude; // For inspector callbacks
-    auto name = CSSPropertyParserHelpers::consumeCounterStyleNameInPrelude(rangeCopy);
+    auto name = CSSPropertyParserHelpers::consumeCounterStyleNameInPrelude(rangeCopy, m_context.mode);
     if (name.isNull())
         return nullptr;
 
@@ -900,7 +900,11 @@ RefPtr<StyleRuleCounterStyle> CSSParserImpl::consumeCounterStyleRule(CSSParserTo
     }
 
     auto declarations = consumeDeclarationListInNewNestingContext(block, StyleRuleType::CounterStyle);
-    return StyleRuleCounterStyle::create(name, createStyleProperties(declarations, m_context.mode));
+    auto properties = createStyleProperties(declarations, m_context.mode);
+    auto descriptors = CSSCounterStyleDescriptors::create(name, properties);
+    if (!descriptors.isValid())
+        return nullptr;
+    return StyleRuleCounterStyle::create(name, WTFMove(properties), WTFMove(descriptors));
 }
 
 RefPtr<StyleRuleLayer> CSSParserImpl::consumeLayerRule(CSSParserTokenRange prelude, std::optional<CSSParserTokenRange> block)

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -4766,7 +4766,7 @@ RefPtr<CSSPrimitiveValue> consumeCounterStyleName(CSSParserTokenRange& range)
 }
 
 // https://www.w3.org/TR/css-counter-styles-3/#typedef-counter-style-name
-AtomString consumeCounterStyleNameInPrelude(CSSParserTokenRange& prelude)
+AtomString consumeCounterStyleNameInPrelude(CSSParserTokenRange& prelude, CSSParserMode mode)
 {
     auto nameToken = prelude.consumeIncludingWhitespace();
     if (!prelude.atEnd())
@@ -4777,7 +4777,8 @@ AtomString consumeCounterStyleNameInPrelude(CSSParserTokenRange& prelude)
     // In the context of the prelude of an @counter-style rule, a <counter-style-name> must not be an ASCII
     // case-insensitive match for "decimal" or "disc". No <counter-style-name>, prelude or not, may be an ASCII
     // case-insensitive match for "none".
-    if (identMatches<CSSValueDecimal, CSSValueDisc, CSSValueNone>(nameToken.id()))
+    auto id = nameToken.id();
+    if (identMatches<CSSValueNone>(id) || (mode != CSSParserMode::UASheetMode && identMatches<CSSValueDecimal, CSSValueDisc>(id)))
         return AtomString();
     auto name = nameToken.value();
     return isPredefinedCounterStyle(nameToken.id()) ? name.convertToASCIILowercaseAtom() : name.toAtomString();

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
@@ -190,7 +190,7 @@ struct FontRaw {
 };
 
 RefPtr<CSSPrimitiveValue> consumeCounterStyleName(CSSParserTokenRange&);
-AtomString consumeCounterStyleNameInPrelude(CSSParserTokenRange&);
+AtomString consumeCounterStyleNameInPrelude(CSSParserTokenRange&, CSSParserMode = CSSParserMode::HTMLStandardMode);
 RefPtr<CSSPrimitiveValue> consumeSingleContainerName(CSSParserTokenRange&);
 
 std::optional<CSSValueID> consumeFontStretchKeywordValueRaw(CSSParserTokenRange&);

--- a/Source/WebCore/style/UserAgentStyle.cpp
+++ b/Source/WebCore/style/UserAgentStyle.cpp
@@ -129,6 +129,7 @@ void static addToCounterStyleRegistry(StyleSheetContents& sheet)
         if (auto* counterStyleRule = dynamicDowncast<StyleRuleCounterStyle>(rule.get()))
             CSSCounterStyleRegistry::addUserAgentCounterStyle(counterStyleRule->descriptors());
     }
+    CSSCounterStyleRegistry::resolveUserAgentReferences();
 }
 
 void UserAgentStyle::addToDefaultStyle(StyleSheetContents& sheet)


### PR DESCRIPTION
#### 853c4e577730e9028620990bd328d13713b6f8ed
<pre>
References resolution for UA counter-styles
<a href="https://bugs.webkit.org/show_bug.cgi?id=252899">https://bugs.webkit.org/show_bug.cgi?id=252899</a>
rdar://103021161

Reviewed by Tim Nguyen.

We need to resolve references for the predefined counter-styles
which rules are stored in UA stylesheet.
These references can be resolved after the counter-style UA stylesheet
is parsed and before resolving references of the author counter styles.

* Source/WebCore/css/CSSCounterStyleDescriptors.cpp:
(WebCore::translateSuffixFromStyleProperties):
(WebCore::extractDataFromSystemDescriptor):
- Small adjustments in the default values for the descriptors.

(WebCore::CSSCounterStyleDescriptors::areSymbolsValidForSystem const):
(WebCore::CSSCounterStyleDescriptors::isValid const):
- Adding functions for validating a descriptor. For now, we only validate
the symbols according to the counter-style system, as described in the spec.

* Source/WebCore/css/CSSCounterStyleDescriptors.h:
* Source/WebCore/css/CSSCounterStyleRegistry.cpp:
(WebCore::CSSCounterStyleRegistry::resolveUserAgentReferences):
(WebCore::CSSCounterStyleRegistry::resolveReferencesIfNeeded):
(WebCore::CSSCounterStyleRegistry::resolveExtendsReference):
(WebCore::CSSCounterStyleRegistry::resolveFallbackReference):
(WebCore::CSSCounterStyleRegistry::counterStyle):
(WebCore::CSSCounterStyleRegistry::resolvedCounterStyle):
- Since the counter-styles map (userAgentCounterStyles()) lives in static memory,
I&apos;m modifying the resolution functions from the CSSCounterStyleRegistry for
being static and receiving a map instead, so they can serve for both
the UA and author counter styles. CSSCounterStyleRegistry::resolveUserAgentReferences()
is the wrapper for when we are resolving references for the UA counter-styles.

* Source/WebCore/css/CSSCounterStyleRegistry.h:
* Source/WebCore/css/CSSCounterStyleRule.cpp:
(WebCore::StyleRuleCounterStyle::create):
* Source/WebCore/css/CSSCounterStyleRule.h:
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumeCounterStyleRule):
- Calling the new validation function for the descriptor before trying
to cerate a StyleRuleCounterStyles.

* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeCounterStyleNameInPrelude):
- The spec says that certain names, reserved for predefined counter-styles,
should not be accepted as a valid name during parser and if matched should
invalidate the rule. This is already done, but since we want to re-use
the same parsing functions for both author and UA rules we need a small tweak:
We are now passing the CSSParserMode to consumeCounterStyleNameInPrelude()
and allowing these reserved names when we are in UA mode.

* Source/WebCore/css/parser/CSSPropertyParserHelpers.h:
* Source/WebCore/style/UserAgentStyle.cpp:
(WebCore::Style::addToCounterStyleRegistry):
- Resolving UA counter-styles references after all counter-styles
are collected from the UA stylesheet to the UA counter-styles map.

* LayoutTests/webexposed/counter-style-image-symbols-not-exposed-expected.txt:
- Rebaselining. Although we parse images as symbols, we don&apos;t support it in counter-style
so the descriptor is invalidated.

Canonical link: <a href="https://commits.webkit.org/260940@main">https://commits.webkit.org/260940@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b8355e3559293b3a6b747669162a7bd273051d2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110012 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19112 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42694 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1455 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/119052 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113965 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20578 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10305 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102270 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115758 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/43543 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/30190 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/85369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11815 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31530 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12437 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17805 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51142 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7584 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14232 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->