### PR TITLE
REGRESSION(260881@main): [GStreamer] DMABuf sink caused several unexpected crashes on the WPE Release bot

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp
@@ -166,9 +166,14 @@ static void webkit_dmabuf_video_sink_class_init(WebKitDMABufVideoSinkClass* klas
 bool webKitDMABufVideoSinkIsEnabled()
 {
     static bool s_disabled = false;
-#if USE(LIBGBM)
     static std::once_flag s_flag;
     std::call_once(s_flag, [&] {
+        const char* useHeadlessBackend = g_getenv("WPE_USE_HEADLESS_VIEW_BACKEND");
+        if (useHeadlessBackend && equalLettersIgnoringASCIICase(useHeadlessBackend, "1"_s)) {
+            s_disabled = true;
+            return;
+        }
+#if USE(LIBGBM)
         const char* value = g_getenv("WEBKIT_GST_DMABUF_SINK_DISABLED");
         s_disabled = value && (equalLettersIgnoringASCIICase(value, "true"_s) || equalLettersIgnoringASCIICase(value, "1"_s));
         if (!s_disabled) {
@@ -178,10 +183,10 @@ bool webKitDMABufVideoSinkIsEnabled()
                 s_disabled = true;
             }
         }
-    });
 #else
-    s_disabled = true;
+        s_disabled = true;
 #endif
+    });
     return !s_disabled;
 }
 


### PR DESCRIPTION
#### 4d486ffaec12a7ff420386388119b1f59d59aeff
<pre>
REGRESSION(260881@main): [GStreamer] DMABuf sink caused several unexpected crashes on the WPE Release bot
<a href="https://bugs.webkit.org/show_bug.cgi?id=253085">https://bugs.webkit.org/show_bug.cgi?id=253085</a>

Reviewed by NOBODY (OOPS!).

Disable the DMABuf video sink when the test WPE headless view backend is in use.

* Source/WebCore/platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp:
(webKitDMABufVideoSinkIsEnabled):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d486ffaec12a7ff420386388119b1f59d59aeff

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110249 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19345 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42902 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1667 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119234 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114199 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20807 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10536 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102508 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115993 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15491 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98697 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43707 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97452 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30361 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85555 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12033 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31698 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12644 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8664 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18010 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51315 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14455 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->