### PR TITLE
Continue porting types to the new IPC serialization format

### DIFF
--- a/Source/WebCore/page/MediaControlsContextMenuItem.h
+++ b/Source/WebCore/page/MediaControlsContextMenuItem.h
@@ -41,40 +41,7 @@ struct MediaControlsContextMenuItem {
     String icon;
     bool checked { false };
     Vector<MediaControlsContextMenuItem> children;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<MediaControlsContextMenuItem> decode(Decoder&);
 };
-
-template<class Encoder>
-void MediaControlsContextMenuItem::encode(Encoder& encoder) const
-{
-    encoder << id;
-    encoder << title;
-    encoder << icon;
-    encoder << checked;
-    encoder << children;
-}
-
-template<class Decoder>
-std::optional<MediaControlsContextMenuItem> MediaControlsContextMenuItem::decode(Decoder& decoder)
-{
-#define DECODE(name, type) \
-    std::optional<type> name; \
-    decoder >> name; \
-    if (!name) \
-        return std::nullopt; \
-
-    DECODE(id, ID);
-    DECODE(title, String);
-    DECODE(icon, String);
-    DECODE(checked, bool);
-    DECODE(children, Vector<MediaControlsContextMenuItem>);
-
-#undef DECODE
-
-    return {{ WTFMove(*id), WTFMove(*title), WTFMove(*icon), WTFMove(*checked), WTFMove(*children) }};
-}
 
 } // namespace WebCore
 

