### PR TITLE
[UI-side compositing] RemoteScrollingTree needs to hold a weak ref to the RemoteScrollingCoordinatorProxy

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.cpp
@@ -126,7 +126,7 @@ TextStream& operator<<(TextStream& ts, ViewportRectStability stability)
 
 TextStream& operator<<(TextStream& ts, WheelEventHandlingResult result)
 {
-    ts << "steps" << result.steps << " was handled " << result.wasHandled;
+    ts << "steps " << result.steps << " was handled " << result.wasHandled;
     return ts;
 }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
@@ -27,10 +27,10 @@
 
 #if ENABLE(UI_SIDE_COMPOSITING)
 
-#include "RemoteScrollingCoordinator.h"
 #include <WebCore/ScrollingConstraints.h>
 #include <WebCore/ScrollingTree.h>
 #include <WebCore/WheelEventTestMonitor.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 class PlatformMouseEvent;
@@ -51,13 +51,13 @@ public:
 
     virtual void handleMouseEvent(const WebCore::PlatformMouseEvent&) { }
 
-    const RemoteScrollingCoordinatorProxy& scrollingCoordinatorProxy() const { return m_scrollingCoordinatorProxy; }
+    RemoteScrollingCoordinatorProxy* scrollingCoordinatorProxy() const;
 
-    void scrollingTreeNodeDidScroll(WebCore::ScrollingTreeScrollingNode&, WebCore::ScrollingLayerPositionAction = WebCore::ScrollingLayerPositionAction::Sync) final;
-    void scrollingTreeNodeDidStopAnimatedScroll(WebCore::ScrollingTreeScrollingNode&) final;
-    bool scrollingTreeNodeRequestsScroll(WebCore::ScrollingNodeID, const WebCore::RequestedScrollData&) final;
+    void scrollingTreeNodeDidScroll(WebCore::ScrollingTreeScrollingNode&, WebCore::ScrollingLayerPositionAction = WebCore::ScrollingLayerPositionAction::Sync) override;
+    void scrollingTreeNodeDidStopAnimatedScroll(WebCore::ScrollingTreeScrollingNode&) override;
+    bool scrollingTreeNodeRequestsScroll(WebCore::ScrollingNodeID, const WebCore::RequestedScrollData&) override;
 
-    void currentSnapPointIndicesDidChange(WebCore::ScrollingNodeID, std::optional<unsigned> horizontal, std::optional<unsigned> vertical) final;
+    void currentSnapPointIndicesDidChange(WebCore::ScrollingNodeID, std::optional<unsigned> horizontal, std::optional<unsigned> vertical) override;
     void reportExposedUnfilledArea(MonotonicTime, unsigned unfilledArea) override;
     void reportSynchronousScrollingReasonsChanged(MonotonicTime, OptionSet<WebCore::SynchronousScrollingReason>) override;
 
@@ -70,7 +70,8 @@ protected:
     void deferWheelEventTestCompletionForReason(WebCore::ScrollingNodeID, WebCore::WheelEventTestMonitor::DeferReason) override;
     void removeWheelEventTestCompletionDeferralForReason(WebCore::ScrollingNodeID, WebCore::WheelEventTestMonitor::DeferReason) override;
 
