### PR TITLE
[web-animations] allow acceleration of CSS property animation to be governed by settings

### DIFF
--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -60,6 +60,7 @@
 #include "QuotesData.h"
 #include "RenderBox.h"
 #include "RenderStyle.h"
+#include "Settings.h"
 #include "StyleCachedImage.h"
 #include "StyleCrossfadeImage.h"
 #include "StyleFilterImage.h"
@@ -686,7 +687,7 @@ public:
 
     CSSPropertyID property() const { return m_property; }
 
-    virtual bool animationIsAccelerated() const { return false; }
+    virtual bool animationIsAccelerated(const Settings&) const { return false; }
 
 private:
     CSSPropertyID m_property;
@@ -1347,7 +1348,7 @@ public:
     }
 
 private:
-    bool animationIsAccelerated() const final { return true; }
+    bool animationIsAccelerated(const Settings&) const final { return true; }
     bool requiresBlendingForAccumulativeIteration(const RenderStyle&, const RenderStyle&) const final { return this->property() == CSSPropertyTransform; }
 };
 
@@ -1361,7 +1362,7 @@ public:
     }
 
 private:
-    bool animationIsAccelerated() const final { return true; }
+    bool animationIsAccelerated(const Settings&) const final { return true; }
 
     bool equals(const RenderStyle& a, const RenderStyle& b) const final
     {
@@ -1378,7 +1379,7 @@ public:
     }
 
 private:
-    bool animationIsAccelerated() const final
+    bool animationIsAccelerated(const Settings&) const final
     {
         return property() == CSSPropertyFilter
 #if ENABLE(FILTERS_LEVEL_2)
@@ -4103,12 +4104,12 @@ bool CSSPropertyAnimation::propertyRequiresBlendingForAccumulativeIteration(cons
     );
 }
 
