### PR TITLE
Support loop OSR entry to and from BBQ baseline JIT

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -31,7 +31,7 @@
 
 namespace JSC { namespace Wasm {
 
-Expected<std::unique_ptr<InternalFunction>, String> parseAndCompileBBQ(CompilationContext&, Callee&, const FunctionData&, const TypeDefinition&, Vector<UnlinkedWasmToWasmCall>&, const ModuleInformation&, MemoryMode, uint32_t functionIndex, std::optional<bool> hasExceptionHandlers, TierUpCount* = nullptr);
+Expected<std::unique_ptr<InternalFunction>, String> parseAndCompileBBQ(CompilationContext&, Callee&, const FunctionData&, const TypeDefinition&, Vector<UnlinkedWasmToWasmCall>&, const ModuleInformation&, MemoryMode, uint32_t functionIndex, std::optional<bool> hasExceptionHandlers, unsigned, TierUpCount* = nullptr);
 
 } } // namespace JSC::Wasm
 

--- a/Source/JavaScriptCore/wasm/WasmFormat.h
+++ b/Source/JavaScriptCore/wasm/WasmFormat.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(WEBASSEMBLY)
 
+#include "CCallHelpers.h"
 #include "CodeLocation.h"
 #include "Identifier.h"
 #include "JSString.h"
@@ -546,6 +547,8 @@ struct InternalFunction {
     StackMaps stackmaps;
 #endif
     Vector<UnlinkedHandlerInfo> exceptionHandlers;
+    Vector<CCallHelpers::Label> bbqLoopEntrypoints;
+    std::optional<CCallHelpers::Label> bbqSharedLoopEntrypoint;
     Entrypoint entrypoint;
     unsigned osrEntryScratchBufferSize { 0 };
 };

