### PR TITLE
[web-animations] add accelerated representation of WebAnimation and KeyframeEffect

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1549,6 +1549,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/Widget.h
     platform/WindowsKeyboardCodes.h
 
+    platform/animation/AcceleratedEffect.h
+    platform/animation/AcceleratedEffectValues.h
     platform/animation/Animation.h
     platform/animation/AnimationList.h
     platform/animation/AnimationUtilities.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2052,6 +2052,8 @@ platform/VideoPixelFormat.cpp
 platform/WebCoreCrossThreadCopier.cpp
 platform/WebCorePersistentCoders.cpp
 platform/Widget.cpp
+platform/animation/AcceleratedEffect.cpp
+platform/animation/AcceleratedEffectValues.cpp
 platform/animation/Animation.cpp
 platform/animation/AnimationList.cpp
 platform/animation/TimingFunction.cpp

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -122,6 +122,7 @@ public:
     virtual FinishedPromise& bindingsFinished() { return finished(); }
     virtual ExceptionOr<void> bindingsPlay() { return play(); }
     virtual ExceptionOr<void> bindingsPause() { return pause(); }
+    std::optional<Seconds> holdTime() const { return m_holdTime; }
 
     virtual std::variant<FramesPerSecond, AnimationFrameRatePreset> bindingsFrameRate() const { return m_bindingsFrameRate; }
     virtual void setBindingsFrameRate(std::variant<FramesPerSecond, AnimationFrameRatePreset>&&);

