### PR TITLE
[WGSL] Add a tiny DSL for declaring built-in types

### DIFF
--- a/Source/WebGPU/WGSL/Overload.h
+++ b/Source/WebGPU/WGSL/Overload.h
@@ -52,7 +52,7 @@ struct TypeVariable {
     };
 
     unsigned id;
-    Constraint constraints;
+    Constraint constraints { None };
 };
 
 struct AbstractVector;

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -118,33 +118,8 @@ TypeChecker::TypeChecker(ShaderModule& shaderModule)
     introduceVariable(AST::Identifier::make("u32"_s), m_types.u32Type());
     introduceVariable(AST::Identifier::make("f32"_s), m_types.f32Type());
 
-    // FIXME: Add all other overloads
-    // FIXME: we should make this a lot more convenient
-    // operator + [T<:Number](T, T) -> T
-    OverloadCandidate plus1;
-    {
-        TypeVariable T { 0, TypeVariable::Number };
-        plus1.typeVariables.append(T);
-        plus1.parameters.append(T);
-        plus1.parameters.append(T);
-        plus1.result = T;
-    }
-    // operator + [T<:Number, N](vector<T, N>, T) -> vector<T, N>
-    OverloadCandidate plus2;
-    {
-        TypeVariable T { 0, TypeVariable::Number };
-        NumericVariable N { 0 };
-        plus2.typeVariables.append(T);
-        plus2.numericVariables.append(N);
-        plus2.parameters.append(AbstractVector { T, N });
-        plus2.parameters.append(T);
-        plus2.result = AbstractVector { T, N };
-    }
-
-    m_overloadedOperations.add("+"_s, WTF::Vector<OverloadCandidate> ({
-        WTFMove(plus1),
-        WTFMove(plus2),
-    }));
+    // This file contains the declarations generated from `TypeDeclarations.rb`
+#include "TypeDeclarations.h" // NOLINT
 }
 
 void TypeChecker::check()

--- a/Source/WebGPU/WGSL/TypeDeclarations.rb
+++ b/Source/WebGPU/WGSL/TypeDeclarations.rb
@@ -1,0 +1,8 @@
+# FIXME: add all the missing type declarations here
+operator :+, {
+    [T < Number].(T, T) => T,
+    [T < Number, N].(Vector[T, N], T) => Vector[T, N],
+    [T < Number, N].(T, Vector[T, N]) => Vector[T, N],
+    [T < Number, N].(Vector[T, N], Vector[T, N]) => Vector[T, N],
+    [T < Float, C, R].(Matrix[T, C, R], Matrix[T, C, R]) => Matrix[T, C, R],
+}

