### PR TITLE
image-set() should serialize in authored order

### DIFF
--- a/LayoutTests/fast/css/image-set-type-crash-expected.txt
+++ b/LayoutTests/fast/css/image-set-type-crash-expected.txt
@@ -1,0 +1,1 @@
+This passes if it does not crash

--- a/LayoutTests/fast/css/image-set-type-crash.html
+++ b/LayoutTests/fast/css/image-set-type-crash.html
@@ -1,0 +1,16 @@
+<style>
+    #x1 {
+        float: right;
+    }
+</style>
+<script>
+    if (window.testRunner)
+        testRunner.dumpAsText();
+    function main() {
+        style = x1.style;
+        style.setProperty("-webkit-shape-outside", "image-set(url(\"\") type(\"a\"))");
+    }
+</script>
+
+<body onload=main()>
+<p id="x1">This passes if it does not crash</p>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-computed.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-computed.sub-expected.txt
@@ -8,8 +8,8 @@ PASS Property background-image value 'image-set(url("http://localhost/example.pn
 PASS Property background-image value '-webkit-image-set(url("http://localhost/example.png") 1dppx)'
 PASS Property background-image value 'image-set(url(http://localhost/example.png) 48dpi)'
 PASS Property background-image value '-webkit-image-set(url(http://localhost/example.png) 48dpi)'
-FAIL Property background-image value 'image-set(url(http://localhost/example.png) 2400dpcm, 'http://localhost/example.png' 2x)' assert_equals: expected "image-set(url(\"http://localhost/example.png\") 63.5dppx, url(\"http://localhost/example.png\") 2dppx)" but got "image-set(url(\"http://localhost/example.png\") 2dppx, url(\"http://localhost/example.png\") 63.5dppx)"
-FAIL Property background-image value '-webkit-image-set(url(http://localhost/example.png) 2400dpcm, 'http://localhost/example.png' 2x)' assert_equals: expected "image-set(url(\"http://localhost/example.png\") 63.5dppx, url(\"http://localhost/example.png\") 2dppx)" but got "image-set(url(\"http://localhost/example.png\") 2dppx, url(\"http://localhost/example.png\") 63.5dppx)"
+PASS Property background-image value 'image-set(url(http://localhost/example.png) 2400dpcm, 'http://localhost/example.png' 2x)'
+PASS Property background-image value '-webkit-image-set(url(http://localhost/example.png) 2400dpcm, 'http://localhost/example.png' 2x)'
 PASS Property background-image value 'image-set('http://localhost/example.jpeg' 240dpi, url(http://localhost/example.png) 3.5x)'
 PASS Property background-image value '-webkit-image-set('http://localhost/example.jpeg' 240dpi, url(http://localhost/example.png) 3.5x)'
 PASS Property background-image value 'image-set(linear-gradient(black, white) 1x)'
@@ -20,6 +20,10 @@ PASS Property background-image value 'image-set(url(http://localhost/example.png
 PASS Property background-image value '-webkit-image-set(url(http://localhost/example.png) type('image/png'))'
 PASS Property background-image value 'image-set(url(http://localhost/example.png) type('image/png') 1x)'
 PASS Property background-image value '-webkit-image-set(url(http://localhost/example.png) type('image/png') 1x)'
