### PR TITLE
REGRESSION (258514@main): Transition of !important property fails to animate

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transition-important-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transition-important-expected.txt
@@ -1,0 +1,3 @@
+
+PASS !important should not override transition
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transition-important.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transition-important.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<title>CSS Transitions Test: !important property</title>
+<link rel="help" href="https://drafts.csswg.org/css-cascade-5/#cascade-sort">
+<script src="/resources/testharness.js" type="text/javascript"></script>
+<script src="/resources/testharnessreport.js" type="text/javascript"></script>
+<style>
+#target {
+    width: 200px;
+    height: 200px;
+    background-color: green;
+    transition: background-color 100s;
+}
+.red {
+    background-color: red !important;
+}
+</style>
+<div id="target"></div>
+<script>
+test(t => {
+    assert_equals(getComputedStyle(target).backgroundColor, "rgb(0, 128, 0)");
+    target.className = "red";
+    assert_equals(getComputedStyle(target).backgroundColor, "rgb(0, 128, 0)");
+}, "!important should not override transition");
+</script>

--- a/Source/WebCore/style/PropertyCascade.cpp
+++ b/Source/WebCore/style/PropertyCascade.cpp
@@ -209,7 +209,7 @@ bool PropertyCascade::addMatch(const MatchedProperties& matchedProperties, Casca
                 ASSERT(!isValueID(current.value(), CSSValueInherit));
                 continue;
             }
-        } else if (m_includedProperties == IncludedProperties::AfterAnimation) {
+        } else if (m_includedProperties == IncludedProperties::AfterAnimation || m_includedProperties == IncludedProperties::AfterTransition) {
             // We only want to re-apply properties that may depend on animated values, or are overriden by !import.
             if (!shouldApplyAfterAnimation(current))
                 continue;
@@ -258,7 +258,7 @@ bool PropertyCascade::shouldApplyAfterAnimation(const StyleProperties::PropertyR
     if (isAnimatedProperty) {
         // "Important declarations from all origins take precedence over animations."
         // https://drafts.csswg.org/css-cascade-5/#importance
-        return property.isImportant();
+        return m_includedProperties == IncludedProperties::AfterAnimation && property.isImportant();
     }
 
     // If we are animating custom properties they may affect other properties so we need to re-resolve them.

--- a/Source/WebCore/style/PropertyCascade.h
+++ b/Source/WebCore/style/PropertyCascade.h
@@ -39,7 +39,7 @@ namespace Style {
 class PropertyCascade {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    enum IncludedProperties { All, InheritedOnly, AfterAnimation };
+    enum IncludedProperties { All, InheritedOnly, AfterAnimation, AfterTransition };
 
     PropertyCascade(const MatchResult&, CascadeLevel, IncludedProperties, const HashSet<AnimatableProperty>* = nullptr);
     PropertyCascade(const PropertyCascade&, CascadeLevel, std::optional<ScopeOrdinal> rollbackScope = { }, std::optional<CascadeLayerPriority> maximumCascadeLayerPriorityForRollback = { });

--- a/Source/WebCore/style/StyleTreeResolver.h
+++ b/Source/WebCore/style/StyleTreeResolver.h
@@ -75,7 +75,7 @@ private:
     std::pair<ElementUpdate, DescendantsToResolve> resolveElement(Element&, const RenderStyle* existingStyle, ResolutionType);
 
     ElementUpdate createAnimatedElementUpdate(ResolvedStyle&&, const Styleable&, Change, const ResolutionContext&);
-    void applyCascadeAfterAnimation(RenderStyle&, const HashSet<AnimatableProperty>&, const MatchResult&, const Element&, const ResolutionContext&);
+    void applyCascadeAfterAnimation(RenderStyle&, const HashSet<AnimatableProperty>&, bool isTransition, const MatchResult&, const Element&, const ResolutionContext&);
 
     std::optional<ElementUpdate> resolvePseudoElement(Element&, PseudoId, const ElementUpdate&);
     std::optional<ElementUpdate> resolveAncestorPseudoElement(Element&, PseudoId, const ElementUpdate&);


### PR DESCRIPTION
#### e0fa0f2073f1886a7272a69040adaaafde9754fd
<pre>
REGRESSION (258514@main): Transition of !important property fails to animate
<a href="https://bugs.webkit.org/show_bug.cgi?id=111329">https://bugs.webkit.org/show_bug.cgi?id=111329</a>
rdar://105929421

Reviewed by Antoine Quint.

The cascade precedence is (<a href="https://drafts.csswg.org/css-cascade-5/#cascade-sort)">https://drafts.csswg.org/css-cascade-5/#cascade-sort)</a>

1) Transition declarations [css-transitions-1]
2) Important user agent declarations
3) Important user declarations
4) Important author declarations
5) Animation declarations [css-animations-1]
6) Normal author declarations
7) Normal user declarations
8) Normal user agent declarations

but we were treating transitions and animations similarly.

* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transition-important-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transition-important.html: Added.
* Source/WebCore/style/PropertyCascade.cpp:
(WebCore::Style::PropertyCascade::addMatch):
(WebCore::Style::PropertyCascade::shouldApplyAfterAnimation):

Don&apos;t let !important properties override transitions.

* Source/WebCore/style/PropertyCascade.h:
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::createAnimatedElementUpdate):

Tell the cascade if this is a transition or animation.
Note that this is still incorrect in the (rare) case where you would have both running on an element at the same time.

(WebCore::Style::TreeResolver::applyCascadeAfterAnimation):
* Source/WebCore/style/StyleTreeResolver.h:

Canonical link: <a href="https://commits.webkit.org/260880@main">https://commits.webkit.org/260880@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54738d139f5a4da8ea0ae1476dee14ec33bd827a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109775 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18890 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42512 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1245 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118895 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113727 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20361 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10088 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/102065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115523 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15159 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98387 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43381 "layout-tests (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97126 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30040 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85178 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11616 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31382 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12268 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8325 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17637 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/50991 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7547 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14018 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->