--- a/Source/WebGPU/WGSL/generator/main.rb
+++ b/Source/WebGPU/WGSL/generator/main.rb
@@ -1,0 +1,264 @@
+class Constraint
+    attr_reader :name
+
+    def initialize(name)
+        @name = name
+    end
+
+    def to_s
+        name.to_s
+    end
+
+    def self.from_type(type)
+        Constraint.new type.name
+    end
+
+    def to_cpp
+        "TypeVariable::#{self}"
+    end
+end
+
+class VariableKind
+    attr_accessor :name
+
+    def initialize(name)
+        @name = name
+    end
+
+    def to_s
+        name.to_s
+    end
+end
+
+class Variable
+    attr_reader :name, :kind, :constraint
+    def initialize(name, kind, constraint=nil)
+        @name = name
+        @kind = kind
+        @constraint = constraint
+    end
+
+    def <(constraint)
+        raise "Expected a Constraint, found: #{constraint.class} "unless constraint.class == Constraint
+        Variable.new(@name, @kind, constraint)
+    end
+
+    def to_s
+        constraint = " is #{@constraint.to_s}" if @constraint
+        "#{@name.to_s}#{constraint}"
+    end
+
+    def to_cpp
+        to_s
+    end
+
+    def declaration(context)
+        index = context[kind]
+        context[kind] += 1
+        constraint = ", #{@constraint.to_cpp}" if @constraint
+        "#{kind} #{name} { #{index}#{constraint} };"
+    end
+
+    def append
+        if @kind == DSL::type_variable
+            "candidate.typeVariables.append(#{name});"
+        else
+            "candidate.numericVariables.append(#{name});"
+        end
+    end
+end
+
+class NumericValue
+    attr_reader :value
+
+    def initialize(value)
+        @value = value
+    end
+
+    def to_cpp
+        "AbstractValue { #{value}u }"
+    end
+end
+
+class AbstractType
+    attr_reader :name
+
+    def initialize(name)
+        @name = name
+    end
+
+    def [](*arguments)
+        ParameterizedType.new(self, arguments)
+    end
+
+    def to_s
+        @name.to_s
+    end
+end
+
+class PrimitiveType
+    attr_reader :name
+
+    def initialize(name)
+        @name = name
+    end
+
+    def to_s
+        @name.to_s
+    end
+
+    def to_cpp
+        "AbstractType { m_types.#{name.downcase}Type() }"
+    end
+end
+
+class ParameterizedType
+    attr_reader :base, :arguments
+
+    def initialize(base, arguments)
+        @base = base
+        @arguments = arguments.map { |a| normalize_argument(a) }
+    end
+
+    def normalize_argument(argument)
+        return argument if argument.is_a? Variable
+        return argument if argument.is_a? PrimitiveType
+
+        raise "Expected an Integer, found a: #{argument.class}" unless argument.is_a? Integer
+
+        NumericValue.new(argument)
+    end
+
+    def to_s
+        "#{base}<#{arguments.join(", ")}>"
+    end
+
+    def to_cpp
+        "Abstract#{base} { #{arguments.map(&:to_cpp).join ", "} }"
+    end
+end
+
+class FunctionType
+    attr_accessor :variables,  :parameters, :return_type
+
+    def initialize(variables, parameters, return_type=nil)
+        @variables = variables
+        @parameters = parameters
+        @return_type = return_type
+    end
+
+    def to_s
+        variables = "<#{@variables.join(', ')}>" unless @variables.empty?
+        "#{variables}(#{@parameters.join(', ')}) -> #{@return_type.to_s}"
+    end
+
+    def to_cpp(name)
+        context = {
+            DSL::type_variable => 0,
+            DSL::numeric_variable => 0,
+        }
+        out = []
+        out << "([&]() -> OverloadCandidate {"
+
+        def append(name)
+            "candidate.parameters.append(#{name});"
+        end
+
+        prefix = "    "
+        out << prefix + "// #{name} :: #{to_s}"
+        out << prefix + "OverloadCandidate candidate;"
+        out += variables.map { |v| prefix + v.declaration(context) }
+        out += variables.map { |v| prefix + v.append }
+        out += parameters.map { |p| prefix + append(p.to_cpp) }
+        out << prefix + "candidate.result = #{return_type.to_cpp};"
+        out << prefix + "return candidate;"
+        out << "}())"
+        out.join "\n"
+    end
+end
+
+class Array
+    def call(*arguments)
+        FunctionType.new(self, arguments)
+    end
+end
+
+
+module DSL
+    @context = binding()
+    @operators = {}
+    @TypeVariable = VariableKind.new(:TypeVariable)
+    @NumericVariable = VariableKind.new(:NumericVariable)
+
+    def self.type_variable
+        @TypeVariable
+    end
+
+    def self.numeric_variable
+        @NumericVariable
+    end
+
+    def self.operator(name, map)
+        overloads = []
+        map.each do |function, return_type|
+            function.return_type = return_type
+            overloads << function
+        end
+
+        if @operators[name]
+            @operators[name] += overloads
+        else
+            @operators[name] = overloads
+        end
+    end
+
+    def self.to_cpp
+        out = []
+        @operators.each do |name, overloads|
+            out << "m_overloadedOperations.add(\"#{name}\"_s, Vector<OverloadCandidate>({"
+            overloads.each { |function| out << "#{function.to_cpp(name)}," }
+            out << "}));"
+        end
+        out << "" # xcode compilation fails if there's not newline at the end of the file
+        out.join "\n"
+    end
+
+    def self.prologue
+        @context.eval <<~EOS
+        Vector = AbstractType.new(:Vector)
+        Matrix = AbstractType.new(:Matrix)
+        Array = AbstractType.new(:Array)
+
+        Bool = PrimitiveType.new(:Bool)
+        I32 = PrimitiveType.new(:I32)
+        U32 = PrimitiveType.new(:U32)
+        F32 = PrimitiveType.new(:F32)
+        AbstractInt = PrimitiveType.new(:AbstractInt)
+
+
+        T = Variable.new(:T, @TypeVariable)
+        N = Variable.new(:N, @NumericVariable)
+        C = Variable.new(:C, @NumericVariable)
+        R = Variable.new(:R, @NumericVariable)
+
+        Number = Constraint.new(:Number)
+        Float = Constraint.new(:Float)
+        EOS
+    end
+
+    def self.run(file)
+        @context.eval(File.open(file).read, file)
+    end
+
+    def self.write_to(output)
+        File.open(output, 'w') { |file| file.write(to_cpp) }
+    end
+end
+
+raise "usage: #{__FILE__} <declaration-file> <output-file>" if ARGV.length != 2
+input = ARGV[0]
+output = ARGV[1]
+
+DSL::prologue()
+DSL::run(input)
+DSL::write_to(output)

