### PR TITLE
Improve JIT comments for WASM OMG

### DIFF
--- a/Source/JavaScriptCore/assembler/AbstractMacroAssembler.h
+++ b/Source/JavaScriptCore/assembler/AbstractMacroAssembler.h
@@ -56,7 +56,7 @@ namespace DFG {
 struct OSRExit;
 }
 
-#define JIT_COMMENT(jit, ...) do { if (UNLIKELY(Options::needDisassemblySupport())) { (jit).comment(__VA_ARGS__); } else { (void) jit; } } while (0);
+#define JIT_COMMENT(jit, ...) do { if (UNLIKELY(Options::needDisassemblySupport())) { (jit).comment(__VA_ARGS__); } else { (void) jit; } } while (0)
 
 class AbstractMacroAssemblerBase {
     WTF_MAKE_FAST_ALLOCATED;

--- a/Source/JavaScriptCore/b3/B3Generate.cpp
+++ b/Source/JavaScriptCore/b3/B3Generate.cpp
@@ -69,7 +69,7 @@ void generateToAir(Procedure& procedure)
 {
     CompilerTimingScope timingScope("Total B3", "generateToAir");
     
-    if (shouldDumpIR(procedure, B3Mode) && !shouldDumpIRAtEachPhase(B3Mode)) {
+    if ((shouldDumpIR(procedure, B3Mode) || Options::dumpGraphAfterParsing()) && !shouldDumpIRAtEachPhase(B3Mode)) {
         dataLog(tierName, "Initial B3:\n");
         dataLog(procedure);
     }

--- a/Source/JavaScriptCore/b3/B3StackmapValue.cpp
+++ b/Source/JavaScriptCore/b3/B3StackmapValue.cpp
@@ -32,6 +32,10 @@
 
 namespace JSC { namespace B3 {
 
+namespace B3StackmapValueInternal {
+constexpr bool dumpRegisters = false;
+}
+
 StackmapValue::~StackmapValue()
 {
 }
@@ -86,8 +90,11 @@ void StackmapValue::dumpChildren(CommaPrinter& comma, PrintStream& out) const
 void StackmapValue::dumpMeta(CommaPrinter& comma, PrintStream& out) const
 {
     out.print(
-        comma, "generator = ", RawPointer(m_generator.get()), ", earlyClobbered = ", m_earlyClobbered,
-        ", lateClobbered = ", m_lateClobbered, ", usedRegisters = ", m_usedRegisters);
+        comma, "generator = ", RawPointer(m_generator.get()));
+    if constexpr (B3StackmapValueInternal::dumpRegisters) {
+        out.print(", earlyClobbered = ", m_earlyClobbered,
+            ", lateClobbered = ", m_lateClobbered, ", usedRegisters = ", m_usedRegisters);
+    }
 }
 
 StackmapValue::StackmapValue(CheckedOpcodeTag, Kind kind, Type type, Origin origin)

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
@@ -48,6 +48,10 @@
 
 namespace JSC {
 
+namespace AssemblyHelpersInternal {
+constexpr bool dumpVerbose = false;
+}
+
 AssemblyHelpers::Jump AssemblyHelpers::branchIfFastTypedArray(GPRReg baseGPR)
 {
     return branch8(
@@ -679,7 +683,10 @@ void AssemblyHelpers::restoreCalleeSavesFromEntryFrameCalleeSavesBuffer(EntryFra
     RegisterAtOffsetList* allCalleeSaves = RegisterSetBuilder::vmCalleeSaveRegisterOffsets();
     auto dontRestoreRegisters = RegisterSetBuilder::stackRegisters();
     unsigned registerCount = allCalleeSaves->registerCount();
-    JIT_COMMENT(*this, "restoreCalleeSavesFromEntryFrameCalleeSavesBuffer ", *allCalleeSaves, " skip: ", dontRestoreRegisters);
+    if constexpr (AssemblyHelpersInternal::dumpVerbose)
+        JIT_COMMENT(*this, "restoreCalleeSavesFromEntryFrameCalleeSavesBuffer ", *allCalleeSaves, " skip: ", dontRestoreRegisters);
+    else
+        JIT_COMMENT(*this, "restoreCalleeSavesFromEntryFrameCalleeSavesBuffer");
 
     GPRReg scratch = InvalidGPRReg;
     unsigned scratchGPREntryIndex = 0;
@@ -766,7 +773,10 @@ void AssemblyHelpers::restoreCalleeSavesFromVMEntryFrameCalleeSavesBufferImpl(GP
     addPtr(TrustedImm32(EntryFrame::calleeSaveRegistersBufferOffset()), entryFrameGPR);
 
     RegisterAtOffsetList* allCalleeSaves = RegisterSetBuilder::vmCalleeSaveRegisterOffsets();
-    JIT_COMMENT(*this, "restoreCalleeSavesFromVMEntryFrameCalleeSavesBufferImpl ", entryFrameGPR, " callee saves: ", *allCalleeSaves, " skip: ", skipList);
+    if constexpr (AssemblyHelpersInternal::dumpVerbose)
+        JIT_COMMENT(*this, "restoreCalleeSavesFromVMEntryFrameCalleeSavesBufferImpl ", entryFrameGPR, " callee saves: ", *allCalleeSaves, " skip: ", skipList);
+    else
+        JIT_COMMENT(*this, "restoreCalleeSavesFromVMEntryFrameCalleeSavesBufferImpl");
     unsigned registerCount = allCalleeSaves->registerCount();
 
     LoadRegSpooler spooler(*this, entryFrameGPR);
@@ -1249,7 +1259,8 @@ void AssemblyHelpers::cageConditionallyAndUntag(Gigacage::Kind kind, GPRReg stor
 
 void AssemblyHelpers::emitSave(const RegisterAtOffsetList& list)
 {
-    JIT_COMMENT(*this, "emitSave ", list);
+    if constexpr (AssemblyHelpersInternal::dumpVerbose)
+        JIT_COMMENT(*this, "emitSave ", list);
     StoreRegSpooler spooler(*this, framePointerRegister);
 
     size_t registerCount = list.registerCount();
@@ -1269,7 +1280,8 @@ void AssemblyHelpers::emitSave(const RegisterAtOffsetList& list)
 
 void AssemblyHelpers::emitRestore(const RegisterAtOffsetList& list, GPRReg baseGPR)
 {
-    JIT_COMMENT(*this, "emitRestore ", list);
+    if constexpr (AssemblyHelpersInternal::dumpVerbose)
+        JIT_COMMENT(*this, "emitRestore ", list);
     LoadRegSpooler spooler(*this, baseGPR);
 
     size_t registerCount = list.registerCount();
@@ -1291,7 +1303,10 @@ void AssemblyHelpers::emitSaveCalleeSavesFor(const RegisterAtOffsetList* calleeS
 {
     auto dontSaveRegisters = RegisterSetBuilder::stackRegisters();
     unsigned registerCount = calleeSaves->registerCount();
-    JIT_COMMENT(*this, "emitSaveCalleeSavesFor ", *calleeSaves, " dontRestore: ", dontSaveRegisters);
+    if constexpr (AssemblyHelpersInternal::dumpVerbose)
+        JIT_COMMENT(*this, "emitSaveCalleeSavesFor ", *calleeSaves, " dontRestore: ", dontSaveRegisters);
+    else
+        JIT_COMMENT(*this, "emitSaveCalleeSavesFor");
 
     StoreRegSpooler spooler(*this, framePointerRegister);
 
@@ -1318,7 +1333,10 @@ void AssemblyHelpers::emitRestoreCalleeSavesFor(const RegisterAtOffsetList* call
 {
     auto dontRestoreRegisters = RegisterSetBuilder::stackRegisters();
     unsigned registerCount = calleeSaves->registerCount();
-    JIT_COMMENT(*this, "emitRestoreCalleeSavesFor ", *calleeSaves, " dontSave: ", dontRestoreRegisters);
+    if constexpr (AssemblyHelpersInternal::dumpVerbose)
+        JIT_COMMENT(*this, "emitRestoreCalleeSavesFor ", *calleeSaves, " dontSave: ", dontRestoreRegisters);
+    else
+        JIT_COMMENT(*this, "emitRestoreCalleeSavesFor");
     
     LoadRegSpooler spooler(*this, framePointerRegister);
 

--- a/Source/JavaScriptCore/jit/AssemblyHelpersSpoolers.h
+++ b/Source/JavaScriptCore/jit/AssemblyHelpersSpoolers.h
@@ -97,9 +97,6 @@ public:
     {
         RELEASE_ASSERT(RegDispatch<RegType>::hasSameType(entry.reg()));
         ASSERT(entry.width() == pointerWidth() || entry.width() == Width64);
-        auto& jit = m_jit;
-        JIT_COMMENT(jit, "Execute Spooler: ", entry);
-        ASSERT(entry.width() == pointerWidth() || entry.width() == Width64);
 
         if constexpr (!hasPairOp)
             return op().executeSingle(entry.offset(), RegDispatch<RegType>::get(entry.reg()));

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -882,7 +882,7 @@ Exception* VM::throwException(JSGlobalObject* globalObject, Exception* exception
     if (UNLIKELY(Options::breakOnThrow())) {
         CodeBlock* codeBlock = throwOriginFrame && !throwOriginFrame->isWasmFrame() ? throwOriginFrame->codeBlock() : nullptr;
         dataLog("Throwing exception in call frame ", RawPointer(throwOriginFrame), " for code block ", codeBlock, "\n");
-        CRASH();
+        WTFBreakpointTrap();
     }
 
     interpreter.notifyDebuggerOfExceptionToBeThrown(*this, globalObject, throwOriginFrame, exceptionToThrow);

--- a/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
@@ -3645,6 +3645,7 @@ Value* B3IRGenerator::emitCatchImpl(CatchKind kind, ControlType& data, unsigned 
     result->resultConstraints.append(ValueRep::reg(GPRInfo::returnValueGPR2));
     result->setGenerator([](CCallHelpers& jit, const StackmapGenerationParams& params) {
         AllowMacroScratchRegisterUsage allowScratch(jit);
+        JIT_COMMENT(jit, "operationWasmRetrieveAndClearExceptionIfCatchable");
         jit.move(params[2].gpr(), GPRInfo::argumentGPR0);
         jit.prepareWasmCallOperation(GPRInfo::wasmContextInstancePointer);
         CCallHelpers::Call call = jit.call(OperationPtrTag);

--- a/Source/JavaScriptCore/wasm/WasmIRGeneratorHelpers.h
+++ b/Source/JavaScriptCore/wasm/WasmIRGeneratorHelpers.h
@@ -138,6 +138,7 @@ static inline void emitRethrowImpl(CCallHelpers& jit)
 
 static inline void emitThrowImpl(CCallHelpers& jit, unsigned exceptionIndex)
 {
+    JIT_COMMENT(jit, "throw impl, index: ", exceptionIndex);
     // Instance in argumentGPR0
     // arguments to the exception off of stack pointer
 

--- a/Source/JavaScriptCore/wasm/WasmModuleInformation.h
+++ b/Source/JavaScriptCore/wasm/WasmModuleInformation.h
@@ -110,7 +110,7 @@ struct ModuleInformation : public ThreadSafeRefCounted<ModuleInformation> {
 
     bool usesSIMD(uint32_t index) const
     {
-        ASSERT(index <= internalFunctionCount());
+        ASSERT(index < internalFunctionCount());
         ASSERT(functions[index].finishedValidating);
 
         // See also: B3Procedure::usesSIMD().
@@ -123,14 +123,14 @@ struct ModuleInformation : public ThreadSafeRefCounted<ModuleInformation> {
 
         return functions[index].usesSIMD;
     }
-    void markUsesSIMD(uint32_t index) { ASSERT(index <= internalFunctionCount()); ASSERT(!functions[index].finishedValidating); functions[index].usesSIMD = true; }
+    void markUsesSIMD(uint32_t index) { ASSERT(index < internalFunctionCount()); ASSERT(!functions[index].finishedValidating); functions[index].usesSIMD = true; }
 
-    bool usesExceptions(uint32_t index) const { ASSERT(index <= internalFunctionCount()); ASSERT(functions[index].finishedValidating); return functions[index].usesExceptions; }
-    void markUsesExceptions(uint32_t index) { ASSERT(index <= internalFunctionCount()); ASSERT(!functions[index].finishedValidating); functions[index].usesExceptions = true; }
-    bool usesAtomics(uint32_t index) const { ASSERT(index <= internalFunctionCount()); ASSERT(functions[index].finishedValidating); return functions[index].usesAtomics; }
-    void markUsesAtomics(uint32_t index) { ASSERT(index <= internalFunctionCount()); ASSERT(!functions[index].finishedValidating); functions[index].usesAtomics = true; }
+    bool usesExceptions(uint32_t index) const { ASSERT(index < internalFunctionCount()); ASSERT(functions[index].finishedValidating); return functions[index].usesExceptions; }
+    void markUsesExceptions(uint32_t index) { ASSERT(index < internalFunctionCount()); ASSERT(!functions[index].finishedValidating); functions[index].usesExceptions = true; }
+    bool usesAtomics(uint32_t index) const { ASSERT(index < internalFunctionCount()); ASSERT(functions[index].finishedValidating); return functions[index].usesAtomics; }
+    void markUsesAtomics(uint32_t index) { ASSERT(index < internalFunctionCount()); ASSERT(!functions[index].finishedValidating); functions[index].usesAtomics = true; }
 
-    void doneSeeingFunction(uint32_t index) { ASSERT(!functions[index].finishedValidating); functions[index].finishedValidating = true; }
+    void doneSeeingFunction(uint32_t index) { ASSERT(index < internalFunctionCount()); ASSERT(!functions[index].finishedValidating); functions[index].finishedValidating = true; }
 
     uint32_t typeCount() const { return typeSignatures.size(); }
 


### PR DESCRIPTION
#### 7b9e64bd5a8b50e7fa1303f9259caf5ca5a6409e
<pre>
Improve JIT comments for WASM OMG
<a href="https://bugs.webkit.org/show_bug.cgi?id=253208">https://bugs.webkit.org/show_bug.cgi?id=253208</a>
rdar://106115519

Reviewed by Yusuke Suzuki.

Improve some comments and assertions.

* Source/JavaScriptCore/b3/B3Generate.cpp:
(JSC::B3::generateToAir):
* Source/JavaScriptCore/b3/B3StackmapValue.cpp:
(JSC::B3::StackmapValue::dumpMeta const):
* Source/JavaScriptCore/b3/B3Value.cpp:
(JSC::B3::Value::generateCompilerConstructionSite):
(JSC::B3::Value::deepDump const):
* Source/JavaScriptCore/jit/AssemblyHelpers.cpp:
(JSC::AssemblyHelpers::restoreCalleeSavesFromEntryFrameCalleeSavesBuffer):
(JSC::AssemblyHelpers::restoreCalleeSavesFromVMEntryFrameCalleeSavesBufferImpl):
(JSC::AssemblyHelpers::emitSave):
(JSC::AssemblyHelpers::emitRestore):
(JSC::AssemblyHelpers::emitSaveCalleeSavesFor):
(JSC::AssemblyHelpers::emitRestoreCalleeSavesFor):
* Source/JavaScriptCore/jit/AssemblyHelpersSpoolers.h:
(JSC::AssemblyHelpers::Spooler::execute):
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::throwException):
* Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp:
(JSC::Wasm::B3IRGenerator::emitCatchImpl):
* Source/JavaScriptCore/wasm/WasmIRGeneratorHelpers.h:
(JSC::Wasm::emitThrowImpl):
* Source/JavaScriptCore/wasm/WasmModuleInformation.h:
(JSC::Wasm::ModuleInformation::isSIMDFunctionImportSpace const):
(JSC::Wasm::ModuleInformation::isSIMDFunction const):
(JSC::Wasm::ModuleInformation::addSIMDFunction):
(JSC::Wasm::ModuleInformation::doneSeeingFunction):

Canonical link: <a href="https://commits.webkit.org/261090@main">https://commits.webkit.org/261090@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a58c50bdd00ff316ad84ec424539919f626f005

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110438 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19525 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/43154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1812 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119346 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20956 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10673 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102673 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116181 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15606 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98794 "Build was cancelled. Recent messages:configuring build; Cleaned up git repository; 'git checkout ...'; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43831 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97567 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30459 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85695 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/99146 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12181 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31796 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/100171 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/10241 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12760 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8763 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31262 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18124 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51413 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/108194 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7683 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14623 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26670 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->