### PR TITLE
Ask system malloc to free up memory in non-visible Web processes

### DIFF
--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -264,7 +264,7 @@ public:
     void pageDidEnterWindow(WebCore::PageIdentifier);
     void pageWillLeaveWindow(WebCore::PageIdentifier);
 
-    void nonVisibleProcessGraphicsCleanupTimerFired();
+    void nonVisibleProcessEarlyMemoryCleanupTimerFired();
 
 #if ENABLE(NON_VISIBLE_WEBPROCESS_MEMORY_CLEANUP_TIMER)
     void nonVisibleProcessMemoryCleanupTimerFired();
@@ -277,6 +277,7 @@ public:
 #if PLATFORM(COCOA)
     RetainPtr<CFDataRef> sourceApplicationAuditData() const;
     void destroyRenderingResources();
+    void releaseSystemMallocMemory();
     void getProcessDisplayName(CompletionHandler<void(String&&)>&&);
     std::optional<audit_token_t> auditTokenForSelf();
 #endif
@@ -675,7 +676,7 @@ private:
     bool m_processIsSuspended { false };
 
     HashSet<WebCore::PageIdentifier> m_pagesInWindows;
-    WebCore::Timer m_nonVisibleProcessGraphicsCleanupTimer;
+    WebCore::Timer m_nonVisibleProcessEarlyMemoryCleanupTimer;
 
 #if ENABLE(NON_VISIBLE_WEBPROCESS_MEMORY_CLEANUP_TIMER)
     WebCore::Timer m_nonVisibleProcessMemoryCleanupTimer;


### PR DESCRIPTION
#### 0668d887feed861cb082fe8cea267f1055c5bb49
<pre>
Ask system malloc to free up memory in non-visible Web processes
<a href="https://bugs.webkit.org/show_bug.cgi?id=253173">https://bugs.webkit.org/show_bug.cgi?id=253173</a>
rdar://106009868

Reviewed by Geoffrey Garen.

We currently do some memory reduction work in non-visible Web processes (those
that only have background tabs) off a timer. We can ask the system malloc to
free up memory off one of these timers too.

malloc_zone_pressure_relief will block the thread it&apos;s called on, so we
call it on a background thread, which is allowed. Local testing shows it
can run for several ms, but it will only cause regular malloc
contention, not block other threads entirely.

This patch repurposes the &quot;graphics cleanup timer&quot; to be an &quot;early
memory cleanup timer&quot;, and we perform the system malloc cleanup off it.
The more aggressive cleanup tasks that can clear caches etc. remain off
the other memory cleanup timer, which runs later.

* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::pageDidEnterWindow):
(WebKit::WebProcess::pageWillLeaveWindow):
(WebKit::WebProcess::nonVisibleProcessEarlyMemoryCleanupTimerFired):
(WebKit::WebProcess::nonVisibleProcessGraphicsCleanupTimerFired): Deleted.
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::releaseSystemMallocMemory):

Canonical link: <a href="https://commits.webkit.org/261087@main">https://commits.webkit.org/261087@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/289e239fcf45242b8e9369fb031b628ef6fc7ab6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110337 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19429 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42962 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1734 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119284 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20876 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10601 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102586 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116081 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15550 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98747 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43765 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97511 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30412 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85620 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12101 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31750 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12696 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8717 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18061 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51365 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14532 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4178 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->