### PR TITLE
HTML maxlength attribute treats emoji of string length 11 as length 1

### DIFF
--- a/LayoutTests/fast/forms/input-maxlength-paste-clusters-in-middle-expected.txt
+++ b/LayoutTests/fast/forms/input-maxlength-paste-clusters-in-middle-expected.txt
@@ -7,8 +7,8 @@ PASS input.value is "abc"
 PASS input.getAttribute("maxlength") is "3"
 input.selectionStart = input.selectionEnd = 2
 getSelection().modify("extend", "backward", "character")
-PASS document.execCommand("insertText", false, "स्"); input.value is "aस्c"
-PASS input.value.length is 4
+PASS document.execCommand("insertText", false, "स्"); input.value is "aसc"
+PASS input.value.length is 3
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/forms/input-maxlength-paste-clusters-in-middle.html
+++ b/LayoutTests/fast/forms/input-maxlength-paste-clusters-in-middle.html
@@ -15,8 +15,8 @@ shouldBeEqualToString('input.value', 'abc');
 shouldBeEqualToString('input.getAttribute("maxlength")', '3');
 evalAndLog('input.selectionStart = input.selectionEnd = 2');
 evalAndLog('getSelection().modify("extend", "backward", "character")');
-shouldBeEqualToString('document.execCommand("insertText", false, "\u0938\u094D"); input.value', 'a\u0938\u094Dc');
-shouldBe('input.value.length', '4');
+shouldBeEqualToString('document.execCommand("insertText", false, "\u0938\u094D"); input.value', 'a\u0938c');
+shouldBe('input.value.length', '3');
 
 var successfullyParsed = true;
 

--- a/LayoutTests/fast/forms/input-text-max-length-emojis-expected.txt
+++ b/LayoutTests/fast/forms/input-text-max-length-emojis-expected.txt
@@ -1,0 +1,10 @@
+Tests that input length limits use code units and not grapheme clusters.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS testInput.value is "👨‍👩‍👧‍"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/input-text-max-length-emojis.html
+++ b/LayoutTests/fast/forms/input-text-max-length-emojis.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    </style>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+  </head>
+  <body>
+    <input id="testInput" maxlength="10" />
+    <script>
+        description("Tests that input length limits use code units and not grapheme clusters.");
+        jsTestIsAsync = true;
+        async function runTest() {
+            testInput = document.getElementById("testInput");
+            await UIHelper.copyText("👨‍👩‍👧‍👦");
+            await UIHelper.activateElementAndWaitForInputSession(testInput);
+            await UIHelper.paste();
+            shouldBeEqualToString("testInput.value", "👨‍👩‍👧‍");
+            finishJSTest();
+        }
+        addEventListener("load", runTest);
+    </script>
+  </body>
+</html>

--- a/LayoutTests/fast/forms/input-text-paste-maxlength-expected.txt
+++ b/LayoutTests/fast/forms/input-text-paste-maxlength-expected.txt
@@ -23,8 +23,8 @@ set maxLength property that is smaller than pasted value
 PASS domValueOf('g') is '12' + fancyX + '45'
 PASS visibleValueOf('g') is '12' + fancyX + '45'
 pasting too much text
-PASS domValueOf('k') is '12' + fancyX + '4'
-PASS visibleValueOf('k') is '12' + fancyX + '4'
+PASS domValueOf('k') is '12' + truncatedFancyX
+PASS visibleValueOf('k') is '12' + truncatedFancyX
 pasting too much text with maxlength=0
 PASS domValueOf('l') is ''
 PASS visibleValueOf('l') is ''

--- a/LayoutTests/fast/forms/input-text-paste-maxlength.html
+++ b/LayoutTests/fast/forms/input-text-paste-maxlength.html
@@ -96,8 +96,9 @@ shouldBe("visibleValueOf('g')", "'12' + fancyX + '45'");
 debug("pasting too much text");
 document.getElementById("k").focus();
 document.execCommand("InsertHTML", false, "12x&#x305;&#x332;45");
-shouldBe("domValueOf('k')", "'12' + fancyX + '4'");
-shouldBe("visibleValueOf('k')", "'12' + fancyX + '4'");
+let truncatedFancyX = "x" + String.fromCharCode(0x305);
+shouldBe("domValueOf('k')", "'12' + truncatedFancyX");
+shouldBe("visibleValueOf('k')", "'12' + truncatedFancyX");
 
 debug("pasting too much text with maxlength=0");
 document.getElementById("l").focus();

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/constraints/input-maxlength-emoji-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/constraints/input-maxlength-emoji-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Emoji gets truncated due to maxlength attribute
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/constraints/input-maxlength-emoji.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/constraints/input-maxlength-emoji.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Tests pasting an emoji in a text field with a maxlength attribute</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=252900">
+<input id="target" type="text" maxlength="10" />
+<script>
+test(function() {
+  let target = document.getElementById("target");
+  target.focus();
+  document.execCommand("InsertHTML", false, "👨‍👩‍👧‍👦");
+  assert_equals(target.value, "👨‍👩‍👧‍");
+}, "Emoji gets truncated due to maxlength attribute");
+</script>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3232,6 +3232,9 @@ webkit.org/b/252878 loader/navigation-policy/should-open-external-urls/subframe-
 webkit.org/b/252878 webrtc/multi-video.html [ Failure Pass Timeout ]
 webkit.org/b/252878 webrtc/peer-connection-remote-audio-mute2.html [ Pass Timeout ]
 
