### PR TITLE
Reject background fetch promise if its registration active worker is null

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/background-fetch/fetch.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/background-fetch/fetch.https.window-expected.txt
@@ -1,7 +1,7 @@
 
 Harness Error (TIMEOUT), message = null
 
-FAIL Background Fetch requires an activated Service Worker assert_unreached: Should have rejected: fetch() must reject on pending and installing workers Reached unreachable code
+PASS Background Fetch requires an activated Service Worker
 PASS Argument verification is done for BackgroundFetchManager.fetch()
 PASS IDs must be unique among active Background Fetch registrations
 PASS Empty URL is OK.

--- a/Source/WebCore/workers/service/server/SWServer.cpp
+++ b/Source/WebCore/workers/service/server/SWServer.cpp
@@ -1634,6 +1634,10 @@ void SWServer::Connection::startBackgroundFetch(ServiceWorkerRegistrationIdentif
             callback(makeUnexpected(ExceptionData { InvalidStateError, "No registration found"_s }));
             return;
         }
+        if (!registration->activeWorker()) {
+            callback(makeUnexpected(ExceptionData { TypeError, "No active worker"_s }));
+            return;
+        }
 
         server->backgroundFetchEngine().startBackgroundFetch(*registration, backgroundFetchIdentifier, WTFMove(requests), WTFMove(options), WTFMove(callback));
     });


### PR DESCRIPTION
#### 404c34249513e41b47991746a2f9cb0ac751c78a
<pre>
Reject background fetch promise if its registration active worker is null
<a href="https://bugs.webkit.org/show_bug.cgi?id=253071">https://bugs.webkit.org/show_bug.cgi?id=253071</a>
rdar://problem/106026006

Reviewed by Sihui Liu.

Add active worker check as per <a href="https://wicg.github.io/background-fetch/#background-fetch-manager-fetch">https://wicg.github.io/background-fetch/#background-fetch-manager-fetch</a> step 8.4.
Covered by WPT test.

* LayoutTests/imported/w3c/web-platform-tests/background-fetch/fetch.https.window-expected.txt:
* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::Connection::startBackgroundFetch):

Canonical link: <a href="https://commits.webkit.org/260993@main">https://commits.webkit.org/260993@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff47bd7f7fa13eac53afbdf9a9ed15bb84b022b7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110018 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19118 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42700 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1460 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119057 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113971 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20584 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10311 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102275 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115764 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15324 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98535 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43541 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97286 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30192 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85378 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11821 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31532 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12443 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8490 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17810 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51144 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7615 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14238 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->