### PR TITLE
[WGSL] Re-land 260735@main

### DIFF
--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -45,7 +45,7 @@ class TypeChecker : public AST::Visitor, public ContextProvider<Type*> {
 public:
     TypeChecker(ShaderModule&);
 
-    void check();
+    std::optional<FailedCheck> check();
 
     // Declarations
     void visit(AST::Structure&) override;
@@ -122,7 +122,7 @@ TypeChecker::TypeChecker(ShaderModule& shaderModule)
 #include "TypeDeclarations.h" // NOLINT
 }
 
-void TypeChecker::check()
+std::optional<FailedCheck> TypeChecker::check()
 {
     // FIXME: fill in struct fields in a second pass since declarations might be
     // out of order
@@ -145,6 +145,14 @@ void TypeChecker::check()
         for (auto& error : m_errors)
             dataLogLn(error);
     }
+
+    if (m_errors.isEmpty())
+        return std::nullopt;
+
+
+    // FIXME: add support for warnings
+    Vector<Warning> warnings { };
+    return FailedCheck { WTFMove(m_errors), WTFMove(warnings) };
 }
 
 // Declarations
@@ -563,9 +571,9 @@ void TypeChecker::typeError(InferBottom inferBottom, const SourceSpan& span, Arg
         inferred(m_types.bottomType());
 }
 
-void typeCheck(ShaderModule& shaderModule)
+std::optional<FailedCheck> typeCheck(ShaderModule& shaderModule)
 {
-    TypeChecker(shaderModule).check();
+    return TypeChecker(shaderModule).check();
 }
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/TypeCheck.h
+++ b/Source/WebGPU/WGSL/TypeCheck.h
@@ -25,10 +25,12 @@
 
 #pragma once
 
+#include "WGSL.h"
+
 namespace WGSL {
 
 class ShaderModule;
 
-void typeCheck(ShaderModule&);
+std::optional<FailedCheck> typeCheck(ShaderModule&);
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/TypeDeclarations.rb
+++ b/Source/WebGPU/WGSL/TypeDeclarations.rb
@@ -6,3 +6,8 @@ operator :+, {
     [T < Number, N].(Vector[T, N], Vector[T, N]) => Vector[T, N],
     [T < Float, C, R].(Matrix[T, C, R], Matrix[T, C, R]) => Matrix[T, C, R],
 }
+
+operator :*, {
+    [T < Float, C, R].(Matrix[T, C, R], Vector[T, C]) => Vector[T, R],
+    [T < Float, C, R].(Vector[T, R], Matrix[T, C, R]) => Vector[T, C],
+}

--- a/Source/WebGPU/WGSL/WGSL.cpp
+++ b/Source/WebGPU/WGSL/WGSL.cpp
@@ -75,8 +75,12 @@ std::variant<SuccessfulCheck, FailedCheck> staticCheck(const String& wgsl, const
         return FailedCheck { { *error }, { /* warnings */ } };
     }
 
+    // FIXME: add more validation
+    auto maybeFailure = typeCheck(shaderModule);
+    if (maybeFailure.has_value())
+        return *maybeFailure;
+
     Vector<Warning> warnings { };
-    // FIXME: add validation
     return std::variant<SuccessfulCheck, FailedCheck>(std::in_place_type<SuccessfulCheck>, WTFMove(warnings), WTFMove(shaderModule));
 }
 
@@ -98,8 +102,6 @@ inline PrepareResult prepareImpl(ShaderModule& ast, const HashMap<String, Pipeli
     {
         PhaseTimer phaseTimer("prepare total", phaseTimes);
 
-        // FIXME: this should run as part of staticCheck
-        RUN_PASS(typeCheck, ast);
         RUN_PASS_WITH_RESULT(callGraph, buildCallGraph, ast);
         RUN_PASS(resolveTypeReferences, ast);
         RUN_PASS(rewriteEntryPoints, callGraph, result);


### PR DESCRIPTION
#### d0f3ad6e6dfcdcec2d4be7019e8b612f30f528a8
<pre>
[WGSL] Re-land 260735@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=253144">https://bugs.webkit.org/show_bug.cgi?id=253144</a>
rdar://106078179

Reviewed by Myles C. Maxfield.

The commit had to reverted together with 260433@main because of build issues with
the JavaScript DSL, so now we re-land it on top of the ruby DSL.

About the actual change (from the original PR):
At first, since there was very little of the type checking implemented, it was
only run right before generating code, errors were only printed and guarded by
a compiler-time flag. While the type checker is still far from complete, it can
now correctly check the examples we&apos;ve been using for development, so we can move
it into the validation phase.

* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::check):
(WGSL::typeCheck):
* Source/WebGPU/WGSL/TypeCheck.h:
* Source/WebGPU/WGSL/TypeDeclarations.rb:
* Source/WebGPU/WGSL/WGSL.cpp:
(WGSL::staticCheck):
(WGSL::prepareImpl):

Canonical link: <a href="https://commits.webkit.org/261127@main">https://commits.webkit.org/261127@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7edcb9901ffdbe9c40efee7754e4fbc63b47bfd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110209 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19306 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42867 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1628 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119199 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20767 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10497 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102485 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115954 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15465 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98669 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43689 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97426 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30333 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85538 "Found 1 new API test failure: /WebKitGTK/TestAuthentication:/webkit/Authentication/authentication-storage (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11996 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31670 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12608 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8633 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17974 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51287 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7710 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14417 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->