### PR TITLE
Floats' trimmed margins should not contribute to containing block's intrinsic sizing (legacy line layout)

### DIFF
--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-trim-float-drives-container-intrinsic-size-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-trim-float-drives-container-intrinsic-size-expected.html
@@ -1,0 +1,33 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="The float should contribute its border box size along with the inline-end margin (since that is not trimmed) to the intrinsic sizing of the containing block">
+<style>
+container {
+    display: block;
+    width: min-content;
+    font-family: monospace;
+    font-size: 10px;
+    border: 1px solid black;
+}
+item {
+    display: block;
+    float: left;
+    width: 50px;
+    height: 50px;
+    margin-inline-end: 30px;
+    background-color: green;
+
+}
+</style>
+</head>
+<body>
+<container>
+    <item></item>
+    many l e t t e r s s e p a r a t e d b y s p a c e s
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-trim-float-drives-container-intrinsic-size-orthogonal-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-trim-float-drives-container-intrinsic-size-orthogonal-expected.html
@@ -1,0 +1,34 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="The float should contribute its border box size along with the inline-end margin (since that is not trimmed) to the intrinsic sizing of the containing block.
+The float is orthogonal so it should be the inline-end margin with respect to the containing block's writing mode">
+<style>
+container {
+    display: block;
+    width: min-content;
+    font-family: monospace;
+    font-size: 10px;
+    border: 1px solid black;
+}
+item {
+    display: block;
+    float: left;
+    width: 50px;
+    height: 50px;
+    margin-inline-end: 30px;
+    background-color: green;
+
+}
+</style>
+</head>
+<body>
+<container>
+    <item></item>
+    many l e t t e r s s e p a r a t e d b y s p a c e s
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-trim-float-drives-container-intrinsic-size-orthogonal.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-trim-float-drives-container-intrinsic-size-orthogonal.html
@@ -1,0 +1,36 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="The float should contribute its border box size along with the inline-end margin (since that is not trimmed) to the intrinsic sizing of the containing block.
+The float is orthogonal so it should be the inline-end margin with respect to the containing block's writing mode">
+<style>
+container {
+    display: block;
+    width: min-content;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline-start;
+    border: 1px solid black;
+}
+item {
+    display: block;
+    float: left;
+    writing-mode: vertical-lr;
+    width: 50px;
+    height: 50px;
+    margin-block: 15px 30px;
+    background-color: green;
+
+}
+</style>
+</head>
+<body>
+<container>
+    <item></item>
+    many l e t t e r s s e p a r a t e d b y s p a c e s
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-trim-float-drives-container-intrinsic-size-rtl-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-trim-float-drives-container-intrinsic-size-rtl-expected.html
@@ -1,0 +1,34 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="The float should contribute its border box size along with the inline-end margin (since that is not trimmed) to the intrinsic sizing of the containing block">
+<style>
+container {
+    display: block;
+    direction: rtl;
+    width: min-content;
+    font-family: monospace;
+    font-size: 10px;
+    border: 1px solid black;
+}
+item {
+    display: block;
+    float: left;
+    width: 50px;
+    height: 50px;
+    margin-inline-end: 30px;
+    background-color: green;
+
+}
+</style>
+</head>
+<body>
+<container>
+    <item></item>
+    many l e t t e r s s e p a r a t e d b y s p a c e s
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-trim-float-drives-container-intrinsic-size-rtl.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-trim-float-drives-container-intrinsic-size-rtl.html
@@ -1,0 +1,35 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="The float should contribute its border box size along with the inline-end margin (since that is not trimmed) to the intrinsic sizing of the containing block">
+<style>
+container {
+    display: block;
+    direction: rtl;
+    width: min-content;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline-start;
+    border: 1px solid black;
+}
+item {
+    display: block;
+    float: left;
+    width: 50px;
+    height: 50px;
+    margin-inline: 15px 30px;
+    background-color: green;
+
+}
+</style>
+</head>
+<body>
+<container>
+    <item></item>
+    many l e t t e r s s e p a r a t e d b y s p a c e s
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-trim-float-drives-container-intrinsic-size.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-trim-float-drives-container-intrinsic-size.html
@@ -1,0 +1,34 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="The float should contribute its border box size along with the inline-end margin (since that is not trimmed) to the intrinsic sizing of the containing block">
+<style>
+container {
+    display: block;
+    width: min-content;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline-start;
+    border: 1px solid black;
+}
+item {
+    display: block;
+    float: left;
+    width: 50px;
+    height: 50px;
+    margin-inline: 30px;
+    background-color: green;
+
+}
+</style>
+</head>
+<body>
+<container>
+    <item></item>
+    many l e t t e r s s e p a r a t e d b y s p a c e s
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-trim-float-drives-container-intrinsic-size-inline-layout-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-trim-float-drives-container-intrinsic-size-inline-layout-expected.html
@@ -1,0 +1,32 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="The float should contribute its border box logical width since margin-trim: inline is specified (and drives the containing block size in this case)">
+<style>
+container {
+    display: block;
+    width: min-content;
+    font-family: monospace;
+    font-size: 10px;
+    border: 1px solid black;
+}
+item {
+    display: block;
+    float: left;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+
+}
+</style>
+</head>
+<body>
+<container>
+    <item></item>
+    many l e t t e r s s e p a r a t e d b y s p a c e s
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-trim-float-drives-container-intrinsic-size-inline-layout.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-trim-float-drives-container-intrinsic-size-inline-layout.html
@@ -1,0 +1,34 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="The float should contribute its border box logical width since margin-trim: inline is specified (and drives the containing block size in this case)">
+<style>
+container {
+    display: block;
+    width: min-content;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline;
+    border: 1px solid black;
+}
+item {
+    display: block;
+    float: left;
+    width: 50px;
+    height: 50px;
+    margin-inline: 30px;
+    background-color: green;
+
+}
+</style>
+</head>
+<body>
+<container>
+    <item></item>
+    many l e t t e r s s e p a r a t e d b y s p a c e s
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-trim-text-drives-container-intrinsic-size-inline-layout-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-trim-text-drives-container-intrinsic-size-inline-layout-expected.html
@@ -1,0 +1,36 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Text should drive the containing block's intrinsic size. Since margin-trim: inline is specified, both margins should be zeroed">
+<style>
+container {
+    display: block;
+    inline-size: min-content;
+    font-family: monospace;
+    font-size: 10px;
+    border: 1px solid black;
+}
+item {
+    display: block;
+    float: left;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+
+}
+.clear-floats {
+    clear: left;
+}
+</style>
+</head>
+<body>
+<container>
+    longwordinfluencescontainerintrinsicsize </br>
+    <item></item>
+    <div class="clear-floats">text that should be after the float</div>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-trim-text-drives-container-intrinsic-size-inline-layout-vert-lr-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-trim-text-drives-container-intrinsic-size-inline-layout-vert-lr-expected.html
@@ -1,0 +1,37 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Text should drive the containing block's intrinsic size. Since margin-trim: inline is specified, both margins should be zeroed">
+<style>
+container {
+    display: block;
+    writing-mode: vertical-lr;
+    inline-size: min-content;
+    font-family: monospace;
+    font-size: 10px;
+    border: 1px solid black;
+}
+item {
+    display: block;
+    float: left;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+
+}
+.clear-floats {
+    clear: left;
+}
+</style>
+</head>
+<body>
+<container>
+    longwordinfluencescontainerintrinsicsize </br>
+    <item></item>
+    <div class="clear-floats">text that should be after the float</div>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-trim-text-drives-container-intrinsic-size-inline-layout-vert-lr.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-trim-text-drives-container-intrinsic-size-inline-layout-vert-lr.html
@@ -1,0 +1,36 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Text should drive the containing block's intrinsic size. Since margin-trim: inline is specified, both margins should be zeroed">
+<style>
+container {
+    display: block;
+    writing-mode: vertical-lr;
+    inline-size: min-content;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline;
+    border: 1px solid black;
+}
+item {
+    display: block;
+    float: left;
+    width: 50px;
+    height: 50px;
+    margin-inline: 200px;
+    background-color: green;
+
+}
+</style>
+</head>
+<body>
+<container>
+    longwordinfluencescontainerintrinsicsize
+    <item></item>
+    text that should be after the float
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-trim-text-drives-container-intrinsic-size-inline-layout.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-trim-text-drives-container-intrinsic-size-inline-layout.html
@@ -1,0 +1,35 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Text should drive the containing block's intrinsic size. Since margin-trim: inline is specified, both margins should be zeroed">
+<style>
+container {
+    display: block;
+    inline-size: min-content;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline;
+    border: 1px solid black;
+}
+item {
+    display: block;
+    float: left;
+    width: 50px;
+    height: 50px;
+    margin-inline: 200px;
+    background-color: green;
+
+}
+</style>
+</head>
+<body>
+<container>
+    longwordinfluencescontainerintrinsicsize
+    <item></item>
+    text that should be after the float
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-trim-float-drives-container-intrinsic-size-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-trim-float-drives-container-intrinsic-size-expected.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="The float should contribute its border box size along with the inline-end margin (since that is not trimmed) to the intrinsic sizing of the containing block">
+<style>
+container {
+    display: block;
+    width: min-content;
+    font-family: monospace;
+    font-size: 10px;
+    border: 1px solid black;
+}
+item {
+    display: block;
+    float: left;
+    width: 50px;
+    height: 50px;
+    margin-inline-end: 30px;
+    background-color: green;
+
+}
+</style>
+</head>
+<body>
+<container>
+    <item></item>
+    many l e t t e r s s e p a r a t e d b y s p a c e s
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-trim-float-drives-container-intrinsic-size-orthogonal-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-trim-float-drives-container-intrinsic-size-orthogonal-expected.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="The float should contribute its border box size along with the inline-end margin (since that is not trimmed) to the intrinsic sizing of the containing block.
+The float is orthogonal so it should be the inline-end margin with respect to the containing block's writing mode">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<style>
+container {
+    display: block;
+    width: min-content;
+    font-family: monospace;
+    font-size: 10px;
+    border: 1px solid black;
+}
+item {
+    display: block;
+    float: left;
+    width: 50px;
+    height: 50px;
+    margin-inline-end: 30px;
+    background-color: green;
+
+}
+</style>
+</head>
+<body>
+<container>
+    <item></item>
+    many l e t t e r s s e p a r a t e d b y s p a c e s
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-trim-float-drives-container-intrinsic-size-orthogonal.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-trim-float-drives-container-intrinsic-size-orthogonal.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="The float should contribute its border box size along with the inline-end margin (since that is not trimmed) to the intrinsic sizing of the containing block.
+The float is orthogonal so it should be the inline-end margin with respect to the containing block's writing mode">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<style>
+container {
+    display: block;
+    width: min-content;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline-start;
+    border: 1px solid black;
+}
+item {
+    display: block;
+    float: left;
+    writing-mode: vertical-lr;
+    width: 50px;
+    height: 50px;
+    margin-block: 15px 30px;
+    background-color: green;
+
+}
+</style>
+</head>
+<body>
+<container>
+    <item></item>
+    many l e t t e r s s e p a r a t e d b y s p a c e s
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-trim-float-drives-container-intrinsic-size-rtl-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-trim-float-drives-container-intrinsic-size-rtl-expected.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="The float should contribute its border box size along with the inline-end margin (since that is not trimmed) to the intrinsic sizing of the containing block">
+<style>
+container {
+    display: block;
+    direction: rtl;
+    width: min-content;
+    font-family: monospace;
+    font-size: 10px;
+    border: 1px solid black;
+}
+item {
+    display: block;
+    float: left;
+    width: 50px;
+    height: 50px;
+    margin-inline-end: 30px;
+    background-color: green;
+
+}
+</style>
+</head>
+<body>
+<container>
+    <item></item>
+    many l e t t e r s s e p a r a t e d b y s p a c e s
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-trim-float-drives-container-intrinsic-size-rtl.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-trim-float-drives-container-intrinsic-size-rtl.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="The float should contribute its border box size along with the inline-end margin (since that is not trimmed) to the intrinsic sizing of the containing block">
+<style>
+container {
+    display: block;
+    direction: rtl;
+    width: min-content;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline-start;
+    border: 1px solid black;
+}
+item {
+    display: block;
+    float: left;
+    width: 50px;
+    height: 50px;
+    margin-inline: 15px 30px;
+    background-color: green;
+
+}
+</style>
+</head>
+<body>
+<container>
+    <item></item>
+    many l e t t e r s s e p a r a t e d b y s p a c e s
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-trim-float-drives-container-intrinsic-size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-trim-float-drives-container-intrinsic-size.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="The float should contribute its border box size along with the inline-end margin (since that is not trimmed) to the intrinsic sizing of the containing block">
+<style>
+container {
+    display: block;
+    width: min-content;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline-start;
+    border: 1px solid black;
+}
+item {
+    display: block;
+    float: left;
+    width: 50px;
+    height: 50px;
+    margin-inline: 30px;
+    background-color: green;
+
+}
+</style>
+</head>
+<body>
+<container>
+    <item></item>
+    many l e t t e r s s e p a r a t e d b y s p a c e s
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-trim-float-drives-container-intrinsic-size-inline-layout-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-trim-float-drives-container-intrinsic-size-inline-layout-expected.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="The float should contribute its border box logical width since margin-trim: inline is specified (and drives the containing block size in this case)">
+<style>
+container {
+    display: block;
+    width: min-content;
+    font-family: monospace;
+    font-size: 10px;
+    border: 1px solid black;
+}
+item {
+    display: block;
+    float: left;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+
+}
+</style>
+</head>
+<body>
+<container>
+    <item></item>
+    many l e t t e r s s e p a r a t e d b y s p a c e s
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-trim-float-drives-container-intrinsic-size-inline-layout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-trim-float-drives-container-intrinsic-size-inline-layout.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="The float should contribute its border box logical width since margin-trim: inline is specified (and drives the containing block size in this case)">
+<style>
+container {
+    display: block;
+    width: min-content;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline;
+    border: 1px solid black;
+}
+item {
+    display: block;
+    float: left;
+    width: 50px;
+    height: 50px;
+    margin-inline: 30px;
+    background-color: green;
+
+}
+</style>
+</head>
+<body>
+<container>
+    <item></item>
+    many l e t t e r s s e p a r a t e d b y s p a c e s
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-trim-text-drives-container-intrinsic-size-inline-layout-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-trim-text-drives-container-intrinsic-size-inline-layout-expected.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Text should drive the containing block's intrinsic size. Since margin-trim: inline is specified, both margins should be zeroed">
+<style>
+container {
+    display: block;
+    inline-size: min-content;
+    font-family: monospace;
+    font-size: 10px;
+    border: 1px solid black;
+}
+item {
+    display: block;
+    float: left;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+
+}
+.clear-floats {
+    clear: left;
+}
+</style>
+</head>
+<body>
+<container>
+    longwordinfluencescontainerintrinsicsize </br>
+    <item></item>
+    <div class="clear-floats">text that should be after the float</div>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-trim-text-drives-container-intrinsic-size-inline-layout-vert-lr-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-trim-text-drives-container-intrinsic-size-inline-layout-vert-lr-expected.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Text should drive the containing block's intrinsic size. Since margin-trim: inline is specified, both margins should be zeroed">
+<style>
+container {
+    display: block;
+    writing-mode: vertical-lr;
+    inline-size: min-content;
+    font-family: monospace;
+    font-size: 10px;
+    border: 1px solid black;
+}
+item {
+    display: block;
+    float: left;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+
+}
+.clear-floats {
+    clear: left;
+}
+</style>
+</head>
+<body>
+<container>
+    longwordinfluencescontainerintrinsicsize </br>
+    <item></item>
+    <div class="clear-floats">text that should be after the float</div>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-trim-text-drives-container-intrinsic-size-inline-layout-vert-lr.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-trim-text-drives-container-intrinsic-size-inline-layout-vert-lr.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Text should drive the containing block's intrinsic size. Since margin-trim: inline is specified, both margins should be zeroed">
+<style>
+container {
+    display: block;
+    writing-mode: vertical-lr;
+    inline-size: min-content;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline;
+    border: 1px solid black;
+}
+item {
+    display: block;
+    float: left;
+    width: 50px;
+    height: 50px;
+    margin-inline: 200px;
+    background-color: green;
+
+}
+</style>
+</head>
+<body>
+<container>
+    longwordinfluencescontainerintrinsicsize
+    <item></item>
+    text that should be after the float
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-trim-text-drives-container-intrinsic-size-inline-layout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-trim-text-drives-container-intrinsic-size-inline-layout.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Text should drive the containing block's intrinsic size. Since margin-trim: inline is specified, both margins should be zeroed">
+<style>
+container {
+    display: block;
+    inline-size: min-content;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline;
+    border: 1px solid black;
+}
+item {
+    display: block;
+    float: left;
+    width: 50px;
+    height: 50px;
+    margin-inline: 200px;
+    background-color: green;
+
+}
+</style>
+</head>
+<body>
+<container>
+    longwordinfluencescontainerintrinsicsize
+    <item></item>
+    text that should be after the float
+</container>
+</body>
+</html>

