### PR TITLE
Check for non-finite values in 'isPointInPathInternal' and 'isPointInStrokeInternal' functions

### DIFF
--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2008, 2010 Nokia Corporation and/or its subsidiary(-ies)
  * Copyright (C) 2007 Alp Toker <alp@atoker.com>
  * Copyright (C) 2008 Eric Seidel <eric@webkit.org>
@@ -1155,6 +1155,9 @@ bool CanvasRenderingContext2DBase::isPointInStroke(Path2D& path, double x, doubl
 
 bool CanvasRenderingContext2DBase::isPointInPathInternal(const Path& path, double x, double y, CanvasFillRule windingRule)
 {
+    if (!std::isfinite(x) || !std::isfinite(y))
+        return false;
+    
     if (!drawingContext())
         return false;
     auto& state = this->state();
@@ -1162,14 +1165,16 @@ bool CanvasRenderingContext2DBase::isPointInPathInternal(const Path& path, doubl
         return false;
 
     auto transformedPoint = valueOrDefault(state.transform.inverse()).mapPoint(FloatPoint(x, y));
-    if (!std::isfinite(transformedPoint.x()) || !std::isfinite(transformedPoint.y()))
-        return false;
+    ASSERT(std::isfinite(transformedPoint.x()) && std::isfinite(transformedPoint.y()));
 
     return path.contains(transformedPoint, toWindRule(windingRule));
 }
 
 bool CanvasRenderingContext2DBase::isPointInStrokeInternal(const Path& path, double x, double y)
 {
+    if (!std::isfinite(x) || !std::isfinite(y))
+        return false;
+
     if (!drawingContext())
         return false;
     auto& state = this->state();
@@ -1177,8 +1182,7 @@ bool CanvasRenderingContext2DBase::isPointInStrokeInternal(const Path& path, dou
         return false;
 
     auto transformedPoint = valueOrDefault(state.transform.inverse()).mapPoint(FloatPoint(x, y));
-    if (!std::isfinite(transformedPoint.x()) || !std::isfinite(transformedPoint.y()))
-        return false;
+    ASSERT(std::isfinite(transformedPoint.x()) && std::isfinite(transformedPoint.y()));
 
     return path.strokeContains(transformedPoint, [&state] (GraphicsContext& context) {
         context.setStrokeThickness(state.lineWidth);


### PR DESCRIPTION
#### 90fc0225ff3420961c296bf972f111c598e23d03
<pre>
Check for non-finite values in &apos;isPointInPathInternal&apos; and &apos;isPointInStrokeInternal&apos; functions

<a href="https://bugs.webkit.org/show_bug.cgi?id=250382">https://bugs.webkit.org/show_bug.cgi?id=250382</a>
rdar://problem/104331898

Reviewed by Said Abou-Hallawa.

This patch introduces check for non-finite values in &apos;isPointInPathInternal&apos; and &apos;isPointInStrokeInternal&apos; functions
by returning false. This is also extended to &apos;transformedPoint&apos; to have finite value by asserting above change.

* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(CanvasRenderingContext2DBase::isPointInPathInternal):
(CanvasRenderingContext2DBase::isPointInStrokeInternal):

Canonical link: <a href="https://commits.webkit.org/260946@main">https://commits.webkit.org/260946@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84cbebe6a88c3d11e90dd3303fc3cc3e679fec86

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109999 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19099 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42681 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1442 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119045 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113952 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20565 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10292 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102257 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115745 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15310 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98525 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43526 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97272 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30182 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85350 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11802 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31522 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12424 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8479 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17792 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51133 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7591 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14219 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->