### PR TITLE
[GStreamer][MSE] Version check for a GStreamer bug fixed in 1.20.6

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
@@ -319,17 +319,17 @@ void webKitMediaSrcEmitStreams(WebKitMediaSrc* source, const Vector<RefPtr<Media
     gst_element_post_message(GST_ELEMENT(source), gst_message_new_stream_collection(GST_OBJECT(source), source->priv->collection.get()));
 
     for (const RefPtr<Stream>& stream: source->priv->streams.values()) {
-        // Workaround: gst_element_add_pad() should already call gst_pad_set_active() if the element is PAUSED or
-        // PLAYING. Unfortunately, as of GStreamer 1.18.2 it does so with the element lock taken, causing a deadlock
-        // in gst_pad_start_task(), who tries to post a `stream-status` message in the element, which also requires
-        // the element lock. Activating the pad beforehand avoids that codepath.
-        // https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/210
-        // FIXME: Remove this workaround when the bug gets fixed and versions without the bug are no longer in use.
-        GstState state;
-        gst_element_get_state(GST_ELEMENT(source), &state, nullptr, 0);
-        if (state > GST_STATE_READY)
-            gst_pad_set_active(GST_PAD(stream->pad.get()), true);
-
+        if (!webkitGstCheckVersion(1, 20, 6)) {
+            // Workaround: gst_element_add_pad() should already call gst_pad_set_active() if the element is PAUSED or
+            // PLAYING. Unfortunately, as of GStreamer 1.18.2 it does so with the element lock taken, causing a deadlock
+            // in gst_pad_start_task(), who tries to post a `stream-status` message in the element, which also requires
+            // the element lock. Activating the pad beforehand avoids that codepath.
+            // https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/210
+            GstState state;
+            gst_element_get_state(GST_ELEMENT(source), &state, nullptr, 0);
+            if (state > GST_STATE_READY)
+                gst_pad_set_active(GST_PAD(stream->pad.get()), true);
+        }
         GST_DEBUG_OBJECT(source, "Adding pad '%s' for stream with name '%s'", GST_OBJECT_NAME(stream->pad.get()), stream->track->trackId().string().utf8().data());
         gst_element_add_pad(GST_ELEMENT(source), GST_PAD(stream->pad.get()));
     }


### PR DESCRIPTION
#### d54e09dcce0da58160346abf6ab95637313c1150
<pre>
[GStreamer][MSE] Version check for a GStreamer bug fixed in 1.20.6
<a href="https://bugs.webkit.org/show_bug.cgi?id=253169">https://bugs.webkit.org/show_bug.cgi?id=253169</a>

Reviewed by Alicia Boya Garcia.

Get the element state before activating a new source pad only in GStreamer versions older than
1.20.6. Newer versions no longer have this bug.

* Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp:
(webKitMediaSrcEmitStreams):

Canonical link: <a href="https://commits.webkit.org/261629@main">https://commits.webkit.org/261629@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6d52c5866b210778d682b7e28af2652a8d83d4c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110304 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19397 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42941 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1708 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119265 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114253 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20853 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10578 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/1204 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116048 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15526 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98730 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102557 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97487 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30394 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43740 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12076 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31731 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85592 "Found 2 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state-changed (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12676 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8693 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18042 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51348 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8110 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14504 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->