### PR TITLE
REGRESSION (260654@main): BaseXcconfigCheckerTest fails when not run from top-level folder

### DIFF
--- a/Tools/Scripts/webkitpy/style/checkers/basexcconfig.py
+++ b/Tools/Scripts/webkitpy/style/checkers/basexcconfig.py
@@ -21,6 +21,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import os
 from webkitpy.common.memoized import memoized
 
 
@@ -47,7 +48,9 @@ class BaseXcconfigChecker(object):
         inherited_vars = {}
         override_vars = {}
 
-        for line in open('Configurations/CommonBase.xcconfig'):
+        common_base_xcconfig_path = os.path.join(
+            os.path.dirname(__file__), '../../../../..', 'Configurations/CommonBase.xcconfig')
+        for line in open(common_base_xcconfig_path):
             # Find lines containing assignments.
             lhs, operator, rhs = map(str.strip, line.partition('='))
 


### PR DESCRIPTION
#### 3464e0af6f31f9b080796edb0576a2ce285a3411
<pre>
REGRESSION (260654@main): BaseXcconfigCheckerTest fails when not run from top-level folder
<a href="https://bugs.webkit.org/show_bug.cgi?id=252946">https://bugs.webkit.org/show_bug.cgi?id=252946</a>
&lt;rdar://105893621&gt;

Reviewed by Alexey Proskuryakov.

Construct a relative path to fix the bug.

* Tools/Scripts/webkitpy/style/checkers/basexcconfig.py:
(BaseXcconfigChecker.read_common_base_xcconfig_variables):
- Construct a relative path using __file__ to
  Configurations/CommonBase.xcconfig so that this test works
  no matter where test-webkitpy (or check-webkit-style) is
  invoked.

Canonical link: <a href="https://commits.webkit.org/260840@main">https://commits.webkit.org/260840@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/858c4546a89c5b020ceba5cc6879cc93bb62240a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109619 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18743 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42369 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1105 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118746 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113516 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20208 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9939 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101888 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115374 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15040 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98279 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43259 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/113087 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97014 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/29931 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85037 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11475 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31273 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12133 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8202 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17498 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50882 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7512 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13873 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->