### PR TITLE
Adjust text input scrollWidth and scrollHeight to include padding and any whitespace added by decorations

### DIFF
--- a/LayoutTests/fast/scrolling/scroll-max-value-expected.txt
+++ b/LayoutTests/fast/scrolling/scroll-max-value-expected.txt
@@ -1,0 +1,12 @@
+PASS Setting test_section.scrollLeft = 100000000 scrolls all the way to the right.
+PASS Setting test_section.scrollTop = 100000000 scrolls all the way to the bottom.
+PASS Setting test_input.scrollLeft = 100000000 scrolls all the way to the right.
+PASS Setting test_input.scrollTop = 100000000 scrolls all the way to the bottom.
+PASS Setting test_input_search.scrollLeft = 100000000 scrolls all the way to the right.
+PASS Setting test_input_search.scrollTop = 100000000 scrolls all the way to the bottom.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+top leftbottom right
+
+Tests that large scrollLeft/Top values scroll to maximum possible value, i.e, Element.scrollWidth/Height - Element.clientWidth/Height.

--- a/LayoutTests/fast/scrolling/scroll-max-value.html
+++ b/LayoutTests/fast/scrolling/scroll-max-value.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <style>
+            #test_section {
+                width: 300px;
+                height: 300px;
+                overflow: auto;
+                border: 1px solid silver;
+            }
+            #test_section > article {
+                width: 1000px;
+                height: 1000px;
+                position: relative;
+            }
+            #top-left {
+                position: absolute;
+                top: 0;
+                left: 0;
+            }
+            #bottom-right {
+                position: absolute;
+                bottom: 0;
+                right: 0;
+            }
+            #test_input {
+              width: 300px;
+              font-size: 1em;
+              padding: 5px 10px 15px 20px;
+              border: 1px solid silver;
+            }
+            #test_input_search {
+              width: 300px;
+              font-size: 1em;
+              padding: 5px 10px 15px 20px;
+              border: 1px solid silver;
+            }
+        </style>
+        <script src="../../resources/js-test.js"></script>
+    </head>
+    <body>
+        <section id="test_section">
+            <article>
+                <span id="top-left">top left</span>
+                <span id="bottom-right">bottom right</span>
+            </article>
+        </section>
+        <section>
+          <input id="test_input" type="text" value="Neque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit">
+          <input id="test_input_search" type="search" value="Neque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit">
+        </section>
+        <p>
+            Tests that large scrollLeft/Top values scroll to maximum possible value, i.e, Element.scrollWidth/Height - Element.clientWidth/Height.
+        </p>
+        <script>
+
+          testScrollToMax('test_section');
+          testScrollToMax('test_input');
+          testScrollToMax('test_input_search');
+
+          function testScrollToMax(id) {
+            var el = document.getElementById(id);
+            expectedScrollLeft = el.scrollWidth - el.clientWidth;
+            expectedScrollTop = el.scrollHeight - el.clientHeight;
+
+            el.scrollLeft = 100000000;
+            el.scrollTop = 100000000;
+
+            if (el.scrollLeft == expectedScrollLeft) {
+                testPassed('Setting ' + el.id + '.scrollLeft = 100000000 ' +
+                    'scrolls all the way to the right.');
+            } else {
+                testFailed('Setting ' + el.id + '.scrollLeft = 100000000 ' +
+                   'scrolls to ' + el.scrollLeft + ', expected ' +
+                    expectedScrollLeft + '.');
+            }
+
+            if (el.scrollTop == expectedScrollTop) {
+                testPassed('Setting ' + el.id + '.scrollTop = 100000000 ' +
+                    'scrolls all the way to the bottom.');
+            } else {
+                testFailed('Setting ' + el.id + '.scrollTop = 100000000 ' +
+                    'scrolls to ' + el.scrollTop + ', expected ' +
+                     expectedScrollTop + '.');
+            }
+          }
+        </script>
+    </body>
+</html>

--- a/Source/WebCore/rendering/RenderTextControlSingleLine.cpp
+++ b/Source/WebCore/rendering/RenderTextControlSingleLine.cpp
@@ -1,7 +1,7 @@
 /**
- * Copyright (C) 2006, 2007, 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2023 Apple Inc. All rights reserved.
  *           (C) 2008 Torch Mobile Inc. All rights reserved. (http://www.torchmobile.com/) 
- * Copyright (C) 2010 Google Inc. All rights reserved.
+ * Copyright (C) 2010-2014 Google Inc. All rights reserved.
  * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies).
  *
  * This library is free software; you can redistribute it and/or
@@ -366,15 +366,21 @@ void RenderTextControlSingleLine::autoscroll(const IntPoint& position)
 
 int RenderTextControlSingleLine::scrollWidth() const
 {
-    if (auto innerTextElement = this->innerTextElement(); innerTextElement && innerTextElement->renderer())
-        return innerTextElement->renderer()->scrollWidth();
+    if (auto* innerTextRenderer = innerTextElement() ? innerTextElement()->renderer() : nullptr) {
+        // Adjust scrollWidth to inculde input element horizontal paddings and decoration width.
+        auto adjustment = clientWidth() - innerTextRenderer->clientWidth();
+        return innerTextRenderer->scrollWidth() + adjustment;
+    }
     return RenderBlockFlow::scrollWidth();
 }
 
 int RenderTextControlSingleLine::scrollHeight() const
 {
-    if (auto innerTextElement = this->innerTextElement(); innerTextElement && innerTextElement->renderer())
-        return innerTextElement->renderer()->scrollHeight();
+    if (auto* innerTextRenderer = innerTextElement() ? innerTextElement()->renderer() : nullptr) {
+        // Adjust scrollHeight to inculde input element vertical paddings and decoration height.
+        auto adjustment = clientHeight() - innerTextRenderer->clientHeight();
+        return innerTextRenderer->scrollHeight() + adjustment;
+    }
     return RenderBlockFlow::scrollHeight();
 }
 


### PR DESCRIPTION
#### 393d4a1bb437c9ee4312816fe53087e53d5fd5ab
<pre>
Adjust text input scrollWidth and scrollHeight to include padding and any whitespace added by decorations

<a href="https://bugs.webkit.org/show_bug.cgi?id=250383">https://bugs.webkit.org/show_bug.cgi?id=250383</a>
rdar://problem/104332108

Reviewed by Alan Baradlay.

This patch is to align WebKit with Blink / Chromium and Gecko / Firefox.

Merge - <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=186123

This patch modifies &quot;ScrollWidth&quot; and &quot;ScrollHeight&quot; functions to ensure that
scrollLeft (and similarly scrollTop) is always within range [0, scrollWidth - clientWidth]
and padding and whitespaces added by decorations are accounted.

* Source/WebCore/rendering/RenderTextControlSingleLine.cpp:
(RenderTextConrolSingleLine::scrollWidth):
(RenderTextConrolSingleLine::scrollHeight):
* LayoutTests/fast/scrolling/scroll-max-value.html: Add Test Case
* LayoutTests/fast/scrolling/scroll-max-value-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/261121@main">https://commits.webkit.org/261121@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e240150124d4273ad60da14ee080a849dbecbed1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110605 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19688 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43187 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1951 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119461 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114564 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21101 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10808 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/1477 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116346 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15711 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102912 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30569 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44029 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12335 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31907 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/85943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12890 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8858 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18254 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51523 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7705 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14826 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->