### PR TITLE
Caret painting should listen for change notifications

### DIFF
--- a/Source/WebCore/editing/FrameSelection.h
+++ b/Source/WebCore/editing/FrameSelection.h
@@ -271,7 +271,9 @@ public:
     CaretAnimator& caretAnimator() { return m_caretAnimator.get(); }
 
     const CaretAnimator& caretAnimator() const { return m_caretAnimator.get(); }
-
+#if PLATFORM(MAC)
+    WEBCORE_EXPORT void caretAnimatorInvalidated(CaretAnimatorType);
+#endif
 private:
     void updateSelectionAppearanceNow();
     void updateAndRevealSelection(const AXTextStateChangeIntent&, ScrollBehavior = ScrollBehavior::Instant, RevealExtentOption = RevealExtentOption::RevealExtent, ForceCenterScrollOption = ForceCenterScrollOption::DoNotForceCenterScroll);
@@ -320,7 +322,6 @@ private:
     void invalidateCaretRect();
 
     void caretAnimationDidUpdate(CaretAnimator&) final;
-    void caretAnimatorInvalidated(CaretAnimator&, CaretAnimatorType) final;
 
     Document* document() final;
 

--- a/Source/WebCore/platform/CaretAnimator.cpp
+++ b/Source/WebCore/platform/CaretAnimator.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "CaretAnimator.h"
 
