### PR TITLE
ImageBuffer flushing is redundant

### DIFF
--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -142,11 +142,10 @@ public:
     WEBCORE_EXPORT virtual RefPtr<ImageBuffer> cloneForDifferentThread();
 
     WEBCORE_EXPORT virtual GraphicsContext& context() const;
-    WEBCORE_EXPORT virtual void flushContext();
 
     virtual bool prefersPreparationForDisplay() { return false; }
-    virtual void flushDrawingContext() { }
-    virtual bool flushDrawingContextAsync() { return false; }
+    WEBCORE_EXPORT virtual void flushDrawingContext();
+    WEBCORE_EXPORT virtual bool flushDrawingContextAsync();
 
     WEBCORE_EXPORT std::unique_ptr<ImageBufferBackend> takeBackend();
     WEBCORE_EXPORT IntSize backendSize() const;

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
@@ -586,7 +586,7 @@ void RemoteDisplayListRecorder::applyDeviceScaleFactor(float scaleFactor)
 
 void RemoteDisplayListRecorder::flushContext(DisplayListRecorderFlushIdentifier identifier)
 {
-    m_imageBuffer->flushContext();
+    m_imageBuffer->flushDrawingContext();
     m_renderingBackend->didFlush(identifier);
 }
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
@@ -268,7 +268,7 @@ void RemoteGraphicsContextGL::paintPixelBufferToImageBuffer(RefPtr<WebCore::Pixe
             else
                 imageBuffer->context().clearRect({ IntPoint(), imageBuffer->backendSize() });
             // Unfortunately "flush" implementation in RemoteRenderingBackend overloads ordering and effects.
-            imageBuffer->flushContext();
+            imageBuffer->flushDrawingContext();
         }
         Locker locker { lock };
         isFinished = true;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
@@ -99,7 +99,6 @@ private:
 
     bool prefersPreparationForDisplay() final { return true; }
     
-    void flushContext() final;
     void flushDrawingContext() final;
     bool flushDrawingContextAsync() final;
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/ImageBufferTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ImageBufferTests.cpp
@@ -219,7 +219,7 @@ TEST(ImageBufferTests, DISABLED_DrawImageBufferDoesNotReferenceExtraMemory)
     auto accelerated = ImageBuffer::create(logicalSize, RenderingPurpose::Unspecified, scale, colorSpace, pixelFormat, { ImageBufferOptions::Accelerated });
     auto fillRect = FloatRect { { }, logicalSize };
     accelerated->context().fillRect(fillRect, Color::green);
-    accelerated->flushContext();
+    accelerated->flushDrawingContext();
     EXPECT_TRUE(memoryFootprintChangedBy(lastFootprint, logicalSizeBytes, footprintError));
 
     auto unaccelerated = ImageBuffer::create(logicalSize, RenderingPurpose::Unspecified, scale, colorSpace, pixelFormat);


### PR DESCRIPTION
#### 6b5c45e49165c4e9143be25face31c9c105ba84b
<pre>
ImageBuffer flushing is redundant
<a href="https://bugs.webkit.org/show_bug.cgi?id=252990">https://bugs.webkit.org/show_bug.cgi?id=252990</a>
rdar://105973502

Reviewed by Simon Fraser.

Overall, flushing is needed to ensure that deferred rendering is done
before read from / write to via *external access* happens. This is means
any defferring: either CG asynchronous rendering or IPC -based rendering.
The conditions for both are identical.

For local rendering, flushing is relevant only when rendering to a
IOSurface via the asynchronous CGContext implementation. For this case,
the *external access* is when:
1. The rendered contents is read through the bitmap by locking the
   IOSurface. This is possible with getImageData() and when drawing
   to bitmap contents from explicit bitmap context mapped from the
   IOSurface.
2. The rendering is altered by a write through the locked IOSurface.
   This is possible with putImageData().
3. The rendered contents is rendered to in GPUP side with asynchronous CG
   implementation and is read through the IOSurface by the WP-side
   asynchronous CG implementation.

Move the flushes to:
i) ImageBufferIOSurfaceBackend for the local process external access points:
   getImageData, putImageData.
ii) RemoteImageBufferProxy for the GPUP-WP external access points:
   draw in GPUP, read from WP via asynchronous CG.

In the future, these will be moved fully into the respective backends when
RemoteImageBufferProxy is removed.

Remove ImageBuffer::flushContext(). It is the same as
ImageBuffer::flushDrawingContext().

For ImageBufferShareableMappedIOSurfaceBackend it also flushed the
WP-side context for the IOSurface. This is not used for any drawing,
so it is pointless to be flushed. It is only used for creating
the WP-side CGImage of the IOSurface.

* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::clipToMask):
(WebCore::ImageBuffer::convertToLuminanceMask):
(WebCore::ImageBuffer::getPixelBuffer const):
(WebCore::ImageBuffer::putPixelBuffer):
(WebCore::ImageBuffer::flushContext): Deleted.
* Source/WebCore/platform/graphics/ImageBuffer.h:
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp:
(WebKit::RemoteDisplayListRecorder::flushContext):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp:
(WebKit::RemoteGraphicsContextGL::paintPixelBufferToImageBuffer):
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp:
(WebKit::RemoteImageBufferProxy::flushContext): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h:
* Tools/TestWebKitAPI/Tests/WebCore/ImageBufferTests.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/261915@main">https://commits.webkit.org/261915@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1be757d7c0e9d538cecf0caa65650451e88b1643

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111883 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21013 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/495 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3644 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120573 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115948 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22361 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12069 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/3392 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117647 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16604 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99758 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104897 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98555 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/326 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45580 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13459 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/336 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/92734 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13975 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9753 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19412 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52337 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8328 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15942 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->