### PR TITLE
Reduce build times by refactoring JSValueInWrappedObject.h

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -543,6 +543,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     bindings/js/JSShadowRealmGlobalScopeBase.h
     bindings/js/JSStyleSheetCustom.h
     bindings/js/JSValueInWrappedObject.h
+    bindings/js/JSValueInWrappedObjectInlines.h
     bindings/js/JSWindowProxy.h
     bindings/js/ReadableStreamDefaultController.h
     bindings/js/RunJavaScriptParameters.h

--- a/Source/WebCore/Modules/indexeddb/IDBCursor.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBCursor.cpp
@@ -34,6 +34,7 @@
 #include "IDBObjectStore.h"
 #include "IDBRequest.h"
 #include "IDBTransaction.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "Logging.h"
 #include "ScriptExecutionContext.h"
 #include "SerializedScriptValue.h"

--- a/Source/WebCore/Modules/indexeddb/IDBCursor.h
+++ b/Source/WebCore/Modules/indexeddb/IDBCursor.h
@@ -34,6 +34,7 @@
 #include "JSValueInWrappedObject.h"
 #include <JavaScriptCore/Strong.h>
 #include <variant>
+#include <wtf/Deque.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -48,7 +49,7 @@ class IDBCursor : public ScriptWrappable, public RefCounted<IDBCursor> {
 public:
     static Ref<IDBCursor> create(IDBObjectStore&, const IDBCursorInfo&);
     static Ref<IDBCursor> create(IDBIndex&, const IDBCursorInfo&);
-    
+
     virtual ~IDBCursor();
 
     using Source = std::variant<RefPtr<IDBObjectStore>, RefPtr<IDBIndex>>;

--- a/Source/WebCore/Modules/indexeddb/IDBRequest.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBRequest.cpp
@@ -41,6 +41,7 @@
 #include "JSDOMConvertIndexedDB.h"
 #include "JSDOMConvertNumbers.h"
 #include "JSDOMConvertSequences.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "Logging.h"
 #include "ScriptExecutionContext.h"
 #include "ThreadSafeDataBuffer.h"

--- a/Source/WebCore/Modules/paymentrequest/PaymentMethodChangeEvent.cpp
+++ b/Source/WebCore/Modules/paymentrequest/PaymentMethodChangeEvent.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(PAYMENT_REQUEST)
 
+#include "JSValueInWrappedObjectInlines.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/paymentrequest/PaymentResponse.cpp
+++ b/Source/WebCore/Modules/paymentrequest/PaymentResponse.cpp
@@ -30,6 +30,7 @@
 
 #include "Document.h"
 #include "JSDOMPromiseDeferred.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "NotImplemented.h"
 #include "PaymentComplete.h"
 #include "PaymentCompleteDetails.h"

--- a/Source/WebCore/Modules/webaudio/AudioBuffer.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioBuffer.cpp
@@ -36,6 +36,7 @@
 #include "AudioContext.h"
 #include "AudioFileReader.h"
 #include "AudioUtilities.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "WebCoreOpaqueRoot.h"
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/TypedArrayInlines.h>

--- a/Source/WebCore/Modules/webaudio/AudioBuffer.h
+++ b/Source/WebCore/Modules/webaudio/AudioBuffer.h
@@ -34,12 +34,14 @@
 #include "JSValueInWrappedObject.h"
 #include <JavaScriptCore/Forward.h>
 #include <JavaScriptCore/TypedArrayAdaptersForwardDeclarations.h>
+#include <wtf/FixedVector.h>
 #include <wtf/Lock.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
 
 class AudioBus;
