### PR TITLE
[GLib] Ensure no final classes have public class structs

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitDownload.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitDownload.cpp
@@ -154,7 +154,9 @@ static void webkit_download_class_init(WebKitDownloadClass* downloadClass)
     objectClass->set_property = webkitDownloadSetProperty;
     objectClass->get_property = webkitDownloadGetProperty;
 
+#if !ENABLE(2022_GLIB_API)
     downloadClass->decide_destination = webkitDownloadDecideDestination;
+#endif
 
     /**
      * WebKitDownload:destination:
@@ -287,8 +289,12 @@ static void webkit_download_class_init(WebKitDownloadClass* downloadClass)
         "decide-destination",
         G_TYPE_FROM_CLASS(objectClass),
         G_SIGNAL_RUN_LAST,
+#if ENABLE(2022_GLIB_API)
+        0,
+#else
         G_STRUCT_OFFSET(WebKitDownloadClass, decide_destination),
-        g_signal_accumulator_true_handled, NULL,
+#endif
+        g_signal_accumulator_true_handled, nullptr,
         g_cclosure_marshal_generic,
         G_TYPE_BOOLEAN, 1,
         G_TYPE_STRING);
@@ -311,6 +317,10 @@ static void webkit_download_class_init(WebKitDownloadClass* downloadClass)
             g_cclosure_marshal_VOID__STRING,
             G_TYPE_NONE, 1,
             G_TYPE_STRING);
+
+#if ENABLE(2022_GLIB_API)
+    g_signal_override_class_handler("decide-destination", WEBKIT_TYPE_DOWNLOAD, G_CALLBACK(webkitDownloadDecideDestination));
+#endif
 }
 
 GRefPtr<WebKitDownload> webkitDownloadCreate(DownloadProxy& downloadProxy, WebKitWebView* webView)

--- a/Source/WebKit/UIProcess/API/glib/WebKitDownload.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitDownload.h.in
@@ -36,11 +36,8 @@ G_BEGIN_DECLS
 #define WEBKIT_DOWNLOAD_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_DOWNLOAD, WebKitDownloadClass))
 #define WEBKIT_IS_DOWNLOAD_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_DOWNLOAD))
 #define WEBKIT_DOWNLOAD_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_DOWNLOAD, WebKitDownloadClass))
-#endif
 
 WEBKIT_DECLARE_TYPE (WebKitDownload, webkit_download, WEBKIT, DOWNLOAD, GObject)
-
-typedef struct _WebKitWebView WebKitWebView;
 
 struct _WebKitDownloadClass {
     GObjectClass parent_class;
@@ -55,6 +52,11 @@ struct _WebKitDownloadClass {
     void (*_webkit_reserved2) (void);
     void (*_webkit_reserved3) (void);
 };
+#else
+WEBKIT_DECLARE_FINAL_TYPE (WebKitDownload, webkit_download, WEBKIT, DOWNLOAD, GObject)
+#endif
+
+typedef struct _WebKitWebView WebKitWebView;
 
 WEBKIT_API WebKitURIRequest *
 webkit_download_get_request              (WebKitDownload *download);

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
@@ -655,7 +655,11 @@ static void webkit_web_context_class_init(WebKitWebContextClass* webContextClass
         g_signal_new("initialize-web-extensions",
             G_TYPE_FROM_CLASS(gObjectClass),
             G_SIGNAL_RUN_LAST,
+#if ENABLE(2022_GLIB_API)
+            0,
+#else
             G_STRUCT_OFFSET(WebKitWebContextClass, initialize_web_extensions),
+#endif
             nullptr, nullptr,
             g_cclosure_marshal_VOID__VOID,
             G_TYPE_NONE, 0);
@@ -679,7 +683,11 @@ static void webkit_web_context_class_init(WebKitWebContextClass* webContextClass
         g_signal_new("initialize-notification-permissions",
             G_TYPE_FROM_CLASS(gObjectClass),
             G_SIGNAL_RUN_LAST,
+#if ENABLE(2022_GLIB_API)
+            0,
+#else
             G_STRUCT_OFFSET(WebKitWebContextClass, initialize_notification_permissions),
+#endif
             nullptr, nullptr,
             g_cclosure_marshal_VOID__VOID,
             G_TYPE_NONE, 0);
@@ -699,7 +707,11 @@ static void webkit_web_context_class_init(WebKitWebContextClass* webContextClass
         g_signal_new("automation-started",
             G_TYPE_FROM_CLASS(gObjectClass),
             G_SIGNAL_RUN_LAST,
+#if ENABLE(2022_GLIB_API)
+            0,
+#else
             G_STRUCT_OFFSET(WebKitWebContextClass, automation_started),
+#endif
             nullptr, nullptr,
             g_cclosure_marshal_VOID__OBJECT,
             G_TYPE_NONE, 1,
@@ -725,7 +737,11 @@ static void webkit_web_context_class_init(WebKitWebContextClass* webContextClass
         "user-message-received",
         G_TYPE_FROM_CLASS(gObjectClass),
         G_SIGNAL_RUN_LAST,
+#if ENABLE(2022_GLIB_API)
+        0,
+#else
         G_STRUCT_OFFSET(WebKitWebContextClass, user_message_received),
+#endif
         g_signal_accumulator_true_handled, nullptr,
         g_cclosure_marshal_generic,
         G_TYPE_BOOLEAN, 1,

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebContext.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebContext.h.in
@@ -49,9 +49,30 @@ G_BEGIN_DECLS
 #define WEBKIT_IS_WEB_CONTEXT(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_WEB_CONTEXT))
 #define WEBKIT_IS_WEB_CONTEXT_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_WEB_CONTEXT))
 #define WEBKIT_WEB_CONTEXT_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_WEB_CONTEXT, WebKitWebContextClass))
-#endif
 
 WEBKIT_DECLARE_TYPE (WebKitWebContext, webkit_web_context, WEBKIT, WEB_CONTEXT, GObject)
+
+struct _WebKitWebContextClass {
+    GObjectClass parent;
+
+    /*< public >*/
+    void     (* download_started)                    (WebKitWebContext        *context,
+                                                      WebKitDownload          *download);
+    void     (* initialize_web_extensions)           (WebKitWebContext        *context);
+    void     (* initialize_notification_permissions) (WebKitWebContext        *context);
+    void     (* automation_started)                  (WebKitWebContext        *context,
+                                                      WebKitAutomationSession *session);
+    gboolean (* user_message_received)               (WebKitWebContext        *context,
+                                                      WebKitUserMessage       *message);
+
+    /*< private >*/
+    void (*_webkit_reserved0) (void);
+    void (*_webkit_reserved1) (void);
+    void (*_webkit_reserved2) (void);
+};
+#else
+WEBKIT_DECLARE_FINAL_TYPE (WebKitWebContext, webkit_web_context, WEBKIT, WEB_CONTEXT, GObject)
+#endif
 
 /**
  * WebKitCacheModel:
@@ -109,27 +130,6 @@ typedef enum {
  */
 typedef void (* WebKitURISchemeRequestCallback) (WebKitURISchemeRequest *request,
                                                  gpointer                user_data);
