### PR TITLE
Add block-step-insert to CSS parser.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -33,6 +33,7 @@ PASS background-repeat
 PASS background-size
 PASS baseline-shift
 PASS block-size
+PASS block-step-insert
 PASS block-step-size
 PASS border-block-end-color
 PASS border-block-end-style

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-computed-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Property block-step-insert value 'margin'
+PASS Property block-step-insert value 'padding'
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-computed.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Rhythm: block-step-insert computed values</title>
+<link rel="author" title="Sammy Gill" href="sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-insert">
+<meta name="assert" content="Checking computed values for block-step-insert">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<style>
+    #target {
+      font-size: 40px;
+    }
+</style>
+</head>
+<body>
+<div id="target"></div>
+<script>
+    test_computed_value("block-step-insert", "margin");
+    test_computed_value("block-step-insert", "padding");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-invalid-expected.txt
@@ -1,0 +1,12 @@
+
+PASS e.style['block-step-insert'] = "auto" should not set the property value
+PASS e.style['block-step-insert'] = "-1px" should not set the property value
+PASS e.style['block-step-insert'] = "min-content" should not set the property value
+PASS e.style['block-step-insert'] = "10%" should not set the property value
+PASS e.style['block-step-insert'] = "20" should not set the property value
+PASS e.style['block-step-insert'] = "none" should not set the property value
+PASS e.style['block-step-insert'] = "border-box" should not set the property value
+PASS e.style['block-step-insert'] = "margin-box" should not set the property value
+PASS e.style['block-step-insert'] = "margin padding" should not set the property value
+PASS e.style['block-step-insert'] = "padding margin" should not set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-invalid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-invalid.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Rhythm: block-step-insert invalid values</title>
+<link rel="author" title="Sammy Gill" href="sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-insert">
+<meta name="assert" content="Invalid values for block-step-insert should not be parsed">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<style>
+    #target {
+      font-size: 40px;
+    }
+</style>
+</head>
+<body>
+<div id="target"></div>
+<script>
+    test_invalid_value("block-step-insert", "auto");
+    test_invalid_value("block-step-insert", "-1px");
+    test_invalid_value("block-step-insert", "min-content");
+    test_invalid_value("block-step-insert", "10%");
+    test_invalid_value("block-step-insert", "20");
+    test_invalid_value("block-step-insert", "none");
+    test_invalid_value("block-step-insert", "border-box");
+    test_invalid_value('block-step-insert', "margin-box");
+    test_invalid_value("block-step-insert", "margin padding");
+    test_invalid_value("block-step-insert", "padding margin");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-valid-expected.txt
@@ -1,0 +1,4 @@
+
+PASS e.style['block-step-insert'] = "margin" should set the property value
+PASS e.style['block-step-insert'] = "padding" should set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-valid.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Rhythm: block-step-insert valid values</title>
+<link rel="author" title="Sammy Gill" href="sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-insert">
+<meta name="assert" content="Parsing valid values for block-step-insert property">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<style>
+    #target {
+      font-size: 40px;
+    }
+</style>
+</head>
+<body>
+<div id="target"></div>
+<script>
+    test_valid_value("block-step-insert", "margin");
+    test_valid_value("block-step-insert", "padding");
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -33,6 +33,7 @@ PASS background-repeat
 PASS background-size
 PASS baseline-shift
 PASS block-size
+PASS block-step-insert
 PASS block-step-size
 PASS border-block-end-color
 PASS border-block-end-style

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -33,6 +33,7 @@ PASS background-repeat
 PASS background-size
 PASS baseline-shift
 PASS block-size
+PASS block-step-insert
 PASS block-step-size
 PASS border-block-end-color
 PASS border-block-end-style

--- a/LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -33,6 +33,7 @@ PASS background-repeat
 PASS background-size
 PASS baseline-shift
 PASS block-size
+PASS block-step-insert
 PASS block-step-size
 PASS border-block-end-color
 PASS border-block-end-style

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -33,6 +33,7 @@ PASS background-repeat
 PASS background-size
 PASS baseline-shift
 PASS block-size
+PASS block-step-insert
 PASS block-step-size
 PASS border-block-end-color
 PASS border-block-end-style

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -33,6 +33,7 @@ PASS background-repeat
 PASS background-size
 PASS baseline-shift
 PASS block-size
+PASS block-step-insert
 PASS block-step-size
 PASS border-block-end-color
 PASS border-block-end-style

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -3687,6 +3687,7 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         case CSSPropertyAnimationPlayState:
         case CSSPropertyAnimationTimingFunction:
         case CSSPropertyAppearance:
+        case CSSPropertyBlockStepInsert:
         case CSSPropertyBlockStepSize:
         case CSSPropertyBorderBlock: // logical shorthand
         case CSSPropertyBorderBlockColor: // logical shorthand

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -216,6 +216,13 @@ template<> constexpr OutlineIsAuto fromCSSValueID(CSSValueID valueID)
     return OutlineIsAuto::Off;
 }
 
+template<> constexpr BlockStepInsert fromCSSValueID(CSSValueID valueID)
+{
+    if (valueID == CSSValueMargin)
+        return BlockStepInsert::Margin;
+    return BlockStepInsert::Padding;
+}
+
 constexpr CSSValueID toCSSValueID(CompositeOperator e, CSSPropertyID propertyID)
 {
     if (propertyID == CSSPropertyMaskComposite) {

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -334,6 +334,16 @@
                 "url": "https://drafts.csswg.org/css-rhythm/#block-step-size"
             }
         },
