### PR TITLE
Optimize TextFieldInputType::sanitizeValue()

### DIFF
--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -1434,6 +1434,7 @@ template<typename CharacterType, typename Predicate> ALWAYS_INLINE Ref<StringImp
 template<typename Predicate>
 inline Ref<StringImpl> StringImpl::removeCharacters(const Predicate& findMatch)
 {
+    static_assert(!std::is_function_v<Predicate>, "Passing a lambda instead of a function pointer helps the compiler with inlining");
     if (is8Bit())
         return removeCharactersImpl(characters8(), findMatch);
     return removeCharactersImpl(characters16(), findMatch);

--- a/Source/WebCore/html/EmailInputType.cpp
+++ b/Source/WebCore/html/EmailInputType.cpp
@@ -90,7 +90,10 @@ bool EmailInputType::supportsSelectionAPI() const
 
 String EmailInputType::sanitizeValue(const String& proposedValue) const
 {
-    String noLineBreakValue = proposedValue.removeCharacters(isHTMLLineBreak);
+    // Passing a lambda instead of a function name helps the compiler inline isHTMLLineBreak.
+    String noLineBreakValue = proposedValue.removeCharacters([](auto character) {
+        return isHTMLLineBreak(character);
+    });
     ASSERT(element());
     if (!element()->multiple())
         return stripLeadingAndTrailingHTMLSpaces(noLineBreakValue);

--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -594,7 +594,11 @@ static bool isAutoFillButtonTypeChanged(const AtomString& attribute, AutoFillBut
 
 String TextFieldInputType::sanitizeValue(const String& proposedValue) const
 {
-    return limitLength(proposedValue.removeCharacters(isHTMLLineBreak), HTMLInputElement::maxEffectiveLength);
+    // Passing a lambda instead of a function name helps the compiler inline isHTMLLineBreak.
+    auto proposedValueWithoutLineBreaks = proposedValue.removeCharacters([](auto character) {
+        return isHTMLLineBreak(character);
+    });
+    return limitLength(WTFMove(proposedValueWithoutLineBreaks), HTMLInputElement::maxEffectiveLength);
 }
 
 void TextFieldInputType::handleBeforeTextInsertedEvent(BeforeTextInsertedEvent& event)

--- a/Source/WebCore/platform/network/CacheValidation.cpp
+++ b/Source/WebCore/platform/network/CacheValidation.cpp
@@ -281,7 +281,9 @@ CacheControlDirectives parseCacheControlDirectives(const HTTPHeaderMap& headers)
 
     String cacheControlValue = headers.get(HTTPHeaderName::CacheControl);
     if (!cacheControlValue.isEmpty()) {
-        auto safeHeaderString = cacheControlValue.removeCharacters(isControlCharacterOrSpace);
+        auto safeHeaderString = cacheControlValue.removeCharacters([](auto character) {
+            return isControlCharacterOrSpace(character);
+        });
         auto directives = parseCacheHeader(safeHeaderString);
 
         size_t directivesSize = directives.size();


### PR DESCRIPTION
#### 2a2bff6e7028e22ab05443ee79f7c742c0db8eeb
<pre>
Optimize TextFieldInputType::sanitizeValue()
<a href="https://bugs.webkit.org/show_bug.cgi?id=252919">https://bugs.webkit.org/show_bug.cgi?id=252919</a>

Reviewed by Darin Adler.

I noticed while looking at profiles that TextFieldInputType::sanitizeValue()
calls String::removeCharacters(isHTMLLineBreak) and that isHTMLLineBreak wasn&apos;t
getting inlined (despite being marked as inline).

If we pass a lambda to String::removeCharacters() instead of a function name,
the compiler seems to be able to inline isHTMLLineBreak just fine, resulting
in better performance.

Before:
Sample Count, Samples %, Normalized CPU %, Symbol
28, 100.0%, 0.0%, WebCore::TextFieldInputType::sanitizeValue(WTF::String const&amp;) const (in WebCore)
22, 78.6%, 0.0%,     WebCore::TextFieldInputType::sanitizeValue(WTF::String const&amp;) const (.cold.1) (in WebCore)
10, 35.7%, 0.0%,         WTF::Ref&lt;WTF::StringImpl, WTF::RawPtrTraits&lt;WTF::StringImpl&gt;&gt; WTF::StringImpl::removeCharacters&lt;bool (char16_t)&gt;(bool  const(&amp;)(char16_t)) (in WebCore)
9, 32.1%, 0.0%,         WebCore::isHTMLLineBreak(char16_t) (in WebCore)
3, 10.7%, 0.0%,     WTF::Ref&lt;WTF::StringImpl, WTF::RawPtrTraits&lt;WTF::StringImpl&gt;&gt; WTF::StringImpl::removeCharacters&lt;bool (char16_t)&gt;(bool  const(&amp;)(char16_t)) (in WebCore)

After:
Sample Count, Samples %, Normalized CPU %, Symbol
7, 100.0%, 0.0%, com.apple.WebKit (65138)
7, 100.0%, 0.0%,     WebCore::TextFieldInputType::sanitizeValue(WTF::String const&amp;) const (in WebCore)

* Source/WebCore/html/EmailInputType.cpp:
(WebCore::EmailInputType::sanitizeValue const):
* Source/WebCore/html/TextFieldInputType.cpp:
(WebCore::TextFieldInputType::sanitizeValue const):

Canonical link: <a href="https://commits.webkit.org/260824@main">https://commits.webkit.org/260824@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42117c583578270b619145e11a8b32be3cb5eb17

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109556 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18679 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42307 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1047 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118693 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113439 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20145 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9876 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101827 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115312 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98230 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/43210 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29883 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/84980 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/98444 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11415 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31226 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/38/builds/99324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/9439 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12075 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8157 "Passed tests") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/38/builds/99324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17439 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50832 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/107320 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7503 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13814 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26489 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->