-    RemoteScrollingCoordinatorProxy& m_scrollingCoordinatorProxy;
+    // This gets nulled out via invalidate(), since the scrolling thread can hold a ref to the ScrollingTree after the RemoteScrollingCoordinatorProxy has gone away.
+    WeakPtr<RemoteScrollingCoordinatorProxy> m_scrollingCoordinatorProxy;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingTreeIOS.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingTreeIOS.cpp
@@ -48,17 +48,20 @@ RemoteScrollingTreeIOS::~RemoteScrollingTreeIOS() = default;
 
 void RemoteScrollingTreeIOS::scrollingTreeNodeWillStartPanGesture(ScrollingNodeID nodeID)
 {
-    m_scrollingCoordinatorProxy.scrollingTreeNodeWillStartPanGesture(nodeID);
+    if (m_scrollingCoordinatorProxy)
+        m_scrollingCoordinatorProxy->scrollingTreeNodeWillStartPanGesture(nodeID);
 }
 
 void RemoteScrollingTreeIOS::scrollingTreeNodeWillStartScroll(ScrollingNodeID nodeID)
 {
-    m_scrollingCoordinatorProxy.scrollingTreeNodeWillStartScroll(nodeID);
+    if (m_scrollingCoordinatorProxy)
+        m_scrollingCoordinatorProxy->scrollingTreeNodeWillStartScroll(nodeID);
 }
 
 void RemoteScrollingTreeIOS::scrollingTreeNodeDidEndScroll(ScrollingNodeID nodeID)
 {
-    m_scrollingCoordinatorProxy.scrollingTreeNodeDidEndScroll(nodeID);
+    if (m_scrollingCoordinatorProxy)
+        m_scrollingCoordinatorProxy->scrollingTreeNodeDidEndScroll(nodeID);
 }
 
 Ref<ScrollingTreeNode> RemoteScrollingTreeIOS::createScrollingTreeNode(ScrollingNodeType nodeType, ScrollingNodeID nodeID)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
@@ -341,8 +341,9 @@ void ScrollingTreeScrollingNodeDelegateIOS::stopAnimatedScroll()
 #if HAVE(UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_HANDLING)
 void ScrollingTreeScrollingNodeDelegateIOS::handleAsynchronousCancelableScrollEvent(UIScrollView *scrollView, UIScrollEvent *scrollEvent, void (^completion)(BOOL handled))
 {
-    auto& scrollingCoordinatorProxy = downcast<WebKit::RemoteScrollingTree>(scrollingTree()).scrollingCoordinatorProxy();
-    scrollingCoordinatorProxy.webPageProxy().pageClient().handleAsynchronousCancelableScrollEvent(scrollView, scrollEvent, completion);
+    auto* scrollingCoordinatorProxy = downcast<WebKit::RemoteScrollingTree>(scrollingTree()).scrollingCoordinatorProxy();
+    if (scrollingCoordinatorProxy)
+        scrollingCoordinatorProxy->webPageProxy().pageClient().handleAsynchronousCancelableScrollEvent(scrollView, scrollEvent, completion);
 }
 #endif
 
