### PR TITLE
Web Inspector: Add precise editing controls for variation axes in Fonts sidebar panel

### DIFF
--- a/LayoutTests/inspector/model/font-styles-conversion.html
+++ b/LayoutTests/inspector/model/font-styles-conversion.html
@@ -36,7 +36,7 @@ function test()
                     "property": "font-style",
                     "value": 0,
                     "expected": "normal",
-                },                
+                },
                 {
                     "tag": "ital",
                     "property": "font-style",
@@ -53,7 +53,7 @@ function test()
                     "tag": "xxxx",
                     "property": "xxxx",
                     "value": 99,
-                    "expected": 99,
+                    "expected": "99",
                 },
             ];
 

--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -996,6 +996,8 @@ localizedStrings["Maximum"] = "Maximum";
 localizedStrings["Maximum CPU Usage: %s"] = "Maximum CPU Usage: %s";
 localizedStrings["Maximum Size: %s"] = "Maximum Size: %s";
 localizedStrings["Maximum maximum memory size in this recording"] = "Maximum maximum memory size in this recording";
+/* Max axis value @ Font Details Sidebar */
+localizedStrings["Maximum value of variation axis"] = "Maximum value of variation axis";
 localizedStrings["Media"] = "Media";
 localizedStrings["Media & Animations"] = "Media & Animations";
 localizedStrings["Media Element"] = "Media Element";
@@ -1014,6 +1016,8 @@ localizedStrings["Message"] = "Message";
 localizedStrings["Method"] = "Method";
 localizedStrings["Microtask Dispatched"] = "Microtask Dispatched";
 localizedStrings["Microtask Fired"] = "Microtask Fired";
+/* Min axis value @ Font Details Sidebar */
+localizedStrings["Minimum value of variation axis"] = "Minimum value of variation axis";
 localizedStrings["Missing result level"] = "Missing result level";
 localizedStrings["Mixed"] = "Mixed";
 localizedStrings["Modifications are saved automatically and will apply the next time the Console Snippet is run."] = "Modifications are saved automatically and will apply the next time the Console Snippet is run.";
@@ -1602,6 +1606,8 @@ localizedStrings["Tabs"] = "Tabs";
 localizedStrings["Tabular Numerals @ Font Details Sidebar Property Value"] = "Tabular Numerals";
 /* A submenu item of 'Edit' to change DOM element's tag name */
 localizedStrings["Tag"] = "Tag";
+/* Tooltip for a variation axis tag that explains what the 4-character label represents. */
+localizedStrings["Tag tooltip @ Font Details Sidebar"] = "Variation axis tag";
 localizedStrings["Take snapshot"] = "Take snapshot";
 localizedStrings["Target"] = "Target";
 localizedStrings["Template Content"] = "Template Content";

--- a/Source/WebInspectorUI/UserInterface/Models/FontStyles.js
+++ b/Source/WebInspectorUI/UserInterface/Models/FontStyles.js
@@ -80,7 +80,7 @@ WI.FontStyles = class FontStyles
         case "ital":
             return value >= 1 ? "italic" : "normal";
         default:
-            return value;
+            return String(value);
         }
     }
 

--- a/Source/WebInspectorUI/UserInterface/Views/DetailsSection.css
+++ b/Source/WebInspectorUI/UserInterface/Views/DetailsSection.css
@@ -252,12 +252,12 @@ body[dir=rtl] .details-section > .header::before {
     margin-inline-start: 5px;
 }
 
