### PR TITLE
[UI-side compositing] The UI process needs to be able to compute the current unobscuredContentRect on the fly

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTree.cpp
@@ -518,9 +518,9 @@ void ScrollingTree::clearLatchedNode()
     m_latchingController.clearLatchedNode();
 }
 
-FloatPoint ScrollingTree::mainFrameScrollPosition() const
+FloatPoint ScrollingTree::mainFrameScrollPosition()
 {
-    ASSERT(m_treeStateLock.isLocked());
+    Locker locker { m_treeStateLock };
     return m_treeState.mainFrameScrollPosition;
 }
 

--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -211,6 +211,8 @@ public:
 
     Lock& treeLock() WTF_RETURNS_LOCK(m_treeLock) { return m_treeLock; }
 
+    WEBCORE_EXPORT FloatPoint mainFrameScrollPosition();
+
     void windowScreenDidChange(PlatformDisplayID, std::optional<FramesPerSecond> nominalFramesPerSecond);
     PlatformDisplayID displayID();
     WEBCORE_EXPORT virtual void displayDidRefresh(PlatformDisplayID) { }
@@ -226,7 +228,6 @@ public:
 protected:
     WheelEventHandlingResult handleWheelEventWithNode(const PlatformWheelEvent&, OptionSet<WheelEventProcessingSteps>, ScrollingTreeNode*, EventTargeting = EventTargeting::Propagate);
 
-    FloatPoint mainFrameScrollPosition() const WTF_REQUIRES_LOCK(m_treeStateLock);
     void setMainFrameScrollPosition(FloatPoint);
 
     void setGestureState(std::optional<WheelScrollGestureState>);

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -141,7 +141,7 @@ void WebPageProxy::didCommitLayerTree(const WebKit::RemoteLayerTreeTransaction& 
         if (layerTreeTransaction.transactionID() >= m_firstLayerTreeTransactionIdAfterDidCommitLoad) {
             m_hasUpdatedRenderingAfterDidCommitLoad = true;
             stopMakingViewBlankDueToLackOfRenderingUpdateIfNecessary();
-            m_lastVisibleContentRectUpdate = VisibleContentRectUpdateInfo();
+            m_lastVisibleContentRectUpdate = { };
         }
     }
 