--- a/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
@@ -361,6 +361,9 @@ static OptionSet<AvoidanceReason> canUseForChild(const RenderBlockFlow& flow, co
             if (renderer.isFloating() && !renderer.parent()->style().isHorizontalWritingMode())
                 return false;
 #endif
+            // Floats where the block container specifies margin-tirm need IFC implementation (geometry adjustment)
+            if (!flow.style().marginTrim().isEmpty())
+                return false;
             if (renderer.isOutOfFlowPositioned()) {
                 if (!renderer.parent()->style().isLeftToRightDirection())
                     return false;

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -4556,8 +4556,8 @@ void RenderBlockFlow::computeInlinePreferredLogicalWidths(LayoutUnit& minLogical
                     if (!child->isFloating())
                         lastText = nullptr;
                     LayoutUnit margins;
-                    Length startMargin = childStyle.marginStartUsing(&style());
-                    Length endMargin = childStyle.marginEndUsing(&style());
+                    Length startMargin = shouldChildInlineMarginContributeToContainerIntrinsicSize(MarginTrimType::InlineStart, *dynamicDowncast<RenderElement>(child)) ? childStyle.marginStartUsing(&style()) : Length(0, LengthType::Fixed); 
+                    Length endMargin = shouldChildInlineMarginContributeToContainerIntrinsicSize(MarginTrimType::InlineEnd, *dynamicDowncast<RenderElement>(child)) ? childStyle.marginEndUsing(&style()) : Length(0, LengthType::Fixed);
                     if (startMargin.isFixed())
                         margins += LayoutUnit::fromFloatCeil(startMargin.value());
                     if (endMargin.isFixed())


### PR DESCRIPTION
#### 35416b6b8ce498954d542f25d74cb15f3a35f089
<pre>
Floats&apos; trimmed margins should not contribute to containing block&apos;s intrinsic sizing (legacy line layout)
<a href="https://bugs.webkit.org/show_bug.cgi?id=252976">https://bugs.webkit.org/show_bug.cgi?id=252976</a>
rdar://105960289

Reviewed by Alan Baradlay.

When a containing block establishes and inline formatting context and
it is being sized under some sort of intrinsic sizing constraint (e.g.
width: min-content), then the margins of any float within that
containing block should not contribute to the intrinsic sizing if it
is specified under margin-trim. The logic is the same as in the block
layout case and we can use the same helper to check whether a margin
should contribute to the sizing:
shouldChildInlineMarginContributeToContainerIntrinsicSize.

container {
    display: block;
    inline-size: min-content;
    font-family: monospace;
    font-size: 10px;
    margin-trim: inline;
    border: 1px solid black;
}
item {
    display: block;
    float: left;
    width: 50px;
    height: 50px;
    margin-inline: 200px;
    background-color: green;

}
&lt;/style&gt;
&lt;container&gt;
    longwordinfluencescontainerintrinsicsize
    &lt;item&gt;&lt;/item&gt;
    text that should be after the float
&lt;/container&gt;

Normally, the logical width of the containing block here would be drove
by the float and its margin box size, but since margin-trim: inline
is specified neither of its inline margins will be taken into
consideration. Only the border box width will be used.

&lt;style&gt;
container {
    display: block;
    width: min-content;
    font-family: monospace;
    font-size: 10px;
    margin-trim: inline-start;
    border: 1px solid black;
}
item {
    display: block;
    float: left;
    width: 50px;
    height: 50px;
    margin-inline: 30px;
    background-color: green;

}
&lt;/style&gt;
&lt;body&gt;
&lt;container&gt;
    &lt;item&gt;&lt;/item&gt;
    many l e t t e r s s e p a r a t e d b y s p a c e s
&lt;/container&gt;

In this case normally the containing block logical width would be drove
by the item&apos;s margin box with both inline margins, but since
margin-trim: inline-start is specified that margin will not be used.
Instead the logical width of the containing block is the float&apos;s
border box logical width + the inline-end margin.

* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-trim-float-drives-container-intrinsic-size-expected.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-trim-float-drives-container-intrinsic-size-orthogonal-expected.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-trim-float-drives-container-intrinsic-size-orthogonal.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-trim-float-drives-container-intrinsic-size-rtl-expected.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-trim-float-drives-container-intrinsic-size-rtl.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-trim-float-drives-container-intrinsic-size.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-trim-float-drives-container-intrinsic-size-inline-layout-expected.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-trim-float-drives-container-intrinsic-size-inline-layout.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-trim-text-drives-container-intrinsic-size-inline-layout-expected.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-trim-text-drives-container-intrinsic-size-inline-layout-vert-lr-expected.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-trim-text-drives-container-intrinsic-size-inline-layout-vert-lr.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-trim-text-drives-container-intrinsic-size-inline-layout.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-trim-float-drives-container-intrinsic-size-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-trim-float-drives-container-intrinsic-size-rtl-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-trim-float-drives-container-intrinsic-size-rtl.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-trim-float-drives-container-intrinsic-size.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-trim-float-drives-container-intrinsic-size-inline-layout-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-trim-float-drives-container-intrinsic-size-inline-layout.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-trim-text-drives-container-intrinsic-size-inline-layout-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-trim-text-drives-container-intrinsic-size-inline-layout-vert-lr-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-trim-text-drives-container-intrinsic-size-inline-layout-vert-lr.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-trim-text-drives-container-intrinsic-size-inline-layout.html: Added.
* Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp:
(WebCore::LayoutIntegration::canUseForChild):
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::computeInlinePreferredLogicalWidths const):

Canonical link: <a href="https://commits.webkit.org/260906@main">https://commits.webkit.org/260906@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/207280d0e3e27229da13845c87e6a1a8457e9bd5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109825 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18938 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42554 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1287 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118926 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113775 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20405 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10134 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102094 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115573 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15189 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98418 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43410 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97152 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30075 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85209 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11657 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31417 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12301 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8354 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17671 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51026 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7562 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14063 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->