### PR TITLE
ImageBufferIOSurfaceBackend should get and put data in WP when in mapped mode

### DIFF
--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -167,7 +167,7 @@ public:
     WEBCORE_EXPORT static std::unique_ptr<SerializedImageBuffer> sinkIntoSerializedImageBuffer(RefPtr<ImageBuffer>&&);
 
     WEBCORE_EXPORT virtual RefPtr<NativeImage> copyNativeImage(BackingStoreCopy = CopyBackingStore) const;
-    WEBCORE_EXPORT virtual RefPtr<NativeImage> copyNativeImageForDrawing(BackingStoreCopy = CopyBackingStore) const;
+    WEBCORE_EXPORT virtual RefPtr<NativeImage> copyNativeImageForDrawing(GraphicsContext& destination) const;
     WEBCORE_EXPORT virtual RefPtr<NativeImage> sinkIntoNativeImage();
     WEBCORE_EXPORT RefPtr<Image> copyImage(BackingStoreCopy = CopyBackingStore, PreserveResolution = PreserveResolution::No) const;
     WEBCORE_EXPORT virtual RefPtr<Image> filteredImage(Filter&);

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.cpp
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.cpp
@@ -55,9 +55,9 @@ ImageBufferBackend::ImageBufferBackend(const Parameters& parameters)
 
 ImageBufferBackend::~ImageBufferBackend() = default;
 
-RefPtr<NativeImage> ImageBufferBackend::copyNativeImageForDrawing(BackingStoreCopy copyBehavior)
+RefPtr<NativeImage> ImageBufferBackend::copyNativeImageForDrawing(GraphicsContext&)
 {
-    return copyNativeImage(copyBehavior);
+    return copyNativeImage(DontCopyBackingStore);
 }
 
 RefPtr<NativeImage> ImageBufferBackend::sinkIntoNativeImage()

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.h
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.h
@@ -114,7 +114,7 @@ public:
     virtual void finalizeDrawIntoContext(GraphicsContext&) { }
     virtual RefPtr<NativeImage> copyNativeImage(BackingStoreCopy) = 0;
 
-    WEBCORE_EXPORT virtual RefPtr<NativeImage> copyNativeImageForDrawing(BackingStoreCopy copyBehavior);
+    WEBCORE_EXPORT virtual RefPtr<NativeImage> copyNativeImageForDrawing(GraphicsContext& destination);
     WEBCORE_EXPORT virtual RefPtr<NativeImage> sinkIntoNativeImage();
 
     virtual void clipToMask(GraphicsContext&, const FloatRect&) { }

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
@@ -146,14 +146,8 @@ void ImageBufferIOSurfaceBackend::invalidateCachedNativeImage()
     // current state of the IOSurface.
     // See https://webkit.org/b/157966 and https://webkit.org/b/228682 for more context.
     context().fillRect({ });
-    m_mayHaveOutstandingBackingStoreReferences = false;
 }
 
-void ImageBufferIOSurfaceBackend::invalidateCachedNativeImageIfNeeded()
-{
-    if (m_mayHaveOutstandingBackingStoreReferences)
-        invalidateCachedNativeImage();
-}
 
 RefPtr<NativeImage> ImageBufferIOSurfaceBackend::copyNativeImage(BackingStoreCopy)
 {
@@ -161,9 +155,18 @@ RefPtr<NativeImage> ImageBufferIOSurfaceBackend::copyNativeImage(BackingStoreCop
     return NativeImage::create(m_surface->createImage());
 }
 
-RefPtr<NativeImage> ImageBufferIOSurfaceBackend::copyNativeImageForDrawing(BackingStoreCopy)
+RefPtr<NativeImage> ImageBufferIOSurfaceBackend::copyNativeImageForDrawing(GraphicsContext& destination)
 {
-    return NativeImage::create(m_surface->createImage());
+    if (destination.hasPlatformContext() && CGContextGetType(destination.platformContext()) == kCGContextTypeBitmap) {
+        // The destination backend is not deferred, so we can return a reference.
+        // The destination backend needs to read the actual pixels. Returning non-refence will
+        // copy the pixels and but still cache the image to the context. This means we must
+        // return the reference or cleanup later if we return the non-reference.
+        return NativeImage::create(adoptCF(CGIOSurfaceContextCreateImageReference(m_surface->ensurePlatformContext())));
+    }
+    // Other backends are deferred (iosurface, display list) or potentially deferred. Must copy for drawing.
+    return ImageBufferIOSurfaceBackend::copyNativeImage(CopyBackingStore);
+
 }
 
 RefPtr<NativeImage> ImageBufferIOSurfaceBackend::sinkIntoNativeImage()
@@ -171,28 +174,23 @@ RefPtr<NativeImage> ImageBufferIOSurfaceBackend::sinkIntoNativeImage()
     return NativeImage::create(IOSurface::sinkIntoImage(WTFMove(m_surface)));
 }
 
