### PR TITLE
[macOS] Add additional heuristics for context menu QR code detection

### DIFF
--- a/Source/WebCore/page/ContextMenuContext.cpp
+++ b/Source/WebCore/page/ContextMenuContext.cpp
@@ -42,9 +42,6 @@ ContextMenuContext::ContextMenuContext(Type type, const HitTestResult& hitTestRe
     : m_type(type)
     , m_hitTestResult(hitTestResult)
     , m_event(event)
-#if ENABLE(SERVICE_CONTROLS)
-    , m_controlledImage(nullptr)
-#endif
 {
 }
 

--- a/Source/WebCore/page/ContextMenuContext.h
+++ b/Source/WebCore/page/ContextMenuContext.h
@@ -67,6 +67,14 @@ public:
     Image* controlledImage() const { return m_controlledImage.get(); }
 #endif
 
+#if ENABLE(CONTEXT_MENU_QR_CODE_DETECTION)
+    void setPotentialQRCodeNodeSnapshotImage(Image* image) { m_potentialQRCodeNodeSnapshotImage = image; }
+    Image* potentialQRCodeNodeSnapshotImage() const { return m_potentialQRCodeNodeSnapshotImage.get(); }
+
+    void setPotentialQRCodeViewportSnapshotImage(Image* image) { m_potentialQRCodeViewportSnapshotImage = image; }
+    Image* potentialQRCodeViewportSnapshotImage() const { return m_potentialQRCodeViewportSnapshotImage.get(); }
+#endif
+
 private:
     Type m_type { Type::ContextMenu };
     HitTestResult m_hitTestResult;
@@ -75,6 +83,11 @@ private:
 
 #if ENABLE(SERVICE_CONTROLS)
     RefPtr<Image> m_controlledImage;
+#endif
+
+#if ENABLE(CONTEXT_MENU_QR_CODE_DETECTION)
+    RefPtr<Image> m_potentialQRCodeNodeSnapshotImage;
+    RefPtr<Image> m_potentialQRCodeViewportSnapshotImage;
 #endif
 };
 

--- a/Source/WebKit/Shared/ContextMenuContextData.h
+++ b/Source/WebKit/Shared/ContextMenuContextData.h
@@ -90,6 +90,9 @@ public:
 #endif // ENABLE(SERVICE_CONTROLS)
 
 #if ENABLE(CONTEXT_MENU_QR_CODE_DETECTION)
+    ShareableBitmap* potentialQRCodeNodeSnapshotImage() const { return m_potentialQRCodeNodeSnapshotImage.get(); }
+    ShareableBitmap* potentialQRCodeViewportSnapshotImage() const { return m_potentialQRCodeViewportSnapshotImage.get(); }
+
     const String& qrCodePayloadString() const { return m_qrCodePayloadString; }
     void setQRCodePayloadString(const String& string) { m_qrCodePayloadString = string; }
 #endif
@@ -107,7 +110,7 @@ private:
     String m_selectedText;
 
 #if ENABLE(SERVICE_CONTROLS)
-    void setImage(WebCore::Image*);
+    void setImage(WebCore::Image&);
     
     RefPtr<ShareableBitmap> m_controlledImage;
     Vector<uint8_t> m_controlledSelectionData;
@@ -120,6 +123,12 @@ private:
 #endif
 
 #if ENABLE(CONTEXT_MENU_QR_CODE_DETECTION)
+    void setPotentialQRCodeNodeSnapshotImage(WebCore::Image&);
+    void setPotentialQRCodeViewportSnapshotImage(WebCore::Image&);
+
+    RefPtr<ShareableBitmap> m_potentialQRCodeNodeSnapshotImage;
+    RefPtr<ShareableBitmap> m_potentialQRCodeViewportSnapshotImage;
+
     String m_qrCodePayloadString;
 #endif
 };

--- a/Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm
@@ -308,73 +308,156 @@ TEST(ContextMenuTests, HitTestResultDoesNotContainEmptyURLs)
 
 #if ENABLE(CONTEXT_MENU_QR_CODE_DETECTION)
 
