### PR TITLE
Restrict background fetch loads to HTTP family

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/background-fetch/mixed-content-and-allowed-schemes.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/background-fetch/mixed-content-and-allowed-schemes.https.window-expected.txt
@@ -3,8 +3,8 @@ PASS https: fetch should register ok
 PASS loopback IPv4 http: fetch should register ok
 PASS loopback IPv6 http: fetch should register ok
 PASS localhost http: fetch should register ok
-FAIL wss: fetch should reject assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL file: fetch should reject assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL data: fetch should reject assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL unknown scheme fetch should reject assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS wss: fetch should reject
+PASS file: fetch should reject
+PASS data: fetch should reject
+PASS unknown scheme fetch should reject
 

--- a/LayoutTests/imported/w3c/web-platform-tests/background-fetch/mixed-content-and-allowed-schemes.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/background-fetch/mixed-content-and-allowed-schemes.https.window.js
@@ -30,22 +30,29 @@ backgroundFetchTest((t, bgFetch) => {
   return bgFetch.fetch(uniqueId(), 'http://localhost');
 }, 'localhost http: fetch should register ok');
 
+function testBgFetch(bgFetch, url)
+{
+  return bgFetch.fetch(uniqueId(), url).then(fetch => {
+    return fetch.match(url);
+  }).then(match => match.responseReady);
+}
+
 backgroundFetchTest((t, bgFetch) => {
   return promise_rejects_js(t, TypeError,
-                         bgFetch.fetch(uniqueId(), 'wss:127.0.0.1'));
+                         testBgFetch(bgFetch, 'wss:127.0.0.1'));
 }, 'wss: fetch should reject');
 
 backgroundFetchTest((t, bgFetch) => {
   return promise_rejects_js(t, TypeError,
-                         bgFetch.fetch(uniqueId(), 'file:///'));
+                         testBgFetch(bgFetch, 'file:///'));
 }, 'file: fetch should reject');
 
 backgroundFetchTest((t, bgFetch) => {
   return promise_rejects_js(t, TypeError,
-                         bgFetch.fetch(uniqueId(), 'data:text/plain,foo'));
+                         testBgFetch(bgFetch, 'data:text/plain,foo'));
 }, 'data: fetch should reject');
 
 backgroundFetchTest((t, bgFetch) => {
   return promise_rejects_js(t, TypeError,
-                         bgFetch.fetch(uniqueId(), 'foobar:bazqux'));
+                         testBgFetch(bgFetch, 'foobar:bazqux'));
 }, 'unknown scheme fetch should reject');

--- a/LayoutTests/imported/w3c/web-platform-tests/background-fetch/port-blocking.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/background-fetch/port-blocking.https.window-expected.txt
@@ -4,5 +4,5 @@ PASS fetch to default http port should register ok
 PASS fetch to port 443 should register ok
 PASS fetch to port 80 should register ok, even over https
 PASS fetch to non-default non-bad port (8080) should register ok
-FAIL fetch to bad port (SMTP) should reject assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS fetch to bad port (SMTP) should reject
 

--- a/LayoutTests/imported/w3c/web-platform-tests/background-fetch/port-blocking.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/background-fetch/port-blocking.https.window.js
@@ -28,8 +28,12 @@ backgroundFetchTest((t, bgFetch) => {
   return bgFetch.fetch(uniqueId(), 'https://example.com:8080');
 }, 'fetch to non-default non-bad port (8080) should register ok');
 
-backgroundFetchTest((t, bgFetch) => {
+backgroundFetchTest(async (t, bgFetch) => {
+  const promise = bgFetch.fetch(uniqueId(), 'https://example.com:587').then(fetch => {
+    return fetch.match('https://example.com:587');
+  }).then(record => record.responseReady);
+
   return promise_rejects_js(
       t, TypeError,
-      bgFetch.fetch(uniqueId(), 'https://example.com:587'));
+      promise);
 }, 'fetch to bad port (SMTP) should reject');

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetch.cpp
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetch.cpp
@@ -319,6 +319,11 @@ void BackgroundFetch::Record::retrieveResponse(BackgroundFetchStore&, RetrieveRe
         return;
     }
 
+    if (m_isCompleted) {
+        callback(makeUnexpected(ExceptionData { TypeError, "Fetch failed"_s }));
+        return;
+    }
+
     m_responseCallbacks.append(WTFMove(callback));
 }
 


### PR DESCRIPTION
#### 39186fb707af4e7aa28391236ccd2dce29c591ff
<pre>
Restrict background fetch loads to HTTP family
<a href="https://bugs.webkit.org/show_bug.cgi?id=253073">https://bugs.webkit.org/show_bug.cgi?id=253073</a>
rdar://problem/106026139

Reviewed by Alex Christensen.

Update BackgroundFetch to handle the case of a synchronously failure.
Previously, the responseReady promise would not resolve given the failure will happen before the responseReady callback is registered.
We are now making sure to answer the responseReady callback if the failure happened before the registration.

Add HTTP check in BackgroundFetchLoad to fail lood immediately for non HTTP loads.

We update the WPT test to cover the case where the fetch registration happens but the load fails.
This is inline with other checks like CSP done at individual fetch level.

* LayoutTests/imported/w3c/web-platform-tests/background-fetch/mixed-content-and-allowed-schemes.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/background-fetch/mixed-content-and-allowed-schemes.https.window.js:
(testBgFetch):
(backgroundFetchTest):
* LayoutTests/imported/w3c/web-platform-tests/background-fetch/port-blocking.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/background-fetch/port-blocking.https.window.js:
(backgroundFetchTest.async t):
* Source/WebCore/workers/service/background-fetch/BackgroundFetch.cpp:
(WebCore::BackgroundFetch::didFinishRecord):
(WebCore::BackgroundFetch::recordIsCompleted):
(WebCore::BackgroundFetch::Record::didFinish):
(WebCore::BackgroundFetch::Record::retrieveResponse):
* Source/WebCore/workers/service/background-fetch/BackgroundFetch.h:
* Source/WebKit/NetworkProcess/BackgroundFetchLoad.cpp:

Canonical link: <a href="https://commits.webkit.org/260994@main">https://commits.webkit.org/260994@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9bd4254e0b66f7610bfa9a9b0c004c46260b3fb1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110017 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19117 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42699 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1459 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119056 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113970 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20583 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10310 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102274 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115763 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15322 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98534 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43542 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97284 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30191 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85368 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11820 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31531 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12442 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8489 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17809 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51143 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7616 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14237 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->