### PR TITLE
[JSC] Remove `move(FPRReg, FPRReg)`

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssembler.h
+++ b/Source/JavaScriptCore/assembler/MacroAssembler.h
@@ -576,12 +576,6 @@ public:
         storeFloat(scratch, dest);
     }
 
-    // Overload mostly for use in templates.
-    void move(FPRegisterID src, FPRegisterID dest)
-    {
-        moveDouble(src, dest);
-    }
-
     void moveDouble(Address src, Address dest, FPRegisterID scratch)
     {
         loadDouble(src, scratch);

--- a/Source/JavaScriptCore/b3/testb3_7.cpp
+++ b/Source/JavaScriptCore/b3/testb3_7.cpp
@@ -1827,7 +1827,7 @@ static void tupleNestedLoop(int32_t first, double second)
         patchpoint->setGenerator([&] (CCallHelpers& jit, const StackmapGenerationParams& params) {
             jit.move(params[3].gpr(), params[0].gpr());
             jit.move(params[0].gpr(), params[2].gpr());
-            jit.move(params[4].fpr(), params[1].fpr());
+            jit.moveDouble(params[4].fpr(), params[1].fpr());
         });
         root->appendNew<VariableValue>(proc, Set, Origin(), varOuter, patchpoint);
         root->appendNew<VariableValue>(proc, Set, Origin(), tookInner, root->appendIntConstant(proc, Origin(), Int32, 0));
@@ -1849,7 +1849,7 @@ static void tupleNestedLoop(int32_t first, double second)
             AllowMacroScratchRegisterUsage allowScratch(jit);
             jit.move(params[3].gpr(), params[0].gpr());
             jit.moveConditionally32(CCallHelpers::Equal, params[5].gpr(), CCallHelpers::TrustedImm32(0), params[0].gpr(), params[5].gpr(), params[2].gpr());
-            jit.move(params[4].fpr(), params[1].fpr());
+            jit.moveDouble(params[4].fpr(), params[1].fpr());
         });
         outerLoop->appendNew<VariableValue>(proc, Set, Origin(), varOuter, patchpoint);
         outerLoop->appendNew<VariableValue>(proc, Set, Origin(), varInner, patchpoint);
@@ -1870,7 +1870,7 @@ static void tupleNestedLoop(int32_t first, double second)
             AllowMacroScratchRegisterUsage allowScratch(jit);
             jit.move(params[3].gpr(), params[0].gpr());
             jit.move(CCallHelpers::TrustedImm32(0), params[2].gpr());
-            jit.move(params[4].fpr(), params[1].fpr());
+            jit.moveDouble(params[4].fpr(), params[1].fpr());
         });
         innerLoop->appendNew<VariableValue>(proc, Set, Origin(), varOuter, patchpoint);
         innerLoop->appendNew<VariableValue>(proc, Set, Origin(), varInner, patchpoint);

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -4358,13 +4358,13 @@ public:
         // Left is strictly greater than right
         isGreaterThan.link(&m_jit);
         auto isGreaterThanResult = IsMinOrMax == MinOrMax::Max ? left : right;
-        m_jit.move(isGreaterThanResult, result);
+        m_jit.moveDouble(isGreaterThanResult, result);
         Jump afterGreaterThan = m_jit.jump();
 
         // Left is strictly less than right
         isLessThan.link(&m_jit);
         auto isLessThanResult = IsMinOrMax == MinOrMax::Max ? right : left;
-        m_jit.move(isLessThanResult, result);
+        m_jit.moveDouble(isLessThanResult, result);
         Jump afterLessThan = m_jit.jump();
 
         // Left is equal to right
@@ -8317,7 +8317,7 @@ private:
             break;
         case TypeKind::F32:
         case TypeKind::F64:
-            m_jit.move(srcLocation.asFPR(), dst.asFPR());
+            m_jit.moveDouble(srcLocation.asFPR(), dst.asFPR());
             break;
         case TypeKind::V128:
             m_jit.moveVector(srcLocation.asFPR(), dst.asFPR());

--- a/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
+++ b/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
@@ -408,7 +408,7 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToJS(VM& vm
             jit.setupArguments<decltype(operationConvertToF32)>(GPRInfo::wasmContextInstancePointer, JSRInfo::returnValueJSR);
             auto call = jit.call(OperationPtrTag);
             exceptionChecks.append(jit.emitJumpIfException(vm));
-            jit.move(FPRInfo::returnValueFPR , dest);
+            jit.moveDouble(FPRInfo::returnValueFPR , dest);
 
             jit.addLinkTask([=] (LinkBuffer& linkBuffer) {
                 linkBuffer.link<OperationPtrTag>(call, operationConvertToF32);
@@ -440,7 +440,7 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToJS(VM& vm
             jit.setupArguments<decltype(operationConvertToF64)>(GPRInfo::wasmContextInstancePointer, JSRInfo::returnValueJSR);
             auto call = jit.call(OperationPtrTag);
             exceptionChecks.append(jit.emitJumpIfException(vm));
-            jit.move(FPRInfo::returnValueFPR, dest);
+            jit.moveDouble(FPRInfo::returnValueFPR, dest);
 
             jit.addLinkTask([=] (LinkBuffer& linkBuffer) {
                 linkBuffer.link<OperationPtrTag>(call, operationConvertToF64);


### PR DESCRIPTION
#### 404a4f2ab533184c3dcf2e5b7acb28f895d77e23
<pre>
[JSC] Remove `move(FPRReg, FPRReg)`
<a href="https://bugs.webkit.org/show_bug.cgi?id=253218">https://bugs.webkit.org/show_bug.cgi?id=253218</a>
rdar://106119654

Reviewed by Justin Michaud.

Previously, this was defined for ease of use. And it is moveDouble. But this is now confusing and wrong,
since we have V128 too. So we should explicitly select moveVector and moveDouble. This patch removes this
implicit helper.

* Source/JavaScriptCore/assembler/MacroAssembler.h:
(JSC::MacroAssembler::moveFloat):
* Source/JavaScriptCore/b3/testb3_7.cpp:
(tupleNestedLoop):
* Source/JavaScriptCore/jit/CCallHelpers.h:
(JSC::CCallHelpers::setupStubArgs):
(JSC::CCallHelpers::setupArgumentsImpl):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJIT::emitMoveRegister):
* Source/JavaScriptCore/wasm/js/WasmToJS.cpp:
(JSC::Wasm::wasmToJS):

Canonical link: <a href="https://commits.webkit.org/261040@main">https://commits.webkit.org/261040@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/117907a4a7e98b5b355bb1fbb1db3d2aff1770fe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110435 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19522 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43027 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1809 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/119345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20953 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10670 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102670 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116178 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/43842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30453 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/85708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/99145 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12179 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/31790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/100168 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/10240 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12759 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31261 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18123 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51407 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/108191 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14621 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26668 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4165 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->