### PR TITLE
Safari translation should treat a floating list item as its own paragraph

### DIFF
--- a/Source/WebCore/editing/TextManipulationController.cpp
+++ b/Source/WebCore/editing/TextManipulationController.cpp
@@ -325,8 +325,13 @@ static bool isEnclosingItemBoundaryElement(const Element& element)
         return true;
 
     auto displayType = renderer->style().display();
-    if (element.hasTagName(HTMLNames::liTag) || element.hasTagName(HTMLNames::aTag)) {
+    bool isListItem = element.hasTagName(HTMLNames::liTag);
+    if (isListItem || element.hasTagName(HTMLNames::aTag)) {
         if (displayType == DisplayType::Block || displayType == DisplayType::InlineBlock)
+            return true;
+
+        auto floating = renderer->style().floating();
+        if (isListItem && (floating == Float::Left || floating == Float::Right))
             return true;
 
         for (RefPtr parent = element.parentElement(); parent; parent = parent->parentElement()) {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextManipulation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextManipulation.mm
@@ -570,6 +570,51 @@ TEST(TextManipulation, StartTextManipulationBreaksParagraphInBetweenListItems)
     EXPECT_WK_STREQ("Ten", items[6].tokens[0].content);
 }
 
+TEST(TextManipulation, StartTextManipulationBreaksParagraphInBetweenFloatingListItems)
+{
+    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    [webView _setTextManipulationDelegate:delegate.get()];
+
+    [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
+        "<style>"
+        "ul {"
+        "    margin: 0;"
+        "    padding: 0;"
+        "    list-style: none"
+        "}"
+        "li {"
+        "    text-align: center;"
+        "    float: left;"
+        "    border: 1px solid #e9e9e9;"
+        "    padding: 1rem;"
+        "}"
+        "</style>"
+        "<ul>"
+        "<li>hello</li>"
+        "<li>world</li>"
+        "<li>WebKit</li>"
+        "</ul>"];
+
+    done = false;
+    [webView _startTextManipulationsWithConfiguration:nil completion:^{
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+
+    NSArray<_WKTextManipulationItem *> *items = [delegate items];
+    EXPECT_EQ(items.count, 3UL);
+
+    EXPECT_EQ(items[0].tokens.count, 1UL);
+    EXPECT_WK_STREQ("hello", items[0].tokens[0].content);
+
+    EXPECT_EQ(items[1].tokens.count, 1UL);
+    EXPECT_WK_STREQ("world", items[1].tokens[0].content);
+
+    EXPECT_EQ(items[2].tokens.count, 1UL);
+    EXPECT_WK_STREQ("WebKit", items[2].tokens[0].content);
+}
+
 TEST(TextManipulation, StartTextManipulationIncludesFullyClippedText)
 {
     auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);


### PR DESCRIPTION
#### f2269d652522d4ca95a77640a24601ee48898a68
<pre>
Safari translation should treat a floating list item as its own paragraph
<a href="https://bugs.webkit.org/show_bug.cgi?id=253205">https://bugs.webkit.org/show_bug.cgi?id=253205</a>
&lt;rdar://104008863&gt;

Reviewed by Sihui Liu.

Treat a floating list item as a boundary element (i.e. paragraph separator)
even if the display style wasn&apos;t block.

* Source/WebCore/editing/TextManipulationController.cpp:
(WebCore::isEnclosingItemBoundaryElement):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextManipulation.mm:
(TextManipulation.StartTextManipulationBreaksParagraphInBetweenFloatingListItems):

Canonical link: <a href="https://commits.webkit.org/261114@main">https://commits.webkit.org/261114@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fbed829b39960f48788142876b5d7821d20bba73

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110440 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19527 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/43214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1814 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119348 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114387 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20958 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10675 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102675 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116183 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15609 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98857 "Build was cancelled. Recent messages:configuring build; Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; 1 api test failed or timed out; 1 api test failed or timed out; Reverted pull request changes; Compiled WebKit (warnings); run-api-tests-without-change (cancelled)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43832 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97570 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30455 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85696 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12183 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31792 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12762 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8765 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18126 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51409 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14625 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4194 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->