### PR TITLE
[GTK][WPE] Remote Web Inspector: the remote inspector(HTTP) does not work from any browsers

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Base/BrowserInspectorFrontendHost.js
+++ b/Source/WebInspectorUI/UserInterface/Base/BrowserInspectorFrontendHost.js
@@ -362,6 +362,11 @@ if (!window.InspectorFrontendHost) {
             throw "unimplemented";
         }
 
+        engineeringSettingsAllowed()
+        {
+            return false;
+        }
+
         // Private
 
         _sendPendingMessagesToBackendIfNeeded()


### PR DESCRIPTION
#### 1506a7bfdb721ad5ca48de068e40439273ac3ff0
<pre>
[GTK][WPE] Remote Web Inspector: the remote inspector(HTTP) does not work from any browsers
<a href="https://bugs.webkit.org/show_bug.cgi?id=253145">https://bugs.webkit.org/show_bug.cgi?id=253145</a>

Reviewed by Carlos Garcia Campos.

Add missing function: engineeringSettingsAllowed to BrowserInspectorFrontendHost.

It solves a regression from: <a href="https://github.com/WebKit/WebKit/commit/2326b1146886546de0d44f6aa85415b2e1257b8a">https://github.com/WebKit/WebKit/commit/2326b1146886546de0d44f6aa85415b2e1257b8a</a>

* Source/WebInspectorUI/UserInterface/Base/BrowserInspectorFrontendHost.js:
(window.InspectorFrontendHost.WI.BrowserInspectorFrontendHost.prototype.engineeringSettingsAllowed):

Canonical link: <a href="https://commits.webkit.org/261056@main">https://commits.webkit.org/261056@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8607a137c6bb606f05ccce72597ab0fec2b0d411

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110218 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19315 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42876 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1637 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119208 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20776 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10506 "Built successfully") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102476 "Reverted pull request changes (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115963 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15467 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98674 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/102476 "Reverted pull request changes (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97428 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30338 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/102476 "Reverted pull request changes (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12005 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31675 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12617 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8639 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17983 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51292 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7656 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14426 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->