### PR TITLE
[UI-side compositing] Hook up the MomentumEventGenerator for UI-side scrolling

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
@@ -82,19 +82,22 @@ private:
 };
 
 
-Ref<RemoteLayerTreeEventDispatcher> RemoteLayerTreeEventDispatcher::create(RemoteScrollingCoordinatorProxyMac& scrollingCoordinator, WebCore::PageIdentifier pageIdentifier)
+Ref<RemoteLayerTreeEventDispatcher> RemoteLayerTreeEventDispatcher::create(RemoteScrollingCoordinatorProxyMac& scrollingCoordinator, PageIdentifier pageIdentifier)
 {
     return adoptRef(*new RemoteLayerTreeEventDispatcher(scrollingCoordinator, pageIdentifier));
 }
 
 static constexpr Seconds wheelEventHysteresisDuration { 500_ms };
 
-RemoteLayerTreeEventDispatcher::RemoteLayerTreeEventDispatcher(RemoteScrollingCoordinatorProxyMac& scrollingCoordinator, WebCore::PageIdentifier pageIdentifier)
+RemoteLayerTreeEventDispatcher::RemoteLayerTreeEventDispatcher(RemoteScrollingCoordinatorProxyMac& scrollingCoordinator, PageIdentifier pageIdentifier)
     : m_scrollingCoordinator(WeakPtr { scrollingCoordinator })
     , m_pageIdentifier(pageIdentifier)
     , m_wheelEventDeltaFilter(WheelEventDeltaFilter::create())
     , m_displayLinkClient(makeUnique<RemoteLayerTreeEventDispatcherDisplayLinkClient>(*this))
     , m_wheelEventActivityHysteresis([this](PAL::HysteresisState state) { wheelEventHysteresisUpdated(state); }, wheelEventHysteresisDuration)
+#if ENABLE(MOMENTUM_EVENT_DISPATCHER)
+    , m_momentumEventDispatcher(WTF::makeUnique<MomentumEventDispatcher>(*this))
+#endif
 {
 }
 
@@ -129,13 +132,11 @@ RefPtr<RemoteScrollingTree> RemoteLayerTreeEventDispatcher::scrollingTree()
 
 void RemoteLayerTreeEventDispatcher::wheelEventHysteresisUpdated(PAL::HysteresisState state)
 {
-    ASSERT(isMainRunLoop());
     startOrStopDisplayLink();
 }
 
 void RemoteLayerTreeEventDispatcher::hasNodeWithAnimatedScrollChanged(bool hasAnimatedScrolls)
 {
-    ASSERT(isMainRunLoop());
     startOrStopDisplayLink();
 }
 
@@ -145,6 +146,15 @@ void RemoteLayerTreeEventDispatcher::willHandleWheelEvent(const NativeWebWheelEv
     
     m_wheelEventActivityHysteresis.impulse();
     m_wheelEventsBeingProcessed.append(wheelEvent);
+
+#if ENABLE(MOMENTUM_EVENT_DISPATCHER)
+    if (wheelEvent.momentumPhase() == WebWheelEvent::PhaseBegan) {
+        auto curve = ScrollingAccelerationCurve::fromNativeWheelEvent(wheelEvent);
+        m_momentumEventDispatcher->setScrollingAccelerationCurve(m_pageIdentifier, curve);
+    }
+#else
+    UNUSED_PARAM(wheelEvent);
+#endif
 }
 
 void RemoteLayerTreeEventDispatcher::handleWheelEvent(const NativeWebWheelEvent& nativeWheelEvent, RectEdges<bool> rubberBandableEdges)
