### PR TITLE
[Screen Orientation API] Change natural orientation on iPad and TV to be landscape-primary

### DIFF
--- a/Source/WebCore/page/ScreenOrientation.cpp
+++ b/Source/WebCore/page/ScreenOrientation.cpp
@@ -185,7 +185,7 @@ uint16_t ScreenOrientation::angle() const
     auto orientation = manager ? manager->currentOrientation() : naturalScreenOrientationType();
 
     // https://w3c.github.io/screen-orientation/#dfn-screen-orientation-values-table
-    if constexpr (isPortait(naturalScreenOrientationType())) {
+    if (isPortrait(naturalScreenOrientationType())) {
         switch (orientation) {
         case Type::PortraitPrimary:
             return 0;

--- a/Source/WebCore/page/ScreenOrientationType.h
+++ b/Source/WebCore/page/ScreenOrientationType.h
@@ -27,6 +27,10 @@
 
 #include <wtf/EnumTraits.h>
 
+#if PLATFORM(IOS)
+#include "Device.h"
+#endif
+
 namespace WebCore {
 
 enum class ScreenOrientationType : uint8_t {
@@ -36,7 +40,7 @@ enum class ScreenOrientationType : uint8_t {
     LandscapeSecondary
 };
 
-constexpr bool isPortait(ScreenOrientationType type)
+constexpr bool isPortrait(ScreenOrientationType type)
 {
     return type == ScreenOrientationType::PortraitPrimary || type == ScreenOrientationType::PortraitSecondary;
 }
@@ -46,12 +50,16 @@ constexpr bool isLandscape(ScreenOrientationType type)
     return type == ScreenOrientationType::LandscapePrimary || type == ScreenOrientationType::LandscapeSecondary;
 }
 
-constexpr ScreenOrientationType naturalScreenOrientationType()
+inline ScreenOrientationType naturalScreenOrientationType()
 {
-#if PLATFORM(IOS_FAMILY)
+#if PLATFORM(IOS)
+    if (deviceHasIPadCapability())
+        return ScreenOrientationType::LandscapePrimary;
+    return ScreenOrientationType::PortraitPrimary;
+#elif PLATFORM(WATCHOS)
     return ScreenOrientationType::PortraitPrimary;
 #else
-    // On Desktop, the natural orientation must be landscape-primary.
+    // On Desktop and TV, the natural orientation must be landscape-primary.
     return ScreenOrientationType::LandscapePrimary;
 #endif
 }

--- a/Source/WebCore/platform/ios/Device.h
+++ b/Source/WebCore/platform/ios/Device.h
@@ -39,7 +39,7 @@ String deviceName(); // Thread-safe.
 WEBCORE_EXPORT bool deviceClassIsSmallScreen();
 
 // FIXME: How does this differ from !deviceClassIsSmallScreen()?
-bool deviceHasIPadCapability();
+WEBCORE_EXPORT bool deviceHasIPadCapability();
 
 }
 

--- a/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp
@@ -75,11 +75,16 @@ static WebCore::ScreenOrientationType resolveScreenOrientationLockType(WebCore::
         return WebCore::ScreenOrientationType::LandscapePrimary;
     case WebCore::ScreenOrientationLockType::LandscapeSecondary:
         return WebCore::ScreenOrientationType::LandscapeSecondary;
-    case WebCore::ScreenOrientationLockType::Natural:
+    case WebCore::ScreenOrientationLockType::Natural: {
+        auto naturalOrientation = naturalScreenOrientationType();
+        if (WebCore::isPortrait(naturalOrientation) == WebCore::isPortrait(currentOrientation))
+            return currentOrientation;
+        return naturalOrientation;
+    }
     case WebCore::ScreenOrientationLockType::Portrait:
         break;
     }
-    if (WebCore::isPortait(currentOrientation))
+    if (WebCore::isPortrait(currentOrientation))
         return currentOrientation;
     return WebCore::ScreenOrientationType::PortraitPrimary;
 }


### PR DESCRIPTION
#### f0224968ed57e28fcf80825627817e4e435231eb
<pre>
[Screen Orientation API] Change natural orientation on iPad and TV to be landscape-primary
<a href="https://bugs.webkit.org/show_bug.cgi?id=253082">https://bugs.webkit.org/show_bug.cgi?id=253082</a>

Reviewed by Darin Adler.

Change natural orientation on iPad and TV to be landscape-primary instead of
portrait-primary.

* Source/WebCore/page/ScreenOrientation.cpp:
(WebCore::ScreenOrientation::lock):
* Source/WebCore/page/ScreenOrientationType.h:
(WebCore::isPortrait):
(WebCore::naturalScreenOrientationType):
(WebCore::isPortait): Deleted.
* Source/WebCore/platform/ios/Device.h:
* Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp:
(WebKit::resolveScreenOrientationLockType):

Canonical link: <a href="https://commits.webkit.org/260984@main">https://commits.webkit.org/260984@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bcf6ea719b33c19632fb8a0b9e6e35d73e7a4140

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110052 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19153 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42733 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1493 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119083 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114004 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20619 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10345 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102311 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115798 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15352 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98563 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43573 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97313 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30223 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85404 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11854 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31561 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12476 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8519 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17841 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51176 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14271 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4142 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->