### PR TITLE
[GTK] Switch back to 0 painting threads

### DIFF
--- a/Source/WebCore/platform/graphics/nicosia/NicosiaPaintingEngine.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaPaintingEngine.cpp
@@ -36,25 +36,21 @@ namespace Nicosia {
 
 std::unique_ptr<PaintingEngine> PaintingEngine::create()
 {
-#if (ENABLE(DEVELOPER_MODE) && PLATFORM(WPE)) || USE(GTK4)
-#if USE(GTK4)
-    unsigned numThreads = 1;
-#else
+    // numThreads defaults to 0 because neither the WPE nor the GTK painting
+    // code is thread safe.
+    // https://bugs.webkit.org/show_bug.cgi?id=251977#c8
     unsigned numThreads = 0;
-#endif
     if (const char* numThreadsEnv = getenv("WEBKIT_NICOSIA_PAINTING_THREADS")) {
         if (sscanf(numThreadsEnv, "%u", &numThreads) == 1) {
             if (numThreads > 8) {
-                WTFLogAlways("The number of Nicosia painting threads is not between 1 and 8. Using the default value 4\n");
-                numThreads = 4;
+                WTFLogAlways("The number of Nicosia painting threads is not between 0 and 8. Using the default value 0\n");
+                numThreads = 0;
             }
         }
     }
 
     if (numThreads)
         return std::unique_ptr<PaintingEngine>(new PaintingEngineThreaded(numThreads));
-#endif
-
     return std::unique_ptr<PaintingEngine>(new PaintingEngineBasic);
 }
 


### PR DESCRIPTION
#### 3f7115bc71de651f901263a04a012b703094d65f
<pre>
[GTK] Switch back to 0 painting threads
<a href="https://bugs.webkit.org/show_bug.cgi?id=253108">https://bugs.webkit.org/show_bug.cgi?id=253108</a>

Reviewed by NOBODY (OOPS!).

We thought it might be safe to use 1 painting thread, but this does not
seem to be true, so go back to 0 for now.

I&apos;ve also removed the DEVELOPER_MODE and platform preprocessor guards
because there&apos;s not really any need for them. It&apos;s fine to gate the
functionality behind an environment variable. The implementation is
compiled unconditionally anyway.

Lastly, change what happens when an invalid value is passed via the
environment variable. Currently the &quot;default value&quot; 4 is used only when
you pass an invalid value via the environment variable. That&apos;s pretty
strange -- it&apos;s &quot;default&quot; only in the sense of default to use when an
invalid value is selected -- so let&apos;s switch to using the actual default
value 0.

* Source/WebCore/platform/graphics/nicosia/NicosiaPaintingEngine.cpp:
(Nicosia::PaintingEngine::create):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f7115bc71de651f901263a04a012b703094d65f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110139 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19238 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42805 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1567 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119144 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114090 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20699 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10428 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102395 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115885 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15415 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98620 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43636 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97376 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30281 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85484 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11933 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31618 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12547 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8585 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17912 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51234 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14351 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->