+static NSString *qrCodeSVGString()
+{
+    return @"<svg xmlns='http://www.w3.org/2000/svg' width='400' height='400' viewBox='0 0 1160 1160'><path fill='#fff' d='M0 0h1160v1160H0z'/><path d='M400 80h40v40h-40zm80 0h40v40h-40zm80 0h40v40h-40z'/><path d='M600 80h40v40h-40zm-200 40h40v40h-40z'/><path d='M440 120h40v40h-40zm80 0h40v40h-40z'/><path d='M560 120h40v40h-40z'/><path d='M600 120h40v40h-40zm120 0h40v40h-40zm-320 40h40v40h-40z'/><path d='M440 160h40v40h-40zm120 0h40v40h-40z'/><path d='M600 160h40v40h-40zm80 0h40v40h-40z'/><path d='M720 160h40v40h-40zm-280 40h40v40h-40z'/><path d='M480 200h40v40h-40z'/><path d='M520 200h40v40h-40zm80 0h40v40h-40z'/><path d='M640 200h40v40h-40z'/><path d='M680 200h40v40h-40z'/><path d='M720 200h40v40h-40zm-320 40h40v40h-40z'/><path d='M440 240h40v40h-40z'/><path d='M480 240h40v40h-40zm120 0h40v40h-40z'/><path d='M640 240h40v40h-40zm80 0h40v40h-40zm-280 40h40v40h-40z'/><path d='M480 280h40v40h-40zm120 0h40v40h-40z'/><path d='M640 280h40v40h-40zm-240 40h40v40h-40zm80 0h40v40h-40zm80 0h40v40h-40z'/><path d='M640 320h40v40h-40zm80 0h40v40h-40zm-240 40h40v40h-40z'/><path d='M520 360h40v40h-40z'/><path d='M560 360h40v40h-40z'/><path d='M600 360h40v40h-40z'/><path d='M640 360h40v40h-40z'/><path d='M680 360h40v40h-40zM80 400h40v40H80zm120 0h40v40h-40z'/><path d='M240 400h40v40h-40z'/><path d='M280 400h40v40h-40z'/><path d='M320 400h40v40h-40z'/><path d='M360 400h40v40h-40z'/><path d='M400 400h40v40h-40zm80 0h40v40h-40z'/><path d='M520 400h40v40h-40z'/><path d='M560 400h40v40h-40zm80 0h40v40h-40zm80 0h40v40h-40z'/><path d='M760 400h40v40h-40zm120 0h40v40h-40zm80 0h40v40h-40z'/><path d='M1000 400h40v40h-40z'/><path d='M1040 400h40v40h-40zM80 440h40v40H80z'/><path d='M120 440h40v40h-40zm80 0h40v40h-40zm200 0h40v40h-40zm80 0h40v40h-40zm80 0h40v40h-40z'/><path d='M600 440h40v40h-40z'/><path d='M640 440h40v40h-40z'/><path d='M680 440h40v40h-40zm80 0h40v40h-40zm80 0h40v40h-40z'/><path d='M880 440h40v40h-40z'/><path d='M920 440h40v40h-40z'/><path d='M960 440h40v40h-40z'/><path d='M1000 440h40v40h-40zm-720 40h40v40h-40z'/><path d='M320 480h40v40h-40z'/><path d='M360 480h40v40h-40zm160 0h40v40h-40zm80 0h40v40h-40zm80 0h40v40h-40zm120 0h40v40h-40z'/><path d='M840 480h40v40h-40zm80 0h40v40h-40zm120 0h40v40h-40zm-840 40h40v40h-40zm200 0h40v40h-40zm240 0h40v40h-40z'/><path d='M680 520h40v40h-40z'/><path d='M720 520h40v40h-40zm120 0h40v40h-40zm80 0h40v40h-40z'/><path d='M960 520h40v40h-40z'/><path d='M1000 520h40v40h-40z'/><path d='M1040 520h40v40h-40zm-920 40h40v40h-40zm80 0h40v40h-40zm120 0h40v40h-40zm200 0h40v40h-40zm160 0h40v40h-40z'/><path d='M720 560h40v40h-40zm80 0h40v40h-40zm240 0h40v40h-40zM80 600h40v40H80z'/><path d='M120 600h40v40h-40zm280 0h40v40h-40z'/><path d='M440 600h40v40h-40zm120 0h40v40h-40z'/><path d='M600 600h40v40h-40zm80 0h40v40h-40z'/><path d='M720 600h40v40h-40z'/><path d='M760 600h40v40h-40zm120 0h40v40h-40zm120 0h40v40h-40zM80 640h40v40H80z'/><path d='M120 640h40v40h-40zm200 0h40v40h-40zm360 0h40v40h-40zm80 0h40v40h-40z'/><path d='M800 640h40v40h-40zm80 0h40v40h-40z'/><path d='M920 640h40v40h-40z'/><path d='M960 640h40v40h-40z'/><path d='M1000 640h40v40h-40z'/><path d='M1040 640h40v40h-40zM80 680h40v40H80zm80 0h40v40h-40z'/><path d='M200 680h40v40h-40zm160 0h40v40h-40zm80 0h40v40h-40zm120 0h40v40h-40zm80 0h40v40h-40zm120 0h40v40h-40zm80 0h40v40h-40zm80 0h40v40h-40z'/><path d='M960 680h40v40h-40zm80 0h40v40h-40zM80 720h40v40H80zm80 0h40v40h-40zm120 0h40v40h-40z'/><path d='M320 720h40v40h-40z'/><path d='M360 720h40v40h-40zm80 0h40v40h-40z'/><path d='M480 720h40v40h-40z'/><path d='M520 720h40v40h-40z'/><path d='M560 720h40v40h-40z'/><path d='M600 720h40v40h-40zm80 0h40v40h-40z'/><path d='M720 720h40v40h-40z'/><path d='M760 720h40v40h-40z'/><path d='M800 720h40v40h-40z'/><path d='M840 720h40v40h-40z'/><path d='M880 720h40v40h-40zm80 0h40v40h-40z'/><path d='M1000 720h40v40h-40zm-600 40h40v40h-40z'/><path d='M440 760h40v40h-40zm80 0h40v40h-40zm200 0h40v40h-40zm160 0h40v40h-40zm80 0h40v40h-40z'/><path d='M1000 760h40v40h-40zm-600 40h40v40h-40zm160 0h40v40h-40zm160 0h40v40h-40zm80 0h40v40h-40zm80 0h40v40h-40z'/><path d='M1040 800h40v40h-40zm-640 40h40v40h-40z'/><path d='M440 840h40v40h-40z'/><path d='M480 840h40v40h-40z'/><path d='M520 840h40v40h-40zm80 0h40v40h-40zm80 0h40v40h-40z'/><path d='M720 840h40v40h-40zm160 0h40v40h-40zm-480 40h40v40h-40z'/><path d='M440 880h40v40h-40zm80 0h40v40h-40zm80 0h40v40h-40zm80 0h40v40h-40z'/><path d='M720 880h40v40h-40z'/><path d='M760 880h40v40h-40z'/><path d='M800 880h40v40h-40z'/><path d='M840 880h40v40h-40z'/><path d='M880 880h40v40h-40zm120 0h40v40h-40z'/><path d='M1040 880h40v40h-40zm-640 40h40v40h-40zm160 0h40v40h-40z'/><path d='M600 920h40v40h-40z'/><path d='M640 920h40v40h-40z'/><path d='M680 920h40v40h-40zm120 0h40v40h-40zm200 0h40v40h-40z'/><path d='M1040 920h40v40h-40zm-600 40h40v40h-40z'/><path d='M480 960h40v40h-40z'/><path d='M520 960h40v40h-40zm80 0h40v40h-40zm160 0h40v40h-40zm120 0h40v40h-40z'/><path d='M920 960h40v40h-40z'/><path d='M960 960h40v40h-40z'/><path d='M1000 960h40v40h-40z'/><path d='M1040 960h40v40h-40zm-520 40h40v40h-40z'/><path d='M560 1000h40v40h-40z'/><path d='M600 1000h40v40h-40zm80 0h40v40h-40zm160 0h40v40h-40z'/><path d='M880 1000h40v40h-40zm80 0h40v40h-40z'/><path d='M1000 1000h40v40h-40z'/><path d='M1040 1000h40v40h-40zm-640 40h40v40h-40z'/><path d='M440 1040h40v40h-40zm80 0h40v40h-40z'/><path d='M560 1040h40v40h-40z'/><path d='M600 1040h40v40h-40zm120 0h40v40h-40z'/><path d='M760 1040h40v40h-40zm160 0h40v40h-40zm120 0h40v40h-40zM318 80H122 80v42 196 42h42 196 42v-42-196-42h-42zm0 238H122V122h196v196zm720-238H842h-42v42 196 42h42 196 42v-42-196-42h-42zm0 238H842V122h196v196zM318 800H122 80v42 196 42h42 196 42v-42-196-42h-42zm0 238H122V842h196v196zM160 160h120v120H160zm720 0h120v120H880zM160 880h120v120H160z'/></svg>";
+}
+
 TEST(ContextMenuTests, ContextMenuElementInfoContainsQRCodePayloadStringDefaultConfiguration)
 {
-    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
-
-    __block bool gotProposedMenu = false;
-    [delegate setGetContextMenuFromProposedMenu:^(NSMenu *menu, _WKContextMenuElementInfo *elementInfo, id<NSSecureCoding>, void (^completion)(NSMenu *)) {
-        NSString *qrCodePayloadString = elementInfo.qrCodePayloadString;
-        EXPECT_NULL(qrCodePayloadString);
-
-        completion(nil);
-        gotProposedMenu = true;
-    }];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
-    [webView setUIDelegate:delegate.get()];
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 600, 600)]);
     [webView synchronouslyLoadHTMLString:@"<img src='qr-code.png'></img>"];