-.details-section > .content > .group > .row:is(.simple, .font-variation):has(.warning) {
+.details-section > .content > .group > .row.simple:has(.warning) {
     background-color: var(--warning-background-color-secondary);
     position: relative;
 }
 
-.details-section > .content > .group > .row:is(.simple, .font-variation) > .warning {
+.details-section > .content > .group > .row.simple > .warning {
     position: absolute;
     right: 0;
     align-self: center;

--- a/Source/WebInspectorUI/UserInterface/Views/FontDetailsPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/FontDetailsPanel.js
@@ -85,7 +85,6 @@ WI.FontDetailsPanel = class FontDetailsPanel extends WI.StyleDetailsPanel
             if (row instanceof WI.FontVariationDetailsSectionRow) {
                 let fontVariationAxis = fontProperty.variations.values().next().value;
                 row.value = fontVariationAxis.value ? fontVariationAxis.value : WI.FontStyles.fontPropertyValueToAxisValue(fontVariationAxis.tag, fontProperty.value);
-                row.warningMessage = (fontVariationAxis.value < fontVariationAxis.minimumValue || fontVariationAxis.value > fontVariationAxis.maximumValue) ? WI.UIString("Axis value outside of supported range: %s – %s", "A warning that is shown in the Font Details Sidebar when the value for a variation axis is outside of the supported range of values").format(this._formatAxisValueAsString(fontVariationAxis.minimumValue), this._formatAxisValueAsString(fontVariationAxis.maximumValue)) : null;
             }
         }
 
@@ -109,7 +108,6 @@ WI.FontDetailsPanel = class FontDetailsPanel extends WI.StyleDetailsPanel
         for (let [tag, fontVariationAxis] of this._fontVariationsMap) {
             let variationRow = this._fontVariationRowsMap.get(tag);
             variationRow.value = fontVariationAxis.value ?? fontVariationAxis.defaultValue;
-            variationRow.warningMessage = (fontVariationAxis.value < fontVariationAxis.minimumValue || fontVariationAxis.value > fontVariationAxis.maximumValue) ? WI.UIString("Axis value outside of supported range: %s – %s", "A warning that is shown in the Font Details Sidebar when the value for a variation axis is outside of the supported range of values").format(this._formatAxisValueAsString(fontVariationAxis.minimumValue), this._formatAxisValueAsString(fontVariationAxis.maximumValue)) : null;
         }
 
         if (!this._fontVariationRowsMap.size) {

--- a/Source/WebInspectorUI/UserInterface/Views/FontVariationDetailsSectionRow.css
+++ b/Source/WebInspectorUI/UserInterface/Views/FontVariationDetailsSectionRow.css
@@ -24,13 +24,16 @@
  */
 
  .details-section > .content > .group > .row.font-variation {
-    --axisValueWidth: 36px;
-    --axisTagWidth: var(--axisValueWidth);
+    --axis-value-width: 42px;
+    --axis-tag-width: 36px;
+    --axis-min-max-label-height: 10px;
+    --warning-icon-size: 11px;
 
     display: grid;
-    gap: 6px;
-    grid-template-columns: [axis-tag] var(--axisTagWidth) [slider] 1fr [axis-value] minmax(max-content, var(--axisValueWidth));
-    padding: 5px 20px 5px 12px;
+    column-gap: 6px;
+    grid-template-columns: [axis-tag] var(--axis-tag-width) [slider] 1fr [axis-value] var(--axis-value-width) [warning-icon] var(--warning-icon-size);
+    padding: 5px 8px calc(5px + var(--axis-min-max-label-height)) 12px;
+    align-items: center;
 }
 
 .details-section > .content > .group > .row.font-variation > .label:not(:empty) {
@@ -42,17 +45,17 @@
     color: var(--text-color-secondary);
 }
 
-.details-section > .content > .group > .row.font-variation > .value {
+.details-section > .content > .group > .row.font-variation > input.value {
     grid-column: axis-value;
-    text-align: end;
+    height: max-content;
+    width: var(--axis-value-width);
+    padding: 4px;
+    border: 1px solid var(--border-color);
     font-variant-numeric: tabular-nums;
 }
 
-.details-section > .content > .group > .row.font-variation:has(.warning) > .value {
-    margin-inline-end: 8px; /* Clearance so warning icon doesn't overlap the axis value. */
-}
-
 .details-section > .content > .group > .row.font-variation > .variation-range {
+    position: relative;
     display: grid;
     grid-column: slider;
     grid-template-columns: [min-value] 1fr [max-value] 1fr;
@@ -62,7 +65,7 @@
     appearance: none;
     grid-column: 1 / -1;
     position: relative;
-    margin-block: 3px 8px;
+    height: var(--slider-height);
     margin-inline: 0;
     background-color: transparent;
 }
@@ -72,8 +75,8 @@
     position: relative;
     z-index: 2;
     margin-top: -9px;
-    width: 8px;
-    height: 20px;
+    width: var(--slider-thumb-width);
+    height: var(--slider-thumb-height);
     border-radius: 6px;
     background: var(--slider-thumb-background);
     box-shadow: var(--slider-thumb-box-shadow);
@@ -95,9 +98,9 @@
     content: "";
     position: absolute;
     z-index: 1;
-    top: -1px;
-    width: 2px;
-    height: 8px;
+    top: calc((var(--slider-height) - var(--slider-track-tick-height)) / 2);
+    width: var(--slider-track-tick-width);
+    height: var(--slider-track-tick-height);
     border-radius: 4px;
     background-color: var(--slider-track-tick-background);
 }
@@ -115,4 +118,25 @@
     grid-column: max-value;
     text-align: end;
     color: var(--text-color-secondary);
+}
+
+.details-section > .content > .group > .row.font-variation > .variation-range > :is(.variation-maxvalue, .variation-minvalue) {
+    position: absolute;
+    width: 100%;
+    bottom: calc(-1 * var(--axis-min-max-label-height));
+}
+
+.details-section > .content > .group > .row.font-variation:has(.warning) {
+    background-color: var(--warning-background-color-secondary);
+}
+
+.details-section > .content > .group > .row.font-variation > .warning {
+    grid-column: warning-icon;
+    display: inline-block;
+    width: var(--warning-icon-size);
+    height: var(--warning-icon-size);
+    background-image: url(/Images/Warning.svg);
+    background-repeat: no-repeat;
+    background-size: var(--warning-icon-size);
+    background-position: center;
 }

--- a/Source/WebInspectorUI/UserInterface/Views/FontVariationDetailsSectionRow.js
+++ b/Source/WebInspectorUI/UserInterface/Views/FontVariationDetailsSectionRow.js
@@ -33,44 +33,55 @@ WI.FontVariationDetailsSectionRow = class FontVariationDetailsSectionRow extends
 
         let {name, tag, value, defaultValue, minimumValue, maximumValue} = fontVariationAxis;
 
+        this._tag = tag;
+        this._minimumValue = minimumValue;
+        this._maximumValue = maximumValue;
+        this._step = this._getAxisResolution();
+
         this._labelElement = this.element.appendChild(document.createElement("div"));
         this._labelElement.className = "label";
 
         this._tagElement = this.element.appendChild(document.createElement("div"));
         this._tagElement.className = "tag";
+        this._tagElement.textContent = this._tag;
+        this._tagElement.tooltip = WI.UIString("Variation axis tag", "Tag tooltip @ Font Details Sidebar", "Tooltip for a variation axis tag that explains what the 4-character label represents.");
 
         this._variationRangeElement = this.element.appendChild(document.createElement("div"));
         this._variationRangeElement.className = "variation-range";
 
-        this._inputRangeElement = this._variationRangeElement.appendChild(document.createElement("input"));
-        this._inputRangeElement.type = "range";
-        this._inputRangeElement.name = tag;
-        this._inputRangeElement.min = minimumValue;
-        this._inputRangeElement.max = maximumValue;
-        this._inputRangeElement.value = value ?? defaultValue;
-        this._inputRangeElement.step = this._getAxisResolution(minimumValue, maximumValue, tag);
+        this._valueSliderElement = this._variationRangeElement.appendChild(document.createElement("input"));
+        this._valueSliderElement.type = "range";
+        this._valueSliderElement.name = tag;
+        this._valueSliderElement.min = minimumValue;
+        this._valueSliderElement.max = maximumValue;
+        this._valueSliderElement.step = this._step;
 
         this._variationMinValueElement = this._variationRangeElement.appendChild(document.createElement("div"));
         this._variationMinValueElement.className = "variation-minvalue";
         this._variationMinValueElement.textContent = this._formatAxisValueAsString(minimumValue);
+        this._variationMinValueElement.tooltip = WI.UIString("Minimum value of variation axis", "Min axis value @ Font Details Sidebar");
 
         this._variationMaxValueElement = this._variationRangeElement.appendChild(document.createElement("div"));
         this._variationMaxValueElement.className = "variation-maxvalue";
         this._variationMaxValueElement.textContent = this._formatAxisValueAsString(maximumValue);
+        this._variationMinValueElement.tooltip = WI.UIString("Maximum value of variation axis", "Max axis value @ Font Details Sidebar");
 
-        this._inputRangeElement.addEventListener("input", (event) => {
-            this.value = event.target.value;
-            this.dispatchEventToListeners(WI.FontVariationDetailsSectionRow.Event.VariationValueChanged, {tag: event.target.name, value: event.target.value});
-        }, {signal: abortSignal});
+        this._valueTextFieldElement = this.element.appendChild(document.createElement("input"));
+        this._valueTextFieldElement.type = "text";
+        this._valueTextFieldElement.name = tag;
+        this._valueTextFieldElement.className = "value";
 
-        this._valueElement = this.element.appendChild(document.createElement("div"));
-        this._valueElement.className = "value";
+        this._valueTextFieldElement.addEventListener("keydown", this._handleValueTextFieldKeydown.bind(this), {signal: abortSignal});
+        this._valueTextFieldElement.addEventListener("input", this._handleValueTextFieldInput.bind(this), {signal: abortSignal});
+        this._valueTextFieldElement.addEventListener("blur", this._handleValueTextFieldBlur.bind(this), {signal: abortSignal});
+        this._valueSliderElement.addEventListener("input", this._handleValueSliderInput.bind(this), {signal: abortSignal});
 
-        this.tag = tag;
         this.label = name;
         this.value = value ?? defaultValue;
 
         this._defaultValue = defaultValue;
+        this._hasValidValue = true;
+        this._skipUpdatingInputValue = false;
     }
 
     // Public
@@ -111,8 +122,15 @@ WI.FontVariationDetailsSectionRow = class FontVariationDetailsSectionRow extends
     {
         this._value = value ?? this._defaultValue;
 
-        this._inputRangeElement.value = this._value;
-        this._valueElement.textContent = this._formatAxisValueAsString(this._value);
+        this._valueSliderElement.value = this._value;
+
+        // Allow an invalid value in the text field while the user is editing.
+        if (!this._hasValidValue && window.document.activeElement === this._valueTextFieldElement)
+            return;
+
+        this._valueTextFieldElement.value = this._formatAxisValueAsString(this._value);
+        this._hasValidValue = this._minimumValue <= this._value && this._value <= this._maximumValue;
+        this._showValidity();
     }
 
     // Private
@@ -127,13 +145,13 @@ WI.FontVariationDetailsSectionRow = class FontVariationDetailsSectionRow extends
         return value.toLocaleString(undefined, options);
     }
 
