### PR TITLE
[webkitcorepy] Add a PartialProxy class

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/setup.py
+++ b/Tools/Scripts/libraries/webkitcorepy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='webkitcorepy',
-    version='0.14.0',
+    version='0.14.1',
     description='Library containing various Python support classes and functions.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
@@ -46,8 +46,9 @@ from webkitcorepy.editor import Editor
 from webkitcorepy.file_lock import FileLock
 from webkitcorepy.null_context import NullContext
 from webkitcorepy.filtered_call import filtered_call
+from webkitcorepy.partial_proxy import PartialProxy
 
-version = Version(0, 14, 0)
+version = Version(0, 14, 1)
 
 from webkitcorepy.autoinstall import Package, AutoInstall
 if sys.version_info > (3, 0):

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/partial_proxy.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/partial_proxy.py
@@ -1,0 +1,81 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from webkitcorepy import mocks
+
+
+class PartialProxy(mocks.ContextStack):
+    top = None
+
+    def __init__(self, hosts, http, https):
+        super(PartialProxy, self).__init__(cls=PartialProxy)
+        self.hosts = hosts
+        self.http = http
+        self.https = https
+
+        self._temp_patches = None
+
+    def __enter__(self):
+        # Allow requests and mock to be managed via autoinstall
+        import requests
+        from mock import patch
+
+        this = self
+
+        class Session(requests.Session):
+            def request(self, method, url, **kwargs):
+                split = url.split('/')
+                protocol = split[0]
+                host = split[2] if len(split) >= 3 else None
+
+                if host and protocol in ('http:', 'https:'):
+                    current = PartialProxy.top
+                    while current:
+                        if host in current.hosts:
+                            kwargs['proxies'] = dict(
+                                http=current.http,
+                                https=current.https,
+                            )
+                            break
+                        current = current.previous
+
+                return super(Session, self).request(method, url, **kwargs)
+
+        self._temp_patches = [
+            patch('requests.Session', new=Session),
+            patch('requests.request', new=lambda *args, **kwargs: Session().request(*args, **kwargs)),
+            patch('requests.get', new=lambda *args, **kwargs: Session().request('GET', *args, **kwargs)),
+            patch('requests.head', new=lambda *args, **kwargs: Session().request('HEAD', *args, **kwargs)),
+            patch('requests.post', new=lambda *args, **kwargs: Session().request('POST', *args, **kwargs)),
+            patch('requests.put', new=lambda *args, **kwargs: Session().request('PUT', *args, **kwargs)),
+            patch('requests.patch', new=lambda *args, **kwargs: Session().request('PATCH', *args, **kwargs)),
+            patch('requests.delete', new=lambda *args, **kwargs: Session().request('DELETE', *args, **kwargs)),
+        ]
+        for patch in self._temp_patches:
+            patch.__enter__()
+        return super(PartialProxy, self).__enter__()
+
+    def __exit__(self, *args, **kwargs):
+        super(PartialProxy, self).__exit__(*args, **kwargs)
+        for patch in reversed(self._temp_patches):
+            patch.__exit__(*args, **kwargs)
+        self._temp_patches = None

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/partial_proxy_unittest.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/partial_proxy_unittest.py
@@ -1,0 +1,58 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import unittest
+
+
+class DummySession(object):
+    PROXIES = None
+
+    def __init__(self):
+        DummySession.PROXIES = None
+
+    def request(self, method, url, **kwargs):
+        DummySession.PROXIES = kwargs.get('proxies', None)
+
+
+class PartialProxyTest(unittest.TestCase):
+    def test_session(self):
+        # Some imports must be done within mock contexts because we're attempting to
+        # test an override of request.Session with an override of request.Session
+        from mock import patch
+
+        with patch('requests.Session', new=DummySession):
+            from webkitcorepy import PartialProxy
+
+            with PartialProxy(
+                ['bugs.webkit.org'],
+                http='http://proxy.webkit.org:80',
+                https='https://proxy.webkit.org:443',
+            ):
+                import requests
+                requests.get('https://bugs.webkit.org')
+                self.assertDictEqual(DummySession.PROXIES, dict(
+                    http='http://proxy.webkit.org:80',
+                    https='https://proxy.webkit.org:443',
+                ))
+
+                requests.get('https://commits.webkit.org')
+                self.assertIsNone(DummySession.PROXIES)


### PR DESCRIPTION
#### 775f730ac67edfb60a140d4550965b89b6205547
<pre>
[webkitcorepy] Add a PartialProxy class
<a href="https://bugs.webkit.org/show_bug.cgi?id=253007">https://bugs.webkit.org/show_bug.cgi?id=253007</a>
rdar://105984609

Rubber-stamped by Aakash Jain.

Allow Python programs to send requests to specific hosts through a proxy, but not requests
to all hosts.

* Tools/Scripts/libraries/webkitcorepy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py: Export PartialProxy class.
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/partial_proxy.py: Added.
(PartialProxy.__init__): Store the hosts and http and https proxies.
(PartialProxy.__enter__): Mock all request calls to use a temporary Session object.
(PartialProxy.__enter__.Session): Add proxy arguments to requests to the specified hosts.
(PartialProxy.__exit__):
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/partial_proxy_unittest.py: Added.
(DummySession): Session object which simply stores the passed proxy arguments.
(PartialProxyTest.test_session):

Canonical link: <a href="https://commits.webkit.org/260909@main">https://commits.webkit.org/260909@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe52f30a16fdb4bce8ae861a03cf47e4d9f172a6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109923 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19027 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/42619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1371 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/118987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113873 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20491 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10217 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/102185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115672 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/42619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/102185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/113370 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/42619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/102185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11733 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/42619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/12364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/108691 "Passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/17733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/42619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14150 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4106 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->