@@ -153,10 +163,8 @@ void RemoteLayerTreeEventDispatcher::handleWheelEvent(const NativeWebWheelEvent&
 
     willHandleWheelEvent(nativeWheelEvent);
 
-    ScrollingThread::dispatch([dispatcher = Ref { *this }, platformWheelEvent = platform(nativeWheelEvent), rubberBandableEdges] {
-        LOG_WITH_STREAM(Scrolling, stream << "RemoteLayerTreeEventDispatcher::handleWheelEvent on scrolling thread " << platformWheelEvent);
-        auto handlingResult = dispatcher->internalHandleWheelEvent(platformWheelEvent, rubberBandableEdges);
-
+    ScrollingThread::dispatch([dispatcher = Ref { *this }, webWheelEvent = WebWheelEvent { nativeWheelEvent }, rubberBandableEdges] {
+        auto handlingResult = dispatcher->scrollingThreadHandleWheelEvent(webWheelEvent, rubberBandableEdges);
         RunLoop::main().dispatch([dispatcher, handlingResult] {
             dispatcher->wheelEventWasHandledByScrollingThread(handlingResult);
         });
@@ -176,23 +184,44 @@ void RemoteLayerTreeEventDispatcher::wheelEventWasHandledByScrollingThread(Wheel
     m_scrollingCoordinator->continueWheelEventHandling(event, handlingResult);
 }
 
-WheelEventHandlingResult RemoteLayerTreeEventDispatcher::internalHandleWheelEvent(const PlatformWheelEvent& wheelEvent, RectEdges<bool> rubberBandableEdges)
+OptionSet<WheelEventProcessingSteps> RemoteLayerTreeEventDispatcher::determineWheelEventProcessing(const WebCore::PlatformWheelEvent& wheelEvent, RectEdges<bool> rubberBandableEdges)
 {
-    ASSERT(ScrollingThread::isCurrentThread());
-
     auto scrollingTree = this->scrollingTree();
     if (!scrollingTree)
-        return WheelEventHandlingResult::unhandled();
+        return { };
 
     // Replicate the hack in EventDispatcher::internalWheelEvent(). We could pass rubberBandableEdges all the way through the
     // WebProcess and back via the ScrollingTree, but we only ever need to consult it here.
     if (wheelEvent.phase() == PlatformWheelEventPhase::Began)
         scrollingTree->setMainFrameCanRubberBand(rubberBandableEdges);
 
-    auto processingSteps = scrollingTree->determineWheelEventProcessing(wheelEvent);
-    LOG_WITH_STREAM(Scrolling, stream << "RemoteLayerTreeEventDispatcher::internalHandleWheelEvent " << wheelEvent << " - steps " << processingSteps);
+    return scrollingTree->determineWheelEventProcessing(wheelEvent);
+}
+
+WheelEventHandlingResult RemoteLayerTreeEventDispatcher::scrollingThreadHandleWheelEvent(const WebWheelEvent& wheelEvent, RectEdges<bool> rubberBandableEdges)
+{
+    auto platformWheelEvent = platform(wheelEvent);
+    auto processingSteps = determineWheelEventProcessing(platformWheelEvent, rubberBandableEdges);
     if (!processingSteps.contains(WheelEventProcessingSteps::ScrollingThread))
-        return WheelEventHandlingResult::unhandled(processingSteps);
+        return WheelEventHandlingResult { processingSteps, false };
+
+#if ENABLE(MOMENTUM_EVENT_DISPATCHER)
+    if (m_momentumEventDispatcher->handleWheelEvent(m_pageIdentifier, wheelEvent, rubberBandableEdges))
+        return WheelEventHandlingResult { processingSteps, true };
+#endif
+
+    LOG_WITH_STREAM(Scrolling, stream << "RemoteLayerTreeEventDispatcher::handleWheelEvent on scrolling thread " << platformWheelEvent);
+    return internalHandleWheelEvent(platformWheelEvent, processingSteps);
+}
+
+WheelEventHandlingResult RemoteLayerTreeEventDispatcher::internalHandleWheelEvent(const PlatformWheelEvent& wheelEvent, OptionSet<WheelEventProcessingSteps> processingSteps)
+{
+    ASSERT(ScrollingThread::isCurrentThread());
+    ASSERT(processingSteps.contains(WheelEventProcessingSteps::ScrollingThread));
+
+    auto scrollingTree = this->scrollingTree();
+    if (!scrollingTree)
+        return WheelEventHandlingResult::unhandled();
 
     scrollingTree->willProcessWheelEvent();
 
@@ -233,7 +262,25 @@ DisplayLink* RemoteLayerTreeEventDispatcher::displayLink() const
 
 void RemoteLayerTreeEventDispatcher::startOrStopDisplayLink()
 {
+    if (isMainRunLoop()) {
+        startOrStopDisplayLinkOnMainThread();
+        return;
+    }
+
+    RunLoop::main().dispatch([strongThis = Ref { *this }] {
+        strongThis->startOrStopDisplayLinkOnMainThread();
+    });
+}
+
+void RemoteLayerTreeEventDispatcher::startOrStopDisplayLinkOnMainThread()
+{
+    ASSERT(isMainRunLoop());
+
     auto needsDisplayLink = [&]() {
+#if ENABLE(MOMENTUM_EVENT_DISPATCHER)
+        if (m_momentumEventDispatcherNeedsDisplayLink)
+            return true;
+#endif
         if (m_wheelEventActivityHysteresis.state() == PAL::HysteresisState::Started)
             return true;
 
@@ -282,6 +329,10 @@ void RemoteLayerTreeEventDispatcher::didRefreshDisplay(PlatformDisplayID display
 {
     ASSERT(ScrollingThread::isCurrentThread());
 
+#if ENABLE(MOMENTUM_EVENT_DISPATCHER)
+    m_momentumEventDispatcher->displayDidRefresh(displayID);
+#endif
+
     auto scrollingTree = this->scrollingTree();
     if (!scrollingTree)
         return;
@@ -289,15 +340,58 @@ void RemoteLayerTreeEventDispatcher::didRefreshDisplay(PlatformDisplayID display
     scrollingTree->displayDidRefresh(displayID);
 }
 
-void RemoteLayerTreeEventDispatcher::mainThreadDisplayDidRefresh(WebCore::PlatformDisplayID)
+void RemoteLayerTreeEventDispatcher::mainThreadDisplayDidRefresh(PlatformDisplayID)
 {
     scrollingTree()->applyLayerPositions();
 }
 
-void RemoteLayerTreeEventDispatcher::windowScreenDidChange(WebCore::PlatformDisplayID, std::optional<WebCore::FramesPerSecond>)
+void RemoteLayerTreeEventDispatcher::windowScreenDidChange(PlatformDisplayID displayID, std::optional<FramesPerSecond> nominalFramesPerSecond)
 {
+#if ENABLE(MOMENTUM_EVENT_DISPATCHER)
+    m_momentumEventDispatcher->pageScreenDidChange(m_pageIdentifier, displayID, nominalFramesPerSecond);
+#else
+    UNUSED_PARAM(displayID);
+    UNUSED_PARAM(nominalFramesPerSecond);
+#endif
     // FIXME: Restart the displayLink if necessary.
 }
+
+#if ENABLE(MOMENTUM_EVENT_DISPATCHER)
+void RemoteLayerTreeEventDispatcher::handleSyntheticWheelEvent(PageIdentifier pageID, const WebWheelEvent& event, RectEdges<bool> rubberBandableEdges)
+{
+    ASSERT_UNUSED(pageID, m_pageIdentifier == pageID);
+
+    auto platformWheelEvent = platform(event);
+    auto processingSteps = determineWheelEventProcessing(platformWheelEvent, rubberBandableEdges);
+    if (!processingSteps.contains(WheelEventProcessingSteps::ScrollingThread))
+        return;
+
+    internalHandleWheelEvent(platformWheelEvent, processingSteps);
+}
+
+void RemoteLayerTreeEventDispatcher::startDisplayDidRefreshCallbacks(PlatformDisplayID)
+{
+    ASSERT(!m_momentumEventDispatcherNeedsDisplayLink);
+    m_momentumEventDispatcherNeedsDisplayLink = true;
+    startOrStopDisplayLink();
+}
+
+void RemoteLayerTreeEventDispatcher::stopDisplayDidRefreshCallbacks(PlatformDisplayID)
+{
+    ASSERT(m_momentumEventDispatcherNeedsDisplayLink);
+    m_momentumEventDispatcherNeedsDisplayLink = false;
+    startOrStopDisplayLink();
+}
+
+#if ENABLE(MOMENTUM_EVENT_DISPATCHER_TEMPORARY_LOGGING)
+void RemoteLayerTreeEventDispatcher::flushMomentumEventLoggingSoon()
+{
+    RunLoop::current().dispatchAfter(1_s, [strongThis = Ref { *this }] {
+        strongThis->m_momentumEventDispatcher->flushLog();
+    });
+}
+#endif // ENABLE(MOMENTUM_EVENT_DISPATCHER_TEMPORARY_LOGGING)
+#endif // ENABLE(MOMENTUM_EVENT_DISPATCHER)
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp
+++ b/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp
@@ -294,6 +294,9 @@ void MomentumEventDispatcher::startDisplayLink()
 
 void MomentumEventDispatcher::stopDisplayLink()
 {
+    if (!m_currentGesture.active)
+        return;
+
     auto displayProperties = this->displayProperties(m_currentGesture.pageIdentifier);
     if (!displayProperties) {
         RELEASE_LOG(ScrollAnimations, "MomentumEventDispatcher failed to stop display link");


### PR DESCRIPTION
#### 7b321c9bc2f7d450a7ce5e98383739d4c4698e8e
<pre>
[UI-side compositing] Hook up the MomentumEventGenerator for UI-side scrolling
<a href="https://bugs.webkit.org/show_bug.cgi?id=253049">https://bugs.webkit.org/show_bug.cgi?id=253049</a>
rdar://106012308

Reviewed by Tim Horton.

Give RemoteLayerTreeEventDispatcher a MomentumEventDispatcher, which synthesizes momentum events
on the UI-sides scrolling thread.

RemoteLayerTreeEventDispatcher becomes a MomentumEventDispatcher::Client so that MomentumEventDispatcher
can keep the display link alive. Fix startOrStopDisplayLink() so it can be called from either thread.

RemoteLayerTreeEventDispatcher::willHandleWheelEvent() is used so allow the MomentumEventDispatcher to extract
the ScrollingAccelerationCurve from the native event.

Factor code into determineWheelEventProcessing() so we can call it before feeding events to MomentumEventDispatcher,
because we need to know if this event is relevant to the scrolling thread before handing it off to MomentumEventDispatcher,
which can&apos;t give an answer about whether it&apos;s handled.

* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp:
(WebKit::RemoteLayerTreeEventDispatcher::create):
(WebKit::RemoteLayerTreeEventDispatcher::RemoteLayerTreeEventDispatcher):
(WebKit::m_momentumEventDispatcher):
(WebKit::RemoteLayerTreeEventDispatcher::wheelEventHysteresisUpdated):
(WebKit::RemoteLayerTreeEventDispatcher::hasNodeWithAnimatedScrollChanged):
(WebKit::RemoteLayerTreeEventDispatcher::willHandleWheelEvent):
(WebKit::RemoteLayerTreeEventDispatcher::handleWheelEvent):
(WebKit::RemoteLayerTreeEventDispatcher::determineWheelEventProcessing):
(WebKit::RemoteLayerTreeEventDispatcher::scrollingThreadHandleWheelEvent):
(WebKit::RemoteLayerTreeEventDispatcher::internalHandleWheelEvent):
(WebKit::RemoteLayerTreeEventDispatcher::startOrStopDisplayLink):
(WebKit::RemoteLayerTreeEventDispatcher::startOrStopDisplayLinkOnMainThread):
(WebKit::RemoteLayerTreeEventDispatcher::didRefreshDisplay):
(WebKit::RemoteLayerTreeEventDispatcher::mainThreadDisplayDidRefresh):
(WebKit::RemoteLayerTreeEventDispatcher::windowScreenDidChange):
(WebKit::RemoteLayerTreeEventDispatcher::handleSyntheticWheelEvent):
(WebKit::RemoteLayerTreeEventDispatcher::startDisplayDidRefreshCallbacks):
(WebKit::RemoteLayerTreeEventDispatcher::stopDisplayDidRefreshCallbacks):
(WebKit::RemoteLayerTreeEventDispatcher::flushMomentumEventLoggingSoon):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h:
* Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.h:

Canonical link: <a href="https://commits.webkit.org/260976@main">https://commits.webkit.org/260976@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca94261d22e2840b4a5b0279d517e290722195c6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110130 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19230 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/42798 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1560 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/119137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20692 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10421 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102388 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115876 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/43628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/30276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/85465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11926 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/31613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/12540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/17905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7606 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14344 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->