-    _getAxisResolution(min, max, tag)
+    _getAxisResolution()
     {
         // The `ital` variation axis acts as an on/off toggle (0 = off, 1 = on).
-        if (tag === "ital" && min === 0 && max === 1)
+        if (this._tag === "ital" && this._minimumValue === 0 && this._maximumValue === 1)
             return 1;
 
-        let delta = max - min;
+        let delta = this._maximumValue - this._minimumValue;
         if (delta <= 1)
             return 0.01;
 
@@ -141,6 +159,87 @@ WI.FontVariationDetailsSectionRow = class FontVariationDetailsSectionRow extends
             return 0.1;
 
         return 1;
+    }
+
+    _showValidity()
+    {
+        if (!this._hasValidValue)
+            this.warningMessage = WI.UIString("Axis value outside of supported range: %s – %s", "A warning that is shown in the Font Details Sidebar when the value for a variation axis is outside of the supported range of values").format(this._formatAxisValueAsString(this._minimumValue), this._formatAxisValueAsString(this._maximumValue));
+        else
+            this.warningMessage = null;
+    }
+
+    _handleValueTextFieldBlur(event)
+    {
+        this.value = this._value;
+    }
+
+    _handleValueTextFieldInput(event)
+    {
+        let valueAsString = event.target.value;
+        let valueAsNumber = parseFloat(event.target.value);
+
+        if (!/^\-?\d+(\.\d+)?$/.test(valueAsString)) {
+            this._hasValidValue = false;
+
+            // Don't warn when preparing to type a new value or starting to type a negative number.
+            if (valueAsString !== "" || valueAsString !== "-")
+                this._showValidity();
+
+            this.dispatchEventToListeners(WI.FontVariationDetailsSectionRow.Event.VariationValueChanged, {tag: this._tag, value: this._defaultValue});
+            return;
+        }
+
+        if (valueAsNumber < this._minimumValue || valueAsNumber > this._maximumValue) {
+            this._hasValidValue = false;
+
+            this._showValidity();
+            this.dispatchEventToListeners(WI.FontVariationDetailsSectionRow.Event.VariationValueChanged, {tag: this._tag, value: Number.constrain(valueAsNumber, this._minimumValue, this._maximumValue)});
+            return;
+        }
+
+        this._hasValidValue = true;
+        this.value = valueAsNumber;
+
+        this.dispatchEventToListeners(WI.FontVariationDetailsSectionRow.Event.VariationValueChanged, {tag: this._tag, value: valueAsNumber});
+    }
+
+    _handleValueTextFieldKeydown(event)
+    {
+        // The value field is a text input but is treated as a number input.
+        if (event.key.length === 1 && !/[0-9\.\-]/.test(event.key)) {
+            event.preventDefault();
+            return;
+        }
+
+        let valueAsNumber = parseFloat(event.target.value);
+        let step = this._step;
+
+        if (isNaN(valueAsNumber))
+            return;
+
+        if (event.shiftKey && event.altKey)
+            step = this._step;
+        else if (event.shiftKey)
+            step = this._step * 10;
+        else if (event.altKey)
+            step = this._step / 10;
+
+        if (event.key === "ArrowUp") {
+            this.value = Number.constrain(valueAsNumber + step, this._minimumValue, this._maximumValue);
+            event.preventDefault();
+        }
+
+        if (event.key === "ArrowDown") {
+            this.value = Number.constrain(valueAsNumber - step, this._minimumValue, this._maximumValue);
+            event.preventDefault();
+        }
+    }
+
+    _handleValueSliderInput(event)
+    {
+        this.value = event.target.valueAsNumber;
+        this.dispatchEventToListeners(WI.FontVariationDetailsSectionRow.Event.VariationValueChanged, {tag: this._tag, value: this._value});
     }
 };
 

