### PR TITLE
WPT css-nesting test should fit in 800*600 window

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6224,6 +6224,7 @@ imported/w3c/web-platform-tests/html/browsers/the-window-object/window-open-noop
 
 # CSS nesting unsupported yet
 imported/w3c/web-platform-tests/css/css-nesting/nest-containing-forgiving.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-nesting/nesting-basic.html [ ImageOnlyFailure ]
 
 # Needs non-zero line gap in 'Arial'
 fast/text/text-edge-no-half-leading-simple.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic-expected.html
@@ -5,8 +5,8 @@
 <style>
   .test {
     background-color: green;
-    width: 100px;
-    height: 100px;
+    width: 30px;
+    height: 30px;
     display: grid;
   }
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic-ref.html
@@ -5,8 +5,8 @@
 <style>
   .test {
     background-color: green;
-    width: 100px;
-    height: 100px;
+    width: 30px;
+    height: 30px;
     display: grid;
   }
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic.html
@@ -6,8 +6,8 @@
 <style>
   .test {
     background-color: red;
-    width: 100px;
-    height: 100px;
+    width: 30px;
+    height: 30px;
     display: grid;
   }
 


### PR DESCRIPTION
#### 07fd62d3686f0f1e86e38e88d1541faaf7a925c4
<pre>
WPT css-nesting test should fit in 800*600 window
<a href="https://bugs.webkit.org/show_bug.cgi?id=252928">https://bugs.webkit.org/show_bug.cgi?id=252928</a>
rdar://105900204

Reviewed by Tim Nguyen.

WPT ref-tests are only check against a window of 800*600,
the rest of the page is ignored.

<a href="https://web-platform-tests.org/writing-tests/reftests.html#components-of-a-reftest">https://web-platform-tests.org/writing-tests/reftests.html#components-of-a-reftest</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic.html:

Canonical link: <a href="https://commits.webkit.org/260830@main">https://commits.webkit.org/260830@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af6d8cdb333c7a07fa38c46b19f0848a96cbcd50

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109550 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18673 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42303 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1043 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118690 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20139 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9870 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101822 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115305 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14994 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98220 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43207 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96966 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29873 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84977 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11409 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31216 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12071 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8152 "Found 1 new test failure: gamepad/gamepad-polling-access.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17433 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50820 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7508 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13808 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->