### PR TITLE
Non-continuous SpeechRecognition returns multiple results, eventually gets stuck returning the same utterance

### DIFF
--- a/Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTask.mm
+++ b/Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTask.mm
@@ -217,12 +217,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)speechRecognitionTask:(SFSpeechRecognitionTask *)task didFinishRecognition:(SFSpeechRecognitionResult *)recognitionResult
 {
     ASSERT(isMainThread());
+
+    if (task.state == SFSpeechRecognitionTaskStateCanceling || (!_doMultipleRecognitions && task.state == SFSpeechRecognitionTaskStateCompleted))
+        return;
+
     [self callbackWithTranscriptions:recognitionResult.transcriptions isFinal:YES];
 
-    if (!_doMultipleRecognitions) {
-        [self sendSpeechEndIfNeeded];
-        [self sendEndIfNeeded];
-    }
+    if (!_doMultipleRecognitions)
+        [self stop];
 }
 
 - (void)speechRecognitionTaskWasCancelled:(SFSpeechRecognitionTask *)task


### PR DESCRIPTION
#### 68c30e63bd2664d632c899686f369678e11685a7
<pre>
Non-continuous SpeechRecognition returns multiple results, eventually gets stuck returning the same utterance
<a href="https://bugs.webkit.org/show_bug.cgi?id=252936">https://bugs.webkit.org/show_bug.cgi?id=252936</a>
rdar://105898841

Reviewed by Sihui Liu.

In non-continuous mode, our SpeechRecognizer behavior differs greatly from
other browsers and the spec: it returns multiple results, and returns all
utterances from the session in confidence order on each new recognition,
resulting in the &quot;most confident&quot; transcript getting &quot;stuck&quot; after a while.

* Source/WebCore/Modules/speech/cocoa/WebSpeechRecognizerTask.mm:
(-[WebSpeechRecognizerTaskImpl speechRecognitionTask:didFinishRecognition:]):
Explicitly stop the session once we get one recognition result when in non-continuous mode,
because this is not communicated to the Speech framework in any other way, so it
just keeps happily recognizing.

Also, avoid dispatching extraneous recognitions while we&apos;re cancelling,
or, more importantly, when we&apos;re stopping in non-continuous mode.

Canonical link: <a href="https://commits.webkit.org/260889@main">https://commits.webkit.org/260889@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11cb27c9f343148b8ad177c5296ea37b62fa08f5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109570 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18693 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42321 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1059 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118703 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113454 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20159 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9890 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101839 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115326 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15007 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98233 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43216 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96979 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29886 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/84988 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11429 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31229 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12088 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8163 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17453 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50835 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7552 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13827 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->