### PR TITLE
Change the linebreak behavior of minlength and maxlength attributes of TEXTAREA

### DIFF
--- a/LayoutTests/fast/forms/textarea-maxlength-expected.txt
+++ b/LayoutTests/fast/forms/textarea-maxlength-expected.txt
@@ -7,10 +7,16 @@ PASS textArea.maxLength is -1
 PASS textArea.maxLength is -1
 PASS textArea.maxLength is -1
 PASS textArea.maxLength is 1
+PASS textArea.maxLength is -1
+PASS textArea.maxLength is -1
+PASS textArea.maxLength is 1
 PASS textArea.maxLength is 256
 PASS textArea.getAttribute("maxlength") is "13"
 PASS textArea.maxLength = -1 threw exception IndexSizeError: The index is not in the allowed range..
 PASS textArea.getAttribute("maxlength") is "13"
+PASS textArea.maxLength = 10 threw exception IndexSizeError: The index is not in the allowed range..
+PASS textArea.getAttribute("maxlength") is "13"
+PASS textArea.maxLength = 11; textArea.getAttribute("maxlength") is "11"
 PASS textArea.maxLength is 0
 PASS textArea.getAttribute("maxlength") is "0"
 PASS textArea.value is "abcd"
@@ -22,12 +28,14 @@ PASS textArea.value is "abcdef"
 PASS textArea.value is "abcde"
 PASS textArea.value is "A\nB"
 PASS textArea.value is "a\n\n"
-PASS textArea.value is "\n\n\n"
-PASS textArea.value is "AB" + fancyX
-PASS textArea.value.length is 5
+PASS textArea.value is "\n\n\n\n\n\n"
+Inserts 2 normal characters + a combining letter with 3 code points into a maxlength=3 element.
+PASS textArea.value is "ABx"
+PASS textArea.value.length is 3
 PASS textArea.value is "ABC"
-PASS textArea.value is "AB" + u10000
-PASS textArea.value.length is 4
+Inserts 2 normal characters + one surrogate pair into a maxlength=3 element
+PASS textArea.value is "AB"
+PASS textArea.value.length is 2
 PASS textArea.value is "ABC"
 PASS textArea.value is ""
 PASS textArea.value is "ABC"

--- a/LayoutTests/fast/forms/textarea-maxlength.html
+++ b/LayoutTests/fast/forms/textarea-maxlength.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
 <body>
 <p id="description"></p>
@@ -21,6 +21,14 @@ shouldBe('textArea.maxLength', '-1');
 textArea.setAttribute('maxlength', 'xyz');
 shouldBe('textArea.maxLength', '-1');
 
+// Leading whitespaces in maxlength attributes
+textArea.setAttribute('maxlength', '\t  \n\r1');
+shouldBe('textArea.maxLength', '1');
+textArea.setAttribute('maxlength', "\u20021");
+shouldBe('textArea.maxLength', '-1');
+textArea.setAttribute('maxlength', "\u20091");
+shouldBe('textArea.maxLength', '-1');
+
 // Valid maxlength attributes
 textArea.setAttribute('maxlength', '1');
 shouldBe('textArea.maxLength', '1');
@@ -33,6 +41,11 @@ shouldBe('textArea.getAttribute("maxlength")', '"13"');
 
 shouldThrowErrorName('textArea.maxLength = -1', 'IndexSizeError');
 shouldBe('textArea.getAttribute("maxlength")', '"13"');  // Not changed
+textArea.minLength = 11;
+shouldThrowErrorName('textArea.maxLength = 10', 'IndexSizeError');
+shouldBe('textArea.getAttribute("maxlength")', '"13"');  // Not changed
+shouldBe('textArea.maxLength = 11; textArea.getAttribute("maxlength")', '"11"');
+textArea.minLength = 0;  // Remove the minlength value to get it out of the way of subsequent tests
 
 textArea.maxLength = null;
 shouldBe('textArea.maxLength', '0');
@@ -109,21 +122,23 @@ document.execCommand('insertLineBreak');
 document.execCommand('insertLineBreak');
 document.execCommand('insertLineBreak');
 document.execCommand('insertLineBreak');
-shouldBe('textArea.value', '"\\n\\n\\n"');
+document.execCommand('insertLineBreak');
+document.execCommand('insertLineBreak');
+document.execCommand('insertLineBreak');
+shouldBeEqualToString('textArea.value', '\n\n\n\n\n\n');
 
 // According to the HTML5 specification, maxLength is code-point length.
