### PR TITLE
Add assertions in CacheStorageCache to help debug threading issues

### DIFF
--- a/Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp
@@ -38,9 +38,13 @@ namespace WebKit {
 
 static String computeKeyURL(const URL& url)
 {
+    RELEASE_ASSERT(url.isValid());
+    RELEASE_ASSERT(!url.isEmpty());
     URL keyURL { url };
     keyURL.removeQueryAndFragmentIdentifier();
-    return keyURL.string();
+    auto keyURLString = keyURL.string();
+    RELEASE_ASSERT(!keyURLString.isEmpty());
+    return keyURLString;
 }
 
 static uint64_t nextRecordIdentifier()
@@ -61,8 +65,12 @@ CacheStorageCache::CacheStorageCache(CacheStorageManager& manager, const String&
     , m_identifier(WebCore::DOMCacheIdentifier::generateThreadSafe())
     , m_name(name)
     , m_uniqueName(uniqueName)
+#if ASSERT_ENABLED
+    , m_queue(queue.copyRef())
+#endif
     , m_store(createStore(uniqueName, path, WTFMove(queue)))
 {
+    assertIsOnCorrectQueue();
 }
 
 CacheStorageManager* CacheStorageCache::manager()
@@ -72,6 +80,8 @@ CacheStorageManager* CacheStorageCache::manager()
 
 void CacheStorageCache::getSize(CompletionHandler<void(uint64_t)>&& callback)
 {
+    assertIsOnCorrectQueue();
+
     if (m_isInitialized) {
         uint64_t size = 0;
         for (auto& urlRecords : m_records.values()) {
@@ -92,18 +102,23 @@ void CacheStorageCache::getSize(CompletionHandler<void(uint64_t)>&& callback)
 
 void CacheStorageCache::open(WebCore::DOMCacheEngine::CacheIdentifierCallback&& callback)
 {
+    assertIsOnCorrectQueue();
+
     if (m_isInitialized)
         return callback(WebCore::DOMCacheEngine::CacheIdentifierOperationResult { m_identifier, false });
 
     m_store->readAllRecordInfos([this, weakThis = WeakPtr { *this }, callback = WTFMove(callback)](auto&& recordInfos) mutable {
         if (!weakThis)
             return callback(makeUnexpected(WebCore::DOMCacheEngine::Error::Internal));
+        
+        assertIsOnCorrectQueue();
 
         std::sort(recordInfos.begin(), recordInfos.end(), [](auto& a, auto& b) {
             return a.insertionTime < b.insertionTime;
         });
 
         for (auto&& recordInfo : recordInfos) {
+            RELEASE_ASSERT(!recordInfo.url.string().impl()->isAtom());
             recordInfo.identifier = nextRecordIdentifier();
             m_records.ensure(computeKeyURL(recordInfo.url), [] {
                 return Vector<CacheStorageRecordInformation> { };
@@ -127,6 +142,7 @@ static CacheStorageRecord toCacheStorageRecord(WebCore::DOMCacheEngine::Record&&
 void CacheStorageCache::retrieveRecords(WebCore::RetrieveRecordsOptions&& options, WebCore::DOMCacheEngine::RecordsCallback&& callback)
 {
     ASSERT(m_isInitialized);
+    assertIsOnCorrectQueue();
 
     Vector<CacheStorageRecordInformation> targetRecordInfos;
     auto url = options.request.url();
@@ -147,6 +163,7 @@ void CacheStorageCache::retrieveRecords(WebCore::RetrieveRecordsOptions&& option
 
         WebCore::CacheQueryOptions queryOptions { options.ignoreSearch, options.ignoreMethod, options.ignoreVary };
         for (auto& record : iterator->value) {
+            RELEASE_ASSERT(!record.url.string().impl()->isAtom());
             if (WebCore::DOMCacheEngine::queryCacheMatch(options.request, record.url, record.hasVaryStar, record.varyHeaders, queryOptions))
                 targetRecordInfos.append(record);
         }
@@ -188,6 +205,7 @@ void CacheStorageCache::retrieveRecords(WebCore::RetrieveRecordsOptions&& option
 void CacheStorageCache::removeRecords(WebCore::ResourceRequest&& request, WebCore::CacheQueryOptions&& options, WebCore::DOMCacheEngine::RecordIdentifiersCallback&& callback)
 {
     ASSERT(m_isInitialized);
+    assertIsOnCorrectQueue();
     
     if (!options.ignoreMethod && request.httpMethod() != "GET"_s)
         return callback({ });
@@ -230,6 +248,7 @@ CacheStorageRecordInformation* CacheStorageCache::findExistingRecord(const WebCo
 
     WebCore::CacheQueryOptions options;
     auto index = iterator->value.findIf([&] (auto& record) {
+        RELEASE_ASSERT(!record.url.string().impl()->isAtom());
         bool hasMatchedIdentifier = !identifier || identifier == record.identifier;
         return hasMatchedIdentifier && WebCore::DOMCacheEngine::queryCacheMatch(request, record.url, record.hasVaryStar, record.varyHeaders, options);
     });
@@ -242,6 +261,7 @@ CacheStorageRecordInformation* CacheStorageCache::findExistingRecord(const WebCo
 void CacheStorageCache::putRecords(Vector<WebCore::DOMCacheEngine::Record>&& records, WebCore::DOMCacheEngine::RecordIdentifiersCallback&& callback)
 {
     ASSERT(m_isInitialized);
+    assertIsOnCorrectQueue();
 
     if (!m_manager)
         return callback(makeUnexpected(WebCore::DOMCacheEngine::Error::Internal));
@@ -272,9 +292,11 @@ void CacheStorageCache::putRecords(Vector<WebCore::DOMCacheEngine::Record>&& rec
 void CacheStorageCache::putRecordsAfterQuotaCheck(Vector<CacheStorageRecord>&& records, WebCore::DOMCacheEngine::RecordIdentifiersCallback&& callback)
 {
     ASSERT(m_isInitialized);
+    assertIsOnCorrectQueue();
 
     Vector<CacheStorageRecordInformation> targetRecordInfos;
     for (auto& record : records) {
+        RELEASE_ASSERT(!record.info.url.string().impl()->isAtom());
         if (auto* existingRecord = findExistingRecord(record.request)) {
             record.info.identifier = existingRecord->identifier;
             targetRecordInfos.append(*existingRecord);
@@ -322,7 +344,8 @@ void CacheStorageCache::putRecordsInStore(Vector<CacheStorageRecord>&& records, 
 
             record.info.key = existingRecordInfo->key;
             record.info.insertionTime = existingRecordInfo->insertionTime;
-            record.info.url = existingRecordInfo->url;
+            // FIXME: Remove isolatedCopy() when rdar://105122133 is resolved.
+            record.info.url = existingRecordInfo->url.isolatedCopy();
             record.requestHeadersGuard = existingRecord->requestHeadersGuard;
             record.request = WTFMove(existingRecord->request);
             record.options = WTFMove(existingRecord->options);
@@ -357,6 +380,8 @@ void CacheStorageCache::putRecordsInStore(Vector<CacheStorageRecord>&& records, 
 
 void CacheStorageCache::removeAllRecords()
 {
+    assertIsOnCorrectQueue();
+
     uint64_t sizeDecreased = 0;
     Vector<CacheStorageRecordInformation> targetRecordInfos;
     for (auto& urlRecords : m_records.values()) {
@@ -375,6 +400,8 @@ void CacheStorageCache::removeAllRecords()
 
 void CacheStorageCache::close()
 {
+    assertIsOnCorrectQueue();
+
     m_records.clear();
     m_isInitialized = false;
 }

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageCache.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageCache.h
@@ -56,6 +56,12 @@ private:
     CacheStorageRecordInformation* findExistingRecord(const WebCore::ResourceRequest&, std::optional<uint64_t> = std::nullopt);
     void putRecordsAfterQuotaCheck(Vector<CacheStorageRecord>&&, WebCore::DOMCacheEngine::RecordIdentifiersCallback&&);
     void putRecordsInStore(Vector<CacheStorageRecord>&&, Vector<std::optional<CacheStorageRecord>>&&, WebCore::DOMCacheEngine::RecordIdentifiersCallback&&);
+    void assertIsOnCorrectQueue()
+    {
+#if ASSERT_ENABLED
+        assertIsCurrent(m_queue.get());
+#endif
+    }
 
     WeakPtr<CacheStorageManager> m_manager;
     bool m_isInitialized { false };
@@ -63,6 +69,9 @@ private:
     String m_name;
     String m_uniqueName;
     HashMap<String, Vector<CacheStorageRecordInformation>> m_records;
+#if ASSERT_ENABLED
+    Ref<WorkQueue> m_queue;
+#endif
     Ref<CacheStorageStore> m_store;
 };
 


### PR DESCRIPTION
#### 5c2607837be66195328f71725114deca9306f2dc
<pre>
Add assertions in CacheStorageCache to help debug threading issues
<a href="https://bugs.webkit.org/show_bug.cgi?id=253223">https://bugs.webkit.org/show_bug.cgi?id=253223</a>
rdar://106124999

Reviewed by Chris Dumez.

rdar://105122133 indicates CacheStorageCache may have threading issues (e.g. record url may become AtomString at some
point), so adding some assertion to help debug that.

This patch also make an isolated copy for record url before passing it to CacheStorageCache.

* Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp:
(WebKit::computeKeyURL):
(WebKit::CacheStorageCache::CacheStorageCache):
(WebKit::CacheStorageCache::getSize):
(WebKit::CacheStorageCache::open):
(WebKit::CacheStorageCache::retrieveRecords):
(WebKit::CacheStorageCache::removeRecords):
(WebKit::CacheStorageCache::findExistingRecord):
(WebKit::CacheStorageCache::putRecords):
(WebKit::CacheStorageCache::putRecordsAfterQuotaCheck):
(WebKit::CacheStorageCache::putRecordsInStore):
(WebKit::CacheStorageCache::removeAllRecords):
(WebKit::CacheStorageCache::close):
* Source/WebKit/NetworkProcess/storage/CacheStorageCache.h:
(WebKit::CacheStorageCache::assertIsOnCorrectQueue):

Canonical link: <a href="https://commits.webkit.org/261147@main">https://commits.webkit.org/261147@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07ae050028bb5428b153f6e50b8598e2fc98668a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110583 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19663 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43174 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1936 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119448 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21085 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10792 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/1416 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116325 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15705 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98896 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102900 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97665 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30563 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44021 "") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12315 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31901 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85934 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12875 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8852 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18239 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51517 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7721 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14759 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->