-
-struct _WebKitWebContextClass {
-    GObjectClass parent;
-
-    /*< public >*/
-#if !ENABLE(2022_GLIB_API)
-    void     (* download_started)                    (WebKitWebContext        *context,
-                                                      WebKitDownload          *download);
-#endif
-    void     (* initialize_web_extensions)           (WebKitWebContext        *context);
-    void     (* initialize_notification_permissions) (WebKitWebContext        *context);
-    void     (* automation_started)                  (WebKitWebContext        *context,
-                                                      WebKitAutomationSession *session);
-    gboolean (* user_message_received)               (WebKitWebContext        *context,
-                                                      WebKitUserMessage       *message);
-
-    /*< private >*/
-    void (*_webkit_reserved0) (void);
-    void (*_webkit_reserved1) (void);
-    void (*_webkit_reserved2) (void);
-};
 
 WEBKIT_API WebKitWebContext *
 webkit_web_context_get_default                      (void);


### PR DESCRIPTION
#### 5e3c2e27ef614802f06ea2408c46f823906cb35b
<pre>
[GLib] Ensure no final classes have public class structs
<a href="https://bugs.webkit.org/show_bug.cgi?id=252827">https://bugs.webkit.org/show_bug.cgi?id=252827</a>

Reviewed by Adrian Perez de Castro.

It doesn&apos;t make sense for non-derivable classes to have virtual function
tables, and that&apos;s all we have in the class structs, so hide them away
behind the WEBKIT_DECLARE_FINAL_TYPE macro. They&apos;re technically still
present in the headers since they&apos;re generated by the macro, but they
won&apos;t contain virtual functions anymore and it&apos;s much less confusing
this way.

* Source/WebKit/UIProcess/API/glib/WebKitDownload.cpp:
(webkit_download_class_init):
* Source/WebKit/UIProcess/API/glib/WebKitDownload.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp:
(webkit_web_context_class_init):
* Source/WebKit/UIProcess/API/glib/WebKitWebContext.h.in:

Canonical link: <a href="https://commits.webkit.org/261011@main">https://commits.webkit.org/261011@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/344e04be1ce06973fa24f8aace5d84e6d2e05b87

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110241 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19338 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42897 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1661 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119229 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20801 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10530 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102501 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115985 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98694 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/43704 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30358 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85552 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12027 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/31695 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12639 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18005 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51312 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7628 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14448 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->