### PR TITLE
ManagedMediaSource content should be evicted whenever it is under memory pressure

### DIFF
--- a/LayoutTests/media/media-source/media-managedmse-memorypressure-expected.txt
+++ b/LayoutTests/media/media-source/media-managedmse-memorypressure-expected.txt
@@ -42,8 +42,56 @@ EVENT(update)
 RUN(sourceBuffer.timestampOffset = sourceBuffer.buffered.end(sourceBuffer.buffered.length - 1))
 RUN(source.endOfStream())
 EVENT(sourceended)
-RUN(video.currentTime = video.duration - 1)
+RUN(video.currentTime = video.duration / 2)
 EVENT(seeked)
+RUN(bufferedStart = sourceBuffer.buffered.start(0))
+RUN(internals.beginSimulatedMemoryPressure())
+EVENT(bufferedchange)
+EXPECTED (bufferedStart != 'sourceBuffer.buffered.start(0)') OK
+RUN(internals.endSimulatedMemoryPressure())
+RUN(sourceBuffer.remove(0, 999999))
+EVENT(updateend)
+Append a media segment.
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0)))
+EVENT(update)
+RUN(sourceBuffer.timestampOffset = sourceBuffer.buffered.end(sourceBuffer.buffered.length - 1))
+Append a media segment.
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0)))
+EVENT(update)
+RUN(sourceBuffer.timestampOffset = sourceBuffer.buffered.end(sourceBuffer.buffered.length - 1))
+Append a media segment.
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0)))
+EVENT(update)
+RUN(sourceBuffer.timestampOffset = sourceBuffer.buffered.end(sourceBuffer.buffered.length - 1))
+Append a media segment.
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0)))
+EVENT(update)
+RUN(sourceBuffer.timestampOffset = sourceBuffer.buffered.end(sourceBuffer.buffered.length - 1))
+Append a media segment.
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0)))
+EVENT(update)
+RUN(sourceBuffer.timestampOffset = sourceBuffer.buffered.end(sourceBuffer.buffered.length - 1))
+Append a media segment.
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0)))
+EVENT(update)
+RUN(sourceBuffer.timestampOffset = sourceBuffer.buffered.end(sourceBuffer.buffered.length - 1))
+Append a media segment.
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0)))
+EVENT(update)
+RUN(sourceBuffer.timestampOffset = sourceBuffer.buffered.end(sourceBuffer.buffered.length - 1))
+Append a media segment.
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0)))
+EVENT(update)
+RUN(sourceBuffer.timestampOffset = sourceBuffer.buffered.end(sourceBuffer.buffered.length - 1))
+Append a media segment.
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0)))
+EVENT(update)
+RUN(sourceBuffer.timestampOffset = sourceBuffer.buffered.end(sourceBuffer.buffered.length - 1))
+RUN(source.endOfStream())
+EVENT(sourceended)
+RUN(video.currentTime = sourceBuffer.buffered.start(0) + (sourceBuffer.buffered.end(0) - sourceBuffer.buffered.start(0)) / 2)
+EVENT(seeked)
+EXPECTED (video.paused == 'false') OK
 RUN(bufferedStart = sourceBuffer.buffered.start(0))
 RUN(internals.beginSimulatedMemoryPressure())
 EVENT(bufferedchange)

--- a/LayoutTests/media/media-source/media-managedmse-memorypressure.html
+++ b/LayoutTests/media/media-source/media-managedmse-memorypressure.html
@@ -18,6 +18,17 @@
         });
     }
 
