### PR TITLE
WebGPU-Vulkan: Reserve vector space where possible

### DIFF
--- a/Tools/WebGPUAPIStructure/WebGPU-Vulkan/QueueImpl.cpp
+++ b/Tools/WebGPUAPIStructure/WebGPU-Vulkan/QueueImpl.cpp
@@ -62,6 +62,8 @@ namespace WebGPU {
     vk::UniqueRenderPass QueueImpl::createSpecificRenderPass(const std::vector<vk::ImageView>& imageViews, const std::vector<vk::Format>& formats) {
         std::vector<vk::AttachmentDescription> attachmentDescriptions;
         std::vector<vk::AttachmentReference> attachmentReferences;
+        attachmentDescriptions.reserve(imageViews.size());
+        attachmentReferences.reserve(imageViews.size());
         for (std::size_t i = 0; i < imageViews.size(); ++i) {
             auto attachmentDescription = vk::AttachmentDescription()
                 .setFormat(formats[i])
@@ -119,8 +121,11 @@ namespace WebGPU {
             imageViews.emplace_back(*deviceImageViews[activeSwapchainIndex]);
             clearValues.emplace_back(vk::ClearColorValue(std::array<float, 4>({ 0.0f, 0.0f, 0.0f, 1.0f })));
             formats.push_back(swapchainFormat);
-        }
-        else {
+        } else {
+            destinationTextures.reserve(*textures.size());
+            imageViews.reserve(*textures.size());
+            clearValues.reserve(*textures.size());
+            formats.reserve(*textures.size());
             for (auto& textureWrapper : *textures) {
                 Texture& texture = textureWrapper;
                 auto downcast = dynamic_cast<TextureImpl*>(&texture);


### PR DESCRIPTION
#### 8292d20a046a37b9c6be992bbf53a144a183f0ff
<pre>
WebGPU-Vulkan: Reserve vector space where possible
<a href="https://bugs.webkit.org/show_bug.cgi?id=253155">https://bugs.webkit.org/show_bug.cgi?id=253155</a>

Reviewed by Michael Catanzaro.

It is good practice to reserve space in vectors before pushing back new elements
with each iteration, as it saves the work of reallocating space between
each push_back or emplace_back.

* Tools\WebGPUAPIStructure\WebGPU-Vulkan\QueueImpl.cpp:(createRenderPass): Reserve space for
vectors

Canonical link: <a href="https://commits.webkit.org/261092@main">https://commits.webkit.org/261092@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8bc643420dbae77fb78b8084da752d5c2e912339

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110548 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19630 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/43125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1907 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119423 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114498 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21057 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/10767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102777 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116290 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/43125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/43939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/43125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/85811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12285 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/43125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12852 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/10767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18216 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/43125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7688 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14728 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->