### PR TITLE
ManagedMediaSource content should be evicted whenever it is under memory pressure

### DIFF
--- a/LayoutTests/media/media-source/media-managedmse-memorypressure-expected.txt
+++ b/LayoutTests/media/media-source/media-managedmse-memorypressure-expected.txt
@@ -42,8 +42,56 @@ EVENT(update)
 RUN(sourceBuffer.timestampOffset = sourceBuffer.buffered.end(sourceBuffer.buffered.length - 1))
 RUN(source.endOfStream())
 EVENT(sourceended)
-RUN(video.currentTime = video.duration - 1)
+RUN(video.currentTime = video.duration / 2)
 EVENT(seeked)
+RUN(bufferedStart = sourceBuffer.buffered.start(0))
+RUN(internals.beginSimulatedMemoryPressure())
+EVENT(bufferedchange)
+EXPECTED (bufferedStart != 'sourceBuffer.buffered.start(0)') OK
+RUN(internals.endSimulatedMemoryPressure())
+RUN(sourceBuffer.remove(0, 999999))
+EVENT(updateend)
+Append a media segment.
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0)))
+EVENT(update)
+RUN(sourceBuffer.timestampOffset = sourceBuffer.buffered.end(sourceBuffer.buffered.length - 1))
+Append a media segment.
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0)))
+EVENT(update)
+RUN(sourceBuffer.timestampOffset = sourceBuffer.buffered.end(sourceBuffer.buffered.length - 1))
+Append a media segment.
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0)))
+EVENT(update)
+RUN(sourceBuffer.timestampOffset = sourceBuffer.buffered.end(sourceBuffer.buffered.length - 1))
+Append a media segment.
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0)))
+EVENT(update)
+RUN(sourceBuffer.timestampOffset = sourceBuffer.buffered.end(sourceBuffer.buffered.length - 1))
+Append a media segment.
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0)))
+EVENT(update)
+RUN(sourceBuffer.timestampOffset = sourceBuffer.buffered.end(sourceBuffer.buffered.length - 1))
+Append a media segment.
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0)))
+EVENT(update)
+RUN(sourceBuffer.timestampOffset = sourceBuffer.buffered.end(sourceBuffer.buffered.length - 1))
+Append a media segment.
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0)))
+EVENT(update)
+RUN(sourceBuffer.timestampOffset = sourceBuffer.buffered.end(sourceBuffer.buffered.length - 1))
+Append a media segment.
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0)))
+EVENT(update)
+RUN(sourceBuffer.timestampOffset = sourceBuffer.buffered.end(sourceBuffer.buffered.length - 1))
+Append a media segment.
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0)))
+EVENT(update)
+RUN(sourceBuffer.timestampOffset = sourceBuffer.buffered.end(sourceBuffer.buffered.length - 1))
+RUN(source.endOfStream())
+EVENT(sourceended)
+RUN(video.currentTime = sourceBuffer.buffered.start(0) + (sourceBuffer.buffered.end(0) - sourceBuffer.buffered.start(0)) / 2)
+EVENT(seeked)
+EXPECTED (video.paused == 'false') OK
 RUN(bufferedStart = sourceBuffer.buffered.start(0))
 RUN(internals.beginSimulatedMemoryPressure())
 EVENT(bufferedchange)

--- a/LayoutTests/media/media-source/media-managedmse-memorypressure.html
+++ b/LayoutTests/media/media-source/media-managedmse-memorypressure.html
@@ -18,6 +18,17 @@
         });
     }
 
