### PR TITLE
Add tests to make sure confirm/prompt work from cross-origin iframes

### DIFF
--- a/Tools/TestWebKitAPI/cocoa/TestUIDelegate.h
+++ b/Tools/TestWebKitAPI/cocoa/TestUIDelegate.h
@@ -29,6 +29,8 @@
 
 @property (nonatomic, copy) WKWebView* (^createWebViewWithConfiguration)(WKWebViewConfiguration *, WKNavigationAction *, WKWindowFeatures *);
 @property (nonatomic, copy) void (^runJavaScriptAlertPanelWithMessage)(WKWebView *, NSString *, WKFrameInfo *, void (^)(void));
+@property (nonatomic, copy) void (^runJavaScriptConfirmPanelWithMessage)(WKWebView *, NSString *, WKFrameInfo *, void (^)(BOOL));
+@property (nonatomic, copy) void (^runJavaScriptPromptPanelWithMessage)(WKWebView *, NSString *, NSString *, WKFrameInfo *, void (^)(NSString *));
 #if PLATFORM(MAC)
 @property (nonatomic, copy) void (^getContextMenuFromProposedMenu)(NSMenu *, _WKContextMenuElementInfo *, id <NSSecureCoding>, void (^)(NSMenu *));
 @property (nonatomic, copy) void (^getWindowFrameWithCompletionHandler)(WKWebView *, void(^)(CGRect));
@@ -37,10 +39,14 @@
 @property (nonatomic, copy) void (^focusWebView)(WKWebView *);
 
 - (NSString *)waitForAlert;
+- (NSString *)waitForConfirm;
+- (NSString *)waitForPromptWithReply:(NSString *)reply;
 
 @end
 
 @interface WKWebView (TestUIDelegateExtras)
 - (NSString *)_test_waitForAlert;
+- (NSString *)_test_waitForConfirm;
+- (NSString *)_test_waitForPromptWithReply:(NSString *)reply;
 - (void)_test_waitForInspectorToShow;
 @end


### PR DESCRIPTION
#### 07412048195177731c9cc21937bd440add942d1d
<pre>
Add tests to make sure confirm/prompt work from cross-origin iframes
with site isolation.
<a href="https://bugs.webkit.org/show_bug.cgi?id=252923">https://bugs.webkit.org/show_bug.cgi?id=252923</a>
rdar://99897405

Reviewed by Alex Christensen.

alert/confirm/prompt dialogs are expected to work from cross-origin
iframes with site isolation. We already tests that alert works, but this
change adds tests for confirm/prompt as well.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/cocoa/TestUIDelegate.h:
* Tools/TestWebKitAPI/cocoa/TestUIDelegate.mm:
(-[TestUIDelegate webView:runJavaScriptConfirmPanelWithMessage:initiatedByFrame:completionHandler:]):
(-[TestUIDelegate webView:runJavaScriptTextInputPanelWithPrompt:defaultText:initiatedByFrame:completionHandler:]):
(-[TestUIDelegate waitForConfirm]):
(-[TestUIDelegate waitForPromptWithDefaultInput:]):
(-[WKWebView _test_waitForConfirm]):
(-[WKWebView _test_waitForPromptWithDefaultInput:]):

Canonical link: <a href="https://commits.webkit.org/260867@main">https://commits.webkit.org/260867@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/474bbf5a5314dee54f8973face9f45521a81ccf5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109745 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18863 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42485 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1218 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118864 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113696 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20332 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10059 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102013 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115495 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15133 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98367 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43356 "Found 15 new test failures: imported/w3c/web-platform-tests/css/css-pseudo/backdrop-animate-002.html, imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-rotate.html, imported/w3c/web-platform-tests/css/css-transforms/group/svg-transform-nested-009.html, imported/w3c/web-platform-tests/css/css-transforms/individual-transform/animation/individual-transform-combine.html, imported/w3c/web-platform-tests/css/css-transforms/transform-3d-rotateY-stair-above-001.xht, imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/kind-of-widget-fallback-color-input-background-color-001.html, imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/kind-of-widget-fallback-select-dropdown-box-background-color-001.html, imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/kind-of-widget-fallback-select-dropdown-box-border-bottom-left-radius-001.html, imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/kind-of-widget-fallback-select-dropdown-box-border-bottom-right-radius-001.html, imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/kind-of-widget-fallback-select-dropdown-box-border-end-end-radius-001.html ... (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97105 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30018 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85147 "Found 2 new API test failures: /TestWebKit:WebKit.OnDeviceChangeCrash, /TestWebKit:WebKit.PrivateBrowsingPushStateNoHistoryCallback (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11589 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31360 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12241 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8298 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17610 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50969 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7532 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13991 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->