### PR TITLE
REGRESSION(257654@main): [ews-build.webkit.org][GTK][WPE] RunWebKitTestsRedTree sub-classes are overwriting the 'first_run' properties on the retry steps.

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -4043,8 +4043,9 @@ class RunWebKitTestsRepeatFailuresRedTree(RunWebKitTestsRedTree):
             self.build.addStepsAfterCurrentStep(next_steps)
         return rc
 
-    def commandComplete(self, cmd):
-        shell.Test.commandComplete(self, cmd)
+    @defer.inlineCallbacks
+    def runCommand(self, command):
+        yield shell.Test.runCommand(self, command)
         logText = self.log_observer.getStdout() + self.log_observer.getStderr()
         logTextJson = self.log_observer_json.getStdout()
         with_change_repeat_failures_results = LayoutTestFailures.results_from_string(logTextJson)
@@ -4090,8 +4091,9 @@ class RunWebKitTestsRepeatFailuresWithoutChangeRedTree(RunWebKitTestsRedTree):
         self.build.addStepsAfterCurrentStep([ArchiveTestResults(), UploadTestResults(identifier='repeat-failures-without-change'), ExtractTestResults(identifier='repeat-failures-without-change'), AnalyzeLayoutTestsResultsRedTree()])
         return rc
 
-    def commandComplete(self, cmd):
-        shell.Test.commandComplete(self, cmd)
+    @defer.inlineCallbacks
+    def runCommand(self, command):
+        yield shell.Test.runCommand(self, command)
         logText = self.log_observer.getStdout() + self.log_observer.getStderr()
         logTextJson = self.log_observer_json.getStdout()
         without_change_repeat_failures_results = LayoutTestFailures.results_from_string(logTextJson)

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -42,6 +42,7 @@ from twisted.python import failure, log
 from twisted.trial import unittest
 import send_email
 
+from layout_test_failures import LayoutTestFailures
 from steps import (AddReviewerToCommitMessage, AnalyzeAPITestsResults, AnalyzeCompileWebKitResults,
                    AnalyzeJSCTestsResults, AnalyzeLayoutTestsResults, ApplyPatch, ApplyWatchList, ArchiveBuiltProduct, ArchiveTestResults, BugzillaMixin,
                    Canonicalize, CheckOutPullRequest, CheckOutSource, CheckOutSpecificRevision, CheckChangeRelevance, CheckStatusOnEWSQueues, CheckStyle,
@@ -2783,6 +2784,13 @@ class TestAnalyzeLayoutTestsResults(BuildStepMixinAdditions, unittest.TestCase):
         return self.runStep()
 
 
+class MockLayoutTestFailures(object):
+    def __init__(self, failing_tests, flaky_tests, did_exceed_test_failure_limit):
+        self.failing_tests = failing_tests
+        self.flaky_tests = flaky_tests
+        self.did_exceed_test_failure_limit = did_exceed_test_failure_limit
+
+
 class TestRunWebKitTestsRedTree(BuildStepMixinAdditions, unittest.TestCase):
     def setUp(self):
         self.longMessage = True
@@ -2794,11 +2802,12 @@ class TestRunWebKitTestsRedTree(BuildStepMixinAdditions, unittest.TestCase):
 
     def configureStep(self):
         self.setupStep(RunWebKitTestsRedTree())
+        self.setProperty('platform', 'wpe')
+        self.setProperty('fullPlatform', 'wpe')
+        self.setProperty('configuration', 'release')
 
     def test_success(self):
         self.configureStep()
-        self.setProperty('fullPlatform', 'gtk')
-        self.setProperty('configuration', 'release')
         self.expectRemoteCommands(
             ExpectShell(workdir='wkdir',
                         logfiles={'json': self.jsonFileName},
@@ -2806,13 +2815,41 @@ class TestRunWebKitTestsRedTree(BuildStepMixinAdditions, unittest.TestCase):
                         command=['python3',
                                  'Tools/Scripts/run-webkit-tests',
                                  '--no-build', '--no-show-results', '--no-new-test-results', '--clobber-old-results',
-                                 '--release', '--results-directory', 'layout-test-results', '--debug-rwt-logging',
+                                 '--release', '--wpe', '--results-directory', 'layout-test-results', '--debug-rwt-logging',
                                  '--exit-after-n-failures', '500', '--skip-failing-tests']
                         )
             + 0,
         )
         self.expectOutcome(result=SUCCESS, state_string='Passed layout tests')
         return self.runStep()
+
+    def test_set_properties_when_executed_scope_this_class(self):
+        self.configureStep()
+        first_run_failures = ['fast/css/test1.html', 'fast/svg/test2.svg', 'imported/test/test3.html']
+        first_run_flakies = ['fast/css/flaky1.html', 'fast/svg/flaky2.svg', 'imported/test/flaky3.html']
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        logfiles={'json': self.jsonFileName},
+                        logEnviron=False,
+                        command=['python3',
+                                 'Tools/Scripts/run-webkit-tests',
+                                 '--no-build', '--no-show-results', '--no-new-test-results', '--clobber-old-results',
+                                 '--release', '--wpe', '--results-directory', 'layout-test-results', '--debug-rwt-logging',
+                                 '--exit-after-n-failures', '500', '--skip-failing-tests']
+                        )
+            + 2
+        )
+        # Patch LayoutTestFailures.results_from_string() to report the expected values
+        # Check this values end on the properties this class should define
+        mock_test_failures = MockLayoutTestFailures(first_run_failures, first_run_flakies, False)
+        self.patch(LayoutTestFailures, 'results_from_string', lambda f: mock_test_failures)
+        self.expectOutcome(result=FAILURE, state_string='layout-tests (failure)')
+        rc = self.runStep()
+        # Note: first_run properties are considered to belong to RunWebKitTestsRedTree() in this case, so they should be set to mock_test_failures
+        self.assertEqual(first_run_failures, self.getProperty('first_run_failures'))
+        self.assertEqual(first_run_flakies, self.getProperty('first_run_flakies'))
+        self.assertFalse(self.getProperty('first_results_exceed_failure_limit'))
+        return rc
 
 
 class TestRunWebKitTestsRepeatFailuresRedTree(BuildStepMixinAdditions, unittest.TestCase):
