### PR TITLE
Apply opacity to the Interaction Regions layer tree

### DIFF
--- a/LayoutTests/interaction-region/layer-tree-expected.txt
+++ b/LayoutTests/interaction-region/layer-tree-expected.txt
@@ -42,8 +42,13 @@
                                   (layer anchorPoint [x: 0 y: 0])
                                   (sublayers
                                     (
+                                      (layer bounds [x: 0 y: 0 width: 200 height: 200])
+                                      (layer position [x: 100 y: 100])
+                                      (layer opacity 0))
+                                    (
                                       (layer bounds [x: 0 y: 0 width: 800 height: 600])
                                       (layer position [x: 400 y: 400])
+                                      (layer opacity 0.8)
                                       (sublayers
                                         (
                                           (layer bounds [x: 0 y: 0 width: 800 height: 20])
@@ -79,8 +84,18 @@
                                       (layer anchorPoint [x: 0 y: 0])
                                       (sublayers
                                         (
+                                          (layer bounds [x: 0 y: 0 width: 200 height: 200])
+                                          (layer position [x: 100 y: 100])
+                                          (layer opacity 0)
+                                          (sublayers
+                                            (
+                                              (type interaction)
+                                              (layer bounds [x: 0 y: 0 width: 74 height: 25])
+                                              (layer position [x: 34 y: 34]))))
+                                        (
                                           (layer bounds [x: 0 y: 0 width: 800 height: 600])
                                           (layer position [x: 400 y: 400])
+                                          (layer opacity 0.8)
                                           (sublayers
                                             (
                                               (type occlusion)
@@ -94,39 +109,41 @@
                                               (layer bounds [x: 0 y: 0 width: 800 height: 20])
                                               (layer position [x: 400 y: 400]))))))))))))))))))
             (
-              (layer bounds [x: 0 y: 0 width: 0 height: 0]))
-            (
               (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
         (
           (layer bounds [x: 0 y: 0 width: 0 height: 0])
           (layer anchorPoint [x: 0 y: 0]))
         (
-          (layer bounds [x: 0 y: 0 width: 794 height: 3])
+          (layer bounds [x: 0 y: 0 width: 794 height: 6])
           (layer position [x: 400 y: 400])
+          (layer opacity 0)
           (sublayers
             (
-              (layer bounds [x: 0 y: 0 width: 794 height: 3])
+              (layer bounds [x: 0 y: 0 width: 794 height: 6])
               (layer position [x: 397 y: 397])
               (layer zPosition 1000)
               (sublayers
                 (
-                  (layer bounds [x: 0 y: 0 width: 794 height: 3])
+                  (layer bounds [x: 0 y: 0 width: 794 height: 6])
                   (layer position [x: 397 y: 397]))))
             (
-              (layer bounds [x: 0 y: 0 width: 794 height: 3])
-              (layer position [x: 397 y: 397]))))
+              (layer bounds [x: 0 y: 0 width: 794 height: 6])
+              (layer position [x: 397 y: 397])
+              (layer opacity 0.005))))
         (
-          (layer bounds [x: 0 y: 0 width: 3 height: 594])
-          (layer position [x: 795.5 y: 795.5])
+          (layer bounds [x: 0 y: 0 width: 6 height: 594])
+          (layer position [x: 794 y: 794])
+          (layer opacity 0)
           (sublayers
             (
-              (layer bounds [x: 0 y: 0 width: 3 height: 594])
-              (layer position [x: 1.5 y: 1.5])
+              (layer bounds [x: 0 y: 0 width: 6 height: 594])
+              (layer position [x: 3 y: 3])
               (layer zPosition 1000)
               (sublayers
                 (
-                  (layer bounds [x: 0 y: 0 width: 3 height: 594])
-                  (layer position [x: 1.5 y: 1.5]))))
+                  (layer bounds [x: 0 y: 0 width: 6 height: 594])
+                  (layer position [x: 3 y: 3]))))
             (
-              (layer bounds [x: 0 y: 0 width: 3 height: 594])
-              (layer position [x: 1.5 y: 1.5]))))))))
+              (layer bounds [x: 0 y: 0 width: 6 height: 594])
+              (layer position [x: 3 y: 3])
+              (layer opacity 0.005))))))))

--- a/LayoutTests/interaction-region/layer-tree.html
+++ b/LayoutTests/interaction-region/layer-tree.html
@@ -22,6 +22,13 @@
     #nested {
         will-change: transform;
     }