@@ -158,6 +158,58 @@ void WebPageProxy::didCommitLayerTree(const WebKit::RemoteLayerTreeTransaction& 
 void WebPageProxy::layerTreeCommitComplete()
 {
     pageClient().layerTreeCommitComplete();
+}
+
+static inline float adjustedUnexposedEdge(float documentEdge, float exposedRectEdge, float factor)
+{
+    if (exposedRectEdge < documentEdge)
+        return documentEdge - factor * (documentEdge - exposedRectEdge);
+    
+    return exposedRectEdge;
+}
+
+static inline float adjustedUnexposedMaxEdge(float documentEdge, float exposedRectEdge, float factor)
+{
+    if (exposedRectEdge > documentEdge)
+        return documentEdge + factor * (exposedRectEdge - documentEdge);
+    
+    return exposedRectEdge;
+}
+
+FloatRect WebPageProxy::computeLayoutViewportRect(const FloatRect& unobscuredContentRect, const FloatRect& unobscuredContentRectRespectingInputViewBounds, const FloatRect& currentLayoutViewportRect, double displayedContentScale, FrameView::LayoutViewportConstraint constraint) const
+{
+    FloatRect constrainedUnobscuredRect = unobscuredContentRect;
+    FloatRect documentRect = pageClient().documentRect();
+
+    if (constraint == FrameView::LayoutViewportConstraint::ConstrainedToDocumentRect)
+        constrainedUnobscuredRect.intersect(documentRect);
+
+    double minimumScale = pageClient().minimumZoomScale();
+    bool isBelowMinimumScale = displayedContentScale < minimumScale;
+    if (isBelowMinimumScale) {
+        const CGFloat slope = 12;
+        CGFloat factor = std::max<CGFloat>(1 - slope * (minimumScale - displayedContentScale), 0);
+            
+        constrainedUnobscuredRect.setX(adjustedUnexposedEdge(documentRect.x(), constrainedUnobscuredRect.x(), factor));
+        constrainedUnobscuredRect.setY(adjustedUnexposedEdge(documentRect.y(), constrainedUnobscuredRect.y(), factor));
+        constrainedUnobscuredRect.setWidth(adjustedUnexposedMaxEdge(documentRect.maxX(), constrainedUnobscuredRect.maxX(), factor) - constrainedUnobscuredRect.x());
+        constrainedUnobscuredRect.setHeight(adjustedUnexposedMaxEdge(documentRect.maxY(), constrainedUnobscuredRect.maxY(), factor) - constrainedUnobscuredRect.y());
+    }
+
+    FloatSize constrainedSize = isBelowMinimumScale ? constrainedUnobscuredRect.size() : unobscuredContentRect.size();
+    FloatRect unobscuredContentRectForViewport = isBelowMinimumScale ? constrainedUnobscuredRect : unobscuredContentRectRespectingInputViewBounds;
+
+    auto layoutViewportSize = FrameView::expandedLayoutViewportSize(m_baseLayoutViewportSize, LayoutSize(documentRect.size()), m_preferences->layoutViewportHeightExpansionFactor());
+    FloatRect layoutViewportRect = FrameView::computeUpdatedLayoutViewportRect(LayoutRect(currentLayoutViewportRect), LayoutRect(documentRect), LayoutSize(constrainedSize), LayoutRect(unobscuredContentRectForViewport), layoutViewportSize, m_minStableLayoutViewportOrigin, m_maxStableLayoutViewportOrigin, constraint);
+    
+    if (layoutViewportRect != currentLayoutViewportRect)
+        LOG_WITH_STREAM(VisibleRects, stream << "WebPageProxy::computeLayoutViewportRect: new layout viewport  " << layoutViewportRect);
+    return layoutViewportRect;
+}
+
+FloatRect WebPageProxy::unconstrainedLayoutViewportRect() const
+{
+    return computeLayoutViewportRect(unobscuredContentRect(), unobscuredContentRectRespectingInputViewBounds(), layoutViewportRect(), displayedContentScale(), FrameView::LayoutViewportConstraint::Unconstrained);
 }
 
 #if ENABLE(DATA_DETECTION)

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.h
@@ -96,8 +96,8 @@ public:
     virtual void sizeToContentAutoSizeMaximumSizeDidChange() { }
     virtual void windowKindDidChange() { }
 
-    virtual void adjustTransientZoom(double, WebCore::FloatPoint) { }
-    virtual void commitTransientZoom(double, WebCore::FloatPoint) { }
+    virtual void adjustTransientZoom(double, WebCore::FloatPoint, WebCore::FloatPoint) { }
+    virtual void commitTransientZoom(double, WebCore::FloatPoint, WebCore::FloatPoint) { }
 
 #if PLATFORM(MAC)
     virtual void didChangeViewExposedRect();

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -462,6 +462,9 @@ public:
 #if PLATFORM(COCOA)
     virtual void didCommitLayerTree(const RemoteLayerTreeTransaction&) = 0;
     virtual void layerTreeCommitComplete() = 0;
+
+    virtual double minimumZoomScale() const = 0;
+    virtual WebCore::FloatRect documentRect() const = 0;
 #endif
 
 #if PLATFORM(IOS_FAMILY)
@@ -485,8 +488,7 @@ public:
     virtual void showDataDetectorsUIForPositionInformation(const InteractionInformationAtPosition&) = 0;
     virtual void disableDoubleTapGesturesDuringTapIfNecessary(WebKit::TapIdentifier) = 0;
     virtual void handleSmartMagnificationInformationForPotentialTap(WebKit::TapIdentifier, const WebCore::FloatRect& renderRect, bool fitEntireRect, double viewportMinimumScale, double viewportMaximumScale, bool nodeIsRootLevel) = 0;
-    virtual double minimumZoomScale() const = 0;
-    virtual WebCore::FloatRect documentRect() const = 0;
+
     virtual void scrollingNodeScrollViewWillStartPanGesture(WebCore::ScrollingNodeID) = 0;
     virtual void scrollingNodeScrollViewDidScroll(WebCore::ScrollingNodeID) = 0;
     virtual void scrollingNodeScrollWillStartScroll(WebCore::ScrollingNodeID) = 0;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -64,6 +64,11 @@ ScrollingNodeID RemoteScrollingCoordinatorProxy::rootScrollingNodeID() const
     return m_scrollingTree->rootNode()->scrollingNodeID();
 }
 
