### PR TITLE
AX remote tokens are not being sent to iframe's WebContent process

### DIFF
--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -321,6 +321,11 @@ public:
 #endif
 #endif
 
+#if PLATFORM(MAC)
+    virtual IPC::DataReference remoteWindowTokenForAccessibility() = 0;
+    virtual IPC::DataReference remoteElementTokenForAccessibility() = 0;
+#endif
+
 #if PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)
     virtual void selectionDidChange() = 0;
 #endif

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -31,6 +31,7 @@
 #include "DrawingAreaMessages.h"
 #include "DrawingAreaProxy.h"
 #include "FrameTreeNodeData.h"
+#include "PageClient.h"
 #include "ProvisionalFrameProxy.h"
 #include "ProvisionalPageProxy.h"
 #include "SubframePageProxy.h"
@@ -410,6 +411,11 @@ void WebFrameProxy::commitProvisionalFrame(FrameIdentifier frameID, FrameInfoDat
     if (m_page) {
         m_subframePage = makeUnique<SubframePageProxy>(*this, *m_page, m_process);
         m_page->didCommitLoadForFrame(frameID, WTFMove(frameInfo), WTFMove(request), navigationID, mimeType, frameHasCustomContentProvider, frameLoadType, certificateInfo, usedLegacyTLS, privateRelayed, containsPluginDocument, hasInsecureContent, mouseEventPolicy, userData);
+#if PLATFORM(MAC)
+        auto elementToken = m_page->pageClient().remoteElementTokenForAccessibility();
+        auto windowToken = m_page->pageClient().remoteWindowTokenForAccessibility();
+        m_subframePage->send(Messages::WebPage::RegisterUIProcessAccessibilityTokens(elementToken, windowToken));
+#endif
     }
 }
 

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -111,6 +111,7 @@ private:
     WebCore::IntRect rootViewToScreen(const WebCore::IntRect&) override;
     WebCore::IntPoint accessibilityScreenToRootView(const WebCore::IntPoint&) override;
     WebCore::IntRect rootViewToAccessibilityScreen(const WebCore::IntRect&) override;
+
     void doneWithKeyEvent(const NativeWebKeyboardEvent&, bool wasEventHandled) override;
 #if ENABLE(TOUCH_EVENTS)
     void doneWithTouchEvent(const NativeWebTouchEvent&, bool wasEventHandled) override;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -431,7 +431,7 @@ IntRect PageClientImpl::rootViewToAccessibilityScreen(const IntRect& rect)
         rootViewRect = [m_contentView accessibilityConvertRectToSceneReferenceCoordinates:rootViewRect];
     return enclosingIntRect(rootViewRect);
 }
-    
+
 void PageClientImpl::doneWithKeyEvent(const NativeWebKeyboardEvent& event, bool eventWasHandled)
 {
     [m_contentView _didHandleKeyEvent:event.nativeEvent() eventWasHandled:eventWasHandled];

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -125,6 +125,9 @@ private:
     WebCore::IntPoint accessibilityScreenToRootView(const WebCore::IntPoint&) override;
     WebCore::IntRect rootViewToAccessibilityScreen(const WebCore::IntRect&) override;
 
+    IPC::DataReference remoteWindowTokenForAccessibility() override;
+    IPC::DataReference remoteElementTokenForAccessibility() override;
+
     void pinnedStateWillChange() final;
     void pinnedStateDidChange() final;
         

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -477,6 +477,16 @@ IntRect PageClientImpl::rootViewToAccessibilityScreen(const IntRect& rect)
     return rootViewToScreen(rect);
 }
 