-    [webView mouseDownAtPoint:NSMakePoint(20, 20) simulatePressure:NO withFlags:0 eventType:NSEventTypeRightMouseDown];
-    [webView mouseUpAtPoint:NSMakePoint(20, 20) withFlags:0 eventType:NSEventTypeRightMouseUp];
-    Util::run(&gotProposedMenu);
+
+    [webView rightClickAtPoint:NSMakePoint(300, 300)];
+    _WKContextMenuElementInfo *elementInfo = [webView _test_waitForContextMenu];
+    EXPECT_NULL(elementInfo.qrCodePayloadString);
 }
 
 TEST(ContextMenuTests, ContextMenuElementInfoContainsQRCodePayloadString)
 {
-    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
-
-    __block bool gotProposedMenu = false;
-    [delegate setGetContextMenuFromProposedMenu:^(NSMenu *menu, _WKContextMenuElementInfo *elementInfo, id<NSSecureCoding>, void (^completion)(NSMenu *)) {
-        NSString *qrCodePayloadString = elementInfo.qrCodePayloadString;
-        EXPECT_WK_STREQ(qrCodePayloadString, "https://www.webkit.org");
-
-        completion(nil);
-        gotProposedMenu = true;
-    }];
-
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration _setContextMenuQRCodeDetectionEnabled:YES];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
-    [webView setUIDelegate:delegate.get()];
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 600, 600) configuration:configuration.get()]);
     [webView synchronouslyLoadHTMLString:@"<img src='qr-code.png'></img>"];
