### PR TITLE
Update some CTAP IDL types

### DIFF
--- a/Source/WebCore/Modules/webauthn/AttestationConveyancePreference.h
+++ b/Source/WebCore/Modules/webauthn/AttestationConveyancePreference.h
@@ -34,7 +34,8 @@ namespace WebCore {
 enum class AttestationConveyancePreference : uint8_t {
     None,
     Indirect,
-    Direct
+    Direct,
+    Enterprise,
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webauthn/AttestationConveyancePreference.idl
+++ b/Source/WebCore/Modules/webauthn/AttestationConveyancePreference.idl
@@ -28,5 +28,6 @@
 ] enum AttestationConveyancePreference {
     "none",
     "indirect",
-    "direct"
+    "direct",
+    "enterprise"
 };

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1002,7 +1002,8 @@ struct WebCore::PublicKeyCredentialDescriptor {
 enum class WebCore::AttestationConveyancePreference : uint8_t {
     None,
     Indirect,
-    Direct
+    Direct,
+    Enterprise
 };
 #endif
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKPublicKeyCredentialCreationOptions.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKPublicKeyCredentialCreationOptions.h
@@ -42,6 +42,7 @@ typedef NS_ENUM(NSInteger, _WKAttestationConveyancePreference) {
     _WKAttestationConveyancePreferenceNone,
     _WKAttestationConveyancePreferenceIndirect,
     _WKAttestationConveyancePreferenceDirect,
+    _WKAttestationConveyancePreferenceEnterprise,
 } WK_API_AVAILABLE(macos(12.0), ios(15.0));
 
 WK_CLASS_AVAILABLE(macos(12.0), ios(15.0))

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
@@ -890,6 +890,8 @@ static WebCore::AttestationConveyancePreference attestationConveyancePreference(
         return WebCore::AttestationConveyancePreference::Indirect;
     case _WKAttestationConveyancePreferenceDirect:
         return WebCore::AttestationConveyancePreference::Direct;
+    case _WKAttestationConveyancePreferenceEnterprise:
+        return WebCore::AttestationConveyancePreference::Enterprise;
     default:
         ASSERT_NOT_REACHED();
         return WebCore::AttestationConveyancePreference::None;

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
@@ -79,6 +79,8 @@ static inline RetainPtr<NSString> toNSString(AttestationConveyancePreference att
         return @"indirect";
     case AttestationConveyancePreference::None:
         return @"none";
+    case AttestationConveyancePreference::Enterprise:
+        return @"enterprise";
     }
 
     return @"none";


### PR DESCRIPTION
#### 8704aa4593bacce3c5ca2b4bbb094890cb553ff1
<pre>
Update some CTAP IDL types
rdar://105614057

Reviewed by J Pascoe.

Add definitions for some missing IDL values.

* Source/WebCore/Modules/webauthn/AttestationConveyancePreference.h:
* Source/WebCore/Modules/webauthn/AttestationConveyancePreference.idl:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/_WKPublicKeyCredentialCreationOptions.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm:
(attestationConveyancePreference):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm:
(WebKit::toNSString):

Canonical link: <a href="https://commits.webkit.org/261088@main">https://commits.webkit.org/261088@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e34e49c4fa317985cf4a2a00ff071a28f9ee0eb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110156 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19254 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42818 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1580 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119156 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114107 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20714 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10443 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102410 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115902 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15425 "Found 1 new test failure: fast/scrolling/keyboard-scrolling-distance-pageDown.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98629 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43642 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97386 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30290 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85481 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11947 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31627 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12560 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8597 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17925 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51243 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7682 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14366 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->