### PR TITLE
Check CSP for background fetches

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/background-fetch/content-security-policy.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/background-fetch/content-security-policy.https.window-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL fetch blocked by CSP should reject assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS fetch blocked by CSP should reject
 

--- a/LayoutTests/imported/w3c/web-platform-tests/background-fetch/content-security-policy.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/background-fetch/content-security-policy.https.window.js
@@ -13,8 +13,11 @@ meta.setAttribute('http-equiv', 'Content-Security-Policy');
 meta.setAttribute('content', "connect-src 'none'");
 document.head.appendChild(meta);
 
-backgroundFetchTest((t, bgFetch) => {
+backgroundFetchTest(async (t, bgFetch) => {
+  const fetch = await bgFetch.fetch(uniqueId(), '/');
+
+  const record = await fetch.match('/');
   return promise_rejects_js(
       t, TypeError,
-      bgFetch.fetch(uniqueId(), 'https://example.com'));
+      record.responseReady);
 }, 'fetch blocked by CSP should reject');

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetch.h
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetch.h
@@ -65,7 +65,7 @@ public:
 
     using RetrieveRecordResponseCallback = CompletionHandler<void(Expected<ResourceResponse, ExceptionData>&&)>;
     using RetrieveRecordResponseBodyCallback = Function<void(Expected<RefPtr<SharedBuffer>, ResourceError>&&)>;
-    using CreateLoaderCallback = Function<std::unique_ptr<BackgroundFetchRecordLoader>(BackgroundFetchRecordLoader::Client&, ResourceRequest&&, FetchOptions&&, const ClientOrigin&)>;
+    using CreateLoaderCallback = Function<std::unique_ptr<BackgroundFetchRecordLoader>(BackgroundFetchRecordLoader::Client&, const BackgroundFetchRequest&, const ClientOrigin&)>;
 
     class Record final : public BackgroundFetchRecordLoader::Client, public RefCounted<Record> {
         WTF_MAKE_FAST_ALLOCATED;

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchEngine.cpp
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchEngine.cpp
@@ -89,8 +89,8 @@ void BackgroundFetchEngine::startBackgroundFetch(SWServerRegistration& registrat
             return;
         }
 
-        fetch->perform([server = WTFMove(server)](auto& client, auto&& request, auto&& options, auto& origin) mutable {
-            return server ? server->createBackgroundFetchRecordLoader(client, WTFMove(request), WTFMove(options), origin) : nullptr;
+        fetch->perform([server = WTFMove(server)](auto& client, auto& request, auto& origin) mutable {
+            return server ? server->createBackgroundFetchRecordLoader(client, request, origin) : nullptr;
         });
 
         callback(fetch->information());

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchRequest.h
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchRequest.h
@@ -27,22 +27,26 @@
 
 #if ENABLE(SERVICE_WORKER)
 
+#include "ContentSecurityPolicyResponseHeaders.h"
 #include "FetchHeadersGuard.h"
 #include "FetchOptions.h"
 #include "HTTPHeaderMap.h"
 #include "ResourceRequest.h"
+#include <wtf/CrossThreadCopier.h>
+#include <wtf/Markable.h>
 
 namespace WebCore {
 
 struct BackgroundFetchRequest {
-    BackgroundFetchRequest isolatedCopy() const & { return { internalRequest.isolatedCopy(), options.isolatedCopy(), guard, httpHeaders.isolatedCopy(), referrer.isolatedCopy() }; }
-    BackgroundFetchRequest isolatedCopy() && { return { WTFMove(internalRequest).isolatedCopy(), WTFMove(options).isolatedCopy(), guard, WTFMove(httpHeaders).isolatedCopy(), WTFMove(referrer).isolatedCopy() }; }
+    BackgroundFetchRequest isolatedCopy() const & { return { internalRequest.isolatedCopy(), options.isolatedCopy(), guard, httpHeaders.isolatedCopy(), referrer.isolatedCopy(), crossThreadCopy(cspResponseHeaders) }; }
+    BackgroundFetchRequest isolatedCopy() && { return { WTFMove(internalRequest).isolatedCopy(), WTFMove(options).isolatedCopy(), guard, WTFMove(httpHeaders).isolatedCopy(), WTFMove(referrer).isolatedCopy(), crossThreadCopy(WTFMove(cspResponseHeaders)) }; }
 
     ResourceRequest internalRequest;
     FetchOptions options;
     FetchHeadersGuard guard;
     HTTPHeaderMap httpHeaders;
     String referrer;
+    Markable<ContentSecurityPolicyResponseHeaders, ContentSecurityPolicyResponseHeaders::MarkableTraits> cspResponseHeaders;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/workers/service/server/SWServer.h
+++ b/Source/WebCore/workers/service/server/SWServer.h
@@ -281,7 +281,7 @@ public:
     WEBCORE_EXPORT std::optional<GatheredClientData> gatherClientData(const ClientOrigin&, ScriptExecutionContextIdentifier);
 
     void requestBackgroundFetchPermission(const ClientOrigin& clientOrigin, CompletionHandler<void(bool)>&& callback) { m_delegate->requestBackgroundFetchPermission(clientOrigin, WTFMove(callback)); }
-    std::unique_ptr<BackgroundFetchRecordLoader> createBackgroundFetchRecordLoader(BackgroundFetchRecordLoader::Client& client, ResourceRequest&& request, FetchOptions&& options, const WebCore::ClientOrigin& origin) { return m_delegate->createBackgroundFetchRecordLoader(client, WTFMove(request), WTFMove(options), origin); }
+    std::unique_ptr<BackgroundFetchRecordLoader> createBackgroundFetchRecordLoader(BackgroundFetchRecordLoader::Client& client, const BackgroundFetchRequest& request, const WebCore::ClientOrigin& origin) { return m_delegate->createBackgroundFetchRecordLoader(client, request, origin); }
     void requestBackgroundFetchSpace(const ClientOrigin& origin, uint64_t size, CompletionHandler<void(bool)>&& callback) { m_delegate->requestBackgroundFetchSpace(origin, size, WTFMove(callback)); }
     Ref<BackgroundFetchStore> createBackgroundFetchStore() { return m_delegate->createBackgroundFetchStore(); }
 

--- a/Source/WebCore/workers/service/server/SWServerDelegate.h
+++ b/Source/WebCore/workers/service/server/SWServerDelegate.h
@@ -48,14 +48,14 @@ struct WorkerFetchResult;
 class SWServerDelegate : public CanMakeWeakPtr<SWServerDelegate> {
 public:
     virtual ~SWServerDelegate() = default;
-    
+
     virtual void softUpdate(ServiceWorkerJobData&&, bool shouldRefreshCache, ResourceRequest&&, CompletionHandler<void(WorkerFetchResult&&)>&&) = 0;
     virtual void createContextConnection(const RegistrableDomain&, std::optional<ProcessIdentifier>, std::optional<ScriptExecutionContextIdentifier>, CompletionHandler<void()>&&) = 0;
     virtual void appBoundDomains(CompletionHandler<void(HashSet<RegistrableDomain>&&)>&&) = 0;
     virtual void addAllowedFirstPartyForCookies(ProcessIdentifier, std::optional<ProcessIdentifier>, RegistrableDomain&&) = 0;
-    
+
     virtual void requestBackgroundFetchPermission(const ClientOrigin&, CompletionHandler<void(bool)>&&) = 0;
-    virtual std::unique_ptr<BackgroundFetchRecordLoader> createBackgroundFetchRecordLoader(BackgroundFetchRecordLoader::Client&, ResourceRequest&&, FetchOptions&&, const WebCore::ClientOrigin&) = 0;
+    virtual std::unique_ptr<BackgroundFetchRecordLoader> createBackgroundFetchRecordLoader(BackgroundFetchRecordLoader::Client&, const BackgroundFetchRequest&, const WebCore::ClientOrigin&) = 0;
     virtual void requestBackgroundFetchSpace(const ClientOrigin&, uint64_t size, CompletionHandler<void(bool)>&&) = 0;
     virtual Ref<BackgroundFetchStore> createBackgroundFetchStore() = 0;
 };

--- a/Source/WebKit/NetworkProcess/BackgroundFetchLoad.h
+++ b/Source/WebKit/NetworkProcess/BackgroundFetchLoad.h
@@ -51,7 +51,7 @@ class NetworkProcess;
 class BackgroundFetchLoad final : public WebCore::BackgroundFetchRecordLoader, public CanMakeWeakPtr<BackgroundFetchLoad>, private NetworkDataTaskClient {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    BackgroundFetchLoad(NetworkProcess&, PAL::SessionID, Client&, WebCore::ResourceRequest&&, WebCore::FetchOptions&&, const WebCore::ClientOrigin&);
+    BackgroundFetchLoad(NetworkProcess&, PAL::SessionID, Client&, const WebCore::BackgroundFetchRequest&, const WebCore::ClientOrigin&);
     ~BackgroundFetchLoad();
 
 private:

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -741,9 +741,9 @@ void NetworkSession::addAllowedFirstPartyForCookies(WebCore::ProcessIdentifier w
     m_networkProcess->addAllowedFirstPartyForCookies(webProcessIdentifier, WTFMove(firstPartyForCookies), LoadedWebArchive::No, [] { });
 }
 
-std::unique_ptr<BackgroundFetchRecordLoader> NetworkSession::createBackgroundFetchRecordLoader(BackgroundFetchRecordLoader::Client& client, ResourceRequest&& request, FetchOptions&& options, const ClientOrigin& clientOrigin)
+std::unique_ptr<BackgroundFetchRecordLoader> NetworkSession::createBackgroundFetchRecordLoader(BackgroundFetchRecordLoader::Client& client, const WebCore::BackgroundFetchRequest& request, const ClientOrigin& clientOrigin)
 {
-    return makeUnique<BackgroundFetchLoad>(m_networkProcess.get(), m_sessionID, client, WTFMove(request), WTFMove(options), clientOrigin);
+    return makeUnique<BackgroundFetchLoad>(m_networkProcess.get(), m_sessionID, client, request, clientOrigin);
 }
 
 void NetworkSession::requestBackgroundFetchSpace(const ClientOrigin& origin, uint64_t size, CompletionHandler<void(bool)>&& callback)

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -274,7 +274,7 @@ protected:
     void appBoundDomains(CompletionHandler<void(HashSet<WebCore::RegistrableDomain>&&)>&&) final;
     void addAllowedFirstPartyForCookies(WebCore::ProcessIdentifier, std::optional<WebCore::ProcessIdentifier>, WebCore::RegistrableDomain&&) final;
     void requestBackgroundFetchPermission(const WebCore::ClientOrigin&, CompletionHandler<void(bool)>&&) final;
-    std::unique_ptr<WebCore::BackgroundFetchRecordLoader> createBackgroundFetchRecordLoader(WebCore::BackgroundFetchRecordLoader::Client&, WebCore::ResourceRequest&&, WebCore::FetchOptions&&, const WebCore::ClientOrigin&) final;
+    std::unique_ptr<WebCore::BackgroundFetchRecordLoader> createBackgroundFetchRecordLoader(WebCore::BackgroundFetchRecordLoader::Client&, const WebCore::BackgroundFetchRequest&, const WebCore::ClientOrigin&) final;
     void requestBackgroundFetchSpace(const WebCore::ClientOrigin&, uint64_t size, CompletionHandler<void(bool)>&&) final;
     Ref<WebCore::BackgroundFetchStore> createBackgroundFetchStore() final;
 #endif // ENABLE(SERVICE_WORKER)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3141,6 +3141,7 @@ struct WebCore::BackgroundFetchRequest {
     WebCore::FetchHeadersGuard guard;
     WebCore::HTTPHeaderMap httpHeaders;
     String referrer;
+    Markable<WebCore::ContentSecurityPolicyResponseHeaders, WebCore::ContentSecurityPolicyResponseHeaders::MarkableTraits> cspResponseHeaders;
 };
 #endif
 


### PR DESCRIPTION
#### 73c255a539a4afc1ede9e8be072eea9c6ed2c690
<pre>
Check CSP for background fetches
<a href="https://bugs.webkit.org/show_bug.cgi?id=253068">https://bugs.webkit.org/show_bug.cgi?id=253068</a>
rdar://problem/106025080

Reviewed by Sihui Liu.

Set the CSP response headers in WebProcess and send them as part of BackgroundFetchRequest to network process.
Pipe it to BackgroundFetchLoad that will send them to NetworkLoadChecker.

Small refactoring to directly pass a BackgroundFetchRequest to BackgroundFetchLoad.

Covered by updated and rebased test.
The WPT test is updated as per specification where the bg fetch promise resolves independently from failures of each indivudal fetch algorithm (where CSP is checked).

* LayoutTests/imported/w3c/web-platform-tests/background-fetch/content-security-policy.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/background-fetch/content-security-policy.https.window.js:
(backgroundFetchTest.async t):
(backgroundFetchTest): Deleted.
* Source/WebCore/workers/service/background-fetch/BackgroundFetch.cpp:
(WebCore::BackgroundFetch::didFinishRecord):
(WebCore::BackgroundFetch::recordIsCompleted):
(WebCore::BackgroundFetch::Record::complete):
(WebCore::BackgroundFetch::Record::didFinish):
(WebCore::BackgroundFetch::Record::retrieveResponse):
* Source/WebCore/workers/service/background-fetch/BackgroundFetch.h:
* Source/WebCore/workers/service/background-fetch/BackgroundFetchEngine.cpp:
(WebCore::BackgroundFetchEngine::startBackgroundFetch):
* Source/WebCore/workers/service/background-fetch/BackgroundFetchManager.cpp:
(WebCore::BackgroundFetchManager::fetch):
* Source/WebCore/workers/service/background-fetch/BackgroundFetchRequest.h:
(WebCore::BackgroundFetchRequest::isolatedCopy const):
(WebCore::BackgroundFetchRequest::isolatedCopy):
* Source/WebCore/workers/service/server/SWServer.h:
(WebCore::SWServer::createBackgroundFetchRecordLoader):
* Source/WebCore/workers/service/server/SWServerDelegate.h:
* Source/WebKit/NetworkProcess/BackgroundFetchLoad.cpp:
(WebKit::BackgroundFetchLoad::BackgroundFetchLoad):
* Source/WebKit/NetworkProcess/BackgroundFetchLoad.h:
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::NetworkSession::createBackgroundFetchRecordLoader):
* Source/WebKit/NetworkProcess/NetworkSession.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/261053@main">https://commits.webkit.org/261053@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e47187322e1861becf7bb1d28d1168ecd7fa1358

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110225 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19322 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42881 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1644 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119213 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114176 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20784 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10514 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102483 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115969 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15473 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98677 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43687 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97434 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30341 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85536 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12011 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31678 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12623 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8645 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17989 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51295 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7653 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14432 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->