### PR TITLE
Revert 260295@main because it was unnecessary

### DIFF
--- a/LayoutTests/platform/mac-wk1/editing/mac/attributed-string/font-style-variant-effect-expected.txt
+++ b/LayoutTests/platform/mac-wk1/editing/mac/attributed-string/font-style-variant-effect-expected.txt
@@ -43,17 +43,7 @@ Alignment 4
     NSKern: 0pt
     NSStrokeColor: #000000 (sRGB)
     NSStrokeWidth: 0
-[ ]
-    NSFont: Times-Roman 16.00 pt.
-    NSKern: 0pt
-    NSStrokeColor: #000000 (sRGB)
-    NSStrokeWidth: 0
-[small-caps]
-    NSFont: Times-Roman 16.00 pt.
-    NSKern: 0pt
-    NSStrokeColor: #000000 (sRGB)
-    NSStrokeWidth: 0
-[ outline emboss ]
+[ small-caps outline emboss ]
     NSFont: Times-Roman 16.00 pt.
     NSKern: 0pt
     NSStrokeColor: #000000 (sRGB)


### PR DESCRIPTION
#### 3a18793778e43a462285dc602e2069b25df31fd5
<pre>
Revert 260295@main because it was unnecessary
<a href="https://bugs.webkit.org/show_bug.cgi?id=253033">https://bugs.webkit.org/show_bug.cgi?id=253033</a>
rdar://105997287

Unreviewed gardening.

1. <a href="https://commits.webkit.org/260130@main">https://commits.webkit.org/260130@main</a> caused the test to fail
2. <a href="https://commits.webkit.org/260295@main">https://commits.webkit.org/260295@main</a> updated the test&apos;s expected results (which is what this radar was originally about)
3. <a href="https://commits.webkit.org/260447@main">https://commits.webkit.org/260447@main</a> caused the test to fail the opposite way

So <a href="https://commits.webkit.org/260447@main">https://commits.webkit.org/260447@main</a> fixed the bug, and <a href="https://commits.webkit.org/260295@main">https://commits.webkit.org/260295@main</a> was wrong.

* LayoutTests/platform/mac-wk1/editing/mac/attributed-string/font-style-variant-effect-expected.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a18793778e43a462285dc602e2069b25df31fd5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109917 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19022 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42615 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1366 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/118984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20485 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10212 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102179 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115666 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43469 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30122 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85280 "Found 1 new API test failure: /WebKitGTK/TestDownloads:/webkit/Downloads/local-file-error (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11728 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31464 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12360 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17729 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51073 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7569 "Failed to update pull request") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14145 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->