### PR TITLE
[CMake] Add Brotli targets

### DIFF
--- a/Source/WebCore/PlatformWin.cmake
+++ b/Source/WebCore/PlatformWin.cmake
@@ -238,8 +238,8 @@ if (USE_WOFF2)
     # The WOFF2 libraries don't compile as DLLs on Windows, so add in
     # the additional libraries WOFF2::dec requires
     list(APPEND WebCore_LIBRARIES
+        Brotli::dec
         WOFF2::common
-        brotlidec
     )
 endif ()
 

--- a/Source/cmake/FindBrotli.cmake
+++ b/Source/cmake/FindBrotli.cmake
@@ -1,0 +1,165 @@
+# Copyright (C) 2023 Sony Interactive Entertainment Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND ITS CONTRIBUTORS ``AS
+# IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR ITS
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#[=======================================================================[.rst:
+FindBrotli
+--------------
+
+Find Brotli headers and libraries.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+``Brotli::common``
+  The Brotli common library, if found.
+
+``Brotli::dec``
+  The Brotli dec library, if found.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This will define the following variables in your project:
+
+``Brotli_FOUND``
+  true if (the requested version of) Brotli is available.
+``Brotli_VERSION``
+  the version of Brotli.
+``Brotli_LIBRARIES``
+  the libraries to link against to use Brotli.
+``Brotli_INCLUDE_DIRS``
+  where to find the Brotli headers.
+``Brotli_COMPILE_OPTIONS``
+  this should be passed to target_compile_options(), if the
+  target is not used for linking
+
+#]=======================================================================]
+
+find_package(PkgConfig QUIET)
+pkg_check_modules(PC_Brotli QUIET libbrotlicommon)
+set(Brotli_COMPILE_OPTIONS ${PC_Brotli_CFLAGS_OTHER})
+set(Brotli_VERSION ${PC_Brotli_VERSION})
+
+find_library(Brotli_LIBRARY
+    NAMES ${Brotli_NAMES} brotlicommon
+    HINTS ${PC_Brotli_LIBDIR} ${PC_Brotli_LIBRARY_DIRS}
+)
+
+# There's nothing in the Brotli headers that could be used to detect the exact
+# Brotli version being used so don't attempt to do so. A version can only be found
+# through pkg-config
+if ("${Brotli_FIND_VERSION}" VERSION_GREATER "${Brotli_VERSION}")
+    if (Brotli_VERSION)
+        message(FATAL_ERROR "Required version (" ${Brotli_FIND_VERSION} ") is higher than found version (" ${Brotli_VERSION} ")")
+    else ()
+        message(WARNING "Cannot determine Brotli version without pkg-config")
+    endif ()
+endif ()
+
+# Find components
+if (Brotli_LIBRARY)
+    set(_Brotli_REQUIRED_LIBS_FOUND ON)
+    set(Brotli_LIBS_FOUND "Brotli (required): ${Brotli_LIBRARY}")
+else ()
+    set(_Brotli_REQUIRED_LIBS_FOUND OFF)
+    set(Brotli_LIBS_NOT_FOUND "Brotli (required)")
+endif ()
+
+if ("dec" IN_LIST Brotli_FIND_COMPONENTS)
+    pkg_check_modules(PC_Brotli_DEC brotlidec)
+
+    find_path(Brotli_INCLUDE_DIR
+        NAMES brotli/decode.h
+        HINTS ${PC_Brotli_DEC_INCLUDEDIR} ${PC_Brotli_DEC_INCLUDE_DIRS}
+    )
+
+    find_library(Brotli_DEC_LIBRARY
+        NAMES ${Brotli_DEC_NAMES} Brotlidec
+        HINTS ${PC_Brotli_DEC_LIBDIR} ${PC_Brotli_DEC_LIBRARY_DIRS}
+    )
+
+    if (Brotli_DEC_LIBRARY)
+        if (Brotli_FIND_REQUIRED_dec)
+            list(APPEND Brotli_LIBS_FOUND "dec (required): ${Brotli_DEC_LIBRARY}")
+        else ()
+            list(APPEND Brotli_LIBS_FOUND "dec (optional): ${Brotli_DEC_LIBRARY}")
+        endif ()
+    else ()
+        if (Brotli_FIND_REQUIRED_dec)
+            set(_Brotli_REQUIRED_LIBS_FOUND OFF)
+            list(APPEND Brotli_LIBS_NOT_FOUND "dec (required)")
+        else ()
+            list(APPEND Brotli_LIBS_NOT_FOUND "dec (optional)")
+        endif ()
+    endif ()
+endif ()
+
+if (NOT Brotli_FIND_QUIETLY)
+    if (Brotli_LIBS_FOUND)
+        message(STATUS "Found the following Brotli libraries:")
+        foreach (found ${Brotli_LIBS_FOUND})
+            message(STATUS " ${found}")
+        endforeach ()
+    endif ()
+    if (Brotli_LIBS_NOT_FOUND)
+        message(STATUS "The following Brotli libraries were not found:")
+        foreach (found ${Brotli_LIBS_NOT_FOUND})
+            message(STATUS " ${found}")
+        endforeach ()
+    endif ()
+endif ()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Brotli
+    FOUND_VAR Brotli_FOUND
+    REQUIRED_VARS Brotli_LIBRARY _Brotli_REQUIRED_LIBS_FOUND
+    VERSION_VAR Brotli_VERSION
+)
+
+if (Brotli_LIBRARY AND NOT TARGET Brotli::common)
+    add_library(Brotli::common UNKNOWN IMPORTED GLOBAL)
+    set_target_properties(Brotli::common PROPERTIES
+        IMPORTED_LOCATION "${Brotli_LIBRARY}"
+        INTERFACE_COMPILE_OPTIONS "${Brotli_COMPILE_OPTIONS}"
+    )
+endif ()
+
+if (Brotli_DEC_LIBRARY AND NOT TARGET Brotli::dec)
+    add_library(Brotli::dec UNKNOWN IMPORTED GLOBAL)
+    set_target_properties(Brotli::dec PROPERTIES
+        IMPORTED_LOCATION "${Brotli_DEC_LIBRARY}"
+        INTERFACE_COMPILE_OPTIONS "${Brotli_COMPILE_OPTIONS}"
+        INTERFACE_INCLUDE_DIRECTORIES "${Brotli_DEC_INCLUDE_DIR}"
+    )
+endif ()
+
+mark_as_advanced(
+    Brotli_LIBRARY
+    Brotli_DEC_INCLUDE_DIR
+    Brotli_DEC_LIBRARY
+)
+
+if (Brotli_FOUND)
+    set(Brotli_LIBRARIES ${Brotli_LIBRARY} ${Brotli_DEC_LIBRARY})
+    set(Brotli_INCLUDE_DIRS ${Brotli_INCLUDE_DIR})
+endif ()

