### PR TITLE
Inline AbstractFrame::page() & AbstractFrame::ownerElement()

### DIFF
--- a/Source/WebCore/html/HTMLFrameOwnerElement.h
+++ b/Source/WebCore/html/HTMLFrameOwnerElement.h
@@ -106,6 +106,11 @@ private:
     ContainerNode* m_root;
 };
 
+inline HTMLFrameOwnerElement* AbstractFrame::ownerElement() const
+{
+    return m_ownerElement.get();
+}
+
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::HTMLFrameOwnerElement)

--- a/Source/WebCore/page/AbstractFrame.cpp
+++ b/Source/WebCore/page/AbstractFrame.cpp
@@ -61,16 +61,6 @@ void AbstractFrame::resetWindowProxy()
     m_windowProxy = WindowProxy::create(*this);
 }
 
-Page* AbstractFrame::page() const
-{
-    return m_page.get();
-}
-
-HTMLFrameOwnerElement* AbstractFrame::ownerElement() const
-{
-    return m_ownerElement.get();
-}
-
 void AbstractFrame::detachFromPage()
 {
     m_page = nullptr;

--- a/Source/WebCore/page/AbstractFrame.h
+++ b/Source/WebCore/page/AbstractFrame.h
@@ -53,9 +53,9 @@ public:
     AbstractDOMWindow* window() const { return virtualWindow(); }
     FrameTree& tree() const { return m_treeNode; }
     FrameIdentifier frameID() const { return m_frameID; }
-    WEBCORE_EXPORT Page* page() const;
+    inline Page* page() const; // Defined in Page.h.
     WEBCORE_EXPORT void detachFromPage();
-    WEBCORE_EXPORT HTMLFrameOwnerElement* ownerElement() const;
+    inline HTMLFrameOwnerElement* ownerElement() const; // Defined in HTMLFrameOwnerElement.h.
     WEBCORE_EXPORT void disconnectOwnerElement();
 
     virtual void frameDetached() = 0;

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1395,6 +1395,11 @@ inline PageGroup& Page::group()
     return *m_group;
 }
 
+inline Page* AbstractFrame::page() const
+{
+    return m_page.get();
+}
+
 WTF::TextStream& operator<<(WTF::TextStream&, RenderingUpdateStep);
 
 } // namespace WebCore


### PR DESCRIPTION
#### 7c82f53bc23f4cfd24a35568e66c89502a3f27ba
<pre>
Inline AbstractFrame::page() &amp; AbstractFrame::ownerElement()
<a href="https://bugs.webkit.org/show_bug.cgi?id=253204">https://bugs.webkit.org/show_bug.cgi?id=253204</a>

Reviewed by Darin Adler.

Inline AbstractFrame::page() &amp; AbstractFrame::ownerElement() since they show in
profiles and are trivial getters.

* Source/WebCore/page/AbstractFrame.cpp:
(WebCore::AbstractFrame::page const): Deleted.
* Source/WebCore/page/AbstractFrame.h:
* Source/WebCore/page/Page.h:
(WebCore::AbstractFrame::page const):

Canonical link: <a href="https://commits.webkit.org/261078@main">https://commits.webkit.org/261078@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d624345175a97335f3bf0114d93fb29d10560879

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110408 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19495 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43005 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1786 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119325 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114355 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20930 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10647 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102646 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116151 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15595 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98779 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43815 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97556 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30444 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85675 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12156 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31781 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12738 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8753 "Found 1 new test failure: imported/w3c/web-platform-tests/background-fetch/mixed-content-and-allowed-schemes.https.window.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18103 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51397 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7674 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14595 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->