### PR TITLE
ImageBufferIOSurfaceBackend should use bitmap CGImages when drawing to bitmap context

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.h
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.h
@@ -164,6 +164,12 @@ public:
 
     RetainPtr<CGContextRef> createCompatibleBitmap(unsigned width, unsigned height);
 
+    struct BitmapConfiguration {
+        CGBitmapInfo bitmapInfo;
+        size_t bitsPerComponent;
+    };
+
+    BitmapConfiguration bitmapConfiguration() const;
 private:
     IOSurface(IntSize, const DestinationColorSpace&, Format, bool& success);
     IOSurface(IOSurfaceRef, std::optional<DestinationColorSpace>&&);
@@ -172,12 +178,6 @@ private:
     void ensureColorSpace();
     std::optional<DestinationColorSpace> surfaceColorSpace() const;
 
-    struct BitmapConfiguration {
-        CGBitmapInfo bitmapInfo;
-        size_t bitsPerComponent;
-    };
-
-    BitmapConfiguration bitmapConfiguration() const;
 
     std::optional<Format> m_format;
     std::optional<DestinationColorSpace> m_colorSpace;


### PR DESCRIPTION
#### f19c998af7876ca2135f956f03ddcd41a117aa3e
<pre>
ImageBufferIOSurfaceBackend should use bitmap CGImages when drawing to bitmap context
<a href="https://bugs.webkit.org/show_bug.cgi?id=252986">https://bugs.webkit.org/show_bug.cgi?id=252986</a>
rdar://problem/105971637

Reviewed by NOBODY (OOPS!).

Previously when drawing IOSurface -based ImageBuffer to a bitmap CGContext,
the IOSurface would be wrapped into a CGImage and drawn. CG would do
the readback, construct a bitmap image and draw it as a bitmap and store the
bitmap to the CGImage. As a fix up step, we would update the
CGIOSurfaceContext artificially to destroy the CGImage, so that it would
not hold the bitmap cache.

Do this explicitly by providing a reference to the IOSurface via bitmap
image. This codepath is only used for drawing and only on specific
backends. These limitations make us be sure that the image does not get
long term references, and as such future modifications do not change
the already rendered content.

 This has the benefit of:
 - Being simpler to reason about: no cleanup step.
 - Image being a reference omits a copy from the IOSurface buffer,
   and thus speeds up the draw considerably.
 - Having the handle to the bitmap image enables further small
   optimizations in future patches.

* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::copyNativeImageForDrawing const):
(WebCore::ImageBuffer::draw):
* Source/WebCore/platform/graphics/ImageBuffer.h:
* Source/WebCore/platform/graphics/ImageBufferBackend.cpp:
(WebCore::ImageBufferBackend::copyNativeImageForDrawing):
* Source/WebCore/platform/graphics/ImageBufferBackend.h:
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp:
(WebCore::createIOSurfaceBitmapImageReference):
(WebCore::ImageBufferIOSurfaceBackend::copyNativeImageForDrawing):
(WebCore::ImageBufferIOSurfaceBackend::finalizeDrawIntoContext): Deleted.
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h:
* Source/WebCore/platform/graphics/cocoa/IOSurface.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp:
(WebKit::RemoteImageBufferProxy::copyNativeImageForDrawing const):
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f19c998af7876ca2135f956f03ddcd41a117aa3e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110714 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19796 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43274 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2202 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119547 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114680 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21203 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10908 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/1989 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116457 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15794 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98968 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103052 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97754 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30636 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44156 "") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12420 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31973 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86035 "Found 1 new API test failure: /WebKitGTK/TestDownloads:/webkit/Downloads/blob-download (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12976 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8939 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18351 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51592 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14911 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->