+    async function loadData() {
+        for (let i = 1; i < 10; i++) {
+                consoleWrite('Append a media segment.')
+                run('sourceBuffer.appendBuffer(loader.mediaSegment(0))');
+                await waitFor(sourceBuffer, 'update');
+                run('sourceBuffer.timestampOffset = sourceBuffer.buffered.end(sourceBuffer.buffered.length - 1)');
+            }
+        run('source.endOfStream()');
+        return waitFor(source, 'sourceended');
+    }
+
     window.addEventListener('load', async event => {
         try {
             findMediaElement();
@@ -40,15 +51,9 @@
             run('sourceBuffer.appendBuffer(loader.initSegment())');
             await waitFor(sourceBuffer, 'update');
 
-            for (let i = 1; i < 10; i++) {
-                consoleWrite('Append a media segment.')
-                run('sourceBuffer.appendBuffer(loader.mediaSegment(0))');
-                await waitFor(sourceBuffer, 'update');
-                run('sourceBuffer.timestampOffset = sourceBuffer.buffered.end(sourceBuffer.buffered.length - 1)');
-            }
-            run('source.endOfStream()');
-            await waitFor(source, 'sourceended');
-            run('video.currentTime = video.duration - 1');
+            await loadData();
+
+            run('video.currentTime = video.duration / 2');
             await waitFor(video, 'seeked');
 
             run('bufferedStart = sourceBuffer.buffered.start(0)');
@@ -56,6 +61,25 @@
             await waitFor(sourceBuffer, 'bufferedchange');
             testExpected('bufferedStart', 'sourceBuffer.buffered.start(0)', '!=');
             run('internals.endSimulatedMemoryPressure()');
+
+            // Remove all content.
+            run('sourceBuffer.remove(0, 999999)');
+            await waitFor(sourceBuffer, 'updateend');
+
+            // Check that data is evicted even if media is currently playing.
+            await loadData();
+            // Seek to middle of buffered range.
+            run('video.currentTime = sourceBuffer.buffered.start(0) + (sourceBuffer.buffered.end(0) - sourceBuffer.buffered.start(0)) / 2');
+            await waitFor(video, 'seeked');
+            await video.play();
+            testExpected('video.paused', false);
+
+            run('bufferedStart = sourceBuffer.buffered.start(0)');
+            run('internals.beginSimulatedMemoryPressure()');
+            await waitFor(sourceBuffer, 'bufferedchange');
+            testExpected('bufferedStart', 'sourceBuffer.buffered.start(0)', '!=');
+            run('internals.endSimulatedMemoryPressure()');
+
             endTest();
         } catch (e) {
             failTest(`Caught exception: "${e}"`);

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -8643,6 +8643,17 @@ void HTMLMediaElement::purgeBufferedDataIfPossible()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
 
+    bool isPausedOrMSE = [&] {
+#if ENABLE(MEDIA_SOURCE)
+        if (m_mediaSource)
+            return true;
+#endif
+        return paused();
+    }();
+
+    if (!isPausedOrMSE)
+        return;
+
     if (!MemoryPressureHandler::singleton().isUnderMemoryPressure() && mediaSession().preferredBufferingPolicy() == BufferingPolicy::Default)
         return;
 

--- a/Source/WebCore/page/MemoryRelease.cpp
+++ b/Source/WebCore/page/MemoryRelease.cpp
@@ -116,10 +116,8 @@ static void releaseCriticalMemory(Synchronous synchronous, MaintainBackForwardCa
     GCController::singleton().deleteAllCode(JSC::DeleteAllCodeIfNotCollecting);
 
 #if ENABLE(VIDEO)
-    for (auto* mediaElement : HTMLMediaElement::allMediaElements()) {
-        if (mediaElement->paused())
-            mediaElement->purgeBufferedDataIfPossible();
-    }
+    for (auto* mediaElement : HTMLMediaElement::allMediaElements())
+        mediaElement->purgeBufferedDataIfPossible();
 #endif
 
     if (synchronous == Synchronous::Yes) {


### PR DESCRIPTION
#### 98b2a211bb5343e6bac6144a68fcc572bd33e940
<pre>
ManagedMediaSource content should be evicted whenever it is under memory pressure
<a href="https://bugs.webkit.org/show_bug.cgi?id=252938">https://bugs.webkit.org/show_bug.cgi?id=252938</a>
rdar://105908445

Reviewed by Youenn Fablet.

Let the MediaElement control when eviction under memory pressure should
occur.

* LayoutTests/media/media-source/media-managedmse-memorypressure-expected.txt:
* LayoutTests/media/media-source/media-managedmse-memorypressure.html:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::purgeBufferedDataIfPossible):
* Source/WebCore/page/MemoryRelease.cpp:
(WebCore::releaseCriticalMemory):

Canonical link: <a href="https://commits.webkit.org/260920@main">https://commits.webkit.org/260920@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/476c5baafdfc0e72b7876287235efa7e7ba57381

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109948 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19054 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42637 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1397 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/119003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113899 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20516 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10242 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102210 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115697 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/43492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30142 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/85310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11756 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/31483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12381 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/17749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51093 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7570 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14174 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->