### PR TITLE
CRASH: GPUP at -[WebCoreNSURLSessionDataTask _cancel]

### DIFF
--- a/Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.mm
+++ b/Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.mm
@@ -811,7 +811,7 @@ void WebCoreNSURLSessionDataTaskClient::loadFinished(PlatformMediaResource& reso
 
 - (WebCoreNSURLSession *)session
 {
-    return _session.get().get();
+    return _session.get().autorelease();
 }
 
 - (void)setSession:(WebCoreNSURLSession *)session


### PR DESCRIPTION
#### 96230945f879c8a4188fd341a56841c79e986378
<pre>
CRASH: GPUP at -[WebCoreNSURLSessionDataTask _cancel]
<a href="https://bugs.webkit.org/show_bug.cgi?id=253044">https://bugs.webkit.org/show_bug.cgi?id=253044</a>
rdar://94878533

Reviewed by Eric Carlson.

-[WebCoreNSURLSessionDataTask session] currently converts a WeakObjC pointer (safely) into
a RetainPtr, then returns a raw pointer from that RetainPtr. The RetainPtr is destroyed after
returning, which reduces the retain count. It is then stored into a RetainPtr again by the
caller inside -_cancel;

Meanwhile, on another thread, the WebCoreNSURLSession can be released by the system, leaving
an opportunity to release the WebCoreNSURLSession and reduce it&apos;s retain count to zero in
between the two RetainPtr calls on the main thread, leading to the client retaining a dealloc&apos;d
object.

Instead, -session should return an autorelease()&apos;d pointer, thereby ensuring the session is
retained long enough for the client to retain it. This will increase retain-count churn, but
will also guarantee the object cannot be destroyed on a background thread while it&apos;s still
being used on the main thread.

* Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.mm:
(-[WebCoreNSURLSessionDataTask session]):

Canonical link: <a href="https://commits.webkit.org/260941@main">https://commits.webkit.org/260941@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c3b85efbb89d3bac7d7a07c7666703110593d399

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109937 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19043 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42627 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1385 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/118994 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113889 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20505 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10231 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102199 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115686 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15265 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98476 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43482 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97228 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30131 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85295 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11747 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31473 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12372 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8431 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17740 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51082 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7587 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14164 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->