### PR TITLE
Entity storage is not very compact

### DIFF
--- a/Source/WebCore/html/parser/HTMLEntityParser.cpp
+++ b/Source/WebCore/html/parser/HTMLEntityParser.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (C) 2008 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2008-2023 Apple Inc. All Rights Reserved.
  * Copyright (C) 2009 Torch Mobile, Inc. http://www.torchmobile.com/
- * Copyright (C) 2010 Google, Inc. All Rights Reserved.
+ * Copyright (C) 2010-2014 Google, Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -81,7 +81,7 @@ public:
         }
         notEnoughCharacters = source.isEmpty();
         if (notEnoughCharacters) {
-            // We can't an entity because there might be a longer entity
+            // We can't decide on an entity because there might be a longer entity
             // that we could match if we had more data.
             unconsumeCharacters(source, consumedCharacters);
             return false;
@@ -96,11 +96,10 @@ public:
             // actual entity.
             unconsumeCharacters(source, consumedCharacters);
             consumedCharacters.clear();
-            const int length = entitySearch.mostRecentMatch()->length;
-            const LChar* reference = entitySearch.mostRecentMatch()->entity;
+            const auto* mostRecent = entitySearch.mostRecentMatch();
+            const int length = mostRecent->length;
             for (int i = 0; i < length; ++i) {
                 cc = source.currentCharacter();
-                ASSERT_UNUSED(reference, cc == *reference++);
                 consumedCharacters.append(cc);
                 source.advancePastNonNewline();
                 ASSERT(!source.isEmpty());

--- a/Source/WebCore/html/parser/HTMLEntitySearch.cpp
+++ b/Source/WebCore/html/parser/HTMLEntitySearch.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2010 Google, Inc. All Rights Reserved.
+ * Copyright (C) 2023 Apple, Inc. All Rights Reserved.
+ * Copyright (C) 2010-2014 Google, Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -47,7 +48,8 @@ HTMLEntitySearch::CompareResult HTMLEntitySearch::compare(const HTMLEntityTableE
 {
     if (entry->length < m_currentLength + 1)
         return Before;
-    UChar entryNextCharacter = entry->entity[m_currentLength];
+    const LChar* entityString = HTMLEntityTable::characters(*entry);
+    UChar entryNextCharacter = entityString[m_currentLength];
     if (entryNextCharacter == nextCharacter)
         return Prefix;
     return entryNextCharacter < nextCharacter ? Before : After;

--- a/Source/WebCore/html/parser/HTMLEntityTable.h
+++ b/Source/WebCore/html/parser/HTMLEntityTable.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2010 Google, Inc. All Rights Reserved.
+ * Copyright (C) 2023 Apple, Inc. All Rights Reserved.
+ * Copyright (C) 2010-2014 Google, Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,13 +30,14 @@
 
 namespace WebCore {
 
+// Member order to optimize packing. There will be thousands of these objects.
 struct HTMLEntityTableEntry {
-    LChar lastCharacter() const { return entity[length - 1]; }
+    LChar lastCharacter() const;
 
-    const LChar* entity;
-    int length;
     UChar32 firstValue;
-    UChar32 secondValue;
+    UChar secondValue; // UChar since double char sequences only use BMP chars.
+    uint16_t entityOffset;
+    uint8_t length;
 };
 
 class HTMLEntityTable {
@@ -45,6 +47,8 @@ public:
 
     static const HTMLEntityTableEntry* firstEntryStartingWith(UChar);
     static const HTMLEntityTableEntry* lastEntryStartingWith(UChar);
+
+    static const LChar* characters(const HTMLEntityTableEntry&);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/parser/create-html-entity-table
+++ b/Source/WebCore/html/parser/create-html-entity-table
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-# Copyright (c) 2010 Google Inc. All rights reserved.
+# Copyright (c) 2023 Apple Inc. All rights reserved.
+# Copyright (c) 2010-2014 Google Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -35,13 +36,6 @@ import sys
 ENTITY = 0
 VALUE = 1
 
-def convert_entity_to_cpp_name(entity):
-    postfix = "EntityName"
-    if entity[-1] == ";":
-        return "%sSemicolon%s" % (entity[:-1], postfix)
-    return "%s%s" % (entity, postfix)
-
-
 def convert_value_to_int(value):
     if not value:
         return "0";
@@ -63,9 +57,8 @@ if len(sys.argv) < 4 or sys.argv[1] != "-o":
 output_path = sys.argv[2]
 input_path = sys.argv[3]
 
-html_entity_names_file = open(input_path)
-entries = list(csv.reader(html_entity_names_file))
-html_entity_names_file.close()
+with open(input_path) as html_entity_names_file:
+    entries = list(csv.reader(html_entity_names_file))
 
 entries.sort(key = lambda entry: entry[ENTITY])
 entity_count = len(entries)
@@ -73,8 +66,7 @@ entity_count = len(entries)
 output_file = open(output_path, "w")
 
 output_file.write("""/*
- * Copyright (C) 2010 Google, Inc. All Rights Reserved.
- * Copyright (C) 2013 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2010-2014 Google, Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -109,60 +101,124 @@ namespace WebCore {
 namespace {
 """)
 
+assert len(entries) > 0, "Code assumes a non-empty entity array."
+def check_ascii(entity_string):
+    for c in entity_string:
+        code = ord(c)
+        assert 0 <= code <= 127, (c + " is not ASCII. Need to change type of storage from LChar to UChar to support this entity.")
+
+output_file.write("static const LChar staticEntityStringStorage[] = {\n")
+output_file.write("'")
+all_data = ""
+entity_offset = 0
+first_output = True
+saved_by_reusing = 0
 for entry in entries:
-    output_file.write("static const LChar %s[] = \"%s\";\n" % (convert_entity_to_cpp_name(entry[ENTITY]), entry[ENTITY]))
+    check_ascii(entry[ENTITY])
+    # Reuse substrings from earlier entries. This saves 1-2000
+    # characters, but it's O(n^2) and not very smart. The optimal
+    # solution has to solve the "Shortest Common Superstring" problem
+    # and that is NP-Complete or worse.
+    #
+    # This would be even more efficient if we didn't store the
+    # semi-colon in the array but as a bit in the entry.
+    entity = entry[ENTITY]
+    already_existing_offset = all_data.find(entity)
+    if already_existing_offset != -1:
+        # Reusing space.
+        this_offset = already_existing_offset
+        saved_by_reusing += len(entity)
+    else:
+        if not first_output:
+            output_file.write(",\n'")
+        first_output = False
+
+        # Try the end of the string and see if we can reuse that to
+        # fit the start of the new entity.
+        data_to_add = entity
+        this_offset = entity_offset
+        for truncated_len in range(len(entity) - 1, 0, -1):
+            if all_data.endswith(entity[:truncated_len]):
+                data_to_add = entity[truncated_len:]
+                this_offset = entity_offset - truncated_len
+                saved_by_reusing += truncated_len
+                break
+
+        output_file.write("', '".join(data_to_add))
+        all_data += data_to_add
+        output_file.write("'")
+        entity_offset += len(data_to_add)
+    assert len(entry) == 2, "We will use slot [2] in the list for the offset."
+    assert this_offset < 32768 # Stored in a 16 bit short.
+    entry.append(this_offset)
+
+output_file.write("};\n")
+
+index = {}
+for offset, entry in enumerate(entries):
+    starting_letter = entry[ENTITY][0]
+    if starting_letter not in index:
+        index[starting_letter] = offset
 
 output_file.write("""
 static const HTMLEntityTableEntry staticEntityTable[%s] = {\n""" % entity_count)
 
-index = {}
-offset = 0
 for entry in entries:
-    letter = entry[ENTITY][0]
-    if letter not in index:
-        index[letter] = offset
     values = entry[VALUE].split(' ')
     assert len(values) <= 2, values
-    output_file.write('    { %s, %s, %s, %s },\n' % (
-        convert_entity_to_cpp_name(entry[ENTITY]),
-        len(entry[ENTITY]),
+    output_file.write('    { %s, %s, %s, %s }, // &%s\n' % (
         convert_value_to_int(values[0]),
-        convert_value_to_int(values[1] if len(values) >= 2 else "")))
-    offset += 1
+        convert_value_to_int(values[1] if len(values) >= 2 else ""),
+        entry[2],
+        len(entry[ENTITY]),
+        entry[ENTITY],
+        ))
 
 output_file.write("""};
 
 """)
 
-output_file.write("static const HTMLEntityTableEntry* uppercaseOffset[] = {\n")
+output_file.write("""
+}
+""")
+
+output_file.write("static const short uppercaseOffset[] = {\n")
 for letter in string.ascii_uppercase:
-    output_file.write("%s\n" % offset_table_entry(index[letter]))
-output_file.write("%s\n" % offset_table_entry(index['a']))
+    output_file.write("%d,\n" % index[letter])
+output_file.write("%d\n" % index['a'])
 output_file.write("""};
 
-static const HTMLEntityTableEntry* lowercaseOffset[] = {\n""")
+static const short lowercaseOffset[] = {\n""")
 for letter in string.ascii_lowercase:
-    output_file.write("%s\n" % offset_table_entry(index[letter]))
-output_file.write("%s\n" % offset_table_entry(entity_count))
+    output_file.write("%d,\n" % index[letter])
+output_file.write("%d\n" % entity_count)
 output_file.write("""};
 
+const LChar* HTMLEntityTable::characters(const HTMLEntityTableEntry& entry)
+{
+    return staticEntityStringStorage + entry.entityOffset;
+}
+
+LChar HTMLEntityTableEntry::lastCharacter() const
+{
+    return HTMLEntityTable::characters(*this)[length - 1];
 }
 
 const HTMLEntityTableEntry* HTMLEntityTable::firstEntryStartingWith(UChar c)
 {
     if (c >= 'A' && c <= 'Z')
-        return uppercaseOffset[c - 'A'];
+        return &staticEntityTable[uppercaseOffset[c - 'A']];
     if (c >= 'a' && c <= 'z')
-        return lowercaseOffset[c - 'a'];
+        return &staticEntityTable[lowercaseOffset[c - 'a']];
     return 0;
 }
 
 const HTMLEntityTableEntry* HTMLEntityTable::lastEntryStartingWith(UChar c)
 {
     if (c >= 'A' && c <= 'Z')
-        return uppercaseOffset[c - 'A' + 1] - 1;
+        return &staticEntityTable[uppercaseOffset[c - 'A' + 1]] - 1;
     if (c >= 'a' && c <= 'z')
-        return lowercaseOffset[c - 'a' + 1] - 1;
+        return &staticEntityTable[lowercaseOffset[c - 'a' + 1]] - 1;
     return 0;
 }
 


### PR DESCRIPTION
#### 6c9eb0e31985f0ab9bcfa34198da9cf10f1dfa6a
<pre>
Entity storage is not very compact

<a href="https://bugs.webkit.org/show_bug.cgi?id=250640">https://bugs.webkit.org/show_bug.cgi?id=250640</a>
rdar://problem/104525785

Reviewed by Darin Adler.

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/0c7555da9c7b6059b8f55820b5b21685469a42c1">https://chromium.googlesource.com/chromium/blink/+/0c7555da9c7b6059b8f55820b5b21685469a42c1</a>

The entity table contained pointers which both makes it big and prevents
it from being reused as-is from the binary. This changes it to make
the storage more compact by replacing pointers with offsets into a
shared string. Also switching to more compact data types.

The new database will look like:

static const LChar staticEntityStringStorage[] = {
&apos;A&apos;, &apos;E&apos;, &apos;l&apos;, &apos;i&apos;, &apos;g&apos;,
&apos;;&apos;,
&apos;A&apos;, &apos;M&apos;, &apos;P&apos;,
&apos;;&apos;,
&apos;A&apos;, &apos;a&apos;, &apos;c&apos;, &apos;u&apos;, &apos;t&apos;, &apos;e&apos;,
&apos;;&apos;,
...

static const HTMLEntityTableEntry staticEntityTable[2231] = {
    { 0x000C6, 0, 0, 5 }, // &amp;AElig
    { 0x000C6, 0, 0, 6 }, // &amp;AElig;
    { 0x00026, 0, 6, 3 }, // &amp;AMP
    { 0x00026, 0, 6, 4 }, // &amp;AMP;
    { 0x000C1, 0, 10, 6 }, // &amp;Aacute
...

It accomplishes the savings by avoiding pointers in the data (resolving pointers
during startup is expensive), using one string instead of 2000+, not storing the
trailing NUL byte, ordering the members for minimum padding, using minimal size
data types and reusing the same string space for things like &quot;amp;&quot; and &quot;amp&quot;.

This is performance neutral on local testing and does not have any regression on Speedometer
using M1 Pro Macbook.

* Source/WebCore/html/parser/HTMLEntityParser.cpp:
* Source/WebCore/html/parser/HTMLEntitySearch.cpp:
(HTMLEntitySearch::compare):
* Source/WebCore/html/parser/HTMLEntityTable.h:
* Source/WebCore/html/parser/create-html-entity-table:

Canonical link: <a href="https://commits.webkit.org/261245@main">https://commits.webkit.org/261245@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d273c7ce653c3c69a93fbf55721b0a7be0363e9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110875 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20023 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43471 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2225 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119746 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114836 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21427 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11141 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2000 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116627 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15915 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99088 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103343 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97875 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30753 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44301 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12550 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32089 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86186 "Found 2 new API test failures: /WebKitGTK/TestDownloads:/webkit/Downloads/blob-download, /WebKitGTK/TestGeolocationManager:/webkit/WebKitGeolocationManager/watch-position (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13107 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9061 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18508 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7800 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15052 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->