### PR TITLE
Fix a couple of memory leaks after 260826@main

### DIFF
--- a/Tools/TestWebKitAPI/Tests/mac/FontManagerTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/FontManagerTests.mm
@@ -198,11 +198,11 @@ TEST(FontManagerTests, ChangeFontWithPanel)
     [webView waitForNextPresentationUpdate];
 
     auto expectSameAttributes = [](NSFont *font1, NSFont *font2) {
-        NSMutableDictionary<NSFontDescriptorAttributeName, id> *fontAttributes1 = font1.fontDescriptor.fontAttributes.mutableCopy;
-        NSMutableDictionary<NSFontDescriptorAttributeName, id> *fontAttributes2 = font2.fontDescriptor.fontAttributes.mutableCopy;
+        auto fontAttributes1 = adoptNS(font1.fontDescriptor.fontAttributes.mutableCopy);
+        auto fontAttributes2 = adoptNS(font2.fontDescriptor.fontAttributes.mutableCopy);
         [fontAttributes1 removeObjectForKey:NSFontVariationAttribute];
         [fontAttributes2 removeObjectForKey:NSFontVariationAttribute];
-        BOOL attributesAreEqual = [fontAttributes1 isEqualToDictionary:fontAttributes2];
+        BOOL attributesAreEqual = [fontAttributes1 isEqualToDictionary:fontAttributes2.get()];
         EXPECT_TRUE(attributesAreEqual);
         if (!attributesAreEqual)
             NSLog(@"Expected %@ to have the same attributes as %@", font1, font2);


### PR DESCRIPTION
#### 6d701f331859f7ab05bd58c9931cc921297db3e7
<pre>
Fix a couple of memory leaks after 260826@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=252922">https://bugs.webkit.org/show_bug.cgi?id=252922</a>

Reviewed by Aditya Keerthi.

Use `adoptNS()` to avoid leaking the +1 dictionaries, returned from `-mutableCopy`.

* Tools/TestWebKitAPI/Tests/mac/FontManagerTests.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/260841@main">https://commits.webkit.org/260841@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f2f817dd0d1c0d90f7b09fed30aee7d637e13d5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109583 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18707 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42335 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1071 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118715 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113467 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20173 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9904 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101853 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115339 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15017 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98248 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43228 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96989 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29901 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85012 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11442 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31243 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12100 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8173 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17465 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50852 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7518 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13840 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->