### PR TITLE
[contain-intrinsic-size] failures related to replaced elements

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4732,9 +4732,6 @@ webkit.org/b/214462 imported/w3c/web-platform-tests/css/css-scoping/slotted-plac
 webkit.org/b/214463 imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/flex-aspect-ratio-038.html [ ImageOnlyFailure ]
 webkit.org/b/214463 imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/floats-aspect-ratio-001.html [ ImageOnlyFailure ]
 
-# contain-intrinsic-size
-webkit.org/b/246283 imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-logical-003.html [ Skip ]
-
 webkit.org/b/214463 imported/w3c/web-platform-tests/css/css-sizing/image-fractional-height-with-wide-aspect-ratio.html [ ImageOnlyFailure ]
 webkit.org/b/214463 imported/w3c/web-platform-tests/css/css-sizing/intrinsic-percent-replaced-dynamic-002.html [ ImageOnlyFailure ]
 webkit.org/b/214463 imported/w3c/web-platform-tests/css/css-sizing/intrinsic-percent-replaced-dynamic-003.html [ ImageOnlyFailure ]
@@ -4858,7 +4855,6 @@ webanimations/translate-property-and-translate-animation-with-delay-on-forced-la
 
 # CSS containment tests that fail
 imported/w3c/web-platform-tests/css/css-contain/contain-inline-size-bfc-floats-001.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-contain/contain-inline-size-intrinsic.html [ ImageOnlyFailure ]
 # forced layout
 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-035.html [ Skip ]
 # c-v: auto

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-028-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-028-expected.txt
@@ -9,84 +9,44 @@ PASS .test 7
 PASS .test 8
 PASS .test 9
 PASS .test 10
-FAIL .test 11 assert_equals:
-<img class="test cis-width" src="/css/support/60x60-green.png" data-expected-client-width="100" data-expected-client-height="60">
-clientWidth expected 100 but got 0
-FAIL .test 12 assert_equals:
-<img class="test cis-both" src="/css/support/60x60-green.png" data-expected-client-width="100" data-expected-client-height="60">
-clientWidth expected 100 but got 0
+PASS .test 11
+PASS .test 12
 PASS .test 13
-FAIL .test 14 assert_equals:
-<img class="test cis-height vertical" src="/css/support/60x60-green.png" data-expected-client-width="60" data-expected-client-height="50">
-clientHeight expected 50 but got 0
+PASS .test 14
 PASS .test 15
-FAIL .test 16 assert_equals:
-<img class="test cis-both vertical" src="/css/support/60x60-green.png" data-expected-client-width="60" data-expected-client-height="50">
-clientHeight expected 50 but got 0
+PASS .test 16
 PASS .test 17
 PASS .test 18
-FAIL .test 19 assert_equals:
-<svg class="test cis-width" data-expected-client-width="100" data-expected-client-height="150"></svg>
-clientWidth expected 100 but got 0
-FAIL .test 20 assert_equals:
-<svg class="test cis-both" data-expected-client-width="100" data-expected-client-height="150"></svg>
-clientWidth expected 100 but got 0
+PASS .test 19
+PASS .test 20
 PASS .test 21
-FAIL .test 22 assert_equals:
-<svg class="test cis-height vertical" data-expected-client-width="300" data-expected-client-height="50"></svg>
-clientHeight expected 50 but got 0
+PASS .test 22
 PASS .test 23
-FAIL .test 24 assert_equals:
-<svg class="test cis-both vertical" data-expected-client-width="300" data-expected-client-height="50"></svg>
-clientHeight expected 50 but got 0
+PASS .test 24
 PASS .test 25
 PASS .test 26
-FAIL .test 27 assert_equals:
-<canvas class="test cis-width" width="40" height="20" data-expected-client-width="100" data-expected-client-height="20"></canvas>
-clientWidth expected 100 but got 0
-FAIL .test 28 assert_equals:
-<canvas class="test cis-both" width="40" height="20" data-expected-client-width="100" data-expected-client-height="20"></canvas>
-clientWidth expected 100 but got 0
+PASS .test 27
+PASS .test 28
 PASS .test 29
-FAIL .test 30 assert_equals:
-<canvas class="test cis-height vertical" width="40" height="20" data-expected-client-width="40" data-expected-client-height="50"></canvas>
-clientHeight expected 50 but got 0
+PASS .test 30
 PASS .test 31
-FAIL .test 32 assert_equals:
-<canvas class="test cis-both vertical" width="40" height="20" data-expected-client-width="40" data-expected-client-height="50"></canvas>
-clientHeight expected 50 but got 0
+PASS .test 32
 PASS .test 33
 PASS .test 34
