### PR TITLE
Gardening `fast/css3-text/css3-text-decoration/text-decoration-skip/text-decoration-skip-ink-inherit.html`

### DIFF
--- a/LayoutTests/fast/css3-text/css3-text-decoration/text-decoration-skip/text-decoration-skip-ink-inherit-expected.html
+++ b/LayoutTests/fast/css3-text/css3-text-decoration/text-decoration-skip/text-decoration-skip-ink-inherit-expected.html
@@ -7,13 +7,13 @@
 This test makes sure that text-decoration-skip: ink is inherited and that it can be overridden.
 </p>
 <p>
-<span style="-webkit-text-decoration-skip: ink; text-decoration: underline;">Outer ypqg span Inner ypgq span</span>
+<span>Outer ypqg span </span><span style="text-decoration: underline; -webkit-text-decoration-skip: ink">Inner ypgq span</span>
 </p>
 <p>
-<span style="-webkit-text-decoration-skip: ink; text-decoration: underline;">Outer ypqg span </span><span style="-webkit-text-decoration-skip: none; text-decoration: underline;">Inner ypgq span</span>
+<span>Outer ypqg span </span><span style="text-decoration: underline; -webkit-text-decoration-skip: none;">Inner ypgq span</span>
 </p>
 <p>
-<span style="-webkit-text-decoration-skip: ink; text-decoration: underline;">Outer ypqg span Inner ypgq span</span>
+<span>Outer ypqg span </span><span style="text-decoration: underline; -webkit-text-decoration-skip: ink;">Inner ypgq span</span>
 </p>
 </body>
 </html>

--- a/LayoutTests/fast/css3-text/css3-text-decoration/text-decoration-skip/text-decoration-skip-ink-inherit.html
+++ b/LayoutTests/fast/css3-text/css3-text-decoration/text-decoration-skip/text-decoration-skip-ink-inherit.html
@@ -7,13 +7,13 @@
 This test makes sure that text-decoration-skip: ink is inherited and that it can be overridden.
 </p>
 <p>
-<span style="-webkit-text-decoration-skip: ink; text-decoration: underline;">Outer ypqg span <span>Inner ypgq span</span></span>
+<span style="-webkit-text-decoration-skip: ink;">Outer ypqg span <span style="text-decoration: underline;">Inner ypgq span</span></span>
 </p>
 <p>
-<span style="-webkit-text-decoration-skip: ink; text-decoration: underline;">Outer ypqg span <span style="-webkit-text-decoration-skip: none;">Inner ypgq span</span></span>
+<span style="-webkit-text-decoration-skip: ink;">Outer ypqg span <span style="text-decoration: underline; -webkit-text-decoration-skip: none;">Inner ypgq span</span></span>
 </p>
 <p>
-<span style="-webkit-text-decoration-skip: ink; text-decoration: underline;">Outer ypqg span <span style="-webkit-text-decoration-skip: inherit;">Inner ypgq span</span></span>
+<span style="-webkit-text-decoration-skip: ink;">Outer ypqg span <span style="text-decoration: underline; -webkit-text-decoration-skip: inherit;">Inner ypgq span</span></span>
 </p>
 </body>
 </html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -2798,7 +2798,6 @@ webkit.org/b/178669 compositing/visible-rect/iframe-no-layers.html [ Pass Failur
 
 # Underlines' starting and ending positions need to be pixel-snapped
 webkit.org/b/142087 fast/css3-text/css3-text-decoration/no-gap-between-two-rounded-textboxes.html [ ImageOnlyFailure ]
-webkit.org/b/142087 fast/css3-text/css3-text-decoration/text-decoration-skip/text-decoration-skip-ink-inherit.html [ ImageOnlyFailure ]
 
 webkit.org/b/178029 http/tests/preload/viewport/meta-viewport-link-headers.py [ Pass Failure ]
 

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -919,7 +919,6 @@ webkit.org/b/142192 svg/transforms/transformed-text-fill-gradient.html [ ImageOn
 
 # Underlines' starting and ending positions need to be pixel-snapped
 webkit.org/b/142087 fast/css3-text/css3-text-decoration/no-gap-between-two-rounded-textboxes.html [ ImageOnlyFailure ]
-webkit.org/b/142087 fast/css3-text/css3-text-decoration/text-decoration-skip/text-decoration-skip-ink-inherit.html [ ImageOnlyFailure ]
 
 # Tests that fail with the SVG -> OTF font converter, but are lower priority than live-on
 webkit.org/b/140588 svg/W3C-SVG-1.1/fonts-desc-02-t.svg [ Failure ]


### PR DESCRIPTION
#### 38074cd9b06f448b87591b0e1923c35903093eb8
<pre>
Gardening `fast/css3-text/css3-text-decoration/text-decoration-skip/text-decoration-skip-ink-inherit.html`

Unreviewed test gardening.

When applied to an inline box, text decorations, including
`text-decoration-skip-ink`, are propagated to all its fragments.

In this test, the `text-decoration` property must be applied to the
inner span, not the outer one.

* LayoutTests/fast/css3-text/css3-text-decoration/text-decoration-skip/text-decoration-skip-ink-inherit-expected.html:
* LayoutTests/fast/css3-text/css3-text-decoration/text-decoration-skip/text-decoration-skip-ink-inherit.html:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/261421@main">https://commits.webkit.org/261421@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77c41287770d34fa83de9abe686f01368ea1747c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111477 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20613 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/80 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3269 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120259 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21983 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11717 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2692 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117240 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16320 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99471 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104223 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98276 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/54 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45031 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13111 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/52 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86827 "13 api tests failed or timed out") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13615 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9501 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19060 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52035 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15582 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4335 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->