### PR TITLE
Clicking on save button dispatches a MouseEvent, button location in element's saveButtonClientRect

### DIFF
--- a/Source/WebCore/html/HTMLAttachmentElement.h
+++ b/Source/WebCore/html/HTMLAttachmentElement.h
@@ -32,6 +32,7 @@
 
 namespace WebCore {
 
+class DOMRectReadOnly;
 class File;
 class HTMLImageElement;
 class RenderAttachment;
@@ -80,6 +81,7 @@ public:
     void requestIconWithSize(const FloatSize&) const;
     FloatSize iconSize() const { return m_iconSize; }
     void invalidateRendering();
+    DOMRectReadOnly* saveButtonClientRect() const;
 
 #if ENABLE(SERVICE_CONTROLS)
     bool isImageMenuEnabled() const { return m_isImageMenuEnabled; }
@@ -89,6 +91,8 @@ public:
     bool isImageOnly() const { return m_implementation == Implementation::ImageOnly; }
 
 private:
+    friend class AttachmentSaveEventListener;
+
     HTMLAttachmentElement(const QualifiedName&, Document&);
     virtual ~HTMLAttachmentElement();
 
@@ -126,6 +130,7 @@ private:
     RefPtr<HTMLElement> m_titleElement;
     RefPtr<HTMLElement> m_subtitleElement;
     RefPtr<HTMLElement> m_saveButton;
+    mutable RefPtr<DOMRectReadOnly> m_saveButtonClientRect;
 
 #if ENABLE(SERVICE_CONTROLS)
     bool m_isImageMenuEnabled { false };

--- a/Source/WebCore/html/HTMLAttachmentElement.idl
+++ b/Source/WebCore/html/HTMLAttachmentElement.idl
@@ -32,6 +32,7 @@
 ] interface HTMLAttachmentElement : HTMLElement {
     attribute File? file;
     readonly attribute DOMString uniqueIdentifier;
+    readonly attribute DOMRectReadOnly? saveButtonClientRect;
 
     static DOMString getAttachmentIdentifier(HTMLImageElement imageElement);
 };


### PR DESCRIPTION
#### b9dad072710ae23d168919abf01468c1763b8d33
<pre>
Clicking on save button dispatches a MouseEvent, button location in element&apos;s saveButtonClientRect
<a href="https://bugs.webkit.org/show_bug.cgi?id=252967">https://bugs.webkit.org/show_bug.cgi?id=252967</a>
rdar://problem/105952126

Reviewed by Tim Nguyen.

Instead of sending a CustomEvent with some hand-picked details, a click on the save button now dispatches a full copy of the original MouseEvent, and the location of the (shadow) save button can be found the element&apos;s saveButtonClientRect property.

* Source/WebCore/html/HTMLAttachmentElement.cpp:
(WebCore::HTMLAttachmentElement::saveButtonClientRect const):
* Source/WebCore/html/HTMLAttachmentElement.h:
* Source/WebCore/html/HTMLAttachmentElement.idl:

Canonical link: <a href="https://commits.webkit.org/261101@main">https://commits.webkit.org/261101@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f9644dcc2fc79d035e97dd59bfbe7ccfa73a824b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110384 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19472 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42987 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1768 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119308 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114330 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20912 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10629 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102627 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116127 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15574 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98761 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43796 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97535 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30426 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85655 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12137 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31764 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12720 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8736 "Found 1 new test failure: swipe/pushState-cached-back-swipe.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18085 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51379 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7692 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14575 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->