### PR TITLE
[Linux] Simplify encoding, decoding of DMABufObject

### DIFF
--- a/Source/WebCore/platform/graphics/gbm/DMABufReleaseFlag.h
+++ b/Source/WebCore/platform/graphics/gbm/DMABufReleaseFlag.h
@@ -78,6 +78,22 @@ struct DMABufReleaseFlag {
             WTFLogAlways("Error writing to the eventfd at DMABufReleaseFlag: %s", safeStrerror(errno).data());
     }
 
+    template<class Encoder> void encode(Encoder& encoder) &&
+    {
+        encoder << WTFMove(fd);
+    }
+
+    template<class Decoder> static std::optional<DMABufReleaseFlag> decode(Decoder& decoder)
+    {
+        auto fd = decoder.template decode<UnixFileDescriptor>();
+        if (!fd)
+            return std::nullopt;
+
+        DMABufReleaseFlag releaseFlag;
+        releaseFlag.fd = WTFMove(*fd);
+        return releaseFlag;
+    }
+
     UnixFileDescriptor fd;
 };
 


### PR DESCRIPTION
#### 30bdd8d25a8ef3254c53e84f5bce5bdd53bf47cc
<pre>
[Linux] Simplify encoding, decoding of DMABufObject
<a href="https://bugs.webkit.org/show_bug.cgi?id=252977">https://bugs.webkit.org/show_bug.cgi?id=252977</a>

Reviewed by Michael Catanzaro.

When encoding and decoding DMABufObject objects, don&apos;t iterate over the planes
and encode/decode each parameter separately. Instead, just encode the standalone
arrays of one side and correspondingly decode them on the other side. Once all
the data is through during decoding, the final DMABufObject can be constructed.

DMABufReleaseFlag gains its own encode and decode methods, simply encoding the
file descriptor on one side and decoding it on the other.

* Source/WebCore/platform/graphics/gbm/DMABufObject.h:
(WebCore::DMABufObject::encode):
(WebCore::DMABufObject::decode):
* Source/WebCore/platform/graphics/gbm/DMABufReleaseFlag.h:
(WebCore::DMABufReleaseFlag::encode):
(WebCore::DMABufReleaseFlag::decode):

Canonical link: <a href="https://commits.webkit.org/260938@main">https://commits.webkit.org/260938@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4cd30967597e87d358ccd801f9b868d5afb15c04

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109751 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18868 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42490 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1223 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118870 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113702 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20338 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10065 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102019 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115500 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15139 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98372 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43361 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97110 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30023 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85153 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11594 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31365 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12246 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8304 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17615 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50974 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7582 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13996 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->