-    [webView mouseDownAtPoint:NSMakePoint(20, 20) simulatePressure:NO withFlags:0 eventType:NSEventTypeRightMouseDown];
-    [webView mouseUpAtPoint:NSMakePoint(20, 20) withFlags:0 eventType:NSEventTypeRightMouseUp];
-    Util::run(&gotProposedMenu);
+
+    [webView rightClickAtPoint:NSMakePoint(150, 150)];
+    _WKContextMenuElementInfo *elementInfo = [webView _test_waitForContextMenu];
+    EXPECT_NULL(elementInfo.qrCodePayloadString);
+
+    [webView rightClickAtPoint:NSMakePoint(300, 300)];
+    elementInfo = [webView _test_waitForContextMenu];
+    EXPECT_WK_STREQ(elementInfo.qrCodePayloadString, "https://www.webkit.org");
 }
 
 TEST(ContextMenuTests, ContextMenuElementInfoContainsQRCodePayloadStringInsideLink)
 {
-    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
-
-    __block bool gotProposedMenu = false;
-    [delegate setGetContextMenuFromProposedMenu:^(NSMenu *menu, _WKContextMenuElementInfo *elementInfo, id<NSSecureCoding>, void (^completion)(NSMenu *)) {
-        NSString *qrCodePayloadString = elementInfo.qrCodePayloadString;
-        EXPECT_NULL(qrCodePayloadString);
-
-        completion(nil);
-        gotProposedMenu = true;
-    }];
-
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration _setContextMenuQRCodeDetectionEnabled:YES];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
-    [webView setUIDelegate:delegate.get()];
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 600, 600) configuration:configuration.get()]);
     [webView synchronouslyLoadHTMLString:@"<a href='https://www.webkit.org'><img src='qr-code.png'></img></a>"];