--- a/Source/WebCore/platform/animation/AcceleratedEffect.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.cpp
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "AcceleratedEffect.h"
+
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+
+#include "AnimationEffect.h"
+#include "CSSPropertyAnimation.h"
+#include "CSSPropertyNames.h"
+#include "DeclarativeAnimation.h"
+#include "Document.h"
+#include "KeyframeEffect.h"
+#include "KeyframeList.h"
+#include "WebAnimation.h"
+#include "WebAnimationTypes.h"
+#include <wtf/IsoMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(AcceleratedEffect);
+
+static AcceleratedEffectProperty acceleratedPropertyFromCSSProperty(AnimatableProperty property, const Settings& settings)
+{
+#if !defined(NDEBUG)
+    ASSERT(CSSPropertyAnimation::animationOfPropertyIsAccelerated(property, settings));
+#else
+    UNUSED_PARAM(settings);
+#endif
+    ASSERT(std::holds_alternative<CSSPropertyID>(property));
+
+    switch (std::get<CSSPropertyID>(property)) {
+    case CSSPropertyOpacity:
+        return AcceleratedEffectProperty::Opacity;
+    case CSSPropertyTransform:
+        return AcceleratedEffectProperty::Transform;
+    case CSSPropertyTranslate:
+        return AcceleratedEffectProperty::Translate;
+    case CSSPropertyRotate:
+        return AcceleratedEffectProperty::Rotate;
+    case CSSPropertyScale:
+        return AcceleratedEffectProperty::Scale;
+    case CSSPropertyOffsetPath:
+        return AcceleratedEffectProperty::OffsetPath;
+    case CSSPropertyOffsetDistance:
+        return AcceleratedEffectProperty::OffsetDistance;
+    case CSSPropertyOffsetPosition:
+        return AcceleratedEffectProperty::OffsetPosition;
+    case CSSPropertyOffsetAnchor:
+        return AcceleratedEffectProperty::OffsetAnchor;
+    case CSSPropertyOffsetRotate:
+        return AcceleratedEffectProperty::OffsetRotate;
+    case CSSPropertyFilter:
+        return AcceleratedEffectProperty::Filter;
+#if ENABLE(FILTERS_LEVEL_2)
+    case CSSPropertyWebkitBackdropFilter:
+        return AcceleratedEffectProperty::BackdropFilter;
+#endif
+    default:
+        ASSERT_NOT_REACHED();
+        return AcceleratedEffectProperty::Invalid;
+    }
+}
+
+Ref<AcceleratedEffect> AcceleratedEffect::create(const KeyframeEffect& effect)
+{
+    return adoptRef(*new AcceleratedEffect(effect));
+}
+
+AcceleratedEffect::AcceleratedEffect(const KeyframeEffect& effect)
+{
+    m_fill = effect.fill();
+    m_direction = effect.direction();
+    m_compositeOperation = effect.composite();
+    m_iterationStart = effect.iterationStart();
+    m_iterations = effect.iterations();
+    m_delay = effect.delay();
+    m_endDelay = effect.endDelay();
+    m_iterationDuration = effect.iterationDuration();
+    m_animationType = effect.animationType();
+
+    ASSERT(effect.animation());
+    if (auto* animation = effect.animation()) {
+        m_paused = animation->playState() == WebAnimation::PlayState::Paused;
+        m_playbackRate = animation->playbackRate();
+        ASSERT(animation->holdTime() || animation->startTime());
+        m_holdTime = animation->holdTime();
+        m_startTime = animation->startTime();
+        if (is<DeclarativeAnimation>(animation)) {
+            if (auto* defaultKeyframeTimingFunction = downcast<DeclarativeAnimation>(*animation).backingAnimation().timingFunction())
+                m_defaultKeyframeTimingFunction = defaultKeyframeTimingFunction;
+        }
+    }
+
+    m_timingFunction = effect.timingFunction();
+
+    if (m_iterationDuration && m_iterations)
+        m_activeDuration = m_iterationDuration * m_iterations;
+
+    m_endTime = std::max(0_s, m_delay + m_activeDuration + m_endDelay);
+
+    ASSERT(effect.document());
+    auto& settings = effect.document()->settings();
+
+    for (auto& srcKeyframe : effect.blendingKeyframes()) {
+        OptionSet<AcceleratedEffectProperty> animatedProperties;
+        for (auto animatedCSSProperty : srcKeyframe.properties()) {
+            if (CSSPropertyAnimation::animationOfPropertyIsAccelerated(animatedCSSProperty, settings)) {
+                auto acceleratedProperty = acceleratedPropertyFromCSSProperty(animatedCSSProperty, settings);
+                animatedProperties.add(acceleratedProperty);
+                m_animatedProperties.add(acceleratedProperty);
+            }
+        }
+
+        if (animatedProperties.isEmpty())
+            continue;
+
+        AcceleratedEffectKeyframe acceleratedKeyframe;
+        acceleratedKeyframe.offset = srcKeyframe.key();
+        acceleratedKeyframe.compositeOperation = srcKeyframe.compositeOperation();
+        acceleratedKeyframe.animatedProperties = WTFMove(animatedProperties);
+
+        acceleratedKeyframe.values = [&]() -> AcceleratedEffectValues {
+            if (auto* style = srcKeyframe.style())
+                return { *style };
+            return { };
+        }();
+
+        acceleratedKeyframe.timingFunction = srcKeyframe.timingFunction();
+
+        m_keyframes.append(WTFMove(acceleratedKeyframe));
+    }
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(THREADED_ANIMATION_RESOLUTION)

--- a/Source/WebCore/platform/animation/AcceleratedEffect.h
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+
+#include "AcceleratedEffectValues.h"
+#include "CompositeOperation.h"
+#include "FillMode.h"
+#include "PlaybackDirection.h"
+#include "TimingFunction.h"
+#include "WebAnimationTypes.h"
+#include <wtf/IsoMalloc.h>
+#include <wtf/OptionSet.h>
+#include <wtf/RefCounted.h>
+#include <wtf/Seconds.h>
+
+namespace WebCore {
+
+class KeyframeEffect;
+
+enum class AcceleratedEffectProperty : uint16_t {
+    Invalid = 1 << 0,
+    Opacity = 1 << 1,
+    Transform = 1 << 2,
+    Translate = 1 << 3,
+    Rotate = 1 << 4,
+    Scale = 1 << 5,
+    OffsetPath = 1 << 6,
+    OffsetDistance = 1 << 7,
+    OffsetPosition = 1 << 8,
+    OffsetAnchor = 1 << 9,
+    OffsetRotate = 1 << 10,
+    Filter = 1 << 11,
+#if ENABLE(FILTERS_LEVEL_2)
+    BackdropFilter = 1 << 12
+#endif
+};
+
+struct AcceleratedEffectKeyframe {
+    double offset;
+    AcceleratedEffectValues values;
+    RefPtr<TimingFunction> timingFunction;
+    std::optional<CompositeOperation> compositeOperation;
+    OptionSet<AcceleratedEffectProperty> animatedProperties;
+};
+
+class AcceleratedEffect : public RefCounted<AcceleratedEffect> {
+    WTF_MAKE_ISO_ALLOCATED(AcceleratedEffect);
+public:
+    static Ref<AcceleratedEffect> create(const KeyframeEffect&);
+
+    virtual ~AcceleratedEffect() = default;
+
+private:
+    AcceleratedEffect(const KeyframeEffect&);
+
+    Vector<AcceleratedEffectKeyframe> m_keyframes;
+    WebAnimationType m_animationType { WebAnimationType::WebAnimation };
+    FillMode m_fill { FillMode::Auto };
+    PlaybackDirection m_direction { PlaybackDirection::Normal };
+    CompositeOperation m_compositeOperation { CompositeOperation::Replace };
+    RefPtr<TimingFunction> m_timingFunction;
+    RefPtr<TimingFunction> m_defaultKeyframeTimingFunction;
+    OptionSet<AcceleratedEffectProperty> m_animatedProperties;
+    bool m_paused { false };
+    double m_iterationStart { 0 };
+    double m_iterations { 1 };
+    double m_playbackRate { 1 };
+    Seconds m_delay { 0_s };
+    Seconds m_endDelay { 0_s };
+    Seconds m_iterationDuration { 0_s };
+    Seconds m_activeDuration { 0_s };
+    Seconds m_endTime { 0_s };
+    std::optional<Seconds> m_startTime;
+    std::optional<Seconds> m_holdTime;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(THREADED_ANIMATION_RESOLUTION)

--- a/Source/WebCore/platform/animation/AcceleratedEffectValues.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffectValues.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "AcceleratedEffectValues.h"
+
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+
+namespace WebCore {
+
+void AcceleratedEffectValues::copyTransformOperations(const TransformOperations& src)
+{
+    auto& transformOperations = transform.operations();
+    auto& srcTransformOperations = src.operations();
+    transformOperations.reserveCapacity(srcTransformOperations.size());
+    for (auto& srcTransformOperation : srcTransformOperations)
+        transformOperations.uncheckedAppend(srcTransformOperation.copyRef());
+}
+
+AcceleratedEffectValues::AcceleratedEffectValues(const AcceleratedEffectValues& src)
+{
+    opacity = src.opacity;
+
+    copyTransformOperations(src.transform);
+    translate = src.translate.copyRef();
+    scale = src.scale.copyRef();
+    rotate = src.rotate.copyRef();
+    transformOrigin = src.transformOrigin;
+
+    offsetPath = src.offsetPath.copyRef();
+    offsetDistance = src.offsetDistance;
+    offsetPosition = src.offsetPosition;
+    offsetAnchor = src.offsetAnchor;
+    offsetRotate = src.offsetRotate;
+
+    for (auto& srcFilterOperation : src.filter.operations())
+        filter.operations().append(srcFilterOperation.copyRef());
+
+#if ENABLE(FILTERS_LEVEL_2)
+    for (auto& srcBackdropFilterOperation : src.backdropFilter.operations())
+        backdropFilter.operations().append(srcBackdropFilterOperation.copyRef());
+#endif
+}
+
+AcceleratedEffectValues::AcceleratedEffectValues(const RenderStyle& style)
+{
+    opacity = style.opacity();
+
+    copyTransformOperations(style.transform());
+    translate = style.translate();
+    scale = style.scale();
+    rotate = style.rotate();
+    transformOrigin = style.transformOriginXY();
+
+    offsetPath = style.offsetPath();
+    offsetPosition = style.offsetPosition();
+    offsetAnchor = style.offsetAnchor();
+    offsetRotate = style.offsetRotate();
+    offsetDistance = style.offsetDistance();
+
+    for (auto srcFilterOperation : style.filter().operations())
+        filter.operations().append(srcFilterOperation.copyRef());
+
+#if ENABLE(FILTERS_LEVEL_2)
+    for (auto srcBackdropFilterOperation : style.backdropFilter().operations())
+        backdropFilter.operations().append(srcBackdropFilterOperation.copyRef());
+#endif
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(THREADED_ANIMATION_RESOLUTION)

--- a/Source/WebCore/platform/animation/AcceleratedEffectValues.h
+++ b/Source/WebCore/platform/animation/AcceleratedEffectValues.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+
+#include "FilterOperations.h"
+#include "Length.h"
+#include "LengthPoint.h"
+#include "OffsetRotation.h"
+#include "PathOperation.h"
+#include "RenderStyle.h"
+#include "RotateTransformOperation.h"
+#include "ScaleTransformOperation.h"
+#include "TransformOperations.h"
+#include "TransformationMatrix.h"
+#include "TranslateTransformOperation.h"
+
+namespace WebCore {
+
+struct AcceleratedEffectValues {
+    float opacity { 1 };
+    LengthPoint transformOrigin { };
+    TransformOperations transform { };
+    RefPtr<TransformOperation> translate;
+    RefPtr<TransformOperation> scale;
+    RefPtr<TransformOperation> rotate;
+    RefPtr<PathOperation> offsetPath;
+    Length offsetDistance { };
+    LengthPoint offsetPosition { };
+    LengthPoint offsetAnchor { };
+    OffsetRotation offsetRotate { };
+    FilterOperations filter { };
+#if ENABLE(FILTERS_LEVEL_2)
+    FilterOperations backdropFilter { };
+#endif
+    
+    AcceleratedEffectValues()
+    {
+    }
+    
+    WEBCORE_EXPORT AcceleratedEffectValues(const AcceleratedEffectValues&);
+    AcceleratedEffectValues(const RenderStyle&);
+    AcceleratedEffectValues& operator=(const AcceleratedEffectValues&) = default;
+    
+    void copyTransformOperations(const TransformOperations&);
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(THREADED_ANIMATION_RESOLUTION)

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(VIDEO)
 
+#include "VideoFrame.h"
 #include "VideoFrameMetadata.h"
 
 namespace WebCore {


### PR DESCRIPTION
#### 3a375e3ac37d8cbefca6d1e73619f844a4a8bb6a
<pre>
[web-animations] add accelerated representation of WebAnimation and KeyframeEffect
<a href="https://bugs.webkit.org/show_bug.cgi?id=253154">https://bugs.webkit.org/show_bug.cgi?id=253154</a>

Reviewed by Dean Jackson.

For the threaded animation resolution work, we need a class that puts together timing and
keyframes properties from WebAnimation and KeyframeEffect which we be able to be encode and
decode over IPC in future patches.

We also fix a small unified build issue in MediaPlayerPrivate.cpp which appeared on GTK EWS.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/animation/WebAnimation.h:
(WebCore::WebAnimation::holdTime const):
* Source/WebCore/platform/animation/AcceleratedEffect.cpp: Added.
(WebCore::acceleratedPropertyFromCSSProperty):
(WebCore::AcceleratedEffect::create):
(WebCore::AcceleratedEffect::AcceleratedEffect):
* Source/WebCore/platform/animation/AcceleratedEffect.h: Added.
* Source/WebCore/platform/animation/AcceleratedEffectValues.cpp: Added.
(WebCore::AcceleratedEffectValues::copyTransformOperations):
(WebCore::AcceleratedEffectValues::AcceleratedEffectValues):
* Source/WebCore/platform/animation/AcceleratedEffectValues.h: Added.
(WebCore::AcceleratedEffectValues::AcceleratedEffectValues):
* Source/WebCore/platform/graphics/MediaPlayerPrivate.cpp:

Canonical link: <a href="https://commits.webkit.org/261014@main">https://commits.webkit.org/261014@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09932c9d16a49a8a6b5ee5bd419be0ce081fb0e5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110302 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/19396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/42940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/1707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/119264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/114251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/20852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/10577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/102556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116046 "Failed to checkout and rebase branch from PR 10868") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/20852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/42940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/102556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/20852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/42940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/102556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/12075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/42940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/12675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/10577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/18041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/42940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/14503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4153 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->