### PR TITLE
Add API to trigger background fetch click event

### DIFF
--- a/LayoutTests/http/wpt/background-fetch/background-fetch-abort.window-expected.txt
+++ b/LayoutTests/http/wpt/background-fetch/background-fetch-abort.window-expected.txt
@@ -1,0 +1,3 @@
+
+PASS background fetch abort should trigger an abort event
+

--- a/LayoutTests/http/wpt/background-fetch/background-fetch-abort.window.html
+++ b/LayoutTests/http/wpt/background-fetch/background-fetch-abort.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/http/wpt/background-fetch/background-fetch-abort.window.js
+++ b/LayoutTests/http/wpt/background-fetch/background-fetch-abort.window.js
@@ -1,0 +1,26 @@
+// META: script=/service-workers/service-worker/resources/test-helpers.sub.js
+// META: script=/background-fetch/resources/utils.js
+
+'use strict';
+
+promise_test(async t => {
+  let serviceWorkerRegistration = await service_worker_unregister_and_register(t, "sw.js", ".");
+  add_completion_callback(() => serviceWorkerRegistration.unregister());
+  await wait_for_state(t, serviceWorkerRegistration.installing, 'activated');
+
+  const id = uniqueId();
+  await serviceWorkerRegistration.backgroundFetch.fetch(id, ['resources/trickle.py?ms=10&count=1000']);
+
+  if (!window.testRunner)
+    return;
+
+  const channel = new MessageChannel();
+  serviceWorkerRegistration.active.postMessage({ type:'waitForAbort', port:channel.port1 }, [channel.port1]);
+  const abortPromise = new Promise(resolve => channel.port2.onmessage = (event) => resolve(event.data));
+
+  const internalId = testRunner.getBackgroundFetchIdentifier();
+  assert_greater_than(internalId.length, 0);
+  testRunner.abortBackgroundFetch(internalId);
+
+  assert_equals(await abortPromise, id);
+}, "background fetch abort should trigger an abort event");

--- a/LayoutTests/http/wpt/background-fetch/background-fetch-click.window-expected.txt
+++ b/LayoutTests/http/wpt/background-fetch/background-fetch-click.window-expected.txt
@@ -1,0 +1,3 @@
+
+PASS background fetch click should trigger a click event
+

--- a/LayoutTests/http/wpt/background-fetch/background-fetch-click.window.html
+++ b/LayoutTests/http/wpt/background-fetch/background-fetch-click.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/http/wpt/background-fetch/background-fetch-click.window.js
+++ b/LayoutTests/http/wpt/background-fetch/background-fetch-click.window.js
@@ -1,0 +1,26 @@
+// META: script=/service-workers/service-worker/resources/test-helpers.sub.js
+// META: script=/background-fetch/resources/utils.js
+
+'use strict';
+
+promise_test(async t => {
+  let serviceWorkerRegistration = await service_worker_unregister_and_register(t, "sw.js", ".");
+  add_completion_callback(() => serviceWorkerRegistration.unregister());
+  await wait_for_state(t, serviceWorkerRegistration.installing, 'activated');
+
+  const id = uniqueId();
+  await serviceWorkerRegistration.backgroundFetch.fetch(id, ['resources/trickle.py?ms=10&count=1000']);
+
+  if (!window.testRunner)
+    return;
+
+  const channel = new MessageChannel();
+  serviceWorkerRegistration.active.postMessage({ type:'waitForClick', port:channel.port1 }, [channel.port1]);
+  const clickPromise = new Promise(resolve => channel.port2.onmessage = (event) => resolve(event.data));
+
+  const internalId = testRunner.getBackgroundFetchIdentifier();
+  assert_greater_than(internalId.length, 0);
+  testRunner.simulateClickBackgroundFetch(internalId);
+
+  assert_equals(await clickPromise, id);
+}, "background fetch click should trigger a click event");

--- a/LayoutTests/http/wpt/background-fetch/sw.js
+++ b/LayoutTests/http/wpt/background-fetch/sw.js
@@ -1,1 +1,17 @@
-// test
+let waitForClickPort, waitForAbortPort;
+onmessage = (event) => {
+  if (event.data.type === "waitForClick")
+    waitForClickPort = event.data.port;
+  if (event.data.type === "waitForAbort")
+    waitForAbortPort = event.data.port;
+}
+
+onbackgroundfetchclick = (event) => {
+  if (waitForClickPort)
+    waitForClickPort.postMessage(event.registration.id);
+}
+
+onbackgroundfetchabort= (event) => {
+  if (waitForAbortPort)
+    waitForAbortPort.postMessage(event.registration.id);
+}

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchEngine.h
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchEngine.h
@@ -59,6 +59,11 @@ public:
 
     WEBCORE_EXPORT void addFetchFromStore(Span<const uint8_t>, CompletionHandler<void(const ServiceWorkerRegistrationKey&, const String&)>&&);
 
+    WEBCORE_EXPORT void abortBackgroundFetch(const ServiceWorkerRegistrationKey&, const String&);
+    WEBCORE_EXPORT void pauseBackgroundFetch(const ServiceWorkerRegistrationKey&, const String&);
+    WEBCORE_EXPORT void resumeBackgroundFetch(const ServiceWorkerRegistrationKey&, const String&);
+    WEBCORE_EXPORT void clickBackgroundFetch(const ServiceWorkerRegistrationKey&, const String&);
+
 private:
     void notifyBackgroundFetchUpdate(BackgroundFetchInformation&&);
 

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchStore.h
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchStore.h
@@ -53,7 +53,7 @@ class BackgroundFetchStore : public RefCounted<BackgroundFetchStore>, public Can
 public:
     virtual ~BackgroundFetchStore() = default;
 
-    virtual void initializeFetches(BackgroundFetchEngine&, const ServiceWorkerRegistrationKey&, CompletionHandler<void()>&&) = 0;
+    virtual void initializeFetches(const ServiceWorkerRegistrationKey&, CompletionHandler<void()>&&) = 0;
     virtual void clearFetch(const ServiceWorkerRegistrationKey&, const String&, CompletionHandler<void()>&& = [] { }) = 0;
     virtual void clearAllFetches(const ServiceWorkerRegistrationKey&, CompletionHandler<void()>&& = [] { }) = 0;
 