+    #faded {
+        width: 200px;
+        height: 200px;
+
+        will-change: opacity;
+        opacity: 0;
+    }
 
 </style>
 <script src="../resources/ui-helper.js"></script>
@@ -34,6 +41,9 @@
     <div id="overlay">
         <a href="#">link</a>
         <div id="nested">layered content</div>
+    </div>
+    <div id="faded">
+        <a href="#">Faded link</a>
     </div>
 </div>
 

--- a/Source/WebCore/rendering/EventRegion.cpp
+++ b/Source/WebCore/rendering/EventRegion.cpp
@@ -442,7 +442,14 @@ void EventRegion::dump(TextStream& ts) const
     
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
     if (!m_interactionRegions.isEmpty()) {
-        ts.dumpProperty("interaction regions", m_interactionRegions);
+        auto sortedInteractionRegions = copyToVector(m_interactionRegions);
+        std::sort(sortedInteractionRegions.begin(), sortedInteractionRegions.end(),
+            [&] (const auto& a, const auto& b) -> bool {
+                return a.regionInLayerCoordinates.bounds().y() == b.regionInLayerCoordinates.bounds().y()
+                    ? a.regionInLayerCoordinates.bounds().x() < b.regionInLayerCoordinates.bounds().x()
+                    : a.regionInLayerCoordinates.bounds().y() < b.regionInLayerCoordinates.bounds().y();
+        });
+        ts.dumpProperty("interaction regions", sortedInteractionRegions);
         ts << "\n";
     }
 #endif

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -179,6 +179,9 @@ static void applyCommonPropertiesToLayer(CALayer *layer, const RemoteLayerTreeTr
         layer.rasterizationScale = properties.contentsScale;
     }
 
+    if (properties.changedProperties & LayerChange::OpacityChanged)
+        layer.opacity = properties.opacity;
+
     if (properties.changedProperties & LayerChange::MasksToBoundsChanged)
         layer.masksToBounds = properties.masksToBounds;
 }
@@ -198,9 +201,6 @@ void RemoteLayerTreePropertyApplier::applyPropertiesToLayer(CALayer *layer, Remo
 
     if (properties.changedProperties & LayerChange::BorderWidthChanged)
         layer.borderWidth = properties.borderWidth;
-
-    if (properties.changedProperties & LayerChange::OpacityChanged)
-        layer.opacity = properties.opacity;
 
     if (properties.changedProperties & LayerChange::DoubleSidedChanged)
         layer.doubleSided = properties.doubleSided;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -113,6 +113,9 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
     if (layer.anchorPointZ)
         ts.dumpProperty("layer anchorPointZ", makeString(layer.anchorPointZ));
 
+    if (layer.opacity != 1.0)
+        ts.dumpProperty("layer opacity", makeString(layer.opacity));
+
     if (traverse && layer.sublayers.count > 0) {
         TextStream::GroupScope scope(ts);
         ts << "sublayers";


### PR DESCRIPTION
#### b5764e2c9a87965d0b412e4c83096020ee8bf0dc
<pre>
Apply opacity to the Interaction Regions layer tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=253109">https://bugs.webkit.org/show_bug.cgi?id=253109</a>
&lt;rdar://105306435&gt;

Reviewed by Tim Horton.

We want Interaction Regions containers to match the opacity of the
content.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::applyCommonPropertiesToLayer):
(WebKit::RemoteLayerTreePropertyApplier::applyPropertiesToLayer):
Move `opacity` to the common properties applier.

* LayoutTests/interaction-region/layer-tree-expected.txt:
* LayoutTests/interaction-region/layer-tree.html:
Tweak the test to cover this change.
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(dumpCALayer):
Add opacity to the test dump format.

* Source/WebCore/rendering/EventRegion.cpp:
(WebCore::EventRegion::dump const):
Sort interaction regions in the dump to make tests more reliable.

Canonical link: <a href="https://commits.webkit.org/261013@main">https://commits.webkit.org/261013@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53eee2948dc2ae1b1e1adb7f462ca2cee5ad9768

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110119 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19219 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42789 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1550 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119128 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114071 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20681 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10410 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102377 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115865 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15398 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98609 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43621 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97359 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30270 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85457 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11915 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31607 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12531 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8567 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17896 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51223 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7630 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14333 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->