### PR TITLE
[webkitflaskpy] Add IPCManager object

### DIFF
--- a/Tools/Scripts/libraries/webkitflaskpy/setup.py
+++ b/Tools/Scripts/libraries/webkitflaskpy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='webkitflaskpy',
-    version='0.4.0',
+    version='0.5.0',
     description="Library supporting the WebKit Team's flask based web services.",
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitflaskpy/webkitflaskpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitflaskpy/webkitflaskpy/__init__.py
@@ -43,7 +43,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(0, 4, 0)
+version = Version(0, 5, 0)
 
 AutoInstall.register(Package('click', Version(7, 1, 2)))
 AutoInstall.register(Package('flask', Version(1, 1, 2)))
@@ -65,5 +65,6 @@ from webkitflaskpy.authed_blueprint import AuthedBlueprint  # noqa: E402
 from webkitflaskpy.response import Response
 from webkitflaskpy.mock_app import mock_app
 from webkitflaskpy.database import Database
+from webkitflaskpy.ipc_manager import IPCManager
 
 name = 'webkitflaskpy'

--- a/Tools/Scripts/libraries/webkitflaskpy/webkitflaskpy/ipc_manager.py
+++ b/Tools/Scripts/libraries/webkitflaskpy/webkitflaskpy/ipc_manager.py
@@ -1,0 +1,125 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import hashlib
+import json
+
+from webkitcorepy import string_utils
+from webkitflaskpy import Database
+
+
+class IPCManager(object):
+    DEFAULT_EXPIRATION = 10 * 60
+    DEFAULT_TIMEOUT = 60
+    RETRY = 3
+
+    @classmethod
+    def encode(cls, data):
+        encoded = json.dumps(data, sort_keys=True)
+        return hashlib.md5(string_utils.encode(encoded)).hexdigest(), encoded
+
+    def __init__(self, *databases):
+        self.databases = databases or [Database()]
+        self.callbacks = dict()
+
+    def register(self, name, callback):
+        if not isinstance(name, str):
+            raise ValueError('Name of registered callback must be a string')
+        if not callable(callback):
+            raise ValueError('Callback must be callable')
+        self.callbacks[name] = callback
+
+    def enqueue(self, name, *args, **kwargs):
+        expiration = kwargs.pop('ex', self.DEFAULT_EXPIRATION)
+        retry = kwargs.pop('retry', self.RETRY)
+        if name not in self.callbacks:
+            raise ValueError("'{}' is not a registered callback".format(name))
+        digest, encoded = self.encode([name, args, kwargs, retry, expiration])
+
+        for database in self.databases:
+            database.set(digest, encoded, ex=expiration)
+        return True
+
+    def dequeue(self, key, filter=None, index=None, timeout=None):
+        timeout = timeout or self.DEFAULT_TIMEOUT
+        if index is None:
+            for i in range(len(self.databases)):
+                result = self.dequeue(key, index=i, timeout=timeout)
+                if result:
+                    return result
+            return False
+
+        lock = self.databases[index].lock(name='lock_{}'.format(key), timeout=timeout, blocking_timeout=0.05)
+        try:
+            if not lock.acquire():
+                return False
+            raw = self.databases[index].get(key)
+            if not raw:
+                self.databases[index].delete(key)
+                return False
+            data = json.loads(raw)
+            if filter and not filter(data):
+                return False
+            if len(data) != 5:
+                self.databases[index].delete(key)
+                return False
+            name, args, kwargs, retry, expiration = data
+            if name not in self.callbacks:
+                self.databases[index].delete(key)
+                return False
+
+            if retry > 0:
+                _, encoded = self.encode([name, args, kwargs, retry - 1, expiration])
+                self.databases[index].set(key, encoded, ex=expiration)
+            else:
+                self.databases[index].delete(key)
+            self.callbacks[name](*args, **kwargs)
+            if retry > 0:
+                self.databases[index].delete(key)
+            return True
+        finally:
+            if lock.local.token is not None:
+                lock.release()
+
+    def dequeue_all(self, filter=None, index=None):
+        result = False
+        indecies = range(len(self.databases)) if index is None else [index]
+        for i in indecies:
+            for key in self.databases[i].scan_iter():
+                key = key.decode()
+                result |= self.dequeue(key, filter=filter, index=i)
+        return result
+
+    def tasks(self, filter=None, index=None):
+        if index is None:
+            for i in range(len(self.databases)):
+                for task in self.tasks(filter=filter, index=i):
+                    yield task
+        else:
+            for key in self.databases[index].scan_iter():
+                key = key.decode()
+                raw = self.databases[index].get(key)
+                if not raw:
+                    continue
+                data = json.loads(raw)[:3]
+                if not filter or filter(data):
+                    yield (key, data)