--- a/Source/WebCore/workers/service/context/SWContextManager.cpp
+++ b/Source/WebCore/workers/service/context/SWContextManager.cpp
@@ -138,8 +138,10 @@ void SWContextManager::firePushSubscriptionChangeEvent(ServiceWorkerIdentifier i
 void SWContextManager::fireNotificationEvent(ServiceWorkerIdentifier identifier, NotificationData&& data, NotificationEventType eventType, CompletionHandler<void(bool)>&& callback)
 {
     auto* serviceWorker = serviceWorkerThreadProxy(identifier);
-    if (!serviceWorker)
+    if (!serviceWorker) {
+        callback(false);
         return;
+    }
 
     serviceWorker->fireNotificationEvent(WTFMove(data), eventType, WTFMove(callback));
 }
@@ -147,10 +149,23 @@ void SWContextManager::fireNotificationEvent(ServiceWorkerIdentifier identifier,
 void SWContextManager::fireBackgroundFetchEvent(ServiceWorkerIdentifier identifier, BackgroundFetchInformation&& info, CompletionHandler<void(bool)>&& callback)
 {
     auto* serviceWorker = serviceWorkerThreadProxy(identifier);
-    if (!serviceWorker)
+    if (!serviceWorker) {
+        callback(false);
         return;
+    }
 
     serviceWorker->fireBackgroundFetchEvent(WTFMove(info), WTFMove(callback));
+}
+
+void SWContextManager::fireBackgroundFetchClickEvent(ServiceWorkerIdentifier identifier, BackgroundFetchInformation&& info, CompletionHandler<void(bool)>&& callback)
+{
+    auto* serviceWorker = serviceWorkerThreadProxy(identifier);
+    if (!serviceWorker) {
+        callback(false);
+        return;
+    }
+
+    serviceWorker->fireBackgroundFetchClickEvent(WTFMove(info), WTFMove(callback));
 }
 
 void SWContextManager::terminateWorker(ServiceWorkerIdentifier identifier, Seconds timeout, Function<void()>&& completionHandler)

--- a/Source/WebCore/workers/service/context/SWContextManager.h
+++ b/Source/WebCore/workers/service/context/SWContextManager.h
@@ -107,6 +107,7 @@ public:
     WEBCORE_EXPORT void firePushSubscriptionChangeEvent(ServiceWorkerIdentifier, std::optional<PushSubscriptionData>&& newSubscriptionData, std::optional<PushSubscriptionData>&& oldSubscriptionData);
     WEBCORE_EXPORT void fireNotificationEvent(ServiceWorkerIdentifier, NotificationData&&, NotificationEventType, CompletionHandler<void(bool)>&&);
     WEBCORE_EXPORT void fireBackgroundFetchEvent(ServiceWorkerIdentifier, BackgroundFetchInformation&&, CompletionHandler<void(bool)>&&);
+    WEBCORE_EXPORT void fireBackgroundFetchClickEvent(ServiceWorkerIdentifier, BackgroundFetchInformation&&, CompletionHandler<void(bool)>&&);
 
     WEBCORE_EXPORT void terminateWorker(ServiceWorkerIdentifier, Seconds timeout, Function<void()>&&);
 

--- a/Source/WebCore/workers/service/context/ServiceWorkerThread.h
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThread.h
@@ -78,6 +78,7 @@ public:
     void queueTaskToFireNotificationEvent(NotificationData&&, NotificationEventType, Function<void(bool)>&&);
 #endif
     void queueTaskToFireBackgroundFetchEvent(BackgroundFetchInformation&&, Function<void(bool)>&&);
+    void queueTaskToFireBackgroundFetchClickEvent(BackgroundFetchInformation&&, Function<void(bool)>&&);
 
     ServiceWorkerIdentifier identifier() const { return m_serviceWorkerIdentifier; }
     std::optional<ServiceWorkerJobDataIdentifier> jobDataIdentifier() const { return m_jobDataIdentifier; }

--- a/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h
@@ -91,6 +91,7 @@ public:
     void firePushSubscriptionChangeEvent(std::optional<PushSubscriptionData>&& newSubscriptionData, std::optional<PushSubscriptionData>&& oldSubscriptionData);
     void fireNotificationEvent(NotificationData&&, NotificationEventType, CompletionHandler<void(bool)>&&);
     void fireBackgroundFetchEvent(BackgroundFetchInformation&&, CompletionHandler<void(bool)>&&);
+    void fireBackgroundFetchClickEvent(BackgroundFetchInformation&&, CompletionHandler<void(bool)>&&);
 
     WEBCORE_EXPORT void didSaveScriptsToDisk(ScriptBuffer&&, HashMap<URL, ScriptBuffer>&& importedScripts);
 

--- a/Source/WebCore/workers/service/server/SWServer.h
+++ b/Source/WebCore/workers/service/server/SWServer.h
@@ -260,6 +260,7 @@ public:
     enum class ShouldSkipEvent : bool { No, Yes };
     void fireFunctionalEvent(SWServerRegistration&, CompletionHandler<void(Expected<SWServerToContextConnection*, ShouldSkipEvent>)>&&);
     void fireBackgroundFetchEvent(SWServerRegistration&, BackgroundFetchInformation&&);
+    void fireBackgroundFetchClickEvent(SWServerRegistration&, BackgroundFetchInformation&&);
 
     ScriptExecutionContextIdentifier clientIdFromVisibleClientId(const String& visibleIdentifier) const { return m_visibleClientIdToInternalClientIdMap.get(visibleIdentifier); }
 
@@ -279,10 +280,12 @@ public:
         String userAgent;
     };
     WEBCORE_EXPORT std::optional<GatheredClientData> gatherClientData(const ClientOrigin&, ScriptExecutionContextIdentifier);
+    WEBCORE_EXPORT void getAllOrigins(CompletionHandler<void(HashSet<ClientOrigin>&&)>&&);
 
     void requestBackgroundFetchPermission(const ClientOrigin& clientOrigin, CompletionHandler<void(bool)>&& callback) { m_delegate->requestBackgroundFetchPermission(clientOrigin, WTFMove(callback)); }
     std::unique_ptr<BackgroundFetchRecordLoader> createBackgroundFetchRecordLoader(BackgroundFetchRecordLoader::Client& client, const BackgroundFetchRequest& request, const WebCore::ClientOrigin& origin) { return m_delegate->createBackgroundFetchRecordLoader(client, request, origin); }
     Ref<BackgroundFetchStore> createBackgroundFetchStore() { return m_delegate->createBackgroundFetchStore(); }
+    WEBCORE_EXPORT BackgroundFetchEngine& backgroundFetchEngine();
 
 private:
     unsigned maxRegistrationCount();
@@ -316,8 +319,6 @@ private:
     void whenImportIsCompletedIfNeeded(CompletionHandler<void()>&&);
 
     ResourceRequest createScriptRequest(const URL&, const ServiceWorkerJobData&, SWServerRegistration&);
-
-    BackgroundFetchEngine& backgroundFetchEngine();
 
     WeakPtr<SWServerDelegate> m_delegate;
 

--- a/Source/WebCore/workers/service/server/SWServerDelegate.h
+++ b/Source/WebCore/workers/service/server/SWServerDelegate.h
@@ -36,6 +36,7 @@
 
 namespace WebCore {
 
+class BackgroundFetchEngine;
 class BackgroundFetchRecordLoader;
 class BackgroundFetchStore;
 class RegistrableDomain;

--- a/Source/WebCore/workers/service/server/SWServerToContextConnection.h
+++ b/Source/WebCore/workers/service/server/SWServerToContextConnection.h
@@ -72,6 +72,7 @@ public:
     virtual void firePushEvent(ServiceWorkerIdentifier, const std::optional<Vector<uint8_t>>&, CompletionHandler<void(bool)>&&) = 0;
     virtual void fireNotificationEvent(ServiceWorkerIdentifier, const NotificationData&, NotificationEventType, CompletionHandler<void(bool)>&&) = 0;
     virtual void fireBackgroundFetchEvent(ServiceWorkerIdentifier, const BackgroundFetchInformation&, CompletionHandler<void(bool)>&&) = 0;
+    virtual void fireBackgroundFetchClickEvent(ServiceWorkerIdentifier, const BackgroundFetchInformation&, CompletionHandler<void(bool)>&&) = 0;
     virtual ProcessIdentifier webProcessIdentifier() const = 0;
 
     // Messages back from the SW host process

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -2367,10 +2367,69 @@ void NetworkProcess::websiteDataOriginDirectoryForTesting(PAL::SessionID session
 #if ENABLE(SERVICE_WORKER)
 void NetworkProcess::processNotificationEvent(NotificationData&& data, NotificationEventType eventType, CompletionHandler<void(bool)>&& callback)
 {
-    if (auto* session = networkSession(data.sourceSession))
-        session->ensureSWServer().processNotificationEvent(WTFMove(data), eventType, WTFMove(callback));
+    auto* session = networkSession(data.sourceSession);
+    if (!session) {
+        callback(false);
+        return;
+    }
+
+    session->ensureSWServer().processNotificationEvent(WTFMove(data), eventType, WTFMove(callback));
 }
 
+void NetworkProcess::getAllBackgroundFetchIdentifiers(PAL::SessionID sessionID, CompletionHandler<void(Vector<String>&&)>&& callback)
+{
+    auto* session = networkSession(sessionID);
+    if (!session) {
+        callback({ });
+        return;
+    }
+
+    session->getAllBackgroundFetchIdentifiers(WTFMove(callback));
+}
+
+void NetworkProcess::abortBackgroundFetch(PAL::SessionID sessionID, const String& identifier, CompletionHandler<void()>&& callback)
+{
+    auto* session = networkSession(sessionID);
+    if (!session) {
+        callback();
+        return;
+    }
+
+    session->abortBackgroundFetch(identifier, WTFMove(callback));
+}
+
+void NetworkProcess::pauseBackgroundFetch(PAL::SessionID sessionID, const String& identifier, CompletionHandler<void()>&& callback)
+{
+    auto* session = networkSession(sessionID);
+    if (!session) {
+        callback();
+        return;
+    }
+
+    session->pauseBackgroundFetch(identifier, WTFMove(callback));
+}
+
+void NetworkProcess::resumeBackgroundFetch(PAL::SessionID sessionID, const String& identifier, CompletionHandler<void()>&& callback)
+{
+    auto* session = networkSession(sessionID);
+    if (!session) {
+        callback();
+        return;
+    }
+
+    session->resumeBackgroundFetch(identifier, WTFMove(callback));
+}
+
+void NetworkProcess::clickBackgroundFetch(PAL::SessionID sessionID, const String& identifier, CompletionHandler<void()>&& callback)
+{
+    auto* session = networkSession(sessionID);
+    if (!session) {
+        callback();
+        return;
+    }
+
+    session->clickBackgroundFetch(identifier, WTFMove(callback));
+}
 #if ENABLE(BUILT_IN_NOTIFICATIONS)
 
 void NetworkProcess::getPendingPushMessages(PAL::SessionID sessionID, CompletionHandler<void(const Vector<WebPushMessage>&)>&& callback)

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -384,6 +384,12 @@ public:
     void getPendingPushMessages(PAL::SessionID, CompletionHandler<void(const Vector<WebPushMessage>&)>&&);
     void processPushMessage(PAL::SessionID, WebPushMessage&&, WebCore::PushPermissionState, CompletionHandler<void(bool)>&&);
     void processNotificationEvent(WebCore::NotificationData&&, WebCore::NotificationEventType, CompletionHandler<void(bool)>&&);
+
+    void getAllBackgroundFetchIdentifiers(PAL::SessionID, CompletionHandler<void(Vector<String>&&)>&&);
+    void abortBackgroundFetch(PAL::SessionID, const String&, CompletionHandler<void()>&&);
+    void pauseBackgroundFetch(PAL::SessionID, const String&, CompletionHandler<void()>&&);
+    void resumeBackgroundFetch(PAL::SessionID, const String&, CompletionHandler<void()>&&);
+    void clickBackgroundFetch(PAL::SessionID, const String&, CompletionHandler<void()>&&);
 #endif
 
     void setPushAndNotificationsEnabledForOrigin(PAL::SessionID, const WebCore::SecurityOriginData&, bool, CompletionHandler<void()>&&);

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -220,6 +220,12 @@ messages -> NetworkProcess LegacyReceiver {
     GetPendingPushMessages(PAL::SessionID sessionID) -> (Vector<WebKit::WebPushMessage> messages)
     ProcessPushMessage(PAL::SessionID sessionID, struct WebKit::WebPushMessage pushMessage, enum:uint8_t WebCore::PushPermissionState pushPermissionState) -> (bool didSucceed)
     ProcessNotificationEvent(struct WebCore::NotificationData data, enum:bool WebCore::NotificationEventType eventType) -> (bool didSucceed)
+
+    GetAllBackgroundFetchIdentifiers(PAL::SessionID sessionID) -> (Vector<String> fetches);
+    AbortBackgroundFetch(PAL::SessionID sessionID, String identifier) -> ();
+    PauseBackgroundFetch(PAL::SessionID sessionID, String identifier) -> ();
+    ResumeBackgroundFetch(PAL::SessionID sessionID, String identifier) -> ();
+    ClickBackgroundFetch(PAL::SessionID sessionID, String identifier) -> ();
 #endif
     SetPushAndNotificationsEnabledForOrigin(PAL::SessionID sessionID, WebCore::SecurityOriginData origin, bool enabled) -> ()
     DeletePushAndNotificationRegistration(PAL::SessionID sessionID, WebCore::SecurityOriginData origin) -> (String errorMessage)

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -748,7 +748,39 @@ std::unique_ptr<BackgroundFetchRecordLoader> NetworkSession::createBackgroundFet
 
 Ref<BackgroundFetchStore> NetworkSession::createBackgroundFetchStore()
 {
-    return BackgroundFetchStoreImpl::create(m_storageManager.get());
+    return ensureBackgroundFetchStore();
+}
+
+BackgroundFetchStoreImpl& NetworkSession::ensureBackgroundFetchStore()
+{
+    if (!m_backgroundFetchStore)
+        m_backgroundFetchStore = BackgroundFetchStoreImpl::create(m_storageManager.get(), ensureSWServer());
+    return *m_backgroundFetchStore;
+}
+
+void NetworkSession::getAllBackgroundFetchIdentifiers(CompletionHandler<void(Vector<String>&&)>&& callback)
+{
+    ensureBackgroundFetchStore().getAllBackgroundFetchIdentifiers(WTFMove(callback));
+}
+
+void NetworkSession::abortBackgroundFetch(const String& identifier, CompletionHandler<void()>&& callback)
+{
+    ensureBackgroundFetchStore().abortBackgroundFetch(identifier, WTFMove(callback));
+}
+
+void NetworkSession::pauseBackgroundFetch(const String& identifier, CompletionHandler<void()>&& callback)
+{
+    ensureBackgroundFetchStore().pauseBackgroundFetch(identifier, WTFMove(callback));
+}
+
+void NetworkSession::resumeBackgroundFetch(const String& identifier, CompletionHandler<void()>&& callback)
+{
+    ensureBackgroundFetchStore().resumeBackgroundFetch(identifier, WTFMove(callback));
+}
+
+void NetworkSession::clickBackgroundFetch(const String& identifier, CompletionHandler<void()>&& callback)
+{
+    ensureBackgroundFetchStore().clickBackgroundFetch(identifier, WTFMove(callback));
 }
 #endif // ENABLE(SERVICE_WORKER)
 

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -71,7 +71,7 @@ enum class Critical : bool;
 }
 
 namespace WebKit {
-
+class BackgroundFetchStoreImpl;
 class NetworkBroadcastChannelRegistry;
 class NetworkDataTask;
 class NetworkLoadScheduler;
@@ -216,6 +216,12 @@ public:
     void unregisterSWServerConnection(WebSWServerConnection&);
 
     bool hasServiceWorkerDatabasePath() const;
+
+    void getAllBackgroundFetchIdentifiers(CompletionHandler<void(Vector<String>&&)>&&);
+    void abortBackgroundFetch(const String&, CompletionHandler<void()>&&);
+    void pauseBackgroundFetch(const String&, CompletionHandler<void()>&&);
+    void resumeBackgroundFetch(const String&, CompletionHandler<void()>&&);
+    void clickBackgroundFetch(const String&, CompletionHandler<void()>&&);
 #endif
 
     WebSharedWorkerServer* sharedWorkerServer() { return m_sharedWorkerServer.get(); }
@@ -276,6 +282,8 @@ protected:
     void requestBackgroundFetchPermission(const WebCore::ClientOrigin&, CompletionHandler<void(bool)>&&) final;
     std::unique_ptr<WebCore::BackgroundFetchRecordLoader> createBackgroundFetchRecordLoader(WebCore::BackgroundFetchRecordLoader::Client&, const WebCore::BackgroundFetchRequest&, const WebCore::ClientOrigin&) final;
     Ref<WebCore::BackgroundFetchStore> createBackgroundFetchStore() final;
+
+    BackgroundFetchStoreImpl& ensureBackgroundFetchStore();
 #endif // ENABLE(SERVICE_WORKER)
 
     PAL::SessionID m_sessionID;
@@ -340,6 +348,7 @@ protected:
     };
     std::optional<ServiceWorkerInfo> m_serviceWorkerInfo;
     std::unique_ptr<WebCore::SWServer> m_swServer;
+    RefPtr<BackgroundFetchStoreImpl> m_backgroundFetchStore;
 #endif
     std::unique_ptr<WebSharedWorkerServer> m_sharedWorkerServer;
 

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
@@ -101,6 +101,7 @@ private:
     void firePushEvent(WebCore::ServiceWorkerIdentifier, const std::optional<Vector<uint8_t>>&, CompletionHandler<void(bool)>&&) final;
     void fireNotificationEvent(WebCore::ServiceWorkerIdentifier, const WebCore::NotificationData&, WebCore::NotificationEventType, CompletionHandler<void(bool)>&&) final;
     void fireBackgroundFetchEvent(WebCore::ServiceWorkerIdentifier, const WebCore::BackgroundFetchInformation&, CompletionHandler<void(bool)>&&) final;
+    void fireBackgroundFetchClickEvent(WebCore::ServiceWorkerIdentifier, const WebCore::BackgroundFetchInformation&, CompletionHandler<void(bool)>&&) final;
     void close() final;
     void focus(WebCore::ScriptExecutionContextIdentifier, CompletionHandler<void(std::optional<WebCore::ServiceWorkerClientData>&&)>&&);
     void navigate(WebCore::ScriptExecutionContextIdentifier, WebCore::ServiceWorkerIdentifier, const URL&, CompletionHandler<void(Expected<std::optional<WebCore::ServiceWorkerClientData>, WebCore::ExceptionData>&&)>&&);

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -51,7 +51,6 @@ class SharedFileHandle;
 }
 
 namespace WebCore {
-class BackgroundFetchStore;
 class IDBCursorInfo;
 class IDBKeyData;
 class IDBIndexInfo;
@@ -113,7 +112,7 @@ public:
 
 #if ENABLE(SERVICE_WORKER)
     void dispatchTaskToBackgroundFetchManager(const WebCore::ClientOrigin&, Function<void(BackgroundFetchStoreManager*)>&&);
-#endif
+#endif // ENABLE(SERVICE_WORKER)
 
 private:
     NetworkStorageManager(PAL::SessionID, IPC::Connection::UniqueID, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, uint64_t defaultOriginQuota, uint64_t defaultThirdPartyOriginQuota, UnifiedOriginStorageLevel);
@@ -211,7 +210,7 @@ private:
     String m_path;
     FileSystem::Salt m_salt;
     bool m_closed { false };
-    HashMap<WebCore::ClientOrigin, std::unique_ptr<OriginStorageManager>> m_originStorageManagers;
+    HashMap<WebCore::ClientOrigin, std::unique_ptr<OriginStorageManager>> m_originStorageManagers WTF_GUARDED_BY_CAPABILITY(workQueue());
     ThreadSafeWeakHashSet<IPC::Connection> m_connections;
     std::unique_ptr<FileSystemStorageHandleRegistry> m_fileSystemStorageHandleRegistry;
     std::unique_ptr<StorageAreaRegistry> m_storageAreaRegistry;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -974,6 +974,78 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
 #endif
 }
 
+-(void)_getAllBackgroundFetchIdentifiers:(void(^)(NSArray<NSString *> *identifiers))completionHandler
+{
+#if ENABLE(SERVICE_WORKER)
+    _websiteDataStore->networkProcess().getAllBackgroundFetchIdentifiers(_websiteDataStore->sessionID(), [completionHandler = makeBlockPtr(completionHandler)] (auto identifiers) {
+        auto result = adoptNS([[NSMutableArray alloc] initWithCapacity:identifiers.size()]);
+        for (auto identifier : identifiers)
+            [result addObject:(NSString *)identifier];
+        completionHandler(result.autorelease());
+    });
+#else
+    completionHandler(nil);
+#endif
+}
+
+-(void)_abortBackgroundFetch:(NSString *) identifier completionHandler:(void(^)(void))completionHandler
+{
+    if (!completionHandler)
+        completionHandler = [] { };
+
+#if ENABLE(SERVICE_WORKER)
+    _websiteDataStore->networkProcess().abortBackgroundFetch(_websiteDataStore->sessionID(), identifier, [completionHandler = makeBlockPtr(completionHandler)] {
+        completionHandler();
+    });
+#else
+    completionHandler();
+#endif
+}
+-(void)_pauseBackgroundFetch:(NSString *) identifier completionHandler:(void(^)(void))completionHandler
+{
+    if (!completionHandler)
+        completionHandler = [] { };
+
+#if ENABLE(SERVICE_WORKER)
+    _websiteDataStore->networkProcess().pauseBackgroundFetch(_websiteDataStore->sessionID(), identifier, [completionHandler = makeBlockPtr(completionHandler)] {
+        completionHandler();
+    });
+#else
+    completionHandler();
+#endif
+}
+
+-(void)_resumeBackgroundFetch:(NSString *) identifier completionHandler:(void(^)(void))completionHandler
+{
+    if (!completionHandler)
+        completionHandler = [] { };
+
+#if ENABLE(SERVICE_WORKER)
+    _websiteDataStore->networkProcess().resumeBackgroundFetch(_websiteDataStore->sessionID(), identifier, [completionHandler = makeBlockPtr(completionHandler)] {
+        completionHandler();
+    });
+#else
+    completionHandler();
+#endif
+}
+
+-(void)_clickBackgroundFetch:(NSString *) identifier completionHandler:(void(^)(void))completionHandler
+{
+    if (!completionHandler)
+        completionHandler = [] { };
+
+#if ENABLE(SERVICE_WORKER)
+    if (!completionHandler)
+        completionHandler = [] { };
+
+    _websiteDataStore->networkProcess().clickBackgroundFetch(_websiteDataStore->sessionID(), identifier, [completionHandler = makeBlockPtr(completionHandler)] {
+        completionHandler();
+    });
+#else
+    completionHandler();
+#endif
+}
+
 -(void)_setServiceWorkerOverridePreferences:(WKPreferences *)preferences
 {
 #if ENABLE(SERVICE_WORKER)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h
@@ -124,6 +124,12 @@ typedef NS_OPTIONS(NSUInteger, _WKWebsiteDataStoreFetchOptions) {
 -(void)_originDirectoryForTesting:(NSURL *)origin topOrigin:(NSURL *)topOrigin type:(NSString *)dataType completionHandler:(void(^)(NSString *))completionHandler WK_API_AVAILABLE(macos(13.0), ios(16.0));
 -(void)_setBackupExclusionPeriodForTesting:(double)seconds completionHandler:(void(^)(void))completionHandler WK_API_AVAILABLE(macos(13.0), ios(16.0));
 
+-(void)_getAllBackgroundFetchIdentifiers:(void(^)(NSArray<NSString *> *identifiers))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+-(void)_abortBackgroundFetch:(NSString *)identifier completionHandler:(void(^_Nullable)(void))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+-(void)_pauseBackgroundFetch:(NSString *)identifier completionHandler:(void(^_Nullable)(void))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+-(void)_resumeBackgroundFetch:(NSString *)identifier completionHandler:(void(^_Nullable)(void))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+-(void)_clickBackgroundFetch:(NSString *)identifier completionHandler:(void(^_Nullable)(void))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+    
 @property (nonatomic, readonly) NSUUID *_identifier;
 @property (nonatomic, readonly) NSString *_webPushPartition;
 

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -1530,6 +1530,37 @@ void NetworkProcessProxy::requestBackgroundFetchPermission(PAL::SessionID sessio
 
     store->client().requestBackgroundFetchPermission(origin.topOrigin, origin.clientOrigin, WTFMove(callback));
 }
+
+void NetworkProcessProxy::getAllBackgroundFetchIdentifiers(PAL::SessionID sessionID, CompletionHandler<void(Vector<String>&&)>&& callback)
+{
+    if (!canSendMessage()) {
+        callback({ });
+        return;
+    }
+    
+    sendWithAsyncReply(Messages::NetworkProcess::GetAllBackgroundFetchIdentifiers { sessionID }, WTFMove(callback));
+}
+
+void NetworkProcessProxy::abortBackgroundFetch(PAL::SessionID sessionID, const String& identifier, CompletionHandler<void()>&& callback)
+{
+    sendWithAsyncReply(Messages::NetworkProcess::AbortBackgroundFetch { sessionID, identifier }, WTFMove(callback));
+}
+
+void NetworkProcessProxy::pauseBackgroundFetch(PAL::SessionID sessionID, const String& identifier, CompletionHandler<void()>&& callback)
+{
+    sendWithAsyncReply(Messages::NetworkProcess::PauseBackgroundFetch { sessionID, identifier }, WTFMove(callback));
+}
+
+void NetworkProcessProxy::resumeBackgroundFetch(PAL::SessionID sessionID, const String& identifier, CompletionHandler<void()>&& callback)
+{
+    sendWithAsyncReply(Messages::NetworkProcess::ResumeBackgroundFetch { sessionID, identifier }, WTFMove(callback));
+}
+
+void NetworkProcessProxy::clickBackgroundFetch(PAL::SessionID sessionID, const String& identifier, CompletionHandler<void()>&& callback)
+{
+    sendWithAsyncReply(Messages::NetworkProcess::ClickBackgroundFetch { sessionID, identifier }, WTFMove(callback));
+}
+
 #endif // ENABLE(SERVICE_WORKER)
 
 void NetworkProcessProxy::requestStorageSpace(PAL::SessionID sessionID, const WebCore::ClientOrigin& origin, uint64_t currentQuota, uint64_t currentSize, uint64_t spaceRequired, CompletionHandler<void(std::optional<uint64_t> quota)>&& completionHandler)

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -290,6 +290,12 @@ public:
     void getPendingPushMessages(PAL::SessionID, CompletionHandler<void(const Vector<WebPushMessage>&)>&&);
     void processPushMessage(PAL::SessionID, const WebPushMessage&, CompletionHandler<void(bool wasProcessed)>&&);
     void processNotificationEvent(const WebCore::NotificationData&, WebCore::NotificationEventType, CompletionHandler<void(bool wasProcessed)>&&);
+
+    void getAllBackgroundFetchIdentifiers(PAL::SessionID, CompletionHandler<void(Vector<String>&&)>&&);
+    void abortBackgroundFetch(PAL::SessionID, const String&, CompletionHandler<void()>&&);
+    void pauseBackgroundFetch(PAL::SessionID, const String&, CompletionHandler<void()>&&);
+    void resumeBackgroundFetch(PAL::SessionID, const String&, CompletionHandler<void()>&&);
+    void clickBackgroundFetch(PAL::SessionID, const String&, CompletionHandler<void()>&&);
 #endif
 
     void setPushAndNotificationsEnabledForOrigin(PAL::SessionID, const WebCore::SecurityOriginData&, bool, CompletionHandler<void()>&&);

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
@@ -317,7 +317,7 @@ void WebSWContextManagerConnection::fireNotificationEvent(ServiceWorkerIdentifie
             callback(result);
         });
     };
-    callOnMainRunLoop([identifier, data = WTFMove(data), eventType, callback = WTFMove(inQueueCallback)]() mutable {
+    callOnMainRunLoop([identifier, data = WTFMove(data).isolatedCopy(), eventType, callback = WTFMove(inQueueCallback)]() mutable {
         SWContextManager::singleton().fireNotificationEvent(identifier, WTFMove(data), eventType, WTFMove(callback));
     });
 }
@@ -331,8 +331,22 @@ void WebSWContextManagerConnection::fireBackgroundFetchEvent(ServiceWorkerIdenti
             callback(result);
         });
     };
-    callOnMainRunLoop([identifier, info = WTFMove(info), callback = WTFMove(inQueueCallback)]() mutable {
+    callOnMainRunLoop([identifier, info = WTFMove(info).isolatedCopy(), callback = WTFMove(inQueueCallback)]() mutable {
         SWContextManager::singleton().fireBackgroundFetchEvent(identifier, WTFMove(info), WTFMove(callback));
+    });
+}
+
+void WebSWContextManagerConnection::fireBackgroundFetchClickEvent(ServiceWorkerIdentifier identifier, BackgroundFetchInformation&& info, CompletionHandler<void(bool)>&& callback)
+{
+    assertIsCurrent(m_queue.get());
+
+    auto inQueueCallback = [queue = m_queue, callback = WTFMove(callback)](bool result) mutable {
+        queue->dispatch([result, callback = WTFMove(callback)]() mutable {
+            callback(result);
+        });
+    };
+    callOnMainRunLoop([identifier, info = WTFMove(info).isolatedCopy(), callback = WTFMove(inQueueCallback)]() mutable {
+        SWContextManager::singleton().fireBackgroundFetchClickEvent(identifier, WTFMove(info), WTFMove(callback));
     });
 }
 

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.h
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.h
@@ -110,6 +110,7 @@ private:
     void firePushEvent(WebCore::ServiceWorkerIdentifier, const std::optional<IPC::DataReference>&, CompletionHandler<void(bool)>&&);
     void fireNotificationEvent(WebCore::ServiceWorkerIdentifier, WebCore::NotificationData&&, WebCore::NotificationEventType, CompletionHandler<void(bool)>&&);
     void fireBackgroundFetchEvent(WebCore::ServiceWorkerIdentifier, WebCore::BackgroundFetchInformation&&, CompletionHandler<void(bool)>&&);
+    void fireBackgroundFetchClickEvent(WebCore::ServiceWorkerIdentifier, WebCore::BackgroundFetchInformation&&, CompletionHandler<void(bool)>&&);
     void terminateWorker(WebCore::ServiceWorkerIdentifier);
 #if ENABLE(SHAREABLE_RESOURCE) && PLATFORM(COCOA)
     void didSaveScriptsToDisk(WebCore::ServiceWorkerIdentifier, WebCore::ScriptBuffer&&, HashMap<URL, WebCore::ScriptBuffer>&& importedScripts);

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.messages.in
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.messages.in
@@ -34,6 +34,7 @@ messages -> WebSWContextManagerConnection {
     FirePushEvent(WebCore::ServiceWorkerIdentifier identifier, std::optional<IPC::DataReference> data) -> (bool result)
     FireNotificationEvent(WebCore::ServiceWorkerIdentifier identifier, struct WebCore::NotificationData data, enum:bool WebCore::NotificationEventType type) -> (bool result)
     FireBackgroundFetchEvent(WebCore::ServiceWorkerIdentifier identifier, struct WebCore::BackgroundFetchInformation info) -> (bool result)
+    FireBackgroundFetchClickEvent(WebCore::ServiceWorkerIdentifier identifier, struct WebCore::BackgroundFetchInformation info) -> (bool result)
 
     TerminateWorker(WebCore::ServiceWorkerIdentifier identifier)
 #if ENABLE(SHAREABLE_RESOURCE) && PLATFORM(COCOA)

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -214,6 +214,13 @@ interface TestRunner {
     undefined simulateWebNotificationClick(object notification);
     undefined simulateWebNotificationClickForServiceWorkerNotifications();
 
+    // Background fech support
+    DOMString getBackgroundFetchIdentifier();
+    undefined abortBackgroundFetch(DOMString identifier);
+    undefined pauseBackgroundFetch(DOMString identifier);
+    undefined resumeBackgroundFetch(DOMString identifier);
+    undefined simulateClickBackgroundFetch(DOMString identifier);
+
     // Geolocation
     undefined setGeolocationPermission(boolean value);
     undefined setMockGeolocationPosition(double latitude, double longitude, double accuracy, optional double? altitude, optional double? altitudeAccuracy, optional double? heading, optional double? speed, optional double? floorLevel);

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
@@ -748,6 +748,13 @@ bool InjectedBundle::isGeolocationProviderActive() const
     return booleanValue(adoptWK(result).get());
 }
 
+WKRetainPtr<WKStringRef> InjectedBundle::getBackgroundFetchIdentifier()
+{
+    WKTypeRef result = nullptr;
+    WKBundlePagePostSynchronousMessageForTesting(page()->page(), toWK("GetBackgroundFetchIdentifier").get(), 0, &result);
+    return static_cast<WKStringRef>(result);
+}
+
 unsigned InjectedBundle::imageCountInGeneralPasteboard() const
 {
     WKTypeRef result = nullptr;

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
@@ -156,6 +156,8 @@ public:
     void clearResourceLoadStatistics();
     void reloadFromOrigin();
 
+    WKRetainPtr<WKStringRef> getBackgroundFetchIdentifier();
+
 private:
     InjectedBundle() = default;
     ~InjectedBundle();

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -51,6 +51,7 @@
 #include <WebKit/WKPagePrivate.h>
 #include <WebKit/WKRetainPtr.h>
 #include <WebKit/WKSerializedScriptValue.h>
+#include <WebKit/WKStringPrivate.h>
 #include <WebKit/WebKit2_C.h>
 #include <wtf/HashMap.h>
 #include <wtf/StdLibExtras.h>
@@ -916,6 +917,32 @@ void TestRunner::simulateWebNotificationClick(JSValueRef notification)
 void TestRunner::simulateWebNotificationClickForServiceWorkerNotifications()
 {
     InjectedBundle::singleton().postSimulateWebNotificationClickForServiceWorkerNotifications();
+}
+
+JSRetainPtr<JSStringRef> TestRunner::getBackgroundFetchIdentifier()
+{
+    auto identifier = InjectedBundle::singleton().getBackgroundFetchIdentifier();
+    return WKStringCopyJSString(identifier.get());
+}
+
+void TestRunner::abortBackgroundFetch(JSStringRef identifier)
+{
+    postSynchronousPageMessageWithReturnValue("AbortBackgroundFetch", toWK(identifier));
+}
+
+void TestRunner::pauseBackgroundFetch(JSStringRef identifier)
+{
+    postSynchronousPageMessageWithReturnValue("PauseBackgroundFetch", toWK(identifier));
+}
+
+void TestRunner::resumeBackgroundFetch(JSStringRef identifier)
+{
+    postSynchronousPageMessageWithReturnValue("ResumeBackgroundFetch", toWK(identifier));
+}
+
+void TestRunner::simulateClickBackgroundFetch(JSStringRef identifier)
+{
+    postSynchronousPageMessageWithReturnValue("SimulateClickBackgroundFetch", toWK(identifier));
 }
 
 void TestRunner::setGeolocationPermission(bool enabled)

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -298,6 +298,12 @@ public:
     static void simulateWebNotificationClick(JSValueRef notification);
     static void simulateWebNotificationClickForServiceWorkerNotifications();
 
+    JSRetainPtr<JSStringRef> getBackgroundFetchIdentifier();
+    void abortBackgroundFetch(JSStringRef);
+    void pauseBackgroundFetch(JSStringRef);
+    void resumeBackgroundFetch(JSStringRef);
+    void simulateClickBackgroundFetch(JSStringRef);
+
     // Geolocation.
     void setGeolocationPermission(bool);
     void setMockGeolocationPosition(double latitude, double longitude, double accuracy, std::optional<double> altitude, std::optional<double> altitudeAccuracy, std::optional<double> heading, std::optional<double> speed, std::optional<double> floorLevel);

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -842,6 +842,29 @@ bool TestController::denyNotificationPermissionOnPrompt(WKStringRef originString
     return true;
 }
 
+#if !PLATFORM(COCOA)
+WKRetainPtr<WKStringRef> TestController::getBackgroundFetchIdentifier()
+{
+    return { };
+}
+
+void TestController::abortBackgroundFetch(WKStringRef)
+{
+}
+
+void TestController::pauseBackgroundFetch(WKStringRef)
+{
+}
+
+void TestController::resumeBackgroundFetch(WKStringRef)
+{
+}
+
+void TestController::simulateClickBackgroundFetch(WKStringRef)
+{
+}
+#endif
+
 void TestController::createWebViewWithOptions(const TestOptions& options)
 {
     auto applicationBundleIdentifier = options.applicationBundleIdentifier();

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -407,6 +407,12 @@ public:
     void unlockScreenOrientation();
 #endif
 
+    WKRetainPtr<WKStringRef> getBackgroundFetchIdentifier();
+    void abortBackgroundFetch(WKStringRef);
+    void pauseBackgroundFetch(WKStringRef);
+    void resumeBackgroundFetch(WKStringRef);
+    void simulateClickBackgroundFetch(WKStringRef);
+
 private:
     WKRetainPtr<WKPageConfigurationRef> generatePageConfiguration(const TestOptions&);
     WKRetainPtr<WKContextConfigurationRef> generateContextConfiguration(const TestOptions&) const;

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -1086,6 +1086,29 @@ WKRetainPtr<WKTypeRef> TestInvocation::didReceiveSynchronousMessageFromInjectedB
     if (WKStringIsEqualToUTF8CString(messageName, "DenyNotificationPermissionOnPrompt"))
         return adoptWK(WKBooleanCreate(TestController::singleton().denyNotificationPermissionOnPrompt(stringValue(messageBody))));
 
+    if (WKStringIsEqualToUTF8CString(messageName, "GetBackgroundFetchIdentifier"))
+        return TestController::singleton().getBackgroundFetchIdentifier();
+
+    if (WKStringIsEqualToUTF8CString(messageName, "AbortBackgroundFetch")) {
+        TestController::singleton().abortBackgroundFetch(stringValue(messageBody));
+        return nullptr;
+    }
+
+    if (WKStringIsEqualToUTF8CString(messageName, "PauseBackgroundFetch")) {
+        TestController::singleton().pauseBackgroundFetch(stringValue(messageBody));
+        return nullptr;
+    }
+
+    if (WKStringIsEqualToUTF8CString(messageName, "ResumeBackgroundFetch")) {
+        TestController::singleton().resumeBackgroundFetch(stringValue(messageBody));
+        return nullptr;
+    }
+
+    if (WKStringIsEqualToUTF8CString(messageName, "SimulateClickBackgroundFetch")) {
+        TestController::singleton().simulateClickBackgroundFetch(stringValue(messageBody));
+        return nullptr;
+    }
+
     if (WKStringIsEqualToUTF8CString(messageName, "IsDoingMediaCapture"))
         return adoptWK(WKBooleanCreate(TestController::singleton().isDoingMediaCapture()));
     

--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -580,4 +580,54 @@ WKRetainPtr<WKStringRef> TestController::takeViewPortSnapshot()
     return adoptWK(WKImageCreateDataURLFromImage(mainWebView()->windowSnapshotImage().get()));
 }
 
+WKRetainPtr<WKStringRef> TestController::getBackgroundFetchIdentifier()
+{
+    __block String result;
+    __block bool isDone = false;
+    [globalWebViewConfiguration().get().websiteDataStore _getAllBackgroundFetchIdentifiers:^(NSArray<NSString *> *identifiers) {
+        if ([identifiers count])
+            result = identifiers[0];
+        isDone = true;
+    }];
+    platformRunUntil(isDone, noTimeout);
+
+    return adoptWK(WKStringCreateWithUTF8CString(result.utf8().data()));
+}
+
+void TestController::abortBackgroundFetch(WKStringRef identifier)
+{
+    __block bool isDone = false;
+    [globalWebViewConfiguration().get().websiteDataStore _abortBackgroundFetch:toWTFString(identifier) completionHandler:^() {
+        isDone = true;
+    }];
+    platformRunUntil(isDone, noTimeout);
+}
+
+void TestController::pauseBackgroundFetch(WKStringRef identifier)
+{
+    __block bool isDone = false;
+    [globalWebViewConfiguration().get().websiteDataStore _pauseBackgroundFetch:toWTFString(identifier) completionHandler:^() {
+        isDone = true;
+    }];
+    platformRunUntil(isDone, noTimeout);
+}
+
+void TestController::resumeBackgroundFetch(WKStringRef identifier)
+{
+    __block bool isDone = false;
+    [globalWebViewConfiguration().get().websiteDataStore _resumeBackgroundFetch:toWTFString(identifier) completionHandler:^() {
+        isDone = true;
+    }];
+    platformRunUntil(isDone, noTimeout);
+}
+
+void TestController::simulateClickBackgroundFetch(WKStringRef identifier)
+{
+    __block bool isDone = false;
+    [globalWebViewConfiguration().get().websiteDataStore _clickBackgroundFetch:toWTFString(identifier) completionHandler:^() {
+        isDone = true;
+    }];
+    platformRunUntil(isDone, noTimeout);
+}
+
 } // namespace WTR


### PR DESCRIPTION
#### 4a7cad9d3d392a6dd9784db1f009c7472ee01aca
<pre>
Add API to trigger background fetch click event
<a href="https://bugs.webkit.org/show_bug.cgi?id=253072">https://bugs.webkit.org/show_bug.cgi?id=253072</a>
rdar://problem/106026054

Reviewed by Sihui Liu.

Expose new WebsiteDataStore API to get a list of background fetch identifiers, click, abort, pause and resume them.
Each call sends IPC to network process to do the actual work.
The work is done through BackgroundFetchStoreImpl that will identify the background fetch registration from the background fetch identifier.
The background fetch identifier is the filename of the persisted background fetch.
Once identified, we send the order to the BackgroundFetchEngine.
This patch only implements abort and click in BackgroundFetchEngine.

We add testRunner API to trigger click, abort, resume and suspend actions.

* LayoutTests/http/wpt/background-fetch/background-fetch-abort.window-expected.txt: Added.
* LayoutTests/http/wpt/background-fetch/background-fetch-abort.window.html: Added.
* LayoutTests/http/wpt/background-fetch/background-fetch-abort.window.js: Added.
(promise_test.async t):
* LayoutTests/http/wpt/background-fetch/background-fetch-click.window-expected.txt: Added.
* LayoutTests/http/wpt/background-fetch/background-fetch-click.window.html: Added.
* LayoutTests/http/wpt/background-fetch/background-fetch-click.window.js: Added.
(promise_test.async t):
* LayoutTests/http/wpt/background-fetch/sw.js:
(onmessage):
(onbackgroundfetchclick):
(onbackgroundfetchabort):
* Source/WebCore/workers/service/background-fetch/BackgroundFetchEngine.cpp:
(WebCore::BackgroundFetchEngine::startBackgroundFetch):
(WebCore::BackgroundFetchEngine::backgroundFetchInformation):
(WebCore::BackgroundFetchEngine::backgroundFetchIdentifiers):
(WebCore::BackgroundFetchEngine::abortBackgroundFetch):
(WebCore::BackgroundFetchEngine::matchBackgroundFetch):
(WebCore::BackgroundFetchEngine::pauseBackgroundFetch):
(WebCore::BackgroundFetchEngine::resumeBackgroundFetch):
(WebCore::BackgroundFetchEngine::clickBackgroundFetch):
* Source/WebCore/workers/service/background-fetch/BackgroundFetchEngine.h:
* Source/WebCore/workers/service/background-fetch/BackgroundFetchStore.h:
* Source/WebCore/workers/service/context/SWContextManager.cpp:
(WebCore::SWContextManager::fireBackgroundFetchClickEvent):
* Source/WebCore/workers/service/context/SWContextManager.h:
* Source/WebCore/workers/service/context/ServiceWorkerThread.cpp:
(WebCore::ServiceWorkerThread::queueTaskToFireBackgroundFetchClickEvent):
* Source/WebCore/workers/service/context/ServiceWorkerThread.h:
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp:
(WebCore::ServiceWorkerThreadProxy::fireBackgroundFetchClickEvent):
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h:
* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::fireBackgroundFetchEvent):
(WebCore::SWServer::fireBackgroundFetchClickEvent):
* Source/WebCore/workers/service/server/SWServer.h:
* Source/WebCore/workers/service/server/SWServerDelegate.h:
* Source/WebCore/workers/service/server/SWServerToContextConnection.h:
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::allBackgroundFetches):
(WebKit::NetworkProcess::abortBackgroundFetch):
(WebKit::NetworkProcess::pauseBackgroundFetch):
(WebKit::NetworkProcess::resumeBackgroundFetch):
(WebKit::NetworkProcess::clickBackgroundFetch):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::NetworkSession::createBackgroundFetchStore):
(WebKit::NetworkSession::ensureBackgroundFetchStore):
(WebKit::NetworkSession::allBackgroundFetches):
(WebKit::NetworkSession::abortBackgroundFetch):
(WebKit::NetworkSession::pauseBackgroundFetch):
(WebKit::NetworkSession::resumeBackgroundFetch):
(WebKit::NetworkSession::clickBackgroundFetch):
* Source/WebKit/NetworkProcess/NetworkSession.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp:
(WebKit::WebSWServerToContextConnection::fireBackgroundFetchClickEvent):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h:
* Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.cpp:
(WebKit::BackgroundFetchStoreImpl::BackgroundFetchStoreImpl):
(WebKit::BackgroundFetchStoreImpl::registerFetch):
(WebKit::BackgroundFetchStoreImpl::initializeFetches):
(WebKit::BackgroundFetchStoreImpl::storeFetch):
(WebKit::BackgroundFetchStoreImpl::fetchInformationFromFilename):
(WebKit::BackgroundFetchStoreImpl::loadAllFetches):
(WebKit::BackgroundFetchStoreImpl::allBackgroundFetches):
(WebKit::BackgroundFetchStoreImpl::abortBackgroundFetch):
(WebKit::BackgroundFetchStoreImpl::pauseBackgroundFetch):
(WebKit::BackgroundFetchStoreImpl::resumeBackgroundFetch):
(WebKit::BackgroundFetchStoreImpl::clickBackgroundFetch):
* Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.h:
(WebKit::BackgroundFetchStoreImpl::create):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::close):
(WebKit::NetworkStorageManager::writeOriginToFileIfNecessary):
(WebKit::NetworkStorageManager::originStorageManager):
(WebKit::NetworkStorageManager::removeOriginStorageManagerIfPossible):
(WebKit::NetworkStorageManager::persisted):
(WebKit::NetworkStorageManager::persist):
(WebKit::NetworkStorageManager::estimate):
(WebKit::NetworkStorageManager::resetStoragePersistedState):
(WebKit::NetworkStorageManager::clearStorageForWebPage):
(WebKit::NetworkStorageManager::cloneSessionStorageForWebPage):
(WebKit::NetworkStorageManager::didIncreaseQuota):
(WebKit::NetworkStorageManager::getAllOrigins):
(WebKit::NetworkStorageManager::suspend):
(WebKit::NetworkStorageManager::handleLowMemoryWarning):
(WebKit::NetworkStorageManager::syncLocalStorage):
(WebKit::NetworkStorageManager::resetQuotaForTesting):
(WebKit::NetworkStorageManager::resetQuotaUpdatedBasedOnUsageForTesting):
(WebKit::NetworkStorageManager::cancelConnectToStorageArea):
(WebKit::NetworkStorageManager::cloneSessionStorageNamespace):
(WebKit::NetworkStorageManager::cacheStorageClearMemoryRepresentation):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(-[WKWebsiteDataStore _getAllBackgroundFetches:]):
(-[WKWebsiteDataStore _abortBackgroundFetch:]):
(-[WKWebsiteDataStore _pauseBackgroundFetch:]):
(-[WKWebsiteDataStore _resumeBackgroundFetch:]):
(-[WKWebsiteDataStore _clickBackgroundFetch:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::allBackgroundFetches):
(WebKit::NetworkProcessProxy::abortBackgroundFetch):
(WebKit::NetworkProcessProxy::pauseBackgroundFetch):
(WebKit::NetworkProcessProxy::resumeBackgroundFetch):
(WebKit::NetworkProcessProxy::clickBackgroundFetch):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp:
(WebKit::WebSWContextManagerConnection::fireBackgroundFetchClickEvent):
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.h:
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.messages.in:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp:
(WTR::InjectedBundle::getBackgroundFetchIdentifier):
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::getBackgroundFetchIdentifier):
(WTR::TestRunner::abortBackgroundFetch):
(WTR::TestRunner::pauseBackgroundFetch):
(WTR::TestRunner::resumeBackgroundFetch):
(WTR::TestRunner::simulateClickBackgroundFetch):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::getBackgroundFetchIdentifier):
(WTR::TestController::abortBackgroundFetch):
(WTR::TestController::pauseBackgroundFetch):
(WTR::TestController::resumeBackgroundFetch):
(WTR::TestController::simulateClickBackgroundFetch):
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveSynchronousMessageFromInjectedBundle):
* Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm:
(WTR::TestController::getBackgroundFetchIdentifier):
(WTR::TestController::abortBackgroundFetch):
(WTR::TestController::pauseBackgroundFetch):
(WTR::TestController::resumeBackgroundFetch):
(WTR::TestController::simulateClickBackgroundFetch):

Canonical link: <a href="https://commits.webkit.org/261136@main">https://commits.webkit.org/261136@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f43c5b82afbec5684324a9dbfcb597cecfea3b6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110698 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19780 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43260 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/2054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119535 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114665 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21188 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10892 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/1557 "layout-tests (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116440 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103021 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30623 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/44131 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/12409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/31961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/86016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12962 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18336 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51579 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7717 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14899 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->