### PR TITLE
Refactor correction indicator removal logic

### DIFF
--- a/Source/WebCore/editing/AlternativeTextController.cpp
+++ b/Source/WebCore/editing/AlternativeTextController.cpp
@@ -399,10 +399,19 @@ void AlternativeTextController::respondToChangedSelection(const VisibleSelection
     }
 }
 
+#if USE(APPLE_INTERNAL_SDK)
+#include <WebKitAdditions/AlternativeTextControllerAdditions.cpp>
+#else
+static inline void removeCorrectionIndicatorMarkers(Document& document)
+{
+    document.markers().removeMarkers(DocumentMarker::CorrectionIndicator);
+}
+#endif
+
 void AlternativeTextController::respondToAppliedEditing(CompositeEditCommand* command)
 {
     if (command->isTopLevelCommand() && !command->shouldRetainAutocorrectionIndicator())
-        m_document.markers().removeMarkers(DocumentMarker::CorrectionIndicator);
+        removeCorrectionIndicatorMarkers(m_document);
 
     markPrecedingWhitespaceForDeletedAutocorrectionAfterCommand(command);
     m_originalStringForLastDeletedAutocorrection = String();


### PR DESCRIPTION
#### 67d8e1c6a1943bafb2827958f0c50b86e719449a
<pre>
Refactor correction indicator removal logic
<a href="https://bugs.webkit.org/show_bug.cgi?id=253122">https://bugs.webkit.org/show_bug.cgi?id=253122</a>
rdar://105737163

Reviewed by Wenson Hsieh.

Move some correction indicator removal logic into static helpers.

* Source/WebCore/editing/AlternativeTextController.cpp:
(WebCore::removeCorrectionIndicatorMarkers):
(WebCore::AlternativeTextController::respondToAppliedEditing):
* Source/WebCore/editing/Editor.cpp:
(WebCore::shouldRemoveAutocorrectionIndicator):
(WebCore::Editor::insertTextWithoutSendingTextEvent):

Canonical link: <a href="https://commits.webkit.org/261028@main">https://commits.webkit.org/261028@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5dd5e5d270d9e6c308c1f2e49e477b308ee4e19b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110159 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19257 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42821 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1583 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119159 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114110 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20717 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10446 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102413 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115905 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15423 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98634 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43649 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97384 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30295 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85489 "Found 1 new API test failure: /WebKitGTK/TestDownloads:/webkit/Downloads/local-file-error (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11950 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31632 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12563 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8595 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17928 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51248 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14369 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4158 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->