### PR TITLE
Adding a SELECT tree to another tree should not reset selection

### DIFF
--- a/LayoutTests/fast/forms/select-ask-for-reset-expected.txt
+++ b/LayoutTests/fast/forms/select-ask-for-reset-expected.txt
@@ -1,4 +1,6 @@
 
+PASS Adding a SELECT tree to another tree should not reset selection.
 PASS Removing a SELECT tree from another tree should not reset selection.
 PASS Reset should select the first option element in the list of options that is not disabled to true
+
 

--- a/LayoutTests/fast/forms/select-ask-for-reset.html
+++ b/LayoutTests/fast/forms/select-ask-for-reset.html
@@ -7,6 +7,17 @@
 <script>
 test(function() {
     var select = document.createElement('select');
+    select.innerHTML = '<option>foo</option>';
+    assert_equals(select.selectedIndex, 0);
+    select.value = '';
+    assert_equals(select.selectedIndex, -1);
+    document.body.appendChild(select);
+    // appendChild shouldn't change selection because it didn't change the
+    // option list.
+    assert_equals(select.selectedIndex, -1);
+}, 'Adding a SELECT tree to another tree should not reset selection.');
+test(function() {
+    var select = document.createElement('select');
     document.body.appendChild(select);
     select.innerHTML = '<option>foo</option>';
     assert_equals(select.selectedIndex, 0);

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -3,7 +3,7 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2001 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2023 Apple Inc. All rights reserved.
  *           (C) 2006 Alexey Proskuryakov (ap@nypop.com)
  * Copyright (C) 2010-2022 Google Inc. All rights reserved.
  * Copyright (C) 2009 Torch Mobile Inc. All rights reserved. (http://www.torchmobile.com/)
@@ -1600,15 +1600,6 @@ void HTMLSelectElement::typeAheadFind(KeyboardEvent& event)
     selectOption(listToOptionIndex(index), DeselectOtherOptions | DispatchChangeEvent | UserDriven);
     if (!usesMenuList())
         listBoxOnChange();
-}
-
-Node::InsertedIntoAncestorResult HTMLSelectElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
-{
-    // When the element is created during document parsing, it won't have any
-    // items yet - but for innerHTML and related methods, this method is called
-    // after the whole subtree is constructed.
-    recalcListItems();
-    return HTMLFormControlElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
 }
 
 void HTMLSelectElement::accessKeySetSelectedIndex(int index)

--- a/Source/WebCore/html/HTMLSelectElement.h
+++ b/Source/WebCore/html/HTMLSelectElement.h
@@ -3,8 +3,8 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2000 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2004, 2005, 2006, 2007, 2009, 2010, 2011 Apple Inc. All rights reserved.
- * Copyright (C) 2010 Google Inc. All rights reserved.
+ * Copyright (C) 2004-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2015 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -157,8 +157,6 @@ private:
     void deselectItems(HTMLOptionElement* excludeElement = nullptr);
     void typeAheadFind(KeyboardEvent&);
     void saveLastSelection();
-
-    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
 
     bool isOptionalFormControl() const final { return !isRequiredFormControl(); }
     bool isRequiredFormControl() const final;


### PR DESCRIPTION
#### 05dc4285c1167fc8dfa6ca77b98c415c36744392
<pre>
Adding a SELECT tree to another tree should not reset selection

<a href="https://bugs.webkit.org/show_bug.cgi?id=248360">https://bugs.webkit.org/show_bug.cgi?id=248360</a>
rdar://problem/102935842

Reviewed by Ryosuke Niwa.

This patch is to align WebKit with Blink / Chromium and Gecko / Firefox.

Partial Merge - <a href="https://chromium.googlesource.com/chromium/src.git/+/049818ff21a38402b788ee340acadeaaf3b37c79">https://chromium.googlesource.com/chromium/src.git/+/049818ff21a38402b788ee340acadeaaf3b37c79</a>

This patch is to remove function &apos;insertedIntoAncestor&apos; so the selection
does not reset on adding in SELECT tree.

* Source/WebCore/html/HTMLSelectElement.cpp:
(HTMLSelectElement::insertedIntoAncestor): Remove function
* Source/WebCore/html/HTMLSelectElement.h: Remove &apos;insertedIntoAncestor&apos;
* LayoutTests/fast/forms/select-ask-for-reset.html: Add Testcase
* LayoutTests/fast/forms/select-ask-for-reset-expected.txt: Add Testcase Expectations

Canonical link: <a href="https://commits.webkit.org/260859@main">https://commits.webkit.org/260859@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cfd7459e5f0a659349802e5751187ca0db0bbfde

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109693 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18810 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42434 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1169 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118815 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113609 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20280 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10009 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101960 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115443 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15096 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98329 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43317 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97069 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29980 "Found 1 new test failure: imported/w3c/web-platform-tests/preload/onerror-event.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85104 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11540 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31322 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12195 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8259 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17562 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50931 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7529 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13941 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->