### PR TITLE
[JSC] Inline Proxy [[Set]] trap in DFG / FTL

### DIFF
--- a/Source/JavaScriptCore/bytecode/InlineCallFrame.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCallFrame.cpp
@@ -118,6 +118,9 @@ void printInternal(PrintStream& out, JSC::InlineCallFrame::Kind kind)
     case JSC::InlineCallFrame::ProxyObjectLoadCall:
         out.print("ProxyObjectLoadCall");
         return;
+    case JSC::InlineCallFrame::ProxyObjectStoreCall:
+        out.print("ProxyObjectStoreCall");
+        return;
     case JSC::InlineCallFrame::BoundFunctionCall:
         out.print("BoundFunctionCall");
         return;

--- a/Source/JavaScriptCore/bytecode/InlineCallFrame.h
+++ b/Source/JavaScriptCore/bytecode/InlineCallFrame.h
@@ -54,6 +54,7 @@ struct InlineCallFrame {
         GetterCall,
         SetterCall,
         ProxyObjectLoadCall,
+        ProxyObjectStoreCall,
         BoundFunctionCall,
         BoundFunctionTailCall,
     };
@@ -67,6 +68,7 @@ struct InlineCallFrame {
         case GetterCall:
         case SetterCall:
         case ProxyObjectLoadCall:
+        case ProxyObjectStoreCall:
         case BoundFunctionCall:
             return CallMode::Regular;
         case TailCall:
@@ -116,6 +118,7 @@ struct InlineCallFrame {
         case GetterCall:
         case SetterCall:
         case ProxyObjectLoadCall:
+        case ProxyObjectStoreCall:
         case BoundFunctionCall:
         case BoundFunctionTailCall:
             return CodeForCall;

--- a/Source/JavaScriptCore/bytecode/PutByVariant.h
+++ b/Source/JavaScriptCore/bytecode/PutByVariant.h
@@ -41,7 +41,8 @@ public:
         NotSet,
         Replace,
         Transition,
-        Setter
+        Setter,
+        Proxy,
     };
     
     PutByVariant(CacheableIdentifier identifier)
@@ -60,6 +61,8 @@ public:
     static PutByVariant transition(CacheableIdentifier, const StructureSet& oldStructure, Structure* newStructure, const ObjectPropertyConditionSet&, PropertyOffset);
     
     static PutByVariant setter(CacheableIdentifier, const StructureSet&, PropertyOffset, const ObjectPropertyConditionSet&, std::unique_ptr<CallLinkStatus>);
+
+    static PutByVariant proxy(CacheableIdentifier, const StructureSet&, std::unique_ptr<CallLinkStatus>);
     
     Kind kind() const { return m_kind; }
     
@@ -68,13 +71,13 @@ public:
     
     const StructureSet& structure() const
     {
-        ASSERT(kind() == Replace || kind() == Setter);
+        ASSERT(kind() == Replace || kind() == Setter || kind() == Proxy);
         return m_oldStructure;
     }
     
     const StructureSet& oldStructure() const
     {
-        ASSERT(kind() == Transition || kind() == Replace || kind() == Setter);
+        ASSERT(kind() == Transition || kind() == Replace || kind() == Setter || kind() == Proxy);
         return m_oldStructure;
     }
     
@@ -85,7 +88,7 @@ public:
     
     StructureSet& oldStructure()
     {
-        ASSERT(kind() == Transition || kind() == Replace || kind() == Setter);
+        ASSERT(kind() == Transition || kind() == Replace || kind() == Setter || kind() == Proxy);
         return m_oldStructure;
     }
     
@@ -124,7 +127,7 @@ public:
     
     CallLinkStatus* callLinkStatus() const
     {
-        ASSERT(kind() == Setter);
+        ASSERT(kind() == Setter || kind() == Proxy);
         return m_callLinkStatus.get();
     }
 

--- a/Source/JavaScriptCore/dfg/DFGOSRExitCompilerCommon.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOSRExitCompilerCommon.cpp
@@ -182,7 +182,8 @@ static CodePtr<JSEntryPtrTag> callerReturnPC(CodeBlock* baselineCodeBlockForCall
                 RELEASE_ASSERT_NOT_REACHED();
             break;
         }
-        case InlineCallFrame::SetterCall: {
+        case InlineCallFrame::SetterCall:
+        case InlineCallFrame::ProxyObjectStoreCall: {
             if (callInstruction.opcodeID() == op_put_by_id)
                 jumpTarget = LLINT_RETURN_LOCATION(op_put_by_id);
             else if (callInstruction.opcodeID() == op_put_by_val)
@@ -216,7 +217,8 @@ static CodePtr<JSEntryPtrTag> callerReturnPC(CodeBlock* baselineCodeBlockForCall
 
         case InlineCallFrame::GetterCall:
         case InlineCallFrame::SetterCall:
-        case InlineCallFrame::ProxyObjectLoadCall: {
+        case InlineCallFrame::ProxyObjectLoadCall:
+        case InlineCallFrame::ProxyObjectStoreCall: {
             StructureStubInfo* stubInfo = baselineCodeBlockForCaller->findStubInfo(CodeOrigin(callBytecodeIndex));
             RELEASE_ASSERT(stubInfo, callInstruction.opcodeID());
             jumpTarget = stubInfo->doneLocation.retagged<JSEntryPtrTag>();

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -868,7 +868,9 @@ public:
     JSFunction* performProxyObjectGetFunction() const;
     JSFunction* performProxyObjectGetFunctionConcurrently() const;
     JSFunction* performProxyObjectSetSloppyFunction() const;
+    JSFunction* performProxyObjectSetSloppyFunctionConcurrently() const;
     JSFunction* performProxyObjectSetStrictFunction() const;
+    JSFunction* performProxyObjectSetStrictFunctionConcurrently() const;
     JSObject* regExpProtoSymbolReplaceFunction() const { return m_regExpProtoSymbolReplace.get(); }
     GetterSetter* regExpProtoGlobalGetter() const;
     GetterSetter* regExpProtoUnicodeGetter() const;

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
@@ -195,7 +195,9 @@ inline JSFunction* JSGlobalObject::stringProtoSubstringFunction() const { return
 inline JSFunction* JSGlobalObject::performProxyObjectGetFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::performProxyObjectGet)); }
 inline JSFunction* JSGlobalObject::performProxyObjectGetFunctionConcurrently() const { return linkTimeConstantConcurrently<JSFunction*>(LinkTimeConstant::performProxyObjectGet); }
 inline JSFunction* JSGlobalObject::performProxyObjectSetSloppyFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::performProxyObjectSetSloppy)); }
+inline JSFunction* JSGlobalObject::performProxyObjectSetSloppyFunctionConcurrently() const { return linkTimeConstantConcurrently<JSFunction*>(LinkTimeConstant::performProxyObjectSetSloppy); }
 inline JSFunction* JSGlobalObject::performProxyObjectSetStrictFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::performProxyObjectSetStrict)); }
