### PR TITLE
Restore 100,000 limit in HTMLOptionsCollection.length setter

### DIFF
--- a/LayoutTests/fast/dom/HTMLSelectElement/select-selectedIndex-expected.txt
+++ b/LayoutTests/fast/dom/HTMLSelectElement/select-selectedIndex-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Blocked attempt to expand the option list to 4294967295 items. The maximum number of items allowed is 10000.
+CONSOLE MESSAGE: Unable to expand the option list to length 4294967295 items. The maximum number of items allowed is 100000.
 
 1) setting length to a negative length
 PASS mySelect.options.length is 2

--- a/LayoutTests/fast/dom/HTMLSelectElement/select-selectedIndex-multiple-expected.txt
+++ b/LayoutTests/fast/dom/HTMLSelectElement/select-selectedIndex-multiple-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Blocked attempt to expand the option list to 4294967295 items. The maximum number of items allowed is 10000.
+CONSOLE MESSAGE: Unable to expand the option list to length 4294967295 items. The maximum number of items allowed is 100000.
 
 1) setting length to a negative length
 PASS mySelect.options.length is 2

--- a/LayoutTests/fast/forms/select-max-length-expected.txt
+++ b/LayoutTests/fast/forms/select-max-length-expected.txt
@@ -1,6 +1,6 @@
-CONSOLE MESSAGE: Blocked attempt to expand the option list to 100001 items. The maximum number of items allowed is 10000.
-CONSOLE MESSAGE: Blocked attempt to expand the option list and set an option at index. The maximum list length is 10000.
-CONSOLE MESSAGE: Blocked attempt to expand the option list and set an option at index. The maximum list length is 10000.
+CONSOLE MESSAGE: Unable to expand the option list to length 100001 items. The maximum number of items allowed is 100000.
+CONSOLE MESSAGE: Unable to expand the option list and set an option at index. The maximum list length is 100000.
+CONSOLE MESSAGE: Unable to expand the option list and set an option at index. The maximum list length is 100000.
 This test that setting HTMLSelectElement.length is capped to 100,000, and you can't add additional Option elements too.
 
 PASS sel.length is 0

--- a/LayoutTests/imported/w3c/web-platform-tests/html/select/options-length-too-large-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/select/options-length-too-large-expected.txt
@@ -1,0 +1,11 @@
+CONSOLE MESSAGE: Unable to expand the option list to length 4294967295 items. The maximum number of items allowed is 100000.
+CONSOLE MESSAGE: Unable to expand the option list to length 100001 items. The maximum number of items allowed is 100000.
+CONSOLE MESSAGE: Unable to expand the option list to length 4294967295 items. The maximum number of items allowed is 100000.
+
+
+PASS select options.length too large
+PASS select options.length too large 1
+PASS select options.length too large 2
+PASS select options.length too large 3
+PASS select options.length too large 4
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/select/options-length-too-large.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/select/options-length-too-large.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="timeout" content="long">
+    <title>select options.length too large</title>
+
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <select id="test">
+      <option value="1"></option>
+      <option value="2"></option>
+      <option value="3"></option>
+    </select>
+
+    <script>
+    var mySelect = document.getElementById("test");
+
+    test(function() {
+        mySelect.options.length = -1;
+        assert_equals(mySelect.options.length, 3, "Length of <select> should remain unchanged");
+    });
+
+    test(function() {
+        mySelect.options.length = 100001;
+        assert_equals(mySelect.options.length, 3, "Length of <select> should remain unchanged");
+    });
+
+    test(function() {
+        mySelect.options.length = Number.MAX_SAFE_INTEGER;
+        assert_equals(mySelect.options.length, 3, "Length of <select> should remain unchanged");
+    });
+
+    test(function() {
+        mySelect.options.length = 100000;
+        assert_equals(mySelect.options.length, 100000, "Length of <select> should be 100,000");
+    });
+
+    test(function() {
+        mySelect.appendChild(new Option());
+        mySelect.appendChild(new Option());
+        assert_equals(mySelect.options.length, 100002, "Manual expansion still works");
+        mySelect.options.length = 100001;
+        assert_equals(mySelect.options.length, 100001, "Truncation works if over the limit");
+    });
+    </script>
+  </body>
+</html>

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -66,8 +66,8 @@ using namespace WTF::Unicode;
 
 using namespace HTMLNames;
 