+# Missing support for UIScriptController.paste()
+fast/forms/input-text-max-length-emojis.html [ Failure ]
+
 # End: Common failures between GTK and WPE.
 
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -288,8 +288,7 @@ bool HTMLInputElement::tooShort(StringView value, NeedsToCheckDirtyFlag check) c
     if (value.isEmpty())
         return false;
 
-    // FIXME: The HTML specification says that the "number of characters" is measured using code-unit length.
-    return numGraphemeClusters(value) < static_cast<unsigned>(min);
+    return value.length() < static_cast<unsigned>(min);
 }
 
 bool HTMLInputElement::tooLong(StringView value, NeedsToCheckDirtyFlag check) const
@@ -303,8 +302,7 @@ bool HTMLInputElement::tooLong(StringView value, NeedsToCheckDirtyFlag check) co
         if (!hasDirtyValue() || !m_wasModifiedByUser)
             return false;
     }
-    // FIXME: The HTML specification says that the "number of characters" is measured using code-unit length.
-    return numGraphemeClusters(value) > max;
+    return value.length() > max;
 }
 
 bool HTMLInputElement::rangeUnderflow() const

--- a/Source/WebCore/html/HTMLTextAreaElement.cpp
+++ b/Source/WebCore/html/HTMLTextAreaElement.cpp
@@ -61,7 +61,7 @@ using namespace HTMLNames;
 // This function returns number of characters considering this.
 static unsigned computeLengthForSubmission(StringView text, unsigned numberOfLineBreaks)
 {
-    return numGraphemeClusters(text) + numberOfLineBreaks;
+    return text.length() + numberOfLineBreaks;
 }
 
 static unsigned numberOfLineBreaks(StringView text)
@@ -77,7 +77,7 @@ static unsigned numberOfLineBreaks(StringView text)
 
 static unsigned computeLengthForSubmission(StringView text)
 {
-    return numGraphemeClusters(text) + numberOfLineBreaks(text);
+    return text.length() + numberOfLineBreaks(text);
 }
 
 static unsigned upperBoundForLengthForSubmission(StringView text, unsigned numberOfLineBreaks)

--- a/Source/WebCore/html/InputType.cpp
+++ b/Source/WebCore/html/InputType.cpp
@@ -585,10 +585,10 @@ String InputType::validationMessage() const
         return validationMessagePatternMismatchText();
 
     if (element()->tooShort())
-        return validationMessageTooShortText(numGraphemeClusters(value), element()->minLength());
+        return validationMessageTooShortText(value.length(), element()->minLength());
 
     if (element()->tooLong())
-        return validationMessageTooLongText(numGraphemeClusters(value), element()->effectiveMaxLength());
+        return validationMessageTooLongText(value.length(), element()->effectiveMaxLength());
 
     if (!isSteppable())
         return emptyString();

--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -507,14 +507,14 @@ bool TextFieldInputType::shouldOnlyShowDataListDropdownButtonWhenFocusedOrEdited
 
 #endif // ENABLE(DATALIST_ELEMENT)
 
-static String limitLength(const String& string, unsigned maxNumGraphemeClusters)
+static String limitLength(const String& string, unsigned maxLength)
 {
-    StringView stringView { string };
-
-    if (!stringView.is8Bit())
-        maxNumGraphemeClusters = numCodeUnitsInGraphemeClusters(stringView, maxNumGraphemeClusters);
-
-    return string.left(maxNumGraphemeClusters);
+    unsigned newLength = std::min(maxLength, string.length());
+    if (newLength == string.length())
+        return string;
+    if (newLength > 0 && U16_IS_LEAD(string[newLength - 1]))
+        --newLength;
+    return string.left(newLength);
 }
 
 static String autoFillButtonTypeToAccessibilityLabel(AutoFillButtonType autoFillButtonType)