--- a/Tools/Scripts/libraries/webkitflaskpy/webkitflaskpy/tests/ipc_manager_unittest.py
+++ b/Tools/Scripts/libraries/webkitflaskpy/webkitflaskpy/tests/ipc_manager_unittest.py
@@ -1,0 +1,136 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import unittest
+
+from webkitflaskpy import IPCManager
+
+
+class IPCManagerUnittest(unittest.TestCase):
+    COUNTER = 0
+    INCREMENT = 'increment'
+    DECREMENT = 'decrement'
+
+    @classmethod
+    def increment(cls, value=1):
+        if value <= 0:
+            raise ValueError('Increment only accepts positive values')
+        cls.COUNTER += value
+
+    @classmethod
+    def decrement(cls, value=1):
+        if value <= 0:
+            raise ValueError('Decrement only accepts positive values')
+        if value > cls.COUNTER:
+            raise ValueError('Trying to decrement more than available in counter')
+        cls.COUNTER -= value
+
+    def test_encoding(self):
+        self.assertEqual(
+            IPCManager.encode(['increment', [1]]),
+            ('65634ae55b36be767ee8e26cc3832151', '["increment", [1]]'),
+        )
+        self.assertEqual(
+            IPCManager.encode(dict(a=1, b=2)),
+            IPCManager.encode(dict(b=2, a=1)),
+        )
+
+    def test_enqueue(self):
+        IPCManagerUnittest.COUNTER = 0
+        manager = IPCManager()
+        manager.register(self.INCREMENT, self.increment)
+        manager.register(self.DECREMENT, self.decrement)
+
+        manager.enqueue(self.INCREMENT, 1)
+        self.assertEqual(
+            [('9ffcb5a7b14e4536e69f6527b1283237', ['increment', [1], {}])],
+            list(manager.tasks()),
+        )
+        manager.enqueue(self.INCREMENT, 2)
+        self.assertEqual(2, len(list(manager.tasks())))
+
+        manager.enqueue(self.DECREMENT, 1)
+        self.assertEqual(3, len(list(manager.tasks())))
+
+        manager.enqueue(self.DECREMENT, 1)
+        self.assertEqual(3, len(list(manager.tasks())))
+
+        self.assertEqual(
+            [('831dff37a383fb74ff75d6c7bca3b143', ['decrement', [1], {}])],
+            list(manager.tasks(filter=lambda data: data[0] == self.DECREMENT)),
+        )
+
+    def test_dequeue(self):
+        IPCManagerUnittest.COUNTER = 0
+        manager = IPCManager()
+        manager.register(self.INCREMENT, self.increment)
+        manager.register(self.DECREMENT, self.decrement)
+
+        self.assertEqual(False, manager.dequeue('abc'))
+
+        manager.enqueue(self.INCREMENT, 1)
+        self.assertEqual(True, manager.dequeue('9ffcb5a7b14e4536e69f6527b1283237'))
+        self.assertEqual(IPCManagerUnittest.COUNTER, 1)
+
+        self.assertEqual(False, manager.dequeue('9ffcb5a7b14e4536e69f6527b1283237'))
+
+    def test_dequeue_all(self):
+        IPCManagerUnittest.COUNTER = 0
+        manager = IPCManager()
+        manager.register(self.INCREMENT, self.increment)
+        manager.register(self.DECREMENT, self.decrement)
+
+        self.assertEqual(False, manager.dequeue_all())
+
+        manager.enqueue(self.INCREMENT, 1)
+        manager.enqueue(self.INCREMENT, 2)
+
+        self.assertEqual(True, manager.dequeue_all())
+        self.assertEqual(IPCManagerUnittest.COUNTER, 3)
+        self.assertEqual(False, manager.dequeue_all())
+
+        manager.enqueue(self.DECREMENT, 1)
+        manager.enqueue(self.INCREMENT, 3)
+
+        self.assertEqual(True, manager.dequeue_all())
+        self.assertEqual(IPCManagerUnittest.COUNTER, 5)
+        self.assertEqual(False, manager.dequeue_all())
+
+    def test_retry(self):
+        IPCManagerUnittest.COUNTER = 0
+        manager = IPCManager()
+        manager.register(self.INCREMENT, self.increment)
+        manager.register(self.DECREMENT, self.decrement)
+
+        manager.enqueue(self.DECREMENT, 1, retry=0)
+        with self.assertRaises(ValueError):
+            manager.dequeue_all()
+        self.assertEqual(0, len(list(manager.tasks())))
+        self.assertEqual(IPCManagerUnittest.COUNTER, 0)
+
+        manager.enqueue(self.DECREMENT, 1, retry=1)
+        with self.assertRaises(ValueError):
+            manager.dequeue_all()
+        self.assertEqual(1, len(list(manager.tasks())))
+        IPCManagerUnittest.COUNTER = 1
+        self.assertEqual(True, manager.dequeue_all())
+        self.assertEqual(IPCManagerUnittest.COUNTER, 0)


