### PR TITLE
[GLib] New API to get the request body of WebKitURISchemeRequest

### DIFF
--- a/Source/WebCore/platform/network/soup/ResourceRequest.h
+++ b/Source/WebCore/platform/network/soup/ResourceRequest.h
@@ -78,6 +78,7 @@ public:
     }
 
     GRefPtr<SoupMessage> createSoupMessage(BlobRegistryImpl&) const;
+    GRefPtr<GInputStream> createBodyStream() const;
 
     void updateFromDelegatePreservingOldProperties(const ResourceRequest& delegateProvidedRequest);
 

--- a/Source/WebCore/platform/network/soup/ResourceRequestSoup.cpp
+++ b/Source/WebCore/platform/network/soup/ResourceRequestSoup.cpp
@@ -140,6 +140,20 @@ void ResourceRequest::updateSoupMessageBody(SoupMessage* soupMessage, BlobRegist
 
 }
 
+GRefPtr<GInputStream> ResourceRequest::createBodyStream() const
+{
+    auto formData = httpBody();
+    if (!formData || formData->isEmpty())
+        return nullptr;
+
+    auto resolvedFormData = formData->resolveBlobReferences();
+    for (auto& element : resolvedFormData->elements()) {
+        if (element.lengthInBytes() > 0)
+            return webkitFormDataInputStreamNew(WTFMove(resolvedFormData));
+    }
+    return nullptr;
+}
+
 void ResourceRequest::updateSoupMessageHeaders(SoupMessageHeaders* soupHeaders) const
 {
     const HTTPHeaderMap& headers = httpHeaderFields();

--- a/Source/WebKit/UIProcess/API/glib/WebKitURISchemeRequest.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitURISchemeRequest.cpp
@@ -204,6 +204,23 @@ SoupMessageHeaders* webkit_uri_scheme_request_get_http_headers(WebKitURISchemeRe
     return request->priv->headers.get();
 }
 
+/**
+ * webkit_uri_scheme_request_get_http_body:
+ * @request: a #WebKitURISchemeRequest
+ *
+ * Get the request body.
+ *
+ * Returns: (transfer full): (nullable): the body of the @request.
+ *
+ * Since: 2.40
+ */
+GInputStream* webkit_uri_scheme_request_get_http_body(WebKitURISchemeRequest* request)
+{
+    g_return_val_if_fail(WEBKIT_IS_URI_SCHEME_REQUEST(request), nullptr);
+
+    return request->priv->task->request().createBodyStream().leakRef();
+}
+
 static void webkitURISchemeRequestReadCallback(GInputStream* inputStream, GAsyncResult* result, WebKitURISchemeRequest* schemeRequest)
 {
     GRefPtr<WebKitURISchemeRequest> request = adoptGRef(schemeRequest);

--- a/Source/WebKit/UIProcess/API/glib/WebKitURISchemeRequest.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitURISchemeRequest.h.in
@@ -70,6 +70,9 @@ webkit_uri_scheme_request_get_http_method (WebKitURISchemeRequest *request);
 WEBKIT_API SoupMessageHeaders *
 webkit_uri_scheme_request_get_http_headers (WebKitURISchemeRequest *request);
 
+WEBKIT_API GInputStream *
+webkit_uri_scheme_request_get_http_body (WebKitURISchemeRequest *request);
+
 WEBKIT_API void
 webkit_uri_scheme_request_finish       (WebKitURISchemeRequest *request,
                                         GInputStream           *stream,


### PR DESCRIPTION
#### 5fe923aa166a3084c973020d99f34c9476dddece
<pre>
[GLib] New API to get the request body of WebKitURISchemeRequest
<a href="https://bugs.webkit.org/show_bug.cgi?id=252564">https://bugs.webkit.org/show_bug.cgi?id=252564</a>

Reviewed by Carlos Garcia Campos, Michael Catanzaro and Adrian Perez de Castro.

* Source/WebCore/platform/network/soup/ResourceRequest.h:
* Source/WebCore/platform/network/soup/ResourceRequestSoup.cpp:
(WebCore::ResourceRequest::createInputStream const): Added new function
API
* Source/WebKit/UIProcess/API/glib/WebKitURISchemeRequest.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitURISchemeRequest.cpp:
(webkit_uri_scheme_request_get_http_body): Added new function API
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebContext.cpp:
(testWebContextURIScheme): Expanded &apos;post&apos; URI scheme to test
webkit_uri_scheme_request_get_http_body

Canonical link: <a href="https://commits.webkit.org/260949@main">https://commits.webkit.org/260949@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d216eaca047b3959817b763dfacc921ca0ee54a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110030 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19130 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42711 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1470 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119064 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113982 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20597 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10323 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102287 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115776 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/43555 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30206 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/85385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11832 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31544 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12454 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17821 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51159 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7590 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14249 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->