### PR TITLE
[web-animations] allow blend() methods to be called from WebKit for OffsetRotation and PathOperation

### DIFF
--- a/Source/WebCore/rendering/PathOperation.h
+++ b/Source/WebCore/rendering/PathOperation.h
@@ -235,7 +235,7 @@ public:
     bool isContaining() const { return m_isContaining; }
 
     bool canBlend(const PathOperation&) const final;
-    RefPtr<PathOperation> blend(const PathOperation*, const BlendingContext&) const final;
+    WEBCORE_EXPORT RefPtr<PathOperation> blend(const PathOperation*, const BlendingContext&) const final;
 
     double lengthForPath() const;
     double lengthForContainPath(const FloatRect& elementRect, double computedPathLength, const FloatPoint& anchor, const OffsetRotation rotation) const;

--- a/Source/WebCore/rendering/style/OffsetRotation.h
+++ b/Source/WebCore/rendering/style/OffsetRotation.h
@@ -33,13 +33,13 @@ struct BlendingContext;
 
 class OffsetRotation {
 public:
-    OffsetRotation(bool hasAuto = false, float angle = 0);
+    WEBCORE_EXPORT OffsetRotation(bool hasAuto = false, float angle = 0);
 
     bool hasAuto() const { return m_hasAuto; }
     float angle() const { return m_angle; }
 
     bool canBlend(const OffsetRotation&) const;
-    OffsetRotation blend(const OffsetRotation&, const BlendingContext&) const;
+    WEBCORE_EXPORT OffsetRotation blend(const OffsetRotation&, const BlendingContext&) const;
 
     bool operator==(const OffsetRotation&) const;
     bool operator!=(const OffsetRotation& o) const { return !(*this == o); }


### PR DESCRIPTION
#### 60089cb1de753738896a4457dc7a3612da7a8551
<pre>
[web-animations] allow blend() methods to be called from WebKit for OffsetRotation and PathOperation
<a href="https://bugs.webkit.org/show_bug.cgi?id=253057">https://bugs.webkit.org/show_bug.cgi?id=253057</a>

Reviewed by Dean Jackson.

* Source/WebCore/rendering/PathOperation.h:
(WebCore::PathOperation::blend const):
* Source/WebCore/rendering/style/OffsetRotation.h:

Canonical link: <a href="https://commits.webkit.org/260932@main">https://commits.webkit.org/260932@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d5f13117cff0777c19d9acc5bc91fbf26d91c0a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109976 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19077 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42659 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1420 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119023 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113927 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20542 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10270 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102234 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115723 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43509 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30160 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85331 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11779 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31501 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12402 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8459 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17770 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51111 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14197 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4112 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->