+        "block-step-insert": {
+            "values": [
+                "margin",
+                "padding"
+            ],
+            "codegen-properties": {
+                "settings-flag": "cssRhythmicSizingEnabled",
+                "parser-grammar": "<<values>>"
+            }
+        },
         "caret-color": {
             "inherited": true,
             "values": [

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -913,6 +913,9 @@ padding-box
 // text
 -webkit-text
 
+// block-step-insert
+margin
+
 //
 // CSS_PROP_MASK_CLIP
 //

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -2846,6 +2846,8 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
             list.append(createSingleAxisPositionValueForLayer(propertyID, *currLayer, style));
         return CSSValueList::createCommaSeparated(WTFMove(list));
     }
+    case CSSPropertyBlockStepInsert:
+        return style.blockStepInsert() == BlockStepInsert::Margin ? CSSPrimitiveValue::create(CSSValueMargin) : CSSPrimitiveValue::create(CSSValuePadding);
     case CSSPropertyBlockStepSize: {
         auto blockStepSize = style.blockStepSize();
         if (!blockStepSize)

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -2058,6 +2058,10 @@ public:
     std::optional<Length> blockStepSize() const { return m_nonInheritedData->rareData->blockStepSize; } 
     void setBlockStepSize(std::optional<Length> length) { SET_NESTED_VAR(m_nonInheritedData, rareData, blockStepSize, length); } 
 
+    static BlockStepInsert initialBlockStepInsert() { return BlockStepInsert::Margin; }
+    BlockStepInsert blockStepInsert() const { return static_cast<BlockStepInsert>(m_nonInheritedData->rareData->blockStepInsert); }
+    void setBlockStepInsert(BlockStepInsert newBlockStepInsert) { SET_NESTED_VAR(m_nonInheritedData, rareData, blockStepInsert, static_cast<unsigned>(newBlockStepInsert)); }
+
 private:
     struct NonInheritedFlags {
         bool operator==(const NonInheritedFlags&) const;

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -1258,6 +1258,11 @@ enum class ContentVisibility : uint8_t {
     Hidden,
 };
 
+enum class BlockStepInsert : uint8_t {
+    Margin,
+    Padding
+};
+
 CSSBoxType transformBoxToCSSBoxType(TransformBox);
 
 extern const float defaultMiterLimit;

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
@@ -86,6 +86,7 @@ StyleRareNonInheritedData::StyleRareNonInheritedData()
     // scrollSnapStop
     , zoom(RenderStyle::initialZoom())
     , blockStepSize(RenderStyle::initialBlockStepSize())
+    , blockStepInsert(static_cast<unsigned>(RenderStyle::initialBlockStepInsert()))
     , overscrollBehaviorX(static_cast<unsigned>(RenderStyle::initialOverscrollBehaviorX()))
     , overscrollBehaviorY(static_cast<unsigned>(RenderStyle::initialOverscrollBehaviorY()))
     , pageSizeType(PAGE_SIZE_AUTO)
@@ -167,6 +168,7 @@ inline StyleRareNonInheritedData::StyleRareNonInheritedData(const StyleRareNonIn
     , scrollSnapStop(o.scrollSnapStop)
     , zoom(o.zoom)
     , blockStepSize(o.blockStepSize)
+    , blockStepInsert(o.blockStepInsert)
     , overscrollBehaviorX(o.overscrollBehaviorX)
     , overscrollBehaviorY(o.overscrollBehaviorY)
     , pageSizeType(o.pageSizeType)
@@ -255,6 +257,7 @@ bool StyleRareNonInheritedData::operator==(const StyleRareNonInheritedData& o) c
         && scrollSnapStop == o.scrollSnapStop
         && zoom == o.zoom
         && blockStepSize == o.blockStepSize
+        && blockStepInsert == o.blockStepInsert
         && overscrollBehaviorX == o.overscrollBehaviorX
         && overscrollBehaviorY == o.overscrollBehaviorY
         && pageSizeType == o.pageSizeType

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -174,6 +174,7 @@ public:
     float zoom;
 
     std::optional<Length> blockStepSize;
+    unsigned blockStepInsert : 1; // BlockStepInsert
 
     unsigned overscrollBehaviorX : 2; // OverscrollBehavior
     unsigned overscrollBehaviorY : 2; // OverscrollBehavior


### PR DESCRIPTION
#### de8f3a3612be144211c763be5806b69e24d7d97e
<pre>
Add block-step-insert to CSS parser.
<a href="https://bugs.webkit.org/show_bug.cgi?id=252206">https://bugs.webkit.org/show_bug.cgi?id=252206</a>
rdar://105421524

Reviewed by Tim Nguyen.

Adds the block-step-insert property to the CSS parser and adds it as
a field to StyleRareNonInheritedData. The grammar of this property is:
margin | padding

with an initial value of margin. So the field &quot;blockStepInsert,&quot; will
always be onne of these 2 values.

* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-computed-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-computed.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-invalid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-invalid.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-valid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-valid.html: Added.
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-invalid.html:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
(WebCore::fromCSSValueID):
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle):
* Source/WebCore/rendering/style/RenderStyle.h:
(WebCore::RenderStyle::initialBlockStepInsert):
(WebCore::RenderStyle::blockStepInsert const):
(WebCore::RenderStyle::setBlockStepInsert):
* Source/WebCore/rendering/style/RenderStyleConstants.h:
* Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp:
(WebCore::StyleRareNonInheritedData::StyleRareNonInheritedData):
(WebCore::StyleRareNonInheritedData::operator== const):
* Source/WebCore/rendering/style/StyleRareNonInheritedData.h:

Canonical link: <a href="https://commits.webkit.org/260970@main">https://commits.webkit.org/260970@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b863cc1d5ebbc3844949c8a22ab896577717f35a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110106 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19206 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42777 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1539 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/119119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114057 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20668 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10397 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102362 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115852 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/43625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30259 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/85462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11903 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31597 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12521 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17886 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51212 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7603 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14321 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->