### PR TITLE
[ iPad OS ] 2 x platform/ipad/fast/viewport are constant failures on iPad.

### DIFF
--- a/LayoutTests/platform/ipad/fast/viewport/viewport-overriden-by-minimum-effective-width-if-ignore-meta-viewport-expected.txt
+++ b/LayoutTests/platform/ipad/fast/viewport/viewport-overriden-by-minimum-effective-width-if-ignore-meta-viewport-expected.txt
@@ -1,41 +1,41 @@
 setMinimumEffectiveWidth(640.00)
-window size: [820, 1156]
-square size: [82, 116]
+window size: [810, 1060]
+square size: [81, 106]
 zoom scale: 1.00
 
 setMinimumEffectiveWidth(768.00)
-window size: [820, 1156]
-square size: [82, 116]
+window size: [810, 1060]
+square size: [81, 106]
 zoom scale: 1.00
 
 setMinimumEffectiveWidth(834.00)
-window size: [834, 1176]
-square size: [83, 118]
-zoom scale: 0.98
+window size: [834, 1091]
+square size: [83, 109]
+zoom scale: 0.97
 
 setMinimumEffectiveWidth(980.00)
-window size: [980, 1382]
-square size: [98, 138]
-zoom scale: 0.84
+window size: [980, 1282]
+square size: [98, 128]
+zoom scale: 0.83
 
 setMinimumEffectiveWidth(1024.00)
-window size: [1024, 1444]
-square size: [102, 144]
-zoom scale: 0.80
+window size: [1024, 1340]
+square size: [102, 134]
+zoom scale: 0.79
 
 setMinimumEffectiveWidth(1112.00)
-window size: [1112, 1568]
-square size: [111, 157]
-zoom scale: 0.74
+window size: [1112, 1455]
+square size: [111, 146]
+zoom scale: 0.73
 
 setMinimumEffectiveWidth(1280.00)
-window size: [1280, 1804]
-square size: [128, 180]
-zoom scale: 0.64
+window size: [1280, 1675]
+square size: [128, 168]
+zoom scale: 0.63
 
 setMinimumEffectiveWidth(1336.00)
-window size: [1336, 1883]
-square size: [134, 188]
+window size: [1336, 1748]
+square size: [134, 175]
 zoom scale: 0.61
 
 

--- a/LayoutTests/platform/ipad/fast/viewport/viewport-unchanged-by-minimum-effective-width-if-not-ignore-meta-viewport-expected.txt
+++ b/LayoutTests/platform/ipad/fast/viewport/viewport-unchanged-by-minimum-effective-width-if-not-ignore-meta-viewport-expected.txt
@@ -1,41 +1,41 @@
 setMinimumEffectiveWidth(640.00)
-window size: [980, 1382]
-square size: [98, 138]
-zoom scale: 0.84
+window size: [980, 1282]
+square size: [98, 128]
+zoom scale: 0.83
 
 setMinimumEffectiveWidth(768.00)
-window size: [980, 1382]
-square size: [98, 138]
-zoom scale: 0.84
+window size: [980, 1282]
+square size: [98, 128]
+zoom scale: 0.83
 
 setMinimumEffectiveWidth(834.00)
-window size: [980, 1382]
-square size: [98, 138]
-zoom scale: 0.84
+window size: [980, 1282]
+square size: [98, 128]
+zoom scale: 0.83
 
 setMinimumEffectiveWidth(980.00)
-window size: [980, 1382]
-square size: [98, 138]
-zoom scale: 0.84
+window size: [980, 1282]
+square size: [98, 128]
+zoom scale: 0.83
 
 setMinimumEffectiveWidth(1024.00)
-window size: [980, 1382]
-square size: [98, 138]
-zoom scale: 0.84
+window size: [980, 1282]
+square size: [98, 128]
+zoom scale: 0.83
 
 setMinimumEffectiveWidth(1112.00)
-window size: [980, 1382]
-square size: [98, 138]
-zoom scale: 0.84
+window size: [980, 1282]
+square size: [98, 128]
+zoom scale: 0.83
 
 setMinimumEffectiveWidth(1280.00)
-window size: [980, 1382]
-square size: [98, 138]
-zoom scale: 0.84
+window size: [980, 1282]
+square size: [98, 128]
+zoom scale: 0.83
 
 setMinimumEffectiveWidth(1336.00)
-window size: [980, 1382]
-square size: [98, 138]
-zoom scale: 0.84
+window size: [980, 1282]
+square size: [98, 128]
+zoom scale: 0.83
 
 


### PR DESCRIPTION
#### 232759b248fb61b3d7795db017586dd320840d2f
<pre>
[ iPad OS ] 2 x platform/ipad/fast/viewport are constant failures on iPad.
rdar://106049249
<a href="https://bugs.webkit.org/show_bug.cgi?id=253087">https://bugs.webkit.org/show_bug.cgi?id=253087</a>

Unreviewed test gardening.

Rebaseline for failing tests.

* LayoutTests/platform/ipad/fast/viewport/viewport-overriden-by-minimum-effective-width-if-ignore-meta-viewport-expected.txt:
* LayoutTests/platform/ipad/fast/viewport/viewport-unchanged-by-minimum-effective-width-if-not-ignore-meta-viewport-expected.txt:

Canonical link: <a href="https://commits.webkit.org/261031@main">https://commits.webkit.org/261031@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/516eb2c36f3b2f29a3ad5da5250475a1f03c64c8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/110409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/19496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/43006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/1787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/119326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/20931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/10648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/102647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/116152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/20931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/43006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/102647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/20931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/43006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/102647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/12157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/43006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/12739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/10648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/18104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/43006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/14596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4160 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->