-void ImageBufferIOSurfaceBackend::finalizeDrawIntoContext(GraphicsContext& destinationContext)
-{
-    if (destinationContext.needsCachedNativeImageInvalidationWorkaround(ImageBufferIOSurfaceBackend::renderingMode))
-        invalidateCachedNativeImage();
-}
-
 RefPtr<PixelBuffer> ImageBufferIOSurfaceBackend::getPixelBuffer(const PixelBufferFormat& outputFormat, const IntRect& srcRect, const ImageBufferAllocator& allocator)
 {
+    const_cast<ImageBufferIOSurfaceBackend*>(this)->prepareForExternalRead();
     IOSurface::Locker lock(*m_surface);
     return ImageBufferBackend::getPixelBuffer(outputFormat, srcRect, lock.surfaceBaseAddress(), allocator);
 }
 
 void ImageBufferIOSurfaceBackend::putPixelBuffer(const PixelBuffer& pixelBuffer, const IntRect& srcRect, const IntPoint& destPoint, AlphaPremultiplication destFormat)
 {
-    invalidateCachedNativeImageIfNeeded();
+    prepareForExternalWrite();
     IOSurface::Locker lock(*m_surface, IOSurface::Locker::AccessMode::ReadWrite);
     ImageBufferBackend::putPixelBuffer(pixelBuffer, srcRect, destPoint, destFormat, lock.surfaceBaseAddress());
 }
 
 IOSurface* ImageBufferIOSurfaceBackend::surface()
 {
-    flushContext();
+    prepareForExternalWrite(); // This is conservative. At the time of writing this is not used.
     return m_surface.get();
 }
 
@@ -235,9 +233,33 @@ void ImageBufferIOSurfaceBackend::setVolatilityState(VolatilityState volatilityS
 
 void ImageBufferIOSurfaceBackend::ensureNativeImagesHaveCopiedBackingStore()
 {
+    // FIXME: This will be removed. This was needed when putImageData was not properly accounting
+    // for outstanding reads.
     if (!m_mayHaveOutstandingBackingStoreReferences)
         return;
-    invalidateCachedNativeImage();
+    prepareForExternalWrite();
+}
+
+void ImageBufferIOSurfaceBackend::prepareForExternalRead()
+{
+    // Ensure that there are no pending draws to this surface. This is ensured by flushing the context
+    // through which the draws may have come.
+    flushContext();
+}
+
+void ImageBufferIOSurfaceBackend::prepareForExternalWrite()
+{
+    // Ensure that there are no future draws from the surface that would use the surface context image cache.
+    if (m_mayHaveOutstandingBackingStoreReferences) {
+        invalidateCachedNativeImage();
+        m_mayHaveOutstandingBackingStoreReferences = false;
+    }
+
+    // Ensure that there are no pending draws to this surface. This is ensured by flushing the context
+    // through which the draws may have come.
+    // Ensure that there are no pending draws from this surface. This is ensured by drawing the invalidation marker before
+    // flushing the the context. The invalidation marker forces the draws from this surface to complete before
+    // the invalidation marker completes.
     flushContext();
 }
 

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h
@@ -59,7 +59,7 @@ protected:
     IntSize backendSize() const override;
     
     RefPtr<NativeImage> copyNativeImage(BackingStoreCopy = CopyBackingStore) override;
-    RefPtr<NativeImage> copyNativeImageForDrawing(BackingStoreCopy = CopyBackingStore) override;
+    RefPtr<NativeImage> copyNativeImageForDrawing(GraphicsContext&) override;
     RefPtr<NativeImage> sinkIntoNativeImage() override;
 
     RefPtr<PixelBuffer> getPixelBuffer(const PixelBufferFormat& outputFormat, const IntRect&, const ImageBufferAllocator&) override;
@@ -79,9 +79,9 @@ protected:
 
     unsigned bytesPerRow() const override;
 
-    void finalizeDrawIntoContext(GraphicsContext& destinationContext) override;
     void invalidateCachedNativeImage();
-    void invalidateCachedNativeImageIfNeeded();
+    void prepareForExternalRead();
+    void prepareForExternalWrite();
 
     std::unique_ptr<IOSurface> m_surface;
     bool m_mayHaveOutstandingBackingStoreReferences { false };

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
@@ -79,7 +79,7 @@ private:
     void waitForDidFlushWithTimeout();
 
     RefPtr<WebCore::NativeImage> copyNativeImage(WebCore::BackingStoreCopy = WebCore::CopyBackingStore) const final;
-    RefPtr<WebCore::NativeImage> copyNativeImageForDrawing(WebCore::BackingStoreCopy = WebCore::CopyBackingStore) const final;
+    RefPtr<WebCore::NativeImage> copyNativeImageForDrawing(WebCore::GraphicsContext&) const final;
     RefPtr<WebCore::NativeImage> sinkIntoNativeImage() final;
 
     RefPtr<ImageBuffer> sinkIntoBufferForDifferentThread() final;
@@ -112,7 +112,9 @@ private:
     Ref<RemoteImageBufferProxyFlushState> m_flushState;
     WeakPtr<RemoteRenderingBackendProxy> m_remoteRenderingBackendProxy;
     RemoteDisplayListRecorderProxy m_remoteDisplayList;
-    bool m_needsFlush { false };
+    // First command might be putPixelBuffer. With canMapBackingStore() == true, it needs to flush
+    // the surface initialization.
+    bool m_needsFlush { true };
 };
 
 class RemoteImageBufferProxyFlushState : public ThreadSafeRefCounted<RemoteImageBufferProxyFlushState> {


### PR DESCRIPTION
#### 812ce301dec978351734e9cd4f2b43a399599747
<pre>
ImageBufferIOSurfaceBackend should get and put data in WP when in mapped mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=252987">https://bugs.webkit.org/show_bug.cgi?id=252987</a>
rdar://problem/105972277

Reviewed by Matt Woodrow.

Make putImageData(), getImageData() access the data directly from the
Web process when IOSurfaces are available there.

Avoids sending messages to GPU process and memcpying the contents
multiple times.

* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::flushContext):
(WebCore::ImageBuffer::copyNativeImageForDrawing const):
(WebCore::ImageBuffer::draw):
(WebCore::ImageBuffer::getPixelBuffer const):
(WebCore::ImageBuffer::putPixelBuffer):
Before, the ImageBuffer would flush the drawing context,
e.g. the IPC commands to the GPUP and flush the draws there,
and then it would flush the backend context.
Move the backend maintainance into the backend functions, as it is
internal detail of the backend.
Instead just flush the drawing context, which on non-GPUP case
flushes the real IOSurface context and GPUP case flushes through
the IPC.

