### PR TITLE
REGRESSION (iOS 16.4 Public Beta) getUserMedia ignores facingMode constraint

### DIFF
--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
@@ -509,7 +509,7 @@ double RealtimeMediaSource::fitnessDistance(const MediaConstraint& constraint)
         auto supportedModes = capabilities.facingMode().map([](auto& mode) {
             return RealtimeMediaSourceSettings::facingMode(mode);
         });
-        return downcast<StringConstraint>(constraint).fitnessDistance(supportedModes) + facingModeFitnessDistanceAdjustment();
+        return downcast<StringConstraint>(constraint).fitnessDistance(supportedModes);
         break;
     }
 
@@ -895,8 +895,10 @@ bool RealtimeMediaSource::supportsConstraints(const MediaConstraints& constraint
         double distance = fitnessDistance(variant);
         switch (variant.constraintType()) {
         case MediaConstraintType::DeviceId:
-        case MediaConstraintType::FacingMode:
             m_fitnessScore += distance ? 1 : 32;
+            break;
+        case MediaConstraintType::FacingMode:
+            m_fitnessScore += facingModeFitnessScoreAdjustment() + (distance ? 1 : 32);
             break;
 
         case MediaConstraintType::Width:

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -243,7 +243,7 @@ public:
     const CaptureDevice& captureDevice() const { return m_device; }
     bool isEphemeral() const { return m_device.isEphemeral(); }
 
-    virtual double facingModeFitnessDistanceAdjustment() const { return 0; }
+    virtual double facingModeFitnessScoreAdjustment() const { return 0; }
 
 protected:
     RealtimeMediaSource(const CaptureDevice&, MediaDeviceHashSalts&& hashSalts = { }, PageIdentifier = { });

--- a/Source/WebCore/platform/mediastream/RealtimeVideoSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeVideoSource.h
@@ -55,7 +55,7 @@ private:
     Ref<RealtimeMediaSource> clone() final;
     void endProducingData() final;
     void stopBeingObserved() final;
-    double facingModeFitnessDistanceAdjustment() const final  { return m_source->facingModeFitnessDistanceAdjustment(); }
+    double facingModeFitnessScoreAdjustment() const final  { return m_source->facingModeFitnessScoreAdjustment(); }
 
     const RealtimeMediaSourceCapabilities& capabilities() final { return m_source->capabilities(); }
     const RealtimeMediaSourceSettings& settings() final { return m_currentSettings; }

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h
@@ -83,7 +83,7 @@ private:
 
     const RealtimeMediaSourceCapabilities& capabilities() final;
     const RealtimeMediaSourceSettings& settings() final;
-    double facingModeFitnessDistanceAdjustment() const final;
+    double facingModeFitnessScoreAdjustment() const final;
     void startProducingData() final;
     void stopProducingData() final;
     void settingsDidChange(OptionSet<RealtimeMediaSourceSettings::Flag>) final;

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
@@ -294,7 +294,7 @@ const RealtimeMediaSourceCapabilities& AVVideoCaptureSource::capabilities()
     return *m_capabilities;
 }
 
-double AVVideoCaptureSource::facingModeFitnessDistanceAdjustment() const
+double AVVideoCaptureSource::facingModeFitnessScoreAdjustment() const
 {
     ASSERT(isMainThread());
 
@@ -321,9 +321,10 @@ double AVVideoCaptureSource::facingModeFitnessDistanceAdjustment() const
     if (relativePriority == NSNotFound)
         relativePriority = devicePriorities.count;
 
-    ALWAYS_LOG_IF(loggerPtr(), LOGIDENTIFIER, captureDevice().label(), " has priority ", relativePriority);
+    auto fitnessScore = devicePriorities.count - relativePriority;
+    ALWAYS_LOG_IF(loggerPtr(), LOGIDENTIFIER, captureDevice().label(), " has fitness adjustment ", fitnessScore);
 
-    return relativePriority;
+    return fitnessScore;
 }
 
 bool AVVideoCaptureSource::prefersPreset(VideoPreset& preset)


### PR DESCRIPTION
#### c9e35ddc3cab05feca0115b83ca0adb780e832d6
<pre>
REGRESSION (iOS 16.4 Public Beta) getUserMedia ignores facingMode constraint
<a href="https://bugs.webkit.org/show_bug.cgi?id=252560">https://bugs.webkit.org/show_bug.cgi?id=252560</a>
rdar://problem/105677398

Reviewed by Eric Carlson.

We added a way to favor some back cameras (those that have a great focal range) against other back cameras.
We did this by increasing the facingMode fitness distance for the telephoto back cameras.

The base fitness distance for user/environment facingMode constraint is either 0 (match) or 1 (no match).
When facingMode is environement, the front camera will have a base fitness distance of 1 and a final fitness distance of 1.

The back camera will have a base fitness distance of 0 and a final fitness distance of 0 + the fitness distance increase.
The fitness distance increase is either 0, 1, 2...

The issue is that RealtimeMediaSource::supportsConstraints computes the fitness score by checking whether distance is 0 or something else.
If distance is 0, the score is 32 otherwise it is 1.
This ensures that facingMode has a big weight on the global fitness score.

We now apply facingModeFitnessDistanceAdjustment directly to the global fitness score.
This requires having good devices with a high value.

Renaming facingModeFitnessDistanceAdjustment to facingModeFitnessScoreAdjustment for that reason.

* Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp:
(WebCore::RealtimeMediaSource::fitnessDistance):
(WebCore::RealtimeMediaSource::supportsConstraints):
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::AVVideoCaptureSource::facingModeFitnessDistanceAdjustment const):

Canonical link: <a href="https://commits.webkit.org/260953@main">https://commits.webkit.org/260953@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8973c25414e48487d769170e2c6e7cc0029e0545

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110045 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19146 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42726 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1486 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119078 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113997 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20612 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10338 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102304 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115791 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/43564 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/30220 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/85395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11847 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/31558 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12469 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17835 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51173 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7592 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14264 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->