### PR TITLE
REGRESSION(260575@main) Tapping PiP Button Crashes UIProcess in -[WebAVPlayerLayer setVideoGravity:]

### DIFF
--- a/Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm
+++ b/Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm
@@ -190,7 +190,7 @@ SOFT_LINK_CLASS_OPTIONAL(AVKit, __AVPlayerLayerView)
     [CATransaction setAnimationDuration:0];
     [CATransaction setDisableActions:YES];
 
-    if (auto* model = _fullscreenInterface->videoFullscreenModel())
+    if (auto* model = _fullscreenInterface ? _fullscreenInterface->videoFullscreenModel() : nullptr)
         model->setVideoLayerFrame(_targetVideoFrame);
 
     _previousVideoGravity = _videoGravity;
@@ -226,7 +226,7 @@ SOFT_LINK_CLASS_OPTIONAL(AVKit, __AVPlayerLayerView)
     else
         ASSERT_NOT_REACHED();
 
-    if (auto* model = _fullscreenInterface->videoFullscreenModel())
+    if (auto* model = _fullscreenInterface ? _fullscreenInterface->videoFullscreenModel() : nullptr)
         model->setVideoLayerGravity(gravity);
 
     [self setNeedsLayout];

--- a/Source/WebCore/platform/cocoa/WebAVPlayerLayerView.mm
+++ b/Source/WebCore/platform/cocoa/WebAVPlayerLayerView.mm
@@ -100,11 +100,11 @@ static void WebAVPlayerLayerView_startRoutingVideoToPictureInPicturePlayerLayerV
     auto *playerLayer = (WebAVPlayerLayer *)[playerLayerView playerLayer];
     auto *pipPlayerLayer = (WebAVPlayerLayer *)[pipView layer];
     [playerLayer setVideoGravity:AVLayerVideoGravityResizeAspectFill];
+    [pipPlayerLayer setFullscreenInterface:playerLayer.fullscreenInterface];
     [pipPlayerLayer setVideoSublayer:playerLayer.videoSublayer];
     [pipPlayerLayer setVideoDimensions:playerLayer.videoDimensions];
     [pipPlayerLayer setVideoGravity:playerLayer.videoGravity];
     [pipPlayerLayer setPlayerController:playerLayer.playerController];
-    [pipPlayerLayer setFullscreenInterface:playerLayer.fullscreenInterface];
     [pipPlayerLayer addSublayer:playerLayer.videoSublayer];
     [pipPlayerLayer layoutSublayers];
 }


### PR DESCRIPTION
#### ba27ab71c4d7d6670e250726a6b1aef9f351da6b
<pre>
REGRESSION(260575@main) Tapping PiP Button Crashes UIProcess in -[WebAVPlayerLayer setVideoGravity:]
<a href="https://bugs.webkit.org/show_bug.cgi?id=253034">https://bugs.webkit.org/show_bug.cgi?id=253034</a>
rdar://105992124

Reviewed by Simon Fraser.

-setVideoGravity is dereferencing _fullscreenInterface unconditionally, and by chance _fullscreenInterface is
nil when entering PiP mode.

Call -setFullscreenInterface: earlier in the process of moving video playback to the PiP window, and as a belt-
and-suspenders technique, also nil check _fullscreennInterface before dereferencing it in WebAVPlayerLayer.

* Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm:
(-[WebAVPlayerLayer resolveBounds]):
(-[WebAVPlayerLayer setVideoGravity:]):
* Source/WebCore/platform/cocoa/WebAVPlayerLayerView.mm:
(WebCore::WebAVPlayerLayerView_startRoutingVideoToPictureInPicturePlayerLayerView):

Canonical link: <a href="https://commits.webkit.org/260943@main">https://commits.webkit.org/260943@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ece2da3f8a2f21cb6603fb347e32c325471fce47

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109915 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19020 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42613 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1364 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118982 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113865 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20483 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10210 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102177 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115664 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15246 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98470 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43468 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97209 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30125 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85279 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11726 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31467 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12358 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8415 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17727 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51076 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7588 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14143 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->