### PR TITLE
[REBASLINE] ([ Mac WK1 ] 2x imported/w3c/web-platform-tests/html/canvas/offscreen/path-objects/2d.path.stroke.scale2*(layout-tests) are constant failures)

### DIFF
--- a/LayoutTests/platform/mac-bigsur-wk1/imported/w3c/web-platform-tests/html/canvas/offscreen/path-objects/2d.path.stroke.scale2-expected.txt
+++ b/LayoutTests/platform/mac-bigsur-wk1/imported/w3c/web-platform-tests/html/canvas/offscreen/path-objects/2d.path.stroke.scale2-expected.txt
@@ -1,0 +1,7 @@
+2d.path.stroke.scale2
+
+Stroke line widths are scaled by the current transformation matrix
+
+
+FAIL Stroke line widths are scaled by the current transformation matrix assert_equals: Red channel of the pixel at (0, 0) expected 0 but got 255
+

--- a/LayoutTests/platform/mac-bigsur-wk1/imported/w3c/web-platform-tests/html/canvas/offscreen/path-objects/2d.path.stroke.scale2.worker-expected.txt
+++ b/LayoutTests/platform/mac-bigsur-wk1/imported/w3c/web-platform-tests/html/canvas/offscreen/path-objects/2d.path.stroke.scale2.worker-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Stroke line widths are scaled by the current transformation matrix assert_equals: Red channel of the pixel at (0, 0) expected 0 but got 255
+


### PR DESCRIPTION
#### 2d9635d62de96e2a93bb7e319a7917b04ff8cfd3
<pre>
[REBASLINE] ([ Mac WK1 ] 2x imported/w3c/web-platform-tests/html/canvas/offscreen/path-objects/2d.path.stroke.scale2*(layout-tests) are constant failures)
rdar://105749926

Unreviewed test gardening.

*LayoutTests/platform/mac-bigsur-wk1/imported/w3c/web-platform-tests/html/canvas/offscreen/path-objects/2d.path.stroke.scale2.worker-expected.txt: Added
*LayoutTests/platform/mac-bigsur-wk1/imported/w3c/web-platform-tests/html/canvas/offscreen/path-objects/2d.path.stroke.scale2-expected.txt: Added

Canonical link: <a href="https://commits.webkit.org/260807@main">https://commits.webkit.org/260807@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13f223b96905c79b2dcc4da219907b6a4c840bbb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109528 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18651 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/42284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/1024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/118677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/20118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/9848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/101803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115283 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/20118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/42284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/101803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/20118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/42284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/101803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/11387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/42284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/12049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/9848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/17414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/42284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/13786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4081 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->