### PR TITLE
Use generated code in ReferrerPolicy.cpp

### DIFF
--- a/Source/WebCore/platform/ReferrerPolicy.cpp
+++ b/Source/WebCore/platform/ReferrerPolicy.cpp
@@ -26,6 +26,7 @@
 #include "ReferrerPolicy.h"
 
 #include "HTTPParsers.h"
+#include "JSFetchReferrerPolicy.h"
 
 namespace WebCore {
 
@@ -90,28 +91,7 @@ std::optional<ReferrerPolicy> parseReferrerPolicy(StringView policyString, Refer
 
 String referrerPolicyToString(const ReferrerPolicy& referrerPolicy)
 {
-    switch (referrerPolicy) {
-    case ReferrerPolicy::NoReferrer:
-        return "no-referrer"_s;
-    case ReferrerPolicy::UnsafeUrl:
-        return "unsafe-url"_s;
-    case ReferrerPolicy::Origin:
-        return "origin"_s;
-    case ReferrerPolicy::OriginWhenCrossOrigin:
-        return "origin-when-cross-origin"_s;
-    case ReferrerPolicy::SameOrigin:
-        return "same-origin"_s;
-    case ReferrerPolicy::StrictOrigin:
-        return "strict-origin"_s;
-    case ReferrerPolicy::StrictOriginWhenCrossOrigin:
-        return "strict-origin-when-cross-origin"_s;
-    case ReferrerPolicy::NoReferrerWhenDowngrade:
-        return "no-referrer-when-downgrade"_s;
-    case ReferrerPolicy::EmptyString:
-        return { };
-    }
-    ASSERT_NOT_REACHED();
-    return { };
+    return convertEnumerationToString(referrerPolicy);
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### de96a0b36261b247a4c939e0aee98323e50114c8
<pre>
Use generated code in ReferrerPolicy.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=252962">https://bugs.webkit.org/show_bug.cgi?id=252962</a>

Reviewed by Youenn Fablet.

Code used for serializing ReferrerPolicy is
generated in JSReferrerPolicy, use that instead of
the current custom code in ReferrerPolicy.cpp.

* Source/WebCore/platform/ReferrerPolicy.cpp:
(WebCore::referrerPolicyToString):

Canonical link: <a href="https://commits.webkit.org/262619@main">https://commits.webkit.org/262619@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d842a4611b265b0c6fee4a900b687749e1cc0884

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2053 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2081 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2148 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2978 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2115 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2027 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2161 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2123 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1875 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2071 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1842 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1842 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2828 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1828 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1819 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1727 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1889 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1867 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2997 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1885 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1686 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1813 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1830 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/512 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1992 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->