-FAIL .test 35 assert_equals:
-<iframe class="test cis-width" data-expected-client-width="100" data-expected-client-height="150"></iframe>
-clientWidth expected 100 but got 0
-FAIL .test 36 assert_equals:
-<iframe class="test cis-both" data-expected-client-width="100" data-expected-client-height="150"></iframe>
-clientWidth expected 100 but got 0
+PASS .test 35
+PASS .test 36
 PASS .test 37
-FAIL .test 38 assert_equals:
-<iframe class="test cis-height vertical" data-expected-client-width="300" data-expected-client-height="50"></iframe>
-clientHeight expected 50 but got 0
+PASS .test 38
 PASS .test 39
-FAIL .test 40 assert_equals:
-<iframe class="test cis-both vertical" data-expected-client-width="300" data-expected-client-height="50"></iframe>
-clientHeight expected 50 but got 0
+PASS .test 40
 PASS .test 41
 PASS .test 42
-FAIL .test 43 assert_equals:
-<video class="test cis-width" data-expected-client-width="100" data-expected-client-height="150"></video>
-clientWidth expected 100 but got 0
-FAIL .test 44 assert_equals:
-<video class="test cis-both" data-expected-client-width="100" data-expected-client-height="150"></video>
-clientWidth expected 100 but got 0
+PASS .test 43
+PASS .test 44
 PASS .test 45
-FAIL .test 46 assert_equals:
-<video class="test cis-height vertical" data-expected-client-width="300" data-expected-client-height="50"></video>
-clientHeight expected 50 but got 0
+PASS .test 46
 PASS .test 47
-FAIL .test 48 assert_equals:
-<video class="test cis-both vertical" data-expected-client-width="300" data-expected-client-height="50"></video>
-clientHeight expected 50 but got 0
+PASS .test 48
 
 
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-logical-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-logical-003-expected.txt
@@ -23,25 +23,13 @@ PASS .test 21
 PASS .test 22
 PASS .test 23
 PASS .test 24
-FAIL .test 25 assert_equals:
-<canvas class="test cis-none" width="40" height="20" data-expected-client-width="0" data-expected-client-height="0"></canvas>
-clientWidth expected 0 but got 769
-FAIL .test 26 assert_equals:
-<canvas class="test cis-block" width="40" height="20" data-expected-client-width="0" data-expected-client-height="50"></canvas>
-clientWidth expected 0 but got 100
-FAIL .test 27 assert_equals:
-<canvas class="test cis-inline" width="40" height="20" data-expected-client-width="100" data-expected-client-height="0"></canvas>
-clientHeight expected 0 but got 50
+PASS .test 25
+PASS .test 26
+PASS .test 27
 PASS .test 28
