### PR TITLE
[GStreamer][GL] Fix includes with USE_WPE_VIDEO_PLANE_DISPLAY_DMABUF

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoFrameHolder.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoFrameHolder.cpp
@@ -28,6 +28,10 @@
 #include "TextureMapperContextAttributes.h"
 #include "TextureMapperGL.h"
 
+#if USE(WPE_VIDEO_PLANE_DISPLAY_DMABUF)
+#include <gst/gl/egl/gstglmemoryegl.h>
+#endif
+
 namespace WebCore {
 
 GstVideoFrameHolder::GstVideoFrameHolder(GstSample* sample, std::optional<GstVideoDecoderPlatform> videoDecoderPlatform, TextureMapperGL::Flags flags, bool gstGLEnabled)

--- a/Source/WebCore/platform/graphics/gstreamer/GUniquePtrGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GUniquePtrGStreamer.h
@@ -36,7 +36,7 @@
 #undef GST_USE_UNSTABLE_API
 #endif
 
-#if USE(WPE_VIDEO_PLANE_DISPLAY_DMABUF)
+#if defined(BUILDING_WebCore) && USE(WPE_VIDEO_PLANE_DISPLAY_DMABUF)
 #include <wpe/extensions/video-plane-display-dmabuf.h>
 #endif
 
@@ -60,7 +60,7 @@ WTF_DEFINE_GPTR_DELETER(GstWebRTCSessionDescription, gst_webrtc_session_descript
 WTF_DEFINE_GPTR_DELETER(GstSDPMessage, gst_sdp_message_free)
 #endif
 
-#if USE(WPE_VIDEO_PLANE_DISPLAY_DMABUF)
+#if defined(BUILDING_WebCore) && USE(WPE_VIDEO_PLANE_DISPLAY_DMABUF)
 WTF_DEFINE_GPTR_DELETER(struct wpe_video_plane_display_dmabuf_source, wpe_video_plane_display_dmabuf_source_destroy)
 #endif
 


### PR DESCRIPTION
#### 397546bb68ccbf36170a131c9ecf7c28c7a20e75
<pre>
[GStreamer][GL] Fix includes with USE_WPE_VIDEO_PLANE_DISPLAY_DMABUF
<a href="https://bugs.webkit.org/show_bug.cgi?id=253138">https://bugs.webkit.org/show_bug.cgi?id=253138</a>

Reviewed by Philippe Normand.

Fixes:
Source/WebCore/platform/graphics/gstreamer/GStreamerVideoFrameHolder.cpp:58:9: error: ‘gst_is_gl_memory_egl’ was not declared in this scope; did you mean ‘gst_is_gl_memory_pbo’?
   58 |     if (gst_is_gl_memory_egl(memory)) {
      |         ^~~~~~~~~~~~~~~~~~~~
      |         gst_is_gl_memory_pbo

WebCore/PrivateHeaders/WebCore/GUniquePtrGStreamer.h:40:10: fatal error: wpe/extensions/video-plane-display-dmabuf.h: No such file or directory
   40 | #include &lt;wpe/extensions/video-plane-display-dmabuf.h&gt;
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

* Source/WebCore/platform/graphics/gstreamer/GStreamerVideoFrameHolder.cpp:
* Source/WebCore/platform/graphics/gstreamer/GUniquePtrGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/260995@main">https://commits.webkit.org/260995@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08bd37802691cd80bb5ff4b30860daf99dc27b71

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110199 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19296 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42857 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1618 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119189 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114150 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20757 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10487 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102456 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115944 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98657 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43667 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30320 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85509 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11986 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31657 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12598 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17964 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51274 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7617 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14407 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->