### PR TITLE
Regression(255659@main) ABN AMRO Creditcard app hangs on launch

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -5357,7 +5357,21 @@ ScreenOrientationAPIEnabled:
     WebKitLegacy:
       default: false
     WebKit:
-      default: true
+      default: WebKit::defaultShouldEnableScreenOrientationAPI()
+    WebCore:
+      default: false
+
+ScreenOrientationLockingAPIEnabled:
+  type: bool
+  status: testable
+  category: dom
+  humanReadableName: "Screen Orientation API (Locking / Unlocking)"
+  humanReadableDescription: "Enable Screen Orientation API (Locking / Unlocking)"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
     WebCore:
       default: false
 

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -104,6 +104,7 @@ enum class SDKAlignedBehavior {
     UIBackForwardSkipsHistoryItemsWithoutUserGesture,
     ProgrammaticFocusDuringUserScriptShowsInputViews,
     UsesGameControllerPhysicalInputProfile,
+    ScreenOrientationAPIEnabled,
 
     NumberOfBehaviors
 };

--- a/Source/WebCore/page/ScreenOrientation.idl
+++ b/Source/WebCore/page/ScreenOrientation.idl
@@ -28,8 +28,8 @@
     EnabledBySetting=ScreenOrientationAPIEnabled,
     Exposed=Window
 ] interface ScreenOrientation : EventTarget {
-    Promise<undefined> lock(OrientationLockType orientation);
-    undefined unlock();
+    [EnabledBySetting=ScreenOrientationLockingAPIEnabled] Promise<undefined> lock(OrientationLockType orientation);
+    [EnabledBySetting=ScreenOrientationLockingAPIEnabled] undefined unlock();
     readonly attribute OrientationType type;
     readonly attribute unsigned short angle;
     attribute EventHandler onchange;

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
@@ -223,4 +223,16 @@ bool defaultGamepadVibrationActuatorEnabled()
 }
 #endif
 
+bool defaultShouldEnableScreenOrientationAPI()
+{
+#if PLATFORM(MAC)
+    return true;
+#elif PLATFORM(IOS_FAMILY)
+    static bool shouldEnableScreenOrientationAPI = linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::ScreenOrientationAPIEnabled);
+    return shouldEnableScreenOrientationAPI;
+#else
+    return false;
+#endif
+}
+
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.h
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.h
@@ -97,4 +97,6 @@ bool defaultGamepadVibrationActuatorEnabled();
 bool defaultShouldTakeSuspendedAssertions();
 bool defaultShowModalDialogEnabled();
 
+bool defaultShouldEnableScreenOrientationAPI();
+
 } // namespace WebKit


### PR DESCRIPTION
#### f144d4e39c665081571eb0557f347d3e19d6522b
<pre>
Regression(255659@main) ABN AMRO Creditcard app hangs on launch
<a href="https://bugs.webkit.org/show_bug.cgi?id=252910">https://bugs.webkit.org/show_bug.cgi?id=252910</a>
rdar://105743884

Reviewed by Geoffrey Garen.

This app is a Cordova/PhoneGap app using the following plugin to support the
screen orientation API:
- <a href="https://www.npmjs.com/package/cordova-plugin-screen-orientation">https://www.npmjs.com/package/cordova-plugin-screen-orientation</a>

The app expects the screen orientation API to work and tries to lock the
orientation to portrait when on an iPhone. When we expose our native screen
orientation API support, the app&apos;s polyfill is no longer used and they try to
lock the orientation using our native API. However, we reject the orientation
locking promise with an UnsupportedError since we only support orientation lock
after using the JS fullscreen API to be in full screen. The promise rejection
was breaking the app, causing it to stop loading after showing its splash
screen.

To address the issue, I made the following changes:
1. Move ScreenOrientation.lock() / ScreenOrientation.unlock() behind a runtime
feature flag, off by default. Sadly, these functions are not currently useful
and always reject the promise with UnsupportedError. The reasons for this are
that locking is gated on using the fullscreen API, which is currently supported
on iPad but not iPhone. As a result, no support on iPhone. While the fullscreen
API works on iPad, screen orientation locking usually doesn&apos;t because apps are
not in control of their orientation if they opt into multitask support (aka
split-view), which apps (such as MobileSafari) usually do.
2. Move the rest of the Screen Orientation API (the readonly part which works
well: ScreenOrientation.type, ScreenOrientation.angle, change event) behind
a linked-on-after check so that it gets exposed only when the app gets rebuilt
with the new SDK.

Change 1 was not sufficient to fix the app. The polyfill will not currently
add the lock() / unlock() functions if `screen.orientation` exists. For this
reason, it had to make change 2 as well.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h:
* Source/WebCore/page/ScreenOrientation.idl:
* Source/WebKit/Shared/WebPreferencesDefaultValues.cpp:
(WebKit::defaultShouldEnableScreenOrientationAPI):
* Source/WebKit/Shared/WebPreferencesDefaultValues.h:

Canonical link: <a href="https://commits.webkit.org/260812@main">https://commits.webkit.org/260812@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5c3abeb9c69f632bb42164115f35895a45cb44e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109496 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18618 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42255 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/994 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118654 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113380 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20086 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9817 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101773 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115251 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/14964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98190 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43168 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29843 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84941 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/98404 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11359 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31186 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/38/builds/99287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/9384 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12022 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8117 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/38/builds/99287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17388 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50790 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/107270 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7490 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13755 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26484 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->