### PR TITLE
REBASELINE REGRESSION(iPad 9th gen): [ iPad Simulator ] 11x fast/viewport tests are constant text failures.

### DIFF
--- a/LayoutTests/platform/ipad/fast/viewport/ios/device-width-viewport-after-changing-view-scale-expected.txt
+++ b/LayoutTests/platform/ipad/fast/viewport/ios/device-width-viewport-after-changing-view-scale-expected.txt
@@ -1,46 +1,46 @@
 setViewScale(0.50)
-window size: [1536, 2008]
-square size: [154, 201]
+window size: [1620, 2120]
+square size: [162, 212]
 zoom scale: 0.50
 
 setViewScale(0.75)
-window size: [1024, 1339]
-square size: [102, 134]
+window size: [1080, 1413]
+square size: [108, 141]
 zoom scale: 0.75
 
 setViewScale(1.00)
-window size: [768, 1004]
-square size: [77, 100]
+window size: [810, 1060]
+square size: [81, 106]
 zoom scale: 1.00
 
 setViewScale(1.25)
-window size: [614, 803]
-square size: [61, 80]
+window size: [648, 848]
+square size: [65, 85]
 zoom scale: 1.25
 
 setViewScale(1.50)
-window size: [512, 669]
-square size: [51, 67]
+window size: [540, 707]
+square size: [54, 71]
 zoom scale: 1.50
 
 setViewScale(1.25)
-window size: [614, 803]
-square size: [61, 80]
+window size: [648, 848]
+square size: [65, 85]
 zoom scale: 1.25
 
 setViewScale(1.00)
-window size: [768, 1004]
-square size: [77, 100]
+window size: [810, 1060]
+square size: [81, 106]
 zoom scale: 1.00
 
 setViewScale(0.75)
-window size: [1024, 1339]
-square size: [102, 134]
+window size: [1080, 1413]
+square size: [108, 141]
 zoom scale: 0.75
 
 setViewScale(0.50)
-window size: [1536, 2008]
-square size: [154, 201]
+window size: [1620, 2120]
+square size: [162, 212]
 zoom scale: 0.50
 
 

--- a/LayoutTests/platform/ipad/fast/viewport/ios/non-responsive-viewport-after-changing-view-scale-expected.txt
+++ b/LayoutTests/platform/ipad/fast/viewport/ios/non-responsive-viewport-after-changing-view-scale-expected.txt
@@ -1,17 +1,17 @@
 setViewScale(1.00)
-window size: [980, 1281]
-zoom scale: 0.78
+window size: [980, 1282]
+zoom scale: 0.83
 
 setViewScale(0.50)
-window size: [1960, 2562]
-zoom scale: 0.39
+window size: [1960, 2565]
+zoom scale: 0.41
 
 setViewScale(2.00)
 window size: [490, 641]
-zoom scale: 1.57
+zoom scale: 1.65
 
 setViewScale(1.00)
-window size: [980, 1281]
-zoom scale: 0.78
+window size: [980, 1282]
+zoom scale: 0.83
 
 

--- a/LayoutTests/platform/ipad/fast/viewport/ios/responsive-viewport-with-minimum-width-after-changing-view-scale-expected.txt
+++ b/LayoutTests/platform/ipad/fast/viewport/ios/responsive-viewport-with-minimum-width-after-changing-view-scale-expected.txt
@@ -1,17 +1,17 @@
 setViewScale(1.00)
-window size: [768, 1004]
+window size: [810, 1060]
 zoom scale: 1.00
 
 setViewScale(2.00)
-window size: [384, 502]
+window size: [405, 530]
 zoom scale: 2.00
 
 setViewScale(2.50)
-window size: [307, 401]
+window size: [324, 424]
 zoom scale: 2.50
 
 setViewScale(1.00)
-window size: [768, 1004]
+window size: [810, 1060]
 zoom scale: 1.00
 
 

