### PR TITLE
REGRESSION (260781@main): [iOS] TestWebKitAPI.FontAttributes.FontTextStyle is consistently failing

### DIFF
--- a/Source/WebCore/editing/cocoa/FontAttributeChangesCocoa.mm
+++ b/Source/WebCore/editing/cocoa/FontAttributeChangesCocoa.mm
@@ -30,6 +30,7 @@
 
 #import "Font.h"
 #import "FontCache.h"
+#import "FontCacheCoreText.h"
 #import "FontDescription.h"
 
 namespace WebCore {
@@ -43,6 +44,8 @@ const String& FontChanges::platformFontFamilyNameForCSS() const
     // This logic was originally from WebHTMLView, and is now in WebCore so that it can
     // be shared between WebKitLegacy and WebKit.
     auto cfFontName = m_fontName.createCFString();
+    if (fontNameIsSystemFont(cfFontName.get()))
+        return m_fontFamily;
     RetainPtr<CFStringRef> fontNameFromDescription;
 
     FontDescription description;

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -52,7 +52,7 @@
 
 namespace WebCore {
 
-static inline bool fontNameIsSystemFont(CFStringRef fontName)
+bool fontNameIsSystemFont(CFStringRef fontName)
 {
     return CFStringGetLength(fontName) > 0 && CFStringGetCharacterAtIndex(fontName, 0) == '.';
 }

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.h
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.h
@@ -82,6 +82,7 @@ RetainPtr<CTFontRef> createFontForInstalledFonts(CTFontRef, AllowUserInstalledFo
 void addAttributesForWebFonts(CFMutableDictionaryRef attributes, AllowUserInstalledFonts);
 RetainPtr<CFSetRef> installedFontMandatoryAttributes(AllowUserInstalledFonts);
 WEBCORE_EXPORT void setOverrideEnhanceTextLegibility(bool);
+bool fontNameIsSystemFont(CFStringRef);
 
 CFStringRef getUIContentSizeCategoryDidChangeNotificationName();
 WEBCORE_EXPORT void setContentSizeCategory(const String&);


### PR DESCRIPTION
#### 3f1cb9750c4d8b376bcb35de57729f53af0ff833
<pre>
REGRESSION (260781@main): [iOS] TestWebKitAPI.FontAttributes.FontTextStyle is consistently failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=252916">https://bugs.webkit.org/show_bug.cgi?id=252916</a>
rdar://105891055

Reviewed by Wenson Hsieh.

This was caused by the logic in FontChanges::platformFontFamilyNameForCSS(). When a font
change occurs, the FontChanges object represents it with 2 fields: m_fontName and m_fontFamily.
The purpose of FontChanges::platformFontFamilyNameForCSS() is to determine what value should be
supplied to the font-family CSS property, to represent the change.

The logic in that function is: Prefer using m_fontFamily, but only if round-tripping the font
family through our font selection logic would end up creating the same font that&apos;s specified by
m_fontName. In the previous sentence, the phrase &quot;the same font&quot; is implemented by comparing
PostScript name. If round-tripping the font creates a different font than m_fontName, use
m_fontName directly.

However, when the font changes to a text style font, m_fontName is &quot;.SFUI-Regular&quot; and
m_fontFamily is &quot;UICTFontTextStyleTitle1&quot;. FontChanges::platformFontFamilyNameForCSS() was
finding that round-tripping the family through our font selection code was no longer producing
a font with the exact same postscript name as &quot;.SFUI-Regular&quot;, and was therefore implementing
the font change by specifying &quot;font-family: .SFUI-Regular&quot; instead of
&quot;font-family: UICTFontTextStyleTitle1&quot;. Ever since 240717@main, dot-prefixed fonts intentionally
don&apos;t work in WebKit, so &quot;font-family: .SFUI-Regular&quot; was causing the test to fail.

Our round-tripping code wasn&apos;t producing a font with the exact same name as &quot;.SFUI-Regular&quot;
because it was instead producing a font with the name &quot;.SFUI-Regular_wdth_opsz_GRAD_wght1F40000&quot;.
This font name _means_ the same thing as the original, but it&apos;s a synthesized name that Core Text
created. Eventually, we should migrate this check to be more robust.

However, a more straightforward solution is to just react to the fact that dot-prefixed fonts
intentionally don&apos;t work in WebKit, and therefore FontChanges::platformFontFamilyNameForCSS()
should just not return a dot-prefixed font name. This is more defensive than changing the font
equality check, and it&apos;s also easier to implement. If there are behavior changes in content,
those behavior changes would be to make more fonts work as requested.

* Source/WebCore/editing/cocoa/FontAttributeChangesCocoa.mm:
(WebCore::FontChanges::platformFontFamilyNameForCSS const):
* Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp:
(WebCore::fontNameIsSystemFont):
* Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.h:

Canonical link: <a href="https://commits.webkit.org/260866@main">https://commits.webkit.org/260866@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91a7ee70d270fa579ab20b02184dcb3a8107b0c9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109734 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18852 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42474 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1207 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118854 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113685 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20321 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10048 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102002 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115484 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15123 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98355 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43345 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97096 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30006 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85135 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11578 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31348 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12231 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8287 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17600 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50957 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7534 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13980 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->