### PR TITLE
TEST: Disable check to see what breaks

### DIFF
--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -278,7 +278,7 @@ OptionSet<WebEventModifier> modifiersForNavigationAction(const NavigationAction&
 {
     OptionSet<WebEventModifier> modifiers;
     auto keyStateEventData = navigationAction.keyStateEventData();
-    if (keyStateEventData && keyStateEventData->isTrusted) {
+    if (keyStateEventData /*&& keyStateEventData->isTrusted*/) {
         if (keyStateEventData->shiftKey)
             modifiers.add(WebEventModifier::ShiftKey);
         if (keyStateEventData->ctrlKey)


### PR DESCRIPTION
#### 6d91884bea12c83295de086ecd9dddf610fc4d92
<pre>
TEST: Disable check to see what breaks
<a href="https://bugs.webkit.org/show_bug.cgi?id=253132">https://bugs.webkit.org/show_bug.cgi?id=253132</a>
rdar://106065627

Reviewed by NOBODY (OOPS!).

* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::modifiersForNavigationAction):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d91884bea12c83295de086ecd9dddf610fc4d92

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110179 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19277 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42838 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1601 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119176 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20737 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10466 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102433 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115925 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15442 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98645 "Found 1 new API test failure: TestWebKitAPI.WebKit.IsNavigationActionTrusted (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43655 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97403 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30306 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85495 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11968 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31643 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12580 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8611 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17945 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51260 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14387 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->