### PR TITLE
[GTK] Use DMABuf and WebKit IPC for rendering instead of wpe/x11

### DIFF
--- a/Source/WebCore/PlatformGTK.cmake
+++ b/Source/WebCore/PlatformGTK.cmake
@@ -47,6 +47,8 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     platform/glib/ApplicationGLib.h
 
+    platform/graphics/egl/PlatformDisplayHeadless.h
+
     platform/graphics/gtk/GdkCairoUtilities.h
 
     platform/graphics/x11/PlatformDisplayX11.h

--- a/Source/WebCore/SourcesGTK.txt
+++ b/Source/WebCore/SourcesGTK.txt
@@ -74,6 +74,7 @@ platform/graphics/egl/GLContext.cpp @no-unify
 platform/graphics/egl/GLContextLibWPE.cpp @no-unify
 platform/graphics/egl/GLContextWayland.cpp @no-unify
 platform/graphics/egl/GLContextX11.cpp @no-unify
+platform/graphics/egl/PlatformDisplayHeadless.cpp
 
 platform/graphics/gbm/GBMBufferSwapchain.cpp
 platform/graphics/gbm/GBMDevice.cpp

--- a/Source/WebCore/platform/graphics/PlatformDisplay.cpp
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.cpp
@@ -303,6 +303,7 @@ void PlatformDisplay::initializeEGLDisplay()
             };
 
         m_eglExtensions.KHR_image_base = findExtension("EGL_KHR_image_base"_s);
+        m_eglExtensions.KHR_surfaceless_context = findExtension("EGL_KHR_surfaceless_context"_s);
         m_eglExtensions.EXT_image_dma_buf_import = findExtension("EGL_EXT_image_dma_buf_import"_s);
         m_eglExtensions.EXT_image_dma_buf_import_modifiers = findExtension("EGL_EXT_image_dma_buf_import_modifiers"_s);
     }

--- a/Source/WebCore/platform/graphics/PlatformDisplay.h
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.h
@@ -79,6 +79,9 @@ public:
 #if USE(WPE_RENDERER)
         WPE,
 #endif
+#if USE(EGL)
+        Headless,
+#endif
     };
 
     virtual Type type() const = 0;
@@ -94,6 +97,7 @@ public:
 
     struct EGLExtensions {
         bool KHR_image_base { false };
+        bool KHR_surfaceless_context { false };
         bool EXT_image_dma_buf_import { false };
         bool EXT_image_dma_buf_import_modifiers { false };
     };

--- a/Source/WebCore/platform/graphics/egl/GLContext.h
+++ b/Source/WebCore/platform/graphics/egl/GLContext.h
@@ -152,7 +152,7 @@ private:
     void destroyWPETarget();
 #endif
 
-    static bool getEGLConfig(EGLDisplay, EGLConfig*, EGLSurfaceType, Function<bool(int)>&& = nullptr);
+    static bool getEGLConfig(PlatformDisplay&, EGLConfig*, EGLSurfaceType, Function<bool(int)>&& = nullptr);
 
     PlatformDisplay& m_display;
     unsigned m_version { 0 };