@@ -2826,11 +2863,12 @@ class TestRunWebKitTestsRepeatFailuresRedTree(BuildStepMixinAdditions, unittest.
 
     def configureStep(self):
         self.setupStep(RunWebKitTestsRepeatFailuresRedTree())
+        self.setProperty('platform', 'wpe')
+        self.setProperty('fullPlatform', 'wpe')
+        self.setProperty('configuration', 'release')
 
     def test_success(self):
         self.configureStep()
-        self.setProperty('fullPlatform', 'gtk')
-        self.setProperty('configuration', 'release')
         first_run_failures = ['fast/css/test1.html', 'imported/test/test2.html', 'fast/svg/test3.svg']
         first_run_flakies = ['fast/css/flaky1.html', 'imported/test/flaky2.html', 'fast/svg/flaky3.svg']
         self.setProperty('first_run_failures', first_run_failures)
@@ -2843,7 +2881,7 @@ class TestRunWebKitTestsRepeatFailuresRedTree(BuildStepMixinAdditions, unittest.
                         command=['python3',
                                  'Tools/Scripts/run-webkit-tests',
                                  '--no-build', '--no-show-results', '--no-new-test-results', '--clobber-old-results',
-                                 '--release', '--results-directory', 'layout-test-results', '--debug-rwt-logging',
+                                 '--release', '--wpe', '--results-directory', 'layout-test-results', '--debug-rwt-logging',
                                  '--skip-failing-tests', '--fully-parallel', '--repeat-each=10'] + sorted(first_run_failures)
                         )
             + 0,
@@ -2851,6 +2889,44 @@ class TestRunWebKitTestsRepeatFailuresRedTree(BuildStepMixinAdditions, unittest.
         self.expectOutcome(result=SUCCESS, state_string='layout-tests')
         return self.runStep()
 
+    def test_set_properties_when_executed_scope_this_class(self):
+        self.configureStep()
+        first_run_failures = ['fast/css/test1.html', 'imported/test/test2.html', 'fast/svg/test3.svg']
+        first_run_flakies = ['fast/css/flaky1.html', 'imported/test/flaky2.html', 'fast/svg/flaky3.svg']
+        # Set good values for properties that only the superclass should set
+        self.setProperty('first_run_failures', first_run_failures)
+        self.setProperty('first_run_flakies', first_run_flakies)
+        self.setProperty('first_results_exceed_failure_limit', False)
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        logfiles={'json': self.jsonFileName},
+                        logEnviron=False,
+                        maxTime=18000,
+                        command=['python3',
+                                 'Tools/Scripts/run-webkit-tests',
+                                 '--no-build', '--no-show-results', '--no-new-test-results', '--clobber-old-results',
+                                 '--release', '--wpe', '--results-directory', 'layout-test-results', '--debug-rwt-logging',
+                                 '--skip-failing-tests', '--fully-parallel', '--repeat-each=10'] + sorted(first_run_failures)
+                        )
+            + 2
+        )
+        # Patch LayoutTestFailures.results_from_string() so it always reports fake values.
+        # Check this fake values do not end on the properties that belong to the superclass.
+        fake_failing_tests = ['fake/should/not/happen/failure1.html', 'imported/fake/failure2.html']
+        fake_flaky_tests = ['fake/should/not/happen/flaky1.html', 'imported/fake/flaky2.html']
+        fake_layout_test_failures = MockLayoutTestFailures(fake_failing_tests, fake_flaky_tests, True)
+        self.patch(LayoutTestFailures, 'results_from_string', lambda f: fake_layout_test_failures)
+        self.expectOutcome(result=FAILURE, state_string='layout-tests (failure)')
+        rc = self.runStep()
+        # first_run properties should not be set to fake_layout_test_failures when running RunWebKitTestsRepeatFailuresRedTree()
+        self.assertEqual(first_run_failures, self.getProperty('first_run_failures'))
+        self.assertEqual(first_run_flakies, self.getProperty('first_run_flakies'))
+        self.assertFalse(self.getProperty('first_results_exceed_failure_limit'))
+        # Test also that this fake values are set _only_ for the properties this class should define
+        self.assertEqual(fake_failing_tests, self.getProperty('with_change_repeat_failures_results_nonflaky_failures'))
+        self.assertEqual(fake_flaky_tests, self.getProperty('with_change_repeat_failures_results_flakies'))
+        self.assertTrue(self.getProperty('with_change_repeat_failures_results_exceed_failure_limit'))
+        return rc
 
 class TestRunWebKitTestsRepeatFailuresWithoutChangeRedTree(BuildStepMixinAdditions, unittest.TestCase):
     def setUp(self):
