### PR TITLE
Fix Gamepad serialization after 260751@main

### DIFF
--- a/Source/WebKit/Shared/Gamepad/GamepadData.cpp
+++ b/Source/WebKit/Shared/Gamepad/GamepadData.cpp
@@ -48,7 +48,7 @@ GamepadData::GamepadData(unsigned index, const String& id, const String& mapping
 
 GamepadData::GamepadData(unsigned index, String&& id, String&& mapping, Vector<double>&& axisValues, Vector<double>&& buttonValues, MonotonicTime lastUpdateTime, WebCore::GamepadHapticEffectTypeSet&& supportedEffectTypes)
     : m_index(index)
-    , m_id(id)
+    , m_id(WTFMove(id))
     , m_mapping(WTFMove(mapping))
     , m_axisValues(WTFMove(axisValues))
     , m_buttonValues(WTFMove(buttonValues))

--- a/Source/WebKit/Shared/Gamepad/GamepadData.h
+++ b/Source/WebKit/Shared/Gamepad/GamepadData.h
@@ -37,16 +37,9 @@ namespace WebKit {
 
 class GamepadData {
 public:
-    GamepadData()
-        : m_isNull(true)
-    {
-    }
-
     GamepadData(unsigned index, const String& id, const String& mapping, const Vector<WebCore::SharedGamepadValue>& axisValues, const Vector<WebCore::SharedGamepadValue>& buttonValues, MonotonicTime lastUpdateTime, const WebCore::GamepadHapticEffectTypeSet& supportedEffectTypes);
     
     GamepadData(unsigned index, String&& id, String&& mapping, Vector<double>&& axisValues, Vector<double>&& buttonValues, MonotonicTime lastUpdateTime, WebCore::GamepadHapticEffectTypeSet&& supportedEffectTypes);
-
-    bool isNull() const { return m_isNull; }
 
     MonotonicTime lastUpdateTime() const { return m_lastUpdateTime; }
     unsigned index() const { return m_index; }
@@ -64,8 +57,6 @@ private:
     Vector<double> m_buttonValues;
     MonotonicTime m_lastUpdateTime;
     WebCore::GamepadHapticEffectTypeSet m_supportedEffectTypes;
-
-    bool m_isNull { false };
 
 #if !LOG_DISABLED
     String loggingString() const;

--- a/Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.cpp
+++ b/Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.cpp
@@ -189,10 +189,10 @@ void UIGamepadProvider::stopMonitoringGamepads()
     m_gamepads.clear();
 }
 
-Vector<GamepadData> UIGamepadProvider::snapshotGamepads()
+Vector<std::optional<GamepadData>> UIGamepadProvider::snapshotGamepads()
 {
     return m_gamepads.map([](auto& gamepad) {
-        return gamepad ? gamepad->gamepadData() : GamepadData { };
+        return gamepad ? std::optional<GamepadData>(gamepad->gamepadData()) : std::nullopt;
     });
 }
 

--- a/Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.h
+++ b/Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.h
@@ -55,7 +55,7 @@ public:
     static void setUsesGameControllerFramework();
 #endif
 
-    Vector<GamepadData> snapshotGamepads();
+    Vector<std::optional<GamepadData>> snapshotGamepads();
 
     size_t numberOfConnectedGamepads() const { return m_gamepads.size(); }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -8933,7 +8933,7 @@ void WebPageProxy::backForwardClear()
 
 #if ENABLE(GAMEPAD)
 
-void WebPageProxy::gamepadActivity(const Vector<GamepadData>& gamepadDatas, EventMakesGamepadsVisible eventVisibility)
+void WebPageProxy::gamepadActivity(const Vector<std::optional<GamepadData>>& gamepadDatas, EventMakesGamepadsVisible eventVisibility)
 {
     send(Messages::WebPage::GamepadActivity(gamepadDatas, eventVisibility));
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1770,7 +1770,7 @@ public:
 #endif
 
 #if ENABLE(GAMEPAD)
-    void gamepadActivity(const Vector<GamepadData>&, WebCore::EventMakesGamepadsVisible);
+    void gamepadActivity(const Vector<std::optional<GamepadData>>&, WebCore::EventMakesGamepadsVisible);
 #endif
 
     void isLoadingChanged() { activityStateDidChange(WebCore::ActivityState::IsLoading); }

--- a/Source/WebKit/WebProcess/Gamepad/WebGamepad.cpp
+++ b/Source/WebKit/WebProcess/Gamepad/WebGamepad.cpp
@@ -61,7 +61,6 @@ const Vector<SharedGamepadValue>& WebGamepad::buttonValues() const
 
 void WebGamepad::updateValues(const GamepadData& gamepadData)
 {
-    ASSERT(!gamepadData.isNull());
     ASSERT(gamepadData.index() == index());
     ASSERT(m_axisValues.size() == gamepadData.axisValues().size());
     ASSERT(m_buttonValues.size() == gamepadData.buttonValues().size());

--- a/Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.cpp
+++ b/Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.cpp
@@ -60,17 +60,17 @@ WebGamepadProvider::~WebGamepadProvider()
 {
 }
 
-void WebGamepadProvider::setInitialGamepads(const Vector<GamepadData>& gamepadDatas)
+void WebGamepadProvider::setInitialGamepads(const Vector<std::optional<GamepadData>>& gamepadDatas)
 {
     WP_MESSAGE_CHECK((m_gamepads.isEmpty()), m_gamepads.size());
 
     m_gamepads.resize(gamepadDatas.size());
     m_rawGamepads.resize(gamepadDatas.size());
     for (size_t i = 0; i < gamepadDatas.size(); ++i) {
-        if (gamepadDatas[i].isNull())
-            continue;
+        if (!gamepadDatas[i])
+            return;
 
-        m_gamepads[i] = makeUnique<WebGamepad>(gamepadDatas[i]);
+        m_gamepads[i] = makeUnique<WebGamepad>(*gamepadDatas[i]);
         m_rawGamepads[i] = m_gamepads[i].get();
     }
 }
@@ -106,15 +106,15 @@ void WebGamepadProvider::gamepadDisconnected(unsigned index)
         client->platformGamepadDisconnected(*disconnectedGamepad);
 }
 
-void WebGamepadProvider::gamepadActivity(const Vector<GamepadData>& gamepadDatas, EventMakesGamepadsVisible eventVisibility)
+void WebGamepadProvider::gamepadActivity(const Vector<std::optional<GamepadData>>& gamepadDatas, EventMakesGamepadsVisible eventVisibility)
 {
     LOG(Gamepad, "WebGamepadProvider::gamepadActivity - %zu gamepad datas with %zu local web gamepads\n", gamepadDatas.size(), m_gamepads.size());
 
     ASSERT(m_gamepads.size() == gamepadDatas.size());
 
     for (size_t i = 0; i < m_gamepads.size(); ++i) {
-        if (m_gamepads[i])
-            m_gamepads[i]->updateValues(gamepadDatas[i]);
+        if (m_gamepads[i] && gamepadDatas[i])
+            m_gamepads[i]->updateValues(*gamepadDatas[i]);
     }
 
     for (auto* client : m_clients)

--- a/Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.h
+++ b/Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.h
@@ -49,9 +49,9 @@ public:
 
     void gamepadConnected(const GamepadData&, WebCore::EventMakesGamepadsVisible);
     void gamepadDisconnected(unsigned index);
-    void gamepadActivity(const Vector<GamepadData>&, WebCore::EventMakesGamepadsVisible);
+    void gamepadActivity(const Vector<std::optional<GamepadData>>&, WebCore::EventMakesGamepadsVisible);
 
-    void setInitialGamepads(const Vector<GamepadData>&);
+    void setInitialGamepads(const Vector<std::optional<GamepadData>>&);
 
 private:
     friend NeverDestroyed<WebGamepadProvider>;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -7450,7 +7450,7 @@ void WebPage::setUserInterfaceLayoutDirection(uint32_t direction)
 
 #if ENABLE(GAMEPAD)
 
-void WebPage::gamepadActivity(const Vector<GamepadData>& gamepadDatas, EventMakesGamepadsVisible eventVisibilty)
+void WebPage::gamepadActivity(const Vector<std::optional<GamepadData>>& gamepadDatas, EventMakesGamepadsVisible eventVisibilty)
 {
     WebGamepadProvider::singleton().gamepadActivity(gamepadDatas, eventVisibilty);
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1312,7 +1312,7 @@ public:
 #endif
 
 #if ENABLE(GAMEPAD)
-    void gamepadActivity(const Vector<GamepadData>&, WebCore::EventMakesGamepadsVisible);
+    void gamepadActivity(const Vector<std::optional<GamepadData>>&, WebCore::EventMakesGamepadsVisible);
 #endif
     
 #if ENABLE(POINTER_LOCK)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -594,7 +594,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
     SetUseIconLoadingClient(bool useIconLoadingClient)
 
 #if ENABLE(GAMEPAD)
-    GamepadActivity(Vector<WebKit::GamepadData> gamepadDatas, enum:bool WebCore::EventMakesGamepadsVisible eventVisibility)
+    GamepadActivity(Vector<std::optional<WebKit::GamepadData>> gamepadDatas, enum:bool WebCore::EventMakesGamepadsVisible eventVisibility)
 #endif
 
     RegisterURLSchemeHandler(WebKit::WebURLSchemeHandlerIdentifier handlerIdentifier, String scheme)

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1102,7 +1102,7 @@ void WebProcess::setHasStylusDevice(bool hasStylusDevice)
 
 #if ENABLE(GAMEPAD)
 
-void WebProcess::setInitialGamepads(const Vector<WebKit::GamepadData>& gamepadDatas)
+void WebProcess::setInitialGamepads(const Vector<std::optional<GamepadData>>& gamepadDatas)
 {
     WebGamepadProvider::singleton().setInitialGamepads(gamepadDatas);
 }

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -459,7 +459,7 @@ private:
     void backgroundResponsivenessPing();
 
 #if ENABLE(GAMEPAD)
-    void setInitialGamepads(const Vector<GamepadData>&);
+    void setInitialGamepads(const Vector<std::optional<GamepadData>>&);
     void gamepadConnected(const GamepadData&, WebCore::EventMakesGamepadsVisible);
     void gamepadDisconnected(unsigned index);
 #endif

--- a/Source/WebKit/WebProcess/WebProcess.messages.in
+++ b/Source/WebKit/WebProcess/WebProcess.messages.in
@@ -96,7 +96,7 @@ messages -> WebProcess LegacyReceiver NotRefCounted {
     BackgroundResponsivenessPing()
 
 #if ENABLE(GAMEPAD)
-    SetInitialGamepads(Vector<WebKit::GamepadData> gamepadDatas)
+    SetInitialGamepads(Vector<std::optional<WebKit::GamepadData>> gamepadDatas)
     GamepadConnected(WebKit::GamepadData gamepadData, enum:bool WebCore::EventMakesGamepadsVisible eventVisibility)
     GamepadDisconnected(unsigned index)
 #endif


### PR DESCRIPTION
#### 0a2e32ae9a4a3164770706475eee73dad25f2fca
<pre>
Fix Gamepad serialization after 260751@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=253102">https://bugs.webkit.org/show_bug.cgi?id=253102</a>
rdar://106046830

Reviewed by Brady Eidson.

We didn&apos;t serialize m_isNull.  We don&apos;t need to, but we do need to remove the nullable state.

* Source/WebKit/Shared/Gamepad/GamepadData.cpp:
(WebKit::GamepadData::GamepadData):
* Source/WebKit/Shared/Gamepad/GamepadData.h:
(WebKit::GamepadData::GamepadData): Deleted.
(WebKit::GamepadData::isNull const): Deleted.
(): Deleted.
* Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.cpp:
(WebKit::UIGamepadProvider::snapshotGamepads):
* Source/WebKit/WebProcess/Gamepad/WebGamepad.cpp:
(WebKit::WebGamepad::updateValues):
* Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.cpp:
(WebKit::WebGamepadProvider::setInitialGamepads):

Canonical link: <a href="https://commits.webkit.org/260965@main">https://commits.webkit.org/260965@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0b34d4a9f45ce1d760ac36f250bd0b1fdc8f375

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110108 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19208 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/42779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/1541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/119121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20670 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10399 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/102364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115854 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/42779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/102364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/42779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/102364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/11905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/42779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/12523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/17888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/42779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14323 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4127 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->