@@ -404,10 +405,13 @@ UIScrollView *ScrollingTreeScrollingNodeDelegateIOS::findActingScrollParent(UISc
 {
     ASSERT(scrollView == this->scrollView());
 
-    auto& scrollingCoordinatorProxy = downcast<RemoteScrollingTree>(scrollingTree()).scrollingCoordinatorProxy();
-    auto host = scrollingCoordinatorProxy.layerTreeHost();
+    auto* scrollingCoordinatorProxy = downcast<RemoteScrollingTree>(scrollingTree()).scrollingCoordinatorProxy();
+    if (!scrollingCoordinatorProxy)
+        return nil;
+
+    auto host = scrollingCoordinatorProxy->layerTreeHost();
     if (!host)
-        return nullptr;
+        return nil;
     
     return WebKit::findActingScrollParent(scrollView, *host);
 }
@@ -424,7 +428,11 @@ void ScrollingTreeScrollingNodeDelegateIOS::computeActiveTouchActionsForGestureR
 
 void ScrollingTreeScrollingNodeDelegateIOS::cancelPointersForGestureRecognizer(UIGestureRecognizer* gestureRecognizer)
 {
-    downcast<RemoteScrollingTree>(scrollingTree()).scrollingCoordinatorProxy().webPageProxy().pageClient().cancelPointersForGestureRecognizer(gestureRecognizer);
+    auto* scrollingCoordinatorProxy = downcast<RemoteScrollingTree>(scrollingTree()).scrollingCoordinatorProxy();
+    if (!scrollingCoordinatorProxy)
+        return;
+
+    scrollingCoordinatorProxy->webPageProxy().pageClient().cancelPointersForGestureRecognizer(gestureRecognizer);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
@@ -61,7 +61,8 @@ void RemoteScrollingTreeMac::handleWheelEventPhase(ScrollingNodeID, PlatformWhee
 
 void RemoteScrollingTreeMac::hasNodeWithAnimatedScrollChanged(bool hasNodeWithAnimatedScroll)
 {
-    m_scrollingCoordinatorProxy.hasNodeWithAnimatedScrollChanged(hasNodeWithAnimatedScroll);
+    if (m_scrollingCoordinatorProxy)
+        m_scrollingCoordinatorProxy->hasNodeWithAnimatedScrollChanged(hasNodeWithAnimatedScroll);
 }
 
 void RemoteScrollingTreeMac::displayDidRefresh(PlatformDisplayID)


### PR DESCRIPTION
#### e8575a9871eced896e8c64b5166f3c59bab146e4
<pre>
[UI-side compositing] RemoteScrollingTree needs to hold a weak ref to the RemoteScrollingCoordinatorProxy
<a href="https://bugs.webkit.org/show_bug.cgi?id=252963">https://bugs.webkit.org/show_bug.cgi?id=252963</a>
rdar://105949247

Reviewed by Tim Horton.

The scrolling thread can extend the lifetime of the RemoteScrollingTree via activity on that thread,
so RemoteScrollingTree needs to hold a nullable reference to the RemoteScrollingCoordinatorProxy;
use a WeakPtr.

Add null checks everywhere we use m_scrollingCoordinatorProxy. All of these are on the main thread.

* Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.cpp:
(WebCore::operator&lt;&lt;): Add missing space in logging.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp:
(WebKit::RemoteScrollingTree::RemoteScrollingTree):
(WebKit::RemoteScrollingTree::invalidate):
(WebKit::RemoteScrollingTree::scrollingCoordinatorProxy const):
(WebKit::RemoteScrollingTree::scrollingTreeNodeDidScroll):
(WebKit::RemoteScrollingTree::scrollingTreeNodeDidStopAnimatedScroll):
(WebKit::RemoteScrollingTree::scrollingTreeNodeRequestsScroll):
(WebKit::RemoteScrollingTree::currentSnapPointIndicesDidChange):
(WebKit::RemoteScrollingTree::reportExposedUnfilledArea):
(WebKit::RemoteScrollingTree::reportSynchronousScrollingReasonsChanged):
(WebKit::RemoteScrollingTree::receivedWheelEventWithPhases):
(WebKit::RemoteScrollingTree::deferWheelEventTestCompletionForReason):
(WebKit::RemoteScrollingTree::removeWheelEventTestCompletionDeferralForReason):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h: Various final -&gt; override since a future patch will override these functions.
(WebKit::RemoteScrollingTree::scrollingCoordinatorProxy const): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingTreeIOS.cpp:
(WebKit::RemoteScrollingTreeIOS::scrollingTreeNodeWillStartPanGesture):
(WebKit::RemoteScrollingTreeIOS::scrollingTreeNodeWillStartScroll):
(WebKit::RemoteScrollingTreeIOS::scrollingTreeNodeDidEndScroll):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm:
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::handleAsynchronousCancelableScrollEvent):
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::findActingScrollParent):
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::cancelPointersForGestureRecognizer):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::RemoteScrollingTreeMac::hasNodeWithAnimatedScrollChanged):

Canonical link: <a href="https://commits.webkit.org/260898@main">https://commits.webkit.org/260898@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/755a722b22e2037af825991a2cd65d242c8e9adc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109697 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18814 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42438 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1173 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118819 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113614 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20284 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10013 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/101964 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115447 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15100 "Found 1 new test failure: fast/mediastream/mock-media-source-webaudio.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98333 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43321 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97073 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29984 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85107 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11544 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31326 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12199 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8263 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17566 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50935 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7558 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13945 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->