### PR TITLE
[Linux] Add UnixCopyableFileDescriptor

### DIFF
--- a/Source/WTF/wtf/unix/UnixFileDescriptor.h
+++ b/Source/WTF/wtf/unix/UnixFileDescriptor.h
@@ -25,8 +25,10 @@
 
 #pragma once
 
+#include <optional>
 #include <utility>
 #include <wtf/Compiler.h>
+#include <wtf/Noncopyable.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/UniStdExtras.h>
 
@@ -34,6 +36,8 @@ namespace WTF {
 
 class UnixFileDescriptor {
 public:
+    WTF_MAKE_NONCOPYABLE(UnixFileDescriptor);
+
     UnixFileDescriptor() = default;
 
     enum AdoptionTag { Adopt };
@@ -53,10 +57,6 @@ public:
         m_value = o.release();
     }
 
-    UnixFileDescriptor(const UnixFileDescriptor& o)
-        : UnixFileDescriptor(o.m_value, Duplicate)
-    { }
-
     UnixFileDescriptor& operator=(UnixFileDescriptor&& o)
     {
         if (&o == this)
@@ -64,16 +64,6 @@ public:
 
         this->~UnixFileDescriptor();
         new (this) UnixFileDescriptor(WTFMove(o));
-        return *this;
-    }
-
-    UnixFileDescriptor& operator=(const UnixFileDescriptor& o)
-    {
-        if (&o == this)
-            return *this;
-
-        this->~UnixFileDescriptor();
-        new (this) UnixFileDescriptor(o);
         return *this;
     }
 
@@ -98,6 +88,50 @@ private:
     int m_value { -1 };
 };
 
+class UnixCopyableFileDescriptor : public UnixFileDescriptor {
+public:
+    UnixCopyableFileDescriptor()
+        : UnixFileDescriptor()
+    { }
+
+    UnixCopyableFileDescriptor(UnixFileDescriptor&& fd)
+        : UnixFileDescriptor(WTFMove(fd))
+    { }
+
+    UnixCopyableFileDescriptor(UnixCopyableFileDescriptor&&) = default;
+    UnixCopyableFileDescriptor& operator=(UnixCopyableFileDescriptor&&) = default;
+
+    UnixCopyableFileDescriptor(const UnixCopyableFileDescriptor& o)
+        : UnixCopyableFileDescriptor(o.duplicate())
+    { }
+
+    UnixCopyableFileDescriptor& operator=(const UnixCopyableFileDescriptor& o)
+    {
+        if (&o == this)
+            return *this;
+
+        this->~UnixCopyableFileDescriptor();
+        new (this) UnixCopyableFileDescriptor(o.duplicate());
+        return *this;
+    }
+
+    template<typename Encoder>
+    void encode(Encoder& encoder) const
+    {
+        encoder << static_cast<const UnixFileDescriptor&>(*this);
+    }
+
+    template<typename Decoder>
+    static std::optional<UnixCopyableFileDescriptor> decode(Decoder& decoder)
+    {
+        auto fd = decoder.template decode<UnixFileDescriptor>();
+        if (!fd)
+            return std::nullopt;
+        return UnixCopyableFileDescriptor(WTFMove(*fd));
+    }
+};
+
 } // namespace WTF
 
 using WTF::UnixFileDescriptor;
+using WTF::UnixCopyableFileDescriptor;


### PR DESCRIPTION
#### 071479c993d50b3fc6ef510aaa2396135cbf3c27
<pre>
[Linux] Add UnixCopyableFileDescriptor
<a href="https://bugs.webkit.org/show_bug.cgi?id=252978">https://bugs.webkit.org/show_bug.cgi?id=252978</a>

Reviewed by NOBODY (OOPS!).

Make UnixFileDescriptor again non-copyable, avoiding unintentional copies of the
underlying file descriptor by default.

But for occasions When copying semantics are required, the
UnixCopyableFileDescriptor type is now provided. This type inherits from
UnixFileDescriptor but also provides the necessary copy constructor and the copy
assignment operator which duplicate the contained file descriptor.

* Source/WTF/wtf/unix/UnixFileDescriptor.h:
(WTF::UnixCopyableFileDescriptor::UnixCopyableFileDescriptor):
(WTF::UnixCopyableFileDescriptor::operator=):
(WTF::UnixCopyableFileDescriptor::encode const):
(WTF::UnixCopyableFileDescriptor::decode):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/071479c993d50b3fc6ef510aaa2396135cbf3c27

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109752 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18869 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42491 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1224 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118871 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20339 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10066 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102020 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115501 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15140 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98373 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43362 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97111 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30024 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85154 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/98619 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11595 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31366 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/99499 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/9628 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12247 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8305 "Found 1 new test failure: http/tests/workers/service/shownotification-allowed.html (failure)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31120 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17616 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50975 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/107514 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/13997 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26535 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->