### PR TITLE
'may_need_more_requests' field of a hidden test group should not be updated to true.

### DIFF
--- a/Websites/perf.webkit.org/public/api/build-requests.php
+++ b/Websites/perf.webkit.org/public/api/build-requests.php
@@ -41,7 +41,7 @@ function main($id, $path, $post_data) {
 
 function update_builds($db, $updates) {
     $db->begin_transaction();
-    $test_groups_may_need_more_requests = array();
+    $processed_test_groups = array();
     foreach ($updates as $id => $info) {
         $id = intval($id);
         $status = $info['status'];
@@ -100,11 +100,11 @@ function update_builds($db, $updates) {
         }
 
         $test_group_id = $request_row['request_group'];
-        if (array_key_exists($test_group_id, $test_groups_may_need_more_requests))
+        if (array_key_exists($test_group_id, $processed_test_groups))
             continue;
 
-        $db->update_row('analysis_test_groups', 'testgroup', array('id' => $test_group_id), array('may_need_more_requests' => TRUE));
-        $test_groups_may_need_more_requests[$test_group_id] = TRUE;
+        $db->update_row('analysis_test_groups', 'testgroup', array('id' => $test_group_id, 'hidden' => FALSE), array('may_need_more_requests' => TRUE));
+        $processed_test_groups[$test_group_id] = TRUE;
     }
     $db->commit_transaction();
 }

--- a/Websites/perf.webkit.org/server-tests/resources/mock-data.js
+++ b/Websites/perf.webkit.org/server-tests/resources/mock-data.js
@@ -64,7 +64,7 @@ MockData = {
             db.insert('test_runs', {id: 801, config: 301, build: 901, mean_cache: 100}),
         ]);
     },
-    addMockData: function (db, statusList, needsNotification = true, urlList = null, commitSetList = null, repetitionType = 'alternating', mayNeedMoreRequests = false)
+    addMockData: function (db, statusList, needsNotification = true, urlList = null, commitSetList = null, repetitionType = 'alternating', mayNeedMoreRequests = false, hidden = false)
     {
         if (!statusList)
             statusList = ['pending', 'pending', 'pending', 'pending'];
@@ -84,7 +84,8 @@ MockData = {
                 start_run: 801, start_run_time: '2015-10-27T12:05:27.1Z',
                 end_run: 801, end_run_time: '2015-10-27T12:05:27.1Z'}),
             db.insert('analysis_test_groups', {id: 600, task: 500, name: 'some test group', initial_repetition_count: 2,
-                needs_notification: needsNotification, repetition_type: repetitionType, may_need_more_requests: mayNeedMoreRequests}),
+                needs_notification: needsNotification, repetition_type: repetitionType,
+                may_need_more_requests: mayNeedMoreRequests, hidden: hidden}),
             db.insert('build_requests', {id: 700, status: statusList[0], url: urlList[0], triggerable: 1000, repository_group: 2001, platform: 65, test: 200, group: 600, order: 0, commit_set: commitSetList[0]}),
             db.insert('build_requests', {id: 701, status: statusList[1], url: urlList[1], triggerable: 1000, repository_group: 2001, platform: 65, test: 200, group: 600, order: 1, commit_set: commitSetList[1]}),
             db.insert('build_requests', {id: 702, status: statusList[2], url: urlList[2], triggerable: 1000, repository_group: 2001, platform: 65, test: 200, group: 600, order: 2, commit_set: commitSetList[2]}),


### PR DESCRIPTION
#### 526f1bce0bbe24ac00f8433542646f0b10d1fdec
<pre>
&apos;may_need_more_requests&apos; field of a hidden test group should not be updated to true.
<a href="https://bugs.webkit.org/show_bug.cgi?id=253045">https://bugs.webkit.org/show_bug.cgi?id=253045</a>
rdar://106004266

Reviewed by Stephanie Lewis.

&apos;/api/build-requests&apos; may set &apos;may_need_more_requests&apos; to true even if the test group is hidden.

* Websites/perf.webkit.org/public/api/build-requests.php: Add logic to only set &apos;may_need_more_requests&apos;
when the test group is not hidden.
* Websites/perf.webkit.org/server-tests/api-build-requests-tests.js: Added a unit test.
* Websites/perf.webkit.org/server-tests/resources/mock-data.js: Added support to mock hidden test groups.
(MockData.addMockData):

Canonical link: <a href="https://commits.webkit.org/261888@main">https://commits.webkit.org/261888@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/796788f25ea4316445011f11d8961ccf48fabf59

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/113149 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/22281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/90/builds/1822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/4920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/121612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/23655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/13463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/87/builds/4920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118936 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/23655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/90/builds/1822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/106233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/23655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/90/builds/1822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/106233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14584 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/90/builds/1822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/106233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/15296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/13463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/20589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/90/builds/1822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8301 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/17145 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->