-    [webView mouseDownAtPoint:NSMakePoint(20, 20) simulatePressure:NO withFlags:0 eventType:NSEventTypeRightMouseDown];
-    [webView mouseUpAtPoint:NSMakePoint(20, 20) withFlags:0 eventType:NSEventTypeRightMouseUp];
-    Util::run(&gotProposedMenu);
+
+    [webView rightClickAtPoint:NSMakePoint(300, 300)];
+    _WKContextMenuElementInfo *elementInfo = [webView _test_waitForContextMenu];
+    EXPECT_NULL(elementInfo.qrCodePayloadString);
+}
+
+TEST(ContextMenuTests, ContextMenuElementInfoContainsQRCodePayloadStringCanvas)
+{
+    auto testMessageHandler = adoptNS([[TestMessageHandler alloc] init]);
+
+    __block bool imageLoaded = false;
+    [testMessageHandler addMessage:@"imageLoaded" withHandler:^{
+        imageLoaded = true;
+    }];
+
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [[configuration userContentController] addScriptMessageHandler:testMessageHandler.get() name:@"testHandler"];
+    [configuration _setContextMenuQRCodeDetectionEnabled:YES];
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 600, 600) configuration:configuration.get()]);
+    [webView synchronouslyLoadHTMLString:@"<canvas id='canvas' width='400' height='400'></canvas>"];
+
+    NSString *drawImageToCanvasScript = @""
+        "var canvas = document.getElementById('canvas');\n"
+        "var ctx = canvas.getContext('2d');\n"
+        "var img = new Image();\n"
+        "img.onload = function() {\n"
+        "    ctx.drawImage(img, 0, 0);\n"
+        "    window.webkit.messageHandlers.testHandler.postMessage('imageLoaded');\n"
+        "};\n"
+        "img.src = 'qr-code.png';\n";
+
+    [webView stringByEvaluatingJavaScript:drawImageToCanvasScript];
+    Util::run(&imageLoaded);
+
+    [webView rightClickAtPoint:NSMakePoint(150, 150)];
+    _WKContextMenuElementInfo *elementInfo = [webView _test_waitForContextMenu];
+    EXPECT_NULL(elementInfo.qrCodePayloadString);
+
+    [webView rightClickAtPoint:NSMakePoint(300, 300)];
+    elementInfo = [webView _test_waitForContextMenu];
+    EXPECT_WK_STREQ(elementInfo.qrCodePayloadString, "https://www.webkit.org");
+}
+
+TEST(ContextMenuTests, ContextMenuElementInfoContainsQRCodePayloadStringSVG)
+{
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration _setContextMenuQRCodeDetectionEnabled:YES];
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 600, 600) configuration:configuration.get()]);
+    [webView synchronouslyLoadHTMLString:qrCodeSVGString()];
+
+    [webView rightClickAtPoint:NSMakePoint(150, 150)];
+    _WKContextMenuElementInfo *elementInfo = [webView _test_waitForContextMenu];
+    EXPECT_NULL(elementInfo.qrCodePayloadString);
+
+    [webView rightClickAtPoint:NSMakePoint(300, 300)];
+    elementInfo = [webView _test_waitForContextMenu];
+    EXPECT_WK_STREQ(elementInfo.qrCodePayloadString, "https://www.webkit.org");
+}
+
+TEST(ContextMenuTests, ContextMenuElementInfoContainsQRCodePayloadStringObscuredSVG)
+{
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration _setContextMenuQRCodeDetectionEnabled:YES];
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 600, 600) configuration:configuration.get()]);
+    [webView synchronouslyLoadHTMLString:[NSString stringWithFormat:@"%@<div style='width: 400px; height: 100px; background: red; position: absolute; top: 0px; left: 0px;'></div>", qrCodeSVGString()]];
+
+    [webView rightClickAtPoint:NSMakePoint(150, 550)];
+    _WKContextMenuElementInfo *elementInfo = [webView _test_waitForContextMenu];
+    EXPECT_NULL(elementInfo.qrCodePayloadString);
+
+    [webView rightClickAtPoint:NSMakePoint(300, 300)];
+    elementInfo = [webView _test_waitForContextMenu];
+    EXPECT_WK_STREQ(elementInfo.qrCodePayloadString, "https://www.webkit.org");
+}
+
+TEST(ContextMenuTests, ContextMenuElementInfoContainsQRCodePayloadStringSVGInsideTransformedElement)
+{
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration _setContextMenuQRCodeDetectionEnabled:YES];
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 600, 600) configuration:configuration.get()]);
+    [webView synchronouslyLoadHTMLString:[NSString stringWithFormat:@"<div style='transform: translateX(100px);'>%@</div>", qrCodeSVGString()]];
+
+    [webView rightClickAtPoint:NSMakePoint(50, 550)];
+    _WKContextMenuElementInfo *elementInfo = [webView _test_waitForContextMenu];
+    EXPECT_NULL(elementInfo.qrCodePayloadString);
+
+    [webView rightClickAtPoint:NSMakePoint(150, 550)];
+    elementInfo = [webView _test_waitForContextMenu];
+    EXPECT_WK_STREQ(elementInfo.qrCodePayloadString, "https://www.webkit.org");
+}
+
+TEST(ContextMenuTests, ContextMenuElementInfoContainsQRCodePayloadStringSVGPageZoom)
+{
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration _setContextMenuQRCodeDetectionEnabled:YES];
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 600, 600) configuration:configuration.get()]);
+    [webView setPageZoom:1.3];
+    [webView synchronouslyLoadHTMLString:qrCodeSVGString()];
+
+    [webView rightClickAtPoint:NSMakePoint(550, 50)];
+    _WKContextMenuElementInfo *elementInfo = [webView _test_waitForContextMenu];
+    EXPECT_NULL(elementInfo.qrCodePayloadString);
+
+    [webView rightClickAtPoint:NSMakePoint(500, 100)];
+    elementInfo = [webView _test_waitForContextMenu];
+    EXPECT_WK_STREQ(elementInfo.qrCodePayloadString, "https://www.webkit.org");
 }
 
 #endif // ENABLE(CONTEXT_MENU_QR_CODE_DETECTION)

