### PR TITLE
[UI-side compositing] Prepare for the event handling asynchrony introduced by a scrolling thread in the UI process

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -92,7 +92,9 @@ public:
 
     void currentSnapPointIndicesDidChange(WebCore::ScrollingNodeID, std::optional<unsigned> horizontal, std::optional<unsigned> vertical);
 
-    WebCore::WheelEventHandlingResult handleWheelEvent(const NativeWebWheelEvent&, WebCore::RectEdges<bool> rubberBandableEdges);
+    virtual void handleWheelEvent(const NativeWebWheelEvent&, WebCore::RectEdges<bool> rubberBandableEdges);
+    void continueWheelEventHandling(const NativeWebWheelEvent&, WebCore::WheelEventHandlingResult);
+
     void handleMouseEvent(const WebCore::PlatformMouseEvent&);
     
     virtual WebCore::PlatformWheelEvent filteredWheelEvent(const WebCore::PlatformWheelEvent& wheelEvent) { return wheelEvent; }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
@@ -28,6 +28,8 @@
 #if PLATFORM(MAC) && ENABLE(SCROLLING_THREAD)
 
 #include "DisplayLinkObserverID.h"
+#include "NativeWebWheelEvent.h"
+#include <wtf/Deque.h>
 #include <wtf/FastMalloc.h>
 #include <wtf/HashMap.h>
 #include <wtf/Lock.h>
@@ -60,8 +62,7 @@ public:
     
     void invalidate();
 
-    void willHandleWheelEvent(const NativeWebWheelEvent&);
-    WebCore::WheelEventHandlingResult handleWheelEvent(const WebWheelEvent&, RectEdges<bool> rubberBandableEdges);
+    void handleWheelEvent(const NativeWebWheelEvent&, RectEdges<bool> rubberBandableEdges);
 
     void setScrollingTree(RefPtr<RemoteScrollingTree>&&);
 
@@ -72,6 +73,9 @@ private:
     WebCore::WheelEventHandlingResult internalHandleWheelEvent(const PlatformWheelEvent&, RectEdges<bool> rubberBandableEdges);
     WebCore::WheelEventHandlingResult scrollingTreeHandleWheelEvent(RemoteScrollingTree&, const PlatformWheelEvent&);
     PlatformWheelEvent filteredWheelEvent(const PlatformWheelEvent&);
+
+    void willHandleWheelEvent(const NativeWebWheelEvent&);
+    void wheelEventWasHandledByScrollingThread(WheelEventHandlingResult);
 
     DisplayLink* displayLink() const;
 
@@ -84,6 +88,8 @@ private:
 
     Lock m_scrollingTreeLock;
     RefPtr<RemoteScrollingTree> m_scrollingTree WTF_GUARDED_BY_LOCK(m_scrollingTreeLock);
+
+    Deque<NativeWebWheelEvent, 2> m_wheelEventsBeingProcessed;
 
     WeakPtr<RemoteScrollingCoordinatorProxyMac> m_scrollingCoordinator;
     WebCore::PageIdentifier m_pageIdentifier;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -328,6 +328,7 @@ struct TextAlternativeWithRange;
 struct TextCheckingResult;
 struct TextRecognitionResult;
 struct ViewportAttributes;
+struct WheelEventHandlingResult;
 struct WindowFeatures;
 
 template<typename> class RectEdges;
@@ -1070,6 +1071,7 @@ public:
 
     bool isProcessingWheelEvents() const;
     void handleWheelEvent(const NativeWebWheelEvent&);
+    void continueWheelEventHandling(const NativeWebWheelEvent&, const WebCore::WheelEventHandlingResult&);
 
     bool isProcessingKeyboardEvents() const;
     bool handleKeyboardEvent(const NativeWebKeyboardEvent&);


### PR DESCRIPTION
#### acc0a64d65110f80170a0a3a89e3432983da85d5
<pre>
[UI-side compositing] Prepare for the event handling asynchrony introduced by a scrolling thread in the UI process
<a href="https://bugs.webkit.org/show_bug.cgi?id=252947">https://bugs.webkit.org/show_bug.cgi?id=252947</a>
rdar://105927794

Reviewed by Alan Baradlay.

Once we dispatch wheel events to a scrolling thread in the UI process, we can no longer
have RemoteScrollingCoordinatorProxy::handleWheelEvent() return a WheelEventHandlingResult
synchronously. So we have to split the wheel event handling code up a little more, introducing
continueWheelEventHandling() which is called once the scrolling thread is done with the event.

Fix RemoteScrollingCoordinatorProxy::handleWheelEvent() to call continueWheelEventHandling();
this code will go away once we start sending events to RemoteLayerTreeEventDispatcher.

Rejigger WebPageProxy::handleWheelEvent() to move a bit of code into continueWheelEventHandling(),
and call that directly for the non-UI-side compositing code path.

continueWheelEventHandling() needs to receive a native wheel event in order to send it to
wheelEventCoalescer, so RemoteLayerTreeEventDispatcher needs a small queue of events to
keep around the event to send back.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::handleWheelEvent):
(WebKit::RemoteScrollingCoordinatorProxy::continueWheelEventHandling):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp:
(WebKit::RemoteLayerTreeEventDispatcher::willHandleWheelEvent):
(WebKit::RemoteLayerTreeEventDispatcher::handleWheelEvent):
(WebKit::RemoteLayerTreeEventDispatcher::wheelEventWasHandledByScrollingThread):
(WebKit::RemoteLayerTreeEventDispatcher::displayLink const):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::handleWheelEvent):
(WebKit::WebPageProxy::continueWheelEventHandling):
* Source/WebKit/UIProcess/WebPageProxy.h:

Canonical link: <a href="https://commits.webkit.org/260845@main">https://commits.webkit.org/260845@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a93c55a6d3379fbdd8301ba2d40f9b5ef62dd53

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109649 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18769 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42394 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1130 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118772 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20236 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9968 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101918 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115402 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15058 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98296 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43279 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97032 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29948 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85060 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11500 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31290 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12156 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8226 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17522 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50899 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7519 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13900 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->