### PR TITLE
[Lockdown Mode] Conditionalize sandbox access

### DIFF
--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
@@ -23,8 +23,13 @@
 
 #include "Shared/Sandbox/iOS/common.sb"
 
+(define (lockdown-mode)
+    (require-not (require-entitlement "com.apple.private.verified-jit")))
+
 #if USE(SANDBOX_VERSION_3)
 (allow dynamic-code-generation)
+(with-filter (lockdown-mode)
+    (deny dynamic-code-generation))
 
 (with-filter (mac-policy-name "Sandbox")
     (allow system-mac-syscall (mac-syscall-number 65 67)))
@@ -1158,9 +1163,6 @@
 
 (with-filter (system-attribute apple-internal)
     (allow syscall-unix (syscall-number SYS_kdebug_trace_string))) ;; Needed for performance sampling, see <rdar://problem/48829655>.
-
-(define (lockdown-mode)
-    (require-not (require-entitlement "com.apple.private.verified-jit")))
     
 (with-filter (lockdown-mode)
     (allow syscall-unix (with report) (with telemetry) (with message "Lockdown mode")
@@ -1397,7 +1399,6 @@
         task_restartable_ranges_synchronize
         thread_get_state_to_user
         thread_resume
-        thread_set_exception_ports
         thread_suspend))
 
 (define (kernel-mig-routine-blocked-in-lockdown-mode)
@@ -1459,6 +1460,9 @@
                 (with message "kernel mig routine used after launch")
                 (kernel-mig-routine-only-in-use-during-launch)))
 #endif
+
+        (with-filter (require-not (lockdown-mode))
+            (allow mach-message-send (kernel-mig-routine thread_set_exception_ports)))
 
         (with-filter (lockdown-mode)
             (allow mach-message-send (with report) (with telemetry) (with message "Lockdown mode")

--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -24,8 +24,13 @@
 #include "Shared/Sandbox/macOS/common.sb"
 #include "Shared/Sandbox/preferences.sb"
 
+(define (lockdown-mode)
+    (require-not (require-entitlement "com.apple.security.cs.allow-jit")))
+
 #if USE(SANDBOX_VERSION_3)
 (allow dynamic-code-generation)
+(with-filter (lockdown-mode)
+    (deny dynamic-code-generation))
 
 (with-filter (mac-policy-name "Sandbox")
     (allow system-mac-syscall (mac-syscall-number 5 65)))
@@ -2136,7 +2141,6 @@
     task_policy_set
     task_restartable_ranges_synchronize
     thread_resume
-    thread_set_exception_ports
     thread_suspend))
 
 (define (kernel-mig-routines-blocked-in-lockdown-mode) (kernel-mig-routine
@@ -2172,6 +2176,9 @@
 #else
             (allow mach-message-send (kernel-mig-routines-blocked-in-lockdown-mode))
 #endif
+            (with-filter (require-not (lockdown-mode))
+                (allow mach-message-send (kernel-mig-routine thread_set_exception_ports)))
+
             (allow mach-message-send (kernel-mig-routines-common)))))
 
 (define (syscall-mach-common) (machtrap-number


### PR DESCRIPTION
#### d31db0a79195f27dfd9da85241bb8374b3fd266b
<pre>
[Lockdown Mode] Conditionalize sandbox access
<a href="https://bugs.webkit.org/show_bug.cgi?id=252621">https://bugs.webkit.org/show_bug.cgi?id=252621</a>
rdar://105698648

Reviewed by Brent Fulgham.

Conditionalize sandbox access based on Lockdown Mode sandbox flag.

* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in:
* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/261005@main">https://commits.webkit.org/261005@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a1a93463e049341f1ad7922cf7d6052f676fbc7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110138 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19237 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42804 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1566 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119143 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20698 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10427 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102394 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115884 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15413 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98621 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43646 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97374 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30282 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85486 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11932 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31619 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12546 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8583 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17911 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51235 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14350 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4150 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->