### PR TITLE
Fix Live Text layout for images with vertical writing mode

### DIFF
--- a/LayoutTests/fast/images/text-recognition/mac/layout-for-vertical-writing-mode-expected.txt
+++ b/LayoutTests/fast/images/text-recognition/mac/layout-for-vertical-writing-mode-expected.txt
@@ -1,0 +1,5 @@
+PASS writingMode is "vertical-rl"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/images/text-recognition/mac/layout-for-vertical-writing-mode.html
+++ b/LayoutTests/fast/images/text-recognition/mac/layout-for-vertical-writing-mode.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<head>
+<script src="../../../../resources/js-test.js"></script>
+<style>
+img {
+    width: 100px;
+    height: 100px;
+    box-sizing: border-box;
+    border: 1px solid black;
+    display: block;
+}
+
+a {
+    display: block;
+}
+</style>
+<script>
+addEventListener("load", () => {
+    let image = document.getElementById("inside-link");
+
+    internals.installImageOverlay(image, [
+        {
+            topLeft : new DOMPointReadOnly(0, 0.3),
+            topRight : new DOMPointReadOnly(1, 0.3),
+            bottomRight : new DOMPointReadOnly(1, 0.7),
+            bottomLeft : new DOMPointReadOnly(0, 0.7),
+            children: [{
+                text : "Hello",
+                topLeft : new DOMPointReadOnly(0, 0.3),
+                topRight : new DOMPointReadOnly(1, 0.3),
+                bottomRight : new DOMPointReadOnly(1, 0.7),
+                bottomLeft : new DOMPointReadOnly(0, 0.7),
+            }],
+            isVertical : true
+        }
+    ]);
+
+    let rect = image.getBoundingClientRect();
+    eventSender.mouseMoveTo(rect.left + rect.width / 2, rect.top + rect.height / 2);
+    const overlay = internals.shadowRoot(image).getElementById("image-overlay");
+    writingMode = getComputedStyle(overlay.childNodes[0].childNodes[0]).writingMode;
+    shouldBeEqualToString("writingMode", "vertical-rl");
+});
+</script>
+</head>
+<body>
+<a href="#">
+    <img id="inside-link" src="../../resources/green-400x400.png"></img>
+</a>
+</body>
+</html>

--- a/Source/WebCore/PAL/pal/spi/cocoa/VisionKitCoreSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/VisionKitCoreSPI.h
@@ -138,8 +138,16 @@ typedef NS_ENUM(NSInteger, VKImageOrientation) {
 @property (nonatomic, readonly) VKQuad *quad;
 @end
 
+typedef NS_ENUM(NSUInteger, CRLayoutDirection) {
+    CRLayoutDirectionUnknown = 0,
+    CRLayoutDirectionLeftToRight,
+    CRLayoutDirectionRightToLeft,
+    CRLayoutDirectionTopToBottom,
+};
+
 @interface VKWKLineInfo : VKWKTextInfo
 @property (nonatomic, readonly) NSArray<VKWKTextInfo *> *children;
+@property (nonatomic, readonly) CRLayoutDirection layoutDirection;
 @end
 
 @class DDScannerResult;
@@ -165,6 +173,7 @@ NS_ASSUME_NONNULL_END
 
 @interface VKWKLineInfo (Staging_85139101)
 @property (nonatomic, readonly) BOOL shouldWrap;
+@property (nonatomic, readonly) CRLayoutDirection layoutDirection;
 @end
 
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)

--- a/Source/WebCore/dom/ImageOverlay.cpp
+++ b/Source/WebCore/dom/ImageOverlay.cpp
@@ -584,10 +584,13 @@ void updateWithTextRecognitionResult(HTMLElement& element, const TextRecognition
             ));
 
             textContainer->setInlineStyleProperty(CSSPropertyWebkitUserSelect, applyUserSelectAll ? CSSValueAll : CSSValueNone);
+
+            if (line.isVertical)
+                textContainer->setInlineStyleProperty(CSSPropertyWritingMode, CSSValueVerticalRl);
         }
 
         if (document->isImageDocument())
-            lineContainer->setInlineStyleProperty(CSSPropertyCursor, CSSValueText);
+            lineContainer->setInlineStyleProperty(CSSPropertyCursor, line.isVertical ? CSSValueVerticalText : CSSValueText);
     }
 
 #if ENABLE(DATA_DETECTION)

