### PR TITLE
REGRESSION(257542@main): Video is misaligned on YouTube site's PiP player after transitioning from full screen

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/model/move-fullscreen-element-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/model/move-fullscreen-element-expected.txt
@@ -1,0 +1,4 @@
+Fullscreen element
+
+PASS Moving the fullscreen element should not leave the fullscreen flag
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/model/move-fullscreen-element.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/model/move-fullscreen-element.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<title>Moving the fullscreen element should not leave the fullscreen flag</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="../trusted-click.js"></script>
+
+<div id="fullscreen-element">Fullscreen element</div>
+
+<div id="new-parent"></div>
+
+<script>
+    promise_test(async () => {
+        const fullscreenElement = document.getElementById("fullscreen-element");
+        await trusted_request(fullscreenElement);
+        assert_true(fullscreenElement.matches(":fullscreen"), "Element has fullscreen flag");
+        assert_equals(document.fullscreenElement, fullscreenElement, "Element is fullscreen element");
+        document.getElementById("new-parent").appendChild(fullscreenElement);
+        assert_false(fullscreenElement.matches(":fullscreen"), "Element no longer has fullscreen flag after being moved");
+        assert_false(!!document.fullscreenElement, "There is no more fullscreen element, since fullscreen flag was removed");
+        await fullScreenChange();
+        assert_false(fullscreenElement.matches(":fullscreen"), "Element no longer has fullscreen flag after fullscreen change event");
+        assert_false(!!document.fullscreenElement, "There is no more fullscreen element, since fullscreen flag was removed");
+    });
+</script>
+</html>

--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -334,8 +334,11 @@ void FullscreenManager::exitFullscreen(RefPtr<DeferredPromise>&& promise)
     }
 
     auto element = exitingDocument->fullscreenManager().fullscreenElement();
-    if (element && !element->isConnected())
+    if (element && !element->isConnected()) {
         addDocumentToFullscreenChangeEventQueue(exitingDocument);
+        element->setFullscreenFlag(false);
+        element->removeFromTopLayer();
+    }
 
     m_pendingExitFullscreen = true;
 


### PR DESCRIPTION
#### d8b353380562d051c4721fa092251ac922413bb6
<pre>
REGRESSION(257542@main): Video is misaligned on YouTube site&apos;s PiP player after transitioning from full screen
<a href="https://bugs.webkit.org/show_bug.cgi?id=253121">https://bugs.webkit.org/show_bug.cgi?id=253121</a>
rdar://105713729

Reviewed by Ryosuke Niwa.

There is a bug with the fullscreen spec that leaves a dangling fullscreen flag when moving elements: <a href="https://github.com/whatwg/fullscreen/issues/217">https://github.com/whatwg/fullscreen/issues/217</a>
This causes fullscreen styles to unintentionally apply on the YouTube site even though the player element which has moved in the DOM tree, has exited
fullscreen.

To fix this, we follow Chromium&apos;s pattern of running an extra &quot;unfullscreen element&quot; step in the synchronous exit fullscreen steps when the element to
be exited is disconnected.

* LayoutTests/imported/w3c/web-platform-tests/fullscreen/model/move-fullscreen-element-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/model/move-fullscreen-element.html: Added.
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::exitFullscreen):

Canonical link: <a href="https://commits.webkit.org/260985@main">https://commits.webkit.org/260985@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c3d6b5cac5df979ed3c4562f666eb663654c3d0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110149 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19247 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42812 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1574 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/119150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114100 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20707 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10436 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102403 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115895 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/43638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30285 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/85476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11941 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31622 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12554 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17919 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51238 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7609 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14359 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->