--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -516,10 +516,15 @@ set(WebKit_SERIALIZATION_IN_FILES
     GPUProcess/graphics/InlinePathData.serialization.in
     GPUProcess/graphics/RemoteRenderingBackendCreationParameters.serialization.in
 
+    GPUProcess/graphics/WebGPU/RemoteGPURequestAdapterResponse.serialization.in
+
+    GPUProcess/media/AudioTrackPrivateRemoteConfiguration.serialization.in
     GPUProcess/media/InitializationSegmentInfo.serialization.in
     GPUProcess/media/MediaDescriptionInfo.serialization.in
     GPUProcess/media/RemoteMediaPlayerProxyConfiguration.serialization.in
     GPUProcess/media/TextTrackPrivateRemoteConfiguration.serialization.in
+    GPUProcess/media/TrackPrivateRemoteConfiguration.serialization.in
+    GPUProcess/media/VideoTrackPrivateRemoteConfiguration.serialization.in
 
     NetworkProcess/NetworkProcessCreationParameters.serialization.in
     NetworkProcess/NetworkResourceLoadParameters.serialization.in
@@ -651,6 +656,8 @@ set(WebKit_SERIALIZATION_IN_FILES
     WebProcess/GPU/media/RemoteCDMConfiguration.serialization.in
     WebProcess/GPU/media/RemoteMediaPlayerConfiguration.serialization.in
     WebProcess/GPU/media/RemoteMediaPlayerState.serialization.in
+
+    WebProcess/WebCoreSupport/WebSpeechSynthesisVoice.serialization.in
 )
 
 list(APPEND WebKit_DERIVED_SOURCES

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -52,6 +52,7 @@ $(PROJECT_DIR)/GPUProcess/graphics/WebGPU/RemoteComputePipeline.messages.in
 $(PROJECT_DIR)/GPUProcess/graphics/WebGPU/RemoteDevice.messages.in
 $(PROJECT_DIR)/GPUProcess/graphics/WebGPU/RemoteExternalTexture.messages.in
 $(PROJECT_DIR)/GPUProcess/graphics/WebGPU/RemoteGPU.messages.in
+$(PROJECT_DIR)/GPUProcess/graphics/WebGPU/RemoteGPURequestAdapterResponse.serialization.in
 $(PROJECT_DIR)/GPUProcess/graphics/WebGPU/RemotePipelineLayout.messages.in
 $(PROJECT_DIR)/GPUProcess/graphics/WebGPU/RemotePresentationContext.messages.in
 $(PROJECT_DIR)/GPUProcess/graphics/WebGPU/RemoteQuerySet.messages.in
@@ -67,6 +68,7 @@ $(PROJECT_DIR)/GPUProcess/graphics/WebGPU/RemoteSwapChain.messages.in
 $(PROJECT_DIR)/GPUProcess/graphics/WebGPU/RemoteTexture.messages.in
 $(PROJECT_DIR)/GPUProcess/graphics/WebGPU/RemoteTextureView.messages.in
 $(PROJECT_DIR)/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
+$(PROJECT_DIR)/GPUProcess/media/AudioTrackPrivateRemoteConfiguration.serialization.in
 $(PROJECT_DIR)/GPUProcess/media/InitializationSegmentInfo.serialization.in
 $(PROJECT_DIR)/GPUProcess/media/MediaDescriptionInfo.serialization.in
 $(PROJECT_DIR)/GPUProcess/media/RemoteAudioDestinationManager.messages.in
@@ -93,6 +95,8 @@ $(PROJECT_DIR)/GPUProcess/media/RemoteTextTrackProxy.messages.in
 $(PROJECT_DIR)/GPUProcess/media/RemoteVideoFrameObjectHeap.messages.in
 $(PROJECT_DIR)/GPUProcess/media/RemoteVideoTrackProxy.messages.in
 $(PROJECT_DIR)/GPUProcess/media/TextTrackPrivateRemoteConfiguration.serialization.in
+$(PROJECT_DIR)/GPUProcess/media/TrackPrivateRemoteConfiguration.serialization.in
+$(PROJECT_DIR)/GPUProcess/media/VideoTrackPrivateRemoteConfiguration.serialization.in
 $(PROJECT_DIR)/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.messages.in
 $(PROJECT_DIR)/GPUProcess/webrtc/LibWebRTCCodecsProxy.messages.in
 $(PROJECT_DIR)/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRenderer.messages.in
@@ -418,6 +422,7 @@ $(PROJECT_DIR)/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.messages
 $(PROJECT_DIR)/WebProcess/WebCoreSupport/WebPermissionController.messages.in
 $(PROJECT_DIR)/WebProcess/WebCoreSupport/WebScreenOrientationManager.messages.in
 $(PROJECT_DIR)/WebProcess/WebCoreSupport/WebSpeechRecognitionConnection.messages.in
+$(PROJECT_DIR)/WebProcess/WebCoreSupport/WebSpeechSynthesisVoice.serialization.in
 $(PROJECT_DIR)/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.messages.in
 $(PROJECT_DIR)/WebProcess/WebPage/DrawingArea.messages.in
 $(PROJECT_DIR)/WebProcess/WebPage/EventDispatcher.messages.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -459,10 +459,14 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	GPUProcess/GPUProcessSessionParameters.serialization.in \
 	GPUProcess/graphics/InlinePathData.serialization.in \
 	GPUProcess/graphics/RemoteRenderingBackendCreationParameters.serialization.in \
+	GPUProcess/graphics/WebGPU/RemoteGPURequestAdapterResponse.serialization.in \
+	GPUProcess/media/AudioTrackPrivateRemoteConfiguration.serialization.in \
 	GPUProcess/media/InitializationSegmentInfo.serialization.in \
 	GPUProcess/media/MediaDescriptionInfo.serialization.in \
 	GPUProcess/media/RemoteMediaPlayerProxyConfiguration.serialization.in \
 	GPUProcess/media/TextTrackPrivateRemoteConfiguration.serialization.in \
+	GPUProcess/media/TrackPrivateRemoteConfiguration.serialization.in \
+	GPUProcess/media/VideoTrackPrivateRemoteConfiguration.serialization.in \
 	NetworkProcess/NetworkProcessCreationParameters.serialization.in \
 	Shared/API/APIError.serialization.in \
 	Shared/API/APIFrameHandle.serialization.in \
@@ -597,6 +601,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	WebProcess/GPU/media/RemoteAudioSessionConfiguration.serialization.in \
 	WebProcess/GPU/media/RemoteMediaPlayerConfiguration.serialization.in \
 	WebProcess/GPU/media/RemoteMediaPlayerState.serialization.in \
+	WebProcess/WebCoreSupport/WebSpeechSynthesisVoice.serialization.in \
 #
 
 all : GeneratedSerializers.h GeneratedSerializers.mm SerializedTypeInfo.mm

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp
@@ -111,7 +111,7 @@ void RemoteGPU::workQueueUninitialize()
     m_backing = nullptr;
 }
 
-void RemoteGPU::requestAdapter(const WebGPU::RequestAdapterOptions& options, WebGPUIdentifier identifier, CompletionHandler<void(std::optional<RequestAdapterResponse>&&)>&& callback)
+void RemoteGPU::requestAdapter(const WebGPU::RequestAdapterOptions& options, WebGPUIdentifier identifier, CompletionHandler<void(std::optional<RemoteGPURequestAdapterResponse>&&)>&& callback)
 {
     assertIsCurrent(workQueue());
     ASSERT(m_backing);

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(GPU_PROCESS)
 
+#include "RemoteGPURequestAdapterResponse.h"
 #include "StreamConnectionWorkQueue.h"
 #include "StreamMessageReceiver.h"
 #include "StreamServerConnection.h"
@@ -72,46 +73,6 @@ public:
 
     void stopListeningForIPC(Ref<RemoteGPU>&& refFromConnection);
 
-    struct RequestAdapterResponse {
-        String name;
-        WebGPU::SupportedFeatures features;
-        WebGPU::SupportedLimits limits;
-        bool isFallbackAdapter;
-
-        template<class Encoder> void encode(Encoder& encoder) const
-        {
-            encoder << name;
-            encoder << features;
-            encoder << limits;
-            encoder << isFallbackAdapter;
-        }
-
-        template<class Decoder> static std::optional<RequestAdapterResponse> decode(Decoder& decoder)
-        {
-            std::optional<String> name;
-            decoder >> name;
-            if (!name)
-                return std::nullopt;
-
-            std::optional<WebGPU::SupportedFeatures> features;
-            decoder >> features;
-            if (!features)
-                return std::nullopt;
-
-            std::optional<WebGPU::SupportedLimits> limits;
-            decoder >> limits;
-            if (!limits)
-                return std::nullopt;
-
-            std::optional<bool> isFallbackAdapter;
-            decoder >> isFallbackAdapter;
-            if (!isFallbackAdapter)
-                return std::nullopt;
-
-            return { { WTFMove(*name), WTFMove(*features), WTFMove(*limits), *isFallbackAdapter } };
-        }
-    };
-
 private:
     friend class WebGPU::ObjectHeap;
 
@@ -135,7 +96,7 @@ private:
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 
-    void requestAdapter(const WebGPU::RequestAdapterOptions&, WebGPUIdentifier, CompletionHandler<void(std::optional<RequestAdapterResponse>&&)>&&);
+    void requestAdapter(const WebGPU::RequestAdapterOptions&, WebGPUIdentifier, CompletionHandler<void(std::optional<RemoteGPURequestAdapterResponse>&&)>&&);
 
     void createPresentationContext(const WebGPU::PresentationContextDescriptor&, WebGPUIdentifier);
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemoteGPU NotRefCounted Stream {
-    void RequestAdapter(WebKit::WebGPU::RequestAdapterOptions options, WebKit::WebGPUIdentifier identifier) -> (std::optional<WebKit::RemoteGPU::RequestAdapterResponse> response) Synchronous
+    void RequestAdapter(WebKit::WebGPU::RequestAdapterOptions options, WebKit::WebGPUIdentifier identifier) -> (std::optional<WebKit::RemoteGPURequestAdapterResponse> response) Synchronous
     void CreatePresentationContext(WebKit::WebGPU::PresentationContextDescriptor descriptor, WebKit::WebGPUIdentifier identifier)
     void CreateCompositorIntegration(WebKit::WebGPUIdentifier identifier)
 }

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPURequestAdapterResponse.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPURequestAdapterResponse.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,20 +25,20 @@
 
 #pragma once
 
-#if ENABLE(GPU_PROCESS) && ENABLE(VIDEO)
+#include "WebGPUSupportedFeatures.h"
+#include "WebGPUSupportedLimits.h"
 
-#include <wtf/MediaTime.h>
+#if ENABLE(GPU_PROCESS)
 
 namespace WebKit {
 
-struct TrackPrivateRemoteConfiguration {
-    AtomString trackId;
-    AtomString label;
-    AtomString language;
-    MediaTime startTimeVariance { MediaTime::zeroTime() };
-    int trackIndex;
+struct RemoteGPURequestAdapterResponse {
+    String name;
+    WebGPU::SupportedFeatures features;
+    WebGPU::SupportedLimits limits;
+    bool isFallbackAdapter;
 };
 
 } // namespace WebKit
 
-#endif // ENABLE(GPU_PROCESS) && ENABLE(VIDEO)
+#endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPURequestAdapterResponse.serialization.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPURequestAdapterResponse.serialization.in
@@ -1,0 +1,32 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE(GPU_PROCESS)
+
+[AdditionalEncoder=StreamConnectionEncoder] struct WebKit::RemoteGPURequestAdapterResponse {
+    String name;
+    WebKit::WebGPU::SupportedFeatures features;
+    WebKit::WebGPU::SupportedLimits limits;
+    bool isFallbackAdapter;
+}
+
+#endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/GPUProcess/media/AudioTrackPrivateRemoteConfiguration.h
+++ b/Source/WebKit/GPUProcess/media/AudioTrackPrivateRemoteConfiguration.h
@@ -36,24 +36,6 @@ struct AudioTrackPrivateRemoteConfiguration : TrackPrivateRemoteConfiguration {
     bool enabled;
     WebCore::AudioTrackPrivate::Kind kind { WebCore::AudioTrackPrivate::Kind::None };
     WebCore::PlatformAudioTrackConfiguration trackConfiguration;
-
-    template<class Encoder>
-    void encode(Encoder& encoder) const
-    {
-        TrackPrivateRemoteConfiguration::encode(encoder);
-        encoder << enabled;
-        encoder << kind;
-        encoder << trackConfiguration;
-    }
-
-    template <class Decoder>
-    static bool WARN_UNUSED_RETURN decode(Decoder& decoder, AudioTrackPrivateRemoteConfiguration& configuration)
-    {
-        return TrackPrivateRemoteConfiguration::decode(decoder, configuration)
-            && decoder.decode(configuration.enabled)
-            && decoder.decode(configuration.kind)
-            && decoder.decode(configuration.trackConfiguration);
-    }
 };
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/media/AudioTrackPrivateRemoteConfiguration.serialization.in
+++ b/Source/WebKit/GPUProcess/media/AudioTrackPrivateRemoteConfiguration.serialization.in
@@ -1,0 +1,31 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE(GPU_PROCESS) && ENABLE(VIDEO)
+
+struct WebKit::AudioTrackPrivateRemoteConfiguration : WebKit::TrackPrivateRemoteConfiguration {
+    bool enabled;
+    WebCore::AudioTrackPrivate::Kind kind;
+    WebCore::PlatformAudioTrackConfiguration trackConfiguration;
+}
+
+#endif // ENABLE(GPU_PROCESS) && ENABLE(VIDEO)

--- a/Source/WebKit/GPUProcess/media/TrackPrivateRemoteConfiguration.serialization.in
+++ b/Source/WebKit/GPUProcess/media/TrackPrivateRemoteConfiguration.serialization.in
@@ -1,0 +1,33 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE(GPU_PROCESS) && ENABLE(VIDEO)
+
+struct WebKit::TrackPrivateRemoteConfiguration {
+    AtomString trackId;
+    AtomString label;
+    AtomString language;
+    MediaTime startTimeVariance;
+    int trackIndex;
+}
+
+#endif // ENABLE(GPU_PROCESS) && ENABLE(VIDEO)

--- a/Source/WebKit/GPUProcess/media/VideoTrackPrivateRemoteConfiguration.h
+++ b/Source/WebKit/GPUProcess/media/VideoTrackPrivateRemoteConfiguration.h
@@ -36,29 +36,6 @@ struct VideoTrackPrivateRemoteConfiguration : TrackPrivateRemoteConfiguration {
     bool selected;
     WebCore::VideoTrackPrivate::Kind kind { WebCore::VideoTrackPrivate::Kind::None };
     WebCore::PlatformVideoTrackConfiguration trackConfiguration;
-
-    template<class Encoder>
-    void encode(Encoder& encoder) const
-    {
-        TrackPrivateRemoteConfiguration::encode(encoder);
-        encoder << selected;
-        encoder << kind;
-        encoder << trackConfiguration;
-    }
-
-    template <class Decoder>
-    static bool WARN_UNUSED_RETURN decode(Decoder& decoder, VideoTrackPrivateRemoteConfiguration& configuration)
-    {
-        if (!TrackPrivateRemoteConfiguration::decode(decoder, configuration))
-            return false;
-        if (!decoder.decode(configuration.selected))
-            return false;
-        if (!decoder.decode(configuration.kind))
-            return false;
-        if (!decoder.decode(configuration.trackConfiguration))
-            return false;
-        return true;
-    }
 };
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/media/VideoTrackPrivateRemoteConfiguration.serialization.in
+++ b/Source/WebKit/GPUProcess/media/VideoTrackPrivateRemoteConfiguration.serialization.in
@@ -1,0 +1,31 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE(GPU_PROCESS) && ENABLE(VIDEO)
+
+struct WebKit::VideoTrackPrivateRemoteConfiguration : WebKit::TrackPrivateRemoteConfiguration {
+    bool selected;
+    WebCore::VideoTrackPrivate::Kind kind;
+    WebCore::PlatformVideoTrackConfiguration trackConfiguration;
+}
+
+#endif // ENABLE(GPU_PROCESS) && ENABLE(VIDEO)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4490,6 +4490,16 @@ struct WebCore::PasteboardItemInfo {
     WebCore::PasteboardItemPresentationStyle preferredPresentationStyle;
 };
 
+#if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
+struct WebCore::MediaControlsContextMenuItem {
+    uint64_t id;
+    String title;
+    String icon;
+    bool checked;
+    Vector<WebCore::MediaControlsContextMenuItem> children;
+};
+#endif
+
 struct WebCore::WorkerOptions {
     WebCore::WorkerType type;
     WebCore::FetchRequestCredentials credentials;

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -7097,6 +7097,7 @@
 		F409BA171E6E64B3009DA28E /* WKDragDestinationAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKDragDestinationAction.h; sourceTree = "<group>"; };
 		F40D1B68220BDC0F00B49A01 /* WebAutocorrectionContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebAutocorrectionContext.h; path = ios/WebAutocorrectionContext.h; sourceTree = "<group>"; };
 		F41056612130699A0092281D /* APIAttachmentCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = APIAttachmentCocoa.mm; sourceTree = "<group>"; };
+		F410A19329AAC81E0082D554 /* RemoteGPURequestAdapterResponse.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteGPURequestAdapterResponse.h; sourceTree = "<group>"; };
 		F4299506270E234C0032298B /* StreamMessageReceiver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StreamMessageReceiver.h; sourceTree = "<group>"; };
 		F42D633F22A0EFD300D2FB3A /* WebAutocorrectionData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WebAutocorrectionData.h; path = ios/WebAutocorrectionData.h; sourceTree = "<group>"; };
 		F430E941224732A9005FE053 /* WebsiteMetaViewportPolicy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebsiteMetaViewportPolicy.h; sourceTree = "<group>"; };
@@ -8525,6 +8526,7 @@
 				1C98C01D27446A03002CCB78 /* RemoteGPU.cpp */,
 				1C98C03827446A09002CCB78 /* RemoteGPU.h */,
 				1C98C0942744BD9B002CCB78 /* RemoteGPU.messages.in */,
+				F410A19329AAC81E0082D554 /* RemoteGPURequestAdapterResponse.h */,
 				1C98C03127446A08002CCB78 /* RemotePipelineLayout.cpp */,
 				1C98C02D27446A07002CCB78 /* RemotePipelineLayout.h */,
 				1C98C0852744BD98002CCB78 /* RemotePipelineLayout.messages.in */,

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisVoice.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisVoice.h
@@ -35,50 +35,7 @@ struct WebSpeechSynthesisVoice {
     String lang;
     bool localService { false };
     bool defaultLang { false };
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<WebSpeechSynthesisVoice> decode(Decoder&);
 };
-
-template<class Encoder>
-void WebSpeechSynthesisVoice::encode(Encoder& encoder) const
-{
-    encoder << voiceURI
-    << name
-    << lang
-    << localService
-    << defaultLang;
-}
-
-template<class Decoder>
-std::optional<WebSpeechSynthesisVoice> WebSpeechSynthesisVoice::decode(Decoder& decoder)
-{
-    std::optional<String> voiceURI;
-    decoder >> voiceURI;
-    if (!voiceURI)
-        return std::nullopt;
-
-    std::optional<String> name;
-    decoder >> name;
-    if (!name)
-        return std::nullopt;
-
-    std::optional<String> lang;
-    decoder >> lang;
-    if (!lang)
-        return std::nullopt;
-
-    std::optional<bool> localService;
-    decoder >> localService;
-    if (!localService)
-        return std::nullopt;
-
-    std::optional<bool> defaultLang;
-    decoder >> defaultLang;
-    if (!defaultLang)
-        return std::nullopt;
-
-    return {{ WTFMove(*voiceURI), WTFMove(*name), WTFMove(*lang), WTFMove(*localService), WTFMove(*defaultLang) }};}
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisVoice.serialization.in
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisVoice.serialization.in
@@ -1,0 +1,33 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE(SPEECH_SYNTHESIS)
+
+struct WebKit::WebSpeechSynthesisVoice {
+    String voiceURI;
+    String name;
+    String lang;
+    bool localService;
+    bool defaultLang;
+};
+
+#endif


### PR DESCRIPTION
#### 121179ecf48e7f11744dbda05e7371bf936845ad
<pre>
Continue porting types to the new IPC serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=252966">https://bugs.webkit.org/show_bug.cgi?id=252966</a>
rdar://105952658

Reviewed by Alex Christensen.

This change includes porting across the following types to the new
serialization format:
    - WebSpeechSynthesisVoice
    - VideoTrackPrivateRemoteConfiguration
    - TrackPrivateRemoteConfiguration
    - AudioTrackPrivateRemoteConfiguration
    - RemoteGPURequestAdapterResponse
    - MediaControlsContextMenuItem

* Source/WebCore/page/MediaControlsContextMenuItem.h:
(WebCore::MediaControlsContextMenuItem::encode const): Deleted.
(WebCore::MediaControlsContextMenuItem::decode): Deleted.
* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp:
(WebKit::RemoteGPU::requestAdapter):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPURequestAdapterResponse.h: Copied from Source/WebKit/GPUProcess/media/TrackPrivateRemoteConfiguration.h.
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPURequestAdapterResponse.serialization.in: Added.
* Source/WebKit/GPUProcess/media/AudioTrackPrivateRemoteConfiguration.h:
(WebKit::AudioTrackPrivateRemoteConfiguration::encode const): Deleted.
(WebKit::AudioTrackPrivateRemoteConfiguration::decode): Deleted.
* Source/WebKit/GPUProcess/media/AudioTrackPrivateRemoteConfiguration.serialization.in: Added.
* Source/WebKit/GPUProcess/media/TrackPrivateRemoteConfiguration.h:
(WebKit::TrackPrivateRemoteConfiguration::encode const): Deleted.
(WebKit::TrackPrivateRemoteConfiguration::decode): Deleted.
* Source/WebKit/GPUProcess/media/TrackPrivateRemoteConfiguration.serialization.in: Added.
* Source/WebKit/GPUProcess/media/VideoTrackPrivateRemoteConfiguration.h:
(WebKit::VideoTrackPrivateRemoteConfiguration::encode const): Deleted.
(WebKit::VideoTrackPrivateRemoteConfiguration::decode): Deleted.
* Source/WebKit/GPUProcess/media/VideoTrackPrivateRemoteConfiguration.serialization.in: Added.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisVoice.h:
(WebKit::WebSpeechSynthesisVoice::encode const): Deleted.
(WebKit::WebSpeechSynthesisVoice::decode): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisVoice.serialization.in: Added.

Canonical link: <a href="https://commits.webkit.org/260964@main">https://commits.webkit.org/260964@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccc42c0aa743b08a7a9e504c3e8c583c36a49dca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110003 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19103 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42685 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1446 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119048 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113956 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20569 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10296 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102261 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115749 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15315 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98527 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43531 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97277 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30184 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85372 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11806 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31524 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12428 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8481 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17796 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51135 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14223 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4126 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->