### PR TITLE
[contain-intrinsic-size] wpt failures related to multi-columns

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-007-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-007-expected.txt
@@ -5,13 +5,9 @@ PASS .test 3
 PASS .test 4
 PASS .test 5
 PASS .test 6
-FAIL .test 7 assert_equals:
-<div class="columns test auto-width" data-expected-client-width="656" data-expected-client-height="0"></div>
-clientWidth expected 656 but got 1328
+PASS .test 7
 PASS .test 8
-FAIL .test 9 assert_equals:
-<div class="columns test auto-both" data-expected-client-width="656" data-expected-client-height="120"></div>
-clientWidth expected 656 but got 1328
+PASS .test 9
 PASS .test 10
 PASS .test 11
 PASS .test 12

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-031-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-031-expected.txt
@@ -5,18 +5,10 @@ PASS .test 3
 PASS .test 4
 PASS .test 5
 PASS .test 6
-FAIL .test 7 assert_equals:
-<div class="test columns-120px-1 cis-width" data-expected-client-width="100" data-expected-client-height="0"></div>
-clientWidth expected 100 but got 120
-FAIL .test 8 assert_equals:
-<div class="test columns-120px-1 cis-both" data-expected-client-width="100" data-expected-client-height="50"></div>
-clientWidth expected 100 but got 120
+PASS .test 7
+PASS .test 8
 PASS .test 9
 PASS .test 10
-FAIL .test 11 assert_equals:
-<div class="test columns-60px-2 cis-width" data-expected-client-width="100" data-expected-client-height="0"></div>
-clientWidth expected 100 but got 205
-FAIL .test 12 assert_equals:
-<div class="test columns-60px-2 cis-both" data-expected-client-width="100" data-expected-client-height="50"></div>
-clientWidth expected 100 but got 205
+PASS .test 11
+PASS .test 12
 

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -345,10 +345,12 @@ void RenderBlockFlow::adjustIntrinsicLogicalWidthsForColumns(LayoutUnit& minLogi
 
 void RenderBlockFlow::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const
 {
+    bool needAdjustIntrinsicLogicalWidthsForColumns = true;
     if (shouldApplySizeOrInlineSizeContainment()) {
         if (auto width = explicitIntrinsicInnerLogicalWidth()) {
             minLogicalWidth = width.value();
             maxLogicalWidth = width.value();
+            needAdjustIntrinsicLogicalWidthsForColumns = false;
         }
     } else if (childrenInline())
         computeInlinePreferredLogicalWidths(minLogicalWidth, maxLogicalWidth);
@@ -357,7 +359,8 @@ void RenderBlockFlow::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth,
 
     maxLogicalWidth = std::max(minLogicalWidth, maxLogicalWidth);
 
-    adjustIntrinsicLogicalWidthsForColumns(minLogicalWidth, maxLogicalWidth);
+    if (needAdjustIntrinsicLogicalWidthsForColumns)
+        adjustIntrinsicLogicalWidthsForColumns(minLogicalWidth, maxLogicalWidth);
 
     if (!style().autoWrap() && childrenInline()) {
         // A horizontal marquee with inline children has no minimum width.


### PR DESCRIPTION
#### 8530f5f0f0305b38ac889674d844506d5631966b
<pre>
[contain-intrinsic-size] wpt failures related to multi-columns
<a href="https://bugs.webkit.org/show_bug.cgi?id=253079">https://bugs.webkit.org/show_bug.cgi?id=253079</a>

Reviewed by Oriol Brufau.

In adjustIntrinsicLogicalWidthsForColumns, it might adjust min/maxLogicalWidth. But if the widths are from
contain-intrinsic-size, they should not be adjusted.

* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-007-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-031-expected.txt:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::computeIntrinsicLogicalWidths const):

Canonical link: <a href="https://commits.webkit.org/261016@main">https://commits.webkit.org/261016@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d66ff6f69b43dccfcc2166390b96075eb84f1724

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110265 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19359 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42915 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1676 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119242 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114213 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20821 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10550 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102523 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116009 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98704 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43716 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30368 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85564 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12046 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31705 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12652 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8671 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18018 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51322 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7633 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14470 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->