### PR TITLE
[GLib] Need API for asynchronously handling WebKitDownload::decide-destination

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitDownloadClient.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitDownloadClient.cpp
@@ -82,9 +82,7 @@ private:
     {
         ASSERT(m_download);
         didReceiveResponse(downloadProxy, resourceResponse);
-        bool allowOverwrite = false;
-        String destination = webkitDownloadDecideDestinationWithSuggestedFilename(m_download.get(), filename.utf8(), allowOverwrite);
-        completionHandler(allowOverwrite ? AllowOverwrite::Yes : AllowOverwrite::No, destination);
+        webkitDownloadDecideDestinationWithSuggestedFilename(m_download.get(), filename.utf8(), WTFMove(completionHandler));
     }
 
     void didCreateDestination(DownloadProxy& downloadProxy, const String& path) override

--- a/Source/WebKit/UIProcess/API/glib/WebKitDownloadPrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitDownloadPrivate.h
@@ -19,11 +19,13 @@
 
 #pragma once
 
+#include "APIDownloadClient.h"
 #include "DownloadProxy.h"
 #include "WebKitDownload.h"
 #include <WebCore/ResourceError.h>
 #include <WebCore/ResourceRequest.h>
 #include <wtf/glib/GRefPtr.h>
+#include <wtf/text/WTFString.h>
 
 GRefPtr<WebKitDownload> webkitDownloadCreate(WebKit::DownloadProxy&, WebKitWebView* = nullptr);
 void webkitDownloadStarted(WebKitDownload*);
@@ -33,5 +35,5 @@ void webkitDownloadNotifyProgress(WebKitDownload*, guint64 bytesReceived);
 void webkitDownloadFailed(WebKitDownload*, const WebCore::ResourceError&);
 void webkitDownloadCancelled(WebKitDownload*);
 void webkitDownloadFinished(WebKitDownload*);
-String webkitDownloadDecideDestinationWithSuggestedFilename(WebKitDownload*, const CString& suggestedFilename, bool& allowOverwrite);
+void webkitDownloadDecideDestinationWithSuggestedFilename(WebKitDownload*, CString&& suggestedFilename, CompletionHandler<void(WebKit::AllowOverwrite, WTF::String)>&&);
 void webkitDownloadDestinationCreated(WebKitDownload*, const String& destinationPath);


### PR DESCRIPTION
#### 878af52cf35811d107d6bb6f38531ce3b73f211d
<pre>
[GLib] Need API for asynchronously handling WebKitDownload::decide-destination
<a href="https://bugs.webkit.org/show_bug.cgi?id=238748">https://bugs.webkit.org/show_bug.cgi?id=238748</a>

Reviewed by Carlos Garcia Campos.

Currently WebKitDownload::decide-destination is emitted when WebKit
wants to know the filesystem location to download the file to. The
application is expected to display a file chooser using
gtk_dialog_run(), then return the result to WebKit using
webkit_download_set_destination(). In GTK 4, gtk_dialog_run() no longer
exists. The only way to accomplish this is to hande it manually,
iterating the default GMainContext inside the signal handler callback.
This is called a &quot;nested main loop&quot; and it&apos;s very dangerous because it
frequently results in code being executed at unexpected times. For
example, the attached bug report shows an unintended but also
unavoidable example of a triple nested main loop that occurs where
a second download starts inside the first decide-destination signal
handler, then another, then another. Not good. (Note this is not a new
problem in GTK 4. gtk_dialog_run() no longer exists because it
internally ran a nested main loop, which had this exact same problem.)

To fix this, we need to allow applications to handle the
decide-destination signal asynchronously, so they can finish the signal
handler without immediately providing a destination, provide it later on
in a future main context iteration, and know that the download will not
actually begin until it has been provided. This is easy to do because
the download implementation is already internally asynchronous. A basic
test is added to make sure it even works.

This commit also contains a few drive-by changes in TestDownloads.cpp,
notably where two of the decide-destination callbacks were missing
return values and therefore triggering undefined behavior. It also fixes
a typo that got copy/pasted around and removes some references to URIs
that are now paths
* Source/WebKit/UIProcess/API/glib/WebKitDownload.cpp:
(_WebKitDownloadPrivate::~_WebKitDownloadPrivate):
(maybeFinishDecideDestination):
(webkitDownloadDecideDestination):
(webkit_download_class_init):
(webkitDownloadDecideDestinationWithSuggestedFilename):
(webkit_download_set_destination):
(webkit_download_cancel):
* Source/WebKit/UIProcess/API/glib/WebKitDownloadClient.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitDownloadPrivate.h:
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestDownloads.cpp:
(downloadLocalFileSuccessfully):
(testDownloadOverwriteDestinationDisallowed):
(testDownloadLocalFileError):
(testDownloadRemoteFile):
(testDownloadRemoteFileError):
(testDownloadAsyncDecideDestination):
(testDownloadAsyncDecideDestinationCancel):
(testDownloadMIMEType):
(testDownloadTextPlainMIMEType):
(testDownloadUserAgent):
(testDownloadEphemeralContext):
(testDownloadDestinationURI):
(beforeAll):

Canonical link: <a href="https://commits.webkit.org/261118@main">https://commits.webkit.org/261118@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/449d64677d91fd566f5c9f42ad3a03e35422dfcc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110584 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19664 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43175 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1937 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119449 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114546 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21086 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10793 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102856 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116326 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15704 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43982 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30562 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85892 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12316 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31900 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12876 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8857 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18240 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51516 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14760 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4197 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->