--- a/LayoutTests/platform/ipad/fast/viewport/ios/shrink-to-fit-content-large-width-breakpoint-expected.txt
+++ b/LayoutTests/platform/ipad/fast/viewport/ios/shrink-to-fit-content-large-width-breakpoint-expected.txt
@@ -1,0 +1,12 @@
+This test verifies that the shrink-to-fit-content heuristic doesn't induce more horizontal scrolling than we would otherwise have. To run the test manually, load the page and check that the bar almost entirely fits within the viewport, with no more than 480px of horizontal scrolling (on a 320px-wide device) and 20px of scrolling (on a 768px-wide device).
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS minScale is 1
+FAIL 800 should be >= document.scrollingElement.scrollWidth. Was 800 (of type number).
+PASS successfullyParsed is true
+Some tests failed.
+
+TEST COMPLETE
+

--- a/LayoutTests/platform/ipad/fast/viewport/ios/shrink-to-fit-for-page-without-viewport-meta-expected.txt
+++ b/LayoutTests/platform/ipad/fast/viewport/ios/shrink-to-fit-for-page-without-viewport-meta-expected.txt
@@ -1,4 +1,4 @@
-window size: [1208, 1579]
-zoom scale: 0.64
+window size: [1208, 1581]
+zoom scale: 0.67
 
 

--- a/LayoutTests/platform/ipad/fast/viewport/ios/use-minimum-device-width-for-page-without-viewport-meta-expected.txt
+++ b/LayoutTests/platform/ipad/fast/viewport/ios/use-minimum-device-width-for-page-without-viewport-meta-expected.txt
@@ -1,46 +1,46 @@
 setMinimumEffectiveWidth(0.00)
-window size: [768, 1004]
-square size: [77, 100]
+window size: [810, 1060]
+square size: [81, 106]
 zoom scale: 1.00
 
 setMinimumEffectiveWidth(640.00)
-window size: [768, 1004]
-square size: [77, 100]
+window size: [810, 1060]
+square size: [81, 106]
 zoom scale: 1.00
 
 setMinimumEffectiveWidth(768.00)
-window size: [768, 1004]
-square size: [77, 100]
+window size: [810, 1060]
+square size: [81, 106]
 zoom scale: 1.00
 
 setMinimumEffectiveWidth(834.00)
-window size: [834, 1090]
+window size: [834, 1091]
 square size: [83, 109]
-zoom scale: 0.92
+zoom scale: 0.97
 
 setMinimumEffectiveWidth(980.00)
-window size: [980, 1281]
+window size: [980, 1282]
 square size: [98, 128]
-zoom scale: 0.78
+zoom scale: 0.83
 
 setMinimumEffectiveWidth(1024.00)
-window size: [1024, 1339]
+window size: [1024, 1340]
 square size: [102, 134]
-zoom scale: 0.75
+zoom scale: 0.79
 
 setMinimumEffectiveWidth(1112.00)
-window size: [1112, 1454]
-square size: [111, 145]
-zoom scale: 0.69
+window size: [1112, 1455]
+square size: [111, 146]
+zoom scale: 0.73
 
 setMinimumEffectiveWidth(1280.00)
-window size: [1280, 1673]
-square size: [128, 167]
-zoom scale: 0.60
+window size: [1280, 1675]
+square size: [128, 168]
+zoom scale: 0.63
 
 setMinimumEffectiveWidth(1336.00)
-window size: [1336, 1747]
+window size: [1336, 1748]
 square size: [134, 175]
-zoom scale: 0.57
+zoom scale: 0.61
 
 

--- a/LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-expected.txt
+++ b/LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-expected.txt
@@ -3,4 +3,4 @@ Viewport: width=device-width
 scale	1.00000
 maxScale	5.00000
 minScale	1.00000
-visibleRect	{"left":"0.00000","top":"0.00000","width":"768.00000","height":"1004.00000"}
+visibleRect	{"left":"0.00000","top":"0.00000","width":"810.00000","height":"1060.00000"}

--- a/LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-overflowing-body-overflow-hidden-expected.txt
+++ b/LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-overflowing-body-overflow-hidden-expected.txt
@@ -3,5 +3,5 @@ Viewport: width=device-width, shrink-to-fit=no
 scale	1.00000
 maxScale	5.00000
 minScale	1.00000