+FloatPoint RemoteScrollingCoordinatorProxy::mainFrameScrollPosition() const
+{
+    return m_scrollingTree->mainFrameScrollPosition();
+}
+
 const RemoteLayerTreeHost* RemoteScrollingCoordinatorProxy::layerTreeHost() const
 {
     auto* drawingArea = m_webPageProxy.drawingArea();
@@ -256,11 +261,6 @@ bool RemoteScrollingCoordinatorProxy::hasScrollableMainFrame() const
 {
     auto* rootNode = m_scrollingTree->rootNode();
     return rootNode && rootNode->canHaveScrollbars();
-}
-
-ScrollingTreeScrollingNode* RemoteScrollingCoordinatorProxy::rootNode() const
-{
-    return m_scrollingTree->rootNode();
 }
 
 void RemoteScrollingCoordinatorProxy::displayDidRefresh(PlatformDisplayID displayID)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -100,6 +100,7 @@ public:
     virtual WebCore::PlatformWheelEvent filteredWheelEvent(const WebCore::PlatformWheelEvent& wheelEvent) { return wheelEvent; }
 
     WebCore::ScrollingNodeID rootScrollingNodeID() const;
+    WebCore::FloatPoint mainFrameScrollPosition() const;
 
     const RemoteLayerTreeHost* layerTreeHost() const;
     WebPageProxy& webPageProxy() const { return m_webPageProxy; }
@@ -121,7 +122,7 @@ public:
     String scrollingTreeAsText() const;
 
     void resetStateAfterProcessExited();
-    WebCore::ScrollingTreeScrollingNode* rootNode() const;
+//    WebCore::ScrollingTreeScrollingNode* rootNode() const;
 
     virtual void displayDidRefresh(WebCore::PlatformDisplayID);
     void reportExposedUnfilledArea(MonotonicTime, unsigned unfilledArea);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h
@@ -50,6 +50,8 @@ public:
 
     DisplayLink& displayLink();
 
+    WebCore::IntSize lastCommittedTotalContentsSize() const { return m_lastCommittedTotalContentsSize; }
+
 private:
     WebCore::DelegatedScrollingMode delegatedScrollingMode() const override;
     std::unique_ptr<RemoteScrollingCoordinatorProxy> createScrollingCoordinatorProxy() const override;
@@ -58,8 +60,8 @@ private:
 
     void didCommitLayerTree(IPC::Connection&, const RemoteLayerTreeTransaction&, const RemoteScrollingCoordinatorTransaction&) override;
 
-    void adjustTransientZoom(double, WebCore::FloatPoint) override;
-    void commitTransientZoom(double, WebCore::FloatPoint) override;
+    void adjustTransientZoom(double scale, WebCore::FloatPoint origin, WebCore::FloatPoint zoomOriginInContentCoordinates) override;
+    void commitTransientZoom(double scale, WebCore::FloatPoint origin, WebCore::FloatPoint zoomOriginInContentCoordinates) override;
     
     void applyTransientZoomToLayer();
     void removeTransientZoomFromLayer();
@@ -73,6 +75,9 @@ private:
     void didChangeViewExposedRect() override;
 
     void setDisplayLinkWantsFullSpeedUpdates(bool) override;
+    
+    WebCore::FloatPoint currentScrollPosition() const;
+    WebCore::FloatRect computeUnobscuredContentRect(double scale, WebCore::FloatPoint origin, WebCore::FloatPoint zoomOriginInContentCoordinates);
 
     void removeObserver(std::optional<DisplayLinkObserverID>&);
 
@@ -92,6 +97,11 @@ private:
     std::optional<TransactionID> m_transactionIDAfterEndingTransientZoom;
     std::optional<double> m_transientZoomScale;
     std::optional<WebCore::FloatPoint> m_transientZoomOrigin;
+    
+    // FIXME: Need to clear these on WebProcess crash.
+    WebCore::IntSize m_lastCommittedTotalContentsSize;
+    WebCore::FloatPoint m_lastCommittedScrollPosition;
+    double m_lastCommittedpageScaleFactor { 1 };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/ViewGestureController.cpp
+++ b/Source/WebKit/UIProcess/ViewGestureController.cpp
@@ -37,6 +37,7 @@
 #include <wtf/NeverDestroyed.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/StringConcatenateNumbers.h>
+#include <wtf/text/TextStream.h>
 
 #if PLATFORM(COCOA)
 #include "RemoteLayerTreeDrawingAreaProxy.h"
@@ -655,11 +656,15 @@ FloatPoint ViewGestureController::scaledMagnificationOrigin(FloatPoint origin, d
     float magnificationOriginScale = 1 - (scale / m_initialMagnification);
     scaledMagnificationOrigin.scale(magnificationOriginScale);
     scaledMagnificationOrigin.move(origin - m_initialMagnificationOrigin);
+
+    LOG_WITH_STREAM(ViewGestures, stream << "ViewGestureController::scaledMagnificationOrigin " << origin << " scale " << scale << " computed scaledMagnificationOrigin " << scaledMagnificationOrigin);
     return scaledMagnificationOrigin;
 }
 
 void ViewGestureController::didCollectGeometryForMagnificationGesture(FloatRect visibleContentRect, bool frameHandlesMagnificationGesture)
 {
+    LOG_WITH_STREAM(ViewGestures, stream << "ViewGestureController::didCollectGeometryForMagnificationGesture - visibleContentRect " << visibleContentRect);
+
     willBeginGesture(ViewGestureType::Magnification);
     m_visibleContentRect = visibleContentRect;
     m_visibleContentRectIsValid = true;
@@ -687,7 +692,7 @@ void ViewGestureController::applyMagnification()
     if (m_frameHandlesMagnificationGesture)
         m_webPageProxy.scalePage(m_magnification, roundedIntPoint(m_magnificationOrigin));
     else
-        m_webPageProxy.drawingArea()->adjustTransientZoom(m_magnification, scaledMagnificationOrigin(m_magnificationOrigin, m_magnification));
+        m_webPageProxy.drawingArea()->adjustTransientZoom(m_magnification, scaledMagnificationOrigin(m_magnificationOrigin, m_magnification), m_magnificationOrigin);
 }
 
 void ViewGestureController::endMagnificationGesture()
@@ -701,7 +706,7 @@ void ViewGestureController::endMagnificationGesture()
         m_webPageProxy.scalePage(newMagnification, roundedIntPoint(m_magnificationOrigin));
     else {
         if (auto drawingArea = m_webPageProxy.drawingArea())
-            drawingArea->commitTransientZoom(newMagnification, scaledMagnificationOrigin(m_magnificationOrigin, newMagnification));
+            drawingArea->commitTransientZoom(newMagnification, scaledMagnificationOrigin(m_magnificationOrigin, newMagnification), m_magnificationOrigin);
     }
 
 #if PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -837,12 +837,24 @@ public:
     void setCanShowPlaceholder(const WebCore::ElementContext&, bool);
 
 #if ENABLE(UI_SIDE_COMPOSITING)
-    void updateVisibleContentRects(const VisibleContentRectUpdateInfo&, bool sendEvenIfUnchanged);
+    double displayedContentScale() const { return m_lastVisibleContentRectUpdate.scale(); }
+    const WebCore::FloatRect& exposedContentRect() const { return m_lastVisibleContentRectUpdate.exposedContentRect(); }
+    const WebCore::FloatRect& unobscuredContentRect() const { return m_lastVisibleContentRectUpdate.unobscuredContentRect(); }
+    bool inStableState() const { return m_lastVisibleContentRectUpdate.inStableState(); }
+    const WebCore::FloatRect& unobscuredContentRectRespectingInputViewBounds() const { return m_lastVisibleContentRectUpdate.unobscuredContentRectRespectingInputViewBounds(); }
+    // When visual viewports are enabled, this is the layout viewport rect.
+    const WebCore::FloatRect& layoutViewportRect() const { return m_lastVisibleContentRectUpdate.layoutViewportRect(); }
+
+    WebCore::FloatRect unconstrainedLayoutViewportRect() const;
+
+    WebCore::FloatRect computeLayoutViewportRect(const WebCore::FloatRect& unobscuredContentRect, const WebCore::FloatRect& unobscuredContentRectRespectingInputViewBounds, const WebCore::FloatRect& currentLayoutViewportRect, double displayedContentScale, WebCore::FrameView::LayoutViewportConstraint = WebCore::FrameView::LayoutViewportConstraint::Unconstrained) const;
 #endif
-        
+
     void adjustLayersForLayoutViewport(const WebCore::FloatPoint& scrollPosition, const WebCore::FloatRect& layoutViewport, double scale);
 
 #if PLATFORM(IOS_FAMILY)
+    void updateVisibleContentRects(const VisibleContentRectUpdateInfo&, bool sendEvenIfUnchanged);
+
     void textInputContextsInRect(WebCore::FloatRect, CompletionHandler<void(const Vector<WebCore::ElementContext>&)>&&);
     void focusTextInputContextAndPlaceCaret(const WebCore::ElementContext&, const WebCore::IntPoint&, CompletionHandler<void(bool)>&&);
 
@@ -853,19 +865,7 @@ public:
     void insertTextPlaceholder(const WebCore::IntSize&, CompletionHandler<void(const std::optional<WebCore::ElementContext>&)>&&);
     void removeTextPlaceholder(const WebCore::ElementContext&, CompletionHandler<void()>&&);
 
-    double displayedContentScale() const { return m_lastVisibleContentRectUpdate.scale(); }
-    const WebCore::FloatRect& exposedContentRect() const { return m_lastVisibleContentRectUpdate.exposedContentRect(); }
-    const WebCore::FloatRect& unobscuredContentRect() const { return m_lastVisibleContentRectUpdate.unobscuredContentRect(); }
-    bool inStableState() const { return m_lastVisibleContentRectUpdate.inStableState(); }
-    const WebCore::FloatRect& unobscuredContentRectRespectingInputViewBounds() const { return m_lastVisibleContentRectUpdate.unobscuredContentRectRespectingInputViewBounds(); }
-    // When visual viewports are enabled, this is the layout viewport rect.
-    const WebCore::FloatRect& layoutViewportRect() const { return m_lastVisibleContentRectUpdate.layoutViewportRect(); }
-
     void resendLastVisibleContentRects();
-
-    WebCore::FloatRect computeLayoutViewportRect(const WebCore::FloatRect& unobscuredContentRect, const WebCore::FloatRect& unobscuredContentRectRespectingInputViewBounds, const WebCore::FloatRect& currentLayoutViewportRect, double displayedContentScale, WebCore::FrameView::LayoutViewportConstraint = WebCore::FrameView::LayoutViewportConstraint::Unconstrained) const;
-
-    WebCore::FloatRect unconstrainedLayoutViewportRect() const;
 
     void scrollingNodeScrollViewWillStartPanGesture(WebCore::ScrollingNodeID);
     void scrollingNodeScrollViewDidScroll(WebCore::ScrollingNodeID);

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -201,6 +201,9 @@ private:
     void didCommitLayerTree(const RemoteLayerTreeTransaction&) override;
     void layerTreeCommitComplete() override;
 
+    double minimumZoomScale() const override;
+    WebCore::FloatRect documentRect() const override;
+
     void registerInsertionUndoGrouping() override;
 
 #if ENABLE(UI_PROCESS_PDF_HUD)

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -38,6 +38,7 @@
 #import "NativeWebMouseEvent.h"
 #import "NativeWebWheelEvent.h"
 #import "NavigationState.h"
+#import "RemoteLayerTreeDrawingAreaProxyMac.h"
 #import "StringUtilities.h"
 #import "UndoOrRedo.h"
 #import "ViewGestureController.h"
@@ -761,6 +762,25 @@ void PageClientImpl::didCommitLayerTree(const RemoteLayerTreeTransaction& layerT
 
 void PageClientImpl::layerTreeCommitComplete()
 {
+}
+
+double PageClientImpl::minimumZoomScale() const
+{
+    // FIXME: Get from ViewGestureController
+    return 1;
+}
+
+WebCore::FloatRect PageClientImpl::documentRect() const
+{
+    auto webPageProxy = m_webView.get()->_page;
+    auto* drawingArea = dynamicDowncast<RemoteLayerTreeDrawingAreaProxy>(webPageProxy->drawingArea());
+    if (!drawingArea)
+        return { };
+
+    ASSERT(drawingArea->isRemoteLayerTreeDrawingAreaProxyMac());
+    auto* drawingAreaMac = static_cast<RemoteLayerTreeDrawingAreaProxyMac*>(drawingArea);
+    
+    return FloatRect { { }, FloatSize { drawingAreaMac->lastCommittedTotalContentsSize() } };
 }
 
 #if ENABLE(FULLSCREEN_API)

--- a/Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.h
@@ -49,8 +49,8 @@ private:
     void updateAcceleratedCompositingMode(uint64_t backingStoreStateID, const LayerTreeContext&) override;
     void didFirstLayerFlush(uint64_t /* backingStoreStateID */, const LayerTreeContext&) override;
 
-    void adjustTransientZoom(double scale, WebCore::FloatPoint origin) override;
-    void commitTransientZoom(double scale, WebCore::FloatPoint origin) override;
+    void adjustTransientZoom(double scale, WebCore::FloatPoint scaleOrigin, WebCore::FloatPoint zoomOriginInContentCoordinates) override;
+    void commitTransientZoom(double scale, WebCore::FloatPoint origin, WebCore::FloatPoint zoomOriginInContentCoordinates) override;
 
     void waitForDidUpdateActivityState(ActivityStateChangeID, WebProcessProxy&) override;
     void dispatchPresentationCallbacksAfterFlushingLayers(IPC::Connection&, Vector<IPC::AsyncReplyID>&&) final;

--- a/Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.mm
@@ -195,12 +195,12 @@ void TiledCoreAnimationDrawingAreaProxy::sendUpdateGeometry()
     }, m_identifier);
 }
 