-FAIL .test 29 assert_equals:
-<canvas class="test cis-none vertical" width="40" height="20" data-expected-client-height="0" data-expected-client-width="0"></canvas>
-clientWidth expected 0 but got 1538
-FAIL .test 30 assert_equals:
-<canvas class="test cis-block vertical" width="40" height="20" data-expected-client-height="0" data-expected-client-width="50"></canvas>
-clientHeight expected 0 but got 25
-FAIL .test 31 assert_equals:
-<canvas class="test cis-inline vertical" width="40" height="20" data-expected-client-height="100" data-expected-client-width="0"></canvas>
-clientWidth expected 0 but got 200
+PASS .test 29
+PASS .test 30
+PASS .test 31
 PASS .test 32
 PASS .test 33
 PASS .test 34

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -5607,8 +5607,6 @@ LayoutUnit synthesizedBaseline(const RenderBox& box, const RenderStyle& parentSt
 
 LayoutUnit RenderBox::intrinsicLogicalWidth() const
 {
-    if (shouldApplyInlineSizeContainment())
-        return LayoutUnit();
     return style().isHorizontalWritingMode() ? intrinsicSize().width() : intrinsicSize().height();
 }
 

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -398,7 +398,7 @@ static bool isVideoWithDefaultObjectSize(const RenderReplaced* maybeVideo)
 void RenderReplaced::computeAspectRatioInformationForRenderBox(RenderBox* contentRenderer, FloatSize& constrainedSize, FloatSize& intrinsicRatio) const
 {
     FloatSize intrinsicSize;
-    if (shouldApplySizeContainment())
+    if (shouldApplySizeOrInlineSizeContainment())
         RenderReplaced::computeIntrinsicRatioInformation(intrinsicSize, intrinsicRatio);
     else if (contentRenderer) {
         contentRenderer->computeIntrinsicRatioInformation(intrinsicSize, intrinsicRatio);
@@ -508,7 +508,7 @@ RoundedRect RenderReplaced::roundedContentBoxRect() const
 void RenderReplaced::computeIntrinsicRatioInformation(FloatSize& intrinsicSize, FloatSize& intrinsicRatio) const
 {
     // If there's an embeddedContentBox() of a remote, referenced document available, this code-path should never be used.
-    ASSERT(!embeddedContentBox() || shouldApplySizeContainment());
+    ASSERT(!embeddedContentBox() || shouldApplySizeOrInlineSizeContainment());
     intrinsicSize = FloatSize(intrinsicLogicalWidth(), intrinsicLogicalHeight());
 
     if (style().hasAspectRatio()) {
@@ -568,8 +568,6 @@ LayoutUnit RenderReplaced::computeReplacedLogicalWidth(ShouldComputePreferred sh
 {
     if (style().logicalWidth().isSpecified())
         return computeReplacedLogicalWidthRespectingMinMaxWidth(computeReplacedLogicalWidthUsing(MainOrPreferredSize, style().logicalWidth()), shouldComputePreferred);
-    if (shouldApplyInlineSizeContainment())
-        return LayoutUnit();
     if (style().logicalWidth().isIntrinsic())
         return computeReplacedLogicalWidthRespectingMinMaxWidth(computeReplacedLogicalWidthUsing(MainOrPreferredSize, style().logicalWidth()), shouldComputePreferred);
 
@@ -582,8 +580,8 @@ LayoutUnit RenderReplaced::computeReplacedLogicalWidth(ShouldComputePreferred sh
 
     if (style().logicalWidth().isAuto()) {
         bool computedHeightIsAuto = style().logicalHeight().isAuto();
-        bool hasIntrinsicWidth = constrainedSize.width() > 0;
-        bool hasIntrinsicHeight = constrainedSize.height() > 0;
+        bool hasIntrinsicWidth = constrainedSize.width() > 0 || shouldApplySizeOrInlineSizeContainment();
+        bool hasIntrinsicHeight = constrainedSize.height() > 0 || shouldApplySizeContainment();
 
         // For flex or grid items where the logical height has been overriden then we should use that size to compute the replaced width as long as the flex or
         // grid item has an intrinsic size. It is possible (indeed, common) for an SVG graphic to have an intrinsic aspect ratio but not to have an intrinsic
@@ -652,8 +650,8 @@ LayoutUnit RenderReplaced::computeReplacedLogicalHeight(std::optional<LayoutUnit
     computeIntrinsicSizesConstrainedByTransferredMinMaxSizes(contentRenderer, constrainedSize, intrinsicRatio);
 
     bool widthIsAuto = style().logicalWidth().isAuto();
-    bool hasIntrinsicHeight = constrainedSize.height() > 0;
-    bool hasIntrinsicWidth = constrainedSize.width() > 0;
+    bool hasIntrinsicHeight = constrainedSize.height() > 0 || shouldApplySizeContainment();
+    bool hasIntrinsicWidth = constrainedSize.width() > 0 || shouldApplySizeOrInlineSizeContainment();
 
     // See computeReplacedLogicalHeight() for a similar check for heights.
     if (!intrinsicRatio.isEmpty() && (isFlexItem() || isGridItem()) && hasOverridingLogicalWidth() && hasIntrinsicSize(contentRenderer, hasIntrinsicWidth, hasIntrinsicHeight))

--- a/Source/WebCore/rendering/RenderReplaced.h
+++ b/Source/WebCore/rendering/RenderReplaced.h
@@ -40,15 +40,12 @@ public:
 
     LayoutSize intrinsicSize() const final
     {
-        if (shouldApplySizeContainment()) {
-            LayoutSize size;
-            if (auto width = explicitIntrinsicInnerWidth())
-                size.setWidth(width.value());
-            if (auto height = explicitIntrinsicInnerHeight())
-                size.setHeight(height.value());
-            return size;
-        }
-        return m_intrinsicSize;
+        LayoutSize size = m_intrinsicSize;
+        if (isHorizontalWritingMode() ? shouldApplySizeOrInlineSizeContainment() : shouldApplySizeContainment())
+            size.setWidth(explicitIntrinsicInnerWidth().value_or(0));
+        if (isHorizontalWritingMode() ? shouldApplySizeContainment() : shouldApplySizeOrInlineSizeContainment())
+            size.setHeight(explicitIntrinsicInnerHeight().value_or(0));
+        return size;
     }
     
     RoundedRect roundedContentBoxRect() const;

--- a/Source/WebCore/rendering/RenderVideo.cpp
+++ b/Source/WebCore/rendering/RenderVideo.cpp
@@ -112,11 +112,8 @@ bool RenderVideo::updateIntrinsicSize()
     return true;
 }
 
-LayoutSize RenderVideo::calculateIntrinsicSize()
+LayoutSize RenderVideo::calculateIntrinsicSizeInternal()
 {
-    if (shouldApplySizeContainment())
-        return intrinsicSize();
-
     // Spec text from 4.8.6
     //
     // The intrinsic width of a video element's playback area is the intrinsic width 
@@ -144,6 +141,21 @@ LayoutSize RenderVideo::calculateIntrinsicSize()
         return LayoutSize(defaultSize().width(), 1);
 
     return defaultSize();
+}
+
+LayoutSize RenderVideo::calculateIntrinsicSize()
+{
+    if (shouldApplySizeContainment())
+        return intrinsicSize();
+
+    auto calculatedIntrinsicSize = calculateIntrinsicSizeInternal();
+    if (shouldApplyInlineSizeContainment()) {
+        if (isHorizontalWritingMode())
+            calculatedIntrinsicSize.setWidth(intrinsicSize().width());
+        else
+            calculatedIntrinsicSize.setHeight(intrinsicSize().height());
+    }
+    return calculatedIntrinsicSize;
 }
 
 void RenderVideo::imageChanged(WrappedImagePtr newImage, const IntRect* rect)
@@ -332,7 +344,12 @@ bool RenderVideo::hasVideoMetadata() const
 
 bool RenderVideo::hasPosterFrameSize() const
 {
-    return videoElement().shouldDisplayPosterImage() && !m_cachedImageSize.isEmpty() && !imageResource().errorOccurred();
+    bool isEmpty = m_cachedImageSize.isEmpty();
+    // For contain: inline-size, if the block-size is not empty, it shouldn't be treated as empty here,
+    // so that contain: inline-size could affect the intrinsic size, which should be 0 x block-size.
+    if (shouldApplyInlineSizeContainment())
+        isEmpty = isHorizontalWritingMode() ? !m_cachedImageSize.height() : !m_cachedImageSize.width();
+    return videoElement().shouldDisplayPosterImage() && !isEmpty && !imageResource().errorOccurred();
 }
 
 bool RenderVideo::hasDefaultObjectSize() const

--- a/Source/WebCore/rendering/RenderVideo.h
+++ b/Source/WebCore/rendering/RenderVideo.h
@@ -62,6 +62,7 @@ private:
     void mediaElement() const = delete;
 
     void intrinsicSizeChanged() final;
+    LayoutSize calculateIntrinsicSizeInternal();
     LayoutSize calculateIntrinsicSize();
     bool updateIntrinsicSize();
 


### PR DESCRIPTION
#### 43b73e296e5003e669fcb0ba76304837e90cbaa9
<pre>
[contain-intrinsic-size] failures related to replaced elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=253013">https://bugs.webkit.org/show_bug.cgi?id=253013</a>

Reviewed by Alan Baradlay.

This patch makes intrinsicSize() considering both contain: size and inline-size,
so that there is no need to handle contain: inline-size specially.
In computeReplacedLogicalWidth/Height, hasIntrinsicWidth/Height is determined by width/height &gt; 0,
for contain: size/inline-size, hasIntrinsicWidth/Height should be true regardless of the value.
For RenderVideo, in calculateIntrinsicSize(), the intrinsic size should consider contain: inline-size,
so this patch adjustSizeForInlineSizeContainment before return.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-028-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-logical-003-expected.txt:
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::intrinsicLogicalWidth const):
* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::RenderReplaced::computeAspectRatioInformationForRenderBox const):
(WebCore::RenderReplaced::computeIntrinsicRatioInformation const):
(WebCore::RenderReplaced::computeReplacedLogicalWidth const):
(WebCore::RenderReplaced::computeReplacedLogicalHeight const):
* Source/WebCore/rendering/RenderReplaced.h:
* Source/WebCore/rendering/RenderVideo.cpp:
(WebCore::RenderVideo::calculateIntrinsicSizeInternal):
(WebCore::RenderVideo::calculateIntrinsicSize):
(WebCore::RenderVideo::hasPosterFrameSize const):
* Source/WebCore/rendering/RenderVideo.h:

Canonical link: <a href="https://commits.webkit.org/261205@main">https://commits.webkit.org/261205@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/363c0be5d5c302d12707debfe11bfd175776febc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110696 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19778 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43258 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2050 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119529 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114663 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21186 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10890 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/1640 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116438 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15781 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98953 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103011 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97742 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30620 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44121 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12408 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31958 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86008 "Found 1 new API test failure: /WebKitGTK/TestWebExtensions:/webkit/WebKitWebExtension/page-id (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12960 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8926 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18334 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51576 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7775 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14897 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->