-FAIL Property content value 'image-set(url('http://localhost/example.png') 192dpi, linear-gradient(black, white) 1x)' assert_equals: expected "image-set(url(\"http://localhost/example.png\") 2dppx, linear-gradient(rgb(0, 0, 0), rgb(255, 255, 255)) 1dppx)" but got "image-set(linear-gradient(rgb(0, 0, 0), rgb(255, 255, 255)) 1dppx, url(\"http://localhost/example.png\") 2dppx)"
-FAIL Property content value '-webkit-image-set(url('http://localhost/example.png') 192dpi, linear-gradient(black, white) 1x)' assert_equals: expected "image-set(url(\"http://localhost/example.png\") 2dppx, linear-gradient(rgb(0, 0, 0), rgb(255, 255, 255)) 1dppx)" but got "image-set(linear-gradient(rgb(0, 0, 0), rgb(255, 255, 255)) 1dppx, url(\"http://localhost/example.png\") 2dppx)"
+PASS Property content value 'image-set(url('http://localhost/example.png') 192dpi, linear-gradient(black, white) 1x)'
+PASS Property content value '-webkit-image-set(url('http://localhost/example.png') 192dpi, linear-gradient(black, white) 1x)'
+PASS Property background-image value 'image-set(url("http://localhost/example.png") type("image/unsupported"))'
+PASS Property background-image value '-webkit-image-set(url("http://localhost/example.png") type("image/unsupported"))'
+PASS Property background-image value 'image-set(url("http://localhost/example.png") 2x type("image/unsupported"), url("http://localhost/example.png") 1x type("image/unsupported"))'
+PASS Property background-image value '-webkit-image-set(url("http://localhost/example.png") 2x type("image/unsupported"), url("http://localhost/example.png") 1x type("image/unsupported"))'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-computed.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-computed.sub.html
@@ -29,4 +29,8 @@ test_computed_value_variants('background-image', "image-set(url(http://{{host}}/
 test_computed_value_variants('background-image', "image-set(url(http://{{host}}/example.png) type('image/png'))", 'image-set(url("http://{{host}}/example.png") 1dppx type("image/png"))');
 test_computed_value_variants('background-image', "image-set(url(http://{{host}}/example.png) type('image/png') 1x)", 'image-set(url("http://{{host}}/example.png") 1dppx type("image/png"))');
 test_computed_value_variants('content', "image-set(url('http://{{host}}/example.png') 192dpi, linear-gradient(black, white) 1x)", 'image-set(url("http://{{host}}/example.png") 2dppx, linear-gradient(rgb(0, 0, 0), rgb(255, 255, 255)) 1dppx)');
+
+// Unsupported type should still serialize.
+test_computed_value_variants('background-image', 'image-set(url("http://{{host}}/example.png") type("image/unsupported"))', 'image-set(url("http://{{host}}/example.png") 1dppx type("image/unsupported"))');
+test_computed_value_variants('background-image', 'image-set(url("http://{{host}}/example.png") 2x type("image/unsupported"), url("http://{{host}}/example.png") 1x type("image/unsupported"))', 'image-set(url("http://{{host}}/example.png") 2dppx type("image/unsupported"), url("http://{{host}}/example.png") 1dppx type("image/unsupported"))');
 </script>

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-computed.sub-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-computed.sub-expected.txt
@@ -8,8 +8,8 @@ PASS Property background-image value 'image-set(url("http://web-platform.test/ex
 PASS Property background-image value '-webkit-image-set(url("http://web-platform.test/example.png") 1dppx)'
 PASS Property background-image value 'image-set(url(http://web-platform.test/example.png) 48dpi)'
 PASS Property background-image value '-webkit-image-set(url(http://web-platform.test/example.png) 48dpi)'
-FAIL Property background-image value 'image-set(url(http://web-platform.test/example.png) 2400dpcm, 'http://web-platform.test/example.png' 2x)' assert_equals: expected "image-set(url(\"http://web-platform.test/example.png\") 63.5dppx, url(\"http://web-platform.test/example.png\") 2dppx)" but got "image-set(url(\"http://web-platform.test/example.png\") 2dppx, url(\"http://web-platform.test/example.png\") 63.5dppx)"
-FAIL Property background-image value '-webkit-image-set(url(http://web-platform.test/example.png) 2400dpcm, 'http://web-platform.test/example.png' 2x)' assert_equals: expected "image-set(url(\"http://web-platform.test/example.png\") 63.5dppx, url(\"http://web-platform.test/example.png\") 2dppx)" but got "image-set(url(\"http://web-platform.test/example.png\") 2dppx, url(\"http://web-platform.test/example.png\") 63.5dppx)"
+PASS Property background-image value 'image-set(url(http://web-platform.test/example.png) 2400dpcm, 'http://web-platform.test/example.png' 2x)'
+PASS Property background-image value '-webkit-image-set(url(http://web-platform.test/example.png) 2400dpcm, 'http://web-platform.test/example.png' 2x)'
 PASS Property background-image value 'image-set('http://web-platform.test/example.jpeg' 240dpi, url(http://web-platform.test/example.png) 3.5x)'
 PASS Property background-image value '-webkit-image-set('http://web-platform.test/example.jpeg' 240dpi, url(http://web-platform.test/example.png) 3.5x)'
 PASS Property background-image value 'image-set(linear-gradient(black, white) 1x)'
@@ -20,6 +20,10 @@ PASS Property background-image value 'image-set(url(http://web-platform.test/exa
 PASS Property background-image value '-webkit-image-set(url(http://web-platform.test/example.png) type('image/png'))'
 PASS Property background-image value 'image-set(url(http://web-platform.test/example.png) type('image/png') 1x)'
 PASS Property background-image value '-webkit-image-set(url(http://web-platform.test/example.png) type('image/png') 1x)'
-FAIL Property content value 'image-set(url('http://web-platform.test/example.png') 192dpi, linear-gradient(black, white) 1x)' assert_equals: expected "image-set(url(\"http://web-platform.test/example.png\") 2dppx, linear-gradient(rgb(0, 0, 0), rgb(255, 255, 255)) 1dppx)" but got "image-set(linear-gradient(rgb(0, 0, 0), rgb(255, 255, 255)) 1dppx, url(\"http://web-platform.test/example.png\") 2dppx)"
-FAIL Property content value '-webkit-image-set(url('http://web-platform.test/example.png') 192dpi, linear-gradient(black, white) 1x)' assert_equals: expected "image-set(url(\"http://web-platform.test/example.png\") 2dppx, linear-gradient(rgb(0, 0, 0), rgb(255, 255, 255)) 1dppx)" but got "image-set(linear-gradient(rgb(0, 0, 0), rgb(255, 255, 255)) 1dppx, url(\"http://web-platform.test/example.png\") 2dppx)"
+PASS Property content value 'image-set(url('http://web-platform.test/example.png') 192dpi, linear-gradient(black, white) 1x)'
+PASS Property content value '-webkit-image-set(url('http://web-platform.test/example.png') 192dpi, linear-gradient(black, white) 1x)'
+PASS Property background-image value 'image-set(url("http://web-platform.test/example.png") type("image/unsupported"))'
+PASS Property background-image value '-webkit-image-set(url("http://web-platform.test/example.png") type("image/unsupported"))'
+PASS Property background-image value 'image-set(url("http://web-platform.test/example.png") 2x type("image/unsupported"), url("http://web-platform.test/example.png") 1x type("image/unsupported"))'
+PASS Property background-image value '-webkit-image-set(url("http://web-platform.test/example.png") 2x type("image/unsupported"), url("http://web-platform.test/example.png") 1x type("image/unsupported"))'
 

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2625,6 +2625,7 @@ rendering/style/StyleGridData.cpp
 rendering/style/StyleGridItemData.cpp
 rendering/style/StyleImageSet.cpp
 rendering/style/StyleInheritedData.cpp
+rendering/style/StyleInvalidImage.cpp
 rendering/style/StyleMarqueeData.cpp
 rendering/style/StyleMiscNonInheritedData.cpp
 rendering/style/StyleMultiColData.cpp

--- a/Source/WebCore/css/CSSImageSetOptionValue.h
+++ b/Source/WebCore/css/CSSImageSetOptionValue.h
@@ -34,19 +34,6 @@ class CSSPrimitiveValue;
 
 class CSSImageSetOptionValue final : public CSSValue {
 public:
-    class Type {
-    public:
-        Type(String);
-
-        bool isSupported() const { return m_isSupported; }
-        String mimeType() const { return m_mimeType; }
-        String cssText() const;
-
-    private:
-        bool m_isSupported;
-        String m_mimeType;
-    };
-
     static Ref<CSSImageSetOptionValue> create(Ref<CSSValue>&&);
     static Ref<CSSImageSetOptionValue> create(Ref<CSSValue>&&, Ref<CSSPrimitiveValue>&&);
     static Ref<CSSImageSetOptionValue> create(Ref<CSSValue>&&, Ref<CSSPrimitiveValue>&&, String);
@@ -54,23 +41,21 @@ public:
     bool equals(const CSSImageSetOptionValue&) const;
     String customCSSText() const;
 
-    Ref<CSSValue> image() const;
+    Ref<CSSValue> image() const { return m_image; }
 
-    RefPtr<CSSPrimitiveValue> resolution() const;
+    Ref<CSSPrimitiveValue> resolution() const { return m_resolution; }
     void setResolution(Ref<CSSPrimitiveValue>&&);
 
-    std::optional<Type> type() const;
-    void setType(Type&&);
-    void setType(String&&);
+    String type() const { return m_mimeType; }
+    void setType(String);
 
 private:
-    CSSImageSetOptionValue(Ref<CSSValue>&&);
     CSSImageSetOptionValue(Ref<CSSValue>&&, Ref<CSSPrimitiveValue>&&);
     CSSImageSetOptionValue(Ref<CSSValue>&&, Ref<CSSPrimitiveValue>&&, String&&);
 
     Ref<CSSValue> m_image;
-    RefPtr<CSSPrimitiveValue> m_resolution;
-    std::optional<Type> m_type;
+    Ref<CSSPrimitiveValue> m_resolution;
+    String m_mimeType;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSImageValue.cpp
+++ b/Source/WebCore/css/CSSImageValue.cpp
@@ -36,12 +36,23 @@
 
 namespace WebCore {
 
+CSSImageValue::CSSImageValue()
+    : CSSValue(ImageClass)
+    , m_isInvalid(true)
+{
+}
+
 CSSImageValue::CSSImageValue(ResolvedURL&& location, LoadedFromOpaqueSource loadedFromOpaqueSource, AtomString&& initiatorType)
     : CSSValue(ImageClass)
     , m_location(WTFMove(location))
     , m_initiatorType(WTFMove(initiatorType))
     , m_loadedFromOpaqueSource(loadedFromOpaqueSource)
 {
+}
+
+Ref<CSSImageValue> CSSImageValue::create()
+{
+    return adoptRef(*new CSSImageValue);
 }
 
 Ref<CSSImageValue> CSSImageValue::create(ResolvedURL location, LoadedFromOpaqueSource loadedFromOpaqueSource, AtomString initiatorType)
@@ -119,6 +130,8 @@ bool CSSImageValue::equals(const CSSImageValue& other) const
 
 String CSSImageValue::customCSSText() const
 {
+    if (m_isInvalid)
+        return ""_s;
     return serializeURL(m_location.specifiedURLString);
 }
 

--- a/Source/WebCore/css/CSSImageValue.h
+++ b/Source/WebCore/css/CSSImageValue.h
@@ -42,6 +42,7 @@ class BuilderState;
 
 class CSSImageValue final : public CSSValue {
 public:
+    static Ref<CSSImageValue> create();
     static Ref<CSSImageValue> create(ResolvedURL, LoadedFromOpaqueSource, AtomString = { });
     static Ref<CSSImageValue> create(URL, LoadedFromOpaqueSource, AtomString = { });
     ~CSSImageValue();
@@ -68,6 +69,7 @@ public:
     RefPtr<StyleImage> createStyleImage(Style::BuilderState&) const;
 
 private:
+    CSSImageValue();
     CSSImageValue(ResolvedURL&&, LoadedFromOpaqueSource, AtomString&&);
 
     ResolvedURL m_location;
@@ -75,6 +77,7 @@ private:
     AtomString m_initiatorType;
     LoadedFromOpaqueSource m_loadedFromOpaqueSource { LoadedFromOpaqueSource::No };
     RefPtr<CSSImageValue> m_unresolvedValue;
+    bool m_isInvalid { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleImage.h
+++ b/Source/WebCore/rendering/style/StyleImage.h
@@ -91,7 +91,7 @@ public:
     ALWAYS_INLINE bool isCachedImage() const { return m_type == Type::CachedImage; }
     ALWAYS_INLINE bool isCursorImage() const { return m_type == Type::CursorImage; }
     ALWAYS_INLINE bool isImageSet() const { return m_type == Type::ImageSet; }
-    ALWAYS_INLINE bool isGeneratedImage() const { return isFilterImage() || isCanvasImage() || isCrossfadeImage() || isGradientImage() || isNamedImage() || isPaintImage(); }
+    ALWAYS_INLINE bool isGeneratedImage() const { return isFilterImage() || isCanvasImage() || isCrossfadeImage() || isGradientImage() || isNamedImage() || isPaintImage() || isInvalidImage(); }
     ALWAYS_INLINE bool isFilterImage() const { return m_type == Type::FilterImage; }
     ALWAYS_INLINE bool isCanvasImage() const { return m_type == Type::CanvasImage; }
     ALWAYS_INLINE bool isCrossfadeImage() const { return m_type == Type::CrossfadeImage; }
@@ -102,6 +102,7 @@ public:
 #else
     ALWAYS_INLINE bool isPaintImage() const { return false; }
 #endif
+    ALWAYS_INLINE bool isInvalidImage() const { return m_type == Type::InvalidImage; }
 
     bool hasCachedImage() const { return m_type == Type::CachedImage || selectedImage()->isCachedImage(); }
 
@@ -115,6 +116,7 @@ protected:
         CrossfadeImage,
         GradientImage,
         NamedImage,
+        InvalidImage,
 #if ENABLE(CSS_PAINTING_API)
         PaintImage,
 #endif

--- a/Source/WebCore/rendering/style/StyleImageSet.h
+++ b/Source/WebCore/rendering/style/StyleImageSet.h
@@ -31,7 +31,7 @@ namespace WebCore {
 class StyleImageSet final : public StyleMultiImage {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<StyleImageSet> create(Vector<ImageWithScale>);
+    static Ref<StyleImageSet> create(Vector<ImageWithScale>&&, Vector<size_t>&&);
     virtual ~StyleImageSet();
 
     bool operator==(const StyleImage& other) const;
@@ -40,7 +40,7 @@ public:
     ImageWithScale selectBestFitImage(const Document&) final;
 
 private:
-    explicit StyleImageSet(Vector<ImageWithScale>&&);
+    explicit StyleImageSet(Vector<ImageWithScale>&&, Vector<size_t>&&);
 
     Ref<CSSValue> computedStyleValue(const RenderStyle&) const final;
 
@@ -51,6 +51,7 @@ private:
     ImageWithScale m_bestFitImage;
     float m_deviceScaleFactor { 1 };
     Vector<ImageWithScale> m_images;
+    Vector<size_t> m_sortedIndices;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleInvalidImage.cpp
+++ b/Source/WebCore/rendering/style/StyleInvalidImage.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleInvalidImage.h"
+
+#include "CSSImageValue.h"
+
+namespace WebCore {
+
+Ref<StyleInvalidImage> StyleInvalidImage::create()
+{
+    return adoptRef(*new StyleInvalidImage);
+}
+
+StyleInvalidImage::~StyleInvalidImage() = default;
+
+StyleInvalidImage::StyleInvalidImage()
+    : StyleGeneratedImage(StyleImage::Type::InvalidImage, true)
+{
+}
+
+void StyleInvalidImage::load(CachedResourceLoader&, const ResourceLoaderOptions&)
+{
+}
+
+RefPtr<Image> StyleInvalidImage::image(const RenderElement*, const FloatSize&) const
+{
+    return &Image::nullImage();
+}
+
+Ref<CSSValue> StyleInvalidImage::computedStyleValue(const RenderStyle&) const
+{
+    return CSSImageValue::create();
+}
+
+} // namespace WebCore
+

--- a/Source/WebCore/rendering/style/StyleInvalidImage.h
+++ b/Source/WebCore/rendering/style/StyleInvalidImage.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "StyleGeneratedImage.h"
+
+namespace WebCore {
+
+class CSSInvalidImageValue;
+
+class StyleInvalidImage final : public StyleGeneratedImage {
+public:
+    static Ref<StyleInvalidImage> create();
+
+    virtual ~StyleInvalidImage();
+
+    bool operator==(const StyleImage&) const final { return false; }
+    bool equals(const StyleInvalidImage&) const { return false; }
+
+    static constexpr bool isFixedSize = true;
+
+protected:
+    void didAddClient(RenderElement&) final { }
+    void didRemoveClient(RenderElement&) final { }
+
+    FloatSize fixedSize(const RenderElement&) const final { return { }; }
+
+private:
+    StyleInvalidImage();
+    
+    bool isPending() const final { return false; }
+    void load(CachedResourceLoader&, const ResourceLoaderOptions&) final;
+    bool knownToBeOpaque(const RenderElement&) const { return false; }
+
+    RefPtr<Image> image(const RenderElement*, const FloatSize&) const final;
+    Ref<CSSValue> computedStyleValue(const RenderStyle&) const;
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_STYLE_IMAGE(StyleInvalidImage, isInvalidImage)

--- a/Source/WebCore/rendering/style/StyleMultiImage.cpp
+++ b/Source/WebCore/rendering/style/StyleMultiImage.cpp
@@ -64,8 +64,6 @@ void StyleMultiImage::load(CachedResourceLoader& loader, const ResourceLoaderOpt
     m_isPending = false;
 
     auto bestFitImage = selectBestFitImage(*loader.document());
-    if (!bestFitImage.image)
-        return;
 
     ASSERT(is<StyleCachedImage>(bestFitImage.image) || is<StyleGeneratedImage>(bestFitImage.image));
 

--- a/Source/WebCore/rendering/style/StyleMultiImage.h
+++ b/Source/WebCore/rendering/style/StyleMultiImage.h
@@ -25,13 +25,14 @@
 #pragma once
 
 #include "StyleImage.h"
+#include "StyleInvalidImage.h"
 
 namespace WebCore {
 
 class Document;
 
 struct ImageWithScale {
-    RefPtr<StyleImage> image;
+    RefPtr<StyleImage> image { StyleInvalidImage::create() };
     float scaleFactor { 1 };
     String mimeType { String() };
 };


### PR DESCRIPTION
#### 2fff06ab22a9a766d9314fdc4eaefeadbf67d63d
<pre>
image-set() should serialize in authored order
<a href="https://bugs.webkit.org/show_bug.cgi?id=251196">https://bugs.webkit.org/show_bug.cgi?id=251196</a>
rdar://104683422

Reviewed by Antti Koivisto.

To make choosing an image in the image-set more efficient we sort the set
by resolution. This was causing us to serialize in a different order than the value
was authored if the author did not also sort by resolution. This change preserves the order
of the image-set-options as authored while providing a vector of sorted indices to enable
linear lookups by device resolution.

In the case where the image-set is empty because there are no supported image types
we introduce the concept of an invalid image[0]. This is a Style object that represents
a zero-sized image. This way we can have a well-defined image object to use in the style,
rendering, and paint systems but no loads will be triggered and the invalid image will
have zero intrinsic size so as not to affect layout calculations.

[0] <a href="http://w3c.github.io/csswg-drafts/css-images-4/#invalid-image">http://w3c.github.io/csswg-drafts/css-images-4/#invalid-image</a>

* LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-computed.sub-expected.txt:
* LayoutTests/fast/css/image-set-type-crash-expected.txt: Added.
* LayoutTests/fast/css/image-set-type-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-computed.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-computed.sub.html:
    Added test cases for checking the computed style of an image-set with no supported image types.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSImageSetOptionValue.cpp:
(WebCore::CSSImageSetOptionValue::CSSImageSetOptionValue):
(WebCore::CSSImageSetOptionValue::create):
(WebCore::CSSImageSetOptionValue::equals const):
(WebCore::CSSImageSetOptionValue::customCSSText const):
(WebCore::CSSImageSetOptionValue::setResolution):
(WebCore::CSSImageSetOptionValue::setType):
(WebCore::CSSImageSetOptionValue::Type::Type): Deleted.
(WebCore::CSSImageSetOptionValue::Type::cssText const): Deleted.
(WebCore::CSSImageSetOptionValue::image const): Deleted.
(WebCore::CSSImageSetOptionValue::resolution const): Deleted.
(WebCore::CSSImageSetOptionValue::type const): Deleted.
* Source/WebCore/css/CSSImageSetOptionValue.h:
    Remove the CSSImageSetOptionValue::Type class. Since we no longer filter the image set
    by given type prior to making the StyleImageSet object, there&apos;s no need to check if the type is
    supported at this stage. Now we just hold the string as given to us by the CSS parser (if any).
    Since type is an optional parameter for the image set option, we represent the lack of
    a specified type with a null string.

* Source/WebCore/css/CSSImageSetValue.cpp:
(WebCore::CSSImageSetValue::createStyleImage const):

* Source/WebCore/rendering/style/StyleImage.h:
(WebCore::StyleImage::isGeneratedImage const):
(WebCore::StyleImage::isInvalidImage const):

* Source/WebCore/rendering/style/StyleImageSet.cpp:
(WebCore::StyleImageSet::create):
(WebCore::StyleImageSet::StyleImageSet):
(WebCore::StyleImageSet::bestImageForScaleFactor):
* Source/WebCore/rendering/style/StyleImageSet.h:

* Source/WebCore/rendering/style/StyleInvalidImage.cpp: Copied from Source/WebCore/css/CSSImageSetOptionValue.h.
(WebCore::StyleInvalidImage::create):
(WebCore::StyleInvalidImage::StyleInvalidImage):
(WebCore::StyleInvalidImage::load):
(WebCore::StyleInvalidImage::image const):
(WebCore::StyleInvalidImage::computedStyleValue const):
* Source/WebCore/rendering/style/StyleInvalidImage.h: Copied from Source/WebCore/css/CSSImageSetOptionValue.h.

* Source/WebCore/rendering/style/StyleMultiImage.cpp:
(WebCore::StyleMultiImage::load):
* Source/WebCore/rendering/style/StyleMultiImage.h:

Canonical link: <a href="https://commits.webkit.org/261015@main">https://commits.webkit.org/261015@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe868c5a144c8a02fdd341fb0a8e9792bfdb8358

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110287 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19382 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42930 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1693 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/119254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114236 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20841 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10566 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102542 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116031 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/43732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/30384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/85582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12064 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/31721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/12665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/18031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7631 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14489 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->