-bool CSSPropertyAnimation::animationOfPropertyIsAccelerated(AnimatableProperty property)
+bool CSSPropertyAnimation::animationOfPropertyIsAccelerated(AnimatableProperty property, const Settings& settings)
 {
     return WTF::switchOn(property,
-        [] (CSSPropertyID cssProperty) {
+        [&] (CSSPropertyID cssProperty) {
             if (auto* wrapper = CSSPropertyAnimationWrapperMap::singleton().wrapperForProperty(cssProperty))
-                return wrapper->animationIsAccelerated();
+                return wrapper->animationIsAccelerated(settings);
             return false;
         }, [] (const AtomString&) { return false; }
     );

--- a/Source/WebCore/animation/CSSPropertyAnimation.h
+++ b/Source/WebCore/animation/CSSPropertyAnimation.h
@@ -39,13 +39,14 @@ namespace WebCore {
 class CSSPropertyBlendingClient;
 class Document;
 class RenderStyle;
+class Settings;
 
 class CSSPropertyAnimation {
 public:
     static bool isPropertyAnimatable(AnimatableProperty);
     static bool isPropertyAdditiveOrCumulative(AnimatableProperty);
     static bool propertyRequiresBlendingForAccumulativeIteration(const CSSPropertyBlendingClient&, AnimatableProperty, const RenderStyle& a, const RenderStyle& b);
-    static bool animationOfPropertyIsAccelerated(AnimatableProperty);
+    static bool animationOfPropertyIsAccelerated(AnimatableProperty, const Settings&);
     static bool propertiesEqual(AnimatableProperty, const RenderStyle& a, const RenderStyle& b, const Document&);
     static bool canPropertyBeInterpolated(AnimatableProperty, const RenderStyle& a, const RenderStyle& b, const Document&);
     static CSSPropertyID getPropertyAtIndex(int, std::optional<bool>& isShorthand);

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -30,6 +30,7 @@
 #include "CSSPropertyBlendingClient.h"
 #include "CompositeOperation.h"
 #include "CompositeOperationOrAuto.h"
+#include "Document.h"
 #include "EffectTiming.h"
 #include "Element.h"
 #include "IterationCompositeOperation.h"
@@ -239,6 +240,8 @@ private:
     bool ticksContinouslyWhileActive() const final;
     std::optional<double> progressUntilNextStep(double) const final;
     bool preventsAnimationReadiness() const final;
+
+    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
 
     AtomString m_keyframesName;
     KeyframeList m_blendingKeyframes { emptyAtom() };

--- a/Source/WebCore/animation/KeyframeEffectStack.cpp
+++ b/Source/WebCore/animation/KeyframeEffectStack.cpp
@@ -30,6 +30,7 @@
 #include "CSSAnimation.h"
 #include "CSSPropertyAnimation.h"
 #include "CSSTransition.h"
+#include "Document.h"
 #include "KeyframeEffect.h"
 #include "WebAnimation.h"
 #include "WebAnimationUtilities.h"
@@ -252,7 +253,7 @@ void KeyframeEffectStack::didApplyCascade(const RenderStyle& styleBeforeCascade,
     HashSet<AnimatableProperty> acceleratedPropertiesOverriddenByCascade;
     if (styleBeforeCascade != styleAfterCascade) {
         for (auto animatedProperty : animatedProperties) {
-            if (!CSSPropertyAnimation::animationOfPropertyIsAccelerated(animatedProperty))
+            if (!CSSPropertyAnimation::animationOfPropertyIsAccelerated(animatedProperty, document.settings()))
                 continue;
             if (!CSSPropertyAnimation::propertiesEqual(animatedProperty, styleBeforeCascade, styleAfterCascade, document))
                 acceleratedPropertiesOverriddenByCascade.add(animatedProperty);

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -2407,7 +2407,7 @@ static inline const RenderStyle* computeRenderStyleForProperty(Element& element,
     if (!renderer)
         renderer = element.renderer();
 
-    if (renderer && renderer->isComposited() && CSSPropertyAnimation::animationOfPropertyIsAccelerated(propertyID)) {
+    if (renderer && renderer->isComposited() && CSSPropertyAnimation::animationOfPropertyIsAccelerated(propertyID, element.document().settings())) {
         ownedStyle = renderer->animatedStyle();
         if (pseudoElementSpecifier != PseudoId::None) {
             // FIXME: This cached pseudo style will only exist if the animation has been run at least once.


### PR DESCRIPTION
#### f14cfb613307745c3ad6dede1b4a63945865e3f2
<pre>
[web-animations] allow acceleration of CSS property animation to be governed by settings
<a href="https://bugs.webkit.org/show_bug.cgi?id=253022">https://bugs.webkit.org/show_bug.cgi?id=253022</a>

Reviewed by Dean Jackson.

The work on threaded animation resolution will allow us to opt certain CSS properties into
being accelerated. In order to be able to do that when that runtime flag is enabled, we need
to pass Settings to AnimationPropertyWrapperBase::animationIsAccelerated(). To that end, we
add a WeakPtr&lt;Document&gt; member to KeyframeEffect, such that we may access settings for the
various method calls that rely on CSSPropertyAnimation::animationOfPropertyIsAccelerated().

* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::AnimationPropertyWrapperBase::animationIsAccelerated const):
(WebCore::CSSPropertyAnimation::animationOfPropertyIsAccelerated):
* Source/WebCore/animation/CSSPropertyAnimation.h:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::create):
(WebCore::KeyframeEffect::KeyframeEffect):
(WebCore::KeyframeEffect::copyPropertiesFromSource):
(WebCore::KeyframeEffect::isRunningAcceleratedAnimationForProperty const):
(WebCore::KeyframeEffect::computeAcceleratedPropertiesState):
(WebCore::KeyframeEffect::document const):
(WebCore::KeyframeEffect::computeHasImplicitKeyframeForAcceleratedProperty):
(WebCore::KeyframeEffect::computeHasKeyframeComposingAcceleratedProperty):
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/animation/KeyframeEffectStack.cpp:
(WebCore::KeyframeEffectStack::didApplyCascade):
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::computeRenderStyleForProperty):

Canonical link: <a href="https://commits.webkit.org/260933@main">https://commits.webkit.org/260933@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e4a7a5778273ced731a6690201291b7132f49d48

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109886 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/18995 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42596 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1342 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118967 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113836 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20461 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10189 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102155 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115634 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15235 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98450 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43452 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97198 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30106 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85260 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11704 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31448 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12342 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8398 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17711 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51057 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14119 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4111 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->