### PR TITLE
Add URLSearchParams's size

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/url/urlsearchparams-size.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/urlsearchparams-size.any-expected.txt
@@ -1,0 +1,6 @@
+
+PASS URLSearchParams's size and deletion
+PASS URLSearchParams's size and addition
+PASS URLSearchParams's size when obtained from a URL
+PASS URLSearchParams's size when obtained from a URL and using .search
+

--- a/LayoutTests/imported/w3c/web-platform-tests/url/urlsearchparams-size.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/urlsearchparams-size.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/url/urlsearchparams-size.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/urlsearchparams-size.any.js
@@ -1,0 +1,34 @@
+test(() => {
+  const params = new URLSearchParams("a=1&b=2&a=3");
+  assert_equals(params.size, 3);
+
+  params.delete("a");
+  assert_equals(params.size, 1);
+}, "URLSearchParams's size and deletion");
+
+test(() => {
+  const params = new URLSearchParams("a=1&b=2&a=3");
+  assert_equals(params.size, 3);
+
+  params.append("b", "4");
+  assert_equals(params.size, 4);
+}, "URLSearchParams's size and addition");
+
+test(() => {
+  const url = new URL("http://localhost/query?a=1&b=2&a=3");
+  assert_equals(url.searchParams.size, 3);
+
+  url.searchParams.delete("a");
+  assert_equals(url.searchParams.size, 1);
+
+  url.searchParams.append("b", 4);
+  assert_equals(url.searchParams.size, 2);
+}, "URLSearchParams's size when obtained from a URL");
+
+test(() => {
+  const url = new URL("http://localhost/query?a=1&b=2&a=3");
+  assert_equals(url.searchParams.size, 3);
+
+  url.search = "?";
+  assert_equals(url.searchParams.size, 0);
+}, "URLSearchParams's size when obtained from a URL and using .search");

--- a/LayoutTests/imported/w3c/web-platform-tests/url/urlsearchparams-size.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/urlsearchparams-size.any.worker-expected.txt
@@ -1,0 +1,6 @@
+
+PASS URLSearchParams's size and deletion
+PASS URLSearchParams's size and addition
+PASS URLSearchParams's size when obtained from a URL
+PASS URLSearchParams's size when obtained from a URL and using .search
+

--- a/LayoutTests/imported/w3c/web-platform-tests/url/urlsearchparams-size.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/urlsearchparams-size.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/Source/WebCore/html/URLSearchParams.h
+++ b/Source/WebCore/html/URLSearchParams.h
@@ -44,6 +44,8 @@ public:
         return adoptRef(*new URLSearchParams(string, associatedURL));
     }
 
+    size_t size() const { return m_pairs.size(); }
+
     void append(const String& name, const String& value);
     void remove(const String& name);
     String get(const String& name) const;

--- a/Source/WebCore/html/URLSearchParams.idl
+++ b/Source/WebCore/html/URLSearchParams.idl
@@ -28,6 +28,8 @@
 ] interface URLSearchParams {
     constructor(optional (sequence<sequence<USVString>> or record<USVString, USVString> or USVString) init = "");
 
+    readonly attribute unsigned long size;
+
     undefined append(USVString name, USVString value);
     [ImplementedAs=remove] undefined delete(USVString name);
     USVString? get(USVString name);


### PR DESCRIPTION
#### 2f4844a6f100a68a14c7682108916b4fd1df787a
<pre>
Add URLSearchParams&apos;s size
<a href="https://bugs.webkit.org/show_bug.cgi?id=252749">https://bugs.webkit.org/show_bug.cgi?id=252749</a>
rdar://105781287

Reviewed by Darin Adler.

Add support for URLSearchParams.size:
- <a href="https://github.com/whatwg/url/pull/734">https://github.com/whatwg/url/pull/734</a>
- <a href="https://github.com/web-platform-tests/wpt/pull/38655">https://github.com/web-platform-tests/wpt/pull/38655</a>

* LayoutTests/imported/w3c/web-platform-tests/url/urlsearchparams-size.any-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/url/urlsearchparams-size.any.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/url/urlsearchparams-size.any.js: Added.
(test):
* LayoutTests/imported/w3c/web-platform-tests/url/urlsearchparams-size.any.worker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/url/urlsearchparams-size.any.worker.html: Added.
* Source/WebCore/html/URLSearchParams.h:
(WebCore::URLSearchParams::size const):
* Source/WebCore/html/URLSearchParams.idl:

Canonical link: <a href="https://commits.webkit.org/260836@main">https://commits.webkit.org/260836@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7e6cf2a8b5453005e9addd728070758c2ad94ec

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109589 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18713 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42341 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1077 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118720 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113481 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20179 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9910 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101860 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115345 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15021 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98251 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43232 "Found 1 new test failure: webgl/2.0.0/conformance2/textures/image_bitmap_from_video/tex-2d-r8ui-red_integer-unsigned_byte.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/96993 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29904 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85004 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11448 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31246 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12106 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8178 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17471 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50855 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7515 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13846 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->