### PR DESCRIPTION
#### ecafc68a10f3675eabed1bf7592ba2e21e1c12fa
<pre>
[webkitflaskpy] Add IPCManager object
<a href="https://bugs.webkit.org/show_bug.cgi?id=253124">https://bugs.webkit.org/show_bug.cgi?id=253124</a>
rdar://106059293

Reviewed by Dewei Zhu.

Implement a generalized version of a Redis queue to pass tasks to worker processes.
These sorts of queues are most often used by web services to handle incoming hooks.

* Tools/Scripts/libraries/webkitflaskpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitflaskpy/webkitflaskpy/__init__.py: Export IPCManager class.
* Tools/Scripts/libraries/webkitflaskpy/webkitflaskpy/ipc_manager.py: Added.
(IPCManager.encode): Return encoded dictionary and database key.
(IPCManager.__init__): Construct manager with a list of databases.
(IPCManager.register): Register a callback with a specific name.
(IPCManager.enqueue): Add a task to be run with arguments, number of retries and expiration.
(IPCManager.dequeue): Execute the specified task. If the execution is successful, delete the task.
Otherwise, decrement the retry counter for that task before raising the thrown exception.
(IPCManager.dequeue_all): Execute all tasks currently in the queue.
(IPCManager.tasks): List all tasks in the queue.
* Tools/Scripts/libraries/webkitflaskpy/webkitflaskpy/tests/ipc_manager_unittest.py: Added.
(IPCManagerUnittest.increment):
(IPCManagerUnittest.decrement):
(IPCManagerUnittest.test_encoding):
(IPCManagerUnittest.test_enqueue):
(IPCManagerUnittest.test_dequeue):
(IPCManagerUnittest.test_dequeue_all):
(IPCManagerUnittest.test_retry):

Canonical link: <a href="https://commits.webkit.org/261343@main">https://commits.webkit.org/261343@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/547cd5bd3bd20944f75d649848e8132ed98cd3e8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/111372 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/20510 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/3067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 wincairo ](https://ews-build.webkit.org/#/builders/WinCairo-EWS "Waiting in queue, processing has not started yet") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/115326 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/21877 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/11603 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/87/builds/3067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/117136 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/21877 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/104040 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/5/builds/114801 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/21877 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/104040 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/99908 "Build is in progress. Recent messages:") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/13011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/104040 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/13521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/11603 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/18964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/15480 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4305 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->