+    async function loadData() {
+        for (let i = 1; i < 10; i++) {
+                consoleWrite('Append a media segment.')
+                run('sourceBuffer.appendBuffer(loader.mediaSegment(0))');
+                await waitFor(sourceBuffer, 'update');
+                run('sourceBuffer.timestampOffset = sourceBuffer.buffered.end(sourceBuffer.buffered.length - 1)');
+            }
+        run('source.endOfStream()');
+        return waitFor(source, 'sourceended');
+    }
+
     window.addEventListener('load', async event => {
         try {
             findMediaElement();
@@ -40,15 +51,9 @@
             run('sourceBuffer.appendBuffer(loader.initSegment())');
             await waitFor(sourceBuffer, 'update');
 
-            for (let i = 1; i < 10; i++) {
-                consoleWrite('Append a media segment.')
-                run('sourceBuffer.appendBuffer(loader.mediaSegment(0))');
-                await waitFor(sourceBuffer, 'update');
-                run('sourceBuffer.timestampOffset = sourceBuffer.buffered.end(sourceBuffer.buffered.length - 1)');
-            }
-            run('source.endOfStream()');
-            await waitFor(source, 'sourceended');
-            run('video.currentTime = video.duration - 1');
+            await loadData();
+
+            run('video.currentTime = video.duration / 2');
             await waitFor(video, 'seeked');
 
             run('bufferedStart = sourceBuffer.buffered.start(0)');
@@ -56,6 +61,25 @@
             await waitFor(sourceBuffer, 'bufferedchange');
             testExpected('bufferedStart', 'sourceBuffer.buffered.start(0)', '!=');
             run('internals.endSimulatedMemoryPressure()');
+
+            // Remove all content.
+            run('sourceBuffer.remove(0, 999999)');
+            await waitFor(sourceBuffer, 'updateend');
+
+            // Check that data is evicted even if media is currently playing.
+            await loadData();
+            // Seek to middle of buffered range.
+            run('video.currentTime = sourceBuffer.buffered.start(0) + (sourceBuffer.buffered.end(0) - sourceBuffer.buffered.start(0)) / 2');
+            await waitFor(video, 'seeked');
+            await video.play();
+            testExpected('video.paused', false);
+
+            run('bufferedStart = sourceBuffer.buffered.start(0)');
+            run('internals.beginSimulatedMemoryPressure()');
+            await waitFor(sourceBuffer, 'bufferedchange');
+            testExpected('bufferedStart', 'sourceBuffer.buffered.start(0)', '!=');
+            run('internals.endSimulatedMemoryPressure()');
+
             endTest();
         } catch (e) {
             failTest(`Caught exception: "${e}"`);

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -8643,6 +8643,17 @@ void HTMLMediaElement::purgeBufferedDataIfPossible()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
 
+    bool isPausedAndNoMSE = [&] {
+#if ENABLE(MEDIA_SOURCE)
+        if (m_mediaSource)
+            return false;
+#endif
+        return paused();
+    }();
+
+    if (isPausedAndNoMSE)
+        return;
+
     if (!MemoryPressureHandler::singleton().isUnderMemoryPressure() && mediaSession().preferredBufferingPolicy() == BufferingPolicy::Default)
         return;
 

--- a/Source/WebCore/page/MemoryRelease.cpp
+++ b/Source/WebCore/page/MemoryRelease.cpp
@@ -116,10 +116,8 @@ static void releaseCriticalMemory(Synchronous synchronous, MaintainBackForwardCa
     GCController::singleton().deleteAllCode(JSC::DeleteAllCodeIfNotCollecting);
 
 #if ENABLE(VIDEO)
-    for (auto* mediaElement : HTMLMediaElement::allMediaElements()) {
-        if (mediaElement->paused())
-            mediaElement->purgeBufferedDataIfPossible();
-    }
+    for (auto* mediaElement : HTMLMediaElement::allMediaElements())
+        mediaElement->purgeBufferedDataIfPossible();
 #endif
 
     if (synchronous == Synchronous::Yes) {


### PR DESCRIPTION
#### fee371950f6239d24a6734e461dfcedd4a1daa8a
<pre>
ManagedMediaSource content should be evicted whenever it is under memory pressure
<a href="https://bugs.webkit.org/show_bug.cgi?id=252938">https://bugs.webkit.org/show_bug.cgi?id=252938</a>
rdar://105908445

Reviewed by Youenn Fablet.

Let the MediaElement control when eviction under memory pressure should
occur.

* LayoutTests/media/media-source/media-managedmse-memorypressure-expected.txt:
* LayoutTests/media/media-source/media-managedmse-memorypressure.html:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::purgeBufferedDataIfPossible):
* Source/WebCore/page/MemoryRelease.cpp:
(WebCore::releaseCriticalMemory):

Canonical link: <a href="https://commits.webkit.org/260871@main">https://commits.webkit.org/260871@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8716e641bfd50a7f38aa904f7fc31fa93432d990

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109761 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18876 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42498 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1231 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118880 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113712 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20347 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10073 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102029 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115509 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15147 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98378 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43369 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/30031 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85162 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11602 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31373 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12254 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8312 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17623 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50982 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7537 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14004 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->