--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -117,6 +117,7 @@
 		3AE27DB528C1BA480043A8E0 /* ASTVariableStatement.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AE27DB428C1BA480043A8E0 /* ASTVariableStatement.h */; };
 		664C92FD286A66090008D143 /* IOSurface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 664C92FC286A66090008D143 /* IOSurface.framework */; };
 		66DC575528627E0B0014CABD /* ParserPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 66DC575428627E0B0014CABD /* ParserPrivate.h */; };
+		97296766299C09BC001C8BD4 /* TypeDeclarations.rb in Sources */ = {isa = PBXBuildFile; fileRef = 97296765299C09B0001C8BD4 /* TypeDeclarations.rb */; };
 		9776BE732992A236002D6D93 /* Overload.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9776BE712992A236002D6D93 /* Overload.cpp */; };
 		9776BE742992A236002D6D93 /* Overload.h in Headers */ = {isa = PBXBuildFile; fileRef = 9776BE722992A236002D6D93 /* Overload.h */; };
 		9776BE7629957E12002D6D93 /* WGSLShaderModule.h in Headers */ = {isa = PBXBuildFile; fileRef = 9776BE7529957E12002D6D93 /* WGSLShaderModule.h */; };
@@ -144,6 +145,24 @@
 		97F547B9298055D90011D79A /* GlobalVariableRewriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 97F547B7298055D90011D79A /* GlobalVariableRewriter.h */; };
 		DD05A35C27BF09C60096EFAB /* libWTF.a in Product Dependencies */ = {isa = PBXBuildFile; fileRef = 1CEBD8292716CAE700A5254D /* libWTF.a */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXBuildRule section */
+		9729675F299BF1BE001C8BD4 /* PBXBuildRule */ = {
+			isa = PBXBuildRule;
+			compilerSpec = com.apple.compilers.proxy.script;
+			filePatterns = "*.rb";
+			fileType = pattern.proxy;
+			inputFiles = (
+				"$(SRCROOT)/WGSL/generator/main.rb",
+			);
+			isEditable = 1;
+			outputFiles = (
+				"$(BUILT_PRODUCTS_DIR)/DerivedSources/WGSL/TypeDeclarations.h",
+			);
+			runOncePerArchitecture = 0;
+			script = "/usr/bin/env ruby \"${SCRIPT_INPUT_FILE_0}\" \"${INPUT_FILE_PATH}\" \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+		};
+/* End PBXBuildRule section */
 
 /* Begin PBXContainerItemProxy section */
 		1CEBD8272716CACC00A5254D /* PBXContainerItemProxy */ = {
@@ -324,6 +343,8 @@
 		3AE27DB428C1BA480043A8E0 /* ASTVariableStatement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTVariableStatement.h; sourceTree = "<group>"; };
 		664C92FC286A66090008D143 /* IOSurface.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOSurface.framework; path = System/Library/Frameworks/IOSurface.framework; sourceTree = SDKROOT; };
 		66DC575428627E0B0014CABD /* ParserPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ParserPrivate.h; sourceTree = "<group>"; };
+		97296764299BFB72001C8BD4 /* main.rb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.ruby; path = main.rb; sourceTree = "<group>"; };
+		97296765299C09B0001C8BD4 /* TypeDeclarations.rb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.ruby; path = TypeDeclarations.rb; sourceTree = "<group>"; };
 		9776BE712992A236002D6D93 /* Overload.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Overload.cpp; sourceTree = "<group>"; };
 		9776BE722992A236002D6D93 /* Overload.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Overload.h; sourceTree = "<group>"; };
 		9776BE7529957E12002D6D93 /* WGSLShaderModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WGSLShaderModule.h; sourceTree = "<group>"; };
@@ -466,6 +487,7 @@
 			isa = PBXGroup;
 			children = (
 				33EA185C27BC193D00A1DD52 /* AST */,
+				97296763299BFB72001C8BD4 /* generator */,
 				979240B1297018290050EA2C /* Metal */,
 				3AD0D2362988D3F90080D728 /* API.h */,
 				9789C318297EA105009E9006 /* CallGraph.cpp */,
@@ -496,6 +518,7 @@
 				338BB2CD27B6B60200E066AB /* Token.h */,
 				978A912E298AD3DA00B37E5E /* TypeCheck.cpp */,
 				978A912D298AD3DA00B37E5E /* TypeCheck.h */,
+				97296765299C09B0001C8BD4 /* TypeDeclarations.rb */,
 				978A9132298BBFD300B37E5E /* Types.cpp */,
 				978A9131298BBFD300B37E5E /* Types.h */,
 				978A9136298D40F100B37E5E /* TypeStore.cpp */,
@@ -603,6 +626,14 @@
 				3A12AE9828FCE94B00C1B975 /* ASTWorkgroupSizeAttribute.h */,
 			);
 			path = AST;
+			sourceTree = "<group>";
+		};
+		97296763299BFB72001C8BD4 /* generator */ = {
+			isa = PBXGroup;
+			children = (
+				97296764299BFB72001C8BD4 /* main.rb */,
+			);
+			path = generator;
 			sourceTree = "<group>";
 		};
 		979240B1297018290050EA2C /* Metal */ = {
@@ -751,6 +782,7 @@
 				1CEBD7F02716B2CC00A5254D /* Frameworks */,
 			);
 			buildRules = (
+				9729675F299BF1BE001C8BD4 /* PBXBuildRule */,
 			);
 			dependencies = (
 			);
@@ -881,6 +913,7 @@
 				979240C4297558F10050EA2C /* ResolveTypeReferences.cpp in Sources */,
 				338BB2D027B6B61B00E066AB /* Token.cpp in Sources */,
 				978A9130298AD3DA00B37E5E /* TypeCheck.cpp in Sources */,
+				97296766299C09BC001C8BD4 /* TypeDeclarations.rb in Sources */,
 				978A9134298BBFD300B37E5E /* Types.cpp in Sources */,
 				978A9138298D40F100B37E5E /* TypeStore.cpp in Sources */,
 				1CEBD8032716BF8200A5254D /* WGSL.cpp in Sources */,


### PR DESCRIPTION
#### af938b06692c084c46725628bcdf9a0e0fc96f32
<pre>
[WGSL] Add a tiny DSL for declaring built-in types
<a href="https://bugs.webkit.org/show_bug.cgi?id=252251">https://bugs.webkit.org/show_bug.cgi?id=252251</a>
rdar://105457268

Reviewed by Myles C. Maxfield.

Initializing all the built-in types in C++ is quite verbose, so this patch adds a tiny
embedded DSL in ruby for declaring such types (similar to JavaScriptCore/BytecodeList.rb)

NOTE: We previously had a PR with this change (#10099) but decided to use a JavaScript
DSL instead. That caused some build issues, so we&apos;re going back to Ruby.

* Source/WebGPU/WGSL/Overload.h:
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::TypeChecker):
* Source/WebGPU/WGSL/TypeDeclarations.rb: Added.
* Source/WebGPU/WGSL/generator/main.rb: Added.
* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/260991@main">https://commits.webkit.org/260991@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7257d815cfd67df366ee3da48b6462aa056f517e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110053 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19154 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42734 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1494 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119084 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20620 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10346 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102312 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115799 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15353 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98565 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43582 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97314 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30225 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85413 "Found 1 new API test failure: /WebKitGTK/TestDownloads:/webkit/Downloads/local-file-error (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11855 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31563 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12477 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8521 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17842 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51178 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7614 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14272 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->