@@ -2863,11 +2939,12 @@ class TestRunWebKitTestsRepeatFailuresWithoutChangeRedTree(BuildStepMixinAdditio
 
     def configureStep(self):
         self.setupStep(RunWebKitTestsRepeatFailuresWithoutChangeRedTree())
+        self.setProperty('platform', 'wpe')
+        self.setProperty('fullPlatform', 'wpe')
+        self.setProperty('configuration', 'release')
 
     def test_success(self):
         self.configureStep()
-        self.setProperty('fullPlatform', 'gtk')
-        self.setProperty('configuration', 'release')
         first_run_failures = ['fast/css/test1.html', 'imported/test/test2.html', 'fast/svg/test3.svg']
         first_run_flakies = ['fast/css/flaky1.html', 'imported/test/flaky2.html', 'fast/svg/flaky3.svg']
         with_change_repeat_failures_results_nonflaky_failures = ['fast/css/test1.html']
@@ -2884,7 +2961,7 @@ class TestRunWebKitTestsRepeatFailuresWithoutChangeRedTree(BuildStepMixinAdditio
                         command=['python3',
                                  'Tools/Scripts/run-webkit-tests',
                                  '--no-build', '--no-show-results', '--no-new-test-results', '--clobber-old-results',
-                                 '--release', '--results-directory', 'layout-test-results', '--debug-rwt-logging',
+                                 '--release', '--wpe', '--results-directory', 'layout-test-results', '--debug-rwt-logging',
                                  '--skip-failing-tests', '--fully-parallel', '--repeat-each=10', '--skipped=always'] + sorted(with_change_repeat_failures_results_nonflaky_failures)
                         )
             + 0,
@@ -2913,7 +2990,7 @@ class TestRunWebKitTestsRepeatFailuresWithoutChangeRedTree(BuildStepMixinAdditio
                         command=['python3',
                                  'Tools/Scripts/run-webkit-tests',
                                  '--no-build', '--no-show-results', '--no-new-test-results', '--clobber-old-results',
-                                 '--release', '--results-directory', 'layout-test-results', '--debug-rwt-logging',
+                                 '--release', '--wpe', '--results-directory', 'layout-test-results', '--debug-rwt-logging',
                                  '--skip-failing-tests', '--fully-parallel', '--repeat-each=10', '--skipped=always'] + sorted(first_run_failures)
                         )
             + 0,
@@ -2921,6 +2998,52 @@ class TestRunWebKitTestsRepeatFailuresWithoutChangeRedTree(BuildStepMixinAdditio
         self.expectOutcome(result=SUCCESS, state_string='layout-tests')
         return self.runStep()
 
+    def test_set_properties_when_executed_scope_this_class(self):
+        self.configureStep()
+        first_run_failures = ['fast/css/test1.html', 'imported/test/test2.html', 'fast/svg/test3.svg']
+        first_run_flakies = ['fast/css/flaky1.html', 'imported/test/flaky2.html', 'fast/svg/flaky3.svg']
+        with_change_repeat_failures_results_nonflaky_failures = ['fast/css/test1.html']
+        with_change_repeat_failures_results_flakies = ['imported/test/test2.html', 'fast/svg/test3.svg']
+        # Set good values for properties that only the superclass should set
+        self.setProperty('first_run_failures', first_run_failures)
+        self.setProperty('first_run_flakies', first_run_flakies)
+        self.setProperty('first_results_exceed_failure_limit', False)
+        self.setProperty('with_change_repeat_failures_results_nonflaky_failures', with_change_repeat_failures_results_nonflaky_failures)
+        self.setProperty('with_change_repeat_failures_results_flakies', with_change_repeat_failures_results_flakies)
+        self.setProperty('with_change_repeat_failures_timedout', False)
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        logfiles={'json': self.jsonFileName},
+                        logEnviron=False,
+                        maxTime=10800,
+                        command=['python3',
+                                 'Tools/Scripts/run-webkit-tests',
+                                 '--no-build', '--no-show-results', '--no-new-test-results', '--clobber-old-results',
+                                 '--release', '--wpe', '--results-directory', 'layout-test-results', '--debug-rwt-logging',
+                                 '--skip-failing-tests', '--fully-parallel', '--repeat-each=10', '--skipped=always'] + sorted(with_change_repeat_failures_results_nonflaky_failures)
+                        )
+            + 2
+        )
+        # Patch LayoutTestFailures.results_from_string() so it always reports fake values.
+        # Check this fake values do not end on the properties that belong to the superclass.
+        fake_failing_tests = ['fake/should/not/happen/failure1.html', 'imported/fake/failure2.html']
+        fake_flaky_tests = ['fake/should/not/happen/flaky1.html', 'imported/fake/flaky2.html']
+        fake_layout_test_failures = MockLayoutTestFailures(fake_failing_tests, fake_flaky_tests, True)
+        self.patch(LayoutTestFailures, 'results_from_string', lambda f: fake_layout_test_failures)
+        self.expectOutcome(result=FAILURE, state_string='layout-tests (failure)')
+        rc = self.runStep()
+        # first_run properties should not be set to fake_layout_test_failures when running RunWebKitTestsRepeatFailuresWithoutChangeRedTree()
+        self.assertEqual(first_run_failures, self.getProperty('first_run_failures'))
+        self.assertEqual(first_run_flakies, self.getProperty('first_run_flakies'))
+        self.assertFalse(self.getProperty('first_results_exceed_failure_limit'))
+        self.assertEqual(with_change_repeat_failures_results_nonflaky_failures, self.getProperty('with_change_repeat_failures_results_nonflaky_failures'))
+        self.assertEqual(with_change_repeat_failures_results_flakies, self.getProperty('with_change_repeat_failures_results_flakies'))
+        self.assertFalse(self.getProperty('with_change_repeat_failures_timedout'))
+        # Test also that this fake values are set _only_ for the properties this class should define
+        self.assertEqual(fake_failing_tests, self.getProperty('without_change_repeat_failures_results_nonflaky_failures'))
+        self.assertEqual(fake_flaky_tests, self.getProperty('without_change_repeat_failures_results_flakies'))
+        self.assertTrue(self.getProperty('without_change_repeat_failures_results_exceed_failure_limit'))
+        return rc
 
 class TestAnalyzeLayoutTestsResultsRedTree(BuildStepMixinAdditions, unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
#### 440943ba5b7ea75da370ea5a3d0325262a055127
<pre>
REGRESSION(257654@main): [ews-build.webkit.org][GTK][WPE] RunWebKitTestsRedTree sub-classes are overwriting the &apos;first_run&apos; properties on the retry steps.
<a href="https://bugs.webkit.org/show_bug.cgi?id=253048">https://bugs.webkit.org/show_bug.cgi?id=253048</a>

Reviewed by Jonathan Bedard.

257654@main changed the way the class RunWebKitTests() works: instead of specializing the function
buildstep.BuildStep.commandComplete() the function buildstep.BuildStep.runCommand() is specialized.

Buildbot first calls runCommand() and then calls commandComplete()

The problem is with the subclasses of RunWebKitTests() which were specializing a commandComplete()
function: now instead of executing the generic buildstep.BuildStep.runCommand() they execute the
specialized RunWebKitTests.runCommand() which was the previous RunWebKitTests.commandComplete()
so this has the undesired effect that the properties defined at RunWebKitTests().runCommand()
(&apos;first_run_flakies&apos;, &apos;first_run_failures&apos; and &apos;first_results_exceed_failure_limit&apos;) get
redefined (overwritten) multiple times with the values generated when running the command
of each one of the sub-classes.

This is wrong and can cause unexpected issues later when analyzing the results in
AnalyzeLayoutTestsResultsRedTree() because the values of the properties &apos;first_run_flakies&apos;
and &apos;first_run_failures&apos; are not the ones from the first run but the ones from the last
retry step executed.

Fix it by specializing runCommand() instead of commandComplete() on the subclasses like
RunWebKitTests() class does now. Add also a few unit tests.

* Tools/CISupport/ews-build/steps.py:
(RunWebKitTestsRepeatFailuresRedTree):
(RunWebKitTestsRepeatFailuresRedTree.runCommand):
(RunWebKitTestsRepeatFailuresWithoutChangeRedTree):
(RunWebKitTestsRepeatFailuresWithoutChangeRedTree.runCommand):
(RunWebKitTestsRepeatFailuresRedTree.commandComplete): Deleted.
(RunWebKitTestsRepeatFailuresWithoutChangeRedTree.commandComplete): Deleted.
* Tools/CISupport/ews-build/steps_unittest.py:
(MockLayoutTestFailures):
(MockLayoutTestFailures.__init__):
(TestRunWebKitTestsRedTree.configureStep):
(TestRunWebKitTestsRedTree.test_success):
(TestRunWebKitTestsRedTree.test_set_properties_when_executed_scope_this_class):
(TestRunWebKitTestsRepeatFailuresRedTree.configureStep):
(TestRunWebKitTestsRepeatFailuresRedTree.test_success):
(TestRunWebKitTestsRepeatFailuresRedTree.test_set_properties_when_executed_scope_this_class):
(TestRunWebKitTestsRepeatFailuresWithoutChangeRedTree.configureStep):
(TestRunWebKitTestsRepeatFailuresWithoutChangeRedTree.test_success):
(TestRunWebKitTestsRepeatFailuresWithoutChangeRedTree.test_step_with_change_did_timeout):
(TestRunWebKitTestsRepeatFailuresWithoutChangeRedTree.test_set_properties_when_executed_scope_this_class):

Canonical link: <a href="https://commits.webkit.org/261167@main">https://commits.webkit.org/261167@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9031d2b9b68e096fac5e4bef7f504f834cc621a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109961 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19064 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42646 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1407 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119011 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113912 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20528 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10255 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/926 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115709 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15280 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98496 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102219 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97242 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30152 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43497 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11766 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31493 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85315 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12389 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8448 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/108728 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17757 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51103 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14184 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4217 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->