@@ -610,7 +610,7 @@ void TextFieldInputType::handleBeforeTextInsertedEvent(BeforeTextInsertedEvent& 
     // because they can be mismatched by sanitizeValue() in
     // HTMLInputElement::subtreeHasChanged() in some cases.
     String innerText = element()->innerTextValue();
-    unsigned oldLength = numGraphemeClusters(innerText);
+    unsigned oldLength = innerText.length();
 
     // selectionLength represents the selection length of this text field to be
     // removed by this insertion.
@@ -622,8 +622,7 @@ void TextFieldInputType::handleBeforeTextInsertedEvent(BeforeTextInsertedEvent& 
         ASSERT(enclosingTextFormControl(element()->document().frame()->selection().selection().start()) == element());
         unsigned selectionStart = element()->selectionStart();
         ASSERT(selectionStart <= element()->selectionEnd());
-        int selectionCodeUnitCount = element()->selectionEnd() - selectionStart;
-        selectionLength = selectionCodeUnitCount ? numGraphemeClusters(StringView(innerText).substring(selectionStart, selectionCodeUnitCount)) : 0;
+        selectionLength = element()->selectionEnd() - selectionStart;
     }
     ASSERT(oldLength >= selectionLength);
 

--- a/Tools/WebKitTestRunner/gtk/UIScriptControllerGtk.cpp
+++ b/Tools/WebKitTestRunner/gtk/UIScriptControllerGtk.cpp
@@ -93,6 +93,11 @@ void UIScriptControllerGtk::copyText(JSStringRef text)
 #endif
 }
 
+void UIScriptControllerGtk::paste()
+{
+    // FIXME: implement.
+}
+
 void UIScriptControllerGtk::dismissMenu()
 {
     // FIXME: implement.

--- a/Tools/WebKitTestRunner/gtk/UIScriptControllerGtk.h
+++ b/Tools/WebKitTestRunner/gtk/UIScriptControllerGtk.h
@@ -45,6 +45,7 @@ public:
     void doAsyncTask(JSValueRef) override;
     void setContinuousSpellCheckingEnabled(bool) override;
     void copyText(JSStringRef) override;
+    void paste() override;
     void dismissMenu() override;
     bool isShowingMenu() const override;
     void activateAtPoint(long x, long y, JSValueRef callback) override;


### PR DESCRIPTION
#### 9743d10df7bc729130bf6bb1fa975aec17e71bc3
<pre>
HTML maxlength attribute treats emoji of string length 11 as length 1
<a href="https://bugs.webkit.org/show_bug.cgi?id=252900">https://bugs.webkit.org/show_bug.cgi?id=252900</a>

Reviewed by Ryosuke Niwa and Aditya Keerthi.

Per the HTML specification[1], minlength/maxlength attributes on &lt;input&gt; should
restrict the length of the value, which is defined in code units [2].

Historically, WebKit has been counting grapheme clusters instead of code units
because we felt it made more sense. However, Blink and Gecko follow the
specification and only WebKit has the particular behavior. This is bad for
interoperability and makes Web developers&apos; life more difficult than it needs to
be.

As a result, I am proposing we update WebKit to align with the HTML
specification and other major browser engines.

[1] <a href="https://html.spec.whatwg.org/multipage/input.html#the-maxlength-and-minlength-attributes">https://html.spec.whatwg.org/multipage/input.html#the-maxlength-and-minlength-attributes</a>
[2] <a href="https://infra.spec.whatwg.org/#string-length">https://infra.spec.whatwg.org/#string-length</a>

* LayoutTests/fast/forms/input-maxlength-paste-clusters-in-middle-expected.txt:
* LayoutTests/fast/forms/input-maxlength-paste-clusters-in-middle.html:
* LayoutTests/fast/forms/input-text-max-length-emojis-expected.txt: Added.
* LayoutTests/fast/forms/input-text-max-length-emojis.html: Added.
* LayoutTests/fast/forms/input-text-paste-maxlength-expected.txt:
* LayoutTests/fast/forms/input-text-paste-maxlength.html:
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::tooShort const):
(WebCore::HTMLInputElement::tooLong const):
* Source/WebCore/html/HTMLTextAreaElement.cpp:
(WebCore::computeLengthForSubmission):
* Source/WebCore/html/InputType.cpp:
(WebCore::InputType::validationMessage const):
* Source/WebCore/html/TextFieldInputType.cpp:
(WebCore::limitLength):
(WebCore::TextFieldInputType::handleBeforeTextInsertedEvent):

Canonical link: <a href="https://commits.webkit.org/260838@main">https://commits.webkit.org/260838@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ab3d20135abace63fe1165dd4e2c2e1ba9ecd20

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109587 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18711 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42339 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1075 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118718 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113479 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20177 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9908 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101858 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115343 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15019 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98250 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43231 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96991 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29903 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85003 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11446 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31245 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12104 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8176 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17469 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50854 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7513 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13844 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->