### PR TITLE
window.onload is repeatedly re-executed when changing URL fragment during onload

### DIFF
--- a/LayoutTests/http/tests/navigation/cross-origin-iframe-location-hash-reexecute-onload-expected.txt
+++ b/LayoutTests/http/tests/navigation/cross-origin-iframe-location-hash-reexecute-onload-expected.txt
@@ -1,0 +1,10 @@
+This tests that the load event is only fired twice when the location hash is changed in an embedded iframe's window.load.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS onload fired twice.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/navigation/cross-origin-iframe-location-hash-reexecute-onload.html
+++ b/LayoutTests/http/tests/navigation/cross-origin-iframe-location-hash-reexecute-onload.html
@@ -1,0 +1,27 @@
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+</head>
+<body>
+<script>
+description("This tests that the load event is only fired twice when the location hash is changed in an embedded iframe's window.load.");
+jsTestIsAsync = true;
+
+let onloadCount = 0;
+
+window.addEventListener("message", () => {
+    if (onloadCount == 2)
+        testPassed("onload fired twice.");
+    else
+        testFailed("onload fired " + onloadCount + " time(s).");
+
+    finishJSTest();
+});
+
+function onloadFired() {
+    onloadCount++;
+}
+</script>
+<iframe src="http://localhost:8000/navigation/resources/change-location-hash-onload.html" onload="onloadFired()"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/navigation/resources/change-location-hash-onload.html
+++ b/LayoutTests/http/tests/navigation/resources/change-location-hash-onload.html
@@ -1,0 +1,8 @@
+<html>
+<script>
+window.onload = () => {
+    window.location.hash = Math.random();
+    window.parent.postMessage("hashchange", "*");
+}
+</script>
+</html>

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1208,8 +1208,8 @@ void FrameLoader::loadInSameDocument(URL url, RefPtr<SerializedScriptValue> stat
     if (auto* parentFrame = dynamicDowncast<LocalFrame>(m_frame.tree().parent()); parentFrame
         && (m_frame.document()->processingLoadEvent() || m_frame.document()->loadEventFinished())
         && !m_frame.document()->securityOrigin().isSameOriginAs(parentFrame->document()->securityOrigin()))
-        m_frame.document()->dispatchWindowLoadEvent();
-    
+        m_frame.ownerElement()->dispatchEvent(Event::create(eventNames().loadEvent, Event::CanBubble::No, Event::IsCancelable::No));
+
     // FrameLoaderClient::didFinishLoad() tells the internal load delegate the load finished with no error
     m_client->didFinishLoad();
 }


### PR DESCRIPTION
#### e9dd88dee6734e6eb661f36d609bcf7fab47b936
<pre>
window.onload is repeatedly re-executed when changing URL fragment during onload
<a href="https://bugs.webkit.org/show_bug.cgi?id=252931">https://bugs.webkit.org/show_bug.cgi?id=252931</a>
rdar://105158419

Reviewed by Chris Dumez.

When a cross-origin iframe changes its fragment identifier while its load event is being processed,
we end up in a state where we will continually re-fire window.onload. We should fix this by only
firing the load event on the frame&apos;s owner element. This still addresses the concern the original
change fixed (259384@main), but without needing to always re-fire the window load event.

* LayoutTests/http/tests/navigation/cross-origin-iframe-location-hash-reexecute-onload-expected.txt: Added.
* LayoutTests/http/tests/navigation/cross-origin-iframe-location-hash-reexecute-onload.html: Added.
* LayoutTests/http/tests/navigation/resources/change-location-hash-onload.html: Added.
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::loadInSameDocument):

Canonical link: <a href="https://commits.webkit.org/260860@main">https://commits.webkit.org/260860@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc83ffd028764a2d6a853455dd4e0e6be0382801

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109582 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18706 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42334 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1070 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118714 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113466 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20172 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9903 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101852 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115338 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15016 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98246 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43227 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96988 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29899 "Found 1 new test failure: imported/w3c/web-platform-tests/preload/onerror-event.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84999 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11441 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31241 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12099 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8172 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17464 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50850 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7530 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13839 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->