### PR TITLE
Trim margins for overconstraining floats that are adjacent to the containing block inner without clear and other intrusive floats

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6269,6 +6269,7 @@ imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/js
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.html [ Skip ]
 
 webkit.org/b/252183 imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-overflowing-float-margins-tirmmed-at-final-position-block-layout.html [ ImageOnlyFailure ]
+webkit.org/b/253055 imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-floats-adjacent-to-containing-block-should-be-trimmed-only.html [ ImageOnlyFailure ]
 
 #Skipping text-spacing tests until the features get implemented.
 imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-spacing-computed.html [ Skip ]

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-nested-inside-nested-inline-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-nested-inside-nested-inline-expected.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="inline-size:100px; block-size: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-nested-inside-nested-inline.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-nested-inside-nested-inline.html
@@ -1,0 +1,38 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Float nested in an inline should determine margin trimming from IFC root">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<style>
+container {
+    display: block;
+    inline-size: 100px;
+    margin-trim: inline;
+    font-size: 0px;
+}
+item {
+    display: block;
+    inline-size: 50px;
+    height: 100px;
+    background-color: green;
+}
+.inline-block {
+    display: inline-block;
+}
+.floating {
+    float: right;
+    margin-inline-end: 20px; 
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+<item class="inline-block"></item>
+<span><item class="floating"></item></span>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-floats-adjacent-to-containing-block-should-be-trimmed-only-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-floats-adjacent-to-containing-block-should-be-trimmed-only-expected.html
@@ -1,0 +1,35 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="If a float is not adjacent to the containing block's edge it should not have its margin trimmed even if it would make it fit at that vertical position"><style>
+container {
+    display: block;
+    border: 1px solid black;
+    inline-size: 100px;
+    font-family: monospace;
+    font-size: 10px;
+}
+item {
+    display: block;
+    inline-size: 10px;
+    block-size: 80px;
+    background-color: green;
+    float: right;
+}
+.inline-end-margin {
+    margin-inline-end: 80px;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>The text</span>
+    <item></item>
+    <item class="inline-end-margin"></item>
+    <span>should wrap alongside the float to the right</span>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-floats-adjacent-to-containing-block-should-be-trimmed-only.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-floats-adjacent-to-containing-block-should-be-trimmed-only.html
@@ -1,0 +1,34 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="If a float is not adjacent to the containing block's edge it should not have its margin trimmed even if it would make it fit at that vertical position"><style>
+container {
+    display: block;
+    border: 1px solid black;
+    inline-size: 100px;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    inline-size: 10px;
+    block-size: 80px;
+    background-color: green;
+    margin-inline-end: 80px;
+    float: right;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>The text</span>
+    <item></item>
+    <item></item>
+    <span>should wrap alongside the float to the right</span>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-left-positioned-float-intersecting-other-float-to-fit-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-left-positioned-float-intersecting-other-float-to-fit-expected.html
@@ -1,0 +1,24 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Float that intersects another float during placement should be able to trim its margins and no longer intersect the other">
+<style>
+container {
+    display: block;
+    inline-size: 100px;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>Test passes if there is a filled green square below.</span></br>
+    <div style="inline-size: 100px; block-size: 100px; background-color: green;"></div>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-left-positioned-float-intersecting-other-float-to-fit.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-left-positioned-float-intersecting-other-float-to-fit.html
@@ -1,0 +1,38 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Float that intersects another float during placement should be able to trim its margins and no longer intersect the other">
+<style>
+container {
+    display: block;
+    inline-size: 100px;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    inline-size: 50px;
+    block-size: 100px;
+    background-color: green;
+}
+.float-right {
+    float: right;
+}
+.float-left {
+    float: left;
+    margin-inline-start: 80px;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>Test passes if there is a filled green square below.</span></br>
+    <item class="float-right"></item>
+    <item class="float-left"></item> 
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-left-positioned-float-overconstraining-line-box-to-fit-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-left-positioned-float-overconstraining-line-box-to-fit-expected.html
@@ -1,0 +1,33 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Float that overconstrains a line box should be able to trim its margins and no longer overconstrain">
+<style>
+container {
+    display: block;
+    border: 1px solid black;
+    inline-size: 300px;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    inline-size: 25px;
+    block-size: 80px;
+    background-color: green;
+    margin-inline-start: 80px;
+    float: left;
+}
+</style>
+</head>
+<body>
+<container>
+    <item></item>
+    <span>The text should wrap alongside the float with the trimmed margin to the left</span>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-left-positioned-float-overconstraining-line-box-to-fit-rtl-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-left-positioned-float-overconstraining-line-box-to-fit-rtl-expected.html
@@ -1,0 +1,34 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Float that overconstrains a line box should be able to trim its margins and no longer overconstrain in rtl direction">
+<style>
+container {
+    display: block;
+    direction: rtl;
+    border: 1px solid black;
+    inline-size: 300px;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    inline-size: 25px;
+    block-size: 80px;
+    background-color: green;
+    margin-inline-start: 80px;
+    float: left;
+}
+</style>
+</head>
+<body>
+<container>
+    <item></item>
+    <span>The text should wrap alongside the float with the trimmed margin to the left</span>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-left-positioned-float-overconstraining-line-box-to-fit-rtl.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-left-positioned-float-overconstraining-line-box-to-fit-rtl.html
@@ -1,0 +1,35 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Float that overconstrains a line box should be able to trim its margins and no longer overconstrain in rtl direction">
+<style>
+container {
+    display: block;
+    direction: rtl;
+    border: 1px solid black;
+    inline-size: 300px;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    inline-size: 25px;
+    block-size: 80px;
+    background-color: green;
+    margin-inline-start: 80px;
+    float: left;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>The text should wrap alongside the float with</span>
+    <item></item>
+    <span>the trimmed margin to the left</span>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-left-positioned-float-overconstraining-line-box-to-fit-vert-lr-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-left-positioned-float-overconstraining-line-box-to-fit-vert-lr-expected.html
@@ -1,0 +1,34 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Float that overconstrains a line box should be able to trim its margins and no longer overconstrain in vertical-lr writing mode">
+<style>
+container {
+    display: block;
+    writing-mode: vertical-lr;
+    border: 1px solid black;
+    inline-size: 300px;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    inline-size: 25px;
+    block-size: 80px;
+    background-color: green;
+    margin-inline-start: 80px;
+    float: left;
+}
+</style>
+</head>
+<body>
+<container>
+    <item></item>
+    <span>The text should wrap alongside the float with the trimmed margin to the left</span>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-left-positioned-float-overconstraining-line-box-to-fit-vert-lr.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-left-positioned-float-overconstraining-line-box-to-fit-vert-lr.html
@@ -1,0 +1,35 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Float that overconstrains a line box should be able to trim its margins and no longer overconstrain in vertical-lr writing mode">
+<style>
+container {
+    display: block;
+    writing-mode: vertical-lr;
+    border: 1px solid black;
+    inline-size: 300px;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    inline-size: 25px;
+    block-size: 80px;
+    background-color: green;
+    margin-inline-start: 80px;
+    float: left;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>The text should wrap alongside the float with</span>
+    <item></item>
+    <span>the trimmed margin to the left</span>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-left-positioned-float-overconstraining-line-box-to-fit.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-left-positioned-float-overconstraining-line-box-to-fit.html
@@ -1,0 +1,34 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Float that overconstrains a line box should be able to trim its margins and no longer overconstrain">
+<style>
+container {
+    display: block;
+    border: 1px solid black;
+    inline-size: 300px;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    inline-size: 25px;
+    block-size: 80px;
+    background-color: green;
+    margin-inline-start: 80px;
+    float: left;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>The text should wrap alongside the float with</span>
+    <item></item>
+    <span>the trimmed margin to the left</span>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-orthogonal-float-overconstraining-line-box-to-fit-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-orthogonal-float-overconstraining-line-box-to-fit-expected.html
@@ -1,0 +1,33 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Trimming should determine margins to used based off the containing block's (IFC root's) writing mode">
+<style>
+container {
+    display: block;
+    border: 1px solid black;
+    inline-size: 100px;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    inline-size: 25px;
+    block-size: 80px;
+    background-color: green;
+    margin-inline-end: 80px;
+    float: right;
+}
+</style>
+</head>
+<body>
+<container>
+    <item></item>
+    <span>The text should wrap alongside the float to the right</span>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-orthogonal-float-overconstraining-line-box-to-fit.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-orthogonal-float-overconstraining-line-box-to-fit.html
@@ -1,0 +1,35 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Float that overconstrains a line box should be able to trim its margins and no longer overconstrain">
+<style>
+container {
+    display: block;
+    border: 1px solid black;
+    inline-size: 100px;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    writing-mode: vertical-lr;
+    inline-size: 80px;
+    block-size: 25px;
+    background-color: green;
+    margin-block-end: 80px;
+    float: right;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>The text</span>
+    <item></item>
+    <span>should wrap alongside the float to the right</span>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-right-positioned-float-intersecting-other-float-to-fit-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-right-positioned-float-intersecting-other-float-to-fit-expected.html
@@ -1,0 +1,24 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Float that intersects another float during placement should be able to trim its margins and no longer intersect the other">
+<style>
+container {
+    display: block;
+    inline-size: 100px;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>Test passes if there is a filled green square below.</span></br>
+    <div style="inline-size: 100px; block-size: 100px; background-color: green;"></div>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-right-positioned-float-intersecting-other-float-to-fit.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-right-positioned-float-intersecting-other-float-to-fit.html
@@ -1,0 +1,38 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Float that intersects another float during placement should be able to trim its margins and no longer intersect the other">
+<style>
+container {
+    display: block;
+    inline-size: 100px;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    inline-size: 50px;
+    block-size: 100px;
+    background-color: green;
+}
+.float-right {
+    float: right;
+    margin-inline-end: 80px;
+}
+.float-left {
+    float: left;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>Test passes if there is a filled green square below.</span></br>
+    <item class="float-left"></item> 
+    <item class="float-right"></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-right-positioned-float-overconstraining-line-box-to-fit-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-right-positioned-float-overconstraining-line-box-to-fit-expected.html
@@ -1,0 +1,33 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Float that overconstrains a line box should be able to trim its margins and no longer overconstrain">
+<style>
+container {
+    display: block;
+    border: 1px solid black;
+    inline-size: 100px;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    inline-size: 25px;
+    block-size: 80px;
+    background-color: green;
+    margin-inline-end: 80px;
+    float: right;
+}
+</style>
+</head>
+<body>
+<container>
+    <item></item>
+    <span>The text should wrap alongside the float to the right</span>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-right-positioned-float-overconstraining-line-box-to-fit-rtl-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-right-positioned-float-overconstraining-line-box-to-fit-rtl-expected.html
@@ -1,0 +1,34 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Float that overconstrains a line box should be able to trim its margins and no longer overconstrain in rtl direction">
+<style>
+container {
+    display: block;
+    direction: rtl;
+    border: 1px solid black;
+    inline-size: 100px;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    inline-size: 25px;
+    block-size: 80px;
+    background-color: green;
+    margin-inline-end: 80px;
+    float: right;
+}
+</style>
+</head>
+<body>
+<container>
+    <item></item>
+    <span>The text should wrap alongside the float to the right</span>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-right-positioned-float-overconstraining-line-box-to-fit-rtl.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-right-positioned-float-overconstraining-line-box-to-fit-rtl.html
@@ -1,0 +1,35 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Float that overconstrains a line box should be able to trim its margins and no longer overconstrain in rtl direction">
+<style>
+container {
+    display: block;
+    direction: rtl;
+    border: 1px solid black;
+    inline-size: 100px;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    inline-size: 25px;
+    block-size: 80px;
+    background-color: green;
+    margin-inline-end: 80px;
+    float: right;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>The text</span>
+    <item></item>
+    <span>should wrap alongside the float to the right</span>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-right-positioned-float-overconstraining-line-box-to-fit-vert-lr-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-right-positioned-float-overconstraining-line-box-to-fit-vert-lr-expected.html
@@ -1,0 +1,34 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Float that overconstrains a line box should be able to trim its margins and no longer overconstrain in vertical-lr writing mode">
+<style>
+container {
+    display: block;
+    writing-mode: vertical-lr;
+    border: 1px solid black;
+    inline-size: 100px;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    inline-size: 25px;
+    block-size: 80px;
+    background-color: green;
+    margin-inline-end: 80px;
+    float: right;
+}
+</style>
+</head>
+<body>
+<container>
+    <item></item>
+    <span>The text should wrap alongside the float to the right</span>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-right-positioned-float-overconstraining-line-box-to-fit-vert-lr.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-right-positioned-float-overconstraining-line-box-to-fit-vert-lr.html
@@ -1,0 +1,35 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Float that overconstrains a line box should be able to trim its margins and no longer overconstrain in vertical-lr writing mode">
+<style>
+container {
+    display: block;
+    writing-mode: vertical-lr;
+    border: 1px solid black;
+    inline-size: 100px;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    inline-size: 25px;
+    block-size: 80px;
+    background-color: green;
+    margin-inline-end: 80px;
+    float: right;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>The text</span>
+    <item></item>
+    <span>should wrap alongside the float to the right</span>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-right-positioned-float-overconstraining-line-box-to-fit.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-right-positioned-float-overconstraining-line-box-to-fit.html
@@ -1,0 +1,34 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Float that overconstrains a line box should be able to trim its margins and no longer overconstrain">
+<style>
+container {
+    display: block;
+    border: 1px solid black;
+    inline-size: 100px;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    inline-size: 25px;
+    block-size: 80px;
+    background-color: green;
+    margin-inline-end: 80px;
+    float: right;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>The text</span>
+    <item></item>
+    <span>should wrap alongside the float to the right</span>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-nested-inside-nested-inline-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-nested-inside-nested-inline-expected.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="inline-size:100px; block-size: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-nested-inside-nested-inline.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-nested-inside-nested-inline.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Float nested in an inline should determine margin trimming from IFC root">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<style>
+container {
+    display: block;
+    inline-size: 100px;
+    margin-trim: inline;
+    font-size: 0px;
+}
+item {
+    display: block;
+    inline-size: 50px;
+    height: 100px;
+    background-color: green;
+}
+.inline-block {
+    display: inline-block;
+}
+.floating {
+    float: right;
+    margin-inline-end: 20px; 
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+<item class="inline-block"></item>
+<span><item class="floating"></item></span>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-floats-adjacent-to-containing-block-should-be-trimmed-only-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-floats-adjacent-to-containing-block-should-be-trimmed-only-expected.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="If a float is not adjacent to the containing block's edge it should not have its margin trimmed even if it would make it fit at that vertical position"><style>
+container {
+    display: block;
+    border: 1px solid black;
+    inline-size: 100px;
+    font-family: monospace;
+    font-size: 10px;
+}
+item {
+    display: block;
+    inline-size: 10px;
+    block-size: 80px;
+    background-color: green;
+    float: right;
+}
+.inline-end-margin {
+    margin-inline-end: 80px;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>The text</span>
+    <item></item>
+    <item class="inline-end-margin"></item>
+    <span>should wrap alongside the float to the right</span>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-floats-adjacent-to-containing-block-should-be-trimmed-only.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-floats-adjacent-to-containing-block-should-be-trimmed-only.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="If a float is not adjacent to the containing block's edge it should not have its margin trimmed even if it would make it fit at that vertical position"><style>
+container {
+    display: block;
+    border: 1px solid black;
+    inline-size: 100px;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    inline-size: 10px;
+    block-size: 80px;
+    background-color: green;
+    margin-inline-end: 80px;
+    float: right;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>The text</span>
+    <item></item>
+    <item></item>
+    <span>should wrap alongside the float to the right</span>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-left-positioned-float-intersecting-other-float-to-fit-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-left-positioned-float-intersecting-other-float-to-fit-expected.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Float that intersects another float during placement should be able to trim its margins and no longer intersect the other">
+<style>
+container {
+    display: block;
+    inline-size: 100px;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>Test passes if there is a filled green square below.</span></br>
+    <div style="inline-size: 100px; block-size: 100px; background-color: green;"></div>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-left-positioned-float-intersecting-other-float-to-fit.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-left-positioned-float-intersecting-other-float-to-fit.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Float that intersects another float during placement should be able to trim its margins and no longer intersect the other">
+<style>
+container {
+    display: block;
+    inline-size: 100px;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    inline-size: 50px;
+    block-size: 100px;
+    background-color: green;
+}
+.float-right {
+    float: right;
+}
+.float-left {
+    float: left;
+    margin-inline-start: 80px;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>Test passes if there is a filled green square below.</span></br>
+    <item class="float-right"></item>
+    <item class="float-left"></item> 
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-left-positioned-float-overconstraining-line-box-to-fit-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-left-positioned-float-overconstraining-line-box-to-fit-expected.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Float that overconstrains a line box should be able to trim its margins and no longer overconstrain">
+<style>
+container {
+    display: block;
+    border: 1px solid black;
+    inline-size: 300px;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    inline-size: 25px;
+    block-size: 80px;
+    background-color: green;
+    margin-inline-start: 80px;
+    float: left;
+}
+</style>
+</head>
+<body>
+<container>
+    <item></item>
+    <span>The text should wrap alongside the float with the trimmed margin to the left</span>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-left-positioned-float-overconstraining-line-box-to-fit-rtl-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-left-positioned-float-overconstraining-line-box-to-fit-rtl-expected.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Float that overconstrains a line box should be able to trim its margins and no longer overconstrain in rtl direction">
+<style>
+container {
+    display: block;
+    direction: rtl;
+    border: 1px solid black;
+    inline-size: 300px;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    inline-size: 25px;
+    block-size: 80px;
+    background-color: green;
+    margin-inline-start: 80px;
+    float: left;
+}
+</style>
+</head>
+<body>
+<container>
+    <item></item>
+    <span>The text should wrap alongside the float with the trimmed margin to the left</span>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-left-positioned-float-overconstraining-line-box-to-fit-rtl.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-left-positioned-float-overconstraining-line-box-to-fit-rtl.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Float that overconstrains a line box should be able to trim its margins and no longer overconstrain in rtl direction">
+<style>
+container {
+    display: block;
+    direction: rtl;
+    border: 1px solid black;
+    inline-size: 300px;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    inline-size: 25px;
+    block-size: 80px;
+    background-color: green;
+    margin-inline-start: 80px;
+    float: left;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>The text should wrap alongside the float with</span>
+    <item></item>
+    <span>the trimmed margin to the left</span>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-left-positioned-float-overconstraining-line-box-to-fit-vert-lr-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-left-positioned-float-overconstraining-line-box-to-fit-vert-lr-expected.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Float that overconstrains a line box should be able to trim its margins and no longer overconstrain in vertical-lr writing mode">
+<style>
+container {
+    display: block;
+    writing-mode: vertical-lr;
+    border: 1px solid black;
+    inline-size: 300px;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    inline-size: 25px;
+    block-size: 80px;
+    background-color: green;
+    margin-inline-start: 80px;
+    float: left;
+}
+</style>
+</head>
+<body>
+<container>
+    <item></item>
+    <span>The text should wrap alongside the float with the trimmed margin to the left</span>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-left-positioned-float-overconstraining-line-box-to-fit-vert-lr.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-left-positioned-float-overconstraining-line-box-to-fit-vert-lr.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Float that overconstrains a line box should be able to trim its margins and no longer overconstrain in vertical-lr writing mode">
+<style>
+container {
+    display: block;
+    writing-mode: vertical-lr;
+    border: 1px solid black;
+    inline-size: 300px;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    inline-size: 25px;
+    block-size: 80px;
+    background-color: green;
+    margin-inline-start: 80px;
+    float: left;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>The text should wrap alongside the float with</span>
+    <item></item>
+    <span>the trimmed margin to the left</span>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-left-positioned-float-overconstraining-line-box-to-fit.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-left-positioned-float-overconstraining-line-box-to-fit.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Float that overconstrains a line box should be able to trim its margins and no longer overconstrain">
+<style>
+container {
+    display: block;
+    border: 1px solid black;
+    inline-size: 300px;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    inline-size: 25px;
+    block-size: 80px;
+    background-color: green;
+    margin-inline-start: 80px;
+    float: left;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>The text should wrap alongside the float with</span>
+    <item></item>
+    <span>the trimmed margin to the left</span>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-orthogonal-float-overconstraining-line-box-to-fit-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-orthogonal-float-overconstraining-line-box-to-fit-expected.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Trimming should determine margins to used based off the containing block's (IFC root's) writing mode">
+<style>
+container {
+    display: block;
+    border: 1px solid black;
+    inline-size: 100px;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    inline-size: 25px;
+    block-size: 80px;
+    background-color: green;
+    margin-inline-end: 80px;
+    float: right;
+}
+</style>
+</head>
+<body>
+<container>
+    <item></item>
+    <span>The text should wrap alongside the float to the right</span>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-orthogonal-float-overconstraining-line-box-to-fit.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-orthogonal-float-overconstraining-line-box-to-fit.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Float that overconstrains a line box should be able to trim its margins and no longer overconstrain">
+<style>
+container {
+    display: block;
+    border: 1px solid black;
+    inline-size: 100px;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    writing-mode: vertical-lr;
+    inline-size: 80px;
+    block-size: 25px;
+    background-color: green;
+    margin-block-end: 80px;
+    float: right;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>The text</span>
+    <item></item>
+    <span>should wrap alongside the float to the right</span>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-right-positioned-float-intersecting-other-float-to-fit-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-right-positioned-float-intersecting-other-float-to-fit-expected.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Float that intersects another float during placement should be able to trim its margins and no longer intersect the other">
+<style>
+container {
+    display: block;
+    inline-size: 100px;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>Test passes if there is a filled green square below.</span></br>
+    <div style="inline-size: 100px; block-size: 100px; background-color: green;"></div>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-right-positioned-float-intersecting-other-float-to-fit.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-right-positioned-float-intersecting-other-float-to-fit.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Float that intersects another float during placement should be able to trim its margins and no longer intersect the other">
+<style>
+container {
+    display: block;
+    inline-size: 100px;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    inline-size: 50px;
+    block-size: 100px;
+    background-color: green;
+}
+.float-right {
+    float: right;
+    margin-inline-end: 80px;
+}
+.float-left {
+    float: left;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>Test passes if there is a filled green square below.</span></br>
+    <item class="float-right"></item>
+    <item class="float-left"></item> 
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-right-positioned-float-overconstraining-line-box-to-fit-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-right-positioned-float-overconstraining-line-box-to-fit-expected.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Float that overconstrains a line box should be able to trim its margins and no longer overconstrain">
+<style>
+container {
+    display: block;
+    border: 1px solid black;
+    inline-size: 100px;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    inline-size: 25px;
+    block-size: 80px;
+    background-color: green;
+    margin-inline-end: 80px;
+    float: right;
+}
+</style>
+</head>
+<body>
+<container>
+    <item></item>
+    <span>The text should wrap alongside the float to the right</span>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-right-positioned-float-overconstraining-line-box-to-fit-rtl-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-right-positioned-float-overconstraining-line-box-to-fit-rtl-expected.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Float that overconstrains a line box should be able to trim its margins and no longer overconstrain in rtl direction">
+<style>
+container {
+    display: block;
+    direction: rtl;
+    border: 1px solid black;
+    inline-size: 100px;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    inline-size: 25px;
+    block-size: 80px;
+    background-color: green;
+    margin-inline-end: 80px;
+    float: right;
+}
+</style>
+</head>
+<body>
+<container>
+    <item></item>
+    <span>The text should wrap alongside the float to the right</span>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-right-positioned-float-overconstraining-line-box-to-fit-rtl.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-right-positioned-float-overconstraining-line-box-to-fit-rtl.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Float that overconstrains a line box should be able to trim its margins and no longer overconstrain in rtl direction">
+<style>
+container {
+    display: block;
+    direction: rtl;
+    border: 1px solid black;
+    inline-size: 100px;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    inline-size: 25px;
+    block-size: 80px;
+    background-color: green;
+    margin-inline-end: 80px;
+    float: right;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>The text</span>
+    <item></item>
+    <span>should wrap alongside the float to the right</span>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-right-positioned-float-overconstraining-line-box-to-fit-vert-lr-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-right-positioned-float-overconstraining-line-box-to-fit-vert-lr-expected.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Float that overconstrains a line box should be able to trim its margins and no longer overconstrain in vertical-lr writing mode">
+<style>
+container {
+    display: block;
+    writing-mode: vertical-lr;
+    border: 1px solid black;
+    inline-size: 100px;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    inline-size: 25px;
+    block-size: 80px;
+    background-color: green;
+    margin-inline-end: 80px;
+    float: right;
+}
+</style>
+</head>
+<body>
+<container>
+    <item></item>
+    <span>The text should wrap alongside the float to the right</span>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-right-positioned-float-overconstraining-line-box-to-fit-vert-lr.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-right-positioned-float-overconstraining-line-box-to-fit-vert-lr.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Float that overconstrains a line box should be able to trim its margins and no longer overconstrain in vertical-lr writing mode">
+<style>
+container {
+    display: block;
+    writing-mode: vertical-lr;
+    border: 1px solid black;
+    inline-size: 100px;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    inline-size: 25px;
+    block-size: 80px;
+    background-color: green;
+    margin-inline-end: 80px;
+    float: right;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>The text</span>
+    <item></item>
+    <span>should wrap alongside the float to the right</span>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-right-positioned-float-overconstraining-line-box-to-fit.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-right-positioned-float-overconstraining-line-box-to-fit.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Float that overconstrains a line box should be able to trim its margins and no longer overconstrain">
+<style>
+container {
+    display: block;
+    border: 1px solid black;
+    inline-size: 100px;
+    font-family: monospace;
+    font-size: 10px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    inline-size: 25px;
+    block-size: 80px;
+    background-color: green;
+    margin-inline-end: 80px;
+    float: right;
+}
+</style>
+</head>
+<body>
+<container>
+    <span>The text</span>
+    <item></item>
+    <span>should wrap alongside the float to the right</span>
+</container>
+</body>
+</html>

--- a/Source/WebCore/rendering/line/BreakingContext.h
+++ b/Source/WebCore/rendering/line/BreakingContext.h
@@ -364,7 +364,26 @@ inline void BreakingContext::handleOutOfFlowPositioned(Vector<RenderBox*>& posit
 inline void BreakingContext::handleFloat()
 {
     auto& floatBox = downcast<RenderBox>(*m_current.renderer());
-    const auto& floatingObject = *m_lineBreaker.insertFloatingObject(floatBox);
+    auto& floatingObject = *m_lineBreaker.insertFloatingObject(floatBox);
+
+    auto wouldFitWithTrimmedMargin = [&](MarginTrimType marginTrimType) {
+        auto widthWitoutMargin = floatingObject.width();
+        widthWitoutMargin -= marginTrimType == MarginTrimType::InlineStart ? floatBox.marginStart(&m_blockStyle) : floatBox.marginEnd(&m_blockStyle);
+        return m_width.fitsOnLineExcludingTrailingWhitespace(widthWitoutMargin.toFloat());
+    };
+    auto hasFloatsOnSideAtVerticalPosition = [&](UsedFloat floatPosition) {
+        return (floatPosition == UsedFloat::Left) ? m_block.logicalLeftOffsetForLine(m_block.logicalHeight(), DoNotIndentText)  != m_block.logicalLeftOffsetForContent(m_block.logicalHeight()) :  m_block.logicalRightOffsetForLine(m_block.logicalHeight(), DoNotIndentText) != m_block.logicalRightOffsetForContent(m_block.logicalHeight());
+    };
+
+    // We should trim a float's margin early at a particular vertical position if the following are true:
+    // 1.) The float's candidate position is adjacent to the containing block's inner edge
+    // 2.) margin-trim is set for that edge (e.g. margin-trim: inline/inline-start for a left positioned float)
+    // 3.) The float overconstrains a line box or intersects with another float at that vertical position
+    //     but would not overconstrain a line box/intersect a float if that margin were trimmed
+    if (m_blockStyle.marginTrim().contains(MarginTrimType::InlineStart) && RenderStyle::usedFloat(floatBox) == UsedFloat::Left && !hasFloatsOnSideAtVerticalPosition(UsedFloat::Left) && wouldFitWithTrimmedMargin(MarginTrimType::InlineStart))
+        m_block.trimMarginForFloat(floatingObject, MarginTrimType::InlineStart);
+    else if (m_blockStyle.marginTrim().contains(MarginTrimType::InlineEnd) && RenderStyle::usedFloat(floatBox) == UsedFloat::Right && !hasFloatsOnSideAtVerticalPosition(UsedFloat::Right) && wouldFitWithTrimmedMargin(MarginTrimType::InlineEnd))
+        m_block.trimMarginForFloat(floatingObject, MarginTrimType::InlineEnd);
     // check if it fits in the current line.
     // If it does, position it now, otherwise, position
     // it after moving to next line (in clearFloats() func)


### PR DESCRIPTION
#### bad6e12c662597b42e88698add408c8a035c7400
<pre>
Trim margins for overconstraining floats that are adjacent to the containing block inner without clear and other intrusive floats
<a href="https://bugs.webkit.org/show_bug.cgi?id=253008">https://bugs.webkit.org/show_bug.cgi?id=253008</a>
rdar://105984917

Reviewed by Alan Baradlay.

When going through float layout and determining their position within a
containing block we check to see if they would overconstrain any lines
boxes or would intersect with any other floats at that candidate
position. If they would, we would hold off on positioning them until we
finish inline layout with the current line. However, with margin-trim
it is possible that these floats would fit at these positions with their
margins trimmed.

In order to determine whether we can trim such a margin, the following
must be true for the float:
1.) The float&apos;s candidate position is adjacent to the containing block&apos;s
    inner edge
2.) margin-trim is set for that edge (e.g. margin-trim:
    inline/inline-start for a left positioned float)
3.) The float overconstrains a line box or intersects with another float
    at that vertical position but would not overconstrain a line
    box/intersect a float if that margin were trimmed

In these scenarios we can trim the appropriate margin for the float and
place it at that vertical position.

container {
    display: block;
    border: 1px solid black;
    inline-size: 100px;
    font-family: monospace;
    font-size: 10px;
    margin-trim: inline;
}
item {
    display: block;
    inline-size: 25px;
    block-size: 80px;
    background-color: green;
    margin-inline-end: 80px;
    float: right;
}
&lt;/style&gt;
&lt;container&gt;
    &lt;span&gt;The text&lt;/span&gt;
    &lt;item&gt;&lt;/item&gt;
    &lt;span&gt;should wrap alongside the float to the right&lt;/span&gt;
&lt;/container&gt;
Without margin-trim the float would overconstrain the first line box
and would not get placed at the same vertical position. However, since
margin-trim is specified, resulting box would fit at that position, and
it would get placed against the containing block&apos;s inner edge,
then we can trim its margins and place it there.

container {
    display: block;
    inline-size: 100px;
    font-family: monospace;
    font-size: 10px;
    margin-trim: inline;
}
item {
    display: block;
    inline-size: 50px;
    block-size: 100px;
    background-color: green;
}
.float-right {
    float: right;
    margin-inline-end: 80px;
}
.float-left {
    float: left;
}
&lt;/style&gt;
&lt;container&gt;
    &lt;span&gt;Test passes if there is a filled green square below.&lt;/span&gt;&lt;/br&gt;
     &lt;item class=&quot;float-left&quot;&gt;&lt;/item&gt;
    &lt;item class=&quot;float-right&quot;&gt;&lt;/item&gt;
&lt;/container&gt;

Similarly, after placing the first float we would not normally be able
to position the second one since the margin would result in it
intersecting with the other one. However due to the same conditions
in the first example we can trim the inline-end margin and place it at
the same vertical position as the other float.
* LayoutTests/TestExpectations:
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-nested-inside-nested-inline-expected.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-float-nested-inside-nested-inline.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-floats-adjacent-to-containing-block-should-be-trimmed-only-expected.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-floats-adjacent-to-containing-block-should-be-trimmed-only.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-left-positioned-float-intersecting-other-float-to-fit-expected.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-left-positioned-float-intersecting-other-float-to-fit.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-left-positioned-float-overconstraining-line-box-to-fit-expected.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-left-positioned-float-overconstraining-line-box-to-fit-rtl-expected.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-left-positioned-float-overconstraining-line-box-to-fit-rtl.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-left-positioned-float-overconstraining-line-box-to-fit-vert-lr-expected.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-left-positioned-float-overconstraining-line-box-to-fit-vert-lr.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-left-positioned-float-overconstraining-line-box-to-fit.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-orthogonal-float-overconstraining-line-box-to-fit-expected.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-orthogonal-float-overconstraining-line-box-to-fit.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-right-positioned-float-intersecting-other-float-to-fit-expected.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-right-positioned-float-intersecting-other-float-to-fit.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-right-positioned-float-overconstraining-line-box-to-fit-expected.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-right-positioned-float-overconstraining-line-box-to-fit-rtl-expected.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-right-positioned-float-overconstraining-line-box-to-fit-rtl.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-right-positioned-float-overconstraining-line-box-to-fit-vert-lr-expected.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-right-positioned-float-overconstraining-line-box-to-fit-vert-lr.html: Added.
* LayoutTests/fast/inline/legacy-margin-trim/block-container-trimmed-margin-allows-right-positioned-float-overconstraining-line-box-to-fit.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-nested-inside-nested-inline-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-nested-inside-nested-inline.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-floats-adjacent-to-containing-block-should-be-trimmed-only-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-floats-adjacent-to-containing-block-should-be-trimmed-only.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-left-positioned-float-intersecting-other-float-to-fit-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-left-positioned-float-intersecting-other-float-to-fit.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-left-positioned-float-overconstraining-line-box-to-fit-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-left-positioned-float-overconstraining-line-box-to-fit-rtl-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-left-positioned-float-overconstraining-line-box-to-fit-rtl.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-left-positioned-float-overconstraining-line-box-to-fit-vert-lr-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-left-positioned-float-overconstraining-line-box-to-fit-vert-lr.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-left-positioned-float-overconstraining-line-box-to-fit.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-orthogonal-float-overconstraining-line-box-to-fit-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-orthogonal-float-overconstraining-line-box-to-fit.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-right-positioned-float-intersecting-other-float-to-fit-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-right-positioned-float-intersecting-other-float-to-fit.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-right-positioned-float-overconstraining-line-box-to-fit-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-right-positioned-float-overconstraining-line-box-to-fit-rtl-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-right-positioned-float-overconstraining-line-box-to-fit-rtl.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-right-positioned-float-overconstraining-line-box-to-fit-vert-lr-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-right-positioned-float-overconstraining-line-box-to-fit-vert-lr.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-trimmed-margin-allows-right-positioned-float-overconstraining-line-box-to-fit.html: Added.
* Source/WebCore/rendering/line/BreakingContext.h:
(WebCore::BreakingContext::handleFloat):

Canonical link: <a href="https://commits.webkit.org/260950@main">https://commits.webkit.org/260950@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77530f0011d0d0c561533f6cfd8d467779a591a6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110041 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19142 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42722 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1481 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/119075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113993 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20608 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10334 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102299 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115787 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/43562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/30217 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/85393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11843 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/31555 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12465 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17832 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51170 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7589 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14260 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->