### PR TITLE
Build fixes for !ENABLE(SERVICE_WORKER) after 260990@main

### DIFF
--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
@@ -190,8 +190,10 @@ String OriginStorageManager::StorageBucket::toStorageIdentifier(StorageType type
         return "IndexedDB"_s;
     case StorageType::CacheStorage:
         return "CacheStorage"_s;
+#if ENABLE(SERVICE_WORKER)
     case StorageType::BackgroundFetchStorage:
         return "BackgroundFetchStorage"_s;
+#endif
     default:
         break;
     }
@@ -591,8 +593,10 @@ String OriginStorageManager::StorageBucket::resolvedPath(WebsiteDataType webiste
         return resolvedIDBStoragePath();
     case StorageType::CacheStorage:
         return resolvedCacheStoragePath();
+#if ENABLE(SERVICE_WORKER)
     case StorageType::BackgroundFetchStorage:
         return resolvedBackgroundFetchStoragePath();
+#endif
     case StorageType::SessionStorage:
     case StorageType::FileSystem:
         return typeStoragePath(*type);

--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -604,14 +604,15 @@ def generate_impl(serialized_types, serialized_enums, headers):
         result.append('template<> bool ' + enum.function_name() + '<' + enum.namespace_and_name() + enum.additional_template_parameter() + '>(' + enum.parameter() + ' value)')
         result.append('{')
         if enum.is_option_set():
-            result.append('    constexpr ' + enum.underlying_type + ' allValidBitsValue =')
+            result.append('    constexpr ' + enum.underlying_type + ' allValidBitsValue = 0')
             for i in range(0, len(enum.valid_values)):
                 valid_value = enum.valid_values[i]
                 if valid_value.condition is not None:
                     result.append('#if ' + valid_value.condition)
-                result.append('        ' + ('' if i == 0 else '| ') + 'static_cast<' + enum.underlying_type + '>(' + enum.namespace_and_name() + '::' + valid_value.name + ')' + (';' if i == len(enum.valid_values) - 1 else ''))
+                result.append('        | static_cast<' + enum.underlying_type + '>(' + enum.namespace_and_name() + '::' + valid_value.name + ')')
                 if valid_value.condition is not None:
                     result.append('#endif')
+            result.append('        | 0;')
             result.append('    return (value.toRaw() | allValidBitsValue) == allValidBitsValue;')
         else:
             result.append('    switch (static_cast<' + enum.namespace_and_name() + '>(value)) {')

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -686,12 +686,53 @@ template<> bool isValidEnum<EnumNamespace::EnumType, void>(uint16_t value)
 
 template<> bool isValidOptionSet<EnumNamespace2::OptionSetEnumType>(OptionSet<EnumNamespace2::OptionSetEnumType> value)
 {
-    constexpr uint8_t allValidBitsValue =
-        static_cast<uint8_t>(EnumNamespace2::OptionSetEnumType::OptionSetFirstValue)
+    constexpr uint8_t allValidBitsValue = 0
+        | static_cast<uint8_t>(EnumNamespace2::OptionSetEnumType::OptionSetFirstValue)
 #if ENABLE(OPTION_SET_SECOND_VALUE)
         | static_cast<uint8_t>(EnumNamespace2::OptionSetEnumType::OptionSetSecondValue)
 #endif
-        | static_cast<uint8_t>(EnumNamespace2::OptionSetEnumType::OptionSetThirdValue);
+        | static_cast<uint8_t>(EnumNamespace2::OptionSetEnumType::OptionSetThirdValue)
+        | 0;
+    return (value.toRaw() | allValidBitsValue) == allValidBitsValue;
+}
+
+template<> bool isValidOptionSet<OptionSetEnumFirstCondition>(OptionSet<OptionSetEnumFirstCondition> value)
+{
+    constexpr uint32_t allValidBitsValue = 0
+#if ENABLE(OPTION_SET_FIRST_VALUE)
+        | static_cast<uint32_t>(OptionSetEnumFirstCondition::OptionSetFirstValue)
+#endif
+        | static_cast<uint32_t>(OptionSetEnumFirstCondition::OptionSetSecondValue)
+        | static_cast<uint32_t>(OptionSetEnumFirstCondition::OptionSetThirdValue)
+        | 0;
+    return (value.toRaw() | allValidBitsValue) == allValidBitsValue;
+}
+
+template<> bool isValidOptionSet<OptionSetEnumLastCondition>(OptionSet<OptionSetEnumLastCondition> value)
+{
+    constexpr uint32_t allValidBitsValue = 0
+        | static_cast<uint32_t>(OptionSetEnumLastCondition::OptionSetFirstValue)
+        | static_cast<uint32_t>(OptionSetEnumLastCondition::OptionSetSecondValue)
+#if ENABLE(OPTION_SET_THIRD_VALUE)
+        | static_cast<uint32_t>(OptionSetEnumLastCondition::OptionSetThirdValue)
+#endif
+        | 0;
+    return (value.toRaw() | allValidBitsValue) == allValidBitsValue;
+}
+
+template<> bool isValidOptionSet<OptionSetEnumAllCondition>(OptionSet<OptionSetEnumAllCondition> value)
+{
+    constexpr uint32_t allValidBitsValue = 0
+#if ENABLE(OPTION_SET_FIRST_VALUE)
+        | static_cast<uint32_t>(OptionSetEnumAllCondition::OptionSetFirstValue)
+#endif
+#if ENABLE(OPTION_SET_SECOND_VALUE)
+        | static_cast<uint32_t>(OptionSetEnumAllCondition::OptionSetSecondValue)
+#endif
+#if ENABLE(OPTION_SET_THIRD_VALUE)
+        | static_cast<uint32_t>(OptionSetEnumAllCondition::OptionSetThirdValue)
+#endif
+        | 0;
     return (value.toRaw() | allValidBitsValue) == allValidBitsValue;
 }
 

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
@@ -35,6 +35,9 @@ enum class EnumWithoutNamespace : uint8_t;
 #if ENABLE(UINT16_ENUM)
 namespace EnumNamespace { enum class EnumType : uint16_t; }
 #endif
+enum class OptionSetEnumFirstCondition : uint32_t;
+enum class OptionSetEnumLastCondition : uint32_t;
+enum class OptionSetEnumAllCondition : uint32_t;
 #if ENABLE(TEST_FEATURE)
 namespace Namespace::Subnamespace { struct StructName; }
 #endif
@@ -138,5 +141,8 @@ template<> bool isValidEnum<EnumWithoutNamespace, void>(uint8_t);
 #if ENABLE(UINT16_ENUM)
 template<> bool isValidEnum<EnumNamespace::EnumType, void>(uint16_t);
 #endif
+template<> bool isValidOptionSet<OptionSetEnumFirstCondition>(OptionSet<OptionSetEnumFirstCondition>);
+template<> bool isValidOptionSet<OptionSetEnumLastCondition>(OptionSet<OptionSetEnumLastCondition>);
+template<> bool isValidOptionSet<OptionSetEnumAllCondition>(OptionSet<OptionSetEnumAllCondition>);
 
 } // namespace WTF