--- a/Tools/TestWebKitAPI/cocoa/TestUIDelegate.h
+++ b/Tools/TestWebKitAPI/cocoa/TestUIDelegate.h
@@ -42,6 +42,10 @@
 - (NSString *)waitForConfirm;
 - (NSString *)waitForPromptWithReply:(NSString *)reply;
 
+#if PLATFORM(MAC)
+- (_WKContextMenuElementInfo *)waitForContextMenu;
+#endif
+
 @end
 
 @interface WKWebView (TestUIDelegateExtras)
@@ -49,4 +53,7 @@
 - (NSString *)_test_waitForConfirm;
 - (NSString *)_test_waitForPromptWithReply:(NSString *)reply;
 - (void)_test_waitForInspectorToShow;
+#if PLATFORM(MAC)
+- (_WKContextMenuElementInfo *)_test_waitForContextMenu;
+#endif
 @end

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
@@ -144,6 +144,7 @@
 - (void)mouseMoveToPoint:(NSPoint)pointInWindow withFlags:(NSEventModifierFlags)flags;
 - (void)sendClicksAtPoint:(NSPoint)pointInWindow numberOfClicks:(NSUInteger)numberOfClicks;
 - (void)sendClickAtPoint:(NSPoint)pointInWindow;
+- (void)rightClickAtPoint:(NSPoint)pointInWindow;
 - (void)wheelEventAtPoint:(CGPoint)pointInWindow wheelDelta:(CGSize)delta;
 - (BOOL)acceptsFirstMouseAtPoint:(NSPoint)pointInWindow;
 - (NSWindow *)hostWindow;

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
@@ -875,6 +875,12 @@ static WKContentView *recursiveFindWKContentView(UIView *view)
     [self sendClicksAtPoint:pointInWindow numberOfClicks:1];
 }
 
