### PR TITLE
[web-animations] add encoding and decoding support for various types needed for threaded animation resolution

### DIFF
--- a/Source/WebCore/platform/animation/AcceleratedEffect.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.cpp
@@ -90,6 +90,11 @@ Ref<AcceleratedEffect> AcceleratedEffect::create(const KeyframeEffect& effect)
     return adoptRef(*new AcceleratedEffect(effect));
 }
 
+Ref<AcceleratedEffect> AcceleratedEffect::create(Vector<AcceleratedEffectKeyframe>&& keyframes, WebAnimationType type, FillMode fill, PlaybackDirection direction, CompositeOperation composite, RefPtr<TimingFunction>&& timingFunction, RefPtr<TimingFunction>&& defaultKeyframeTimingFunction, OptionSet<WebCore::AcceleratedEffectProperty>&& animatedProperties, bool paused, double iterationStart, double iterations, double playbackRate, Seconds delay, Seconds endDelay, Seconds iterationDuration, Seconds activeDuration, Seconds endTime, std::optional<Seconds> startTime, std::optional<Seconds> holdTime)
+{
+    return adoptRef(*new AcceleratedEffect(WTFMove(keyframes), type, fill, direction, composite, WTFMove(timingFunction), WTFMove(defaultKeyframeTimingFunction), WTFMove(animatedProperties), paused, iterationStart, iterations, playbackRate, delay, endDelay, iterationDuration, activeDuration, endTime, startTime, holdTime));
+}
+
 AcceleratedEffect::AcceleratedEffect(const KeyframeEffect& effect)
 {
     m_fill = effect.fill();
@@ -153,6 +158,29 @@ AcceleratedEffect::AcceleratedEffect(const KeyframeEffect& effect)
 
         m_keyframes.append(WTFMove(acceleratedKeyframe));
     }
