### PR TITLE
Prefer make_unique over unique_pointer + new

### DIFF
--- a/PerformanceTests/MallocBench/MallocBench/churn.cpp
+++ b/PerformanceTests/MallocBench/MallocBench/churn.cpp
@@ -45,9 +45,9 @@ void benchmark_churn(CommandLine& commandLine)
     if (commandLine.isParallel())
         times /= cpuCount();
 
-    auto total = std::unique_ptr<HeapDouble>(new HeapDouble(0.0));
+    auto total = std::make_unique<HeapDouble>(0.0);
     for (size_t i = 0; i < times; ++i) {
-        auto heapDouble = std::unique_ptr<HeapDouble>(new HeapDouble(i));
+        auto heapDouble = std::make_unique<HeapDouble>(i);
         *total += *heapDouble;
     }
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -8208,7 +8208,7 @@ void WebPage::textAutosizingUsesIdempotentModeChanged()
 PlatformXRSystemProxy& WebPage::xrSystemProxy()
 {
     if (!m_xrSystemProxy)
-        m_xrSystemProxy = std::unique_ptr<PlatformXRSystemProxy>(new PlatformXRSystemProxy(*this));
+        m_xrSystemProxy = std::make_unique<PlatformXRSystemProxy>(*this);
     return *m_xrSystemProxy;
 }
 #endif

--- a/Tools/WebGPUAPIStructure/Example/Example.cpp
+++ b/Tools/WebGPUAPIStructure/Example/Example.cpp
@@ -237,16 +237,16 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
     auto vertexShader = readFile("C:\\Users\\lithe\\Documents\\VertexShader2.spv");
     auto fragmentShader = readFile("C:\\Users\\lithe\\Documents\\FragmentShader2.spv");
 
-    vertexBufferRTT = std::unique_ptr<WebGPU::BufferHolder>(new WebGPU::BufferHolder(device->getBuffer(static_cast<unsigned int>(sizeof(float) * 6))));
-    buffer = std::unique_ptr<WebGPU::BufferHolder>(new WebGPU::BufferHolder(device->getBuffer(static_cast<unsigned int>(sizeof(float)))));
-    vertexBuffer = std::unique_ptr<WebGPU::BufferHolder>(new WebGPU::BufferHolder(device->getBuffer(static_cast<unsigned int>(sizeof(float) * 12))));
+    vertexBufferRTT = std::make_unique<WebGPU::BufferHolder>(device->getBuffer(static_cast<unsigned int>(sizeof(float) * 6)));
+    buffer = std::make_unique<WebGPU::BufferHolder>(device->getBuffer(static_cast<unsigned int>(sizeof(float))));
+    vertexBuffer = std::make_unique<WebGPU::BufferHolder>(device->getBuffer(static_cast<unsigned int>(sizeof(float) * 12)));
 
-    sampler = std::unique_ptr<WebGPU::SamplerHolder>(new WebGPU::SamplerHolder(device->getSampler(WebGPU::AddressMode::Repeat, WebGPU::Filter::Linear)));
+    sampler = std::make_unique<WebGPU::SamplerHolder>(device->getSampler(WebGPU::AddressMode::Repeat, WebGPU::Filter::Linear));
 
     WINDOWINFO windowInfo;
     auto success = GetWindowInfo(hWnd, &windowInfo);
     assert(success);
-    texture = std::unique_ptr<WebGPU::TextureHolder>(new WebGPU::TextureHolder(device->getTexture(windowInfo.rcClient.right - windowInfo.rcClient.left, windowInfo.rcClient.bottom - windowInfo.rcClient.top, WebGPU::PixelFormat::RGBA8)));
+    texture = std::make_unique<WebGPU::TextureHolder>(device->getTexture(windowInfo.rcClient.right - windowInfo.rcClient.left, windowInfo.rcClient.bottom - windowInfo.rcClient.top, WebGPU::PixelFormat::RGBA8));
 
     std::vector<WebGPU::RenderState::VertexAttribute> vertexAttributes = { {WebGPU::RenderState::VertexFormat::Float2, 0, 0} };
     std::vector<WebGPU::PixelFormat> colorPixelFormats = { WebGPU::PixelFormat::RGBA8 };

--- a/Tools/WebGPUAPIStructure/WebGPU-Vulkan/DeviceImpl.cpp
+++ b/Tools/WebGPUAPIStructure/WebGPU-Vulkan/DeviceImpl.cpp
@@ -36,7 +36,7 @@ namespace WebGPU {
     static const vk::Format framebufferColorPixelFormat = vk::Format::eR8G8B8A8Srgb;
 
     std::unique_ptr<Device> Device::create(HINSTANCE hInstance, HWND hWnd) {
-        return std::unique_ptr<Device>(new DeviceImpl(hInstance, hWnd));
+        return std::make_unique<Device>(hInstance, hWnd);
     }
 
     static vk::Format convertPixelFormat(PixelFormat pixelFormat) {
@@ -167,7 +167,7 @@ namespace WebGPU {
             swapchainImageViews.push_back(device->createImageViewUnique(imageViewCreateInfo));
         }
 
-        queue = std::unique_ptr<QueueImpl>(new QueueImpl(*device, *commandPool, swapchainImageViews, *swapchain, surfaceCapabilities.currentExtent, framebufferColorPixelFormat, device->getQueue(queueFamilyIndex, 0)));
+        queue = std::make_unique<QueueImpl>(*device, *commandPool, swapchainImageViews, *swapchain, surfaceCapabilities.currentExtent, framebufferColorPixelFormat, device->getQueue(queueFamilyIndex, 0));
 
         vk::PipelineCacheCreateInfo pipelineCacheCreateInfo;
         pipelineCache = device->createPipelineCacheUnique(pipelineCacheCreateInfo);


### PR DESCRIPTION
#### 146e98384814d057a4082057eefde7fe1a08ead0
<pre>
Prefer WTF::makeUnique/make_unique over unique_pointer + new
<a href="https://bugs.webkit.org/show_bug.cgi?id=253156">https://bugs.webkit.org/show_bug.cgi?id=253156</a>

Reviewed by NOBODY (OOPS!).

std::unique_ptr is just calling std::make_unique, when we have
WTF::makeUnique for this purpose.

* PerformanceTests\MallocBench\MallocBench\churn.cpp:(benchmark_churn):
  Prefer make_unique over unique_ptr.

* Source\JavaScriptCore\jit\JIT.cpp:(JIT::compileAndLinkWithoutFinalizing):
  Prefer WTF::makeUnique over unique_ptr.

* Source\WebKit\WebProcess\WebPage\WebPage.cpp:(
  WebPage::textAutosizingUsesIdempotentModeChanged): Prefer make_unique
  over unique_ptr.

* Tools\WebGPUAPIStructure\Example\Example.cpp:(wWinMain): Ditto.

* Tools\WebGPUAPIStructure\WebGPU-Vulkan\DeviceImpl.cpp: Ditto.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af49d4925f7f8b2d653ec1cd86dc20056cdab6f8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4938 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5064 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5236 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6455 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5044 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4932 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5239 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5036 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5298 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5024 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5099 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4428 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6471 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2587 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4426 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9383 "layout-tests (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4450 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4498 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6091 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4907 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4004 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4406 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8474 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4768 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->