### PR TITLE
Add Interaction Regions for aria roles button & menuitem

### DIFF
--- a/LayoutTests/interaction-region/aria-roles-expected.txt
+++ b/LayoutTests/interaction-region/aria-roles-expected.txt
@@ -1,0 +1,29 @@
+This works like a button
+Menu option 1
+Menu option 2
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (drawsContent 1)
+      (backgroundColor #FFFFFF)
+      (event region
+        (rect (0,0) width=800 height=600)
+
+      (interaction regions [
+        (interaction
+            (rect (40,36) width=760 height=20)
+)
+        (borderRadius 0.00),
+        (interaction
+            (rect (40,56) width=760 height=20)
+)
+        (borderRadius 0.00)])
+      )
+    )
+  )
+)
+

--- a/LayoutTests/interaction-region/aria-roles.html
+++ b/LayoutTests/interaction-region/aria-roles.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<style>
+    body { margin: 0; }
+</style>
+<body>
+<div aria-role="button">This works like a button</div>
+<ul role="menu">
+    <li role="menuitem">Menu option 1</li>
+    <li role="menuitem">Menu option 2</li>
+</ul>
+<pre id="results"></pre>
+<script>
+document.body.addEventListener("click", function(e) {
+    console.log(e, "event delegation");
+});
+
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.onload = function () {
+    if (window.internals)
+       results.textContent = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+};
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -97,6 +97,14 @@ static bool shouldAllowNonPointerCursorForElement(const Element& element)
     if (is<SliderThumbElement>(element))
         return true;
 
+    auto role = [](const Element& element) -> AccessibilityRole {
+        return AccessibilityObject::ariaRoleToWebCoreRole(element.attributeWithoutSynchronization(HTMLNames::roleAttr));
+    };
+
+    auto elementRole = role(element);
+    if (elementRole == AccessibilityRole::Button || elementRole == AccessibilityRole::MenuItem)
+        return true;
+
     return false;
 }
 


### PR DESCRIPTION
#### 629fc5bf5089d0f3abe8237401ecdd940a250a32
<pre>
Add Interaction Regions for aria roles button &amp; menuitem
<a href="https://bugs.webkit.org/show_bug.cgi?id=253189">https://bugs.webkit.org/show_bug.cgi?id=253189</a>
&lt;rdar://103095071&gt;

Reviewed by Tim Horton.

Allow non `pointer:cursor` elements with the aria roles `button` and
`menuitem` to get Interaction Regions.

* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::shouldAllowNonPointerCursorForElement):
Get the role attribute value from the element to see if it should get an
Interaction Region even without `pointer: cursor`.

* LayoutTests/interaction-region/aria-roles-expected.txt: Added.
* LayoutTests/interaction-region/aria-roles.html: Added.
Add a test covering these rules.

Canonical link: <a href="https://commits.webkit.org/261059@main">https://commits.webkit.org/261059@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/edf7c4106511a86629e8ace2834f0f9b2e00f307

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110355 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19445 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42970 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1746 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119292 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114303 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20890 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10612 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102601 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116099 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15559 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98751 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43775 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97520 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30416 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85631 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12113 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31754 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12704 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8723 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18069 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51369 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14549 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4170 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->