### PR TITLE
Prefer std::abs over fabs

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssembler.h
+++ b/Source/JavaScriptCore/assembler/MacroAssembler.h
@@ -1418,7 +1418,7 @@ public:
         if (bitwise_cast<uint64_t>(value * 1.0) != bitwise_cast<uint64_t>(value))
             return shouldConsiderBlinding();
 
-        value = fabs(value);
+        value = std::abs(value);
         // Only allow a limited set of fractional components
         double scaledValue = value * 8;
         if (scaledValue / 8 != value)

--- a/Source/JavaScriptCore/b3/B3ConstDoubleValue.cpp
+++ b/Source/JavaScriptCore/b3/B3ConstDoubleValue.cpp
@@ -106,7 +106,7 @@ Value* ConstDoubleValue::doubleToFloatConstant(Procedure& proc) const
 
 Value* ConstDoubleValue::absConstant(Procedure& proc) const
 {
-    return proc.add<ConstDoubleValue>(origin(), fabs(m_value));
+    return proc.add<ConstDoubleValue>(origin(), std::abs(m_value));
 }
 
 Value* ConstDoubleValue::ceilConstant(Procedure& proc) const

--- a/Source/JavaScriptCore/b3/B3ConstFloatValue.cpp
+++ b/Source/JavaScriptCore/b3/B3ConstFloatValue.cpp
@@ -105,7 +105,7 @@ Value* ConstFloatValue::floatToDoubleConstant(Procedure& proc) const
 
 Value* ConstFloatValue::absConstant(Procedure& proc) const
 {
-    return proc.add<ConstFloatValue>(origin(), static_cast<float>(fabs(m_value)));
+    return proc.add<ConstFloatValue>(origin(), static_cast<float>(std::abs(m_value)));
 }
 
 Value* ConstFloatValue::ceilConstant(Procedure& proc) const

--- a/Source/JavaScriptCore/b3/testb3_3.cpp
+++ b/Source/JavaScriptCore/b3/testb3_3.cpp
@@ -1683,7 +1683,7 @@ void testAbsArg(double a)
             proc, Abs, Origin(),
                 root->appendNew<ArgumentRegValue>(proc, Origin(), FPRInfo::argumentFPR0)));
 
-    CHECK(isIdentical(compileAndRun<double>(proc, a), fabs(a)));
+    CHECK(isIdentical(compileAndRun<double>(proc, a), std::abs(a)));
 }
 
 void testAbsImm(double a)
@@ -1695,7 +1695,7 @@ void testAbsImm(double a)
         proc, Return, Origin(),
         root->appendNew<Value>(proc, Abs, Origin(), argument));
 
-    CHECK(isIdentical(compileAndRun<double>(proc), fabs(a)));
+    CHECK(isIdentical(compileAndRun<double>(proc), std::abs(a)));
 }
 
 void testAbsMem(double a)
@@ -1708,7 +1708,7 @@ void testAbsMem(double a)
         proc, Return, Origin(),
         root->appendNew<Value>(proc, Abs, Origin(), loadDouble));
 
-    CHECK(isIdentical(compileAndRun<double>(proc, &a), fabs(a)));
+    CHECK(isIdentical(compileAndRun<double>(proc, &a), std::abs(a)));
 }
 
 void testAbsAbsArg(double a)
@@ -1720,7 +1720,7 @@ void testAbsAbsArg(double a)
     Value* secondAbs = root->appendNew<Value>(proc, Abs, Origin(), firstAbs);
     root->appendNewControlValue(proc, Return, Origin(), secondAbs);
 
-    CHECK(isIdentical(compileAndRun<double>(proc, a), fabs(fabs(a))));
+    CHECK(isIdentical(compileAndRun<double>(proc, a), std::abs(std::abs(a))));
 }
 
 void testAbsNegArg(double a)
@@ -1732,7 +1732,7 @@ void testAbsNegArg(double a)
     Value* abs = root->appendNew<Value>(proc, Abs, Origin(), neg);
     root->appendNewControlValue(proc, Return, Origin(), abs);
 
-    CHECK(isIdentical(compileAndRun<double>(proc, a), fabs(- a)));
+    CHECK(isIdentical(compileAndRun<double>(proc, a), std::abs(- a)));
 }
 
 void testAbsBitwiseCastArg(double a)
@@ -1744,7 +1744,7 @@ void testAbsBitwiseCastArg(double a)
     Value* absValue = root->appendNew<Value>(proc, Abs, Origin(), argumentAsDouble);
     root->appendNewControlValue(proc, Return, Origin(), absValue);
 
-    CHECK(isIdentical(compileAndRun<double>(proc, bitwise_cast<int64_t>(a)), fabs(a)));
+    CHECK(isIdentical(compileAndRun<double>(proc, bitwise_cast<int64_t>(a)), std::abs(a)));
 }
 
 void testBitwiseCastAbsBitwiseCastArg(double a)
@@ -1758,7 +1758,7 @@ void testBitwiseCastAbsBitwiseCastArg(double a)
 
     root->appendNewControlValue(proc, Return, Origin(), resultAsInt64);
 
-    int64_t expectedResult = bitwise_cast<int64_t>(fabs(a));
+    int64_t expectedResult = bitwise_cast<int64_t>(std::abs(a));
     CHECK(isIdentical(compileAndRun<int64_t>(proc, bitwise_cast<int64_t>(a)), expectedResult));
 }
 
@@ -1773,7 +1773,7 @@ void testAbsArg(float a)
     Value* result32 = root->appendNew<Value>(proc, BitwiseCast, Origin(), result);
     root->appendNewControlValue(proc, Return, Origin(), result32);
 
-    CHECK(isIdentical(compileAndRun<int32_t>(proc, bitwise_cast<int32_t>(a)), bitwise_cast<int32_t>(static_cast<float>(fabs(a)))));
+    CHECK(isIdentical(compileAndRun<int32_t>(proc, bitwise_cast<int32_t>(a)), bitwise_cast<int32_t>(static_cast<float>(std::abs(a)))));
 }
 
 void testAbsImm(float a)
@@ -1785,7 +1785,7 @@ void testAbsImm(float a)
     Value* result32 = root->appendNew<Value>(proc, BitwiseCast, Origin(), result);
     root->appendNewControlValue(proc, Return, Origin(), result32);
 
-    CHECK(isIdentical(compileAndRun<int32_t>(proc, bitwise_cast<int32_t>(a)), bitwise_cast<int32_t>(static_cast<float>(fabs(a)))));
+    CHECK(isIdentical(compileAndRun<int32_t>(proc, bitwise_cast<int32_t>(a)), bitwise_cast<int32_t>(static_cast<float>(std::abs(a)))));
 }
 
 void testAbsMem(float a)
@@ -1798,7 +1798,7 @@ void testAbsMem(float a)
     Value* result32 = root->appendNew<Value>(proc, BitwiseCast, Origin(), result);
     root->appendNewControlValue(proc, Return, Origin(), result32);
 
-    CHECK(isIdentical(compileAndRun<int32_t>(proc, &a), bitwise_cast<int32_t>(static_cast<float>(fabs(a)))));
+    CHECK(isIdentical(compileAndRun<int32_t>(proc, &a), bitwise_cast<int32_t>(static_cast<float>(std::abs(a)))));
 }
 
 void testAbsAbsArg(float a)
@@ -1812,7 +1812,7 @@ void testAbsAbsArg(float a)
     Value* secondAbs = root->appendNew<Value>(proc, Abs, Origin(), firstAbs);
     root->appendNewControlValue(proc, Return, Origin(), secondAbs);
 
-    CHECK(isIdentical(compileAndRun<float>(proc, bitwise_cast<int32_t>(a)), static_cast<float>(fabs(fabs(a)))));
+    CHECK(isIdentical(compileAndRun<float>(proc, bitwise_cast<int32_t>(a)), static_cast<float>(std::abs(std::abs(a)))));
 }
 
 void testAbsNegArg(float a)
@@ -1826,7 +1826,7 @@ void testAbsNegArg(float a)
     Value* abs = root->appendNew<Value>(proc, Abs, Origin(), neg);
     root->appendNewControlValue(proc, Return, Origin(), abs);
 
-    CHECK(isIdentical(compileAndRun<float>(proc, bitwise_cast<int32_t>(a)), static_cast<float>(fabs(- a))));
+    CHECK(isIdentical(compileAndRun<float>(proc, bitwise_cast<int32_t>(a)), static_cast<float>(std::abs(- a))));
 }
 
 void testAbsBitwiseCastArg(float a)
@@ -1839,7 +1839,7 @@ void testAbsBitwiseCastArg(float a)
     Value* absValue = root->appendNew<Value>(proc, Abs, Origin(), argumentAsfloat);
     root->appendNewControlValue(proc, Return, Origin(), absValue);
 
-    CHECK(isIdentical(compileAndRun<float>(proc, bitwise_cast<int32_t>(a)), static_cast<float>(fabs(a))));
+    CHECK(isIdentical(compileAndRun<float>(proc, bitwise_cast<int32_t>(a)), static_cast<float>(std::abs(a))));
 }
 
 void testBitwiseCastAbsBitwiseCastArg(float a)
@@ -1854,7 +1854,7 @@ void testBitwiseCastAbsBitwiseCastArg(float a)
 
     root->appendNewControlValue(proc, Return, Origin(), resultAsInt64);
 
-    int32_t expectedResult = bitwise_cast<int32_t>(static_cast<float>(fabs(a)));
+    int32_t expectedResult = bitwise_cast<int32_t>(static_cast<float>(std::abs(a)));
     CHECK(isIdentical(compileAndRun<int32_t>(proc, bitwise_cast<int32_t>(a)), expectedResult));
 }
 
@@ -1871,7 +1871,7 @@ void testAbsArgWithUselessDoubleConversion(float a)
     Value* result32 = root->appendNew<Value>(proc, BitwiseCast, Origin(), floatResult);
     root->appendNewControlValue(proc, Return, Origin(), result32);
 
-    CHECK(isIdentical(compileAndRun<int32_t>(proc, bitwise_cast<int32_t>(a)), bitwise_cast<int32_t>(static_cast<float>(fabs(a)))));
+    CHECK(isIdentical(compileAndRun<int32_t>(proc, bitwise_cast<int32_t>(a)), bitwise_cast<int32_t>(static_cast<float>(std::abs(a)))));
 }
 
 void testAbsArgWithEffectfulDoubleConversion(float a)
@@ -1891,8 +1891,8 @@ void testAbsArgWithEffectfulDoubleConversion(float a)
 
     double effect = 0;
     int32_t resultValue = compileAndRun<int32_t>(proc, bitwise_cast<int32_t>(a), &effect);