--- a/Source/WebCore/platform/graphics/egl/GLContextLibWPE.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLContextLibWPE.cpp
@@ -57,9 +57,8 @@ EGLSurface GLContext::createWindowSurfaceWPE(EGLDisplay display, EGLConfig confi
 
 std::unique_ptr<GLContext> GLContext::createWPEContext(PlatformDisplay& platformDisplay, EGLContext sharingContext)
 {
-    EGLDisplay display = platformDisplay.eglDisplay();
     EGLConfig config;
-    if (!getEGLConfig(display, &config, WindowSurface)) {
+    if (!getEGLConfig(platformDisplay, &config, WindowSurface)) {
         WTFLogAlways("Cannot obtain EGL WPE context configuration: %s\n", lastErrorString());
         return nullptr;
     }
@@ -82,6 +81,7 @@ std::unique_ptr<GLContext> GLContext::createWPEContext(PlatformDisplay& platform
         return nullptr;
     }
 
+    EGLDisplay display = platformDisplay.eglDisplay();
     EGLSurface surface = eglCreateWindowSurface(display, config, static_cast<EGLNativeWindowType>(window), nullptr);
     if (surface == EGL_NO_SURFACE) {
         WTFLogAlways("Cannot create EGL WPE window surface: %s\n", lastErrorString());

--- a/Source/WebCore/platform/graphics/egl/GLContextWayland.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLContextWayland.cpp
@@ -48,15 +48,15 @@ EGLSurface GLContext::createWindowSurfaceWayland(EGLDisplay display, EGLConfig c
 
 std::unique_ptr<GLContext> GLContext::createWaylandContext(PlatformDisplay& platformDisplay, EGLContext sharingContext)
 {
-    EGLDisplay display = platformDisplay.eglDisplay();
     EGLConfig config;
-    if (!getEGLConfig(display, &config, WindowSurface))
+    if (!getEGLConfig(platformDisplay, &config, WindowSurface))
         return nullptr;
 
     EGLContext context = createContextForEGLVersion(platformDisplay, config, sharingContext);
     if (context == EGL_NO_CONTEXT)
         return nullptr;
 
+    EGLDisplay display = platformDisplay.eglDisplay();
     WlUniquePtr<struct wl_surface> wlSurface(downcast<PlatformDisplayWayland>(platformDisplay).createSurface());
     if (!wlSurface) {
         eglDestroyContext(display, context);

--- a/Source/WebCore/platform/graphics/egl/GLContextX11.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLContextX11.cpp
@@ -46,15 +46,15 @@ EGLSurface GLContext::createWindowSurfaceX11(EGLDisplay display, EGLConfig confi
 
 std::unique_ptr<GLContext> GLContext::createPixmapContext(PlatformDisplay& platformDisplay, EGLContext sharingContext)
 {
-    EGLDisplay display = platformDisplay.eglDisplay();
     EGLConfig config;
-    if (!getEGLConfig(display, &config, PixmapSurface))
+    if (!getEGLConfig(platformDisplay, &config, PixmapSurface))
         return nullptr;
 
     EGLContext context = createContextForEGLVersion(platformDisplay, config, sharingContext);
     if (context == EGL_NO_CONTEXT)
         return nullptr;
 
+    EGLDisplay display = platformDisplay.eglDisplay();
     EGLint visualId;
     if (!eglGetConfigAttrib(display, config, EGL_NATIVE_VISUAL_ID, &visualId)) {
         eglDestroyContext(display, context);

--- a/Source/WebCore/platform/graphics/egl/PlatformDisplayHeadless.cpp
+++ b/Source/WebCore/platform/graphics/egl/PlatformDisplayHeadless.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2023 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE COMPUTER, INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE COMPUTER, INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "PlatformDisplayHeadless.h"
+
+#if USE(EGL)
+#include "GLContext.h"
+#include <epoxy/egl.h>
+
+namespace WebCore {
+
+std::unique_ptr<PlatformDisplayHeadless> PlatformDisplayHeadless::create()
+{
+    return std::unique_ptr<PlatformDisplayHeadless>(new PlatformDisplayHeadless());
+}
+
+PlatformDisplayHeadless::PlatformDisplayHeadless()
+{
+#if PLATFORM(GTK)
+    PlatformDisplay::setSharedDisplayForCompositing(*this);
+#endif
+
+    const char* extensions = eglQueryString(nullptr, EGL_EXTENSIONS);
+    if (GLContext::isExtensionSupported(extensions, "EGL_EXT_platform_base"))
+        m_eglDisplay = eglGetPlatformDisplayEXT(EGL_PLATFORM_SURFACELESS_MESA, EGL_DEFAULT_DISPLAY, nullptr);
+    else if (GLContext::isExtensionSupported(extensions, "EGL_KHR_platform_base"))
+        m_eglDisplay = eglGetPlatformDisplay(EGL_PLATFORM_SURFACELESS_MESA, EGL_DEFAULT_DISPLAY, nullptr);
+
+    PlatformDisplay::initializeEGLDisplay();
+}
+
+PlatformDisplayHeadless::~PlatformDisplayHeadless()
+{
+}
+
+} // namespace WebCore
+
+#endif // USE(EGL)

--- a/Source/WebCore/platform/graphics/egl/PlatformDisplayHeadless.h
+++ b/Source/WebCore/platform/graphics/egl/PlatformDisplayHeadless.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2023 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE COMPUTER, INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE COMPUTER, INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(EGL)
+#include "PlatformDisplay.h"
+
+namespace WebCore {
+
+class PlatformDisplayHeadless final : public PlatformDisplay {
+public:
+    static std::unique_ptr<PlatformDisplayHeadless> create();
+
+    virtual ~PlatformDisplayHeadless();
+private:
+    PlatformDisplayHeadless();
+
+    Type type() const override { return PlatformDisplay::Type::Headless; }
+};
+
+} // namespace WebCore
+
+#endif // USE(EGL)

--- a/Source/WebKit/PlatformGTK.cmake
+++ b/Source/WebKit/PlatformGTK.cmake
@@ -53,6 +53,8 @@ list(APPEND WebKit_UNIFIED_SOURCE_LIST_FILES
 list(APPEND WebKit_MESSAGES_IN_FILES
     UIProcess/ViewGestureController
 
+    UIProcess/gtk/AcceleratedBackingStoreDMABuf
+
     WebProcess/gtk/GtkSettingsManagerProxy
     WebProcess/WebPage/ViewGestureGeometryCollector
 )

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -913,6 +913,7 @@ def headers_for_type(type):
         'WebKit::WebScriptMessageHandlerData': ['"WebUserContentControllerDataTypes.h"'],
         'WebKit::WebUserScriptData': ['"WebUserContentControllerDataTypes.h"'],
         'WebKit::WebUserStyleSheetData': ['"WebUserContentControllerDataTypes.h"'],
+        'WTF::UnixFileDescriptor': ['<wtf/unix/UnixFileDescriptor.h>'],
         'webrtc::WebKitEncodedFrameInfo': ['"RTCWebKitEncodedFrameInfo.h"', '<WebCore/LibWebRTCEnumTraits.h>'],
     }
 

--- a/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.h
+++ b/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.h
@@ -47,6 +47,8 @@ public:
     class Client {
     public:
         virtual uint64_t nativeSurfaceHandleForCompositing() = 0;
+        virtual void didCreateGLContext() = 0;
+        virtual void willDestroyGLContext() = 0;
         virtual void didDestroyGLContext() = 0;
 
         virtual void resize(const WebCore::IntSize&) = 0;

--- a/Source/WebKit/Shared/WebProcessCreationParameters.cpp
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.cpp
@@ -187,6 +187,7 @@ void WebProcessCreationParameters::encode(IPC::Encoder& encoder) const
 #endif
 
 #if PLATFORM(GTK)
+    encoder << useDMABufSurfaceForCompositing;
     encoder << useSystemAppearanceForScrollbars;
     encoder << gtkSettings;
 #endif
@@ -520,6 +521,11 @@ bool WebProcessCreationParameters::decode(IPC::Decoder& decoder, WebProcessCreat
 #endif
 
 #if PLATFORM(GTK)
+    std::optional<bool> useDMABufSurfaceForCompositing;
+    decoder >> useDMABufSurfaceForCompositing;
+    if (!useDMABufSurfaceForCompositing)
+        return false;
+    parameters.useDMABufSurfaceForCompositing = WTFMove(*useDMABufSurfaceForCompositing);
     std::optional<bool> useSystemAppearanceForScrollbars;
     decoder >> useSystemAppearanceForScrollbars;
     if (!useSystemAppearanceForScrollbars)

--- a/Source/WebKit/Shared/WebProcessCreationParameters.h
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.h
@@ -228,6 +228,7 @@ struct WebProcessCreationParameters {
 #endif
 
 #if PLATFORM(GTK)
+    bool useDMABufSurfaceForCompositing { false };
     bool useSystemAppearanceForScrollbars { false };
     GtkSettingsState gtkSettings;
 #endif

--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -262,6 +262,7 @@ UIProcess/glib/WebProcessProxyGLib.cpp
 UIProcess/gstreamer/WebPageProxyGStreamer.cpp
 
 UIProcess/gtk/AcceleratedBackingStore.cpp @no-unify
+UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp @no-unify
 UIProcess/gtk/AcceleratedBackingStoreWayland.cpp @no-unify
 UIProcess/gtk/AcceleratedBackingStoreX11.cpp @no-unify
 UIProcess/gtk/Clipboard.cpp
@@ -328,6 +329,7 @@ WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
 
 WebProcess/WebPage/glib/WebPageGLib.cpp
 
+WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.cpp
 WebProcess/WebPage/gtk/AcceleratedSurfaceX11.cpp @no-unify
 WebProcess/WebPage/gtk/WebPageGtk.cpp
 WebProcess/WebPage/gtk/WebPrintOperationGtk.cpp

--- a/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
@@ -54,7 +54,11 @@
 
 #if PLATFORM(GTK)
 #include "GtkSettingsManager.h"
+#if USE(GBM)
+#include "AcceleratedBackingStoreDMABuf.h"
 #endif
+#endif
+
 
 namespace WebKit {
 
@@ -82,8 +86,13 @@ void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process
     }
 #endif
 
+#if PLATFORM(GTK) && USE(GBM)
+    if (AcceleratedBackingStoreDMABuf::checkRequirements())
+        parameters.useDMABufSurfaceForCompositing = true;
+#endif
+
 #if PLATFORM(WAYLAND)
-    if (WebCore::PlatformDisplay::sharedDisplay().type() == WebCore::PlatformDisplay::Type::Wayland) {
+    if (WebCore::PlatformDisplay::sharedDisplay().type() == WebCore::PlatformDisplay::Type::Wayland && !parameters.useDMABufSurfaceForCompositing) {
         wpe_loader_init("libWPEBackend-fdo-1.0.so.1");
         if (AcceleratedBackingStoreWayland::checkRequirements()) {
             parameters.hostClientFileDescriptor = UnixFileDescriptor { wpe_renderer_host_create_client(), UnixFileDescriptor::Adopt };

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.cpp
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.cpp
@@ -40,10 +40,14 @@
 #include "AcceleratedBackingStoreX11.h"
 #endif
 
+#if USE(GBM)
+#include "AcceleratedBackingStoreDMABuf.h"
+#endif
+
 namespace WebKit {
 using namespace WebCore;
 
-#if PLATFORM(WAYLAND)
+#if USE(GBM)
 static bool gtkCanUseHardwareAcceleration()
 {
     static bool canUseHardwareAcceleration;
@@ -68,6 +72,10 @@ static bool gtkCanUseHardwareAcceleration()
 
 bool AcceleratedBackingStore::checkRequirements()
 {
+#if USE(GBM)
+    if (AcceleratedBackingStoreDMABuf::checkRequirements())
+        return gtkCanUseHardwareAcceleration();
+#endif
 #if PLATFORM(WAYLAND)
     if (PlatformDisplay::sharedDisplay().type() == PlatformDisplay::Type::Wayland)
         return AcceleratedBackingStoreWayland::checkRequirements() && gtkCanUseHardwareAcceleration();
@@ -85,6 +93,10 @@ std::unique_ptr<AcceleratedBackingStore> AcceleratedBackingStore::create(WebPage
     if (!HardwareAccelerationManager::singleton().canUseHardwareAcceleration())
         return nullptr;
 
+#if USE(GBM)
+    if (AcceleratedBackingStoreDMABuf::checkRequirements())
+        return AcceleratedBackingStoreDMABuf::create(webPage);
+#endif
 #if PLATFORM(WAYLAND)
     if (PlatformDisplay::sharedDisplay().type() == PlatformDisplay::Type::Wayland)
         return AcceleratedBackingStoreWayland::create(webPage);

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp
@@ -1,0 +1,438 @@
+/*
+ * Copyright (C) 2023 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE COMPUTER, INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE COMPUTER, INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "AcceleratedBackingStoreDMABuf.h"
+
+#if USE(GBM)
+#include "AcceleratedBackingStoreDMABufMessages.h"
+#include "LayerTreeContext.h"
+#include "WebPageProxy.h"
+#include "WebProcessProxy.h"
+#include <WebCore/GBMDevice.h>
+#include <WebCore/GLContext.h>
+#include <WebCore/IntRect.h>
+#include <WebCore/PlatformDisplay.h>
+#include <epoxy/egl.h>
+#include <gbm.h>
+#include <wtf/glib/GUniquePtr.h>
+
+#if PLATFORM(X11) && USE(GTK4)
+#include <gdk/x11/gdkx.h>
+#endif
+
+namespace WebKit {
+
+static bool gtkGLContextIsEGL()
+{
+    static bool isEGL = true;
+    static std::once_flag onceFlag;
+    std::call_once(onceFlag, [] {
+#if PLATFORM(X11)
+    if (WebCore::PlatformDisplay::sharedDisplay().type() == WebCore::PlatformDisplay::Type::X11) {
+#if USE(GTK4)
+        isEGL = !!gdk_x11_display_get_egl_display(gdk_display_get_default());
+#else
+        isEGL = false;
+#endif
+    }
+#endif
+    });
+    return isEGL;
+}
+
+bool AcceleratedBackingStoreDMABuf::checkRequirements()
+{
+    static bool available;
+    static std::once_flag onceFlag;
+    std::call_once(onceFlag, [] {
+        const char* disableDMABuf = getenv("WEBKIT_DISABLE_DMABUF_RENDERER");
+        if (disableDMABuf && strcmp(disableDMABuf, "0")) {
+            available = false;
+            return;
+        }
+
+        const auto& eglExtensions = WebCore::PlatformDisplay::sharedDisplay().eglExtensions();
+        available = eglExtensions.KHR_image_base
+            && eglExtensions.KHR_surfaceless_context
+            && eglExtensions.EXT_image_dma_buf_import
+            && WebCore::GLContext::isExtensionSupported(eglQueryString(nullptr, EGL_EXTENSIONS), "EGL_MESA_platform_surfaceless");
+    });
+    return available;
+}
+
+std::unique_ptr<AcceleratedBackingStoreDMABuf> AcceleratedBackingStoreDMABuf::create(WebPageProxy& webPage)
+{
+    ASSERT(checkRequirements());
+    return std::unique_ptr<AcceleratedBackingStoreDMABuf>(new AcceleratedBackingStoreDMABuf(webPage));
+}
+
+AcceleratedBackingStoreDMABuf::AcceleratedBackingStoreDMABuf(WebPageProxy& webPage)
+    : AcceleratedBackingStore(webPage)
+{
+}
+
+AcceleratedBackingStoreDMABuf::~AcceleratedBackingStoreDMABuf()
+{
+    if (m_surface.id)
+        m_webPage.process().removeMessageReceiver(Messages::AcceleratedBackingStoreDMABuf::messageReceiverName(), m_surface.id);
+
+    if (m_gdkGLContext && m_gdkGLContext.get() == gdk_gl_context_get_current())
+        gdk_gl_context_clear_current();
+}
+
+AcceleratedBackingStoreDMABuf::RenderSource::RenderSource(const WebCore::IntSize& size, float deviceScaleFactor)
+    : m_size(size)
+    , m_deviceScaleFactor(deviceScaleFactor)
+{
+}
+
+AcceleratedBackingStoreDMABuf::Texture::Texture(GdkGLContext* glContext, const UnixFileDescriptor& backFD, const UnixFileDescriptor& frontFD, int fourcc, int32_t offset, int32_t stride, const WebCore::IntSize& size, float deviceScaleFactor)
+    : RenderSource(size, deviceScaleFactor)
+    , m_context(glContext)
+{
+    gdk_gl_context_make_current(m_context.get());
+    auto& display = WebCore::PlatformDisplay::sharedDisplay();
+    Vector<EGLAttrib> attributeList = {
+        EGL_WIDTH, m_size.width(),
+        EGL_HEIGHT, m_size.height(),
+        EGL_LINUX_DRM_FOURCC_EXT, fourcc,
+        EGL_DMA_BUF_PLANE0_FD_EXT, backFD.value(),
+        EGL_DMA_BUF_PLANE0_OFFSET_EXT, offset,
+        EGL_DMA_BUF_PLANE0_PITCH_EXT, stride,
+        EGL_NONE };
+    m_backImage = display.createEGLImage(EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, nullptr, attributeList);
+    if (!m_backImage) {
+        WTFLogAlways("Failed to create EGL image from DMABuf with file descriptor %d", backFD.value());
+        return;
+    }
+    attributeList[7] = frontFD.value();
+    m_frontImage = display.createEGLImage(EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, nullptr, attributeList);
+    if (!m_frontImage) {
+        WTFLogAlways("Failed to create EGL image from DMABuf with file descriptor %d", frontFD.value());
+        display.destroyEGLImage(m_backImage);
+        m_backImage = nullptr;
+        return;
+    }
+
+    glGenTextures(1, &m_textureID);
+    glBindTexture(GL_TEXTURE_2D, m_textureID);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+
+#if USE(GTK4)
+    glEGLImageTargetTexture2DOES(GL_TEXTURE_2D, m_backImage);
+    m_texture[0] = adoptGRef(gdk_gl_texture_new(m_context.get(), m_textureID, m_size.width(), m_size.height(), nullptr, nullptr));
+    m_texture[1] = adoptGRef(gdk_gl_texture_new(m_context.get(), m_textureID, m_size.width(), m_size.height(), nullptr, nullptr));
+    m_textureIndex = 1;
+#endif
+}
+
+AcceleratedBackingStoreDMABuf::Texture::~Texture()
+{
+    gdk_gl_context_make_current(m_context.get());
+    auto& display = WebCore::PlatformDisplay::sharedDisplay();
+    if (m_backImage)
+        display.destroyEGLImage(m_backImage);
+    if (m_frontImage)
+        display.destroyEGLImage(m_frontImage);
+    if (m_textureID)
+        glDeleteTextures(1, &m_textureID);
+}
+
+bool AcceleratedBackingStoreDMABuf::Texture::swap()
+{
+    std::swap(m_backImage, m_frontImage);
+    if (!m_textureID)
+        return false;
+
+    gdk_gl_context_make_current(m_context.get());
+    glBindTexture(GL_TEXTURE_2D, m_textureID);
+    glEGLImageTargetTexture2DOES(GL_TEXTURE_2D, m_frontImage);
+#if USE(GTK4)
+    m_textureIndex = !m_textureIndex;
+#endif
+    return true;
+}
+
+#if USE(GTK4)
+void AcceleratedBackingStoreDMABuf::Texture::snapshot(GtkSnapshot* gtkSnapshot) const
+{
+    if (!m_textureID)
+        return;
+
+    gdk_gl_context_make_current(m_context.get());
+    graphene_rect_t bounds = GRAPHENE_RECT_INIT(0, 0, static_cast<float>(m_size.width() / m_deviceScaleFactor), static_cast<float>(m_size.height() / m_deviceScaleFactor));
+    gtk_snapshot_append_texture(gtkSnapshot, m_texture[m_textureIndex].get(), &bounds);
+}
+#else
+void AcceleratedBackingStoreDMABuf::Texture::paint(GtkWidget* widget, cairo_t* cr, const WebCore::IntRect&) const
+{
+    if (!m_textureID)
+        return;
+
+    gdk_gl_context_make_current(m_context.get());
+    cairo_save(cr);
+    gdk_cairo_draw_from_gl(cr, gtk_widget_get_window(widget), m_textureID, GL_TEXTURE, m_deviceScaleFactor, 0, 0, m_size.width(), m_size.height());
+    cairo_restore(cr);
+}
+#endif
+
+AcceleratedBackingStoreDMABuf::Surface::Surface(const UnixFileDescriptor& backFD, const UnixFileDescriptor& frontFD, int fourcc, int32_t offset, int32_t stride, const WebCore::IntSize& size, float deviceScaleFactor)
+    : RenderSource(size, deviceScaleFactor)
+{
+    auto* device = WebCore::GBMDevice::singleton().device();
+    struct gbm_import_fd_data fdData = { backFD.value(), static_cast<uint32_t>(m_size.width()), static_cast<uint32_t>(m_size.height()), static_cast<uint32_t>(stride), static_cast<uint32_t>(fourcc) };
+    m_backBuffer = gbm_bo_import(device, GBM_BO_IMPORT_FD, &fdData, GBM_BO_USE_RENDERING);
+    if (!m_backBuffer) {
+        WTFLogAlways("Failed to import DMABuf with file descriptor %d", fdData.fd);
+        return;
+    }
+    fdData.fd = frontFD.value();
+    m_frontBuffer = gbm_bo_import(device, GBM_BO_IMPORT_FD, &fdData, GBM_BO_USE_RENDERING);
+    if (!m_frontBuffer) {
+        WTFLogAlways("Failed to import DMABuf with file descriptor %d", fdData.fd);
+        gbm_bo_destroy(m_backBuffer);
+        m_backBuffer = nullptr;
+    }
+}
+
+AcceleratedBackingStoreDMABuf::Surface::~Surface()
+{
+    m_surface = nullptr;
+
+    if (m_backBuffer)
+        gbm_bo_destroy(m_backBuffer);
+    if (m_frontBuffer)
+        gbm_bo_destroy(m_frontBuffer);
+}
+
+RefPtr<cairo_surface_t> AcceleratedBackingStoreDMABuf::Surface::map(struct gbm_bo* buffer) const
+{
+    if (!buffer)
+        return nullptr;
+
+    uint32_t mapStride = 0;
+    void* mapData = nullptr;
+    void* map = gbm_bo_map(buffer, 0, 0, static_cast<uint32_t>(m_size.width()), static_cast<uint32_t>(m_size.height()), GBM_BO_TRANSFER_READ, &mapStride, &mapData);
+    if (!map)
+        return nullptr;
+
+    RefPtr<cairo_surface_t> surface = adoptRef(cairo_image_surface_create_for_data(static_cast<unsigned char*>(map), CAIRO_FORMAT_ARGB32, m_size.width(), m_size.height(), mapStride));
+    cairo_surface_set_device_scale(surface.get(), m_deviceScaleFactor, m_deviceScaleFactor);
+    struct BufferData {
+        WTF_MAKE_STRUCT_FAST_ALLOCATED;
+        struct gbm_bo* buffer;
+        void* data;
+    };
+    auto bufferData = makeUnique<BufferData>(BufferData { buffer, mapData });
+    static cairo_user_data_key_t s_surfaceDataKey;
+    cairo_surface_set_user_data(surface.get(), &s_surfaceDataKey, bufferData.release(), [](void* data) {
+        std::unique_ptr<BufferData> bufferData(static_cast<BufferData*>(data));
+        gbm_bo_unmap(bufferData->buffer, bufferData->data);
+    });
+    return surface;
+}
+
+bool AcceleratedBackingStoreDMABuf::Surface::swap()
+{
+    std::swap(m_backBuffer, m_frontBuffer);
+    m_surface = map(m_frontBuffer);
+    if (m_surface) {
+        cairo_surface_mark_dirty(m_surface.get());
+        return true;
+    }
+    return false;
+}
+
+#if USE(GTK4)
+void AcceleratedBackingStoreDMABuf::Surface::snapshot(GtkSnapshot* gtkSnapshot) const
+{
+    if (!m_surface)
+        return;
+
+    graphene_rect_t bounds = GRAPHENE_RECT_INIT(0, 0, static_cast<float>(m_size.width()), static_cast<float>(m_size.height()));
+    RefPtr<cairo_t> cr = adoptRef(gtk_snapshot_append_cairo(gtkSnapshot, &bounds));
+    cairo_set_source_surface(cr.get(), m_surface.get(), 0, 0);
+    cairo_set_operator(cr.get(), CAIRO_OPERATOR_OVER);
+    cairo_paint(cr.get());
+}
+#else
+void AcceleratedBackingStoreDMABuf::Surface::paint(GtkWidget*, cairo_t* cr, const WebCore::IntRect& clipRect) const
+{
+    if (!m_surface)
+        return;
+
+    cairo_save(cr);
+    cairo_matrix_t transform;
+    cairo_matrix_init(&transform, 1, 0, 0, -1, 0, cairo_image_surface_get_height(m_surface.get()) / m_deviceScaleFactor);
+    cairo_transform(cr, &transform);
+    cairo_rectangle(cr, clipRect.x(), clipRect.y(), clipRect.width(), clipRect.height());
+    cairo_set_source_surface(cr, m_surface.get(), 0, 0);
+    cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
+    cairo_fill(cr);
+    cairo_restore(cr);
+}
+#endif
+
+void AcceleratedBackingStoreDMABuf::configure(UnixFileDescriptor&& backFD, UnixFileDescriptor&& frontFD, int fourcc, int32_t offset, int32_t stride, WebCore::IntSize&& size)
+{
+    m_surface.backFD = WTFMove(backFD);
+    m_surface.frontFD = WTFMove(frontFD);
+    m_surface.fourcc = fourcc;
+    m_surface.offset = offset;
+    m_surface.stride = stride;
+    m_surface.size = WTFMove(size);
+    if (gtk_widget_get_realized(m_webPage.viewWidget()))
+        m_pendingSource = createSource();
+}
+
+std::unique_ptr<AcceleratedBackingStoreDMABuf::RenderSource> AcceleratedBackingStoreDMABuf::createSource()
+{
+    if (!gtkGLContextIsEGL())
+        return makeUnique<Surface>(m_surface.backFD, m_surface.frontFD, m_surface.fourcc, m_surface.offset, m_surface.stride, m_surface.size, m_webPage.deviceScaleFactor());
+
+    ensureGLContext();
+    return makeUnique<Texture>(m_gdkGLContext.get(), m_surface.backFD, m_surface.frontFD, m_surface.fourcc, m_surface.offset, m_surface.stride, m_surface.size, m_webPage.deviceScaleFactor());
+}
+
+void AcceleratedBackingStoreDMABuf::frame(CompletionHandler<void()>&& completionHandler)
+{
+    if (m_pendingSource)
+        m_committedSource = WTFMove(m_pendingSource);
+
+    std::swap(m_surface.backFD, m_surface.frontFD);
+    if (!m_committedSource || !m_committedSource->swap()) {
+        completionHandler();
+        return;
+    }
+
+    ASSERT(!m_frameCompletionHandler);
+    m_frameCompletionHandler = WTFMove(completionHandler);
+    gtk_widget_queue_draw(m_webPage.viewWidget());
+}
+
+void AcceleratedBackingStoreDMABuf::realize()
+{
+    if (!m_surface.backFD && !m_surface.frontFD)
+        return;
+
+    m_committedSource = createSource();
+    gtk_widget_queue_draw(m_webPage.viewWidget());
+}
+
+void AcceleratedBackingStoreDMABuf::unrealize()
+{
+    m_pendingSource = nullptr;
+    m_committedSource = nullptr;
+
+    if (m_gdkGLContext) {
+        if (m_gdkGLContext.get() == gdk_gl_context_get_current())
+            gdk_gl_context_clear_current();
+
+        m_gdkGLContext = nullptr;
+    }
+}
+
+void AcceleratedBackingStoreDMABuf::ensureGLContext()
+{
+    if (m_gdkGLContext)
+        return;
+
+    GUniqueOutPtr<GError> error;
+#if USE(GTK4)
+    m_gdkGLContext = adoptGRef(gdk_surface_create_gl_context(gtk_native_get_surface(gtk_widget_get_native(m_webPage.viewWidget())), &error.outPtr()));
+#else
+    m_gdkGLContext = adoptGRef(gdk_window_create_gl_context(gtk_widget_get_window(m_webPage.viewWidget()), &error.outPtr()));
+#endif
+    if (!m_gdkGLContext)
+        g_error("GDK is not able to create a GL context: %s.", error->message);
+
+#if USE(OPENGL_ES)
+    gdk_gl_context_set_use_es(m_gdkGLContext.get(), TRUE);
+#endif
+
+    if (!gdk_gl_context_realize(m_gdkGLContext.get(), &error.outPtr()))
+        g_error("GDK failed to realize the GL context: %s.", error->message);
+}
+
+bool AcceleratedBackingStoreDMABuf::makeContextCurrent()
+{
+    if (!gtkGLContextIsEGL())
+        return false;
+
+    if (!gtk_widget_get_realized(m_webPage.viewWidget()))
+        return false;
+
+    ensureGLContext();
+    gdk_gl_context_make_current(m_gdkGLContext.get());
+    return true;
+}
+
+void AcceleratedBackingStoreDMABuf::update(const LayerTreeContext& context)
+{
+    if (m_surface.id == context.contextID)
+        return;
+
+    if (m_surface.id) {
+        if (auto completionHandler = std::exchange(m_frameCompletionHandler, nullptr))
+            completionHandler();
+        m_webPage.process().removeMessageReceiver(Messages::AcceleratedBackingStoreDMABuf::messageReceiverName(), m_surface.id);
+    }
+
+    m_surface.id = context.contextID;
+    if (m_surface.id)
+        m_webPage.process().addMessageReceiver(Messages::AcceleratedBackingStoreDMABuf::messageReceiverName(), m_surface.id, *this);
+}
+
+#if USE(GTK4)
+void AcceleratedBackingStoreDMABuf::snapshot(GtkSnapshot* gtkSnapshot)
+{
+    if (!m_committedSource)
+        return;
+
+    m_committedSource->snapshot(gtkSnapshot);
+    if (auto completionHandler = std::exchange(m_frameCompletionHandler, nullptr))
+        completionHandler();
+}
+#else
+bool AcceleratedBackingStoreDMABuf::paint(cairo_t* cr, const WebCore::IntRect& clipRect)
+{
+    if (!m_committedSource)
+        return false;
+
+    m_committedSource->paint(m_webPage.viewWidget(), cr, clipRect);
+    if (auto completionHandler = std::exchange(m_frameCompletionHandler, nullptr))
+        completionHandler();
+
+    return true;
+}
+#endif
+
+} // namespace WebKit
+
+#endif // USE(GBM)

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2023 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE COMPUTER, INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE COMPUTER, INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "AcceleratedBackingStore.h"
+
+#if USE(GBM)
+#include "MessageReceiver.h"
+#include <WebCore/IntSize.h>
+#include <WebCore/RefPtrCairo.h>
+#include <gtk/gtk.h>
+#include <wtf/CompletionHandler.h>
+#include <wtf/glib/GRefPtr.h>
+#include <wtf/unix/UnixFileDescriptor.h>
+
+typedef void *EGLImage;
+struct gbm_bo;
+
+namespace WebCore {
+class IntRect;
+}
+
+namespace WTF {
+class UnixFileDescriptor;
+}
+
+namespace WebKit {
+
+class WebPageProxy;
+
+class AcceleratedBackingStoreDMABuf final : public AcceleratedBackingStore, public IPC::MessageReceiver {
+    WTF_MAKE_NONCOPYABLE(AcceleratedBackingStoreDMABuf); WTF_MAKE_FAST_ALLOCATED;
+public:
+    static bool checkRequirements();
+    static std::unique_ptr<AcceleratedBackingStoreDMABuf> create(WebPageProxy&);
+    ~AcceleratedBackingStoreDMABuf();
+private:
+    AcceleratedBackingStoreDMABuf(WebPageProxy&);
+
+    // IPC::MessageReceiver.
+    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+
+    void configure(WTF::UnixFileDescriptor&&, WTF::UnixFileDescriptor&&, int fourcc, int32_t offset, int32_t stride, WebCore::IntSize&&);
+    void frame(CompletionHandler<void()>&&);
+    void ensureGLContext();
+
+#if USE(GTK4)
+    void snapshot(GtkSnapshot*) override;
+#else
+    bool paint(cairo_t*, const WebCore::IntRect&) override;
+#endif
+    void realize() override;
+    void unrealize() override;
+    bool makeContextCurrent() override;
+    void update(const LayerTreeContext&) override;
+
+    class RenderSource {
+        WTF_MAKE_FAST_ALLOCATED;
+    public:
+        virtual ~RenderSource() = default;
+        virtual bool swap() = 0;
+#if USE(GTK4)
+        virtual void snapshot(GtkSnapshot*) const = 0;
+#else
+        virtual void paint(GtkWidget*, cairo_t*, const WebCore::IntRect&) const = 0;
+#endif
+
+        const WebCore::IntSize size() const { return m_size; }
+
+    protected:
+        RenderSource(const WebCore::IntSize&, float deviceScaleFactor);
+
+        WebCore::IntSize m_size;
+        float m_deviceScaleFactor { 1 };
+    };
+
+    class Texture final : public RenderSource {
+    public:
+        Texture(GdkGLContext*, const WTF::UnixFileDescriptor&, const WTF::UnixFileDescriptor&, int fourcc, int32_t offset, int32_t stride, const WebCore::IntSize&, float deviceScaleFactor);
+        ~Texture();
+
+        unsigned texture() const { return m_textureID; }
+
+    private:
+        bool swap() override;
+#if USE(GTK4)
+        void snapshot(GtkSnapshot*) const override;
+#else
+        void paint(GtkWidget*, cairo_t*, const WebCore::IntRect&) const override;
+#endif
+
+        GRefPtr<GdkGLContext> m_context;
+        unsigned m_textureID { 0 };
+        EGLImage m_backImage { nullptr };
+        EGLImage m_frontImage { nullptr };
+#if USE(GTK4)
+        GRefPtr<GdkTexture> m_texture[2];
+        uint16_t m_textureIndex : 1;
+#endif
+    };
+
+    class Surface final : public RenderSource {
+    public:
+        Surface(const WTF::UnixFileDescriptor&, const WTF::UnixFileDescriptor&, int fourcc, int32_t offset, int32_t stride, const WebCore::IntSize&, float deviceScaleFactor);
+        ~Surface();
+
+        cairo_surface_t* surface() const { return m_surface.get(); }
+
+    private:
+        bool swap() override;
+#if USE(GTK4)
+        void snapshot(GtkSnapshot*) const override;
+#else
+        void paint(GtkWidget*, cairo_t*, const WebCore::IntRect&) const override;
+#endif
+
+        RefPtr<cairo_surface_t> map(struct gbm_bo*) const;
+
+        struct gbm_bo* m_backBuffer { nullptr };
+        struct gbm_bo* m_frontBuffer { nullptr };
+        RefPtr<cairo_surface_t> m_surface;
+        RefPtr<cairo_surface_t> m_backSurface;
+    };
+
+    std::unique_ptr<RenderSource> createSource();
+
+    GRefPtr<GdkGLContext> m_gdkGLContext;
+    bool m_glContextInitialized { false };
+    struct {
+        uint64_t id { 0 };
+        WTF::UnixFileDescriptor backFD;
+        WTF::UnixFileDescriptor frontFD;
+        int fourcc { 0 };
+        int32_t offset { 0 };
+        int32_t stride { 0 };
+        WebCore::IntSize size;
+    } m_surface;
+    std::unique_ptr<RenderSource> m_pendingSource;
+    std::unique_ptr<RenderSource> m_committedSource;
+    CompletionHandler<void()> m_frameCompletionHandler;
+};
+
+} // namespace WebKit
+
+#endif // USE(GBM)

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.messages.in
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.messages.in
@@ -1,0 +1,26 @@
+# Copyright (C) 2023 Igalia S.L.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+messages -> AcceleratedBackingStoreDMABuf NotRefCounted {
+    Configure(UnixFileDescriptor backFD, UnixFileDescriptor frontFD, int fourcc, int32_t offset, int32_t stride, WebCore::IntSize size)
+    Frame() -> ()
+}

--- a/Source/WebKit/WebProcess/WebPage/AcceleratedSurface.cpp
+++ b/Source/WebKit/WebProcess/WebPage/AcceleratedSurface.cpp
@@ -37,11 +37,19 @@
 #include "AcceleratedSurfaceLibWPE.h"
 #endif
 
+#if USE(GBM)
+#include "AcceleratedSurfaceDMABuf.h"
+#endif
+
 namespace WebKit {
 using namespace WebCore;
 
 std::unique_ptr<AcceleratedSurface> AcceleratedSurface::create(WebPage& webPage, Client& client)
 {
+#if USE(GBM)
+    if (PlatformDisplay::sharedDisplayForCompositing().type() == PlatformDisplay::Type::Headless)
+        return AcceleratedSurfaceDMABuf::create(webPage, client);
+#endif
 #if PLATFORM(WAYLAND)
     if (PlatformDisplay::sharedDisplay().type() == PlatformDisplay::Type::Wayland)
         return AcceleratedSurfaceLibWPE::create(webPage, client);

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -406,6 +406,16 @@ uint64_t LayerTreeHost::nativeSurfaceHandleForCompositing()
     return m_surface->window();
 }
 
+void LayerTreeHost::didCreateGLContext()
+{
+    m_surface->didCreateGLContext();
+}
+
+void LayerTreeHost::willDestroyGLContext()
+{
+    m_surface->willDestroyGLContext();
+}
+
 void LayerTreeHost::didDestroyGLContext()
 {
     m_surface->finalize();

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
@@ -120,6 +120,8 @@ private:
 
     // ThreadedCompositor::Client
     uint64_t nativeSurfaceHandleForCompositing() override;
+    void didCreateGLContext() override;
+    void willDestroyGLContext() override;
     void didDestroyGLContext() override;
     void resize(const WebCore::IntSize&) override;
     void willRenderFrame() override;

--- a/Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.cpp
+++ b/Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.cpp
@@ -1,0 +1,208 @@
+/*
+ * Copyright (C) 2023 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "AcceleratedSurfaceDMABuf.h"
+
+#if USE(GBM)
+#include "AcceleratedBackingStoreDMABufMessages.h"
+#include "WebPage.h"
+#include "WebProcess.h"
+#include <WebCore/DMABufFormat.h>
+#include <WebCore/GBMDevice.h>
+#include <WebCore/PlatformDisplay.h>
+#include <epoxy/egl.h>
+#include <gbm.h>
+#include <wtf/SafeStrerror.h>
+
+namespace WebKit {
+
+std::unique_ptr<AcceleratedSurfaceDMABuf> AcceleratedSurfaceDMABuf::create(WebPage& webPage, Client& client)
+{
+    return std::unique_ptr<AcceleratedSurfaceDMABuf>(new AcceleratedSurfaceDMABuf(webPage, client));
+}
+
+AcceleratedSurfaceDMABuf::AcceleratedSurfaceDMABuf(WebPage& webPage, Client& client)
+    : AcceleratedSurface(webPage, client)
+{
+}
+
+AcceleratedSurfaceDMABuf::~AcceleratedSurfaceDMABuf()
+{
+}
+
+void AcceleratedSurfaceDMABuf::didCreateGLContext()
+{
+    glGenTextures(1, &m_texture);
+    glBindTexture(GL_TEXTURE_2D, m_texture);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+
+    glGenFramebuffers(1, &m_fbo);
+    glBindFramebuffer(GL_FRAMEBUFFER, m_fbo);
+
+    clientResize(m_size);
+}
+
+void AcceleratedSurfaceDMABuf::willDestroyGLContext()
+{
+    auto& display = WebCore::PlatformDisplay::sharedDisplayForCompositing();
+    if (m_backImage) {
+        display.destroyEGLImage(m_backImage);
+        m_backImage = nullptr;
+    }
+
+    if (m_frontImage) {
+        display.destroyEGLImage(m_frontImage);
+        m_frontImage = nullptr;
+    }
+
+    if (m_texture) {
+        glDeleteTextures(1, &m_texture);
+        m_texture = 0;
+    }
+
+    if (m_depthStencilBuffer) {
+        glDeleteRenderbuffers(1, &m_depthStencilBuffer);
+        m_depthStencilBuffer = 0;
+    }
+
+    if (m_fbo) {
+        glDeleteFramebuffers(1, &m_fbo);
+        m_fbo = 0;
+    }
+}
+
+uint64_t AcceleratedSurfaceDMABuf::surfaceID() const
+{
+    return m_webPage.identifier().toUInt64();
+}
+
+void AcceleratedSurfaceDMABuf::clientResize(const WebCore::IntSize& size)
+{
+    auto& display = WebCore::PlatformDisplay::sharedDisplayForCompositing();
+    if (m_backImage) {
+        display.destroyEGLImage(m_backImage);
+        m_backImage = nullptr;
+    }
+
+    if (m_frontImage) {
+        display.destroyEGLImage(m_frontImage);
+        m_frontImage = nullptr;
+    }
+
+    if (m_depthStencilBuffer) {
+        glDeleteRenderbuffers(1, &m_depthStencilBuffer);
+        m_depthStencilBuffer = 0;
+    }
+
+    if (size.isEmpty())
+        return;
+
+    auto* backObject = gbm_bo_create(WebCore::GBMDevice::singleton().device(), size.width(), size.height(), uint32_t(DMABufFormat::FourCC::ARGB8888), 0);
+    if (!backObject) {
+        WTFLogAlways("Failed to create GBM buffer of size %dx%d: %s", size.width(), size.height(), safeStrerror(errno).data());
+        return;
+    }
+    UnixFileDescriptor backFD(gbm_bo_get_fd(backObject), UnixFileDescriptor::Adopt);
+    Vector<EGLAttrib> attributes = {
+        EGL_WIDTH, gbm_bo_get_width(backObject),
+        EGL_HEIGHT, gbm_bo_get_height(backObject),
+        EGL_LINUX_DRM_FOURCC_EXT, gbm_bo_get_format(backObject),
+        EGL_DMA_BUF_PLANE0_FD_EXT, backFD.value(),
+        EGL_DMA_BUF_PLANE0_OFFSET_EXT, gbm_bo_get_offset(backObject, 0),
+        EGL_DMA_BUF_PLANE0_PITCH_EXT, gbm_bo_get_stride(backObject),
+        EGL_NONE
+    };
+    m_backImage = display.createEGLImage(EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, nullptr, attributes);
+    if (!m_backImage) {
+        WTFLogAlways("Failed to create EGL image for DMABuf with file descriptor: %d", backFD.value());
+        gbm_bo_destroy(backObject);
+        return;
+    }
+    auto* frontObject = gbm_bo_create(WebCore::GBMDevice::singleton().device(), size.width(), size.height(), uint32_t(DMABufFormat::FourCC::ARGB8888), 0);
+    if (!frontObject) {
+        WTFLogAlways("Failed to create GBM buffer of size %dx%d: %s", size.width(), size.height(), safeStrerror(errno).data());
+        display.destroyEGLImage(m_backImage);
+        m_backImage = nullptr;
+        gbm_bo_destroy(backObject);
+        return;
+    }
+    UnixFileDescriptor frontFD(gbm_bo_get_fd(frontObject), UnixFileDescriptor::Adopt);
+    attributes[7] = frontFD.value();
+    m_frontImage = display.createEGLImage(EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, nullptr, attributes);
+    if (!m_frontImage) {
+        WTFLogAlways("Failed to create EGL image for DMABuf with file descriptor: %d", frontFD.value());
+        gbm_bo_destroy(frontObject);
+        display.destroyEGLImage(m_backImage);
+        m_backImage = nullptr;
+        gbm_bo_destroy(backObject);
+        return;
+    }
+
+    glGenRenderbuffers(1, &m_depthStencilBuffer);
+    glBindRenderbuffer(GL_RENDERBUFFER, m_depthStencilBuffer);
+    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8_OES, size.width(), size.height());
+
+    WebProcess::singleton().parentProcessConnection()->send(Messages::AcceleratedBackingStoreDMABuf::Configure(WTFMove(backFD), WTFMove(frontFD), gbm_bo_get_format(backObject), gbm_bo_get_offset(backObject, 0), gbm_bo_get_stride(backObject), size), m_webPage.identifier());
+    gbm_bo_destroy(backObject);
+    gbm_bo_destroy(frontObject);
+}
+
+void AcceleratedSurfaceDMABuf::willRenderFrame()
+{
+    if (!m_backImage)
+        return;
+
+    glBindTexture(GL_TEXTURE_2D, m_texture);
+    glEGLImageTargetTexture2DOES(GL_TEXTURE_2D, m_backImage);
+    glBindFramebuffer(GL_FRAMEBUFFER, m_fbo);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_texture, 0);
+    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, m_depthStencilBuffer);
+    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, m_depthStencilBuffer);
+}
+
+void AcceleratedSurfaceDMABuf::didRenderFrame()
+{
+    if (!m_backImage)
+        return;
+
+    glFlush();
+    WebProcess::singleton().parentProcessConnection()->sendWithAsyncReply(Messages::AcceleratedBackingStoreDMABuf::Frame(), [this, weakThis = WeakPtr { *this }, runLoop = Ref { RunLoop::current() }]() mutable {
+        // FIXME: it would be great if there was an option to send replies to the current run loop directly.
+        runLoop->dispatch([this, weakThis = WTFMove(weakThis)] {
+            if (!weakThis)
+                return;
+            std::swap(m_backImage, m_frontImage);
+            m_client.frameComplete();
+        });
+    }, m_webPage.identifier());
+}
+
+} // namespace WebKit
+
+#endif // USE(GBM)

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -707,7 +707,7 @@ private:
     WeakHashMap<WebCore::UserGestureToken, uint64_t> m_userGestureTokens;
 
 #if PLATFORM(WAYLAND)
-    std::unique_ptr<WebCore::PlatformDisplayLibWPE> m_wpeDisplay;
+    std::unique_ptr<WebCore::PlatformDisplay> m_displayForCompositing;
 #endif
 
     bool m_hasSuspendedPageProxy { false };


### PR DESCRIPTION
#### d2424c0fc67f6a46921edb52874720bb99c0c699
<pre>
[GTK] Use DMABuf and WebKit IPC for rendering instead of wpe/x11
<a href="https://bugs.webkit.org/show_bug.cgi?id=252988">https://bugs.webkit.org/show_bug.cgi?id=252988</a>

Reviewed by Žan Doberšek.

Instead of the wpe rendered, which uses a nested wayland compositor, and
x11, which uses a redirected xcomposite window, we can make the web
process render always into a pbuffer using mesa surfaceless platform and
export the rendered texture using DMAbuf to be consumed by the UI
process. This way the rendering is independent from the platform
(wayland/x11), and in the UI process we just import the DMABuf into a
texture that we pass to GTK for rendering into the web view widget. If
under X11 GTK uses GLX instead of EGL we manually import the DMABuf
using libgbm to create a cairo surface that we can pass to GTK without
using GL.

* Source/WebCore/PlatformGTK.cmake:
* Source/WebCore/SourcesGTK.txt:
* Source/WebCore/platform/graphics/PlatformDisplay.cpp:
(WebCore::PlatformDisplay::initializeEGLDisplay):
* Source/WebCore/platform/graphics/PlatformDisplay.h:
* Source/WebCore/platform/graphics/egl/GLContextEGL.cpp:
(WebCore::GLContextEGL::getEGLConfig):
(WebCore::GLContextEGL::createWindowContext):
(WebCore::GLContextEGL::createPbufferContext):
(WebCore::GLContextEGL::createSurfacelessContext):
(WebCore::GLContextEGL::createContext):
(WebCore::GLContextEGL::createSharingContext):
* Source/WebCore/platform/graphics/egl/GLContextEGL.h:
* Source/WebCore/platform/graphics/egl/GLContextEGLLibWPE.cpp:
(WebCore::GLContextEGL::createWPEContext):
* Source/WebCore/platform/graphics/egl/GLContextEGLWayland.cpp:
(WebCore::GLContextEGL::createWaylandContext):
* Source/WebCore/platform/graphics/egl/GLContextEGLX11.cpp:
(WebCore::GLContextEGL::createPixmapContext):
* Source/WebCore/platform/graphics/egl/PlatformDisplayHeadless.cpp: Added.
(WebCore::PlatformDisplayHeadless::create):
(WebCore::PlatformDisplayHeadless::PlatformDisplayHeadless):
(WebCore::PlatformDisplayHeadless::~PlatformDisplayHeadless):
* Source/WebCore/platform/graphics/egl/PlatformDisplayHeadless.h: Added.
* Source/WebKit/PlatformGTK.cmake:
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp:
(WebKit::ThreadedCompositor::createGLContext):
(WebKit::ThreadedCompositor::invalidate):
* Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.h:
* Source/WebKit/Shared/WebProcessCreationParameters.cpp:
(WebKit::WebProcessCreationParameters::encode const):
(WebKit::WebProcessCreationParameters::decode):
* Source/WebKit/Shared/WebProcessCreationParameters.h:
* Source/WebKit/SourcesGTK.txt:
* Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp:
(WebKit::WebKitProtocolHandler::handleGPU):
* Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp:
(WebKit::WebProcessPool::platformInitializeWebProcess):
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.cpp:
(WebKit::AcceleratedBackingStore::checkRequirements):
(WebKit::AcceleratedBackingStore::create):
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp: Added.
(WebKit::gtkGLContextIsEGL):
(WebKit::AcceleratedBackingStoreDMABuf::checkRequirements):
(WebKit::AcceleratedBackingStoreDMABuf::create):
(WebKit::AcceleratedBackingStoreDMABuf::AcceleratedBackingStoreDMABuf):
(WebKit::AcceleratedBackingStoreDMABuf::~AcceleratedBackingStoreDMABuf):
(WebKit::AcceleratedBackingStoreDMABuf::RenderSource::RenderSource):
(WebKit::AcceleratedBackingStoreDMABuf::Texture::Texture):
(WebKit::AcceleratedBackingStoreDMABuf::Texture::~Texture):
(WebKit::AcceleratedBackingStoreDMABuf::Texture::swap):
(WebKit::AcceleratedBackingStoreDMABuf::Texture::snapshot const):
(WebKit::AcceleratedBackingStoreDMABuf::Texture::paint const):
(WebKit::AcceleratedBackingStoreDMABuf::Surface::Surface):
(WebKit::AcceleratedBackingStoreDMABuf::Surface::~Surface):
(WebKit::AcceleratedBackingStoreDMABuf::Surface::map const):
(WebKit::AcceleratedBackingStoreDMABuf::Surface::swap):
(WebKit::AcceleratedBackingStoreDMABuf::Surface::snapshot const):
(WebKit::AcceleratedBackingStoreDMABuf::Surface::paint const):
(WebKit::AcceleratedBackingStoreDMABuf::configure):
(WebKit::AcceleratedBackingStoreDMABuf::frame):
(WebKit::AcceleratedBackingStoreDMABuf::unrealize):
(WebKit::AcceleratedBackingStoreDMABuf::ensureGLContext):
(WebKit::AcceleratedBackingStoreDMABuf::makeContextCurrent):
(WebKit::AcceleratedBackingStoreDMABuf::update):
(WebKit::AcceleratedBackingStoreDMABuf::snapshot):
(WebKit::AcceleratedBackingStoreDMABuf::paint):
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h: Added.
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.messages.in: Added.
* Source/WebKit/WebProcess/WebPage/AcceleratedSurface.cpp:
(WebKit::AcceleratedSurface::create):
* Source/WebKit/WebProcess/WebPage/AcceleratedSurface.h:
(WebKit::AcceleratedSurface::didCreateGLContext):
(WebKit::AcceleratedSurface::willDestroyGLContext):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::didCreateGLContext):
(WebKit::LayerTreeHost::willDestroyGLContext):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h:
* Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.cpp: Added.
(WebKit::AcceleratedSurfaceDMABuf::create):
(WebKit::AcceleratedSurfaceDMABuf::AcceleratedSurfaceDMABuf):
(WebKit::AcceleratedSurfaceDMABuf::~AcceleratedSurfaceDMABuf):
(WebKit::AcceleratedSurfaceDMABuf::didCreateGLContext):
(WebKit::AcceleratedSurfaceDMABuf::willDestroyGLContext):
(WebKit::AcceleratedSurfaceDMABuf::surfaceID const):
(WebKit::AcceleratedSurfaceDMABuf::clientResize):
(WebKit::AcceleratedSurfaceDMABuf::willRenderFrame):
(WebKit::AcceleratedSurfaceDMABuf::didRenderFrame):
* Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.h: Added.
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/glib/WebProcessGLib.cpp:
(WebKit::WebProcess::platformInitializeWebProcess):

Canonical link: <a href="https://commits.webkit.org/262210@main">https://commits.webkit.org/262210@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e0be399d0f3e1700e14e3273ac18a78bd044854

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/908 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/932 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/968 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1302 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/803 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/895 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/982 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1017 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1007 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/915 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/853 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/853 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1240 "Built successfully") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/935 "webkitpy-tests (failure)") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/850 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/847 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/822 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/877 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/1875 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/863 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/810 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/861 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/877 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/94 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->