### PR TITLE
[UI-side compositing] Throttle AdjustTransientZoom IPC calls

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h
@@ -86,6 +86,7 @@ private:
     std::unique_ptr<RemoteLayerTreeDisplayLinkClient> m_displayLinkClient;
     WebCore::GraphicsLayer::PlatformLayerID m_pageScalingLayerID;
 
+    std::optional<TransactionID> m_transactionIDForSentTransientZoomUpdate;
     std::optional<TransactionID> m_transactionIDAfterEndingTransientZoom;
     std::optional<double> m_transientZoomScale;
     std::optional<WebCore::FloatPoint> m_transientZoomOrigin;


### PR DESCRIPTION
#### 19a2cf97badbbf2ac31af0a47ecd9cffe401161c
<pre>
[UI-side compositing] Throttle AdjustTransientZoom IPC calls
<a href="https://bugs.webkit.org/show_bug.cgi?id=252365">https://bugs.webkit.org/show_bug.cgi?id=252365</a>
rdar://105806821

Reviewed by NOBODY (OOPS!).

Throttle calls to AdjustTransientZoom by waiting for a layer tree commit from the web
process after each call to AdjustTransientZoom. This solution currently doesn&apos;t work
in this configuration as we only receive layer tree commits when prepopulateRectForZoom
actually causes tiles to get populated. We should either find a way to trigger a
commit for every call to AdjustTransientZoom or wait to land this once we are updating
tiles in AdjustTransientZoom.

* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::didCommitLayerTree):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::adjustTransientZoom):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19a2cf97badbbf2ac31af0a47ecd9cffe401161c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110395 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19483 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42998 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1779 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119319 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20923 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10640 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102638 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116138 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15589 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98778 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43804 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97550 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30443 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85663 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12148 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31780 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12731 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8744 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18096 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51396 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14586 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->