### PR TITLE
Background fetch response bodies need to be stored in memory for ephemeral sessions

### DIFF
--- a/LayoutTests/http/wpt/background-fetch/background-fetch-non-persistent.window-expected.txt
+++ b/LayoutTests/http/wpt/background-fetch/background-fetch-non-persistent.window-expected.txt
@@ -1,0 +1,3 @@
+
+PASS background fetch response should be available in ephemeral sessions
+

--- a/LayoutTests/http/wpt/background-fetch/background-fetch-non-persistent.window.html
+++ b/LayoutTests/http/wpt/background-fetch/background-fetch-non-persistent.window.html
@@ -1,0 +1,2 @@
+<!-- webkit-test-runner [ useEphemeralSession=true ] -->
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/http/wpt/background-fetch/background-fetch-non-persistent.window.js
+++ b/LayoutTests/http/wpt/background-fetch/background-fetch-non-persistent.window.js
@@ -1,0 +1,18 @@
+// META: script=/service-workers/service-worker/resources/test-helpers.sub.js
+// META: script=/background-fetch/resources/utils.js
+
+'use strict';
+
+promise_test(async t => {
+  let serviceWorkerRegistration = await service_worker_unregister_and_register(t, "sw.js", ".");
+  add_completion_callback(() => serviceWorkerRegistration.unregister());
+  await wait_for_state(t, serviceWorkerRegistration.installing, 'activated');
+
+  const channel = new MessageChannel();
+  serviceWorkerRegistration.active.postMessage({ type:'waitForSuccess', record:'resources/trickle.py?ms=10&count=1', port:channel.port1 }, [channel.port1]);
+  const successPromise = new Promise(resolve => channel.port2.onmessage = (event) => resolve(event.data));
+
+  await serviceWorkerRegistration.backgroundFetch.fetch(uniqueId(), ['resources/trickle.py?ms=10&count=1']);
+
+  assert_equals(await successPromise, "TEST_TRICKLE\n");
+}, "background fetch response should be available in ephemeral sessions");

--- a/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreManager.h
+++ b/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreManager.h
@@ -27,6 +27,7 @@
 #if ENABLE(SERVICE_WORKER)
 
 #include <WebCore/BackgroundFetchStore.h>
+#include <WebCore/SharedBuffer.h>
 #include <wtf/FastMalloc.h>
 #include <wtf/Function.h>
 #include <wtf/WeakPtr.h>
@@ -34,10 +35,6 @@
 
 namespace WTF {
 class WorkQueue;
-}
-
-namespace WebCore {
-class SharedBuffer;
 }
 
 namespace WebKit {
@@ -71,6 +68,8 @@ private:
     Ref<WTF::WorkQueue> m_taskQueue;
     Ref<WTF::WorkQueue> m_ioQueue;
     QuotaCheckFunction m_quotaCheckFunction;
+
+    HashMap<String, Vector<WebCore::SharedBufferBuilder>> m_nonPersistentChunks;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -1520,7 +1520,7 @@ void NetworkProcessProxy::endServiceWorkerBackgroundProcessing(WebCore::ProcessI
 
 void NetworkProcessProxy::requestBackgroundFetchPermission(PAL::SessionID sessionID, const WebCore::ClientOrigin& origin, CompletionHandler<void(bool)>&& callback)
 {
-    RELEASE_LOG(Storage, "%p - NetworkProcessProxy::requestStorageSpace", this);
+    RELEASE_LOG(ServiceWorker, "%p - NetworkProcessProxy::requestBackgroundFetchPermission", this);
     auto* store = websiteDataStoreFromSessionID(sessionID);
 
     if (!store) {

--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -160,7 +160,9 @@ void TestController::platformInitializeDataStore(WKPageConfigurationRef, const T
         if (options.enableInAppBrowserPrivacy())
             [websiteDataStoreConfig setEnableInAppBrowserPrivacyForTesting:YES];
 #endif
-        m_websiteDataStore = (__bridge WKWebsiteDataStoreRef)adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfig.get()]).get();
+        auto store = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfig.get()]);
+        m_websiteDataStore = (__bridge WKWebsiteDataStoreRef)store.get();
+        [store set_delegate:globalWebsiteDataStoreDelegateClient().get()];
     } else
         m_websiteDataStore = (__bridge WKWebsiteDataStoreRef)[globalWebViewConfiguration() websiteDataStore];
 }


### PR DESCRIPTION
#### e23513fa4f02b36817d8f0f11e455673386d8891
<pre>
Background fetch response bodies need to be stored in memory for ephemeral sessions
<a href="https://bugs.webkit.org/show_bug.cgi?id=253148">https://bugs.webkit.org/show_bug.cgi?id=253148</a>
rdar://problem/106080848

Reviewed by Chris Dumez.

In case path is empty (ephemeral sessions), BackgroundFetchStoreManager now stores the response chunks in a map.
Add support for clearing the map as needed.

* LayoutTests/http/wpt/background-fetch/background-fetch-non-persistent.window-expected.txt: Added.
* LayoutTests/http/wpt/background-fetch/background-fetch-non-persistent.window.html: Added.
* LayoutTests/http/wpt/background-fetch/background-fetch-non-persistent.window.js: Added.
(promise_test.async t):
* LayoutTests/http/wpt/background-fetch/sw.js:
(onmessage):
(onbackgroundfetchsuccess.async event):
* Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreManager.cpp:
(WebKit::BackgroundFetchStoreManager::clearFetch):
(WebKit::BackgroundFetchStoreManager::clearAllFetches):
(WebKit::BackgroundFetchStoreManager::storeFetchResponseBodyChunk):
(WebKit::BackgroundFetchStoreManager::retrieveResponseBody):
* Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreManager.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::requestBackgroundFetchPermission):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreClient.h:
(WebKit::WebsiteDataStoreClient::requestBackgroundFetchPermission):
* Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm:
(WTR::TestController::platformInitializeDataStore):
* Tools/WebKitTestRunner/cocoa/TestWebsiteDataStoreDelegate.mm:
(-[TestWebsiteDataStoreDelegate requestBackgroundFetchPermission:frameOrigin:decisionHandler:]):

Canonical link: <a href="https://commits.webkit.org/261219@main">https://commits.webkit.org/261219@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a91914daa136137723f1f06ab7840f701f522fb7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110733 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19814 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43290 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2333 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119561 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114699 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21221 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10926 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/2019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116478 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15811 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99017 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103112 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97771 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30644 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44203 "") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12428 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31981 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86083 "Found 3 new API test failures: /WebKitGTK/TestUIClient:/webkit/WebKitWebView/display-usermedia-permission-request, /WebKitGTK/TestDownloads:/webkit/Downloads/blob-download, /WebKitGTK/TestContextMenu:/webkit/WebKitWebView/populate-menu (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12992 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8952 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18369 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51600 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7789 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14949 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->