### PR TITLE
REGRESSION (259655@main): [iOS] Crash when opening a PDF after searching for text in a webpage

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKPDFView.mm
+++ b/Source/WebKit/UIProcess/ios/WKPDFView.mm
@@ -699,6 +699,16 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     return nil;
 }
 
+- (BOOL)supportsTextReplacement
+{
+    return NO;
+}
+
+- (void)scrollRangeToVisible:(UITextRange *)range inDocument:(UITextSearchDocumentIdentifier)document
+{
+    // Intentionally empty. PDFHostViewController has a single method for decoration and scrolling, so scrolling is performed in `decorateFoundTextRange`.
+}
+
 - (NSComparisonResult)compareFoundRange:(UITextRange *)fromRange toRange:(UITextRange *)toRange inDocument:(UITextSearchDocumentIdentifier)document
 {
     auto from = dynamic_objc_cast<WKPDFFoundTextPosition>(fromRange.start);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPage.mm
@@ -920,6 +920,29 @@ TEST(WebKit, FindInPDFAfterReload)
     searchForText();
 }
 
+TEST(WebKit, FindInPDFAfterFindInPage)
+{
+    auto webView = adoptNS([[FindInPageTestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);
+    [webView synchronouslyLoadTestPageNamed:@"lots-of-text"];
+
+    auto *findInteraction = [webView findInteraction];
+    [findInteraction presentFindNavigatorShowingReplace:NO];
+    [webView waitForNextPresentationUpdate];
+
+    [findInteraction dismissFindNavigator];
+    [webView waitForNextPresentationUpdate];
+
+    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"test" withExtension:@"pdf" subdirectory:@"TestWebKitAPI.resources"]];
+    [webView loadRequest:request];
+    [webView _test_waitForDidFinishNavigation];
+
+    [findInteraction presentFindNavigatorShowingReplace:NO];
+    [webView waitForNextPresentationUpdate];
+
+    [findInteraction dismissFindNavigator];
+    [webView waitForNextPresentationUpdate];
+}
+
 TEST(WebKit, FindInteractionSupportsTextReplacement)
 {
     auto webView = adoptNS([[FindInPageTestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);


### PR DESCRIPTION
#### ad5c950167f181eee11e8de16b70e54bc789a609
<pre>
REGRESSION (259655@main): [iOS] Crash when opening a PDF after searching for text in a webpage
<a href="https://bugs.webkit.org/show_bug.cgi?id=253194">https://bugs.webkit.org/show_bug.cgi?id=253194</a>
rdar://105784161

Reviewed by Wenson Hsieh, Megan Gardner and Tim Horton.

259655@main fixed find-in-PDF behavior by ensuring the `UIFindSession`&apos;s
&quot;searchable object&quot; is always up-to-date.

When switching from a webpage to a PDF, WebKit switches the type of the
searchable object from `WKContentView` to `WKPDFView`. UIKit is not robust
against searchable object modification, as they cache the existence of
optional protocol methods and do not update the result when the object changes.
Consequently, optional protocol methods are called unconditionally on
`WKPDFView`, simply because `WKContentView` implements them.

Ideally, WebKit would recreate the `UIFindSession` itself when the searchable
object changes. However, this is not possible with existing API/SPI.

To fix, implement &quot;optional&quot; protocol methods that UIKit may end up calling
when searching for text. This prevents crashing due to unrecognized selectors.

* Source/WebKit/UIProcess/ios/WKPDFView.mm:
(-[WKPDFView supportsTextReplacement]):
(-[WKPDFView scrollRangeToVisible:inDocument:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPage.mm:
(TEST):

Add a regression test that opens and closes the find panel on web content, loads
a PDF, and then attempts to open and close the find panel on the PDF content.

The test crashes without this patch.

Canonical link: <a href="https://commits.webkit.org/261071@main">https://commits.webkit.org/261071@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1bb95f4af76a6069539358dfbd41c70a4e9615c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110396 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19484 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42999 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1780 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119320 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114342 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20924 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10641 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102639 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116139 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15586 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98775 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43807 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97547 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30440 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85667 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12149 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31778 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12732 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8743 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18097 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51393 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14587 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4172 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->