-visibleRect	{"left":"0.00000","top":"0.00000","width":"768.00000","height":"1004.00000"}
+visibleRect	{"left":"0.00000","top":"0.00000","width":"810.00000","height":"1060.00000"}
 

--- a/LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-overflowing-body-overflow-hidden-tall-expected.txt
+++ b/LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-overflowing-body-overflow-hidden-tall-expected.txt
@@ -1,7 +1,7 @@
 Viewport: width=device-width
 
-scale	0.76190
-maxScale	3.80952
-minScale	0.76190
-visibleRect	{"left":"0.00000","top":"0.00000","width":"1008.00000","height":"1317.75000"}
+scale	0.80364
+maxScale	4.01786
+minScale	0.80364
+visibleRect	{"left":"0.00000","top":"0.00000","width":"1007.91510","height":"1319.00000"}
 

--- a/LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-overflowing-expected.txt
+++ b/LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-overflowing-expected.txt
@@ -3,5 +3,5 @@ Viewport: width=device-width, shrink-to-fit=no
 scale	1.00000
 maxScale	5.00000
 minScale	1.00000
-visibleRect	{"left":"0.00000","top":"0.00000","width":"768.00000","height":"1004.00000"}
+visibleRect	{"left":"0.00000","top":"0.00000","width":"810.00000","height":"1060.00000"}
 

--- a/LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-overflowing-no-shrink-to-fit-expected.txt
+++ b/LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-overflowing-no-shrink-to-fit-expected.txt
@@ -3,5 +3,5 @@ Viewport: width=device-width, shrink-to-fit=no
 scale	1.00000
 maxScale	5.00000
 minScale	1.00000
-visibleRect	{"left":"0.00000","top":"0.00000","width":"768.00000","height":"1004.00000"}
+visibleRect	{"left":"0.00000","top":"0.00000","width":"810.00000","height":"1060.00000"}
 


### PR DESCRIPTION
#### a7ee3e90c35b46dde6f2103a51bd5532d96a05fd
<pre>
REBASELINE REGRESSION(iPad 9th gen): [ iPad Simulator ] 11x fast/viewport tests are constant text failures.
rdar://106110830
<a href="https://bugs.webkit.org/show_bug.cgi?id=253201">https://bugs.webkit.org/show_bug.cgi?id=253201</a>

Unreviewed test gardening.

Rebaseline for failing tests.

* LayoutTests/platform/ipad/fast/viewport/ios/device-width-viewport-after-changing-view-scale-expected.txt:
* LayoutTests/platform/ipad/fast/viewport/ios/non-responsive-viewport-after-changing-view-scale-expected.txt:
* LayoutTests/platform/ipad/fast/viewport/ios/responsive-viewport-with-minimum-width-after-changing-view-scale-expected.txt:
* LayoutTests/platform/ipad/fast/viewport/ios/shrink-to-fit-content-large-width-breakpoint-expected.txt: Added.
* LayoutTests/platform/ipad/fast/viewport/ios/shrink-to-fit-for-page-without-viewport-meta-expected.txt:
* LayoutTests/platform/ipad/fast/viewport/ios/use-minimum-device-width-for-page-without-viewport-meta-expected.txt:
* LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-expected.txt:
* LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-overflowing-body-overflow-hidden-expected.txt:
* LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-overflowing-body-overflow-hidden-tall-expected.txt:
* LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-overflowing-expected.txt:
* LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-overflowing-no-shrink-to-fit-expected.txt:

Canonical link: <a href="https://commits.webkit.org/261030@main">https://commits.webkit.org/261030@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef8521e29d63d1321fef86a41fcc6b41b8bdf86f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/110406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/19493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/43004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/1785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/119324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/20929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/10646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/102645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/116149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/20929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/43004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/102645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/20929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/43004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/102645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/12155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/43004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/12737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/10646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/18102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/43004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/14594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4159 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->