-void TiledCoreAnimationDrawingAreaProxy::adjustTransientZoom(double scale, FloatPoint origin)
+void TiledCoreAnimationDrawingAreaProxy::adjustTransientZoom(double scale, FloatPoint origin, FloatPoint)
 {
     m_webPageProxy.send(Messages::DrawingArea::AdjustTransientZoom(scale, origin), m_identifier);
 }
 
-void TiledCoreAnimationDrawingAreaProxy::commitTransientZoom(double scale, FloatPoint origin)
+void TiledCoreAnimationDrawingAreaProxy::commitTransientZoom(double scale, FloatPoint origin, FloatPoint)
 {
     m_webPageProxy.send(Messages::DrawingArea::CommitTransientZoom(scale, origin), m_identifier);
 }

--- a/Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm
+++ b/Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm
@@ -131,7 +131,6 @@ void ViewGestureController::handleMagnificationGestureEvent(NSEvent *event, Floa
 
         // FIXME: We drop the first frame of the gesture on the floor, because we don't have the visible content bounds yet.
         prepareMagnificationGesture(origin);
-
         return;
     }
 
@@ -217,10 +216,10 @@ void ViewGestureController::didCollectGeometryForSmartMagnificationGesture(Float
     targetOrigin.moveBy(-targetRect.center());
 
     m_initialMagnification = m_webPageProxy.pageScaleFactor();
-    m_initialMagnificationOrigin = FloatPoint();
+    m_initialMagnificationOrigin = { };
 
-    m_webPageProxy.drawingArea()->adjustTransientZoom(m_webPageProxy.pageScaleFactor(), scaledMagnificationOrigin(FloatPoint(), m_webPageProxy.pageScaleFactor()));
-    m_webPageProxy.drawingArea()->commitTransientZoom(targetMagnification, targetOrigin);
+    m_webPageProxy.drawingArea()->adjustTransientZoom(m_webPageProxy.pageScaleFactor(), scaledMagnificationOrigin({ }, m_webPageProxy.pageScaleFactor()), { });
+    m_webPageProxy.drawingArea()->commitTransientZoom(targetMagnification, targetOrigin, m_initialMagnificationOrigin);
 
     m_lastSmartMagnificationUnscaledTargetRect = unscaledTargetRect;
     m_lastSmartMagnificationOrigin = origin;


### PR DESCRIPTION
#### 6e2e8fe4dfc260ee248c09f9b42c05e6ef166a55
<pre>
[UI-side compositing] The UI process needs to be able to compute the current unobscuredContentRect on the fly
<a href="https://bugs.webkit.org/show_bug.cgi?id=253089">https://bugs.webkit.org/show_bug.cgi?id=253089</a>
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

WIP

* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::didCommitLayerTree):
(WebKit::adjustedUnexposedEdge):
(WebKit::adjustedUnexposedMaxEdge):
(WebKit::WebPageProxy::computeLayoutViewportRect const):
(WebKit::WebPageProxy::unconstrainedLayoutViewportRect const):
* Source/WebKit/UIProcess/DrawingAreaProxy.h:
(WebKit::DrawingAreaProxy::adjustTransientZoom):
(WebKit::DrawingAreaProxy::commitTransientZoom):
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::didCommitLayerTree):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::adjustTransientZoom):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::commitTransientZoom):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::computeUnobscuredContentRect):
* Source/WebKit/UIProcess/ViewGestureController.cpp:
(WebKit::ViewGestureController::scaledMagnificationOrigin):
(WebKit::ViewGestureController::didCollectGeometryForMagnificationGesture):
(WebKit::ViewGestureController::applyMagnification):
(WebKit::ViewGestureController::endMagnificationGesture):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::adjustedUnexposedEdge): Deleted.
(WebKit::adjustedUnexposedMaxEdge): Deleted.
(WebKit::WebPageProxy::computeLayoutViewportRect const): Deleted.
(WebKit::WebPageProxy::unconstrainedLayoutViewportRect const): Deleted.
* Source/WebKit/UIProcess/mac/PageClientImplMac.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::minimumZoomScale const):
(WebKit::PageClientImpl::documentRect const):
* Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.h:
* Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.mm:
(WebKit::TiledCoreAnimationDrawingAreaProxy::adjustTransientZoom):
(WebKit::TiledCoreAnimationDrawingAreaProxy::commitTransientZoom):
* Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm:
(WebKit::ViewGestureController::handleMagnificationGestureEvent):
(WebKit::ViewGestureController::didCollectGeometryForSmartMagnificationGesture):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e2e8fe4dfc260ee248c09f9b42c05e6ef166a55

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110163 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19261 "Hash 6e2e8fe4 for PR 10807 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42823 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1585 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119161 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114114 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20721 "Hash 6e2e8fe4 for PR 10807 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10450 "Built successfully") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102417 "Hash 6e2e8fe4 for PR 10807 does not build (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115909 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/76/builds/20721 "Hash 6e2e8fe4 for PR 10807 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98638 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/102417 "Hash 6e2e8fe4 for PR 10807 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/76/builds/20721 "Hash 6e2e8fe4 for PR 10807 does not build (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30299 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/102417 "Hash 6e2e8fe4 for PR 10807 does not build (failure)") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11953 "Hash 6e2e8fe4 for PR 10807 does not build (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31636 "Passed tests") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12565 "Hash 6e2e8fe4 for PR 10807 does not build (failure)") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8600 "Passed tests") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17930 "Hash 6e2e8fe4 for PR 10807 does not build (failure)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51253 "Passed tests") | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14372 "Hash 6e2e8fe4 for PR 10807 does not build (failure)") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->