--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -209,6 +209,31 @@ Vector<SerializedEnumInfo> allSerializedEnums()
 #endif
             static_cast<uint64_t>(EnumNamespace2::OptionSetEnumType::OptionSetThirdValue),
         } },
+        { "OptionSetEnumFirstCondition"_s, sizeof(OptionSetEnumFirstCondition), true, {
+#if ENABLE(OPTION_SET_FIRST_VALUE)
+            static_cast<uint64_t>(OptionSetEnumFirstCondition::OptionSetFirstValue),
+#endif
+            static_cast<uint64_t>(OptionSetEnumFirstCondition::OptionSetSecondValue),
+            static_cast<uint64_t>(OptionSetEnumFirstCondition::OptionSetThirdValue),
+        } },
+        { "OptionSetEnumLastCondition"_s, sizeof(OptionSetEnumLastCondition), true, {
+            static_cast<uint64_t>(OptionSetEnumLastCondition::OptionSetFirstValue),
+            static_cast<uint64_t>(OptionSetEnumLastCondition::OptionSetSecondValue),
+#if ENABLE(OPTION_SET_THIRD_VALUE)
+            static_cast<uint64_t>(OptionSetEnumLastCondition::OptionSetThirdValue),
+#endif
+        } },
+        { "OptionSetEnumAllCondition"_s, sizeof(OptionSetEnumAllCondition), true, {
+#if ENABLE(OPTION_SET_FIRST_VALUE)
+            static_cast<uint64_t>(OptionSetEnumAllCondition::OptionSetFirstValue),
+#endif
+#if ENABLE(OPTION_SET_SECOND_VALUE)
+            static_cast<uint64_t>(OptionSetEnumAllCondition::OptionSetSecondValue),
+#endif
+#if ENABLE(OPTION_SET_THIRD_VALUE)
+            static_cast<uint64_t>(OptionSetEnumAllCondition::OptionSetThirdValue),
+#endif
+        } },
     };
 }
 

