### PR TITLE
[GTK][WPE] WebKitDownload destination should be a path instead of a URI

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitDownload.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitDownload.h.in
@@ -64,7 +64,7 @@ webkit_download_get_destination          (WebKitDownload *download);
 
 WEBKIT_API void
 webkit_download_set_destination          (WebKitDownload *download,
-                                          const gchar    *uri);
+                                          const gchar    *destination);
 
 WEBKIT_API WebKitURIResponse*
 webkit_download_get_response             (WebKitDownload *download);

--- a/Source/WebKit/gtk/migrating-to-webkitgtk-6.0.md
+++ b/Source/WebKit/gtk/migrating-to-webkitgtk-6.0.md
@@ -140,3 +140,9 @@ removed. WebKit will draw scrollbars that match the Adwaita GTK theme.
 been removed. Instead, [method@WebKit.UserContentManager.register_script_message_handler]
 and [method@WebKit.UserContentManager.unregister_script_message_handler] have
 gained parameters to specify the script world to use.
+
+## Download Destination
+
+[method@WebKit.Download.set_destination], [method@WebKit.Download.get_destination],
+[property@WebKit.Download:destination], and [signal@WebKit.Download::created-destination]
+now all use a filesystem path rather than a URI. All uses must be updated accordingly.


### PR DESCRIPTION
#### 6fea66849a84ce320661a103dae1c90bcbff5827
<pre>
[GTK][WPE] WebKitDownload destination should be a path instead of a URI
<a href="https://bugs.webkit.org/show_bug.cgi?id=253146">https://bugs.webkit.org/show_bug.cgi?id=253146</a>

Reviewed by Michael Catanzaro and Adrian Perez de Castro.

Destination is handled as a path internally, so using URIs in the API
means we have to convert to/from URI all the time. We can&apos;t change this
in the current API, but for simplicity we can allow passing a path,
while still support URIs for backwards compatibility.
WebKiDownload::created-destination always returns a URI in the old API
for compatibilty, but webkit_download_get_destination() only returns a
URI when a URI was set with webkit_download_set_destination(). The new
API only allows to pass a path, and a path is also passed to
WebKiDownload::created-destination signal.

This patch is based on previous patch by Michael Catanzaro.

* Source/WebKit/UIProcess/API/glib/WebKitDownload.cpp:
(webkitDownloadDecideDestination):
(webkit_download_class_init):
(webkitDownloadDecideDestinationWithSuggestedFilename):
(webkitDownloadDestinationCreated):
(webkit_download_get_destination):
(webkit_download_set_destination):
* Source/WebKit/UIProcess/API/glib/WebKitDownload.h.in:
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestDownloads.cpp:
(testDownloadRemoteFileError):
(testWebViewDownloadURI):
(testPolicyResponseDownload):
(testDownloadEphemeralContext):
(testDownloadDestinationURI):
(testContextMenuDownloadActions):
(testBlobDownload):
(beforeAll):

Canonical link: <a href="https://commits.webkit.org/261002@main">https://commits.webkit.org/261002@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07c95b20b8895d55963fa454ba65e57f998480f6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110233 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19330 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42889 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1653 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119221 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114184 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20792 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10522 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102492 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115977 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98686 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/43695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/30350 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/85542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12019 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/31687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12631 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17997 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51304 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14440 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4149 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->