### PR TITLE
[UI-side compositing] Give RemoteLayerTreeEventDispatcher a HysteresisActivity

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -99,7 +99,7 @@ public:
     bool isScrollAnimationInProgressForNode(ScrollingNodeID);
     void setScrollAnimationInProgressForNode(ScrollingNodeID, bool);
 
-    bool hasNodeWithActiveScrollAnimations();
+    WEBCORE_EXPORT bool hasNodeWithActiveScrollAnimations();
 
     virtual void invalidate() { }
     WEBCORE_EXPORT void commitTreeState(std::unique_ptr<ScrollingStateTree>&&);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
@@ -29,6 +29,7 @@
 
 #include "DisplayLinkObserverID.h"
 #include "NativeWebWheelEvent.h"
+#include <pal/HysteresisActivity.h>
 #include <wtf/Deque.h>
 #include <wtf/FastMalloc.h>
 #include <wtf/HashMap.h>
@@ -74,6 +75,8 @@ private:
     WebCore::WheelEventHandlingResult scrollingTreeHandleWheelEvent(RemoteScrollingTree&, const PlatformWheelEvent&);
     PlatformWheelEvent filteredWheelEvent(const PlatformWheelEvent&);
 
+    void wheelEventHysteresisUpdated(PAL::HysteresisState);
+
     void willHandleWheelEvent(const NativeWebWheelEvent&);
     void wheelEventWasHandledByScrollingThread(WheelEventHandlingResult);
 
@@ -97,6 +100,7 @@ private:
     std::unique_ptr<WebCore::WheelEventDeltaFilter> m_wheelEventDeltaFilter;
     std::unique_ptr<RemoteLayerTreeEventDispatcherDisplayLinkClient> m_displayLinkClient;
     std::optional<DisplayLinkObserverID> m_displayRefreshObserverID;
+    PAL::HysteresisActivity m_wheelEventActivityHysteresis;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### 390d437355c65ff2d7e02444aed8fd3328e73843
<pre>
[UI-side compositing] Give RemoteLayerTreeEventDispatcher a HysteresisActivity
<a href="https://bugs.webkit.org/show_bug.cgi?id=252950">https://bugs.webkit.org/show_bug.cgi?id=252950</a>
rdar://105935338

Reviewed by Alan Baradlay.

Use HysteresisActivity to keep the display link alive for 500ms after the last wheel event, to avoid
repeated stops/starts of the display link. This is similar to what we have in WebPageProxy.

* Source/WebCore/page/scrolling/ScrollingTree.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp:
(WebKit::m_wheelEventActivityHysteresis):
(WebKit::RemoteLayerTreeEventDispatcher::wheelEventHysteresisUpdated):
(WebKit::RemoteLayerTreeEventDispatcher::willHandleWheelEvent):
(WebKit::RemoteLayerTreeEventDispatcher::startOrStopDisplayLink):
(WebKit::m_displayLinkClient): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h:

Canonical link: <a href="https://commits.webkit.org/260854@main">https://commits.webkit.org/260854@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f41c3ea98005a6485e3d7f2b97847d380b952ae

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109681 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18798 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42422 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1158 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118803 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113596 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20268 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/9997 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101948 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115432 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15087 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98318 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43307 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97060 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29970 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85091 "Found 2 new API test failures: /TestWebKit:WebKit.OnDeviceChangeCrash, /TestWebKit:WebKit.PrivateBrowsingPushStateNoHistoryCallback (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11529 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31312 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12184 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8248 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17551 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50921 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7524 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13929 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->