### PR TITLE
Disable Apple Compression API in Compression Streams

### DIFF
--- a/Source/WebCore/Modules/compression/DecompressionStreamDecoder.cpp
+++ b/Source/WebCore/Modules/compression/DecompressionStreamDecoder.cpp
@@ -66,11 +66,6 @@ ExceptionOr<RefPtr<Uint8Array>> DecompressionStreamDecoder::flush()
 
 inline ExceptionOr<RefPtr<JSC::ArrayBuffer>> DecompressionStreamDecoder::decompress(const uint8_t* input, const size_t inputLength)
 {
-#if PLATFORM(COCOA)
-    if (m_usingAppleCompressionFramework)
-        return decompressAppleCompressionFramework(input, inputLength);
-#endif
-
     return decompressZlib(input, inputLength);
 }
 

--- a/Source/WebCore/Modules/compression/DecompressionStreamDecoder.h
+++ b/Source/WebCore/Modules/compression/DecompressionStreamDecoder.h
@@ -94,15 +94,7 @@ private:
     explicit DecompressionStreamDecoder(unsigned char format) 
         : m_format(static_cast<Formats::CompressionFormat>(format))
     {
-
-    std::memset(&m_zstream, 0, sizeof(m_zstream));
-
-#if PLATFORM(COCOA)
-    std::memset(&m_stream, 0, sizeof(m_stream));
-
-    if (m_format == Formats::CompressionFormat::Deflate)
-        m_usingAppleCompressionFramework = true;
-#endif
+        std::memset(&m_zstream, 0, sizeof(m_zstream));
     }
 };
 } // namespace WebCore


### PR DESCRIPTION
#### fe58e5cd0281e47d9e9739df609cf404067d1c96
<pre>
Disable Apple Compression API in Compression Streams
<a href="https://bugs.webkit.org/show_bug.cgi?id=253042">https://bugs.webkit.org/show_bug.cgi?id=253042</a>

Reviewed by Brent Fulgham.

Disable Compression API for Compression Streams right now as it is causing issues
on web sites.

* Source/WebCore/Modules/compression/DecompressionStreamDecoder.cpp:
(WebCore::DecompressionStreamDecoder::decompress):
* Source/WebCore/Modules/compression/DecompressionStreamDecoder.h:
(WebCore::DecompressionStreamDecoder::DecompressionStreamDecoder):

Canonical link: <a href="https://commits.webkit.org/260923@main">https://commits.webkit.org/260923@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b82fa2e7a485043256eb684a58dbad521ce19c1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109934 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19040 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42624 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1382 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118992 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113884 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20502 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10228 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102196 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115683 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43479 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30128 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85291 "Found 2 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state-changed (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11744 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/31470 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12369 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8428 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17738 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51079 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7574 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14161 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->