### PR TITLE
Crash under PowerObserver::didReceiveSystemPowerNotification()

### DIFF
--- a/Source/WebCore/platform/mac/PowerObserverMac.cpp
+++ b/Source/WebCore/platform/mac/PowerObserverMac.cpp
@@ -65,8 +65,10 @@ void PowerObserver::didReceiveSystemPowerNotification(io_service_t, uint32_t mes
         return;
 
     // We need to restart the timer on the main thread.
+    WeakPtr weakThis { *this };
     CFRunLoopPerformBlock(CFRunLoopGetMain(), kCFRunLoopCommonModes, ^() {
-        m_powerOnHander();
+        if (weakThis)
+            weakThis->m_powerOnHander();
     });
 }
 

--- a/Source/WebCore/platform/mac/PowerObserverMac.h
+++ b/Source/WebCore/platform/mac/PowerObserverMac.h
@@ -31,10 +31,11 @@
 #import <wtf/Function.h>
 #import <wtf/Noncopyable.h>
 #import <wtf/OSObjectPtr.h>
+#import <wtf/WeakPtr.h>
 
 namespace WebCore {
 
-class PowerObserver {
+class PowerObserver : public CanMakeWeakPtr<PowerObserver, WeakPtrFactoryInitialization::Eager> {
     WTF_MAKE_NONCOPYABLE(PowerObserver); WTF_MAKE_FAST_ALLOCATED;
 
 public:


### PR DESCRIPTION
#### 624d3538fd22d2a7e7a14f4937daf64f5361d9e7
<pre>
Crash under PowerObserver::didReceiveSystemPowerNotification()
<a href="https://bugs.webkit.org/show_bug.cgi?id=252940">https://bugs.webkit.org/show_bug.cgi?id=252940</a>
rdar://90891509

Reviewed by David Kilzer.

Make sure `this` is still alive when we execute the block on the main thread,
before running m_powerOnHander.

* Source/WebCore/platform/mac/PowerObserverMac.cpp:
(WebCore::PowerObserver::didReceiveSystemPowerNotification):
* Source/WebCore/platform/mac/PowerObserverMac.h:

Canonical link: <a href="https://commits.webkit.org/260835@main">https://commits.webkit.org/260835@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fdd778a1538d19ffb32d83d3198ee222f95e82b7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109584 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18708 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42336 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1072 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118716 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113470 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20174 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9905 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101854 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115340 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15018 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98247 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43229 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96990 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29900 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85001 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11443 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31242 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12101 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8174 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17466 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50851 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7514 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13841 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->