--- a/Source/JavaScriptCore/wasm/WasmIRGeneratorHelpers.h
+++ b/Source/JavaScriptCore/wasm/WasmIRGeneratorHelpers.h
@@ -80,6 +80,11 @@ struct PatchpointExceptionHandle {
 static inline void computeExceptionHandlerAndLoopEntrypointLocations(Vector<CodeLocationLabel<ExceptionHandlerPtrTag>>& handlers, Vector<CodeLocationLabel<WasmEntryPtrTag>>& loopEntrypoints, const InternalFunction* function, const CompilationContext& context, LinkBuffer& linkBuffer)
 {
     if (!context.procedure) {
+        ASSERT(Options::useSinglePassBBQJIT());
+
+        for (auto label : function->bbqLoopEntrypoints)
+            loopEntrypoints.append(linkBuffer.locationOf<WasmEntryPtrTag>(label));
+
         unsigned index = 0;
         for (const UnlinkedHandlerInfo& handlerInfo : function->exceptionHandlers) {
             if (handlerInfo.m_type == HandlerType::Delegate) {

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -457,6 +457,60 @@ JSC_DEFINE_JIT_OPERATION(operationWasmTriggerOSREntryNow, void, (Probe::Context&
     return returnWithoutOSREntry();
 }
 
+JSC_DEFINE_JIT_OPERATION(operationWasmLoopOSREnterBBQJIT, void, (Probe::Context& context))
+{
+    TierUpCount& tierUp = *context.arg<TierUpCount*>();
+    uint64_t* osrEntryScratchBuffer = bitwise_cast<uint64_t*>(context.gpr(GPRInfo::argumentGPR0));
+    unsigned loopIndex = osrEntryScratchBuffer[0]; // First entry in scratch buffer is the loop index when tiering up to BBQ.
+
+    // We just populated the callee in the frame before we entered this operation, so let's use it.
+    CalleeBits calleeBits = *bitwise_cast<CalleeBits*>(bitwise_cast<uint8_t*>(context.fp()) + (unsigned)CallFrameSlot::callee * sizeof(Register));
+    BBQCallee& callee = *bitwise_cast<BBQCallee*>(calleeBits.asWasmCallee());
+
+    OSREntryData& entryData = tierUp.osrEntryData(loopIndex);
+    RELEASE_ASSERT(entryData.loopIndex() == loopIndex);
+    
+    const StackMap& stackMap = entryData.values();
+    auto writeValueToRep = [&](uint64_t encodedValue, const OSREntryValue& value) {
+        B3::Type type = value.type();
+        if (value.isGPR()) {
+            ASSERT(!type.isFloat() && !type.isVector());
+            context.gpr(value.gpr()) = encodedValue;
+        } else if (value.isFPR()) {
+            ASSERT(type.isFloat()); // We don't expect vectors from LLInt right now.
+            context.fpr(value.fpr()) = encodedValue;
+        } else if (value.isStack()) {
+            auto* baseStore = bitwise_cast<uint8_t*>(context.fp()) + value.offsetFromFP();
+            switch (type.kind()) {
+            case B3::Int32:
+                *bitwise_cast<uint32_t*>(baseStore) = static_cast<uint32_t>(encodedValue);
+                break;
+            case B3::Int64:
+                *bitwise_cast<uint64_t*>(baseStore) = encodedValue;
+                break;
+            case B3::Float:
+                *bitwise_cast<float*>(baseStore) = bitwise_cast<float>(static_cast<uint32_t>(encodedValue));
+                break;
+            case B3::Double:
+                *bitwise_cast<double*>(baseStore) = bitwise_cast<double>(encodedValue);
+                break;
+            case B3::V128:
+                RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("We shouldn't be receiving v128 values when tiering up from LLInt into BBQ.");
+                break;
+            default:
+                RELEASE_ASSERT_NOT_REACHED();
+                break;
+            }
+        }
+    };
+
+    unsigned indexInScratchBuffer = BBQCallee::extraOSRValuesForLoopIndex;
+    for (const auto& entry : stackMap)
+        writeValueToRep(osrEntryScratchBuffer[indexInScratchBuffer ++], entry);
+
+    context.gpr(GPRInfo::nonPreservedNonArgumentGPR0) = bitwise_cast<UCPURegister>(callee.loopEntrypoints()[loopIndex].taggedPtr());
+}
+
 JSC_DEFINE_JIT_OPERATION(operationWasmTriggerTierUpNow, void, (Instance* instance, uint32_t functionIndex))
 {
     Wasm::CalleeGroup& calleeGroup = *instance->calleeGroup();

--- a/Source/JavaScriptCore/wasm/WasmOperations.h
+++ b/Source/JavaScriptCore/wasm/WasmOperations.h
@@ -51,6 +51,7 @@ typedef int64_t EncodedWasmValue;
 #if ENABLE(WEBASSEMBLY_B3JIT)
 void loadValuesIntoBuffer(Probe::Context&, const StackMap&, uint64_t* buffer, SavedFPWidth);
 JSC_DECLARE_JIT_OPERATION(operationWasmTriggerOSREntryNow, void, (Probe::Context&));
+JSC_DECLARE_JIT_OPERATION(operationWasmLoopOSREnterBBQJIT, void, (Probe::Context&));
 JSC_DECLARE_JIT_OPERATION(operationWasmTriggerTierUpNow, void, (Instance*, uint32_t functionIndex));
 #endif
 JSC_DECLARE_JIT_OPERATION(operationWasmUnwind, void*, (Instance*));

--- a/Source/JavaScriptCore/wasm/WasmTierUpCount.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTierUpCount.cpp
@@ -45,6 +45,11 @@ OSREntryData& TierUpCount::addOSREntryData(uint32_t functionIndex, uint32_t loop
     return *m_osrEntryData.last().get();
 }
 
+OSREntryData& TierUpCount::osrEntryData(uint32_t loopIndex)
+{
+    return *m_osrEntryData[loopIndex];
+}
+
 } } // namespace JSC::Wasm
 
 #endif // ENABLE(WEBASSEMBLY_B3JIT)

--- a/Source/JavaScriptCore/wasm/WasmTierUpCount.h
+++ b/Source/JavaScriptCore/wasm/WasmTierUpCount.h
@@ -70,6 +70,7 @@ public:
     Lock& getLock() { return m_lock; }
 
     OSREntryData& addOSREntryData(uint32_t functionIndex, uint32_t loopIndex, StackMap&&);
+    OSREntryData& osrEntryData(uint32_t loopIndex);
 
     void optimizeAfterWarmUp(uint32_t functionIndex)
     {


### PR DESCRIPTION
#### c428fc6916fa86f12d0fa545d3577ce3e0438143
<pre>
Support loop OSR entry to and from BBQ baseline JIT
<a href="https://bugs.webkit.org/show_bug.cgi?id=252939">https://bugs.webkit.org/show_bug.cgi?id=252939</a>
rdar://105909610

Reviewed by Yusuke Suzuki and Justin Michaud.

Adds support for loop OSR entry tier-up to the new BBQ baseline JIT.
This lets us tier up from single-pass BBQ compiled code into OMG, or
tier up from LLInt into the new BBQ compiler.

To facilitate tiering up into OMG, we now generate a stackmap for every
WASM loop, and perform a tier-up check at the loop start. When this
exceeds a certain threshold, we trigger an OMG tier up, largely reusing
the existing machinery.

For tiering up from LLInt, it&apos;s a bit more involved. The existing Air
backend generates unique entrypoints for every loop index, and the B3
backend generates unique compilations for every loop index. To avoid
using a lot of executable memory, BBQ now generates a single shared
loop entrypoint, which sets up the call frame and then calls into an
operation. This operation looks up the stack map and label for the target
loop index in the BBQ callee, sets up the BBQ locals and temps using a
probe, then returns the label address back to our function, where we can
indirectly jump to it.

* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
* Source/JavaScriptCore/wasm/WasmBBQJIT.h:
* Source/JavaScriptCore/wasm/WasmBBQPlan.cpp:
(JSC::Wasm::BBQPlan::work):
(JSC::Wasm::BBQPlan::compileFunction):
(JSC::Wasm::BBQPlan::initializeCallees):
* Source/JavaScriptCore/wasm/WasmCallee.h:
* Source/JavaScriptCore/wasm/WasmFormat.h:
* Source/JavaScriptCore/wasm/WasmIRGeneratorHelpers.h:
(JSC::Wasm::computeExceptionHandlerAndLoopEntrypointLocations):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/wasm/WasmOperations.h:
* Source/JavaScriptCore/wasm/WasmSlowPaths.cpp:
(JSC::LLInt::WASM_SLOW_PATH_DECL):
* Source/JavaScriptCore/wasm/WasmTierUpCount.cpp:
(JSC::Wasm::TierUpCount::osrEntryData):
* Source/JavaScriptCore/wasm/WasmTierUpCount.h:

Canonical link: <a href="https://commits.webkit.org/260955@main">https://commits.webkit.org/260955@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f640a66e84ff220df0e63f50ad98dfa4ce4f56ac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110071 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19172 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42747 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1510 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/119094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20638 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10364 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102330 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115817 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/43586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/30232 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/85417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/98865 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11872 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31570 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/99812 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/9913 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12494 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31186 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17859 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51185 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/107832 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7598 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14290 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26598 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->