### PR TITLE
Update Node.lookupNamespaceURI() and XPathEvaluatorBase.createNSResolver()

### DIFF
--- a/LayoutTests/dom/xhtml/level3/core/nodelookupnamespaceuri16.js
+++ b/LayoutTests/dom/xhtml/level3/core/nodelookupnamespaceuri16.js
@@ -77,7 +77,7 @@ function loadComplete() {
 /**
 * 
 	Invoke lookupNamespaceURI on a new Attribute node with with a namespace URI
-	and prefix and verify if the namespaceURI returned is null.
+	and prefix and verify if the namespaceURI returned is correct.
 
 * @author IBM
 * @author Neil Delima
@@ -101,7 +101,7 @@ function nodelookupnamespaceuri16() {
       attr = doc.createAttributeNS("http://www.w3.org/XML/1998/namespace","xml:lang");
       attNode = elem.setAttributeNodeNS(attr);
       namespaceURI = attr.lookupNamespaceURI("xml");
-      assertNull("nodelookupnamespaceuri16",namespaceURI);
+      assertEquals("nodelookupnamespaceuri16","http://www.w3.org/XML/1998/namespace",namespaceURI);
     
 }
 

--- a/LayoutTests/fast/dom/gc-9-expected.txt
+++ b/LayoutTests/fast/dom/gc-9-expected.txt
@@ -37,8 +37,6 @@ PASS: document.styleSheets[0].cssRules.myCustomProperty should be 1 and is.
 PASS: document.styleSheets[0].cssRules[0].myCustomProperty should be 1 and is.
 PASS: new XPathEvaluator().myCustomProperty should be undefined and is.
 PASS: new XPathEvaluator().evaluate('/', document, null, 0, null).myCustomProperty should be undefined and is.
-PASS: document.createNSResolver(document).myCustomProperty should be undefined and is.
-PASS: document.createExpression('/', document.createNSResolver(document)).myCustomProperty should be undefined and is.
 DOM OBJECTS AFTER GARBAGE COLLECTION:
 PASS: document.implementation.myCustomProperty should be 1 and is.
 PASS: document.myCustomProperty should be 1 and is.
@@ -72,8 +70,6 @@ PASS: document.styleSheets[0].cssRules.myCustomProperty should be 1 and is.
 PASS: document.styleSheets[0].cssRules[0].myCustomProperty should be 1 and is.
 PASS: new XPathEvaluator().myCustomProperty should be undefined and is.
 PASS: new XPathEvaluator().evaluate('/', document, null, 0, null).myCustomProperty should be undefined and is.
-PASS: document.createNSResolver(document).myCustomProperty should be undefined and is.
-PASS: document.createExpression('/', document.createNSResolver(document)).myCustomProperty should be undefined and is.
 DOM EVENT BEFORE GARBAGE COLLECTION
 PASS: event.myCustomProperty should be 1 and is.
 DOM EVENT AFTER GARBAGE COLLECTION

--- a/LayoutTests/fast/dom/gc-9.html
+++ b/LayoutTests/fast/dom/gc-9.html
@@ -150,8 +150,6 @@ var objectsToTest = [
 
     [ "new XPathEvaluator()" ], // XPathEvaluator
     [ "new XPathEvaluator().evaluate('/', document, null, 0, null)" ], // XPathResult
-    [ "document.createNSResolver(document)" ], // XPathNSResolver
-    [ "document.createExpression('/', document.createNSResolver(document))" ] // XPathExpression
 
     // should not cache: NodeIterator, NodeFilter, TreeWalker, XMLHttpRequest
     // add to test: DOMRect, MediaList, Counter, Range

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/Node-lookupNamespaceURI-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/Node-lookupNamespaceURI-expected.txt
@@ -4,6 +4,7 @@ LookupNamespaceURI and IsDefaultNamespace
 PASS DocumentFragment should have null namespace, prefix null
 PASS DocumentFragment should have null namespace, prefix ""
 PASS DocumentFragment should have null namespace, prefix "foo"
+PASS DocumentFragment should have null namespace, prefix "xml"
 PASS DocumentFragment should have null namespace, prefix "xmlns"
 PASS DocumentFragment is in default namespace, prefix null
 PASS DocumentFragment is in default namespace, prefix ""
@@ -12,6 +13,7 @@ PASS DocumentFragment is in default namespace, prefix "xmlns"
 PASS DocumentType should have null namespace, prefix null
 PASS DocumentType should have null namespace, prefix ""
 PASS DocumentType should have null namespace, prefix "foo"
+PASS DocumentType should have null namespace, prefix "xml"
 PASS DocumentType should have null namespace, prefix "xmlns"
 PASS DocumentType is in default namespace, prefix null
 PASS DocumentType is in default namespace, prefix ""
@@ -20,7 +22,8 @@ PASS DocumentType is in default namespace, prefix "xmlns"
 PASS Element should have null namespace, prefix null
 PASS Element should have null namespace, prefix ""
 PASS Element should not have namespace matching prefix with namespaceURI value
-PASS Element should not have XMLNS namespace
+PASS Element should have XML namespace
+PASS Element should have XMLNS namespace
 PASS Element has namespace URI matching prefix
 PASS Empty namespace is not default, prefix null
 PASS Empty namespace is not default, prefix ""
@@ -28,7 +31,7 @@ PASS fooNamespace is not default
 PASS xmlns namespace is not default
 PASS Element should have baz namespace, prefix null
 PASS Element should have baz namespace, prefix ""
-PASS Element does not has namespace with xlmns prefix
+PASS Element should have namespace with xmlns prefix
 PASS Element has bar namespace
 PASS Empty namespace is not default on fooElem, prefix null
 PASS Empty namespace is not default on fooElem, prefix ""
@@ -46,7 +49,7 @@ PASS For comment, inherited bar namespace is not default
 PASS For comment, inherited baz namespace is default
 PASS Child element should inherit baz namespace
 PASS Child element should have null namespace
-PASS Child element should not have XMLNS namespace
+PASS Child element should have XMLNS namespace
 PASS Child element has namespace URI matching prefix
 PASS Empty namespace is not default for child, prefix null
 PASS Empty namespace is not default for child, prefix ""
@@ -66,5 +69,11 @@ PASS For document, xmlns namespace is not default
 PASS For document, bar namespace is not default
 PASS For document, baz namespace is not default
 PASS For document, xhtml namespace is default
+PASS Document without documentElement has no namespace URI matching "xml"
+PASS Document without documentElement has no namespace URI matching "xmlns"
+PASS Disconnected Attr has no namespace URI matching "xml"
+PASS Disconnected Attr has no namespace URI matching "xmlns"
+PASS Connected Attr has namespace URI matching "xml"
+PASS Connected Attr no namespace URI matching "xmlns"
 PASS Comment does not have bar namespace
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/Node-lookupNamespaceURI.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/Node-lookupNamespaceURI.html
@@ -26,6 +26,7 @@ var frag = document.createDocumentFragment();
 lookupNamespaceURI(frag, null, null, 'DocumentFragment should have null namespace, prefix null');
 lookupNamespaceURI(frag, '', null, 'DocumentFragment should have null namespace, prefix ""');
 lookupNamespaceURI(frag, 'foo', null, 'DocumentFragment should have null namespace, prefix "foo"');
+lookupNamespaceURI(frag, 'xml', null, 'DocumentFragment should have null namespace, prefix "xml"');
 lookupNamespaceURI(frag, 'xmlns', null, 'DocumentFragment should have null namespace, prefix "xmlns"');
 isDefaultNamespace(frag, null, true, 'DocumentFragment is in default namespace, prefix null');
 isDefaultNamespace(frag, '', true, 'DocumentFragment is in default namespace, prefix ""');
@@ -36,6 +37,7 @@ var docType = document.doctype;
 lookupNamespaceURI(docType, null, null, 'DocumentType should have null namespace, prefix null');
 lookupNamespaceURI(docType, '', null, 'DocumentType should have null namespace, prefix ""');
 lookupNamespaceURI(docType, 'foo', null, 'DocumentType should have null namespace, prefix "foo"');
+lookupNamespaceURI(docType, 'xml', null, 'DocumentType should have null namespace, prefix "xml"');
 lookupNamespaceURI(docType, 'xmlns', null, 'DocumentType should have null namespace, prefix "xmlns"');
 isDefaultNamespace(docType, null, true, 'DocumentType is in default namespace, prefix null');
 isDefaultNamespace(docType, '', true, 'DocumentType is in default namespace, prefix ""');
@@ -44,23 +46,25 @@ isDefaultNamespace(docType, 'xmlns', false, 'DocumentType is in default namespac
 
 var fooElem = document.createElementNS('fooNamespace', 'prefix:elem');
 fooElem.setAttribute('bar', 'value');
-
+const XMLNS_NS = 'http://www.w3.org/2000/xmlns/';
+const XML_NS =  'http://www.w3.org/XML/1998/namespace';
 lookupNamespaceURI(fooElem, null, null, 'Element should have null namespace, prefix null');
 lookupNamespaceURI(fooElem, '', null, 'Element should have null namespace, prefix ""');
 lookupNamespaceURI(fooElem, 'fooNamespace', null, 'Element should not have namespace matching prefix with namespaceURI value');
-lookupNamespaceURI(fooElem, 'xmlns', null, 'Element should not have XMLNS namespace');
+lookupNamespaceURI(fooElem, 'xml', XML_NS, 'Element should have XML namespace');
+lookupNamespaceURI(fooElem, 'xmlns', XMLNS_NS, 'Element should have XMLNS namespace');
 lookupNamespaceURI(fooElem, 'prefix', 'fooNamespace', 'Element has namespace URI matching prefix');
 isDefaultNamespace(fooElem, null, true, 'Empty namespace is not default, prefix null');
 isDefaultNamespace(fooElem, '', true, 'Empty namespace is not default, prefix ""');
 isDefaultNamespace(fooElem, 'fooNamespace', false, 'fooNamespace is not default');
-isDefaultNamespace(fooElem, 'http://www.w3.org/2000/xmlns/', false, 'xmlns namespace is not default');
+isDefaultNamespace(fooElem, XMLNS_NS, false, 'xmlns namespace is not default');
 
-fooElem.setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:bar', 'barURI');
-fooElem.setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns', 'bazURI');
+fooElem.setAttributeNS(XMLNS_NS, 'xmlns:bar', 'barURI');
+fooElem.setAttributeNS(XMLNS_NS, 'xmlns', 'bazURI');
 
 lookupNamespaceURI(fooElem, null, 'bazURI', 'Element should have baz namespace, prefix null');
 lookupNamespaceURI(fooElem, '', 'bazURI', 'Element should have baz namespace, prefix ""');
-lookupNamespaceURI(fooElem, 'xmlns', null, 'Element does not has namespace with xlmns prefix');
+lookupNamespaceURI(fooElem, 'xmlns', XMLNS_NS, 'Element should have namespace with xmlns prefix');
 lookupNamespaceURI(fooElem, 'bar', 'barURI', 'Element has bar namespace');
 
 isDefaultNamespace(fooElem, null, false, 'Empty namespace is not default on fooElem, prefix null');
@@ -79,7 +83,7 @@ lookupNamespaceURI(comment, 'bar', 'barURI', 'Comment should inherit bar namespa
 isDefaultNamespace(comment, null, false, 'For comment, empty namespace is not default, prefix null');
 isDefaultNamespace(comment, '', false, 'For comment, empty namespace is not default, prefix ""');
 isDefaultNamespace(comment, 'fooNamespace', false, 'For comment, fooNamespace is not default');
-isDefaultNamespace(comment, 'http://www.w3.org/2000/xmlns/', false, 'For comment, xmlns namespace is not default');
+isDefaultNamespace(comment, XMLNS_NS, false, 'For comment, xmlns namespace is not default');
 isDefaultNamespace(comment, 'barURI', false, 'For comment, inherited bar namespace is not default');
 isDefaultNamespace(comment, 'bazURI', true, 'For comment, inherited baz namespace is default');
 
@@ -88,19 +92,19 @@ fooElem.appendChild(fooChild);
 
 lookupNamespaceURI(fooChild, null, 'childNamespace', 'Child element should inherit baz namespace');
 lookupNamespaceURI(fooChild, '', 'childNamespace', 'Child element should have null namespace');
-lookupNamespaceURI(fooChild, 'xmlns', null, 'Child element should not have XMLNS namespace');
+lookupNamespaceURI(fooChild, 'xmlns', XMLNS_NS, 'Child element should have XMLNS namespace');
 lookupNamespaceURI(fooChild, 'prefix', 'fooNamespace', 'Child element has namespace URI matching prefix');
 
 isDefaultNamespace(fooChild, null, false, 'Empty namespace is not default for child, prefix null');
 isDefaultNamespace(fooChild, '', false, 'Empty namespace is not default for child, prefix ""');
 isDefaultNamespace(fooChild, 'fooNamespace', false, 'fooNamespace is not default for child');
-isDefaultNamespace(fooChild, 'http://www.w3.org/2000/xmlns/', false, 'xmlns namespace is not default for child');
+isDefaultNamespace(fooChild, XMLNS_NS, false, 'xmlns namespace is not default for child');
 isDefaultNamespace(fooChild, 'barURI', false, 'bar namespace is not default for child');
 isDefaultNamespace(fooChild, 'bazURI', false, 'baz namespace is default for child');
 isDefaultNamespace(fooChild, 'childNamespace', true, 'childNamespace is default for child');
 
-document.documentElement.setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:bar', 'barURI');
-document.documentElement.setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns', 'bazURI');
+document.documentElement.setAttributeNS(XMLNS_NS, 'xmlns:bar', 'barURI');
+document.documentElement.setAttributeNS(XMLNS_NS, 'xmlns', 'bazURI');
 
 lookupNamespaceURI(document, null, 'http://www.w3.org/1999/xhtml', 'Document should have xhtml namespace, prefix null');
 lookupNamespaceURI(document, '', 'http://www.w3.org/1999/xhtml', 'Document should have xhtml namespace, prefix ""');
@@ -110,10 +114,21 @@ lookupNamespaceURI(document, 'bar', 'barURI', 'Document has bar namespace');
 isDefaultNamespace(document, null, false, 'For document, empty namespace is not default, prefix null');
 isDefaultNamespace(document, '', false, 'For document, empty namespace is not default, prefix ""');
 isDefaultNamespace(document, 'fooNamespace', false, 'For document, fooNamespace is not default');
-isDefaultNamespace(document, 'http://www.w3.org/2000/xmlns/', false, 'For document, xmlns namespace is not default');
+isDefaultNamespace(document, XMLNS_NS, false, 'For document, xmlns namespace is not default');
 isDefaultNamespace(document, 'barURI', false, 'For document, bar namespace is not default');
 isDefaultNamespace(document, 'bazURI', false, 'For document, baz namespace is not default');
 isDefaultNamespace(document, 'http://www.w3.org/1999/xhtml', true, 'For document, xhtml namespace is default');
+
+const doc = new Document();
+lookupNamespaceURI(doc, 'xml', null, 'Document without documentElement has no namespace URI matching "xml"');
+lookupNamespaceURI(doc, 'xmlns', null, 'Document without documentElement has no namespace URI matching "xmlns"');
+
+const attr = document.createAttribute('foo');
+lookupNamespaceURI(attr, 'xml', null, 'Disconnected Attr has no namespace URI matching "xml"');
+lookupNamespaceURI(attr, 'xmlns', null, 'Disconnected Attr has no namespace URI matching "xmlns"');
+document.body.setAttributeNode(attr);
+lookupNamespaceURI(attr, 'xml', XML_NS, 'Connected Attr has namespace URI matching "xml"');
+lookupNamespaceURI(attr, 'xmlns', XMLNS_NS, 'Connected Attr no namespace URI matching "xmlns"');
 
 var comment = document.createComment('comment');
 document.appendChild(comment);

--- a/LayoutTests/imported/w3c/web-platform-tests/domxpath/xpathevaluatorbase-creatensresolver-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/domxpath/xpathevaluatorbase-creatensresolver-expected.txt
@@ -1,0 +1,6 @@
+
+PASS createNSResolver() should return the specified node as is. (HTMLDocument)
+PASS createNSResolver() resultant object should not add support of 'xml' prefix. (HTMLDocument)
+PASS createNSResolver() should return the specified node as is. (XPathEvaluator)
+PASS createNSResolver() resultant object should not add support of 'xml' prefix. (XPathEvaluator)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/domxpath/xpathevaluatorbase-creatensresolver.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/domxpath/xpathevaluatorbase-creatensresolver.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+<body>
+<script>
+[document, new XPathEvaluator()].forEach(evaluator => {
+  test(() => {
+    assert_equals(evaluator.createNSResolver(document), document, 'Document');
+    const fragment = document.createDocumentFragment();
+    assert_equals(evaluator.createNSResolver(fragment), fragment,
+                  'DocumentFragment');
+    assert_equals(evaluator.createNSResolver(document.doctype),
+                  document.doctype, 'DocumentType');
+    assert_equals(evaluator.createNSResolver(document.body), document.body,
+                  'Element');
+    assert_equals(evaluator.createNSResolver(document.body.firstChild),
+                  document.body.firstChild, 'Text');
+    const attr = document.createAttribute('foo');
+    assert_equals(evaluator.createNSResolver(attr), attr, 'Attr');
+  }, `createNSResolver() should return the specified node as is. (${evaluator.constructor.name})`);
+
+  function createAndLookup(evaluator, node) {
+    return evaluator.createNSResolver(node).lookupNamespaceURI('xml');
+  }
+
+  test(() => {
+    assert_equals(createAndLookup(evaluator, new Document()), null, 'Document');
+    assert_equals(createAndLookup(evaluator, new DocumentFragment()), null,
+                  'DocumentFragment');
+    assert_equals(createAndLookup(evaluator, document.doctype), null,
+                  'DocumentType');
+    assert_equals(createAndLookup(evaluator, document.createElement('body')),
+                  'http://www.w3.org/XML/1998/namespace', 'Element');
+    assert_equals(createAndLookup(evaluator, document.createTextNode('foo')),
+                  null, 'Text');
+    assert_equals(createAndLookup(evaluator, document.createAttribute('bar')),
+                  null, 'Attr');
+  }, `createNSResolver() resultant object should not add support of 'xml' prefix. (${evaluator.constructor.name})`);
+});
+</script>
+</body>

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1141,6 +1141,7 @@ public:
     WEBCORE_EXPORT ExceptionOr<Ref<XPathExpression>> createExpression(const String& expression, RefPtr<XPathNSResolver>&&);
     WEBCORE_EXPORT Ref<XPathNSResolver> createNSResolver(Node& nodeResolver);
     WEBCORE_EXPORT ExceptionOr<Ref<XPathResult>> evaluate(const String& expression, Node& contextNode, RefPtr<XPathNSResolver>&&, unsigned short type, XPathResult*);
+    static void createNSResolverForBindings(Node&) { } // Legacy.
 
     bool hasNodesWithNonFinalStyle() const { return m_hasNodesWithNonFinalStyle; }
     void setHasNodesWithNonFinalStyle() { m_hasNodesWithNonFinalStyle = true; }

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -1517,6 +1517,11 @@ static const AtomString& locateDefaultNamespace(const Node& node, const AtomStri
 {
     switch (node.nodeType()) {
     case Node::ELEMENT_NODE: {
+        if (prefix == xmlAtom())
+            return XMLNames::xmlNamespaceURI.get();
+        if (prefix == xmlnsAtom())
+            return XMLNSNames::xmlnsNamespaceURI.get();
+
         auto& element = downcast<Element>(node);
         auto& namespaceURI = element.namespaceURI();
         if (!namespaceURI.isNull() && element.prefix() == prefix)

--- a/Source/WebCore/xml/XPathEvaluator.h
+++ b/Source/WebCore/xml/XPathEvaluator.h
@@ -41,6 +41,7 @@ public:
 
     ExceptionOr<Ref<XPathExpression>> createExpression(const String& expression, RefPtr<XPathNSResolver>&&);
     Ref<XPathNSResolver> createNSResolver(Node& nodeResolver);
+    static void createNSResolverForBindings(Node&) { } // Legacy.
     ExceptionOr<Ref<XPathResult>> evaluate(const String& expression, Node& contextNode, RefPtr<XPathNSResolver>&&, unsigned short type, XPathResult*);
 
 private:

--- a/Source/WebCore/xml/XPathEvaluatorBase.idl
+++ b/Source/WebCore/xml/XPathEvaluatorBase.idl
@@ -26,7 +26,7 @@
 // https://dom.spec.whatwg.org/#xpathevaluatorbase
 interface mixin XPathEvaluatorBase {
     [NewObject] XPathExpression createExpression(DOMString expression, optional XPathNSResolver? resolver);
-    XPathNSResolver createNSResolver(Node nodeResolver);
+    [ImplementedAs=createNSResolverForBindings] Node createNSResolver([ReturnValue] Node nodeResolver); // legacy
     // XPathResult.ANY_TYPE = 0
     XPathResult evaluate(DOMString expression, Node contextNode, optional XPathNSResolver? resolver, optional unsigned short type = 0, optional XPathResult? inResult);
 };


### PR DESCRIPTION
#### b0e1a9c1d9b3b952faa97d997c57d6358d11b79f
<pre>
Update Node.lookupNamespaceURI() and XPathEvaluatorBase.createNSResolver()
<a href="https://bugs.webkit.org/show_bug.cgi?id=252716">https://bugs.webkit.org/show_bug.cgi?id=252716</a>

Reviewed by Darin Adler.

Update Node.lookupNamespaceURI() and XPathEvaluatorBase.createNSResolver() per:
<a href="https://github.com/whatwg/dom/pull/1165">https://github.com/whatwg/dom/pull/1165</a>
<a href="https://github.com/web-platform-tests/wpt/pull/38636">https://github.com/web-platform-tests/wpt/pull/38636</a>

- lookupNamespaceURI():
Element should handle &quot;xml&quot; and &quot;xmlns&quot; by default.

- createNSResolver():
It should return the argument as is, and should not add &quot;xml&quot; prefix support.

* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/Node-lookupNamespaceURI-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/Node-lookupNamespaceURI.html:
* LayoutTests/imported/w3c/web-platform-tests/domxpath/xpathevaluatorbase-creatensresolver-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/domxpath/xpathevaluatorbase-creatensresolver.html: Added.
* Source/WebCore/dom/Document.h:
(WebCore::Document::createNSResolverForBindings const):
* Source/WebCore/dom/Node.cpp:
(WebCore::locateDefaultNamespace):
* Source/WebCore/xml/XPathEvaluator.h:
(WebCore::XPathEvaluator::createNSResolverForBindings const):
* Source/WebCore/xml/XPathEvaluatorBase.idl:

Canonical link: <a href="https://commits.webkit.org/260848@main">https://commits.webkit.org/260848@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0eb53819ee9417f4ef2a4bc12001a6247a081269

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109666 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18784 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42409 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1145 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118788 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113562 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20254 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9984 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101935 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115417 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15076 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98309 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43296 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97050 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/29961 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85081 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11515 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/31303 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12171 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8239 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17537 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50912 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7521 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13915 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->