+}
+
+AcceleratedEffect::AcceleratedEffect(Vector<AcceleratedEffectKeyframe>&& keyframes, WebAnimationType type, FillMode fill, PlaybackDirection direction, CompositeOperation composite, RefPtr<TimingFunction>&& timingFunction, RefPtr<TimingFunction>&& defaultKeyframeTimingFunction, OptionSet<WebCore::AcceleratedEffectProperty>&& animatedProperties, bool paused, double iterationStart, double iterations, double playbackRate, Seconds delay, Seconds endDelay, Seconds iterationDuration, Seconds activeDuration, Seconds endTime, std::optional<Seconds> startTime, std::optional<Seconds> holdTime)
+    : m_keyframes(WTFMove(keyframes))
+    , m_animationType(type)
+    , m_fill(fill)
+    , m_direction(direction)
+    , m_compositeOperation(composite)
+    , m_timingFunction(WTFMove(timingFunction))
+    , m_defaultKeyframeTimingFunction(WTFMove(defaultKeyframeTimingFunction))
+    , m_animatedProperties(WTFMove(animatedProperties))
+    , m_paused(paused)
+    , m_iterationStart(iterationStart)
+    , m_iterations(iterations)
+    , m_playbackRate(playbackRate)
+    , m_delay(delay)
+    , m_endDelay(endDelay)
+    , m_iterationDuration(iterationDuration)
+    , m_activeDuration(activeDuration)
+    , m_endTime(endTime)
+    , m_startTime(startTime)
+    , m_holdTime(holdTime)
+{
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/animation/AcceleratedEffect.h
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.h
@@ -72,11 +72,34 @@ class AcceleratedEffect : public RefCounted<AcceleratedEffect> {
     WTF_MAKE_ISO_ALLOCATED(AcceleratedEffect);
 public:
     static Ref<AcceleratedEffect> create(const KeyframeEffect&);
+    WEBCORE_EXPORT static Ref<AcceleratedEffect> create(Vector<AcceleratedEffectKeyframe>&&, WebAnimationType, FillMode, PlaybackDirection, CompositeOperation, RefPtr<TimingFunction>&& timingFunction, RefPtr<TimingFunction>&& defaultKeyframeTimingFunction, OptionSet<AcceleratedEffectProperty>&&, bool paused, double iterationStart, double iterations, double playbackRate, Seconds delay, Seconds endDelay, Seconds iterationDuration, Seconds activeDuration, Seconds endTime, std::optional<Seconds> startTime, std::optional<Seconds> holdTime);
 
     virtual ~AcceleratedEffect() = default;
 
+    // Encoding and decoding support
+    const Vector<AcceleratedEffectKeyframe>& keyframes() const { return m_keyframes; }
+    WebAnimationType animationType() const { return m_animationType; }
+    FillMode fill() const { return m_fill; }
+    PlaybackDirection direction() const { return m_direction; }
+    CompositeOperation compositeOperation() const { return m_compositeOperation; }
+    const RefPtr<TimingFunction>& timingFunction() const { return m_timingFunction; }
+    const RefPtr<TimingFunction>& defaultKeyframeTimingFunction() const { return m_defaultKeyframeTimingFunction; }
+    const OptionSet<AcceleratedEffectProperty>& animatedProperties() const { return m_animatedProperties; }
+    bool paused() const { return m_paused; }
+    double iterationStart() const { return m_iterationStart; }
+    double iterations() const { return m_iterations; }
+    double playbackRate() const { return m_playbackRate; }
+    Seconds delay() const { return m_delay; }
+    Seconds endDelay() const { return m_endDelay; }
+    Seconds iterationDuration() const { return m_iterationDuration; }
+    Seconds activeDuration() const { return m_activeDuration; }
+    Seconds endTime() const { return m_endTime; }
+    std::optional<Seconds> startTime() const { return m_startTime; }
+    std::optional<Seconds> holdTime() const { return m_holdTime; }
+
 private:
     AcceleratedEffect(const KeyframeEffect&);
+    explicit AcceleratedEffect(Vector<AcceleratedEffectKeyframe>&&, WebAnimationType, FillMode, PlaybackDirection, CompositeOperation, RefPtr<TimingFunction>&& timingFunction, RefPtr<TimingFunction>&& defaultKeyframeTimingFunction, OptionSet<AcceleratedEffectProperty>&&, bool paused, double iterationStart, double iterations, double playbackRate, WTF::Seconds delay, WTF::Seconds endDelay, WTF::Seconds iterationDuration, WTF::Seconds activeDuration, WTF::Seconds endTime, std::optional<WTF::Seconds> startTime, std::optional<WTF::Seconds> holdTime);
 
     Vector<AcceleratedEffectKeyframe> m_keyframes;
     WebAnimationType m_animationType { WebAnimationType::WebAnimation };

--- a/Source/WebCore/platform/animation/AcceleratedEffectValues.h
+++ b/Source/WebCore/platform/animation/AcceleratedEffectValues.h
@@ -61,7 +61,22 @@ struct AcceleratedEffectValues {
     AcceleratedEffectValues()
     {
     }
-    
+
+    AcceleratedEffectValues(float opacity, LengthPoint&& transformOrigin, TransformOperations&& transform, RefPtr<TransformOperation>&& translate, RefPtr<TransformOperation>&& scale, RefPtr<TransformOperation>&& rotate, RefPtr<PathOperation>&& offsetPath, Length&& offsetDistance, LengthPoint&& offsetPosition, LengthPoint&& offsetAnchor, OffsetRotation&& offsetRotate)
+        : opacity(opacity)
+        , transformOrigin(WTFMove(transformOrigin))
+        , transform(WTFMove(transform))
+        , translate(WTFMove(translate))
+        , scale(WTFMove(scale))
+        , rotate(WTFMove(rotate))
+        , offsetPath(WTFMove(offsetPath))
+        , offsetDistance(WTFMove(offsetDistance))
+        , offsetPosition(WTFMove(offsetPosition))
+        , offsetAnchor(WTFMove(offsetAnchor))
+        , offsetRotate(WTFMove(offsetRotate))
+    {
+    }
+
     WEBCORE_EXPORT AcceleratedEffectValues(const AcceleratedEffectValues&);
     AcceleratedEffectValues(const RenderStyle&);
     AcceleratedEffectValues& operator=(const AcceleratedEffectValues&) = default;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4758,3 +4758,105 @@ enum class WebCore::StorageType : uint8_t {
     Local,
     TransientLocal,
 };
+
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+struct WebCore::LengthPoint {
+    WebCore::Length x();
+    WebCore::Length y();
+}
+
+class WebCore::OffsetRotation {
+    bool hasAuto();
+    float angle();
+}
+
+[OptionSet] enum class WebCore::AcceleratedEffectProperty : uint16_t {
+    Opacity,
+    Transform,
+    Translate,
+    Rotate,
+    Scale,
+    OffsetPath,
+    OffsetDistance,
+    OffsetPosition,
+    OffsetAnchor,
+    OffsetRotate,
+    Filter,
+#if ENABLE(FILTERS_LEVEL_2)
+    BackdropFilter
+#endif
+};
+
+header: <WebCore/WebAnimationTypes.h>
+[CustomHeader] enum class WebCore::WebAnimationType : uint8_t {
+    CSSAnimation,
+    CSSTransition,
+    WebAnimation
+};
+
+enum class WebCore::FillMode : uint8_t {
+    None,
+    Forwards,
+    Backwards,
+    Both,
+    Auto
+};
+
+enum class WebCore::PlaybackDirection : uint8_t {
+    Normal,
+    Reverse,
+    Alternate,
+    AlternateReverse
+};
+
+enum class WebCore::CompositeOperation : uint8_t {
+    Replace,
+    Add,
+    Accumulate
+};
+
+struct WebCore::AcceleratedEffectValues {
+    float opacity;
+    WebCore::LengthPoint transformOrigin;
+    WebCore::TransformOperations transform;
+    RefPtr<WebCore::TransformOperation> translate;
+    RefPtr<WebCore::TransformOperation> scale;
+    RefPtr<WebCore::TransformOperation> rotate;
+    RefPtr<WebCore::PathOperation> offsetPath;
+    WebCore::Length offsetDistance;
+    WebCore::LengthPoint offsetPosition;
+    WebCore::LengthPoint offsetAnchor;
+    WebCore::OffsetRotation offsetRotate;
+}
+
+header: <WebCore/AcceleratedEffect.h>
+[CustomHeader] struct WebCore::AcceleratedEffectKeyframe {
+    double offset;
+    WebCore::AcceleratedEffectValues values;
+    RefPtr<WebCore::TimingFunction> timingFunction;
+    std::optional<WebCore::CompositeOperation> compositeOperation;
+    OptionSet<WebCore::AcceleratedEffectProperty> animatedProperties;
+};
+
+[RefCounted] class WebCore::AcceleratedEffect {
+    Vector<WebCore::AcceleratedEffectKeyframe> keyframes();
+    WebCore::WebAnimationType animationType();
+    WebCore::FillMode fill();
+    WebCore::PlaybackDirection direction();
+    WebCore::CompositeOperation compositeOperation();
+    RefPtr<WebCore::TimingFunction> timingFunction();
+    RefPtr<WebCore::TimingFunction> defaultKeyframeTimingFunction();
+    OptionSet<WebCore::AcceleratedEffectProperty> animatedProperties();
+    bool paused();
+    double iterationStart();
+    double iterations();
+    double playbackRate();
+    WTF::Seconds delay();
+    WTF::Seconds endDelay();
+    WTF::Seconds iterationDuration();
+    WTF::Seconds activeDuration();
+    WTF::Seconds endTime();
+    std::optional<WTF::Seconds> startTime();
+    std::optional<WTF::Seconds> holdTime();
+};
+#endif // ENABLE(THREADED_ANIMATION_RESOLUTION)


### PR DESCRIPTION
#### a8dab28990ee750ad9c530203cd7b27910e9b176
<pre>
[web-animations] add encoding and decoding support for various types needed for threaded animation resolution
<a href="https://bugs.webkit.org/show_bug.cgi?id=253059">https://bugs.webkit.org/show_bug.cgi?id=253059</a>

Reviewed by Dean Jackson.

For threaded animation resolution, we&apos;ll need to encode and decode additional types to send effects over IPC.

* Source/WebCore/platform/animation/AcceleratedEffect.cpp:
(WebCore::AcceleratedEffect::create):
(WebCore::AcceleratedEffect::AcceleratedEffect):
* Source/WebCore/platform/animation/AcceleratedEffect.h:
(WebCore::AcceleratedEffect::keyframes const):
(WebCore::AcceleratedEffect::animationType const):
(WebCore::AcceleratedEffect::fill const):
(WebCore::AcceleratedEffect::direction const):
(WebCore::AcceleratedEffect::compositeOperation const):
(WebCore::AcceleratedEffect::timingFunction const):
(WebCore::AcceleratedEffect::defaultKeyframeTimingFunction const):
(WebCore::AcceleratedEffect::animatedProperties const):
(WebCore::AcceleratedEffect::paused const):
(WebCore::AcceleratedEffect::iterationStart const):
(WebCore::AcceleratedEffect::iterations const):
(WebCore::AcceleratedEffect::playbackRate const):
(WebCore::AcceleratedEffect::delay const):
(WebCore::AcceleratedEffect::endDelay const):
(WebCore::AcceleratedEffect::iterationDuration const):
(WebCore::AcceleratedEffect::activeDuration const):
(WebCore::AcceleratedEffect::endTime const):
(WebCore::AcceleratedEffect::startTime const):
(WebCore::AcceleratedEffect::holdTime const):
* Source/WebCore/platform/animation/AcceleratedEffectValues.h:
(WebCore::AcceleratedEffectValues::AcceleratedEffectValues):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/261049@main">https://commits.webkit.org/261049@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad1df2002adc61c2b2c7fb813ec242c87173ea75

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110325 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19418 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42954 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1726 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119276 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114274 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20868 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10593 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102577 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116069 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15540 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98740 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43757 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97501 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30404 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85612 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12093 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31742 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12688 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8708 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18053 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51358 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14522 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4169 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->