### PR TITLE
REBASELINE REGRESSION(iPad 9th gen): [ iPad Simulator ] 15X scrolling layout-tests are constant text failures (253200)

### DIFF
--- a/LayoutTests/platform/ipad/fast/scrolling/ios/change-scrollability-on-content-resize-nested-expected.txt
+++ b/LayoutTests/platform/ipad/fast/scrolling/ios/change-scrollability-on-content-resize-nested-expected.txt
@@ -55,13 +55,21 @@
           (contentsScale 2.00)
           (children 1
             (GraphicsLayer
-              (bounds 200.00 50.00)
-              (contentsOpaque 1)
-              (transform [1.00 0.00 0.00 0.00] [0.00 1.00 0.00 0.00] [0.00 0.00 1.00 0.00] [50.00 100.00 0.00 1.00])
-              (visible rect 0.00, 0.00 200.00 x 50.00)
-              (coverage rect -50.00, -100.00 300.00 x 200.00)
-              (intersects coverage rect 1)
+              (visible rect 0.00, 0.00 0.00 x 0.00)
+              (coverage rect 0.00, 0.00 300.00 x 200.00)
+              (intersects coverage rect 0)
               (contentsScale 2.00)
+              (children 1
+                (GraphicsLayer
+                  (bounds 200.00 50.00)
+                  (contentsOpaque 1)
+                  (transform [1.00 0.00 0.00 0.00] [0.00 1.00 0.00 0.00] [0.00 0.00 1.00 0.00] [50.00 100.00 0.00 1.00])
+                  (visible rect 0.00, 0.00 200.00 x 50.00)
+                  (coverage rect -50.00, -100.00 300.00 x 200.00)
+                  (intersects coverage rect 1)
+                  (contentsScale 2.00)
+                )
+              )
             )
           )
         )
@@ -84,7 +92,7 @@
   (min layout viewport origin (0,0))
   (max layout viewport origin (0,0))
   (behavior for fixed 1)
-  (children 1
+  (children 2
     (Overflow scrolling node
       (scrollable area size 300 200)
       (contents size 300 400)
@@ -94,6 +102,9 @@
         (horizontal scrollbar mode 0)
         (vertical scrollbar mode 0)
         (allows vertical scrolling 1))
+    )
+    (Overflow scroll proxy node
+      (related overflow scrolling node scroll position (0,0))
     )
   )
 )

--- a/LayoutTests/platform/ipad/fast/scrolling/ios/clipping-ancestor-with-accelerated-scrolling-ancestor-expected.txt
+++ b/LayoutTests/platform/ipad/fast/scrolling/ios/clipping-ancestor-with-accelerated-scrolling-ancestor-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 768x1004
-  RenderView at (0,0) size 768x1004
-layer at (0,0) size 768x316
-  RenderBlock {HTML} at (0,0) size 768x316
-    RenderBody {BODY} at (8,8) size 752x300
+layer at (0,0) size 810x1060
+  RenderView at (0,0) size 810x1060
+layer at (0,0) size 810x316
+  RenderBlock {HTML} at (0,0) size 810x316
+    RenderBody {BODY} at (8,8) size 794x300
 layer at (8,8) size 300x300
   RenderBlock {DIV} at (0,0) size 300x300
 layer at (8,8) size 100x100 scrollHeight 200