* Source/WebCore/platform/graphics/ImageBuffer.h:
* Source/WebCore/platform/graphics/ImageBufferBackend.cpp:
(WebCore::ImageBufferBackend::copyNativeImageForDrawing):
Provide the destination context to copyNativeImageForDrawing instead
of unused BackingStoreCopy argument.

* Source/WebCore/platform/graphics/ImageBufferBackend.h:
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp:
(WebCore::ImageBufferIOSurfaceBackend::invalidateCachedNativeImage):
(WebCore::ImageBufferIOSurfaceBackend::copyNativeImageForDrawing):
Fix the copyNativeImageForDrawing(). Before, it would return a CGImage
but not mark the m_mayHaveOutstandingBackingStoreReferences. The intention
was that instead, it would call invalidateCachedNativeImage() to cleanup
the bitmap cache from the cached CGImage. However, this would still leave
some backends, like display list and iosurface, to reference the IOSurface
without ImageBufferIOSurfaceBackend knowing about it. In these cases,
putImageData could change the underlying IOSurface before the display list
or iosurface renderer would have completed their use.

Instead, use CGIOSurfaceContextCreateImageReference which has the added
benefit of not needing the fixup case for cleaning up the memory footprint
after bitmap rendering.

(WebCore::ImageBufferIOSurfaceBackend::getPixelBuffer):
Flush the writes through the backends drawing context.

(WebCore::ImageBufferIOSurfaceBackend::putPixelBuffer):
Flush the writes through the drawing context and CGImage reads.

(WebCore::ImageBufferIOSurfaceBackend::surface):
(WebCore::ImageBufferIOSurfaceBackend::ensureNativeImagesHaveCopiedBackingStore):
(WebCore::ImageBufferIOSurfaceBackend::prepareForExternalRead):
(WebCore::ImageBufferIOSurfaceBackend::prepareForExternalWrite):
(WebCore::ImageBufferIOSurfaceBackend::invalidateCachedNativeImageIfNeeded): Deleted.
(WebCore::ImageBufferIOSurfaceBackend::finalizeDrawIntoContext): Deleted.
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h:

* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp:
(WebKit::RemoteImageBufferProxy::copyNativeImageForDrawing const):
(WebKit::RemoteImageBufferProxy::getPixelBuffer const):
(WebKit::RemoteImageBufferProxy::putPixelBuffer):
The remote proxy putPutlBuffer/getPixelBuffer can now directly call the
normal ImageBufferIOSurfaceBackend codepath for the put/get.
The IPC is flushed by the ImageBuffer calling flushDrawingContext()
The pending read references through the local iosurface are maintained
by the ImageBufferIOSurfaceBackend.
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h:
The m_needsFlush needs to be flipped to true, since now the first
command might be local putPixelBuffer. This needs to complete after
the initial CGContextFillRect that clears the IOSurface.
Before this was not needed, as all the commands were executed on GPUP
side.

Canonical link: <a href="https://commits.webkit.org/261130@main">https://commits.webkit.org/261130@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5fbf8ac441b6e563b61740969a5cbaf98c62c705

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110217 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19314 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42875 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1636 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119207 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114168 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20775 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10505 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102475 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115962 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15468 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98675 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43682 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97429 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30339 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85526 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12004 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31676 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12616 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8640 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17982 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51293 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7711 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14425 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->