-    CHECK(isIdentical(resultValue, bitwise_cast<int32_t>(static_cast<float>(fabs(a)))));
-    CHECK(isIdentical(effect, static_cast<double>(fabs(a))));
+    CHECK(isIdentical(resultValue, bitwise_cast<int32_t>(static_cast<float>(std::abs(a)))));
+    CHECK(isIdentical(effect, static_cast<double>(std::abs(a))));
 }
 
 void testCeilArg(double a)

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -1296,7 +1296,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         switch (node->child1().useKind()) {
         case Int32Use:
             if (std::optional<double> number = child.toNumberFromPrimitive()) {
-                JSValue result = jsNumber(fabs(*number));
+                JSValue result = jsNumber(std::abs(*number));
                 if (result.isInt32()) {
                     setConstant(node, result);
                     break;
@@ -1306,7 +1306,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
             break;
         case DoubleRepUse:
             if (std::optional<double> number = child.toNumberFromPrimitive()) {
-                setConstant(node, jsDoubleNumber(fabs(*number)));
+                setConstant(node, jsDoubleNumber(std::abs(*number)));
                 break;
             }
             setNonCellTypeForNode(node, typeOfDoubleAbs(forNode(node->child1()).m_type));

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -671,7 +671,7 @@ JSC_DEFINE_JIT_OPERATION(operationArithAbs, double, (JSGlobalObject* globalObjec
     JSValue op1 = JSValue::decode(encodedOp1);
     double a = op1.toNumber(globalObject);
     RETURN_IF_EXCEPTION(scope, PNaN);
-    return fabs(a);
+    return std::abs(a);
 }
 
 JSC_DEFINE_JIT_OPERATION(operationArithClz32, UCPUStrictInt32, (JSGlobalObject* globalObject, EncodedJSValue encodedOp1))

--- a/Source/JavaScriptCore/jit/AssemblyHelpersSpoolers.h
+++ b/Source/JavaScriptCore/jit/AssemblyHelpersSpoolers.h
@@ -401,7 +401,7 @@ private:
             regToStore1 = temp1<RegType>();
             regToStore2 = temp2<RegType>();
 
-            int offsetDelta = abs(srcOffset1 - srcOffset2);
+            int offsetDelta = std::abs(srcOffset1 - srcOffset2);
             int minOffset = std::min(srcOffset1, srcOffset2);
             bool isValidOffset = isValidLoadPairImm<RegType>(minOffset);
 
@@ -470,7 +470,7 @@ private:
         int dstOffset1 = m_deferredStoreOffset - m_dstOffsetAdjustment;
         int dstOffset2 = storeOffset - m_dstOffsetAdjustment;
 
-        int offsetDelta = abs(dstOffset1 - dstOffset2);
+        int offsetDelta = std::abs(dstOffset1 - dstOffset2);
         int minOffset = std::min(dstOffset1, dstOffset2);
         bool isValidOffset = isValidStorePairImm<RegType>(minOffset);
 

--- a/Source/JavaScriptCore/runtime/DateConversion.cpp
+++ b/Source/JavaScriptCore/runtime/DateConversion.cpp
@@ -89,7 +89,7 @@ String formatDateTime(const GregorianDateTime& t, DateTimeFormat format, bool as
         builder.append(" GMT");
 
         if (!asUTCVariant) {
-            int offset = abs(t.utcOffsetInMinute());
+            int offset = std::abs(t.utcOffsetInMinute());
             builder.append(t.utcOffsetInMinute() < 0 ? '-' : '+');
             appendNumber<2>(builder, offset / 60);
             appendNumber<2>(builder, offset % 60);

--- a/Source/JavaScriptCore/runtime/ISO8601.cpp
+++ b/Source/JavaScriptCore/runtime/ISO8601.cpp
@@ -1278,7 +1278,7 @@ String temporalDateToString(PlainDate plainDate)
     if (year < 0 || year > 9999) {
         prefix = year < 0 ? "-"_s : "+"_s;
         yearDigits = 6;
-        year = abs(year);
+        year = std::abs(year);
     }
 
     return makeString(prefix, pad('0', yearDigits, year), '-', pad('0', 2, plainDate.month()), '-', pad('0', 2, plainDate.day()));

--- a/Source/JavaScriptCore/runtime/MathCommon.cpp
+++ b/Source/JavaScriptCore/runtime/MathCommon.cpp
@@ -231,7 +231,7 @@ static double fdlibmPow(double x, double y)
         }
     }
 
-    ax   = fabs(x);
+    ax   = std::abs(x);
     /* special value of x */
     if(lx==0) {
         if(ix==0x7ff00000||ix==0||ix==0x3ff00000){
@@ -413,7 +413,7 @@ JSC_DEFINE_JIT_OPERATION(operationMathPow, double, (double x, double y))
 {
     if (std::isnan(y))
         return PNaN;
-    double absoluteBase = fabs(x);
+    double absoluteBase = std::abs(x);
     if (absoluteBase == 1 && std::isinf(y))
         return PNaN;
 

--- a/Source/JavaScriptCore/runtime/MathObject.cpp
+++ b/Source/JavaScriptCore/runtime/MathObject.cpp
@@ -126,7 +126,7 @@ void MathObject::finishCreation(VM& vm, JSGlobalObject* globalObject)
 
 JSC_DEFINE_HOST_FUNCTION(mathProtoFuncAbs, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    return JSValue::encode(jsNumber(fabs(callFrame->argument(0).toNumber(globalObject))));
+    return JSValue::encode(jsNumber(std::abs(callFrame->argument(0).toNumber(globalObject))));
 }
 
 JSC_DEFINE_HOST_FUNCTION(mathProtoFuncACos, (JSGlobalObject* globalObject, CallFrame* callFrame))
@@ -202,7 +202,7 @@ JSC_DEFINE_HOST_FUNCTION(mathProtoFuncHypot, (JSGlobalObject* globalObject, Call
     for (double argument : args) {
         if (std::isinf(argument))
             return JSValue::encode(jsDoubleNumber(+std::numeric_limits<double>::infinity()));
-        max = std::max(fabs(argument), max);
+        max = std::max(std::abs(argument), max);
     }
 
     if (!max)

--- a/Source/JavaScriptCore/runtime/NumberPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/NumberPrototype.cpp
@@ -436,7 +436,7 @@ JSC_DEFINE_HOST_FUNCTION(numberProtoFuncToFixed, (JSGlobalObject* globalObject, 
     // 15.7.4.5.7 states "If x >= 10^21, then let m = ToString(x)"
     // This also covers Ininity, and structure the check so that NaN
     // values are also handled by numberToString
-    if (!(fabs(x) < 1e+21))
+    if (!(std::abs(x) < 1e+21))
         return JSValue::encode(jsString(vm, String::number(x)));
 
     // The check above will return false for NaN or Infinity, these will be

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -5547,7 +5547,7 @@ public:
                     m_jit.and32(TrustedImm32(static_cast<int32_t>(0x80000000u)), wasmScratchGPR, wasmScratchGPR);
                     m_jit.move32ToFloat(wasmScratchGPR, wasmScratchFPR);
 
-                    emitMoveConst(Value::fromF32(std::fabs(lhs.asF32())), resultLocation);
+                    emitMoveConst(Value::fromF32(std::abs(lhs.asF32())), resultLocation);
                     m_jit.orFloat(resultLocation.asFPR(), wasmScratchFPR, resultLocation.asFPR());
                 } else {
                     bool signBit = bitwise_cast<uint32_t>(rhs.asF32()) & 0x80000000u;
@@ -5611,7 +5611,7 @@ public:
                     m_jit.move64ToDouble(wasmScratchGPR, wasmScratchFPR);
 
                     // Moving this constant clobbers wasmScratchGPR, but not wasmScratchFPR
-                    emitMoveConst(Value::fromF64(std::fabs(lhs.asF64())), resultLocation);
+                    emitMoveConst(Value::fromF64(std::abs(lhs.asF64())), resultLocation);
                     m_jit.orDouble(resultLocation.asFPR(), wasmScratchFPR, resultLocation.asFPR());
                 } else {
                     bool signBit = bitwise_cast<uint64_t>(rhs.asF64()) & 0x8000000000000000ull;

--- a/Source/WTF/wtf/CurrentTime.cpp
+++ b/Source/WTF/wtf/CurrentTime.cpp
@@ -180,7 +180,7 @@ static inline double currentTime()
     // force a clock re-sync if we've drifted
     double lowResElapsed = lowResTime - syncLowResUTCTime;
     const double maximumAllowedDriftMsec = 15.625 * 2.0; // 2x the typical low-res accuracy
-    if (fabs(highResElapsed - lowResElapsed) > maximumAllowedDriftMsec)
+    if (std::abs(highResElapsed - lowResElapsed) > maximumAllowedDriftMsec)
         syncedTime = false;
 
     // make sure time doesn't run backwards (only correct if difference is < 2 seconds, since DST or clock changes could occur)

--- a/Source/WTF/wtf/DateMath.cpp
+++ b/Source/WTF/wtf/DateMath.cpp
@@ -933,7 +933,7 @@ double parseDateFromNullTerminatedCharacters(const char* dateString, bool& isLoc
                 return std::numeric_limits<double>::quiet_NaN();
 
             int sgn = (o < 0) ? -1 : 1;
-            o = abs(o);
+            o = std::abs(o);
             if (*dateString != ':') {
                 if (o >= 24)
                     offset = ((o / 100) * 60 + (o % 100)) * sgn;
@@ -1028,7 +1028,7 @@ String makeRFC2822DateString(unsigned dayOfWeek, unsigned day, unsigned month, u
     stringBuilder.append(' ');
 
     stringBuilder.append(utcOffset > 0 ? '+' : '-');
-    int absoluteUTCOffset = abs(utcOffset);
+    int absoluteUTCOffset = std::abs(utcOffset);
     appendTwoDigitNumber(stringBuilder, absoluteUTCOffset / 60);
     appendTwoDigitNumber(stringBuilder, absoluteUTCOffset % 60);
 

--- a/Source/WTF/wtf/MediaTime.cpp
+++ b/Source/WTF/wtf/MediaTime.cpp
@@ -595,7 +595,7 @@ MediaTime abs(const MediaTime& rhs)
     if (rhs.isNegativeInfinite() || rhs.isPositiveInfinite())
         return MediaTime::positiveInfiniteTime();
     if (rhs.hasDoubleValue())
-        return MediaTime::createWithDouble(fabs(rhs.m_timeValueAsDouble));
+        return MediaTime::createWithDouble(std::abs(rhs.m_timeValueAsDouble));
 
     MediaTime val = rhs;
     val.m_timeValue = std::abs(rhs.m_timeValue);

--- a/Source/WTF/wtf/text/TextStream.cpp
+++ b/Source/WTF/wtf/text/TextStream.cpp
@@ -37,7 +37,7 @@ static inline bool hasFractions(double val)
     static constexpr double s_epsilon = 0.0001;
     int ival = static_cast<int>(val);
     double dval = static_cast<double>(ival);
-    return fabs(val - dval) > s_epsilon;
+    return std::abs(val - dval) > s_epsilon;
 }
 
 TextStream& TextStream::operator<<(bool b)

--- a/Source/WebCore/Modules/mediasession/MediaSessionCoordinator.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaSessionCoordinator.cpp
@@ -436,7 +436,7 @@ bool MediaSessionCoordinator::currentPositionApproximatelyEqualTo(double time) c
     if (!currentPosition)
         return false;
 
-    auto delta = Seconds(abs(*currentPosition - time));
+    auto delta = Seconds(std::abs(*currentPosition - time));
     return delta <= CommandTimeTolerance;
 }
 

--- a/Source/WebCore/Modules/webaudio/AudioParam.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioParam.cpp
@@ -143,7 +143,7 @@ bool AudioParam::smooth()
         m_smoothedValue += (m_value - m_smoothedValue) * SmoothingConstant;
 
         // If we get close enough then snap to actual value.
-        if (fabs(m_smoothedValue - m_value) < SnapThreshold) // FIXME: the threshold needs to be adjustable depending on range - but this is OK general purpose value.
+        if (std::abs(m_smoothedValue - m_value) < SnapThreshold) // FIXME: the threshold needs to be adjustable depending on range - but this is OK general purpose value.
             m_smoothedValue = m_value;
     }
 

--- a/Source/WebCore/Modules/webaudio/AudioParamTimeline.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioParamTimeline.cpp
@@ -807,9 +807,9 @@ void AudioParamTimeline::processSetTargetFollowedByRamp(int eventIndex, ParamEve
     //    2 * f - 2 <= 2 * Fs * t0 <= 2 * f
     //    -2 <= 2 * Fs * t0 - 2 * f <= 0
     //    -1 <= 2 * Fs * t0 - 2 * f + 1 <= 1
-    //     abs(2 * Fs * t0 - 2 * f + 1) <= 1
+    //     std::abs(2 * Fs * t0 - 2 * f + 1) <= 1
 
-    if (fabs(2 * sampleRate * event->time().value() - 2 * currentFrame + 1) <= 1) {
+    if (std::abs(2 * sampleRate * event->time().value() - 2 * currentFrame + 1) <= 1) {
         // SetTarget is starting somewhere between currentFrame - 1 and currentFrame. Compute the value
         // the SetTarget would have at the currentFrame.
         value = event->value() + (value - event->value()) * exp(-(currentFrame / sampleRate - event->time().value()) / event->timeConstant());

--- a/Source/WebCore/Modules/webaudio/IIRFilterNode.cpp
+++ b/Source/WebCore/Modules/webaudio/IIRFilterNode.cpp
@@ -69,7 +69,7 @@ static bool isFilterStable(const Vector<double>& feedback)
     for (int n = order; n >= 1; --n) {
         double k = coefficients[n];
 
-        if (std::fabs(k) >= 1)
+        if (std::abs(k) >= 1)
             return false;
 
         // Note that A[n](1/z)/z^n is basically the coefficients of A[n]

--- a/Source/WebCore/Modules/webaudio/OscillatorNode.cpp
+++ b/Source/WebCore/Modules/webaudio/OscillatorNode.cpp
@@ -290,7 +290,7 @@ double OscillatorNode::processARate(int n, float* destP, double virtualReadIndex
         float frequency = invRateScale * incr;
         m_periodicWave->waveDataForFundamentalFrequency(frequency, lowerWaveData, higherWaveData, tableInterpolationFactor);
 
-        float sample = doInterpolation(virtualReadIndex, fabs(incr), readIndexMask, tableInterpolationFactor, lowerWaveData, higherWaveData);
+        float sample = doInterpolation(virtualReadIndex, std::abs(incr), readIndexMask, tableInterpolationFactor, lowerWaveData, higherWaveData);
 
         *destP++ = sample;
 
@@ -325,7 +325,7 @@ double OscillatorNode::processKRate(int n, float* destP, double virtualReadIndex
     float incr = frequency * rateScale;
 
     for (int k = 0; k < n; ++k) {
-        float sample = doInterpolation(virtualReadIndex, fabs(incr), readIndexMask, tableInterpolationFactor, lowerWaveData, higherWaveData);
+        float sample = doInterpolation(virtualReadIndex, std::abs(incr), readIndexMask, tableInterpolationFactor, lowerWaveData, higherWaveData);
 
         *destP++ = sample;
 

--- a/Source/WebCore/Modules/webaudio/PeriodicWave.cpp
+++ b/Source/WebCore/Modules/webaudio/PeriodicWave.cpp
@@ -136,7 +136,7 @@ PeriodicWave::PeriodicWave(float sampleRate)
 void PeriodicWave::waveDataForFundamentalFrequency(float fundamentalFrequency, float* &lowerWaveData, float* &higherWaveData, float& tableInterpolationFactor)
 {
     // Negative frequencies are allowed, in which case we alias to the positive frequency.
-    fundamentalFrequency = fabsf(fundamentalFrequency);
+    fundamentalFrequency = std::abs(fundamentalFrequency);
 
     // Calculate the pitch range.
     float ratio = fundamentalFrequency > 0 ? fundamentalFrequency / m_lowestFundamentalFrequency : 0.5;

--- a/Source/WebCore/Modules/webaudio/RealtimeAnalyser.cpp
+++ b/Source/WebCore/Modules/webaudio/RealtimeAnalyser.cpp
@@ -174,7 +174,7 @@ void RealtimeAnalyser::doFFTAnalysisIfNecessary()
     size_t n = magnitudeBuffer().size();
     for (size_t i = 0; i < n; ++i) {
         std::complex<double> c(realP[i], imagP[i]);
-        double scalarMagnitude = abs(c) * magnitudeScale;        
+        double scalarMagnitude = std::abs(c) * magnitudeScale;        
         destination[i] = static_cast<float>(k * destination[i] + (1 - k) * scalarMagnitude);
     }
 

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -897,7 +897,7 @@ Path AccessibilityRenderObject::elementPath() const
         bool needsPath = false;
         IntRect unionRect = rects[0];
         for (size_t i = 1; i < rects.size(); ++i) {
-            needsPath = abs(rects[i].y() - unionRect.maxY()) < yTolerance // This rect is in a new line.
+            needsPath = std::abs(rects[i].y() - unionRect.maxY()) < yTolerance // This rect is in a new line.
                 && (rightToLeftText ? rects[i].x() - unionRect.x() > xTolerance
                     : unionRect.x() - rects[i].x() > xTolerance); // And this rect is to right/left of all previous rects.
 

--- a/Source/WebCore/bindings/js/JSDOMConvertNumbers.cpp
+++ b/Source/WebCore/bindings/js/JSDOMConvertNumbers.cpp
@@ -137,7 +137,7 @@ static inline T toSmallerInt(JSGlobalObject& lexicalGlobalObject, JSValue value)
     if (std::isnan(x) || std::isinf(x) || !x)
         return 0;
 
-    x = x < 0 ? -floor(fabs(x)) : floor(fabs(x));
+    x = x < 0 ? -floor(-x) : floor(x);
     x = fmod(x, LimitsTrait::numberOfValues);
 
     return static_cast<T>(x > LimitsTrait::maxValue ? x - LimitsTrait::numberOfValues : x);
@@ -183,11 +183,10 @@ static inline T toSmallerUInt(JSGlobalObject& lexicalGlobalObject, JSValue value
     if (std::isnan(x) || std::isinf(x) || !x)
         return 0;
 
-    x = x < 0 ? -floor(fabs(x)) : floor(fabs(x));
+    x = x < 0 ? -floor(-x) : floor(x);
     x = fmod(x, LimitsTrait::numberOfValues);
-    if (x < 0)
-        x += LimitsTrait::numberOfValues;
-    return static_cast<T>(x);
+
+    return static_cast<T>(x < 0 ? x + LimitsTrait::numberOfValues : x);
 }
 
 template<> int8_t convertToIntegerEnforceRange<int8_t>(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value)

--- a/Source/WebCore/contentextensions/DFABytecodeCompiler.cpp
+++ b/Source/WebCore/contentextensions/DFABytecodeCompiler.cpp
@@ -542,7 +542,7 @@ void DFABytecodeCompiler::compile()
         uint32_t destination = m_nodeStartOffsets[linkRecord.destinationNodeIndex];
         RELEASE_ASSERT(destination < static_cast<uint32_t>(std::numeric_limits<int32_t>::max()));
         int32_t distance = destination - linkRecord.instructionLocation;
-        ASSERT(abs(distance) <= abs(linkRecord.longestPossibleJump));
+        ASSERT(std::abs(distance) <= std::abs(linkRecord.longestPossibleJump));
         
         switch (linkRecord.jumpSize) {
         case DFABytecodeJumpSize::Int8:

--- a/Source/WebCore/display/css/DisplayBoxDecorationPainter.cpp
+++ b/Source/WebCore/display/css/DisplayBoxDecorationPainter.cpp
@@ -650,8 +650,8 @@ void BorderPainter::drawLineForBoxSide(PaintingContext& paintingContext, const F
             float adjacent1BigThird = ceilToDevicePixel(adjacentWidth1 / 3, deviceScaleFactor);
             float adjacent2BigThird = ceilToDevicePixel(adjacentWidth2 / 3, deviceScaleFactor);
 
-            float offset1 = floorToDevicePixel(fabs(adjacentWidth1) * 2 / 3, deviceScaleFactor);
-            float offset2 = floorToDevicePixel(fabs(adjacentWidth2) * 2 / 3, deviceScaleFactor);
+            float offset1 = floorToDevicePixel(std::abs(adjacentWidth1) * 2 / 3, deviceScaleFactor);
+            float offset2 = floorToDevicePixel(std::abs(adjacentWidth2) * 2 / 3, deviceScaleFactor);
 
             float mitreOffset1 = adjacentWidth1 < 0 ? offset1 : 0;
             float mitreOffset2 = adjacentWidth1 > 0 ? offset1 : 0;
@@ -722,7 +722,7 @@ void BorderPainter::drawLineForBoxSide(PaintingContext& paintingContext, const F
             offset2 = ceilToDevicePixel(adjacentWidth2 / 2, deviceScaleFactor);
 
         if (((side == BoxSide::Top || side == BoxSide::Left) && adjacentWidth1 > 0) || ((side == BoxSide::Bottom || side == BoxSide::Right) && adjacentWidth1 < 0))
-            offset3 = floorToDevicePixel(fabs(adjacentWidth1) / 2, deviceScaleFactor);
+            offset3 = floorToDevicePixel(std::abs(adjacentWidth1) / 2, deviceScaleFactor);
 
         if (((side == BoxSide::Top || side == BoxSide::Left) && adjacentWidth2 > 0) || ((side == BoxSide::Bottom || side == BoxSide::Right) && adjacentWidth2 < 0))
             offset4 = ceilToDevicePixel(adjacentWidth2 / 2, deviceScaleFactor);

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -2672,7 +2672,7 @@ UChar FrameSelection::characterInRelationToCaretSelection(int amount) const
 {
     auto position = m_selection.visibleStart();
     if (amount < 0) {
-        int count = abs(amount);
+        int count = std::abs(amount);
         for (int i = 0; i < count; i++)
             position = position.previous();
         return position.characterBefore();
@@ -2857,7 +2857,7 @@ std::optional<SimpleRange> FrameSelection::rangeByAlteringCurrentSelection(EAlte
     FrameSelection frameSelection;
     frameSelection.setSelection(m_selection);
     SelectionDirection direction = amount > 0 ? SelectionDirection::Forward : SelectionDirection::Backward;
-    for (int i = 0; i < abs(amount); i++)
+    for (int i = 0; i < std::abs(amount); i++)
         frameSelection.modify(alteration, direction, TextGranularity::CharacterGranularity);
     return frameSelection.selection().toNormalizedRange();
 }

--- a/Source/WebCore/editing/cocoa/HTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/HTMLConverter.mm
@@ -947,9 +947,9 @@ NSDictionary *HTMLConverter::computedAttributesForElement(Element& element)
         fontSize = defaultFontSize;
     if (fontSize < minimumFontSize)
         fontSize = minimumFontSize;
-    if (fabs(floor(2.0 * fontSize + 0.5) / 2.0 - fontSize) < 0.05)
+    if (std::abs(floor(2.0 * fontSize + 0.5) / 2.0 - fontSize) < 0.05)
         fontSize = floor(2.0 * fontSize + 0.5) / 2;
-    else if (fabs(floor(10.0 * fontSize + 0.5) / 10.0 - fontSize) < 0.005)
+    else if (std::abs(floor(10.0 * fontSize + 0.5) / 10.0 - fontSize) < 0.005)
         fontSize = floor(10.0 * fontSize + 0.5) / 10;
 
     if (fontSize <= 0.0)
@@ -1025,7 +1025,7 @@ NSDictionary *HTMLConverter::computedAttributesForElement(Element& element)
             [attrs setObject:@0.0 forKey:NSKernAttributeName];
         else {
             double kernVal = letterSpacing.length() ? letterSpacing.toDouble() : 0.0;
-            if (fabs(kernVal - 0) < FLT_EPSILON)
+            if (std::abs(kernVal - 0) < FLT_EPSILON)
                 [attrs setObject:@0.0 forKey:NSKernAttributeName]; // auto and normal, the other possible values, are both "kerning enabled"
             else
                 [attrs setObject:@(kernVal) forKey:NSKernAttributeName];

--- a/Source/WebCore/html/CustomPaintImage.cpp
+++ b/Source/WebCore/html/CustomPaintImage.cpp
@@ -150,8 +150,8 @@ void CustomPaintImage::drawPattern(GraphicsContext& destContext, const FloatRect
 
     // Factor in the destination context's scale to generate at the best resolution
     AffineTransform destContextCTM = destContext.getCTM(GraphicsContext::DefinitelyIncludeDeviceScale);
-    double xScale = fabs(destContextCTM.xScale());
-    double yScale = fabs(destContextCTM.yScale());
+    double xScale = std::abs(destContextCTM.xScale());
+    double yScale = std::abs(destContextCTM.yScale());
     AffineTransform adjustedPatternCTM = patternTransform;
     adjustedPatternCTM.scale(1.0 / xScale, 1.0 / yScale);
     adjustedSrcRect.scale(xScale, yScale);

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -4412,7 +4412,7 @@ void HTMLMediaElement::endScanning()
 
 double HTMLMediaElement::nextScanRate()
 {
-    double rate = std::min(ScanMaximumRate, fabs(playbackRate() * 2));
+    double rate = std::min(ScanMaximumRate, std::abs(playbackRate() * 2));
     if (m_scanDirection == Backward)
         rate *= -1;
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -2086,9 +2086,9 @@ std::optional<InspectorOverlay::Highlight::FlexHighlightOverlay> InspectorOverla
             auto childCrossAxisTrailingEdge = correctedCrossAxisTrailingEdge(childRect);
 
             // Build bounds for space between the current item and the cross-axis space.
-            if (std::fabs(childCrossAxisLeadingEdge - currentLineCrossAxisLeadingEdge) > 1)
+            if (std::abs(childCrossAxisLeadingEdge - currentLineCrossAxisLeadingEdge) > 1)
                 populateHighlightForGapOrSpace(childMainAxisLeadingEdge, childMainAxisTrailingEdge, currentLineCrossAxisLeadingEdge, childCrossAxisLeadingEdge, flexHighlightOverlay.spaceBetweenItemsAndCrossAxisSpace);
-            if (std::fabs(childCrossAxisTrailingEdge - currentLineCrossAxisTrailingEdge) > 1)
+            if (std::abs(childCrossAxisTrailingEdge - currentLineCrossAxisTrailingEdge) > 1)
                 populateHighlightForGapOrSpace(childMainAxisLeadingEdge, childMainAxisTrailingEdge, currentLineCrossAxisTrailingEdge, childCrossAxisTrailingEdge, flexHighlightOverlay.spaceBetweenItemsAndCrossAxisSpace);
 
             // Build bounds for gaps and space between the current item and previous item (or container edge).

--- a/Source/WebCore/layout/Verification.cpp
+++ b/Source/WebCore/layout/Verification.cpp
@@ -53,7 +53,7 @@ static bool areEssentiallyEqual(LayoutUnit a, LayoutUnit b)
         return true;
     // 1/4th CSS pixel.
     constexpr float epsilon = kFixedPointDenominator / 4;
-    return abs(a.rawValue() - b.rawValue()) <= epsilon;
+    return std::abs(a.rawValue() - b.rawValue()) <= epsilon;
 }
 
 static bool areEssentiallyEqual(float a, InlineLayoutUnit b)

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -4276,7 +4276,7 @@ bool EventHandler::mouseMovementExceedsThreshold(const FloatPoint& viewportLocat
     IntPoint location = view->windowToContents(flooredIntPoint(viewportLocation));
     IntSize delta = location - m_mouseDownContentsPosition;
     
-    return abs(delta.width()) >= pointsThreshold || abs(delta.height()) >= pointsThreshold;
+    return std::abs(delta.width()) >= pointsThreshold || std::abs(delta.height()) >= pointsThreshold;
 }
 
 bool EventHandler::handleTextInputEvent(const String& text, Event* underlyingEvent, TextEventInputType inputType)

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -650,12 +650,12 @@ FloatSize LocalFrame::resizePageRectsKeepingRatio(const FloatSize& originalSize,
         return FloatSize();
 
     if (contentRenderer()->style().isHorizontalWritingMode()) {
-        ASSERT(fabs(originalSize.width()) > std::numeric_limits<float>::epsilon());
+        ASSERT(std::abs(originalSize.width()) > std::numeric_limits<float>::epsilon());
         float ratio = originalSize.height() / originalSize.width();
         resultSize.setWidth(floorf(expectedSize.width()));
         resultSize.setHeight(floorf(resultSize.width() * ratio));
     } else {
-        ASSERT(fabs(originalSize.height()) > std::numeric_limits<float>::epsilon());
+        ASSERT(std::abs(originalSize.height()) > std::numeric_limits<float>::epsilon());
         float ratio = originalSize.width() / originalSize.height();
         resultSize.setHeight(floorf(expectedSize.height()));
         resultSize.setWidth(floorf(resultSize.height() * ratio));

--- a/Source/WebCore/page/WheelEventDeltaFilter.cpp
+++ b/Source/WebCore/page/WheelEventDeltaFilter.cpp
@@ -151,7 +151,7 @@ void BasicWheelEventDeltaFilter::reset()
 
 static inline bool deltaIsPredominantlyVertical(const FloatSize& delta)
 {
-    return fabs(delta.height()) > fabs(delta.width());
+    return std::abs(delta.height()) > std::abs(delta.width());
 }
 
 std::optional<ScrollEventAxis> BasicWheelEventDeltaFilter::dominantAxis() const

--- a/Source/WebCore/page/ios/FrameIOS.mm
+++ b/Source/WebCore/page/ios/FrameIOS.mm
@@ -355,7 +355,7 @@ Node* LocalFrame::qualifyingNodeAtViewportLocation(const FloatPoint& viewportLoc
         for (unsigned n = 0; n < std::size(testOffsets); n += 2) {
             IntSize testOffset(testOffsets[n] * searchRadius, testOffsets[n + 1] * searchRadius);
             IntPoint testPoint = testCenter + testOffset;
-            int testRadius = std::max(abs(testOffset.width()), abs(testOffset.height()));
+            int testRadius = std::max(std::abs(testOffset.width()), std::abs(testOffset.height()));
             if (testRadius > currentTestRadius) {
                 // Bail out with the best match within a radius
                 currentTestRadius = testRadius;

--- a/Source/WebCore/platform/LayoutUnit.h
+++ b/Source/WebCore/platform/LayoutUnit.h
@@ -240,7 +240,7 @@ private:
     }
     static bool isInBounds(double value)
     {
-        return ::fabs(value) <= std::numeric_limits<int>::max() / kFixedPointDenominator;
+        return ::abs(value) <= std::numeric_limits<int>::max() / kFixedPointDenominator;
     }
 
     inline void setValue(int value)

--- a/Source/WebCore/platform/LocalizedStrings.cpp
+++ b/Source/WebCore/platform/LocalizedStrings.cpp
@@ -1125,7 +1125,7 @@ String localizedMediaTimeDescription(float time)
     if (!std::isfinite(time))
         return WEB_UI_STRING("indefinite time", "accessibility help text for an indefinite media controller time value");
 
-    int seconds = static_cast<int>(fabsf(time));
+    int seconds = static_cast<int>(std::abs(time));
     int days = seconds / (60 * 60 * 24);
     int hours = seconds / (60 * 60);
     int minutes = (seconds / 60) % 60;

--- a/Source/WebCore/platform/ScrollAnimationKeyboard.cpp
+++ b/Source/WebCore/platform/ScrollAnimationKeyboard.cpp
@@ -186,10 +186,10 @@ bool ScrollAnimationKeyboard::animateScroll(MonotonicTime currentTime)
             force = unitVectorForScrollDirection(direction).scaled(parameters.rubberBandForce);
         }
 
-        if (fabs(m_velocity.width()) >= fabs(m_currentKeyboardScroll->maximumVelocity.width()))
+        if (std::abs(m_velocity.width()) >= std::abs(m_currentKeyboardScroll->maximumVelocity.width()))
             force.setWidth(0);
 
-        if (fabs(m_velocity.height()) >= fabs(m_currentKeyboardScroll->maximumVelocity.height()))
+        if (std::abs(m_velocity.height()) >= std::abs(m_currentKeyboardScroll->maximumVelocity.height()))
             force.setHeight(0);
     }
 

--- a/Source/WebCore/platform/ScrollAnimationKinetic.cpp
+++ b/Source/WebCore/platform/ScrollAnimationKinetic.cpp
@@ -100,7 +100,7 @@ bool ScrollAnimationKinetic::PerAxisData::animateScroll(Seconds elapsedTime)
         m_offset = m_upper;
     }
 
-    if (fabs(m_velocity) < 1 || (lastTime > 0_s && fabs(m_offset - lastOffset) < 1)) {
+    if (std::abs(m_velocity) < 1 || (lastTime > 0_s && std::abs(m_offset - lastOffset) < 1)) {
         m_offset = round(m_offset);
         m_velocity = 0;
     }

--- a/Source/WebCore/platform/ScrollView.cpp
+++ b/Source/WebCore/platform/ScrollView.cpp
@@ -837,7 +837,7 @@ void ScrollView::scrollContents(const IntSize& scrollDelta)
     if (m_drawPanScrollIcon) {
         // FIXME: the pan icon is broken when accelerated compositing is on, since it will draw under the compositing layers.
         // https://bugs.webkit.org/show_bug.cgi?id=47837
-        int panIconDirtySquareSizeLength = 2 * (panIconSizeLength + std::max(abs(scrollDelta.width()), abs(scrollDelta.height()))); // We only want to repaint what's necessary
+        int panIconDirtySquareSizeLength = 2 * (panIconSizeLength + std::max(std::abs(scrollDelta.width()), std::abs(scrollDelta.height()))); // We only want to repaint what's necessary
         IntPoint panIconDirtySquareLocation = IntPoint(m_panScrollIconPoint.x() - (panIconDirtySquareSizeLength / 2), m_panScrollIconPoint.y() - (panIconDirtySquareSizeLength / 2));
         IntRect panScrollIconDirtyRect = IntRect(panIconDirtySquareLocation, IntSize(panIconDirtySquareSizeLength, panIconDirtySquareSizeLength));
         panScrollIconDirtyRect.intersect(clipRect);

--- a/Source/WebCore/platform/audio/Biquad.cpp
+++ b/Source/WebCore/platform/audio/Biquad.cpp
@@ -585,7 +585,7 @@ void Biquad::getFrequencyResponse(unsigned nFrequencies, const float* frequency,
             std::complex<double> numerator = b0 + (b1 + b2 * z) * z;
             std::complex<double> denominator = std::complex<double>(1, 0) + (a1 + a2 * z) * z;
             std::complex<double> response = numerator / denominator;
-            magResponse[k] = static_cast<float>(abs(response));
+            magResponse[k] = static_cast<float>(std::abs(response));
             phaseResponse[k] = static_cast<float>(atan2(imag(response), real(response)));
         }
     }
@@ -602,7 +602,7 @@ static double repeatedRootResponse(double n, double c1, double c2, double r, dou
     // This helps with finding a nuemrical solution because this
     // approximately linearizes the response for large n.
 
-    return (n - 2) * std::log(r) + std::log(std::fabs(c1 * (n + 1) * r * r + c2)) - logEPS;
+    return (n - 2) * std::log(r) + std::log(std::abs(c1 * (n + 1) * r * r + c2)) - logEPS;
 }
 
 
@@ -637,7 +637,7 @@ static double rootFinder(double low, double high, double logEPS, double c1, doub
     int iteration;
     for (iteration = 0; iteration < maxIterations; ++iteration) {
         root = (fLow * high - fHigh * low) / (fLow - fHigh);
-        if (fabs(high - low) < accuracyThreshold * std::fabs(high + low))
+        if (std::abs(high - low) < accuracyThreshold * std::abs(high + low))
             break;
         double fr = repeatedRootResponse(root, c1, c2, r, logEPS);
 
@@ -794,7 +794,7 @@ double Biquad::tailFrame(size_t coefIndex, double maxFrame)
         // Compute the real roots so that r1 has the largest magnitude.
         double rplus = (-a1 + std::sqrt(discrim)) / 2;
         double rminus = (-a1 - std::sqrt(discrim)) / 2;
-        double r1 = std::fabs(rplus) >= std::fabs(rminus) ? rplus : rminus;
+        double r1 = std::abs(rplus) >= std::abs(rminus) ? rplus : rminus;
         // Use the fact that a2 = r1*r2
         double r2 = a2 / r1;
 
@@ -809,7 +809,7 @@ double Biquad::tailFrame(size_t coefIndex, double maxFrame)
         // It's possible for maxTailAmplitude to be greater than c1 + c2.
         // This may produce a negative tail frame. Just clamp the tail
         // frame to 0.
-        double tailFrame = clampTo(1 + std::log(maxTailAmplitude / (std::fabs(c1) + std::fabs(c2))) / std::log(std::fabs(r1)), 0);
+        double tailFrame = clampTo(1 + std::log(maxTailAmplitude / (std::abs(c1) + std::abs(c2))) / std::log(std::abs(r1)), 0);
 
         ASSERT(std::isfinite(tailFrame));
         return tailFrame;

--- a/Source/WebCore/platform/audio/Cone.cpp
+++ b/Source/WebCore/platform/audio/Cone.cpp
@@ -54,11 +54,11 @@ double ConeEffect::gain(FloatPoint3D sourcePosition, FloatPoint3D sourceOrientat
 
     // Angle between the source orientation vector and the source-listener vector
     double angle = rad2deg(acos(dotProduct));
-    double absAngle = fabs(angle);
+    double absAngle = std::abs(angle);
 
     // Divide by 2.0 here since API is entire angle (not half-angle)
-    double absInnerAngle = fabs(m_innerAngle) / 2.0;
-    double absOuterAngle = fabs(m_outerAngle) / 2.0;
+    double absInnerAngle = std::abs(m_innerAngle) / 2.0;
+    double absOuterAngle = std::abs(m_outerAngle) / 2.0;
     double gain = 1.0;
 
     if (absAngle <= absInnerAngle) {

--- a/Source/WebCore/platform/audio/DenormalDisabler.h
+++ b/Source/WebCore/platform/audio/DenormalDisabler.h
@@ -78,7 +78,7 @@ public:
         // For systems using x87 instead of sse, there's no hardware support
         // to flush denormals automatically. Hence, we need to flush
         // denormals to zero manually.
-        return (fabs(f) < FLT_MIN) ? 0.0f : f;
+        return (std::abs(f) < FLT_MIN) ? 0.0f : f;
 #else
         return f;
 #endif
@@ -139,7 +139,7 @@ public:
     // need to flush denormals to zero manually.
     static inline float flushDenormalFloatToZero(float f)
     {
-        return (fabs(f) < FLT_MIN) ? 0.0f : f;
+        return (std::abs(f) < FLT_MIN) ? 0.0f : f;
     }
 };
 

--- a/Source/WebCore/platform/audio/FFTFrame.cpp
+++ b/Source/WebCore/platform/audio/FFTFrame.cpp
@@ -102,8 +102,8 @@ void FFTFrame::interpolateFrequencyComponents(const FFTFrame& frame1, const FFTF
         std::complex<double> c1(realP1[i], imagP1[i]);
         std::complex<double> c2(realP2[i], imagP2[i]);
 
-        double mag1 = abs(c1);
-        double mag2 = abs(c2);
+        double mag1 = std::abs(c1);
+        double mag2 = std::abs(c2);
 
         // Interpolate magnitudes in decibels
         double mag1db = 20.0 * log10(mag1);
@@ -223,7 +223,7 @@ double FFTFrame::extractAverageGroupDelay()
     // Calculate weighted average group delay
     for (int i = 0; i < halfSize; i++) {
         std::complex<double> c(realP[i], imagP[i]);
-        double mag = abs(c);
+        double mag = std::abs(c);
         double phase = arg(c);
 
         double deltaPhase = phase - lastPhase;
@@ -270,7 +270,7 @@ void FFTFrame::addConstantGroupDelay(double sampleFrameDelay)
     // Add constant group delay
     for (int i = 1; i < halfSize; i++) {
         std::complex<double> c(realP[i], imagP[i]);
-        double mag = abs(c);
+        double mag = std::abs(c);
         double phase = arg(c);
 
         phase += i * phaseAdj;

--- a/Source/WebCore/platform/audio/HRTFPanner.cpp
+++ b/Source/WebCore/platform/audio/HRTFPanner.cpp
@@ -289,12 +289,12 @@ void HRTFPanner::pan(double desiredAzimuth, double elevation, const AudioBus* in
             // Update cross-fade value from local.
             m_crossfadeX = x;
 
-            if (m_crossfadeIncr > 0 && fabs(m_crossfadeX - 1) < m_crossfadeIncr) {
+            if (m_crossfadeIncr > 0 && std::abs(m_crossfadeX - 1) < m_crossfadeIncr) {
                 // We've fully made the crossfade transition from 1 -> 2.
                 m_crossfadeSelection = CrossfadeSelection2;
                 m_crossfadeX = 1;
                 m_crossfadeIncr = 0;
-            } else if (m_crossfadeIncr < 0 && fabs(m_crossfadeX) < -m_crossfadeIncr) {
+            } else if (m_crossfadeIncr < 0 && std::abs(m_crossfadeX) < -m_crossfadeIncr) {
                 // We've fully made the crossfade transition from 2 -> 1.
                 m_crossfadeSelection = CrossfadeSelection1;
                 m_crossfadeX = 0;

--- a/Source/WebCore/platform/audio/IIRFilter.cpp
+++ b/Source/WebCore/platform/audio/IIRFilter.cpp
@@ -151,7 +151,7 @@ void IIRFilter::getFrequencyResponse(unsigned length, const float* frequency, fl
             auto numerator = evaluatePolynomial(m_feedforward.data(), zRecip, m_feedforward.size() - 1);
             auto denominator = evaluatePolynomial(m_feedback.data(), zRecip, m_feedback.size() - 1);
             auto response = numerator / denominator;
-            magResponse[k] = static_cast<float>(abs(response));
+            magResponse[k] = static_cast<float>(std::abs(response));
             phaseResponse[k] = static_cast<float>(atan2(imag(response), real(response)));
         }
     }

--- a/Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.mm
+++ b/Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.mm
@@ -158,7 +158,7 @@ void AudioSampleDataSource::pushSamplesInternal(const AudioBufferList& bufferLis
     if (m_converterInputOffset)
         ringBufferIndexToWrite += m_converterInputOffset;
 
-    if (m_expectedNextPushedSampleTimeValue && abs((float)m_expectedNextPushedSampleTimeValue - (float)ringBufferIndexToWrite) <= 1)
+    if (m_expectedNextPushedSampleTimeValue && std::abs((float)m_expectedNextPushedSampleTimeValue - (float)ringBufferIndexToWrite) <= 1)
         ringBufferIndexToWrite = m_expectedNextPushedSampleTimeValue;
 
     m_expectedNextPushedSampleTimeValue = ringBufferIndexToWrite + sampleCount;

--- a/Source/WebCore/platform/graphics/FloatLine.cpp
+++ b/Source/WebCore/platform/graphics/FloatLine.cpp
@@ -49,7 +49,7 @@ const FloatPoint FloatLine::pointAtRelativeDistance(float relativeDistance) cons
 
 const FloatLine FloatLine::extendedToBounds(const FloatRect& bounds) const
 {
-    if (fabs(m_start.x() - m_end.x()) <= fabs(m_start.y() - m_end.y())) {
+    if (std::abs(m_start.x() - m_end.x()) <= std::abs(m_start.y() - m_end.y())) {
         // The line is roughly vertical, so construct points at the top and bottom of the bounds.
         FloatPoint top = { (((bounds.y() - m_start.y()) * (m_end.x() - m_start.x())) / (m_end.y() - m_start.y())) + m_start.x(), bounds.y() };
         FloatPoint bottom = { (((bounds.y() + bounds.height() - m_start.y()) * (m_end.x() - m_start.x())) / (m_end.y() - m_start.y())) + m_start.x(), bounds.y() + bounds.height() };

--- a/Source/WebCore/platform/graphics/FloatSize.cpp
+++ b/Source/WebCore/platform/graphics/FloatSize.cpp
@@ -47,7 +47,7 @@ FloatSize FloatSize::constrainedBetween(const FloatSize& min, const FloatSize& m
 
 bool FloatSize::isZero() const
 {
-    return fabs(m_width) < std::numeric_limits<float>::epsilon() && fabs(m_height) < std::numeric_limits<float>::epsilon();
+    return std::abs(m_width) < std::numeric_limits<float>::epsilon() && std::abs(m_height) < std::numeric_limits<float>::epsilon();
 }
 
 bool FloatSize::isExpressibleAsIntSize() const

--- a/Source/WebCore/platform/graphics/GradientImage.cpp
+++ b/Source/WebCore/platform/graphics/GradientImage.cpp
@@ -63,8 +63,8 @@ void GradientImage::drawPattern(GraphicsContext& destContext, const FloatRect& d
 
     // Factor in the destination context's scale to generate at the best resolution
     AffineTransform destContextCTM = destContext.getCTM(GraphicsContext::DefinitelyIncludeDeviceScale);
-    double xScale = fabs(destContextCTM.xScale());
-    double yScale = fabs(destContextCTM.yScale());
+    double xScale = std::abs(destContextCTM.xScale());
+    double yScale = std::abs(destContextCTM.yScale());
     AffineTransform adjustedPatternCTM = patternTransform;
     adjustedPatternCTM.scale(1.0 / xScale, 1.0 / yScale);
     adjustedSrcRect.scale(xScale, yScale);

--- a/Source/WebCore/platform/graphics/IntSize.h
+++ b/Source/WebCore/platform/graphics/IntSize.h
@@ -134,12 +134,12 @@ public:
 
     template<typename T = CrashOnOverflow> Checked<unsigned, T> area() const
     {
-        return Checked<unsigned, T>(abs(m_width)) * abs(m_height);
+        return Checked<unsigned, T>(std::abs(m_width)) * std::abs(m_height);
     }
 
     uint64_t unclampedArea() const
     {
-        return static_cast<uint64_t>(abs(m_width)) * abs(m_height);
+        return static_cast<uint64_t>(std::abs(m_width)) * std::abs(m_height);
     }
 
     constexpr int diagonalLengthSquared() const

--- a/Source/WebCore/platform/graphics/PathUtilities.cpp
+++ b/Source/WebCore/platform/graphics/PathUtilities.cpp
@@ -323,8 +323,8 @@ Vector<Path> PathUtilities::pathsWithShrinkWrappedRects(const Vector<FloatRect>&
 
             // Clamp the radius to no more than half the length of either adjacent edge,
             // because we want a smooth curve and don't want unequal radii.
-            float clampedRadius = std::min(radius, fabsf(fromEdgeVec.x() ? fromEdgeVec.x() : fromEdgeVec.y()) / 2);
-            clampedRadius = std::min(clampedRadius, fabsf(toEdgeVec.x() ? toEdgeVec.x() : toEdgeVec.y()) / 2);
+            float clampedRadius = std::min(radius, std::abs(fromEdgeVec.x() ? fromEdgeVec.x() : fromEdgeVec.y()) / 2);
+            clampedRadius = std::min(clampedRadius, std::abs(toEdgeVec.x() ? toEdgeVec.x() : toEdgeVec.y()) / 2);
 
             FloatPoint fromEdgeNorm = fromEdgeVec;
             fromEdgeNorm.normalize();

--- a/Source/WebCore/platform/graphics/ShadowBlur.cpp
+++ b/Source/WebCore/platform/graphics/ShadowBlur.cpp
@@ -451,8 +451,8 @@ std::optional<ShadowBlur::LayerImageProperties> ShadowBlur::calculateLayerBoundi
 
     // Set the origin as the top left corner of the scratch image, or, in case there's a clipped
     // out region, set the origin accordingly to the full bounding rect's top-left corner.
-    float translationX = -shadowedRect.x() + inflation.width() - fabsf(clippedOut.width());
-    float translationY = -shadowedRect.y() + inflation.height() - fabsf(clippedOut.height());
+    float translationX = -shadowedRect.x() + inflation.width() - std::abs(clippedOut.width());
+    float translationY = -shadowedRect.y() + inflation.height() - std::abs(clippedOut.height());
     calculatedLayerImageProperties.layerContextTranslation = FloatSize(translationX, translationY);
 
     return calculatedLayerImageProperties;

--- a/Source/WebCore/platform/graphics/UnitBezier.h
+++ b/Source/WebCore/platform/graphics/UnitBezier.h
@@ -75,7 +75,7 @@ namespace WebCore {
                 if (fabs (x2) < epsilon)
                     return t2;
                 d2 = sampleCurveDerivativeX(t2);
-                if (fabs(d2) < 1e-6)
+                if (std::abs(d2) < 1e-6)
                     break;
                 t2 = t2 - x2 / d2;
             }
@@ -92,7 +92,7 @@ namespace WebCore {
 
             while (t0 < t1) {
                 x2 = sampleCurveX(t2);
-                if (fabs(x2 - x) < epsilon)
+                if (std::abs(x2 - x) < epsilon)
                     return t2;
                 if (x > x2)
                     t0 = t2;

--- a/Source/WebCore/platform/graphics/cairo/CairoOperations.cpp
+++ b/Source/WebCore/platform/graphics/cairo/CairoOperations.cpp
@@ -859,7 +859,7 @@ void drawPattern(GraphicsContextCairo& platformContext, cairo_surface_t* surface
 void drawSurface(GraphicsContextCairo& platformContext, cairo_surface_t* surface, const FloatRect& destRect, const FloatRect& originalSrcRect, InterpolationQuality imageInterpolationQuality, float globalAlpha, const ShadowState& shadowState, OrientationSizing orientationSizing)
 {
     // Avoid invalid cairo matrix with small values.
-    if (std::fabs(destRect.width()) < 0.5f || std::fabs(destRect.height()) < 0.5f)
+    if (std::abs(destRect.width()) < 0.5f || std::abs(destRect.height()) < 0.5f)
         return;
 
     FloatRect srcRect = originalSrcRect;
@@ -867,11 +867,11 @@ void drawSurface(GraphicsContextCairo& platformContext, cairo_surface_t* surface
     // We need to account for negative source dimensions by flipping the rectangle.
     if (originalSrcRect.width() < 0) {
         srcRect.setX(originalSrcRect.x() + originalSrcRect.width());
-        srcRect.setWidth(std::fabs(originalSrcRect.width()));
+        srcRect.setWidth(std::abs(originalSrcRect.width()));
     }
     if (originalSrcRect.height() < 0) {
         srcRect.setY(originalSrcRect.y() + originalSrcRect.height());
-        srcRect.setHeight(std::fabs(originalSrcRect.height()));
+        srcRect.setHeight(std::abs(originalSrcRect.height()));
     }
 
     RefPtr<cairo_surface_t> patternSurface = surface;
@@ -918,11 +918,11 @@ void drawSurface(GraphicsContextCairo& platformContext, cairo_surface_t* surface
     float scaleX = 1;
     float scaleY = 1;
     if (didUseWidthAsHeight) {
-        scaleX = std::fabs(srcRect.width() / destRect.height());
-        scaleY = std::fabs(srcRect.height() / destRect.width());
+        scaleX = std::abs(srcRect.width() / destRect.height());
+        scaleY = std::abs(srcRect.height() / destRect.width());
     } else {
-        scaleX = std::fabs(srcRect.width() / destRect.width());
-        scaleY = std::fabs(srcRect.height() / destRect.height());
+        scaleX = std::abs(srcRect.width() / destRect.width());
+        scaleY = std::abs(srcRect.height() / destRect.height());
     }
     cairo_matrix_t matrix = { scaleX, 0, 0, scaleY, leftPadding, topPadding };
     cairo_pattern_set_matrix(pattern.get(), &matrix);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/TiledBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/TiledBackingStore.cpp
@@ -106,7 +106,7 @@ double TiledBackingStore::tileDistance(const IntRect& viewport, const Tile::Coor
     IntPoint viewCenter = viewport.location() + IntSize(viewport.width() / 2, viewport.height() / 2);
     Tile::Coordinate centerCoordinate = tileCoordinateForPoint(viewCenter);
 
-    return std::max(abs(centerCoordinate.y() - tileCoordinate.y()), abs(centerCoordinate.x() - tileCoordinate.x()));
+    return std::max(std::abs(centerCoordinate.y() - tileCoordinate.y()), std::abs(centerCoordinate.x() - tileCoordinate.x()));
 }
 
 // Returns a ratio between 0.0f and 1.0f of the surface covered by rendered tiles.

--- a/Source/WebCore/platform/graphics/transforms/AffineTransform.cpp
+++ b/Source/WebCore/platform/graphics/transforms/AffineTransform.cpp
@@ -345,7 +345,7 @@ void AffineTransform::blend(const AffineTransform& from, double progress, Compos
     srA.angle = fmod(srA.angle, 2 * piDouble);
     srB.angle = fmod(srB.angle, 2 * piDouble);
 
-    if (fabs(srA.angle - srB.angle) > piDouble) {
+    if (std::abs(srA.angle - srB.angle) > piDouble) {
         if (srA.angle > srB.angle)
             srA.angle -= piDouble * 2;
         else

--- a/Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp
+++ b/Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp
@@ -213,7 +213,7 @@ static bool inverse(const TransformationMatrix::Matrix4& matrix, TransformationM
     // then the inverse matrix is not unique.
     double det = determinant4x4(matrix);
 
-    if (fabs(det) < SMALL_NUMBER)
+    if (std::abs(det) < SMALL_NUMBER)
         return false;
 
     // Scale the adjoint matrix to get the inverse
@@ -1585,7 +1585,7 @@ bool TransformationMatrix::isInvertible() const
     if (type == Type::IdentityOrTranslation)
         return true;
 
-    return fabs(type == Type::Affine ? (m11() * m22() - m12() * m21()) : WebCore::determinant4x4(m_matrix)) >= SMALL_NUMBER;
+    return std::abs(type == Type::Affine ? (m11() * m22() - m12() * m21()) : WebCore::determinant4x4(m_matrix)) >= SMALL_NUMBER;
 }
 
 std::optional<TransformationMatrix> TransformationMatrix::inverse() const
@@ -1611,7 +1611,7 @@ std::optional<TransformationMatrix> TransformationMatrix::inverse() const
         double e = m41();
         double f = m42();
         double determinant = a * d - b * c;
-        if (fabs(determinant) < SMALL_NUMBER)
+        if (std::abs(determinant) < SMALL_NUMBER)
             return std::nullopt;
 
         double inverseDeterminant = 1 / determinant;
@@ -1697,7 +1697,7 @@ void TransformationMatrix::blend2(const TransformationMatrix& from, double progr
     if (!toDecomp.angle)
         toDecomp.angle = 360;
 
-    if (fabs(fromDecomp.angle - toDecomp.angle) > 180) {
+    if (std::abs(fromDecomp.angle - toDecomp.angle) > 180) {
         if (fromDecomp.angle > toDecomp.angle)
             fromDecomp.angle -= 360;
         else
@@ -1952,7 +1952,7 @@ bool TransformationMatrix::isBackFaceVisible() const
     double determinant = WebCore::determinant4x4(m_matrix);
 
     // If the matrix is not invertible, then we assume its backface is not visible.
-    if (fabs(determinant) < SMALL_NUMBER)
+    if (std::abs(determinant) < SMALL_NUMBER)
         return false;
 
     double cofactor33 = determinant3x3(m11(), m12(), m14(), m21(), m22(), m24(), m41(), m42(), m44());

--- a/Source/WebCore/platform/graphics/win/FontCacheWin.cpp
+++ b/Source/WebCore/platform/graphics/win/FontCacheWin.cpp
@@ -480,11 +480,11 @@ static int CALLBACK matchImprovingEnumProc(CONST LOGFONT* candidate, CONST TEXTM
         return 1;
     }
 
-    unsigned chosenWeightDeltaMagnitude = abs(matchData->m_chosen.lfWeight - matchData->m_desiredWeight);
-    unsigned candidateWeightDeltaMagnitude = abs(candidate->lfWeight - matchData->m_desiredWeight);
+    unsigned chosenWeightDeltaMagnitude = std::abs(matchData->m_chosen.lfWeight - matchData->m_desiredWeight);
+    unsigned candidateWeightDeltaMagnitude = std::abs(candidate->lfWeight - matchData->m_desiredWeight);
 
     // If both are the same distance from the desired weight, prefer the candidate if it is further from regular.
-    if (chosenWeightDeltaMagnitude == candidateWeightDeltaMagnitude && abs(candidate->lfWeight - FW_NORMAL) > abs(matchData->m_chosen.lfWeight - FW_NORMAL)) {
+    if (chosenWeightDeltaMagnitude == candidateWeightDeltaMagnitude && std::abs(candidate->lfWeight - FW_NORMAL) > std::abs(matchData->m_chosen.lfWeight - FW_NORMAL)) {
         matchData->m_chosen = *candidate;
         return 1;
     }

--- a/Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.cpp
+++ b/Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.cpp
@@ -2444,7 +2444,7 @@ HRESULT MediaPlayerPrivateMediaFoundation::VideoScheduler::processSample(IMFSamp
 
             // Since sleeping is using the system clock, we need to convert the sleep time
             // from presentation time to system time.
-            nextSleepTime = (LONG)(nextSleepTime / fabsf(m_playbackRate));
+            nextSleepTime = (LONG)(nextSleepTime / std::abs(m_playbackRate));
 
             presentNow = false;
         }

--- a/Source/WebCore/platform/graphics/win/SystemFontDatabaseWin.cpp
+++ b/Source/WebCore/platform/graphics/win/SystemFontDatabaseWin.cpp
@@ -80,7 +80,7 @@ auto SystemFontDatabase::platformSystemFontShorthandInfo(FontShorthand fontShort
             return { WebKitFontFamilyNames::standardFamily, 16, normalWeightValue() };
     }
     }
-    float size = shouldUseDefaultControlFontPixelSize ? defaultControlFontPixelSize : abs(logFont.lfHeight);
+    float size = shouldUseDefaultControlFontPixelSize ? defaultControlFontPixelSize : std::abs(logFont.lfHeight);
     auto weight = logFont.lfWeight >= 700 ? boldWeightValue() : normalWeightValue();
     return { logFont.lfFaceName, size, weight };
 }

--- a/Source/WebCore/platform/ios/ScrollAnimatorIOS.mm
+++ b/Source/WebCore/platform/ios/ScrollAnimatorIOS.mm
@@ -109,11 +109,11 @@ bool ScrollAnimatorIOS::handleTouchEvent(const PlatformTouchEvent& touchEvent)
         const int latchAxisMovementThreshold = 10;
         if (!horizontallyScrollable && verticallyScrollable) {
             m_touchScrollAxisLatch = AxisLatchVertical;
-            if (abs(deltaFromStart.height()) >= latchAxisMovementThreshold)
+            if (std::abs(deltaFromStart.height()) >= latchAxisMovementThreshold)
                 m_committedToScrollAxis = true;
         } else if (horizontallyScrollable && !verticallyScrollable) {
             m_touchScrollAxisLatch = AxisLatchHorizontal;
-            if (abs(deltaFromStart.width()) >= latchAxisMovementThreshold)
+            if (std::abs(deltaFromStart.width()) >= latchAxisMovementThreshold)
                 m_committedToScrollAxis = true;
         } else {
             m_committedToScrollAxis = true;
@@ -121,7 +121,7 @@ bool ScrollAnimatorIOS::handleTouchEvent(const PlatformTouchEvent& touchEvent)
             if (m_touchScrollAxisLatch == AxisLatchNotComputed) {
                 const float lockAngleDegrees = 20;
                 if (deltaFromStart.width() && deltaFromStart.height()) {
-                    float dragAngle = atanf(static_cast<float>(abs(deltaFromStart.height())) / abs(deltaFromStart.width()));
+                    float dragAngle = atanf(static_cast<float>(std::abs(deltaFromStart.height())) / std::abs(deltaFromStart.width()));
                     if (dragAngle <= deg2rad(lockAngleDegrees))
                         m_touchScrollAxisLatch = AxisLatchHorizontal;
                     else if (dragAngle >= deg2rad(90 - lockAngleDegrees))
@@ -139,13 +139,13 @@ bool ScrollAnimatorIOS::handleTouchEvent(const PlatformTouchEvent& touchEvent)
     // Horizontal
     if (m_touchScrollAxisLatch != AxisLatchVertical) {
         int delta = touchDelta.width();
-        handled |= m_scrollableAreaForTouchSequence->scroll(delta < 0 ? ScrollLeft : ScrollRight, ScrollGranularity::Pixel, abs(delta));
+        handled |= m_scrollableAreaForTouchSequence->scroll(delta < 0 ? ScrollLeft : ScrollRight, ScrollGranularity::Pixel, std::abs(delta));
     }
     
     // Vertical
     if (m_touchScrollAxisLatch != AxisLatchHorizontal) {
         int delta = touchDelta.height();
-        handled |= m_scrollableAreaForTouchSequence->scroll(delta < 0 ? ScrollUp : ScrollDown, ScrollGranularity::Pixel, abs(delta));
+        handled |= m_scrollableAreaForTouchSequence->scroll(delta < 0 ? ScrollUp : ScrollDown, ScrollGranularity::Pixel, std::abs(delta));
     }
     
     // Return false until we manage to scroll at all, and then keep returning true until the gesture ends.

--- a/Source/WebCore/platform/ios/WebAVPlayerController.mm
+++ b/Source/WebCore/platform/ios/WebAVPlayerController.mm
@@ -869,8 +869,8 @@ Class webAVPlayerControllerClass()
 
             if (isfinite([self liveUpdateInterval]) && [self liveUpdateInterval] > WebAVPlayerControllerLiveStreamMinimumTargetDuration) {
                 // Only update the timing if the new time differs by one segment duration plus the hysteresis delta.
-                minTimingNeedsUpdate = isnan(oldMinTime) || (fabs(oldMinTime - newMinTime) > [self liveUpdateInterval] + WebAVPlayerControllerLiveStreamSeekableTimeRangeDurationHysteresisDelta) || ([[self minTiming] rate] != newMinTimingRate);
-                maxTimingNeedsUpdate = isnan(oldMaxTime) || (fabs(oldMaxTime - newMaxTime) > [self liveUpdateInterval] + WebAVPlayerControllerLiveStreamSeekableTimeRangeDurationHysteresisDelta);
+                minTimingNeedsUpdate = isnan(oldMinTime) || (std::abs(oldMinTime - newMinTime) > [self liveUpdateInterval] + WebAVPlayerControllerLiveStreamSeekableTimeRangeDurationHysteresisDelta) || ([[self minTiming] rate] != newMinTimingRate);
+                maxTimingNeedsUpdate = isnan(oldMaxTime) || (std::abs(oldMaxTime - newMaxTime) > [self liveUpdateInterval] + WebAVPlayerControllerLiveStreamSeekableTimeRangeDurationHysteresisDelta);
             }
 
             if (minTimingNeedsUpdate || maxTimingNeedsUpdate) {

--- a/Source/WebCore/platform/ios/wak/WKView.mm
+++ b/Source/WebCore/platform/ios/wak/WKView.mm
@@ -259,7 +259,7 @@ static void _WKViewAutoresizeCoord(bool bByHeight, unsigned int sizingMethod, co
                 // one pixel shorter...
                 // FIXME: If origMarginsTotal is in the range (0, 1) then we won't do the 50/50 split. Is this right?
                 else if (origMarginsTotal == 0.0f 
-                    || (abs(static_cast<int>(origMarginsTotal)) == 1)) {
+                    || (std::abs(static_cast<int>(origMarginsTotal)) == 1)) {
                     prop = 0.5f;  // Then split it 50:50.
                 }
                 else {

--- a/Source/WebCore/platform/mac/ScrollAnimationRubberBand.mm
+++ b/Source/WebCore/platform/mac/ScrollAnimationRubberBand.mm
@@ -46,7 +46,7 @@ static inline float roundTowardZero(float num)
 static inline float roundToDevicePixelTowardZero(float num)
 {
     float roundedNum = roundf(num);
-    if (fabs(num - roundedNum) < 0.125)
+    if (std::abs(num - roundedNum) < 0.125)
         num = roundedNum;
 
     return roundTowardZero(num);

--- a/Source/WebCore/platform/mac/ScrollingEffectsController.mm
+++ b/Source/WebCore/platform/mac/ScrollingEffectsController.mm
@@ -83,7 +83,7 @@ void ScrollingEffectsController::stopAllTimers()
 
 static ScrollEventAxis dominantAxisFavoringVertical(FloatSize delta)
 {
-    if (fabsf(delta.height()) >= fabsf(delta.width()))
+    if (std::abs(delta.height()) >= std::abs(delta.width()))
         return ScrollEventAxis::Vertical;
 
     return ScrollEventAxis::Horizontal;
@@ -248,9 +248,9 @@ bool ScrollingEffectsController::modifyScrollDeltaForStretching(const PlatformWh
     if (isVerticallyStretched) {
         if (!isHorizontallyStretched && affectedSide && m_client.isPinnedOnSide(*affectedSide)) {
             // Stretching only in the vertical.
-            if (delta.height() && (fabsf(delta.width() / delta.height()) < rubberbandDirectionLockStretchRatio))
+            if (delta.height() && (std::abs(delta.width() / delta.height()) < rubberbandDirectionLockStretchRatio))
                 delta.setWidth(0);
-            else if (fabsf(delta.width()) < rubberbandMinimumRequiredDeltaBeforeStretch) {
+            else if (std::abs(delta.width()) < rubberbandMinimumRequiredDeltaBeforeStretch) {
                 m_unappliedOverscrollDelta.expand(delta.width(), 0);
                 delta.setWidth(0);
             } else
@@ -263,9 +263,9 @@ bool ScrollingEffectsController::modifyScrollDeltaForStretching(const PlatformWh
     if (isHorizontallyStretched) {
         // Stretching only in the horizontal.
         if (affectedSide && m_client.isPinnedOnSide(*affectedSide)) {
-            if (delta.width() && (fabsf(delta.height() / delta.width()) < rubberbandDirectionLockStretchRatio))
+            if (delta.width() && (std::abs(delta.height() / delta.width()) < rubberbandDirectionLockStretchRatio))
                 delta.setHeight(0);
-            else if (fabsf(delta.height()) < rubberbandMinimumRequiredDeltaBeforeStretch) {
+            else if (std::abs(delta.height()) < rubberbandMinimumRequiredDeltaBeforeStretch) {
                 m_unappliedOverscrollDelta.expand(0, delta.height());
                 delta.setHeight(0);
             } else
@@ -277,8 +277,8 @@ bool ScrollingEffectsController::modifyScrollDeltaForStretching(const PlatformWh
 
     // Not stretching at all yet.
     if (affectedSide && m_client.isPinnedOnSide(*affectedSide)) {
-        if (fabsf(delta.height()) >= fabsf(delta.width())) {
-            if (fabsf(delta.width()) < rubberbandMinimumRequiredDeltaBeforeStretch) {
+        if (std::abs(delta.height()) >= std::abs(delta.width())) {
+            if (std::abs(delta.width()) < rubberbandMinimumRequiredDeltaBeforeStretch) {
                 m_unappliedOverscrollDelta.expand(delta.width(), 0);
                 delta.setWidth(0);
             } else
@@ -458,7 +458,7 @@ void ScrollingEffectsController::startRubberBandAnimationIfNecessary()
     auto initialVelocity = m_momentumVelocity;
 
     // Just like normal scrolling, prefer vertical rubberbanding
-    if (fabsf(initialVelocity.height()) >= fabsf(initialVelocity.width()))
+    if (std::abs(initialVelocity.height()) >= std::abs(initialVelocity.width()))
         initialVelocity.setWidth(0);
 
     // Don't rubber-band horizontally if it's not possible to scroll horizontally

--- a/Source/WebCore/platform/win/BitmapInfo.h
+++ b/Source/WebCore/platform/win/BitmapInfo.h
@@ -50,8 +50,8 @@ struct BitmapInfo : public BITMAPINFO {
 
     bool is16bit() const { return bmiHeader.biBitCount == 16; }
     bool is32bit() const { return bmiHeader.biBitCount == 32; }
-    unsigned width() const { return abs(bmiHeader.biWidth); }
-    unsigned height() const { return abs(bmiHeader.biHeight); }
+    unsigned width() const { return std::abs(bmiHeader.biWidth); }
+    unsigned height() const { return std::abs(bmiHeader.biHeight); }
     IntSize size() const { return IntSize(width(), height()); }
     unsigned bytesPerLine() const { return (width() * bmiHeader.biBitCount + 7) / 8; }
     unsigned paddedBytesPerLine() const { return (bytesPerLine() + 3) & ~0x3; }

--- a/Source/WebCore/platform/win/PopupMenuWin.cpp
+++ b/Source/WebCore/platform/win/PopupMenuWin.cpp
@@ -536,7 +536,7 @@ void PopupMenuWin::incrementWheelDelta(int delta)
 void PopupMenuWin::reduceWheelDelta(int delta)
 {
     ASSERT(delta >= 0);
-    ASSERT(delta <= abs(m_wheelDelta));
+    ASSERT(delta <= std::abs(m_wheelDelta));
 
     if (m_wheelDelta > 0)
         m_wheelDelta -= delta;
@@ -1052,14 +1052,14 @@ LRESULT PopupMenuWin::wndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lPa
                 break;
 
             int i = 0;
-            for (incrementWheelDelta(GET_WHEEL_DELTA_WPARAM(wParam)); abs(wheelDelta()) >= WHEEL_DELTA; reduceWheelDelta(WHEEL_DELTA)) {
+            for (incrementWheelDelta(GET_WHEEL_DELTA_WPARAM(wParam)); std::abs(wheelDelta()) >= WHEEL_DELTA; reduceWheelDelta(WHEEL_DELTA)) {
                 if (wheelDelta() > 0)
                     ++i;
                 else
                     --i;
             }
 
-            ScrollableArea::scroll(i > 0 ? ScrollUp : ScrollDown, ScrollGranularity::Line, abs(i));
+            ScrollableArea::scroll(i > 0 ? ScrollUp : ScrollDown, ScrollGranularity::Line, std::abs(i));
             break;
         }
 

--- a/Source/WebCore/platform/xr/openxr/OpenXRUtils.h
+++ b/Source/WebCore/platform/xr/openxr/OpenXRUtils.h
@@ -98,7 +98,7 @@ inline Device::FrameData::Pose XrPosefToPose(XrPosef pose)
 inline Device::FrameData::View xrViewToPose(XrView view)
 {
     Device::FrameData::View pose;
-    pose.projection = Device::FrameData::Fov { fabs(view.fov.angleUp), fabs(view.fov.angleDown), fabs(view.fov.angleLeft), fabs(view.fov.angleRight) };
+    pose.projection = Device::FrameData::Fov { std::abs(view.fov.angleUp), std::abs(view.fov.angleDown), std::abs(view.fov.angleLeft), std::abs(view.fov.angleRight) };
     pose.offset = XrPosefToPose(view.pose);
     return pose;
 }

--- a/Source/WebCore/rendering/AttachmentLayout.mm
+++ b/Source/WebCore/rendering/AttachmentLayout.mm
@@ -123,7 +123,7 @@ void AttachmentLayout::layOutTitle(const RenderAttachment& attachment)
             // look right, so make them the same exact size.
             if (i) {
                 float previousBackgroundRectWidth = lines[i-1].backgroundRect.width();
-                if (fabs(line.backgroundRect.width() - previousBackgroundRectWidth) < attachmentTitleBackgroundRadius * 4) {
+                if (std::abs(line.backgroundRect.width() - previousBackgroundRectWidth) < attachmentTitleBackgroundRadius * 4) {
                     float newBackgroundRectWidth = std::max(previousBackgroundRectWidth, line.backgroundRect.width());
                     line.backgroundRect.inflateX((newBackgroundRectWidth - line.backgroundRect.width()) / 2);
                     lines[i-1].backgroundRect.inflateX((newBackgroundRectWidth - previousBackgroundRectWidth) / 2);

--- a/Source/WebCore/rendering/BorderPainter.cpp
+++ b/Source/WebCore/rendering/BorderPainter.cpp
@@ -1194,8 +1194,8 @@ void BorderPainter::drawLineForBoxSide(GraphicsContext& graphicsContext, const D
             float adjacent1BigThird = ceilToDevicePixel(adjacentWidth1 / 3, deviceScaleFactor);
             float adjacent2BigThird = ceilToDevicePixel(adjacentWidth2 / 3, deviceScaleFactor);
 
-            float offset1 = floorToDevicePixel(fabs(adjacentWidth1) * 2 / 3, deviceScaleFactor);
-            float offset2 = floorToDevicePixel(fabs(adjacentWidth2) * 2 / 3, deviceScaleFactor);
+            float offset1 = floorToDevicePixel(std::abs(adjacentWidth1) * 2 / 3, deviceScaleFactor);
+            float offset2 = floorToDevicePixel(std::abs(adjacentWidth2) * 2 / 3, deviceScaleFactor);
 
             float mitreOffset1 = adjacentWidth1 < 0 ? offset1 : 0;
             float mitreOffset2 = adjacentWidth1 > 0 ? offset1 : 0;
@@ -1268,7 +1268,7 @@ void BorderPainter::drawLineForBoxSide(GraphicsContext& graphicsContext, const D
             offset2 = ceilToDevicePixel(adjacentWidth2 / 2, deviceScaleFactor);
 
         if (((side == BoxSide::Top || side == BoxSide::Left) && adjacentWidth1 > 0) || ((side == BoxSide::Bottom || side == BoxSide::Right) && adjacentWidth1 < 0))
-            offset3 = floorToDevicePixel(fabs(adjacentWidth1) / 2, deviceScaleFactor);
+            offset3 = floorToDevicePixel(std::abs(adjacentWidth1) / 2, deviceScaleFactor);
 
         if (((side == BoxSide::Top || side == BoxSide::Left) && adjacentWidth2 > 0) || ((side == BoxSide::Bottom || side == BoxSide::Right) && adjacentWidth2 < 0))
             offset4 = ceilToDevicePixel(adjacentWidth2 / 2, deviceScaleFactor);

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -1830,9 +1830,9 @@ void RenderLayerScrollableArea::panScrollFromPoint(const IntPoint& sourcePoint)
 
     IntSize delta = lastKnownMousePosition - sourcePoint;
 
-    if (abs(delta.width()) <= ScrollView::noPanScrollRadius) // at the center we let the space for the icon
+    if (std::abs(delta.width()) <= ScrollView::noPanScrollRadius) // at the center we let the space for the icon
         delta.setWidth(0);
-    if (abs(delta.height()) <= ScrollView::noPanScrollRadius)
+    if (std::abs(delta.height()) <= ScrollView::noPanScrollRadius)
         delta.setHeight(0);
 
     scrollByRecursively(adjustedScrollDelta(delta));

--- a/Source/WebCore/rendering/RenderListBox.cpp
+++ b/Source/WebCore/rendering/RenderListBox.cpp
@@ -580,7 +580,7 @@ void RenderListBox::panScroll(const IntPoint& panStartMousePosition)
     // If the point is too far from the center we limit the speed
     yDelta = std::max<int>(std::min<int>(yDelta, maxSpeed), -maxSpeed);
     
-    if (abs(yDelta) < iconRadius) // at the center we let the space for the icon
+    if (std::abs(yDelta) < iconRadius) // at the center we let the space for the icon
         return;
 
     if (yDelta > 0)

--- a/Source/WebCore/rendering/RenderMarquee.cpp
+++ b/Source/WebCore/rendering/RenderMarquee.cpp
@@ -281,7 +281,7 @@ void RenderMarquee::timerFired()
         }
         bool positive = range > 0;
         int clientSize = (isHorizontal() ? roundToInt(m_layer->renderBox()->clientWidth()) : roundToInt(m_layer->renderBox()->clientHeight()));
-        int increment = abs(intValueForLength(m_layer->renderer().style().marqueeIncrement(), clientSize));
+        int increment = std::abs(intValueForLength(m_layer->renderer().style().marqueeIncrement(), clientSize));
         int currentPos = (isHorizontal() ? scrollableArea->scrollOffset().x() : scrollableArea->scrollOffset().y());
         newPos =  currentPos + (addIncrement ? increment : -increment);
         if (positive)

--- a/Source/WebCore/rendering/shapes/RasterShape.cpp
+++ b/Source/WebCore/rendering/shapes/RasterShape.cpp
@@ -68,7 +68,7 @@ void MarginIntervalGenerator::set(int y, const IntShapeInterval& interval)
 
 IntShapeInterval MarginIntervalGenerator::intervalAt(int y) const
 {
-    unsigned xInterceptsIndex = abs(y - m_y);
+    unsigned xInterceptsIndex = std::abs(y - m_y);
     int dx = (xInterceptsIndex >= m_xIntercepts.size()) ? 0 : m_xIntercepts[xInterceptsIndex];
     return IntShapeInterval(m_x1 - dx, m_x2 + dx);
 }

--- a/Source/WebCore/rendering/svg/SVGMarkerData.h
+++ b/Source/WebCore/rendering/svg/SVGMarkerData.h
@@ -92,7 +92,7 @@ private:
             return narrowPrecisionToFloat(outAngle);
         case MidMarker:
             // WK193015: Prevent bugs due to angles being non-continuous.
-            if (fabs(inAngle - outAngle) > 180)
+            if (std::abs(inAngle - outAngle) > 180)
                 inAngle += 360;
             return narrowPrecisionToFloat((inAngle + outAngle) / 2);
         case EndMarker:

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp
@@ -182,7 +182,7 @@ float SVGTextLayoutEngineBaseline::calculateGlyphOrientationAngle(bool isVertica
 
 static inline bool glyphOrientationIsMultiplyOf180Degrees(float orientationAngle)
 {
-    return !fabsf(fmodf(orientationAngle, 180));
+    return !(fmodf(orientationAngle, 180));
 }
 
 float SVGTextLayoutEngineBaseline::calculateGlyphAdvanceAndOrientation(bool isVerticalText, SVGTextMetrics& metrics, float angle, float& xOrientationShift, float& yOrientationShift) const

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -1646,7 +1646,7 @@ inline StyleContentAlignmentData BuilderConverter::convertContentAlignmentData(B
 
 inline GlyphOrientation BuilderConverter::convertGlyphOrientation(BuilderState&, const CSSValue& value)
 {
-    float angle = fabsf(fmodf(downcast<CSSPrimitiveValue>(value).floatValue(), 360.0f));
+    float angle = std::abs(fmodf(downcast<CSSPrimitiveValue>(value).floatValue(), 360.0f));
     if (angle <= 45.0f || angle > 315.0f)
         return GlyphOrientation::Degrees0;
     if (angle > 45.0f && angle <= 135.0f)

--- a/Source/WebCore/style/StyleFontSizeFunctions.cpp
+++ b/Source/WebCore/style/StyleFontSizeFunctions.cpp
@@ -47,7 +47,7 @@ float computedFontSizeFromSpecifiedSize(float specifiedSize, bool isAbsoluteSize
     // exempt from minimum font size rules. Acid3 relies on this for pixel-perfect
     // rendering. This is also compatible with other browsers that have minimum
     // font size settings (e.g. Firefox).
-    if (fabsf(specifiedSize) < std::numeric_limits<float>::epsilon())
+    if (std::abs(specifiedSize) < std::numeric_limits<float>::epsilon())
         return 0.0f;
 
     // We support two types of minimum font size. The first is a hard override that applies to

--- a/Source/WebCore/svg/SVGPathParser.cpp
+++ b/Source/WebCore/svg/SVGPathParser.cpp
@@ -476,7 +476,7 @@ bool SVGPathParser::decomposeArcToCubic(float angle, float rx, float ry, FloatPo
 
     // Some results of atan2 on some platform implementations are not exact enough. So that we get more
     // cubic curves than expected here. Adding 0.001f reduces the count of sgements to the correct count.
-    int segments = ceilf(fabsf(thetaArc / (piOverTwoFloat + 0.001f)));
+    int segments = ceilf(std::abs(thetaArc / (piOverTwoFloat + 0.001f)));
     for (int i = 0; i < segments; ++i) {
         float startTheta = theta1 + i * thetaArc / segments;
         float endTheta = theta1 + (i + 1) * thetaArc / segments;

--- a/Source/WebCore/svg/properties/SVGAnimationAdditiveValueFunctionImpl.h
+++ b/Source/WebCore/svg/properties/SVGAnimationAdditiveValueFunctionImpl.h
@@ -181,7 +181,7 @@ public:
         SVGLengthContext lengthContext(&targetElement);
         auto fromLength = SVGLengthValue(m_lengthMode, from);
         auto toLength = SVGLengthValue(m_lengthMode, to);
-        return fabsf(toLength.value(lengthContext) - fromLength.value(lengthContext));
+        return std::abs(toLength.value(lengthContext) - fromLength.value(lengthContext));
     }
 
 private:

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -439,8 +439,8 @@ static inline CGFloat floorToDevicePixel(CGFloat input, float deviceScaleFactor)
 
 static inline bool pointsEqualInDevicePixels(CGPoint a, CGPoint b, float deviceScaleFactor)
 {
-    return fabs(a.x * deviceScaleFactor - b.x * deviceScaleFactor) < std::numeric_limits<float>::epsilon()
-        && fabs(a.y * deviceScaleFactor - b.y * deviceScaleFactor) < std::numeric_limits<float>::epsilon();
+    return std::abs(a.x * deviceScaleFactor - b.x * deviceScaleFactor) < std::numeric_limits<float>::epsilon()
+        && std::abs(a.y * deviceScaleFactor - b.y * deviceScaleFactor) < std::numeric_limits<float>::epsilon();
 }
 
 static CGSize roundScrollViewContentSize(const WebKit::WebPageProxy& page, CGSize contentSize)
@@ -1238,7 +1238,7 @@ static void addOverlayEventRegions(WebCore::GraphicsLayer::PlatformLayerID layer
         const double minimumZoomDuration = 0.1;
         const double zoomDurationFactor = 0.3;
 
-        duration = std::min(fabs(log(zoomScale) - log(scale)) * zoomDurationFactor + minimumZoomDuration, maximumZoomDuration);
+        duration = std::min(std::abs(log(zoomScale) - log(scale)) * zoomDurationFactor + minimumZoomDuration, maximumZoomDuration);
     }
 
     if (scale != zoomScale)
@@ -1659,7 +1659,7 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
     double currentScale = contentZoomScale(self);
     double targetScale = [self _targetContentZoomScaleForRect:targetRect currentScale:currentScale fitEntireRect:fitEntireRect minimumScale:minimumScale maximumScale:maximumScale];
 
-    if (fabs(targetScale - currentScale) < maximumScaleFactorDeltaForPanScroll) {
+    if (std::abs(targetScale - currentScale) < maximumScaleFactorDeltaForPanScroll) {
         if ([self _scrollToRect:targetRect origin:origin minimumScrollDistance:minimumScrollDistance])
             return true;
     } else if (targetScale != currentScale) {

--- a/Source/WebKit/UIProcess/gtk/KeyBindingTranslator.cpp
+++ b/Source/WebKit/UIProcess/gtk/KeyBindingTranslator.cpp
@@ -125,7 +125,7 @@ static void deleteFromCursorCallback(GtkWidget* widget, GtkDeleteType deleteType
     if (!rawCommand)
         return;
 
-    for (int i = 0; i < abs(count); i++)
+    for (int i = 0; i < std::abs(count); i++)
         translator->addPendingEditorCommand(rawCommand);
 }
 
@@ -166,7 +166,7 @@ static void moveCursorCallback(GtkWidget* widget, GtkMovementStep step, gint cou
     if (!rawCommand)
         return;
 
-    for (int i = 0; i < abs(count); i++)
+    for (int i = 0; i < std::abs(count); i++)
         translator->addPendingEditorCommand(rawCommand);
 }
 

--- a/Source/WebKit/UIProcess/gtk/ViewGestureControllerGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/ViewGestureControllerGtk.cpp
@@ -217,7 +217,7 @@ bool ViewGestureController::SwipeProgressTracker::shouldCancel()
     bool swipingLeft = m_viewGestureController.isPhysicallySwipingLeft(m_direction);
     double relativeVelocity = m_velocity * (swipingLeft ? 1 : -1);
 
-    if (abs(m_progress) > swipeCancelArea)
+    if (std::abs(m_progress) > swipeCancelArea)
         return (relativeVelocity * m_distance < -swipeCancelVelocityThreshold);
 
     return (relativeVelocity * m_distance < swipeCancelVelocityThreshold);

--- a/Source/WebKit/UIProcess/ios/WKKeyboardScrollingAnimator.mm
+++ b/Source/WebKit/UIProcess/ios/WKKeyboardScrollingAnimator.mm
@@ -419,9 +419,9 @@ static WebCore::FloatPoint farthestPointInDirection(WebCore::FloatPoint a, WebCo
         // If we've reached or exceeded the maximum velocity, stop applying any force.
         // However, we won't let the spring snap, we'll just keep going at the same
         // velocity until the user raises their finger or we hit an edge.
-        if (fabs(_velocity.width()) >= fabs(_currentScroll->maximumVelocity.width()))
+        if (std::abs(_velocity.width()) >= std::abs(_currentScroll->maximumVelocity.width()))
             force.setWidth(0);
-        if (fabs(_velocity.height()) >= fabs(_currentScroll->maximumVelocity.height()))
+        if (std::abs(_velocity.height()) >= std::abs(_currentScroll->maximumVelocity.height()))
             force.setHeight(0);
     }
 

--- a/Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.cpp
+++ b/Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.cpp
@@ -743,14 +743,14 @@ LRESULT WebPopupMenuProxyWin::onMouseWheel(HWND hWnd, UINT message, WPARAM wPara
         return 0;
 
     int i = 0;
-    for (incrementWheelDelta(GET_WHEEL_DELTA_WPARAM(wParam)); abs(wheelDelta()) >= WHEEL_DELTA; reduceWheelDelta(WHEEL_DELTA)) {
+    for (incrementWheelDelta(GET_WHEEL_DELTA_WPARAM(wParam)); std::abs(wheelDelta()) >= WHEEL_DELTA; reduceWheelDelta(WHEEL_DELTA)) {
         if (wheelDelta() > 0)
             ++i;
         else
             --i;
     }
 
-    ScrollableArea::scroll(i > 0 ? ScrollUp : ScrollDown, ScrollGranularity::Line, abs(i));
+    ScrollableArea::scroll(i > 0 ? ScrollUp : ScrollDown, ScrollGranularity::Line, std::abs(i));
     return 0;
 }
 
@@ -930,7 +930,7 @@ void WebPopupMenuProxyWin::incrementWheelDelta(int delta)
 void WebPopupMenuProxyWin::reduceWheelDelta(int delta)
 {
     ASSERT(delta >= 0);
-    ASSERT(delta <= abs(m_wheelDelta));
+    ASSERT(delta <= std::abs(m_wheelDelta));
 
     if (m_wheelDelta > 0)
         m_wheelDelta -= delta;

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -1966,7 +1966,7 @@ void WebPage::moveSelectionByOffset(int32_t offset, CompletionHandler<void()>&& 
         return;
     SelectionDirection direction = offset < 0 ? SelectionDirection::Backward : SelectionDirection::Forward;
     VisiblePosition position = startPosition;
-    for (int i = 0; i < abs(offset); ++i) {
+    for (int i = 0; i < std::abs(offset); ++i) {
         position = positionOfNextBoundaryOfGranularity(position, TextGranularity::CharacterGranularity, direction);
         if (position.isNull())
             break;
@@ -2754,9 +2754,9 @@ static void focusedElementPositionInformation(WebPage& page, Element& focusedEle
     else if (position > endPosition)
         position = endPosition;
     IntRect caretRect = view->contentsToRootView(position.absoluteCaretBounds());
-    float deltaX = abs(caretRect.x() + (caretRect.width() / 2) - request.point.x());
-    float deltaYFromTheTop = abs(caretRect.y() - request.point.y());
-    float deltaYFromTheBottom = abs(caretRect.y() + caretRect.height() - request.point.y());
+    float deltaX = std::abs(caretRect.x() + (caretRect.width() / 2) - request.point.x());
+    float deltaYFromTheTop = std::abs(caretRect.y() - request.point.y());
+    float deltaYFromTheBottom = std::abs(caretRect.y() + caretRect.height() - request.point.y());
 
     info.isNearMarkedText = !(deltaX > kHitAreaWidth || deltaYFromTheTop > kHitAreaHeight || deltaYFromTheBottom > kHitAreaHeight);
 }
@@ -4151,7 +4151,7 @@ std::optional<float> WebPage::scaleFromUIProcess(const VisibleContentRectUpdateI
     float currentScale = m_page->pageScaleFactor();
 
     double scaleNoiseThreshold = 0.005;
-    if (!m_isInStableState && fabs(scaleFromUIProcess - currentScale) < scaleNoiseThreshold) {
+    if (!m_isInStableState && std::abs(scaleFromUIProcess - currentScale) < scaleNoiseThreshold) {
         // Tiny changes of scale during interactive zoom cause content to jump by one pixel, creating
         // visual noise. We filter those useless updates.
         scaleFromUIProcess = currentScale;

--- a/Source/WebKitLegacy/ios/WebCoreSupport/WebFrameIOS.mm
+++ b/Source/WebKitLegacy/ios/WebCoreSupport/WebFrameIOS.mm
@@ -333,7 +333,7 @@ using namespace WebCore;
     static const CGFloat FlipMargin = 30;
     bool didFlipStartEnd = false;
     bool canFlipStartEnd = allowFlipping && 
-        (fabs(basePoint.x - extentPoint.x) > FlipMargin || fabs(basePoint.y - extentPoint.y) > FlipMargin);
+        (std::abs(basePoint.x - extentPoint.x) > FlipMargin || std::abs(basePoint.y - extentPoint.y) > FlipMargin);
 
     VisiblePosition base;
     if (baseIsStart) {                

--- a/Source/WebKitLegacy/mac/WebView/WebDynamicScrollBarsView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebDynamicScrollBarsView.mm
@@ -538,7 +538,7 @@ static const unsigned cMaxUpdateScrollbarsPass = 2;
     NSEventPhase momentumPhase = [event momentumPhase];
     BOOL isLatchingEvent = momentumPhase & NSEventPhaseBegan || momentumPhase & NSEventPhaseStationary;
 
-    if (fabsf(deltaY) > fabsf(deltaX)) {
+    if (std::abs(deltaY) > std::abs(deltaX)) {
         if (![self allowsVerticalScrolling]) {
             [[self nextResponder] scrollWheel:event];
             return;

--- a/Tools/TestRunnerShared/EventSerialization/mac/EventSerializerMac.mm
+++ b/Tools/TestRunnerShared/EventSerialization/mac/EventSerializerMac.mm
@@ -168,7 +168,7 @@ bool eventIsOfGestureTypes(CGEventRef event, IOHIDEventType first, Types ... res
     double value = CGEventGetDoubleValueField(rawEvent, field); \
     if (!isnan(value)) { \
         double plainValue = CGEventGetDoubleValueField(rawPlainEvent, field); \
-        if (fabs(value - plainValue) >= FLT_EPSILON) \
+        if (std::abs(value - plainValue) >= FLT_EPSILON) \
             dict.get()[@#field] = @(value); \
     } \
 }();

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/GPUProcess.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/GPUProcess.mm
@@ -355,10 +355,10 @@ TEST(GPUProcess, CrashWhilePlayingVideo)
         do {
             TestWebKitAPI::Util::runFor(0.1_s);
             currentTime = [[webView objectByEvaluatingJavaScript:@"document.getElementsByTagName('video')[0].currentTime"] doubleValue];
-            if (fabs(currentTime - initialTime) > 0.01)
+            if (std::abs(currentTime - initialTime) > 0.01)
                 break;
         } while (timeout++ < 100);
-        return fabs(currentTime - initialTime) > 0.01;
+        return std::abs(currentTime - initialTime) > 0.01;
     };
     EXPECT_TRUE(ensureIsPlaying());
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm
@@ -703,8 +703,8 @@ static bool drawFooterCalled;
 - (void)_webView:(WKWebView *)webView drawHeaderInRect:(CGRect)rect forPageWithTitle:(NSString *)title URL:(NSURL *)url
 {
     EXPECT_EQ(rect.origin.x, 72);
-    EXPECT_TRUE(fabs(rect.origin.y - 698.858398) < .00001);
-    EXPECT_TRUE(fabs(rect.size.height - 3.141590) < .00001);
+    EXPECT_TRUE(std::abs(rect.origin.y - 698.858398) < .00001);
+    EXPECT_TRUE(std::abs(rect.size.height - 3.141590) < .00001);
     EXPECT_EQ(rect.size.width, 468.000000);
     EXPECT_STREQ(title.UTF8String, "test_title");
     EXPECT_STREQ(url.absoluteString.UTF8String, "http://example.com/");
@@ -715,7 +715,7 @@ static bool drawFooterCalled;
 {
     EXPECT_EQ(rect.origin.x, 72);
     EXPECT_EQ(rect.origin.y, 90);
-    EXPECT_TRUE(fabs(rect.size.height - 2.718280) < .00001);
+    EXPECT_TRUE(std::abs(rect.size.height - 2.718280) < .00001);
     EXPECT_EQ(rect.size.width, 468.000000);
     EXPECT_STREQ(url.absoluteString.UTF8String, "http://example.com/");
     drawFooterCalled = true;

--- a/Tools/TestWebKitAPI/Tests/ios/FullscreenTouchSecheuristicTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/ios/FullscreenTouchSecheuristicTests.cpp
@@ -101,7 +101,7 @@ TEST(FullscreenTouchSecheuristic, TapOnceVsTapTwice)
         onceScore = once.scoreOfNextTouch(location1, tapDelta + tapDuration);
     }
 
-    ASSERT_LT(abs(twiceScore - onceScore), 0.01);
+    ASSERT_LT(std::abs(twiceScore - onceScore), 0.01);
 }
 
 TEST(FullscreenTouchSecheuristic, WKFullScreenViewControllerParameters)

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
@@ -666,7 +666,7 @@ static void dumpFrameScrollPosition(WKBundleFrameRef frame, StringBuilder& strin
 {
     double x = numericWindowProperty(frame, "pageXOffset");
     double y = numericWindowProperty(frame, "pageYOffset");
-    if (fabs(x) <= 0.00000001 && fabs(y) <= 0.00000001)
+    if (std::abs(x) <= 0.00000001 && std::abs(y) <= 0.00000001)
         return;
     if (shouldIncludeFrameName)
         stringBuilder.append("frame '", adoptWK(WKBundleFrameCopyName(frame)).get(), "' ");


### PR DESCRIPTION
#### da934454c84ac2dcbf9fca9e5f4ac2644ef25d72
<pre>
Prefer std::abs over fabs
<a href="https://bugs.webkit.org/show_bug.cgi?id=252974">https://bugs.webkit.org/show_bug.cgi?id=252974</a>

Reviewed by Ryosuke Niwa.

Unlike the C library versions, std::abs has overloads for every type, so one does not need to worry about which version of the function to call.

* Source/JavaScriptCore/assembler/MacroAssembler.h:
* Source/JavaScriptCore/b3/B3ConstDoubleValue.cpp:
* Source/JavaScriptCore/b3/B3ConstFloatValue.cpp:
* Source/JavaScriptCore/b3/testb3_3.cpp:
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
* Source/JavaScriptCore/jit/AssemblyHelpersSpoolers.h:
* Source/JavaScriptCore/runtime/DateConversion.cpp:
* Source/JavaScriptCore/runtime/ISO8601.cpp:
* Source/JavaScriptCore/runtime/MathCommon.cpp:
* Source/JavaScriptCore/runtime/MathObject.cpp:
* Source/JavaScriptCore/runtime/NumberPrototype.cpp:
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
* Source/WTF/wtf/CurrentTime.cpp:
* Source/WTF/wtf/DateMath.cpp:
* Source/WTF/wtf/MediaTime.cpp:
* Source/WTF/wtf/text/TextStream.cpp:
* Source/WebCore/Modules/mediasession/MediaSessionCoordinator.cpp:
* Source/WebCore/Modules/webaudio/AudioParam.cpp:
* Source/WebCore/Modules/webaudio/AudioParamTimeline.cpp:
* Source/WebCore/Modules/webaudio/IIRFilterNode.cpp:
* Source/WebCore/Modules/webaudio/OscillatorNode.cpp:
* Source/WebCore/Modules/webaudio/PeriodicWave.cpp:
* Source/WebCore/Modules/webaudio/RealtimeAnalyser.cpp:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
* Source/WebCore/bindings/js/JSDOMConvertNumbers.cpp:
* Source/WebCore/contentextensions/DFABytecodeCompiler.cpp:
* Source/WebCore/display/css/DisplayBoxDecorationPainter.cpp:
* Source/WebCore/editing/FrameSelection.cpp:
* Source/WebCore/editing/cocoa/HTMLConverter.mm:
* Source/WebCore/html/CustomPaintImage.cpp:
* Source/WebCore/html/HTMLMediaElement.cpp:
* Source/WebCore/inspector/InspectorOverlay.cpp:
* Source/WebCore/layout/Verification.cpp:
* Source/WebCore/page/EventHandler.cpp:
* Source/WebCore/page/Frame.cpp:
* Source/WebCore/page/WheelEventDeltaFilter.cpp:
* Source/WebCore/page/ios/FrameIOS.mm:
* Source/WebCore/platform/LayoutUnit.h:
* Source/WebCore/platform/LocalizedStrings.cpp:
* Source/WebCore/platform/ScrollAnimationKeyboard.cpp:
* Source/WebCore/platform/ScrollAnimationKinetic.cpp:
* Source/WebCore/platform/ScrollView.cpp:
* Source/WebCore/platform/audio/Biquad.cpp:
* Source/WebCore/platform/audio/Cone.cpp:
* Source/WebCore/platform/audio/DenormalDisabler.h:
* Source/WebCore/platform/audio/FFTFrame.cpp:
* Source/WebCore/platform/audio/HRTFPanner.cpp:
* Source/WebCore/platform/audio/IIRFilter.cpp:
* Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.mm:
* Source/WebCore/platform/graphics/FloatLine.cpp:
* Source/WebCore/platform/graphics/FloatSize.cpp:
* Source/WebCore/platform/graphics/GradientImage.cpp:
* Source/WebCore/platform/graphics/IntSize.h:
* Source/WebCore/platform/graphics/PathUtilities.cpp:
* Source/WebCore/platform/graphics/ShadowBlur.cpp:
* Source/WebCore/platform/graphics/UnitBezier.h:
* Source/WebCore/platform/graphics/cairo/CairoOperations.cpp:
* Source/WebCore/platform/graphics/texmap/coordinated/TiledBackingStore.cpp:
* Source/WebCore/platform/graphics/transforms/AffineTransform.cpp:
* Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp:
* Source/WebCore/platform/graphics/win/FontCacheWin.cpp:
* Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.cpp:
* Source/WebCore/platform/graphics/win/SystemFontDatabaseWin.cpp:
* Source/WebCore/platform/ios/ScrollAnimatorIOS.mm:
* Source/WebCore/platform/ios/WebAVPlayerController.mm:
* Source/WebCore/platform/ios/wak/WKView.mm:
* Source/WebCore/platform/mac/ScrollAnimationRubberBand.mm:
* Source/WebCore/platform/mac/ScrollingEffectsController.mm:
* Source/WebCore/platform/win/BitmapInfo.h:
* Source/WebCore/platform/win/PopupMenuWin.cpp:
* Source/WebCore/platform/xr/openxr/OpenXRUtils.h:
* Source/WebCore/rendering/AttachmentLayout.mm:
* Source/WebCore/rendering/BorderPainter.cpp:
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
* Source/WebCore/rendering/RenderListBox.cpp:
* Source/WebCore/rendering/RenderMarquee.cpp:
* Source/WebCore/rendering/shapes/RasterShape.cpp:
* Source/WebCore/rendering/svg/SVGMarkerData.h:
* Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp:
* Source/WebCore/style/StyleBuilderConverter.h:
* Source/WebCore/style/StyleFontSizeFunctions.cpp:
* Source/WebCore/svg/SVGPathParser.cpp:
* Source/WebCore/svg/properties/SVGAnimationAdditiveValueFunctionImpl.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
* Source/WebKit/UIProcess/gtk/KeyBindingTranslator.cpp:
* Source/WebKit/UIProcess/gtk/ViewGestureControllerGtk.cpp:
* Source/WebKit/UIProcess/ios/WKKeyboardScrollingAnimator.mm:
* Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.cpp:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
* Source/WebKitLegacy/ios/WebCoreSupport/WebFrameIOS.mm:
* Source/WebKitLegacy/mac/WebView/WebDynamicScrollBarsView.mm:
* Tools/TestRunnerShared/EventSerialization/mac/EventSerializerMac.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/GPUProcess.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm:
* Tools/TestWebKitAPI/Tests/ios/FullscreenTouchSecheuristicTests.cpp:
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp:

Canonical link: <a href="https://commits.webkit.org/261584@main">https://commits.webkit.org/261584@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9982a47ba33872c4fc6c67ca8d0cc2d259943d6d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112208 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21343 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/835 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4009 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120853 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116270 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22690 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/12426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/4775 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117971 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16858 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100041 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105270 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/88/builds/582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/45869 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/100614 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13750 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/623 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/93865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/11873 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14428 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/12426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/101960 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19793 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52622 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31875 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8077 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16222 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/110003 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/27176 "Passed tests") | 
<!--EWS-Status-Bubble-End-->