### PR TITLE
ImageBufferBackend::clearContents() is redundant function

### DIFF
--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -566,12 +566,6 @@ void ImageBuffer::setVolatilityState(VolatilityState volatilityState)
         backend->setVolatilityState(volatilityState);
 }
 
-void ImageBuffer::clearContents()
-{
-    if (auto* backend = ensureBackendCreated())
-        backend->clearContents();
-}
-
 std::unique_ptr<ThreadSafeImageBufferFlusher> ImageBuffer::createFlusher()
 {
     if (auto* backend = ensureBackendCreated())

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -212,9 +212,6 @@ public:
     WEBCORE_EXPORT SetNonVolatileResult setNonVolatile();
     WEBCORE_EXPORT VolatilityState volatilityState() const;
     WEBCORE_EXPORT void setVolatilityState(VolatilityState);
-
-    WEBCORE_EXPORT void clearContents();
-
     WEBCORE_EXPORT virtual std::unique_ptr<ThreadSafeImageBufferFlusher> createFlusher();
 
 protected:

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.h
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.h
@@ -156,8 +156,6 @@ public:
 
     virtual void setOwnershipIdentity(const ProcessIdentity&) { }
 
-    virtual void clearContents() { ASSERT_NOT_REACHED(); }
-
     const Parameters& parameters() { return m_parameters; }
 
 protected:

--- a/Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.h
@@ -48,7 +48,7 @@ public:
     WebCore::IntSize backendSize() const final;
     ImageBufferBackendHandle createBackendHandle(SharedMemory::Protection = SharedMemory::Protection::ReadWrite) const final;
 
-    void clearContents() final;
+    void releaseGraphicsContext() final;
 
     // NOTE: These all ASSERT_NOT_REACHED().
     RefPtr<WebCore::NativeImage> copyNativeImage(WebCore::BackingStoreCopy = WebCore::CopyBackingStore) final;

--- a/Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.mm
@@ -178,7 +178,7 @@ unsigned CGDisplayListImageBufferBackend::bytesPerRow() const
     return calculateBytesPerRow(backendSize());
 }
 
-void CGDisplayListImageBufferBackend::clearContents()
+void CGDisplayListImageBufferBackend::releaseGraphicsContext()
 {
     m_context = nullptr;
 }

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
@@ -238,7 +238,7 @@ SetNonVolatileResult RemoteLayerBackingStore::swapToValidFrontBuffer()
 
 #if ENABLE(CG_DISPLAY_LIST_BACKED_IMAGE_BUFFER)
     if (m_displayListBuffer)
-        m_displayListBuffer->clearContents();
+        m_displayListBuffer->releaseGraphicsContext();
 #endif
 
     m_contentsBufferHandle = std::nullopt;


### PR DESCRIPTION
#### 433f17507ed5091eb42fdd4f1d0ac638665f101c
<pre>
ImageBufferBackend::clearContents() is redundant function
<a href="https://bugs.webkit.org/show_bug.cgi?id=253065">https://bugs.webkit.org/show_bug.cgi?id=253065</a>
rdar://problem/106020763

Reviewed by Antti Koivisto.

Remove ImageBuffer{,Backend}::clearContents(), it is only implemented
for CG display list -backed ImageBuffers.

Use ImageBuffer::releaseGraphicsContext() to remove all commands to
CG display list -backed ImageBuffer. This should stay consistent with the
abstraction that the caller expects: For the purposes of the call, e.g.
ensuring that the list does not grow indefinitively, it is expected that
the relevant draw commands are part of the context.

* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::clearContents): Deleted.
* Source/WebCore/platform/graphics/ImageBuffer.h:
* Source/WebCore/platform/graphics/ImageBufferBackend.h:
(WebCore::ImageBufferBackend::clearContents): Deleted.
* Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.h:
* Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.mm:
(WebKit::CGDisplayListImageBufferBackend::releaseGraphicsContext):
(WebKit::CGDisplayListImageBufferBackend::clearContents): Deleted.
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::RemoteLayerBackingStore::swapToValidFrontBuffer):

Canonical link: <a href="https://commits.webkit.org/261057@main">https://commits.webkit.org/261057@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab3d05a7591df3b573cd5a527dc28417b3e608b3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109985 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19086 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42668 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1429 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119032 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113937 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20551 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10279 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102243 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115732 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15299 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98513 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43517 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97261 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30170 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85339 "Found 1 new API test failure: /WebKitGTK/TestDownloads:/webkit/Downloads/local-file-error (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11788 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31510 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12411 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8467 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17779 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51121 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7655 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14206 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->