### PR TITLE
Some Scroll To Text Fragment URLs do not find existing text on the page.

### DIFF
--- a/LayoutTests/http/tests/scroll-to-text-fragment/start-text-fancy-quote-expected.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/start-text-fancy-quote-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<meta charset="utf-8" />
+<title>Scroll to text fragment - highlight text with quotes</title>
+<style>
+  span {
+    background-color: rgb(255, 238, 190);
+  }
+</style>
+
+<p>The test passes if the following word has a yellow background.</p>
+<div>Select <span>“isn’t”</span> to pass.</div>

--- a/LayoutTests/http/tests/scroll-to-text-fragment/start-text-fancy-quote.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/start-text-fancy-quote.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>Scroll to text fragment - highlight text with quotes</title>
+<link rel="help" href="https://wicg.github.io/scroll-to-text-fragment/">
+<meta name="assert" content="This test checks that a fragment directive with quotes and apostrophes is correctly highlighted.">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-1000" />
+
+<p>The test passes if the following word has a yellow background.</p>
+<div>Select <span>“isn’t”</span> to pass.</div>
+
+<script>
+  location.href = "#:~:text=%E2%80%9Cisn%27t%E2%80%9D";
+</script>
+</html>

--- a/LayoutTests/platform/glib/http/tests/scroll-to-text-fragment/start-text-fancy-quote-expected.html
+++ b/LayoutTests/platform/glib/http/tests/scroll-to-text-fragment/start-text-fancy-quote-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<meta charset="utf-8" />
+<title>Scroll to text fragment - highlight text with quotes</title>
+<style>
+  span {
+    background-color: rgba(255, 255, 0, 0.8);
+  }
+</style>
+
+<p>The test passes if the following word has a yellow background.</p>
+<div>Select <span>“isn’t”</span> to pass.</div>

--- a/LayoutTests/platform/wincairo/http/tests/scroll-to-text-fragment/start-text-fancy-quote-expected.html
+++ b/LayoutTests/platform/wincairo/http/tests/scroll-to-text-fragment/start-text-fancy-quote-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<meta charset="utf-8" />
+<title>Scroll to text fragment - highlight text with quotes</title>
+<style>
+  span {
+    background-color: rgba(255, 255, 0, 0.8);
+  }
+</style>
+
+<p>The test passes if the following word has a yellow background.</p>
+<div>Select <span>“isn’t”</span> to pass.</div>

--- a/Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp
+++ b/Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp
@@ -149,6 +149,7 @@ static std::optional<SimpleRange> findRangeFromNodeList(const String& query, con
     searchBuffer = searchBufferBuilder.toString();
     
     searchBuffer = foldQuoteMarks(searchBuffer);
+    auto foldedQuery = foldQuoteMarks(query);
     
     unsigned searchStart = 0;
     
@@ -162,17 +163,17 @@ static std::optional<SimpleRange> findRangeFromNodeList(const String& query, con
     
     while (!matchIndex) {
         // FIXME: find only using the base characters i.e. also fold accents and others.
-        auto potentialIndex = searchBuffer.findIgnoringASCIICase(query, searchStart);
+        auto potentialIndex = searchBuffer.findIgnoringASCIICase(foldedQuery, searchStart);
 
         if (potentialIndex == notFound)
             return std::nullopt;
         matchIndex = potentialIndex;
         
         start = boundaryPointAtIndexInNodes(*matchIndex, nodes, BoundaryPointIsAtEnd::No);
-        end = boundaryPointAtIndexInNodes(*matchIndex + query.length(), nodes, BoundaryPointIsAtEnd::Yes);
+        end = boundaryPointAtIndexInNodes(*matchIndex + foldedQuery.length(), nodes, BoundaryPointIsAtEnd::Yes);
         
         if (((wordStartBounded == WordBounded::Yes) && !indexIsAtWordBoundary(searchBuffer, *matchIndex))
-            || ((wordEndBounded == WordBounded::Yes) && !indexIsAtWordBoundary(searchBuffer, *matchIndex + query.length()))) {
+            || ((wordEndBounded == WordBounded::Yes) && !indexIsAtWordBoundary(searchBuffer, *matchIndex + foldedQuery.length()))) {
             searchStart = *matchIndex + 1;
             matchIndex = std::nullopt;
         }
@@ -182,7 +183,7 @@ static std::optional<SimpleRange> findRangeFromNodeList(const String& query, con
     if (nodes.last().ptr() == &searchRange.endContainer())
         endInset = searchRange.endContainer().length() - searchRange.endOffset();
     
-    if (*matchIndex + query.length() > searchBuffer.length() - endInset)
+    if (*matchIndex + foldedQuery.length() > searchBuffer.length() - endInset)
         return std::nullopt;
     
     ASSERT_WITH_MESSAGE(start, "Scroll To Text Fragment: Start cannot be null");


### PR DESCRIPTION
#### 23b973250328701b81c10e39b82a9d6d9cdd231f
<pre>
Some Scroll To Text Fragment URLs do not find existing text on the page.
<a href="https://bugs.webkit.org/show_bug.cgi?id=253118">https://bugs.webkit.org/show_bug.cgi?id=253118</a>
rdar://103416130

Reviewed by Aditya Keerthi.

We were carefully folding the quotes for the text to make sure that we would match
against all kinds of fancy quotes, but failed to fold the input quotes,
so if you had a query string with a fancy quote, it would fail to find matching
quotes on the page. Easily fixed by folding the quotes on the input string.

* LayoutTests/http/tests/scroll-to-text-fragment/start-text-fancy-quote-expected.html: Added.
* LayoutTests/http/tests/scroll-to-text-fragment/start-text-fancy-quote.html: Added.
* Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp:
(WebCore::FragmentDirectiveRangeFinder::findRangeFromNodeList):

Canonical link: <a href="https://commits.webkit.org/261302@main">https://commits.webkit.org/261302@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3d9824bfbe133941aea45e004c6e79f3a54089a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110390 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19478 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42993 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1774 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119314 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114336 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20918 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10635 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/1252 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116133 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15582 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98766 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102633 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97543 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30431 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43799 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12143 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31769 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85658 "Found 1 new API test failure: /WebKitGTK/TestDownloads:/webkit/Downloads/local-file-error (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12726 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8740 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18091 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51384 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7834 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14581 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->