+- (void)rightClickAtPoint:(NSPoint)pointInWindow
+{
+    [self mouseDownAtPoint:pointInWindow simulatePressure:NO withFlags:0 eventType:NSEventTypeRightMouseDown];
+    [self mouseUpAtPoint:pointInWindow withFlags:0 eventType:NSEventTypeRightMouseUp];
+}
+
 - (BOOL)acceptsFirstMouseAtPoint:(NSPoint)pointInWindow
 {
     return [self acceptsFirstMouse:[self _mouseEventWithType:NSEventTypeLeftMouseDown atLocation:pointInWindow]];


### PR DESCRIPTION
#### 03b876ebc5479fe38e607b80d1f09a43bccd2a8c
<pre>
[macOS] Add additional heuristics for context menu QR code detection
<a href="https://bugs.webkit.org/show_bug.cgi?id=252972">https://bugs.webkit.org/show_bug.cgi?id=252972</a>
rdar://105953041

Reviewed by Wenson Hsieh.

260897@main added initial support for QR code detection when showing context
menus. However, websites have markup-driven ways of constructing QR codes that
do not involve images. In these cases, the `HitTestResult` obtained prior to
presenting a context menu does not contain an image, and the UI process has
nothing to analyze.

This patch ports Safari heuristics to detect markup-drive QR codes into WebKit.
Specifically, &lt;svg&gt;, &lt;canvas&gt;, and &lt;table&gt; QR codes are now supported, with
additional logic to account for zooming, transforms, and partially obscured
content.

* Source/WebCore/page/ContextMenuContext.cpp:
(WebCore::ContextMenuContext::ContextMenuContext):
* Source/WebCore/page/ContextMenuContext.h:
(WebCore::ContextMenuContext::setPotentialQRCodeNodeSnapshotImage):
(WebCore::ContextMenuContext::potentialQRCodeNodeSnapshotImage const):
(WebCore::ContextMenuContext::setPotentialQRCodeViewportSnapshotImage):
(WebCore::ContextMenuContext::potentialQRCodeViewportSnapshotImage const):
* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::prepareContextForQRCode):

Add a node and viewport snapshot of the element that may be a QR code, to be
sent to the UI process for analysis. These snapshots are only taken for certain
elements that are likely to contain a QR code, and if the `HitTestResult` is
missing a link and image.

Node snapshotting is unreliable, since it does not take transforms into account.
Consequently, a viewport-level snapshot is also taken. However, a viewport-level
snaphot is insufficient for partially obscured elements. Hence, two snapshots
are taken for analysis.

This approach mirrors Safari&apos;s implementation and limits the frequency of spurious
analysis. Note that taking the viewport snapshot only if QR code detection fails
for the node snapshot was considered, but this would require another IPC
roundtrip and would complicate the context menu presentation logic. The approach
used in this patch was chosen since this logic does not run frequently.

(WebCore::ContextMenuController::maybeCreateContextMenu):
* Source/WebKit/Shared/ContextMenuContextData.cpp:

Encode and decode the snapshot images as ShareableBitmaps for use in the
UI process.

(WebKit::ContextMenuContextData::ContextMenuContextData):

Drive-by cleanup. `RefPtr` does not need to be explicitly initialized.

(WebKit::ContextMenuContextData::setImage):

Drive-by cleanup to align with modern idiom used below.

(WebKit::ContextMenuContextData::setPotentialQRCodeNodeSnapshotImage):
(WebKit::ContextMenuContextData::setPotentialQRCodeViewportSnapshotImage):
(WebKit::ContextMenuContextData::encode const):
(WebKit::ContextMenuContextData::decode):
* Source/WebKit/Shared/ContextMenuContextData.h:
(WebKit::ContextMenuContextData::potentialQRCodeNodeSnapshotImage const):
(WebKit::ContextMenuContextData::potentialQRCodeViewportSnapshotImage const):
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm:
(WebKit::WebContextMenuProxyMac::showAfterPostProcessingContextData):

Analyze the snapshot images, if the `WebHitTestResultData` is missing an image
and a link.

* Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm:
(TestWebKitAPI::qrCodeSVGString):
(TestWebKitAPI::TEST):

Add tests to exercise the various heuristics.

* Tools/TestWebKitAPI/cocoa/TestUIDelegate.h:

Add helper methods to wait for context menu presentation and extract
element information.

* Tools/TestWebKitAPI/cocoa/TestUIDelegate.mm:
(-[TestUIDelegate waitForContextMenu]):
(-[WKWebView _test_waitForContextMenu]):
* Tools/TestWebKitAPI/cocoa/TestWKWebView.h:
* Tools/TestWebKitAPI/cocoa/TestWKWebView.mm:
(-[TestWKWebView rightClickAtPoint:]):

Implement a helper method to perform a right click.

Canonical link: <a href="https://commits.webkit.org/261019@main">https://commits.webkit.org/261019@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0828dbefee35a039ad56f4b0d9736ae5cf99dce0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110182 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19280 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42842 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1604 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119179 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114133 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20740 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10469 "Built successfully") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102437 "Reverted pull request changes (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115928 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15444 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98651 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/102437 "Reverted pull request changes (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97405 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30311 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/102437 "Reverted pull request changes (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11971 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31648 "Found 1 new test failure: media/video-playback-quality.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12583 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8616 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17948 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51265 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7634 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14390 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->