--- a/Source/WebInspectorUI/UserInterface/Views/Variables.css
+++ b/Source/WebInspectorUI/UserInterface/Views/Variables.css
@@ -220,12 +220,17 @@
 
     --blackboxed-opacity: 0.5;
 
+    --slider-height: 20px;
     --slider-thumb-background: white;
     --slider-thumb-background-active: hsl(0, 0%, 94%);
     --slider-thumb-box-shadow: 0px 0 2px 0 hsl(0, 0%, 55%);
+    --slider-thumb-height: var(--slider-height);
+    --slider-thumb-width: 8px;
     --slider-track-background: hsl(0, 0%, 88%);
     --slider-track-box-shadow: inset 0 0 3px hsl(0, 0%, 70%);
     --slider-track-tick-background: hsl(0, 0%, 70%);
+    --slider-track-tick-height: 8px;
+    --slider-track-tick-width: 2px;
 }
 
 body.window-inactive {


### PR DESCRIPTION
#### d0dcfc4c0662f638e82d05512843ff0000a66c05
<pre>
Web Inspector: Add precise editing controls for variation axes in Fonts sidebar panel
<a href="https://bugs.webkit.org/show_bug.cgi?id=253199">https://bugs.webkit.org/show_bug.cgi?id=253199</a>

Reviewed by Patrick Angle.

Adds input fields to the Fonts siderbar panel to allow editing variation axis values.

HTML number input fields accept and display any character, so we restrict keyboard
input to just the ones that make up number values supported as axis values.

The warning for an invalid input is delayed while a user is typing to allow them to finish.

An input can accept and display and invalid value. It will be marked with a warning.
However, the value written to the stylesheet will be either:
- the default axis value when the input value is invalid;
- the clamped min/max value when the input value is out of bounds;

When focus is moved away from an invalid input,
it will update to reflect the actual value used.

Holding the ArrowUp/ArrowDown keys increments/decrements the value within
the bounds of the min/max range with the corresponding step for that axis.

Holding the Shift key will increase the step by an order of magnitude.
Holding the Alt/Option key will decrease the step by an order of magnitude.

* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:
* Source/WebInspectorUI/UserInterface/Models/FontStyles.js:
Ensure values written to CSS properties are strings.

(WI.FontStyles.axisValueToFontPropertyValue):
* Source/WebInspectorUI/UserInterface/Views/FontDetailsPanel.js:
(WI.FontDetailsPanel.prototype.update):
* Source/WebInspectorUI/UserInterface/Views/FontVariationDetailsSectionRow.css:
(.details-section &gt; .content &gt; .group &gt; .row.font-variation &gt; input[type=&quot;number&quot;]):
(.details-section &gt; .content &gt; .group &gt; .row.font-variation:has(.warning) &gt; input[type=&quot;number&quot;]):
(.details-section &gt; .content &gt; .group &gt; .row.font-variation &gt; input[type=&quot;number&quot;]::-webkit-inner-spin-button):
(.details-section &gt; .content &gt; .group &gt; .row.font-variation &gt; .value): Deleted.
(.details-section &gt; .content &gt; .group &gt; .row.font-variation:has(.warning) &gt; .value): Deleted.
* Source/WebInspectorUI/UserInterface/Views/FontVariationDetailsSectionRow.js:
(WI.FontVariationDetailsSectionRow):
(WI.FontVariationDetailsSectionRow.prototype.set value):
(WI.FontVariationDetailsSectionRow.prototype._getAxisResolution):
(WI.FontVariationDetailsSectionRow.prototype._showValidity):
(WI.FontVariationDetailsSectionRow.prototype._handleValueBlurEvent):
(WI.FontVariationDetailsSectionRow.prototype._handleValueInputEvent):
(WI.FontVariationDetailsSectionRow.prototype._handleValueKeydownEvent):

Canonical link: <a href="https://commits.webkit.org/261162@main">https://commits.webkit.org/261162@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/595218e4bbe73ebf2be1508d1e81b2deb6f6b6d5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110772 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19855 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/43323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2118 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/119589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21260 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10964 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/1823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116519 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/43323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/103127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/43323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/103127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/12454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/43323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/103127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/13022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18403 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/43323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7732 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/14973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->