--- a/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
@@ -109,4 +109,33 @@ struct NullableSoftLinkedMember {
   WebCore::SpringTimingFunction
 }
 
+[OptionSet] enum class OptionSetEnumFirstCondition : uint32_t {
+#if ENABLE(OPTION_SET_FIRST_VALUE)
+    OptionSetFirstValue,
+#endif
+    OptionSetSecondValue,
+    OptionSetThirdValue,
+}
+
+[OptionSet] enum class OptionSetEnumLastCondition : uint32_t {
+    OptionSetFirstValue,
+    OptionSetSecondValue,
+#if ENABLE(OPTION_SET_THIRD_VALUE)
+    OptionSetThirdValue,
+#endif
+}
+
+[OptionSet] enum class OptionSetEnumAllCondition : uint32_t {
+#if ENABLE(OPTION_SET_FIRST_VALUE)
+    OptionSetFirstValue,
+#endif
+#if ENABLE(OPTION_SET_SECOND_VALUE)
+    OptionSetSecondValue,
+#endif
+#if ENABLE(OPTION_SET_THIRD_VALUE)
+    OptionSetThirdValue,
+#endif
+}
+
 using WebCore::SharedStringHash = uint32_t
+


### PR DESCRIPTION
#### 0cc96819dbaf270ff4d6ac9db974159d46bc6c06
<pre>
Build fixes for !ENABLE(SERVICE_WORKER) after 260990@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=253187">https://bugs.webkit.org/show_bug.cgi?id=253187</a>

Reviewed by Alex Christensen.

Add ENABLE(SERVICE_WORKER) guards to code in OriginStorageManager
that is using StorageType::BackgroundFetchStorage.

We saw errors where the generated serializers appeared to be effectively
missing the trailing semi-colon on the allValidBitsValue calculation
in isValidOptionSet due to the last item being in a preprocessor if.
Add a check for the case where the last item is in such an if and add an
else that provides the semi-colon.

* Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp:
(WebKit::OriginStorageManager::StorageBucket::toStorageIdentifier const):
(WebKit::OriginStorageManager::StorageBucket::resolvedPath):
* Source/WebKit/Scripts/generate-serializers.py:
(generate_impl):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h:
* Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp:
* Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in:

Canonical link: <a href="https://commits.webkit.org/261094@main">https://commits.webkit.org/261094@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52c1ce33a3f3d59a6f8e9c2307fcebf705b609c8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110582 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19662 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/43173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/1935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/119447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/21084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/10791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/102799 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116324 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/21084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/43173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/102799 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/113999 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/21084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/43173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/102799 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12314 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/43173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/12874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/10791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/18238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/43173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14758 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4179 "'git push ...'") | | | | 
<!--EWS-Status-Bubble-End-->