### PR TITLE
[JSC] Implement wasm exception in new BBQ

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmB3IRGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmB3IRGenerator.h
@@ -55,6 +55,7 @@ struct CompilationContext {
     std::unique_ptr<OpaqueByproducts> wasmEntrypointByproducts;
     std::unique_ptr<B3::Procedure> procedure;
     Box<PCToCodeOriginMap> pcToCodeOriginMap;
+    Vector<CCallHelpers::Label> catchEntrypoints;
 };
 
 Expected<std::unique_ptr<InternalFunction>, String> parseAndCompileB3(CompilationContext&, Callee&, const FunctionData&, const TypeDefinition&, Vector<UnlinkedWasmToWasmCall>&, const ModuleInformation&, MemoryMode, CompilationMode, uint32_t functionIndex, std::optional<bool> hasExceptionHandlers, uint32_t loopIndexForOSREntry, TierUpCount* = nullptr);

--- a/Source/JavaScriptCore/wasm/WasmIRGeneratorHelpers.h
+++ b/Source/JavaScriptCore/wasm/WasmIRGeneratorHelpers.h
@@ -79,8 +79,17 @@ struct PatchpointExceptionHandle {
 
 static inline void computeExceptionHandlerAndLoopEntrypointLocations(Vector<CodeLocationLabel<ExceptionHandlerPtrTag>>& handlers, Vector<CodeLocationLabel<WasmEntryPtrTag>>& loopEntrypoints, const InternalFunction* function, const CompilationContext& context, LinkBuffer& linkBuffer)
 {
-    if (!context.procedure)
+    if (!context.procedure) {
+        unsigned index = 0;
+        for (const UnlinkedHandlerInfo& handlerInfo : function->exceptionHandlers) {
+            if (handlerInfo.m_type == HandlerType::Delegate) {
+                handlers.append({ });
+                continue;
+            }
+            handlers.append(linkBuffer.locationOf<ExceptionHandlerPtrTag>(context.catchEntrypoints[index++]));
+        }
         return;
+    }
 
     unsigned entrypointIndex = 1;
     unsigned numEntrypoints = context.procedure->numEntrypoints();


### PR DESCRIPTION
#### e2672d2623ed17421641e2827515bd6b02c893ea
<pre>
[JSC] Implement wasm exception in new BBQ
<a href="https://bugs.webkit.org/show_bug.cgi?id=252959">https://bugs.webkit.org/show_bug.cgi?id=252959</a>
rdar://105692614

Reviewed by Tadeu Zagallo.

This patch implements wasm exception in new BBQ. The implementation is just following
to how exception is implemented in the other tiers (LLInt, old BBQ Air), so not introducing a new concept.

1. Catch / CatchAll blocks should have implicit stack slot to hold exception (as the same to old Air and LLInt).
   This is represented as implicitSlots.
2. When catch / catch-all is running, we already flush everything in endBlock. Thus, we do not need to have stackmap
   at all: every wasm temps are on stack. So only thing we need is just spreading wasm exception parameters to the
   block&apos;s parameters (this is the same to what wasm LLInt exception handling is doing).
3. Each try-block and exception-throwing operations incremenets m_callSiteIndex. And emit it to
   CCallHelpers::tagFor(CallFrameSlot::argumentCountIncludingThis) slot. This number is used as a range of covering of
   the exception handler. (This is exactly the same design to DFG / FTL exception handling). And this is the same to
   old BBQ Air exception handling.
4. Entrance of exception handler is represented as a label inside code. And these labels are extracted for exception handlers.

* Source/JavaScriptCore/wasm/WasmB3IRGenerator.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJIT::ControlData::ControlData):
(JSC::Wasm::BBQJIT::ControlData::endBlock):
(JSC::Wasm::BBQJIT::ControlData::startBlock):
(JSC::Wasm::BBQJIT::ControlData::resumeBlock):
(JSC::Wasm::BBQJIT::ControlData::releaseJumps):
(JSC::Wasm::BBQJIT::ControlData::implicitSlots const):
(JSC::Wasm::BBQJIT::ControlData::argumentLocations const):
(JSC::Wasm::BBQJIT::ControlData::resultLocations const):
(JSC::Wasm::BBQJIT::ControlData::setCatchKind):
(JSC::Wasm::BBQJIT::ControlData::tryStart const):
(JSC::Wasm::BBQJIT::ControlData::tryEnd const):
(JSC::Wasm::BBQJIT::ControlData::tryCatchDepth const):
(JSC::Wasm::BBQJIT::ControlData::setTryInfo):
(JSC::Wasm::BBQJIT::BBQJIT):
(JSC::Wasm::BBQJIT::topValue):
(JSC::Wasm::BBQJIT::exception):
(JSC::Wasm::BBQJIT::emitEntryTierUpCheck):
(JSC::Wasm::BBQJIT::addTopLevel):
(JSC::Wasm::BBQJIT::addBlock):
(JSC::Wasm::BBQJIT::addLoop):
(JSC::Wasm::BBQJIT::addIf):
(JSC::Wasm::BBQJIT::addElse):
(JSC::Wasm::BBQJIT::addElseToUnreachable):
(JSC::Wasm::BBQJIT::addTry):
(JSC::Wasm::BBQJIT::emitCatchPrologue):
(JSC::Wasm::BBQJIT::emitCatchAllImpl):
(JSC::Wasm::BBQJIT::emitCatchImpl):
(JSC::Wasm::BBQJIT::addCatch):
(JSC::Wasm::BBQJIT::addCatchToUnreachable):
(JSC::Wasm::BBQJIT::addCatchAll):
(JSC::Wasm::BBQJIT::addCatchAllToUnreachable):
(JSC::Wasm::BBQJIT::addDelegate):
(JSC::Wasm::BBQJIT::addDelegateToUnreachable):
(JSC::Wasm::BBQJIT::addThrow):
(JSC::Wasm::BBQJIT::addRethrow):
(JSC::Wasm::BBQJIT::prepareForExceptions):
(JSC::Wasm::BBQJIT::addReturn):
(JSC::Wasm::BBQJIT::endBlock):
(JSC::Wasm::BBQJIT::addEndToUnreachable):
(JSC::Wasm::BBQJIT::endTopLevel):
(JSC::Wasm::BBQJIT::flushRegistersForException):
(JSC::Wasm::BBQJIT::returnValuesFromCall):
(JSC::Wasm::BBQJIT::emitCCall):
(JSC::Wasm::BBQJIT::addCall):
(JSC::Wasm::BBQJIT::emitIndirectCall):
(JSC::Wasm::BBQJIT::notifyFunctionUsesSIMD):
(JSC::Wasm::BBQJIT::takeExceptionHandlers):
(JSC::Wasm::BBQJIT::takeCatchEntrypoints):
(JSC::Wasm::BBQJIT::emitShuffle):
(JSC::Wasm::parseAndCompileBBQ):
(JSC::Wasm::BBQJIT::ControlData::allocateArgumentOrResult): Deleted.
* Source/JavaScriptCore/wasm/WasmIRGeneratorHelpers.h:
(JSC::Wasm::computeExceptionHandlerAndLoopEntrypointLocations):

Canonical link: <a href="https://commits.webkit.org/260905@main">https://commits.webkit.org/260905@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9dbeb89fad047c8323d95f76ae7fd128844f55c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109891 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/19000 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/42601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/1347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/118972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/20466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/10194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/102160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115639 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/20466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/42601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/102160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/20466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/42601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/102160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/98721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/11709 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/42601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/38/builds/99632 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/9744 "Built successfully and passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/12347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/10194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/31152 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/17716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/42601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/107650 "Built successfully") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/14124 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/26563 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4103 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->