+#include "GraphicsContext.h"
 #include "Page.h"
 
 namespace WebCore {
@@ -50,6 +51,16 @@ void CaretAnimator::scheduleAnimation()
 {
     if (auto* page = this->page())
         page->scheduleRenderingUpdate(RenderingUpdateStep::CaretAnimation);
+}
+
+void CaretAnimator::paint(const Node&, GraphicsContext& context, const FloatRect& caret, const Color& color, const LayoutPoint&) const
+{
+    context.fillRect(caret, color);
+}
+
+LayoutRect CaretAnimator::repaintCaretRectForLocalRect(LayoutRect rect) const
+{
+    return rect;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/CaretAnimator.h
+++ b/Source/WebCore/platform/CaretAnimator.h
@@ -31,21 +31,24 @@
 
 namespace WebCore {
 
-class CaretAnimator;
-class Document;
-class Page;
-
-enum class CaretAnimatorType {
+enum class CaretAnimatorType : uint8_t {
     Default,
     Alternate
 };
+
+class CaretAnimator;
+class Color;
+class Document;
+class FloatRect;
+class GraphicsContext;
+class Node;
+class Page;
 
 class CaretAnimationClient {
 public:
     virtual ~CaretAnimationClient() = default;
 
     virtual void caretAnimationDidUpdate(CaretAnimator&) { }
-    virtual void caretAnimatorInvalidated(CaretAnimator&, CaretAnimatorType) { }
     virtual LayoutRect localCaretRect() const = 0;
 
     virtual Document* document() = 0;
@@ -86,7 +89,9 @@ public:
     virtual void setVisible(bool) = 0;
 
     PresentationProperties presentationProperties() const { return m_presentationProperties; }
-    virtual CaretAnimatorType type() const { return CaretAnimatorType::Default; }
+    virtual void paint(const Node&, GraphicsContext&, const FloatRect&, const Color&, const LayoutPoint&) const;
+    virtual LayoutRect repaintCaretRectForLocalRect(LayoutRect) const;
+    virtual void addLine(float, float, TextDirection) const { }
 
 protected:
     explicit CaretAnimator(CaretAnimationClient& client)

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -85,7 +85,7 @@ namespace WebCore {
 #if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/RenderBlockAdditions.h>)
 #include <WebKitAdditions/RenderBlockAdditions.h>
 #else
-static bool renderCaretInsideContentsClip()
+inline static bool renderCaretInsideContentsClip()
 {
     return true;
 }

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -693,6 +693,7 @@ def headers_for_type(type):
         'WebCore::BezierCurveData': ['<WebCore/InlinePathData.h>'],
         'WebCore::BlendMode': ['<WebCore/GraphicsTypes.h>'],
         'WebCore::BrowsingContextGroupSwitchDecision': ['<WebCore/FrameLoaderTypes.h>'],
+        'WebCore::CaretAnimatorType': ['<WebCore/CaretAnimator.h>'],
         'WebCore::COEPDisposition': ['<WebCore/CrossOriginEmbedderPolicy.h>'],
         'WebCore::ColorSchemePreference': ['<WebCore/DocumentLoader.h>'],
         'WebCore::CompositeOperator': ['<WebCore/GraphicsTypes.h>'],

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4862,3 +4862,11 @@ header: <WebCore/AcceleratedEffect.h>
     std::optional<WTF::Seconds> holdTime();
 };
 #endif // ENABLE(THREADED_ANIMATION_RESOLUTION)
+
+#if PLATFORM(MAC)
+header: <WebCore/CaretAnimator.h>
+[CustomHeader] enum class WebCore::CaretAnimatorType : uint8_t {
+    Default,
+    Alternate,
+};
+#endif

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -10280,6 +10280,11 @@ void WebPageProxy::handleAutoplayEvent(WebCore::AutoplayEvent event, OptionSet<A
 }
 
 #if PLATFORM(MAC)
+void WebPageProxy::setCaretAnimatorType(WebCore::CaretAnimatorType caretType)
+{
+    send(Messages::WebPage::SetCaretAnimatorType(caretType));
+}
+
 void WebPageProxy::performImmediateActionHitTestAtLocation(FloatPoint point)
 {
     send(Messages::WebPage::PerformImmediateActionHitTestAtLocation(point));

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -275,6 +275,7 @@ class TextIndicator;
 class ValidationBubble;
 
 enum class AutoplayEvent : uint8_t;
+enum class CaretAnimatorType : uint8_t;
 enum class CookieConsentDecisionResult : uint8_t;
 enum class CreateNewGroupForHighlight : bool;
 enum class DataOwnerType : uint8_t;
@@ -1030,6 +1031,7 @@ public:
     void changeFont(WebCore::FontChanges&&);
 
 #if PLATFORM(MAC)
+    void setCaretAnimatorType(WebCore::CaretAnimatorType);
     void attributedSubstringForCharacterRangeAsync(const EditingRange&, CompletionHandler<void(const WebCore::AttributedString&, const EditingRange&)>&&);
 
     void startWindowDrag();

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -939,6 +939,8 @@ private:
 #if HAVE(TRANSLATION_UI_SERVICES) && ENABLE(CONTEXT_MENUS)
     WeakObjCPtr<NSPopover> m_lastContextMenuTranslationPopover;
 #endif
+
+    RetainPtr<NSObject> _textInputNotifications;
 };
     
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -1130,6 +1130,8 @@ static NSTrackingAreaOptions trackingAreaOptions()
     return options;
 }
 
+static RetainPtr<NSObject> subscribeToTextInputNotifications(WebViewImpl*);
+
 WebViewImpl::WebViewImpl(NSView <WebViewImplDelegate> *view, WKWebView *outerWebView, WebProcessPool& processPool, Ref<API::PageConfiguration>&& configuration)
     : m_view(view)
     , m_pageClient(makeUnique<PageClientImpl>(view, outerWebView))
@@ -1207,6 +1209,8 @@ WebViewImpl::WebViewImpl(NSView <WebViewImplDelegate> *view, WKWebView *outerWeb
 #if HAVE(NSSCROLLVIEW_SEPARATOR_TRACKING_ADAPTER)
     m_lastScrollViewFrame = scrollViewFrame();
 #endif
+
+    _textInputNotifications = subscribeToTextInputNotifications(this);
 
     WebProcessPool::statistics().wkViewCount++;
 }
@@ -3151,6 +3155,14 @@ NSTextCheckingTypes WebViewImpl::getTextCheckingTypes() const
     return NSTextCheckingTypeSpelling | NSTextCheckingTypeReplacement | NSTextCheckingTypeCorrection;
 }
 #endif
+
+#ifndef WEB_VIEW_IMPL_ADDITIONS_SUSCRIBE_TO_TEXT_INPUT_NOTIFICATIONS_DEFINED
+static RetainPtr<NSObject> subscribeToTextInputNotifications(WebViewImpl*)
+{
+    return nullptr;
+}
+#endif //  WEB_VIEW_IMPL_ADDITIONS_SUSCRIBE_TO_TEXT_INPUT_NOTIFICATIONS_DEFINED
+
 
 void WebViewImpl::requestCandidatesForSelectionIfNeeded()
 {

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -261,7 +261,9 @@ void WebPage::insertDictatedTextAsync(const String& text, const EditingRange& re
     if (focusedElement && options.shouldSimulateKeyboardInput)
         focusedElement->dispatchEvent(Event::create(eventNames().keydownEvent, Event::CanBubble::Yes, Event::IsCancelable::Yes));
 
-    ASSERT(!frame->editor().hasComposition());
+    if (frame->editor().hasComposition())
+        return;
+
     frame->editor().insertDictatedText(text, dictationAlternativeLocations, nullptr /* triggeringEvent */);
 
     if (focusedElement && options.shouldSimulateKeyboardInput) {

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5699,6 +5699,11 @@ void WebPage::stopSpeaking()
 #endif
 
 #if PLATFORM(MAC)
+void WebPage::setCaretAnimatorType(WebCore::CaretAnimatorType caretType)
+{
+    Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
+    frame->selection().caretAnimatorInvalidated(caretType);
+}
 
 RetainPtr<PDFDocument> WebPage::pdfDocumentForPrintingFrame(Frame* coreFrame)
 {

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -237,6 +237,7 @@ class VisiblePosition;
 
 enum SyntheticClickType : int8_t;
 enum class COEPDisposition : bool;
+enum class CaretAnimatorType : uint8_t;
 enum class CreateNewGroupForHighlight : bool;
 enum class DOMPasteAccessCategory : uint8_t;
 enum class DOMPasteAccessResponse : uint8_t;
@@ -1011,6 +1012,7 @@ public:
 #endif // PLATFORM(COCOA)
 
 #if PLATFORM(MAC)
+    void setCaretAnimatorType(WebCore::CaretAnimatorType);
     void attributedSubstringForCharacterRangeAsync(const EditingRange&, CompletionHandler<void(const WebCore::AttributedString&, const EditingRange&)>&&);
     void requestAcceptsFirstMouse(int eventNumber, const WebKit::WebMouseEvent&);
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -506,6 +506,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
 #if PLATFORM(MAC)
     AttributedSubstringForCharacterRangeAsync(struct WebKit::EditingRange range) -> (struct WebCore::AttributedString string, struct WebKit::EditingRange range)
     RequestAcceptsFirstMouse(int eventNumber, WebKit::WebMouseEvent event) AllowedWhenWaitingForSyncReplyDuringUnboundedIPC
+    SetCaretAnimatorType(enum:uint8_t WebCore::CaretAnimatorType caretType)
 #endif
 
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)


### PR DESCRIPTION
#### 67d841b77448d21fea79f6cff02908859b307eca
<pre>
Caret painting should listen for change notifications
<a href="https://bugs.webkit.org/show_bug.cgi?id=252879">https://bugs.webkit.org/show_bug.cgi?id=252879</a>
&lt;radar://105862690&gt;

Reviewed by Aditya Keerthi.

Addition refactoring that listens to notifications from the UI process.

* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::repaintCaretForLocalRect):
(WebCore::CaretBase::paintCaret const):
(WebCore::FrameSelection::caretAnimatorInvalidated):
Repaint the caret when it changes.

(WebCore::fillCaretRect): Deleted.
(WebCore::repaintCaretRectForLocalRect): Deleted.
Move some static functions into CaretAnimator.

* Source/WebCore/editing/FrameSelection.h:
* Source/WebCore/platform/CaretAnimator.cpp:
(WebCore::CaretAnimator::paint const):
(WebCore::CaretAnimator::repaintCaretRectForLocalRect const):
Move some static functions into CaretAnimator.

* Source/WebCore/platform/CaretAnimator.h:
(WebCore::CaretAnimationClient::caretAnimationDidUpdate):
(WebCore::CaretAnimationClient::caretAnimatorInvalidated): Deleted.
Renamed.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::setCaretAppearance):
Update the caret.

* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::WebViewImpl):
Listen for notifications.

* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::insertDictatedTextAsync):
This assertion is regularly triggered and igorning it results
in duplicated text insertion during dictation, so early return
when it is encountered which results in what appears to be correct
behavior.

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::setCaretAppearance):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
Allow UI process to signal caret appearance updates.

Canonical link: <a href="https://commits.webkit.org/261089@main">https://commits.webkit.org/261089@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b2c5859fff0535e1bc8fd8c05d55a058ef329e4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110542 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19624 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/43122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/1904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/119420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114491 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21053 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/10764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102774 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116284 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/43122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/43920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/113959 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/43122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/85793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12279 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/43122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12849 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/10764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18213 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/43122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7677 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14722 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->