--- a/Source/WebCore/platform/TextRecognitionResult.h
+++ b/Source/WebCore/platform/TextRecognitionResult.h
@@ -56,16 +56,18 @@ struct TextRecognitionWordData {
 };
 
 struct TextRecognitionLineData {
-    TextRecognitionLineData(FloatQuad&& quad, Vector<TextRecognitionWordData>&& theChildren, bool newline)
+    TextRecognitionLineData(FloatQuad&& quad, Vector<TextRecognitionWordData>&& theChildren, bool newline, bool isVertical)
         : normalizedQuad(WTFMove(quad))
         , children(WTFMove(theChildren))
         , hasTrailingNewline(newline)
+        , isVertical(isVertical)
     {
     }
 
     FloatQuad normalizedQuad;
     Vector<TextRecognitionWordData> children;
     bool hasTrailingNewline { true };
+    bool isVertical { false };
 };
 
 #if ENABLE(DATA_DETECTION)

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -6089,7 +6089,8 @@ static TextRecognitionLineData makeDataForLine(const Internals::ImageOverlayLine
         line.children.map([](auto& textChild) -> TextRecognitionWordData {
             return { textChild.text, getQuad(textChild), textChild.hasLeadingWhitespace };
         }),
-        line.hasTrailingNewline
+        line.hasTrailingNewline,
+        line.isVertical
     };
 }
 

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1006,6 +1006,7 @@ public:
         RefPtr<DOMPointReadOnly> bottomLeft;
         Vector<ImageOverlayText> children;
         bool hasTrailingNewline { true };
+        bool isVertical { false };
 
         ~ImageOverlayLine();
     };

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -319,6 +319,7 @@ enum HEVCParameterCodec {
     required DOMPointReadOnly bottomLeft;
     sequence<ImageOverlayText> children;
     boolean hasTrailingNewline = true;
+    boolean isVertical = false;
 };
 
 [

--- a/Source/WebKit/Platform/cocoa/ImageAnalysisUtilities.mm
+++ b/Source/WebKit/Platform/cocoa/ImageAnalysisUtilities.mm
@@ -122,7 +122,8 @@ TextRecognitionResult makeTextRecognitionResult(CocoaImageAnalysis *analysis)
         VKWKLineInfo *nextLine = nextLineIndex < allLines.count ? allLines[nextLineIndex] : nil;
         // The `shouldWrap` property indicates whether or not a line should wrap, relative to the previous line.
         bool hasTrailingNewline = nextLine && (![nextLine respondsToSelector:@selector(shouldWrap)] || ![nextLine shouldWrap]);
-        result.lines.uncheckedAppend({ floatQuad(line.quad), WTFMove(children), hasTrailingNewline });
+        bool isVertical = [line respondsToSelector:@selector(layoutDirection)] && [line layoutDirection] == CRLayoutDirectionTopToBottom;
+        result.lines.uncheckedAppend({ floatQuad(line.quad), WTFMove(children), hasTrailingNewline, isVertical });
         isFirstLine = false;
         nextLineIndex++;
     }

--- a/Source/WebKit/Shared/TextRecognitionResult.serialization.in
+++ b/Source/WebKit/Shared/TextRecognitionResult.serialization.in
@@ -34,6 +34,7 @@ header: <WebCore/TextRecognitionResult.h>
     WebCore::FloatQuad normalizedQuad;
     Vector<WebCore::TextRecognitionWordData> children;
     bool hasTrailingNewline;
+    bool isVertical;
 };
 
 header: <WebCore/TextRecognitionResult.h>


### PR DESCRIPTION
#### 655c6f748f08e8b475ea137a5d782c6b2915c336
<pre>
Fix Live Text layout for images with vertical writing mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=253020">https://bugs.webkit.org/show_bug.cgi?id=253020</a>
rdar://101314828

Reviewed by Wenson Hsieh.

* LayoutTests/fast/images/text-recognition/mac/layout-for-vertical-writing-mode-expected.txt: Added.
* LayoutTests/fast/images/text-recognition/mac/layout-for-vertical-writing-mode.html: Added.
* Source/WebCore/PAL/pal/spi/cocoa/VisionKitCoreSPI.h:
* Source/WebCore/dom/ImageOverlay.cpp:
(WebCore::ImageOverlay::updateWithTextRecognitionResult):
* Source/WebCore/platform/TextRecognitionResult.h:
(WebCore::TextRecognitionLineData::TextRecognitionLineData):
* Source/WebCore/testing/Internals.cpp:
(WebCore::makeDataForLine):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/Platform/cocoa/ImageAnalysisUtilities.mm:
(WebKit::makeTextRecognitionResult):
* Source/WebKit/Shared/TextRecognitionResult.serialization.in:

Canonical link: <a href="https://commits.webkit.org/260968@main">https://commits.webkit.org/260968@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/061acad4e20db075e5fa5fbc70da78d1492353df

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109879 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18988 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42590 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1335 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118961 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113829 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20455 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10183 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102147 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115627 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15231 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98448 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43449 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97194 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30104 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85256 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11698 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31446 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12336 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8394 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17709 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51055 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7602 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14112 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->