### PR TITLE
Regression(255659@main) Unable to log into twitch.tv

### DIFF
--- a/LayoutTests/fast/screen-orientation/natural-orientation-expected.txt
+++ b/LayoutTests/fast/screen-orientation/natural-orientation-expected.txt
@@ -1,0 +1,11 @@
+Natural screen orientation should be landcape-primary on Desktop
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Default orientation is landscape-primary.
+Default angle is 0.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/screen-orientation/natural-orientation.html
+++ b/LayoutTests/fast/screen-orientation/natural-orientation.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script>
+description("Natural screen orientation should be landcape-primary on Desktop");
+
+debug("Default orientation is " + screen.orientation.type +  ".");
+debug("Default angle is " + screen.orientation.angle + ".");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/orientation-reading-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/orientation-reading-expected.txt
@@ -2,7 +2,7 @@
 Harness Error (FAIL), message = Test named 'Test the orientations and associated angles' specified 1 'cleanup' function, and 1 failed.
 
 PASS Test screen.orientation properties
-FAIL Test screen.orientation default values. assert_true: expected true got false
+PASS Test screen.orientation default values.
 PASS Test the orientations and associated angles
 PASS Test that screen.orientation properties are not writable
 PASS Test that screen.orientation is always the same object

--- a/LayoutTests/platform/ios/fast/screen-orientation/natural-orientation-expected.txt
+++ b/LayoutTests/platform/ios/fast/screen-orientation/natural-orientation-expected.txt
@@ -1,0 +1,11 @@
+Natural screen orientation should be landcape-primary on Desktop
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Default orientation is portrait-primary.
+Default angle is 0.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/Source/WebCore/page/ScreenOrientation.cpp
+++ b/Source/WebCore/page/ScreenOrientation.cpp
@@ -175,27 +175,38 @@ auto ScreenOrientation::type() const -> Type
 {
     auto* manager = this->manager();
     if (!manager)
-        return Type::PortraitPrimary;
+        return naturalScreenOrientationType();
     return manager->currentOrientation();
 }
 
 uint16_t ScreenOrientation::angle() const
 {
     auto* manager = this->manager();
-    if (!manager)
-        return 0;
+    auto orientation = manager ? manager->currentOrientation() : naturalScreenOrientationType();
 
-    // The angle should depend on the device's natural orientation. We currently
-    // consider Portrait as the natural orientation.
-    switch (manager->currentOrientation()) {
-    case Type::PortraitPrimary:
-        return 0;
-    case Type::PortraitSecondary:
-        return 180;
-    case Type::LandscapePrimary:
-        return 90;
-    case Type::LandscapeSecondary:
-        return 270;
+    // https://w3c.github.io/screen-orientation/#dfn-screen-orientation-values-table
+    if constexpr (isPortait(naturalScreenOrientationType())) {
+        switch (orientation) {
+        case Type::PortraitPrimary:
+            return 0;
+        case Type::PortraitSecondary:
+            return 180;
+        case Type::LandscapePrimary:
+            return 90;
+        case Type::LandscapeSecondary:
+            return 270;
+        }
+    } else {
+        switch (orientation) {
+        case Type::PortraitPrimary:
+            return 90;
+        case Type::PortraitSecondary:
+            return 270;
+        case Type::LandscapePrimary:
+            return 0;
+        case Type::LandscapeSecondary:
+            return 180;
+        }
     }
     ASSERT_NOT_REACHED();
     return 0;

--- a/Source/WebCore/page/ScreenOrientationType.h
+++ b/Source/WebCore/page/ScreenOrientationType.h
@@ -46,6 +46,16 @@ constexpr bool isLandscape(ScreenOrientationType type)
     return type == ScreenOrientationType::LandscapePrimary || type == ScreenOrientationType::LandscapeSecondary;
 }
 
+constexpr ScreenOrientationType naturalScreenOrientationType()
+{
+#if PLATFORM(IOS_FAMILY)
+    return ScreenOrientationType::PortraitPrimary;
+#else
+    // On Desktop, the natural orientation must be landscape-primary.
+    return ScreenOrientationType::LandscapePrimary;
+#endif
+}
+
 } // namespace WebCore
 
 namespace WTF {

--- a/Source/WebCore/platform/ScreenOrientationProvider.cpp
+++ b/Source/WebCore/platform/ScreenOrientationProvider.cpp
@@ -75,7 +75,7 @@ ScreenOrientationType ScreenOrientationProvider::currentOrientation()
     if (m_currentOrientation)
         return *m_currentOrientation;
 
-    auto orientation = platformCurrentOrientation().value_or(ScreenOrientationType::PortraitPrimary);
+    auto orientation = platformCurrentOrientation().value_or(WebCore::naturalScreenOrientationType());
     if (!m_observers.isEmptyIgnoringNullReferences())
         m_currentOrientation = orientation;
     return orientation;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.cpp
@@ -50,7 +50,7 @@ WebCore::ScreenOrientationType WebScreenOrientationManager::currentOrientation()
         return *m_currentOrientation;
 
     auto sendResult = m_page.sendSync(Messages::WebScreenOrientationManagerProxy::CurrentOrientation { });
-    auto [currentOrientation] = sendResult.takeReplyOr(WebCore::ScreenOrientationType::PortraitPrimary);
+    auto [currentOrientation] = sendResult.takeReplyOr(WebCore::naturalScreenOrientationType());
     if (!m_observers.isEmptyIgnoringNullReferences())
         m_currentOrientation = currentOrientation;
     return currentOrientation;


### PR DESCRIPTION
#### 541ca5a79560c6998b3e433980a19d25b0f28fd9
<pre>
Regression(255659@main) Unable to log into twitch.tv
<a href="https://bugs.webkit.org/show_bug.cgi?id=253026">https://bugs.webkit.org/show_bug.cgi?id=253026</a>
rdar://105891522

Reviewed by Wenson Hsieh and Darin Adler.

The Twitch.tv login was failing because `screen.orientation` was returning
&quot;portrait-primary&quot; on macOS. The natural/default orientation on desktop should
be &quot;landscape-primary&quot; so this was confusing Twitch.

Also update our `screen.angle` logic to take into account the natural
orientation based on:
- <a href="https://w3c.github.io/screen-orientation/#dfn-screen-orientation-values-table">https://w3c.github.io/screen-orientation/#dfn-screen-orientation-values-table</a>

I have verified that Chrome on macOS returns &quot;landscape-primary&quot; for the type
and 0 for the angle. Our behavior is now aligned.

* LayoutTests/fast/screen-orientation/natural-orientation-expected.txt: Added.
* LayoutTests/fast/screen-orientation/natural-orientation.html: Added.
* LayoutTests/platform/ios/screen-orientation/natural-orientation-expected.txt: Added.
* Source/WebCore/page/ScreenOrientation.cpp:
(WebCore::ScreenOrientation::lock):
* Source/WebCore/page/ScreenOrientationType.h:
(WebCore::naturalScreenOrientationType):
* Source/WebCore/platform/ScreenOrientationProvider.cpp:
(WebCore::ScreenOrientationProvider::currentOrientation):
* Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.cpp:
(WebKit::WebScreenOrientationManager::currentOrientation):

Canonical link: <a href="https://commits.webkit.org/260944@main">https://commits.webkit.org/260944@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/491d27d723e58b8087ae55f35c9099d783c65aca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110039 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19139 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42720 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/1479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/119073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113991 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20606 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10332 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/102297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115785 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/102297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/30214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/102297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/11841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/31552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/12463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/17830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14258 "Failed to checkout and rebase branch from PR 10760") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4116 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->