### PR TITLE
[GStreamer][1.22] webrtc/receiver-track-should-stay-live-even-if-receiver-is-inactive.html crashing

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1812,7 +1812,6 @@ webkit.org/b/224074 webrtc/concurrentVideoPlayback2.html [ Timeout Pass ]
 # Pending investigation.
 webkit.org/b/206656 imported/w3c/web-platform-tests/mediacapture-streams/MediaStream-removetrack.https.html [ Crash Failure Timeout ]
 webkit.org/b/206656 imported/w3c/web-platform-tests/mediacapture-streams/MediaStream-MediaElement-preload-none-manual.https.html [ Crash Failure Pass ]
-webkit.org/b/251146 webrtc/receiver-track-should-stay-live-even-if-receiver-is-inactive.html [ Crash ]
 
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of WebRTC-related bugs

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp
@@ -73,7 +73,12 @@ std::optional<RTCRtpTransceiverDirection> GStreamerRtpTransceiverBackend::curren
 
 void GStreamerRtpTransceiverBackend::setDirection(RTCRtpTransceiverDirection direction)
 {
-    g_object_set(m_rtcTransceiver.get(), "direction", fromRTCRtpTransceiverDirection(direction), nullptr);
+    auto gstDirection = fromRTCRtpTransceiverDirection(direction);
+#ifndef GST_DISABLE_GST_DEBUG
+    GUniquePtr<char> directionString(g_enum_to_string(GST_TYPE_WEBRTC_RTP_TRANSCEIVER_DIRECTION, gstDirection));
+    GST_DEBUG_OBJECT(m_rtcTransceiver.get(), "Setting direction to %s", directionString.get());
+#endif
+    g_object_set(m_rtcTransceiver.get(), "direction", gstDirection, nullptr);
 }
 
 String GStreamerRtpTransceiverBackend::mid()

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
@@ -521,6 +521,11 @@ GRefPtr<GstCaps> capsFromSDPMedia(const GstSDPMedia* media)
         for (unsigned j = 0; j < gst_caps_get_size(formatCaps); j++) {
             auto* structure = gst_caps_get_structure(formatCaps, j);
             gst_structure_set_name(structure, "application/x-rtp");
+
+            // Remove attributes unrelated with codec preferences, potentially leading to internal
+            // webrtcbin confusions such as duplicated RTP direction attributes for instance.
+            gst_structure_remove_fields(structure, "a-setup", "a-ice-ufrag", "a-ice-pwd", "a-sendrecv", "a-inactive",
+                "a-sendonly", "a-recvonly", nullptr);
         }
 
         gst_caps_append(caps.get(), formatCaps);


### PR DESCRIPTION
#### d6668df3100e97dcc6d36e0aff664b1a0ae67225
<pre>
[GStreamer][1.22] webrtc/receiver-track-should-stay-live-even-if-receiver-is-inactive.html crashing
<a href="https://bugs.webkit.org/show_bug.cgi?id=251146">https://bugs.webkit.org/show_bug.cgi?id=251146</a>

Reviewed by Xabier Rodriguez-Calvar.

The crash was due to webrtcbin detecting an invalid SDP message, containing 2 RTP direction
attributes instead of one. So we now remove attributes unrelated with codec preferences, potentially
leading to internal webrtcbin confusions such as duplicated RTP direction attributes for instance.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp:
(WebCore::GStreamerRtpTransceiverBackend::setDirection):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp:
(WebCore::capsFromSDPMedia):

Canonical link: <a href="https://commits.webkit.org/260996@main">https://commits.webkit.org/260996@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ebbb49954c2f375d2a5bc171eae205405d11e1ba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110042 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19143 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42723 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1483 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119076 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113994 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20609 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10335 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102300 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115788 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15345 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98556 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43560 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97306 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30216 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85391 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11844 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31554 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12466 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8511 "Found 1 new test failure: imported/w3c/web-platform-tests/background-fetch/port-blocking.https.window.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17833 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51169 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7618 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14261 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->