### PR TITLE
Make sure child is a RenderElement before trying to pass it into shouldChildInlineMarginContributeToContainerIntrinsicSize in RenderBlock::computeBlockPreferredLogicalWidths

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -3544,6 +3544,7 @@ fast/text/design-system-ui-16.html [ ImageOnlyFailure ]
 
 # This is a crash test.
 fast/editing/apply-relative-font-style-change-crash-004.html [ Pass Failure ]
+webkit.org/b/253182 fast/editing/ruby-with-edited-text-crash.html [ Skip ] 
 
 # wpt css-images failures
 webkit.org/b/200207 imported/w3c/web-platform-tests/css/css-images/css-image-fallbacks-and-annotations002.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/editing/ruby-with-edited-text-crash-expected.txt
+++ b/LayoutTests/fast/editing/ruby-with-edited-text-crash-expected.txt
@@ -1,0 +1,2 @@
+CONSOLE MESSAGE: The test PASS if it does not crash.
+  Hello! This rendering should not crash.

--- a/LayoutTests/fast/editing/ruby-with-edited-text-crash.html
+++ b/LayoutTests/fast/editing/ruby-with-edited-text-crash.html
@@ -1,0 +1,27 @@
+<style>
+* { 
+    -webkit-user-modify: read-write;
+}
+</style>
+<script>
+    function main() {
+        if (window.testRunner)
+            testRunner.dumpAsText();
+        console.log('The test PASS if it does not crash.')
+        document.designMode = "on";
+        document.execCommand("selectAll", false, null);
+        document.execCommand("italic", false, null);
+        document.execCommand("italic", false, null);
+    }
+</script>
+
+<body onload="main()">
+<ruby>
+<h1></h1>
+<rt>
+<p></p>
+<input>
+</rt>
+Hello! This rendering should not crash.
+<rp></rp>
+</ruby>

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -2370,8 +2370,12 @@ void RenderBlock::computeBlockPreferredLogicalWidths(LayoutUnit& minLogicalWidth
         //
         // Floats inside a block level box may not use their margins in their
         // intrinsic size contributions if margin-trim is set for that margin type
-        Length startMarginLength = shouldChildInlineMarginContributeToContainerIntrinsicSize(MarginTrimType::InlineStart, *dynamicDowncast<RenderElement>(child)) ? childStyle.marginStartUsing(&styleToUse) : Length { 0, LengthType::Fixed };
-        Length endMarginLength = shouldChildInlineMarginContributeToContainerIntrinsicSize(MarginTrimType::InlineEnd, *dynamicDowncast<RenderElement>(child)) ? childStyle.marginEndUsing(&styleToUse) : Length { 0, LengthType::Fixed };
+        Length startMarginLength;
+        Length endMarginLength;
+        if (auto* renderElement = dynamicDowncast<RenderElement>(child); renderElement && shouldChildInlineMarginContributeToContainerIntrinsicSize(MarginTrimType::InlineStart, *renderElement))
+            startMarginLength = childStyle.marginStartUsing(&styleToUse);
+        if (auto* renderElement = dynamicDowncast<RenderElement>(child); renderElement && shouldChildInlineMarginContributeToContainerIntrinsicSize(MarginTrimType::InlineEnd, *renderElement))
+            endMarginLength = shouldChildInlineMarginContributeToContainerIntrinsicSize(MarginTrimType::InlineEnd, *dynamicDowncast<RenderElement>(child)) ? childStyle.marginEndUsing(&styleToUse) : Length { 0, LengthType::Fixed };
 
         LayoutUnit margin;
         LayoutUnit marginStart;


### PR DESCRIPTION
#### 02bb8ae9d5735cb1a73164b46be85937d254dde0
<pre>
Make sure child is a RenderElement before trying to pass it into shouldChildInlineMarginContributeToContainerIntrinsicSize in RenderBlock::computeBlockPreferredLogicalWidths
<a href="https://bugs.webkit.org/show_bug.cgi?id=253165">https://bugs.webkit.org/show_bug.cgi?id=253165</a>
rdar://105848359

Reviewed by Alan Baradlay.

We should not be assuming that child is always doing to be a
RenderElement in this method. It can sometimes be a RenderText (like
in the attached test case), which will cause a nullptr dereference.
Instead, we should check the result of the dynamicDowncast before
passing it into shouldChildInlineMarginContributeToContainerIntrinsicSize.

The only other change is that we use the default constructor for
startMarginLength and endMarginLength. This should be ok even if we do
not enter the code guarded by the if statement because the isFixed()
call will return false and not impact the margins.

* LayoutTests/TestExpectations:
* LayoutTests/fast/editing/ruby-with-edited-text-crash-expected.txt: Added.
* LayoutTests/fast/editing/ruby-with-edited-text-crash.html: Added.
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::computeBlockPreferredLogicalWidths const):

Canonical link: <a href="https://commits.webkit.org/261063@main">https://commits.webkit.org/261063@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f4e5f8265ce180631f639ca43fdfe7155b82d9c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110328 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19421 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42957 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1729 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119279 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114277 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20871 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10596 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102580 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116072 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15545 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98744 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43760 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97506 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30409 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85615 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12096 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31746 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12691 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8712 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18056 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51362 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7662 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14525 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->