--- a/LayoutTests/platform/ipad/fast/scrolling/ios/overflow-scrolling-ancestor-clip-expected.txt
+++ b/LayoutTests/platform/ipad/fast/scrolling/ios/overflow-scrolling-ancestor-clip-expected.txt
@@ -1,9 +1,9 @@
 (GraphicsLayer
   (anchor 0.00 0.00)
-  (bounds 768.00 1004.00)
+  (bounds 810.00 1060.00)
   (children 1
     (GraphicsLayer
-      (bounds 768.00 1004.00)
+      (bounds 810.00 1060.00)
       (contentsOpaque 1)
       (children 2
         (GraphicsLayer

--- a/LayoutTests/platform/ipad/fast/scrolling/ios/overflow-scrolling-ancestor-clip-size-expected.txt
+++ b/LayoutTests/platform/ipad/fast/scrolling/ios/overflow-scrolling-ancestor-clip-size-expected.txt
@@ -1,9 +1,9 @@
 (GraphicsLayer
   (anchor 0.00 0.00)
-  (bounds 768.00 1004.00)
+  (bounds 810.00 1060.00)
   (children 1
     (GraphicsLayer
-      (bounds 768.00 1004.00)
+      (bounds 810.00 1060.00)
       (contentsOpaque 1)
       (children 2
         (GraphicsLayer

--- a/LayoutTests/platform/ipad/fast/scrolling/ios/scrolling-content-clip-to-viewport-expected.txt
+++ b/LayoutTests/platform/ipad/fast/scrolling/ios/scrolling-content-clip-to-viewport-expected.txt
@@ -1,9 +1,9 @@
 (GraphicsLayer
   (anchor 0.00 0.00)
-  (bounds 768.00 1004.00)
+  (bounds 810.00 1060.00)
   (children 1
     (GraphicsLayer
-      (bounds 768.00 1004.00)
+      (bounds 810.00 1060.00)
       (contentsOpaque 1)
       (children 1
         (GraphicsLayer

--- a/LayoutTests/platform/ipad/fast/scrolling/ios/subpixel-overflow-scrolling-with-ancestor-expected.txt
+++ b/LayoutTests/platform/ipad/fast/scrolling/ios/subpixel-overflow-scrolling-with-ancestor-expected.txt
@@ -1,9 +1,9 @@
 (GraphicsLayer
   (anchor 0.00 0.00)
-  (bounds 768.00 1004.00)
+  (bounds 810.00 1060.00)
   (children 1
     (GraphicsLayer
-      (bounds 768.00 1004.00)
+      (bounds 810.00 1060.00)
       (contentsOpaque 1)
       (children 2
         (GraphicsLayer

--- a/LayoutTests/platform/ipad/fast/scrolling/ios/touch-stacking-expected.txt
+++ b/LayoutTests/platform/ipad/fast/scrolling/ios/touch-stacking-expected.txt
@@ -1,13 +1,13 @@
-layer at (0,0) size 768x1004
-  RenderView at (0,0) size 768x1004
-layer at (0,0) size 768x148 layerType: background only
+layer at (0,0) size 810x1060
+  RenderView at (0,0) size 810x1060
+layer at (0,0) size 810x148 layerType: background only
 layer at (0,0) size 100x100
   RenderBlock (positioned) zI: -1 {DIV} at (0,0) size 100x100 [bgcolor=#FF0000]
-layer at (0,0) size 768x148 layerType: foreground only
-  RenderBlock {HTML} at (0,0) size 768x148
-    RenderBody {BODY} at (8,120) size 752x20
-      RenderBlock {DIV} at (0,0) size 752x0
-      RenderBlock {DIV} at (0,0) size 752x20
+layer at (0,0) size 810x148 layerType: foreground only
+  RenderBlock {HTML} at (0,0) size 810x148
+    RenderBody {BODY} at (8,120) size 794x20
+      RenderBlock {DIV} at (0,0) size 794x0
+      RenderBlock {DIV} at (0,0) size 794x20
         RenderText {#text} at (0,0) size 217x19
           text run at (0,0) width 217: "PASS: computed zIndex was auto"
 layer at (0,0) size 100x100

--- a/LayoutTests/platform/ipad/scrollingcoordinator/ios/fixed-in-overflow-scroll-scrolling-tree-expected.txt
+++ b/LayoutTests/platform/ipad/scrollingcoordinator/ios/fixed-in-overflow-scroll-scrolling-tree-expected.txt
@@ -1,15 +1,15 @@
 
 (scrolling tree
   (frame scrolling node
-    (scrollable area size width=768 height=1004)
-    (total content size width=768 height=1004)
+    (scrollable area size width=810 height=1060)
+    (total content size width=810 height=1060)
     (last committed scroll position (0,0))
     (scrollable area parameters
       (horizontal scroll elasticity 1)
       (vertical scroll elasticity 1)
       (horizontal scrollbar mode 0)
       (vertical scrollbar mode 0))
-    (layout viewport (0,0) width=768 height=1004)
+    (layout viewport (0,0) width=810 height=1060)
     (min layoutViewport origin (0,0))
     (max layoutViewport origin (0,0))
     (behavior for fixed 1)
@@ -25,6 +25,6 @@
         (allows vertical scrolling 1)))
     (fixed node
       (fixed constraints
-        (viewport-rect-at-last-layout (0,0) width=768 height=1004)
+        (viewport-rect-at-last-layout (0,0) width=810 height=1060)
         (layer-position-at-last-layout (19,211)))
       (layer top left (19,211)))))

--- a/LayoutTests/platform/ipad/scrollingcoordinator/ios/fixed-scrolling-with-keyboard-expected.txt
+++ b/LayoutTests/platform/ipad/scrollingcoordinator/ios/fixed-scrolling-with-keyboard-expected.txt
@@ -2,22 +2,22 @@
 
 (scrolling tree
   (frame scrolling node
-    (scrollable area size width=768 height=1004)
-    (total content size width=768 height=4021)
+    (scrollable area size width=810 height=1060)
+    (total content size width=810 height=4021)
     (last committed scroll position (0,0))
     (scrollable area parameters
       (horizontal scroll elasticity 1)
       (vertical scroll elasticity 1)
       (horizontal scrollbar mode 0)
       (vertical scrollbar mode 0))
-    (layout viewport (0,0) width=768 height=1004)
+    (layout viewport (0,0) width=810 height=1060)
     (min layoutViewport origin (0,0))
-    (max layoutViewport origin (0,3017))
-    (override visual viewport size width=768 height=949)
+    (max layoutViewport origin (0,2961))
+    (override visual viewport size width=810 height=1005)
     (behavior for fixed 1)
     (visual viewport is smaller than layout viewport 1)
     (fixed node
       (fixed constraints
-        (viewport-rect-at-last-layout (0,0) width=768 height=1004)
+        (viewport-rect-at-last-layout (0,0) width=810 height=1060)
         (layer-position-at-last-layout (0,0)))
       (layer top left (0,0)))))

--- a/LayoutTests/platform/ipad/scrollingcoordinator/ios/ui-scrolling-tree-expected.txt
+++ b/LayoutTests/platform/ipad/scrollingcoordinator/ios/ui-scrolling-tree-expected.txt
@@ -1,7 +1,7 @@
 
 (scrolling tree
   (frame scrolling node
-    (scrollable area size width=768 height=1004)
+    (scrollable area size width=810 height=1060)
     (total content size width=1308 height=2021)
     (last committed scroll position (0,0))
     (scrollable area parameters
@@ -9,12 +9,12 @@
       (vertical scroll elasticity 1)
       (horizontal scrollbar mode 0)
       (vertical scrollbar mode 0))
-    (layout viewport (0,0) width=768 height=1004)
+    (layout viewport (0,0) width=810 height=1060)
     (min layoutViewport origin (0,0))
-    (max layoutViewport origin (540,1017))
+    (max layoutViewport origin (498,961))
     (behavior for fixed 1)
     (fixed node
       (fixed constraints
-        (viewport-rect-at-last-layout (0,0) width=768 height=1004)
+        (viewport-rect-at-last-layout (0,0) width=810 height=1060)
         (layer-position-at-last-layout (12,10)))
       (layer top left (12,10)))))


### PR DESCRIPTION
#### 267c6488d001547238f8b6480c68cc5ed8b9b5bd
<pre>
REBASELINE REGRESSION(iPad 9th gen): [ iPad Simulator ] 15X scrolling layout-tests are constant text failures (253200)
<a href="https://bugs.webkit.org/show_bug.cgi?id=253200">https://bugs.webkit.org/show_bug.cgi?id=253200</a>
rdar://106110468

Unreviewed test gardening.

* LayoutTests/platform/ipad/fast/scrolling/ios/change-scrollability-on-content-resize-nested-expected.txt:
* LayoutTests/platform/ipad/fast/scrolling/ios/clipping-ancestor-with-accelerated-scrolling-ancestor-expected.txt:
* LayoutTests/platform/ipad/fast/scrolling/ios/overflow-scrolling-ancestor-clip-expected.txt:
* LayoutTests/platform/ipad/fast/scrolling/ios/overflow-scrolling-ancestor-clip-size-expected.txt:
* LayoutTests/platform/ipad/fast/scrolling/ios/scrolling-content-clip-to-viewport-expected.txt:
* LayoutTests/platform/ipad/fast/scrolling/ios/subpixel-overflow-scrolling-with-ancestor-expected.txt:
* LayoutTests/platform/ipad/fast/scrolling/ios/touch-stacking-expected.txt:
* LayoutTests/platform/ipad/scrollingcoordinator/ios/fixed-in-overflow-scroll-scrolling-tree-expected.txt:
* LayoutTests/platform/ipad/scrollingcoordinator/ios/fixed-scrolling-with-keyboard-expected.txt:
* LayoutTests/platform/ipad/scrollingcoordinator/ios/ui-scrolling-tree-expected.txt:

Canonical link: <a href="https://commits.webkit.org/261034@main">https://commits.webkit.org/261034@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d529e0f1e8983999f76b2e8db487df31dcd7e400

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110422 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/19509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/43015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/1796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/119334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/20940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/10657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/102656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/116165 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/20940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/43015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/102656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/20940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/43015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/102656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/12166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/43015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/12748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/10657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/18112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/43015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/14608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4161 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->