-// Upper limit agreed upon with representatives of Opera and Mozilla.
-static const unsigned maxSelectItems = 10000;
+// https://html.spec.whatwg.org/#dom-htmloptionscollection-length
+static constexpr unsigned maxSelectItems = 100000;
 
 HTMLSelectElement::HTMLSelectElement(const QualifiedName& tagName, Document& document, HTMLFormElement* form)
     : HTMLFormControlElement(tagName, document, form)
@@ -466,8 +466,9 @@ ExceptionOr<void> HTMLSelectElement::setItem(unsigned index, HTMLOptionElement* 
         return { };
     }
 
-    if (index >= length() && index >= maxSelectItems) {
-        document().addConsoleMessage(MessageSource::Other, MessageLevel::Warning, makeString("Blocked attempt to expand the option list and set an option at index. The maximum list length is ", maxSelectItems, '.'));
+    // If we are adding options, we should check 'index > maxSelectItems' first to avoid integer overflow.
+    if (index > length() && index >= maxSelectItems) {
+        document().addConsoleMessage(MessageSource::Other, MessageLevel::Warning, makeString("Unable to expand the option list and set an option at index. The maximum list length is ", maxSelectItems, '.'));
         return { };
     }
 
@@ -498,8 +499,9 @@ ExceptionOr<void> HTMLSelectElement::setItem(unsigned index, HTMLOptionElement* 
 
 ExceptionOr<void> HTMLSelectElement::setLength(unsigned newLength)
 {
+    // If we are adding options, we should check 'index > maxSelectItems' first to avoid integer overflow.
     if (newLength > length() && newLength > maxSelectItems) {
-        document().addConsoleMessage(MessageSource::Other, MessageLevel::Warning, makeString("Blocked attempt to expand the option list to ", newLength, " items. The maximum number of items allowed is ", maxSelectItems, '.'));
+        document().addConsoleMessage(MessageSource::Other, MessageLevel::Warning, makeString("Unable to expand the option list to length ", newLength, " items. The maximum number of items allowed is ", maxSelectItems, '.'));
         return { };
     }
 


### PR DESCRIPTION
#### a27ac64f683e8d0a798123758cb4bf5a0bc75cd0
<pre>
Restore 100,000 limit in HTMLOptionsCollection.length setter

<a href="https://bugs.webkit.org/show_bug.cgi?id=252983">https://bugs.webkit.org/show_bug.cgi?id=252983</a>

Reviewed by Chris Dumez.

This patch is to align WebKit with Blink / Chromium and Gecko / Firefox.

Merge - <a href="https://chromium.googlesource.com/chromium/src/+/f27e6ea87ecf211c8b8644813422a9e7f19cd1cc">https://chromium.googlesource.com/chromium/src/+/f27e6ea87ecf211c8b8644813422a9e7f19cd1cc</a>

This patch updates &apos;maxSelectItems&apos; to new value of 100,000
to reflect update in spec.
Further, it is updated to be only used when new length is
greater than current length.
Additionally, add comments to reflect the details as needed.

Web-Spec: <a href="https://html.spec.whatwg.org/#dom-htmloptionscollection-length">https://html.spec.whatwg.org/#dom-htmloptionscollection-length</a>
Issue: <a href="https://github.com/whatwg/html/issues/8337">https://github.com/whatwg/html/issues/8337</a>

* Source/WebCore/html/HTMLSelectElement.cpp:
(maxSelectItems): Update constant value
(HTMLSelectElement::setItem): Remove &apos;=&apos; and update comments and console message
(HTMLSelectElement::setLength): Add comment and update console message
* LayoutTests/imported/w3c/web-platform-tests/html/select/options-length-too-large.html: Add Test Case
* LayoutTests/imported/w3c/web-platform-tests/html/select/options-length-too-large-expected.txt: Add Test Case Expectation
* LayoutTests/fast/forms/select-max-length-expected.txt: Rebaselined
* LayoutTests/fast/dom/HTMLSelectElement/select-selectedIndex-multiple-expected.txt: Rebaselined
* LayoutTests/fast/dom/HTMLSelectElement/select-selectedIndex-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/260896@main">https://commits.webkit.org/260896@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/feee81464c78d20f33687f74b884a1f5b9d6d93f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109855 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18965 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/42573 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1312 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/118945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113805 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20431 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10160 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102123 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115603 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/42573 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/43433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/42573 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/85235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11677 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/42573 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/12320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/17689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/42573 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7553 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14089 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->