+inline JSFunction* JSGlobalObject::performProxyObjectSetStrictFunctionConcurrently() const { return linkTimeConstantConcurrently<JSFunction*>(LinkTimeConstant::performProxyObjectSetStrict); }
 inline GetterSetter* JSGlobalObject::regExpProtoGlobalGetter() const { return bitwise_cast<GetterSetter*>(linkTimeConstant(LinkTimeConstant::regExpProtoGlobalGetter)); }
 inline GetterSetter* JSGlobalObject::regExpProtoUnicodeGetter() const { return bitwise_cast<GetterSetter*>(linkTimeConstant(LinkTimeConstant::regExpProtoUnicodeGetter)); }
 


### PR DESCRIPTION
#### 1d89fdbdb2bae963b88585f0b94091cc2e3e590c
<pre>
[JSC] Inline Proxy [[Set]] trap in DFG / FTL
<a href="https://bugs.webkit.org/show_bug.cgi?id=253179">https://bugs.webkit.org/show_bug.cgi?id=253179</a>
rdar://106097171

Reviewed by Alexey Shvayka.

This patch implements inlining of Proxy [[Set]] trap as the similar way to <a href="https://commits.webkit.org/260282@main.">https://commits.webkit.org/260282@main.</a>
The approach is that we set Proxy PutByVariant, and handle it in DFG handlePutById. This offers 20% improvement in
proxy-set microbenchmarks.

                                       ToT                     Patched

    proxy-set-miss-handler       17.5355+-0.0455     ^     14.6011+-0.0285        ^ definitely 1.2010x faster
    proxy-set                    14.6974+-0.0503     ^     11.9129+-0.0726        ^ definitely 1.2337x faster

* Source/JavaScriptCore/bytecode/InlineCallFrame.cpp:
(WTF::printInternal):
* Source/JavaScriptCore/bytecode/InlineCallFrame.h:
(JSC::InlineCallFrame::callModeFor):
(JSC::InlineCallFrame::specializationKindFor):
* Source/JavaScriptCore/bytecode/PutByStatus.cpp:
(JSC::PutByStatus::computeForStubInfo):
* Source/JavaScriptCore/bytecode/PutByVariant.cpp:
(JSC::PutByVariant::proxy):
(JSC::PutByVariant::writesStructures const):
(JSC::PutByVariant::reallocatesStorage const):
(JSC::PutByVariant::makesCalls const):
(JSC::PutByVariant::attemptToMerge):
(JSC::PutByVariant::dumpInContext const):
* Source/JavaScriptCore/bytecode/PutByVariant.h:
(JSC::PutByVariant::structure const):
(JSC::PutByVariant::oldStructure const):
(JSC::PutByVariant::oldStructure):
(JSC::PutByVariant::callLinkStatus const):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::inlineCall):
(JSC::DFG::ByteCodeParser::handlePutById):
* Source/JavaScriptCore/dfg/DFGOSRExitCompilerCommon.cpp:
(JSC::DFG::callerReturnPC):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
* Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h:
(JSC::JSGlobalObject::performProxyObjectSetSloppyFunctionConcurrently const):
(JSC::JSGlobalObject::performProxyObjectSetStrictFunctionConcurrently const):

Canonical link: <a href="https://commits.webkit.org/261058@main">https://commits.webkit.org/261058@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d543e84c261ae2ab761fcf598686c1dccf5d095

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110439 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19526 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43030 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1813 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119347 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20957 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10674 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102674 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116182 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43833 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30458 "Found 1 new test failure: imported/w3c/web-platform-tests/preload/onerror-event.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85698 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/99147 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12182 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31795 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/100172 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/10242 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12761 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31263 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18125 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51412 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/108195 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7657 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14624 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26671 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->