### PR TITLE
Remove windows code from build.webkit.org

### DIFF
--- a/Tools/CISupport/build-webkit-org/loadConfig_unittest.py
+++ b/Tools/CISupport/build-webkit-org/loadConfig_unittest.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2020-2021 Apple Inc. All rights reserved.
+# Copyright (C) 2020-2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -88,8 +88,8 @@ class TagsForBuilderTest(unittest.TestCase):
         self.verifyTags('32-EWS', ['32'])
         self.verifyTags('iOS-11-EWS', ['iOS'])
         self.verifyTags('iOS(11),(test)-EWS', ['iOS', 'test'])
-        self.verifyTags('Windows-EWS', ['Windows'])
-        self.verifyTags('Windows_Windows', ['Windows'])
+        self.verifyTags('iOS-EWS', ['iOS'])
+        self.verifyTags('iOS_iOS', ['iOS'])
         self.verifyTags('GTK-Build-EWS', ['GTK', 'Build'])
         self.verifyTags('GTK-WK2-Tests-EWS', ['GTK', 'WK2', 'Tests'])
         self.verifyTags('macOS-Sierra-Release-WK1-EWS', ['Sierra', 'Release', 'macOS', 'WK1'])

--- a/Tools/CISupport/delete-stale-build-files
+++ b/Tools/CISupport/delete-stale-build-files
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (C) 2013-2022 Apple Inc.  All rights reserved.
+# Copyright (C) 2013-2023 Apple Inc.  All rights reserved.
 # Copyright (C) 2012 Google Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -25,7 +25,6 @@
 
 import optparse
 import os
-import shutil
 import subprocess
 import sys
 
@@ -41,9 +40,6 @@ def main():
     if not options.platform:
         parser.error('Platform is required')
         return -1
-
-    if options.platform == 'win':
-        return deleteWindowsStaleFiles()
 
     if not options.configuration:
         parser.error('Configuration is required')
@@ -90,20 +86,6 @@ def webkitBuildDirectory(platform, fullPlatform, configuration):
         platform = 'device'
     return subprocess.Popen(['perl', os.path.join(os.path.dirname(__file__), "..", "Scripts", "webkit-build-directory"),
         "--" + platform, "--" + configuration, '--top-level'], stdout=subprocess.PIPE).communicate()[0].strip()
-
-def deleteWindowsStaleFiles():
-    directoriesToDelete = ['/cygdrive/c/Program Files (x86)/Windows Kits/10/Debuggers/x64/sym/WebKit.pdb',
-                           '/cygdrive/c/Program Files (x86)/Windows Kits/10/Debuggers/x64/sym/WTF.pdb',
-                           '/cygdrive/c/Program Files (x86)/Windows Kits/10/Debuggers/x64/sym/JavaScriptCore.pdb',
-                           '/cygdrive/c/Program Files (x86)/Windows Kits/10/Debuggers/x64/sym/DumpRenderTreeLib.pdb']
-    for directory in directoriesToDelete:
-        try:
-            print(f'Removing: {directory}')
-            shutil.rmtree(directory)
-        except OSError as e:
-            print(f'Failed to remove: {directory}, error: {e}')
-            continue
-        print('Done')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
#### dcfcca1924313cd7feacd61d0c65d86ce157a506
<pre>
Remove windows code from build.webkit.org
<a href="https://bugs.webkit.org/show_bug.cgi?id=252929">https://bugs.webkit.org/show_bug.cgi?id=252929</a>

Reviewed by Ryan Haddad.

As announced on webkit-dev, we are decommissioning the Apple Windows port.
We already removed the queues. We should remove the code specific to windows from build.webkit.org

* Tools/CISupport/build-webkit-org/loadConfig_unittest.py:
* Tools/CISupport/delete-stale-build-files:

Canonical link: <a href="https://commits.webkit.org/260817@main">https://commits.webkit.org/260817@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/465e2639f1b7f00539d7253127c47a044d04a623

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109540 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/18663 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/42295 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/1035 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/118684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113423 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/20130 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/9860 "Build was cancelled. Recent messages:Pull request contains relevant changes; Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/101814 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115295 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/20130 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/42295 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/101814 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/20130 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/42295 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/101814 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11399 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/42295 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12061 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/9860 "Build was cancelled. Recent messages:Pull request contains relevant changes; Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/108305 "Passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/17425 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/42295 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13798 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4085 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->