+IPC::DataReference PageClientImpl::remoteWindowTokenForAccessibility()
+{
+    return m_impl->remoteWindowToken();
+}
+
+IPC::DataReference PageClientImpl::remoteElementTokenForAccessibility()
+{
+    return m_impl->remoteElementToken();
+}
+
 void PageClientImpl::doneWithKeyEvent(const NativeWebKeyboardEvent& event, bool eventWasHandled)
 {
     m_impl->doneWithKeyEvent(event.nativeEvent(), eventWasHandled);

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -691,6 +691,9 @@ public:
     void beginTextRecognitionForVideoInElementFullscreen(const ShareableBitmapHandle&, WebCore::FloatRect);
     void cancelTextRecognitionForVideoInElementFullscreen();
 
+    IPC::DataReference remoteElementToken();
+    IPC::DataReference remoteWindowToken();
+
 private:
 #if HAVE(TOUCH_BAR)
     void setUpTextTouchBar(NSTouchBar *);

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -3487,14 +3487,24 @@ void WebViewImpl::updateRemoteAccessibilityRegistration(bool registerProcess)
         [NSAccessibilityRemoteUIElement unregisterRemoteUIProcessIdentifier:pid];
 }
 
+IPC::DataReference WebViewImpl::remoteElementToken()
+{
+    NSData *remoteElementToken = [NSAccessibilityRemoteUIElement remoteTokenForLocalUIElement:m_view.getAutoreleased()];
+    IPC::DataReference elementToken = IPC::DataReference(reinterpret_cast<const uint8_t*>([remoteElementToken bytes]), [remoteElementToken length]);
+    return elementToken;
+}
+
+IPC::DataReference WebViewImpl::remoteWindowToken()
+{
+    NSData *remoteWindowToken = [NSAccessibilityRemoteUIElement remoteTokenForLocalUIElement:[m_view window]];
+    IPC::DataReference windowToken = IPC::DataReference(reinterpret_cast<const uint8_t*>([remoteWindowToken bytes]), [remoteWindowToken length]);
+    return windowToken;
+}
+
 void WebViewImpl::accessibilityRegisterUIProcessTokens()
 {
     // Initialize remote accessibility when the window connection has been established.
-    NSData *remoteElementToken = [NSAccessibilityRemoteUIElement remoteTokenForLocalUIElement:m_view.getAutoreleased()];
-    NSData *remoteWindowToken = [NSAccessibilityRemoteUIElement remoteTokenForLocalUIElement:[m_view window]];
-    IPC::DataReference elementToken = IPC::DataReference(reinterpret_cast<const uint8_t*>([remoteElementToken bytes]), [remoteElementToken length]);
-    IPC::DataReference windowToken = IPC::DataReference(reinterpret_cast<const uint8_t*>([remoteWindowToken bytes]), [remoteWindowToken length]);
-    m_page->registerUIProcessAccessibilityTokens(elementToken, windowToken);
+    m_page->registerUIProcessAccessibilityTokens(remoteElementToken(), remoteWindowToken());
 }
 
 id WebViewImpl::accessibilityFocusedUIElement()


### PR DESCRIPTION
#### af7cce33a111f6a364bcc5976f53123374a93af7
<pre>
AX remote tokens are not being sent to iframe&apos;s WebContent process
<a href="https://bugs.webkit.org/show_bug.cgi?id=252698">https://bugs.webkit.org/show_bug.cgi?id=252698</a>
rdar://problem/105750275

Reviewed by NOBODY (OOPS!).

Make sure the remote element and window AX tokens are being sent to the iframe&apos;s WebContent process.

* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::commitProvisionalFrame):
(WebKit::PageClientImpl::remoteWindowTokenForAccessibility):
(WebKit::PageClientImpl::remoteElementTokenForAccessibility):
* Source/WebKit/UIProcess/mac/PageClientImplMac.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::remoteWindowTokenForAccessibility):
(WebKit::PageClientImpl::remoteElementTokenForAccessibility):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::remoteElementToken):
(WebKit::WebViewImpl::remoteWindowToken):
(WebKit::WebViewImpl::accessibilityRegisterUIProcessTokens):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af7cce33a111f6a364bcc5976f53123374a93af7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110855 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19941 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43493 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2209 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119731 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21421 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11163 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/1994 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116607 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15908 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99106 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103367 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97868 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30771 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44313 "") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12535 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32107 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86192 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13092 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9082 "Found 1 new test failure: fast/images/avif-image-decoding.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18493 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51728 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15037 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->