+class JSDOMGlobalObject;
 class WebCoreOpaqueRoot;
 
 class AudioBuffer : public RefCounted<AudioBuffer> {

--- a/Source/WebCore/Modules/webaudio/AudioWorkletProcessor.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletProcessor.cpp
@@ -37,6 +37,7 @@
 #include "AudioWorkletProcessorConstructionData.h"
 #include "JSCallbackData.h"
 #include "JSDOMExceptionHandling.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "MessagePort.h"
 #include "WebCoreOpaqueRoot.h"
 #include <JavaScriptCore/JSTypedArrays.h>

--- a/Source/WebCore/Modules/webxr/WebXRRigidTransform.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRRigidTransform.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(WEBXR)
 
 #include "DOMPointReadOnly.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "TransformationMatrix.h"
 #include <JavaScriptCore/TypedArrayInlines.h>
 #include <wtf/IsoMallocInlines.h>

--- a/Source/WebCore/Modules/webxr/WebXRView.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRView.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(WEBXR)
 
+#include "JSValueInWrappedObjectInlines.h"
 #include "WebXRFrame.h"
 #include "WebXRRigidTransform.h"
 #include <JavaScriptCore/TypedArrayInlines.h>

--- a/Source/WebCore/bindings/js/JSAbortSignalCustom.cpp
+++ b/Source/WebCore/bindings/js/JSAbortSignalCustom.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "JSAbortSignal.h"
 
+#include "JSValueInWrappedObjectInlines.h"
 #include "WebCoreOpaqueRootInlines.h"
 
 namespace WebCore {

--- a/Source/WebCore/bindings/js/JSAudioWorkletGlobalScopeCustom.cpp
+++ b/Source/WebCore/bindings/js/JSAudioWorkletGlobalScopeCustom.cpp
@@ -28,6 +28,7 @@
 
 #include "AudioWorkletGlobalScope.h"
 #include "AudioWorkletProcessor.h"
+#include "JSValueInWrappedObjectInlines.h"
 
 #if ENABLE(WEB_AUDIO)
 

--- a/Source/WebCore/bindings/js/JSDOMConvertAny.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertAny.h
@@ -27,7 +27,7 @@
 
 #include "IDLTypes.h"
 #include "JSDOMConvertBase.h"
-#include "JSValueInWrappedObject.h"
+#include "JSValueInWrappedObjectInlines.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/bindings/js/JSHistoryCustom.cpp
+++ b/Source/WebCore/bindings/js/JSHistoryCustom.cpp
@@ -29,6 +29,7 @@
 #include "config.h"
 #include "JSHistory.h"
 
+#include "JSValueInWrappedObjectInlines.h"
 #include "SerializedScriptValue.h"
 #include <JavaScriptCore/JSCInlines.h>
 

--- a/Source/WebCore/bindings/js/JSValueInWrappedObject.h
+++ b/Source/WebCore/bindings/js/JSValueInWrappedObject.h
@@ -24,14 +24,21 @@
 
 #pragma once
 
-#include "DOMWrapperWorld.h"
-#include "JSDOMWrapper.h"
-#include <JavaScriptCore/JSCJSValueInlines.h>
-#include <JavaScriptCore/SlotVisitor.h>
-#include <JavaScriptCore/WeakInlines.h>
-#include <variant>
+#include <JavaScriptCore/JSCJSValue.h>
+#include <JavaScriptCore/Weak.h>
+
+namespace JSC {
+
+class JSCell;
+class JSGlobalObject;
+class ThrowScope;
+class VM;
+
+}
 
 namespace WebCore {
+
+class JSDOMObject;
 
 // This class includes a lot of GC related subtle things, and changing this class easily causes GC crashes.
 // Any changes on this class must be reviewed by JavaScriptCore reviewers too.
@@ -40,15 +47,16 @@ class JSValueInWrappedObject {
     WTF_MAKE_NONCOPYABLE(JSValueInWrappedObject);
     WTF_MAKE_NONMOVABLE(JSValueInWrappedObject);
 public:
-    JSValueInWrappedObject(JSC::JSValue = { });
+    inline JSValueInWrappedObject();
+    inline JSValueInWrappedObject(JSC::JSValue);
 
-    explicit operator bool() const;
-    template<typename Visitor> void visit(Visitor&) const;
-    void clear();
+    inline explicit operator bool() const;
+    template<typename Visitor> inline void visit(Visitor&) const;
+    inline void clear();
 
-    void set(JSC::VM&, const JSC::JSCell* owner, JSC::JSValue);
-    void setWeakly(JSC::JSValue);
-    JSC::JSValue getValue(JSC::JSValue nullValue = JSC::jsUndefined()) const;
+    inline void set(JSC::VM&, const JSC::JSCell* owner, JSC::JSValue);
+    inline void setWeakly(JSC::JSValue);
+    inline JSC::JSValue getValue(JSC::JSValue nullValue = JSC::jsUndefined()) const;
 
 private:
     // Keep in mind that all of these fields are accessed concurrently without lock from concurrent GC thread.
@@ -56,70 +64,6 @@ private:
     JSC::Weak<JSC::JSCell> m_cell { };
 };
 
-JSC::JSValue cachedPropertyValue(JSC::ThrowScope&, JSC::JSGlobalObject&, const JSDOMObject& owner, JSValueInWrappedObject& cacheSlot, const Function<JSC::JSValue(JSC::ThrowScope&)>&);
-
-inline JSValueInWrappedObject::JSValueInWrappedObject(JSC::JSValue value)
-{
-    setWeakly(value);
-}
-
-inline JSC::JSValue JSValueInWrappedObject::getValue(JSC::JSValue nullValue) const
-{
-    if (m_nonCell)
-        return m_nonCell;
-    return m_cell ? m_cell.get() : nullValue;
-}
-
-inline JSValueInWrappedObject::operator bool() const
-{
-    return m_nonCell || m_cell;
-}
-
-template<typename Visitor>
-inline void JSValueInWrappedObject::visit(Visitor& visitor) const
-{
-    visitor.append(m_cell);
-}
-
-template void JSValueInWrappedObject::visit(JSC::AbstractSlotVisitor&) const;
-template void JSValueInWrappedObject::visit(JSC::SlotVisitor&) const;
-
-inline void JSValueInWrappedObject::setWeakly(JSC::JSValue value)
-{
-    if (!value.isCell()) {
-        m_nonCell = value;
-        m_cell.clear();
-        return;
-    }
-    m_nonCell = { };
-    JSC::Weak weak { value.asCell() };
-    WTF::storeStoreFence();
-    m_cell = WTFMove(weak);
-}
-
-inline void JSValueInWrappedObject::set(JSC::VM& vm, const JSC::JSCell* owner, JSC::JSValue value)
-{
-    setWeakly(value);
-    vm.writeBarrier(owner, value);
-}
-
-inline void JSValueInWrappedObject::clear()
-{
-    m_nonCell = { };
-    m_cell.clear();
-}
-
-inline JSC::JSValue cachedPropertyValue(JSC::ThrowScope& throwScope, JSC::JSGlobalObject& lexicalGlobalObject, const JSDOMObject& owner, JSValueInWrappedObject& cachedValue, const Function<JSC::JSValue(JSC::ThrowScope&)>& function)
-{
-    if (cachedValue && isWorldCompatible(lexicalGlobalObject, cachedValue.getValue()))
-        return cachedValue.getValue();
-
-    auto value = function(throwScope);
-    RETURN_IF_EXCEPTION(throwScope, { });
-
-    cachedValue.set(lexicalGlobalObject.vm(), &owner, cloneAcrossWorlds(lexicalGlobalObject, owner, value));
-    ASSERT(isWorldCompatible(lexicalGlobalObject, cachedValue.getValue()));
-    return cachedValue.getValue();
-}
+inline JSC::JSValue cachedPropertyValue(JSC::ThrowScope&, JSC::JSGlobalObject&, const JSDOMObject& owner, JSValueInWrappedObject& cacheSlot, const Function<JSC::JSValue(JSC::ThrowScope&)>&);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSValueInWrappedObjectInlines.h
+++ b/Source/WebCore/bindings/js/JSValueInWrappedObjectInlines.h
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "DOMWrapperWorld.h"
+#include "JSDOMWrapper.h"
+#include "JSValueInWrappedObject.h"
+#include <JavaScriptCore/JSCJSValueInlines.h>
+#include <JavaScriptCore/SlotVisitor.h>
+#include <JavaScriptCore/WeakInlines.h>
+
+namespace WebCore {
+
+inline JSValueInWrappedObject::JSValueInWrappedObject()
+{
+    setWeakly({ });
+}
+
+inline JSValueInWrappedObject::JSValueInWrappedObject(JSC::JSValue value)
+{
+    setWeakly(value);
+}
+
+inline JSC::JSValue JSValueInWrappedObject::getValue(JSC::JSValue nullValue) const
+{
+    if (m_nonCell)
+        return m_nonCell;
+    return m_cell ? m_cell.get() : nullValue;
+}
+
+inline JSValueInWrappedObject::operator bool() const
+{
+    return m_nonCell || m_cell;
+}
+
+template<typename Visitor>
+inline void JSValueInWrappedObject::visit(Visitor& visitor) const
+{
+    visitor.append(m_cell);
+}
+
+template void JSValueInWrappedObject::visit(JSC::AbstractSlotVisitor&) const;
+template void JSValueInWrappedObject::visit(JSC::SlotVisitor&) const;
+
+inline void JSValueInWrappedObject::setWeakly(JSC::JSValue value)
+{
+    if (!value.isCell()) {
+        m_nonCell = value;
+        m_cell.clear();
+        return;
+    }
+    m_nonCell = { };
+    JSC::Weak weak { value.asCell() };
+    WTF::storeStoreFence();
+    m_cell = WTFMove(weak);
+}
+
+inline void JSValueInWrappedObject::set(JSC::VM& vm, const JSC::JSCell* owner, JSC::JSValue value)
+{
+    setWeakly(value);
+    vm.writeBarrier(owner, value);
+}
+
+inline void JSValueInWrappedObject::clear()
+{
+    m_nonCell = { };
+    m_cell.clear();
+}
+
+inline JSC::JSValue cachedPropertyValue(JSC::ThrowScope& throwScope, JSC::JSGlobalObject& lexicalGlobalObject, const JSDOMObject& owner, JSValueInWrappedObject& cachedValue, const Function<JSC::JSValue(JSC::ThrowScope&)>& function)
+{
+    if (cachedValue && isWorldCompatible(lexicalGlobalObject, cachedValue.getValue()))
+        return cachedValue.getValue();
+
+    auto value = function(throwScope);
+    RETURN_IF_EXCEPTION(throwScope, { });
+
+    cachedValue.set(lexicalGlobalObject.vm(), &owner, cloneAcrossWorlds(lexicalGlobalObject, owner, value));
+    ASSERT(isWorldCompatible(lexicalGlobalObject, cachedValue.getValue()));
+    return cachedValue.getValue();
+}
+
+}

--- a/Source/WebCore/bindings/js/JSWebXRRigidTransformCustom.cpp
+++ b/Source/WebCore/bindings/js/JSWebXRRigidTransformCustom.cpp
@@ -29,6 +29,7 @@
 #include "JSWebXRRigidTransform.h"
 
 #include "JSDOMConvertBufferSource.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "WebXRRigidTransform.h"
 
 namespace WebCore {

--- a/Source/WebCore/bindings/js/JSWebXRViewCustom.cpp
+++ b/Source/WebCore/bindings/js/JSWebXRViewCustom.cpp
@@ -29,6 +29,7 @@
 #include "JSWebXRView.h"
 
 #include "JSDOMConvertBufferSource.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "WebXRView.h"
 
 namespace WebCore {

--- a/Source/WebCore/dom/AbortSignal.cpp
+++ b/Source/WebCore/dom/AbortSignal.cpp
@@ -32,6 +32,7 @@
 #include "Event.h"
 #include "EventNames.h"
 #include "JSDOMException.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "ScriptExecutionContext.h"
 #include "WebCoreOpaqueRoot.h"
 #include <JavaScriptCore/Exception.h>

--- a/Source/WebCore/dom/AbortSignal.h
+++ b/Source/WebCore/dom/AbortSignal.h
@@ -36,6 +36,7 @@
 namespace WebCore {
 
 class AbortAlgorithm;
+class JSDOMGlobalObject;
 class ScriptExecutionContext;
 class WebCoreOpaqueRoot;
 

--- a/Source/WebCore/dom/CustomEvent.cpp
+++ b/Source/WebCore/dom/CustomEvent.cpp
@@ -27,6 +27,7 @@
 #include "config.h"
 #include "CustomEvent.h"
 
+#include "JSValueInWrappedObjectInlines.h"
 #include <JavaScriptCore/JSCInlines.h>
 #include <wtf/IsoMallocInlines.h>
 

--- a/Source/WebCore/dom/ErrorEvent.cpp
+++ b/Source/WebCore/dom/ErrorEvent.cpp
@@ -34,6 +34,7 @@
 
 #include "DOMWrapperWorld.h"
 #include "EventNames.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include <JavaScriptCore/HeapInlines.h>
 #include <JavaScriptCore/StrongInlines.h>
 #include <wtf/IsoMallocInlines.h>

--- a/Source/WebCore/dom/MessageEvent.cpp
+++ b/Source/WebCore/dom/MessageEvent.cpp
@@ -31,6 +31,7 @@
 #include "Blob.h"
 #include "EventNames.h"
 #include "JSMessageEvent.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include <JavaScriptCore/JSCInlines.h>
 #include <wtf/IsoMallocInlines.h>
 

--- a/Source/WebCore/dom/PopStateEvent.cpp
+++ b/Source/WebCore/dom/PopStateEvent.cpp
@@ -29,6 +29,7 @@
 
 #include "EventNames.h"
 #include "History.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include <JavaScriptCore/JSCInlines.h>
 #include <wtf/IsoMallocInlines.h>
 

--- a/Source/WebCore/dom/PromiseRejectionEvent.cpp
+++ b/Source/WebCore/dom/PromiseRejectionEvent.cpp
@@ -28,6 +28,7 @@
 
 #include "DOMWrapperWorld.h"
 #include "JSDOMPromise.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include <JavaScriptCore/HeapInlines.h>
 #include <JavaScriptCore/StrongInlines.h>
 #include <wtf/IsoMallocInlines.h>

--- a/Source/WebCore/html/HTMLPlugInElement.cpp
+++ b/Source/WebCore/html/HTMLPlugInElement.cpp
@@ -33,6 +33,7 @@
 #include "FrameTree.h"
 #include "HTMLNames.h"
 #include "HitTestResult.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "Logging.h"
 #include "MIMETypeRegistry.h"
 #include "Page.h"

--- a/Source/WebCore/page/History.cpp
+++ b/Source/WebCore/page/History.cpp
@@ -33,6 +33,7 @@
 #include "FrameLoaderClient.h"
 #include "HistoryController.h"
 #include "HistoryItem.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "Logging.h"
 #include "NavigationScheduler.h"
 #include "Page.h"

--- a/Source/WebCore/workers/service/FetchEvent.cpp
+++ b/Source/WebCore/workers/service/FetchEvent.cpp
@@ -33,6 +33,7 @@
 #include "JSDOMPromise.h"
 #include "JSFetchResponse.h"
 #include "Logging.h"
+#include <JavaScriptCore/JSCJSValueInlines.h>
 #include <wtf/IsoMallocInlines.h>
 
 #if ENABLE(SERVICE_WORKER)


### PR DESCRIPTION
#### 637dfb1db867ce05fd0db118072c872586f9ec4e
<pre>
Reduce build times by refactoring JSValueInWrappedObject.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=253098">https://bugs.webkit.org/show_bug.cgi?id=253098</a>
rdar://106045427

Reviewed by NOBODY (OOPS!).

Separate out the implementation of JSValueInWrappedObject which requires pulling in JSCJSValueInlines.h,
WeakInlines.h, JSDOMWrapaper.h and DOMWrapperWorld.h into a JSValueInWrappedObjectInlines.h header.

This reduces the number of times JSCJSValueInlines.h is included in the WebCore project from 262 to 242
(-20), and JSDOMGlobalObject.h from 243 to 222 (-21).

* Source/WebCore/Modules/indexeddb/IDBCursor.cpp:
* Source/WebCore/Modules/indexeddb/IDBRequest.cpp:
* Source/WebCore/Modules/paymentrequest/PaymentMethodChangeEvent.cpp:
* Source/WebCore/Modules/paymentrequest/PaymentResponse.cpp:
* Source/WebCore/Modules/webaudio/AudioBuffer.cpp:
* Source/WebCore/Modules/webaudio/AudioBuffer.h:
* Source/WebCore/Modules/webaudio/AudioWorkletProcessor.cpp:
* Source/WebCore/Modules/webxr/WebXRRigidTransform.cpp:
* Source/WebCore/Modules/webxr/WebXRView.cpp:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/JSAbortSignalCustom.cpp:
* Source/WebCore/bindings/js/JSDOMConvertAny.h:
* Source/WebCore/bindings/js/JSHistoryCustom.cpp:
* Source/WebCore/bindings/js/JSValueInWrappedObject.h:
(WebCore::JSValueInWrappedObject::JSValueInWrappedObject): Deleted.
(WebCore::JSValueInWrappedObject::getValue const): Deleted.
(WebCore::JSValueInWrappedObject::operator bool const): Deleted.
(WebCore::JSValueInWrappedObject::visit const): Deleted.
(WebCore::JSValueInWrappedObject::setWeakly): Deleted.
(WebCore::JSValueInWrappedObject::set): Deleted.
(WebCore::JSValueInWrappedObject::clear): Deleted.
(WebCore::cachedPropertyValue): Deleted.
* Source/WebCore/bindings/js/JSValueInWrappedObjectInlines.h: Added.
(WebCore::JSValueInWrappedObject::JSValueInWrappedObject):
(WebCore::JSValueInWrappedObject::getValue const):
(WebCore::JSValueInWrappedObject::operator bool const):
(WebCore::JSValueInWrappedObject::visit const):
(WebCore::JSValueInWrappedObject::setWeakly):
(WebCore::JSValueInWrappedObject::set):
(WebCore::JSValueInWrappedObject::clear):
(WebCore::cachedPropertyValue):
* Source/WebCore/bindings/js/JSWebXRRigidTransformCustom.cpp:
* Source/WebCore/dom/AbortSignal.cpp:
* Source/WebCore/dom/AbortSignal.h:
* Source/WebCore/dom/CustomEvent.cpp:
* Source/WebCore/dom/ErrorEvent.cpp:
* Source/WebCore/dom/MessageEvent.cpp:
* Source/WebCore/dom/PopStateEvent.cpp:
* Source/WebCore/dom/PromiseRejectionEvent.cpp:
* Source/WebCore/html/HTMLPlugInElement.cpp:
* Source/WebCore/page/History.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/637dfb1db867ce05fd0db118072c872586f9ec4e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110797 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19883 "Hash 637dfb1d for PR 10814 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43345 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2656 "Hash 637dfb1d for PR 10814 does not build (failure)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119613 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114762 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21284 "Hash 637dfb1d for PR 10814 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10988 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2237 "layout-tests (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116547 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/76/builds/21284 "Hash 637dfb1d for PR 10814 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99018 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103344 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/76/builds/21284 "Hash 637dfb1d for PR 10814 does not build (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30684 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44299 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12475 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32020 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86183 "Found 2 new API test failures: /WebKitGTK/TestGeolocationManager:/webkit/WebKitGeolocationManager/watch-position, /WebKitGTK/TestDownloads:/webkit/Downloads/local-file-error (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13044 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9000 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18427 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51641 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14998 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->