### PR TITLE
REGRESSION (260822@main): [macOS] media/media-source/media-webm-opus-partial-abort.html is a flaky failure

### DIFF
--- a/LayoutTests/media/media-source/content/test-opus-manifest.json
+++ b/LayoutTests/media/media-source/content/test-opus-manifest.json
@@ -1,7 +1,7 @@
 {
     "url": "content/test-opus.webm",
     "type": "audio/webm; codecs=\"opus\"",
-    "init": { "offset": 0, "size": 461 },
+    "init": { "offset": 0, "size": 367 },
     "duration": 90.001,
     "media": [
         { "offset": 461, "size": 42710, "timestamp": 0, "duration": 4.981 },


### PR DESCRIPTION
#### 3dcbed3753fad3d2f6a058bc721d265cbc1d9234
<pre>
REGRESSION (260822@main): [macOS] media/media-source/media-webm-opus-partial-abort.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=253027">https://bugs.webkit.org/show_bug.cgi?id=253027</a>
rdar://105995589

Reviewed by Simon Fraser.

The recorded size of the init segment was incorrect. The test randomly
split the init segment and ensure that we only emit the `loadedmetadata`
event once the full init segment has been received.
If the value chose to split was greater than 367 bytes, we would have in
fact parsed the whole init segment as defined by
<a href="https://w3c.github.io/mse-byte-stream-format-webm/#webm-init-segments">https://w3c.github.io/mse-byte-stream-format-webm/#webm-init-segments</a>
making the test fail.

Correct the size.

* LayoutTests/media/media-source/content/test-opus-manifest.json:

Canonical link: <a href="https://commits.webkit.org/261054@main">https://commits.webkit.org/261054@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1040ca659dbbc5202b719498957c4b27e0edc93c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110445 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19532 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43036 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1819 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/119351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20963 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10680 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102681 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116188 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43835 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30463 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85700 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12188 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/31800 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12767 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18130 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51418 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7650 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14630 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->