--- a/Source/cmake/OptionsWin.cmake
+++ b/Source/cmake/OptionsWin.cmake
@@ -100,6 +100,7 @@ endif ()
 
 find_package(WOFF2 1.0.2 COMPONENTS dec)
 if (WOFF2_FOUND)
+    find_package(Brotli REQUIRED COMPONENTS dec)
     SET_AND_EXPOSE_TO_BUILD(USE_WOFF2 ON)
 endif ()
 


### PR DESCRIPTION
#### ed511336d6db9e83af4d78ee2f9429e096f17e5f
<pre>
[CMake] Add Brotli targets
<a href="https://bugs.webkit.org/show_bug.cgi?id=253025">https://bugs.webkit.org/show_bug.cgi?id=253025</a>

Reviewed by Michael Catanzaro.

The Windows port needs to link in Brotli&apos;s decoder library to support
WOFF2 so turn it into a proper find module. The module itself is the
same as the WOFF2 module. Update the WebCore library listing to use the
target.

The module will also be used by the PlayStation port in the near future.

* Source/WebCore/PlatformWin.cmake:
* Source/cmake/FindBrotli.cmake: Added.
* Source/cmake/OptionsWin.cmake:

Canonical link: <a href="https://commits.webkit.org/260954@main">https://commits.webkit.org/260954@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90444b98ced329d34ba81f16e31e3083b06b0dfc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109922 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19026 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42618 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1370 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118986 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113872 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20490 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10216 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102184 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115671 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15254 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98469 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43474 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97217 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30124 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85285 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/98737 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11732 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31466 "Found 1 new test failure: media/video-playback-quality.html (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/99663 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/9768 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12363 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8420 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31159 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17732 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51075 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/107681 "Built successfully") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/7597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14149 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26570 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->