### PR TITLE
Build failure in CARingBuffer.h when the build is not unified

### DIFF
--- a/Source/WebCore/platform/audio/cocoa/CARingBuffer.h
+++ b/Source/WebCore/platform/audio/cocoa/CARingBuffer.h
@@ -39,6 +39,8 @@ typedef struct AudioBufferList AudioBufferList;
 
 namespace WebCore {
 
+class CAAudioStreamDescription;
+
 class CARingBuffer {
     WTF_MAKE_FAST_ALLOCATED;
 public:
@@ -113,7 +115,6 @@ inline CARingBuffer::FetchMode CARingBuffer::fetchModeForMixing(AudioStreamDescr
         return MixFloat64;
     }
 }
-
 
 class InProcessCARingBuffer final : public CARingBuffer {
 public:


### PR DESCRIPTION
#### 989e6bef9a95ef968b4bf97946edd01af8aacd72
<pre>
Build failure in CARingBuffer.h when the build is not unified
<a href="https://bugs.webkit.org/show_bug.cgi?id=253016">https://bugs.webkit.org/show_bug.cgi?id=253016</a>

Reviewed by Alexey Proskuryakov.

* Source/WebCore/platform/audio/cocoa/CARingBuffer.h:

Canonical link: <a href="https://commits.webkit.org/260926@main">https://commits.webkit.org/260926@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53ce19dac4ee85abbeb45ae2e5fd3a1a25148da0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109887 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18996 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42597 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1343 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118968 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113837 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20462 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10190 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102156 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115635 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15232 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98453 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43454 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97195 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30108 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85262 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11705 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31450 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12343 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8400 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17712 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51059 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14120 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4108 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->