-// However WebKit handles it as grapheme length.
 
 // fancyX should be treated as 1 grapheme.
 var fancyX = "x\u0305\u0332";// + String.fromCharCode(0x305) + String.fromCharCode(0x332);
 // u10000 is one character consisted of a surrogate pair.
 var u10000 = "\ud800\udc00";
 
-// Inserts 5 code-points in UTF-16
+debug('Inserts 2 normal characters + a combining letter with 3 code points into a maxlength=3 element.')
 createFocusedTextAreaWithMaxLength(3);
 document.execCommand('insertText', false, 'AB' + fancyX);
-shouldBe('textArea.value', '"AB" + fancyX');
-shouldBe('textArea.value.length', '5');
+shouldBeEqualToString('textArea.value', 'ABx');
+shouldBe('textArea.value.length', '3');
 
 createFocusedTextAreaWithMaxLength(3);
 textArea.value = 'AB' + fancyX;
@@ -131,11 +146,11 @@ textArea.setSelectionRange(2, 5);  // Select fancyX
 document.execCommand('insertText', false, 'CDE');
 shouldBe('textArea.value', '"ABC"');
 
-// Inserts 4 code-points in UTF-16
+debug('Inserts 2 normal characters + one surrogate pair into a maxlength=3 element');
 createFocusedTextAreaWithMaxLength(3);
 document.execCommand('insertText', false, 'AB' + u10000);
-shouldBe('textArea.value', '"AB" + u10000');
-shouldBe('textArea.value.length', '4');
+shouldBeEqualToString('textArea.value', 'AB');
+shouldBe('textArea.value.length', '2');
 
 createFocusedTextAreaWithMaxLength(3);
 textArea.value = 'AB' + u10000;
@@ -161,6 +176,5 @@ textArea.value = '';
 document.execCommand('insertText', false, 'ABC');
 shouldBe('textArea.value', '"ABC"');
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/Source/WebCore/html/HTMLTextAreaElement.h
+++ b/Source/WebCore/html/HTMLTextAreaElement.h
@@ -60,6 +60,7 @@ private:
 
     void didAddUserAgentShadowRoot(ShadowRoot&) final;
 
+    static String sanitizeUserInputValue(const String& proposedValue, unsigned maxLength);
     void handleBeforeTextInsertedEvent(BeforeTextInsertedEvent&) const;
     void updateValue() const;
     void setNonDirtyValue(const String&, TextControlSetValueSelection);


### PR DESCRIPTION
#### 2252898e2468994720be25176170e00bc7b26ca3
<pre>
Change the linebreak behavior of minlength and maxlength attributes of TEXTAREA
<a href="https://bugs.webkit.org/show_bug.cgi?id=249916">https://bugs.webkit.org/show_bug.cgi?id=249916</a>
rdar://103856355

Reviewed by Darin Adler.

Align the linebreak behavior of minlength and maxlength attributes of TEXTAREA with
the specification, Blink and Gecko.

Old behavior:
 CRLF, CR, or LF is counted as 2 because we limited the submission value.

New behavior:
 CRLF, CR, or LF is counted as 1 because we limit the API value.

This is a cherry-pick of Blink:
<a href="https://chromium.googlesource.com/chromium/src.git/+/a15474ff7adff41a8956ab436ac63a7d5b7a090f%5E%21/#F3">https://chromium.googlesource.com/chromium/src.git/+/a15474ff7adff41a8956ab436ac63a7d5b7a090f%5E%21/#F3</a>

* LayoutTests/fast/forms/textarea-maxlength-expected.txt:
* LayoutTests/fast/forms/textarea-maxlength.html:
* Source/WebCore/html/HTMLTextAreaElement.cpp:
(WebCore::computeLengthForAPIValue):
(WebCore::HTMLTextAreaElement::handleBeforeTextInsertedEvent const):
(WebCore::HTMLTextAreaElement::sanitizeUserInputValue):
(WebCore::HTMLTextAreaElement::validationMessage const):
(WebCore::HTMLTextAreaElement::tooShort const):
(WebCore::HTMLTextAreaElement::tooLong const):
(WebCore::computeLengthForSubmission): Deleted.
(WebCore::numberOfLineBreaks): Deleted.
(WebCore::upperBoundForLengthForSubmission): Deleted.
* Source/WebCore/html/HTMLTextAreaElement.h:

Canonical link: <a href="https://commits.webkit.org/260861@main">https://commits.webkit.org/260861@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f58777c65796ba5905481dbe35fa6bf8df3e3e7a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109668 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18786 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42411 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1147 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118790 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113570 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20256 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9986 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101937 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115419 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15077 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98308 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43297 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97051 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29960 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85082 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11517 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31302 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12173 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8240 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17539 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50911 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7531 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13917 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->