### PR TITLE
REGRESSION(260774@main): [iPad] Video turns black after entering element fullscreen

### DIFF
--- a/Source/WebCore/platform/cocoa/VideoFullscreenChangeObserver.h
+++ b/Source/WebCore/platform/cocoa/VideoFullscreenChangeObserver.h
@@ -36,6 +36,7 @@ public:
     virtual void requestUpdateInlineRect() = 0;
     virtual void requestVideoContentLayer() = 0;
     virtual void returnVideoContentLayer() = 0;
+    virtual void returnVideoView() = 0;
     virtual void didSetupFullscreen() = 0;
     virtual void didEnterFullscreen(const FloatSize&) = 0;
     virtual void failedToEnterFullscreen() = 0;

--- a/Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.mm
+++ b/Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.mm
@@ -1265,7 +1265,7 @@ void VideoFullscreenInterfaceAVKit::doSetup()
     [m_playerLayerView setHidden:[playerController() isExternalPlaybackActive]];
     [m_playerLayerView setBackgroundColor:clearUIColor()];
 
-    if (!m_currentMode.hasPictureInPicture()) {
+    if (!m_currentMode.hasPictureInPicture() && !m_changingStandbyOnly) {
         [m_playerLayerView setVideoView:m_videoView.get()];
         [m_playerLayerView addSubview:m_videoView.get()];
     }
@@ -1303,7 +1303,7 @@ void VideoFullscreenInterfaceAVKit::doSetup()
     [[m_playerViewController view] setNeedsLayout];
     [[m_playerViewController view] layoutIfNeeded];
 
-    if (m_targetStandby && !m_currentMode.hasVideo()) {
+    if (m_targetStandby && !m_currentMode.hasVideo() && !m_returningToStandby) {
         [m_window setHidden:YES];
         [[m_playerViewController view] setHidden:YES];
     }
@@ -1487,6 +1487,10 @@ void VideoFullscreenInterfaceAVKit::enterFullscreenHandler(BOOL success, NSError
 void VideoFullscreenInterfaceAVKit::returnToStandby()
 {
     m_returningToStandby = false;
+
+    if (m_fullscreenChangeObserver)
+        m_fullscreenChangeObserver->returnVideoView();
+
     [m_window setHidden:YES];
     [[m_playerViewController view] setHidden:YES];
 

--- a/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
+++ b/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
@@ -126,6 +126,7 @@ private:
     void requestUpdateInlineRect() final;
     void requestVideoContentLayer() final;
     void returnVideoContentLayer() final;
+    void returnVideoView() final { }
     void didSetupFullscreen() final;
     void failedToEnterFullscreen() final { }
     void didEnterFullscreen(const FloatSize&) final { }

--- a/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.h
@@ -120,6 +120,7 @@ private:
     void requestUpdateInlineRect() final;
     void requestVideoContentLayer() final;
     void returnVideoContentLayer() final;
+    void returnVideoView() final;
     void didSetupFullscreen() final;
     void failedToEnterFullscreen() final;
     void didEnterFullscreen(const WebCore::FloatSize&) final;
@@ -218,6 +219,7 @@ private:
     void requestUpdateInlineRect(PlaybackSessionContextIdentifier);
     void requestVideoContentLayer(PlaybackSessionContextIdentifier);
     void returnVideoContentLayer(PlaybackSessionContextIdentifier);
+    void returnVideoView(PlaybackSessionContextIdentifier);
     void didSetupFullscreen(PlaybackSessionContextIdentifier);
     void willExitFullscreen(PlaybackSessionContextIdentifier);
     void didExitFullscreen(PlaybackSessionContextIdentifier);

--- a/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm
@@ -252,6 +252,12 @@ void VideoFullscreenModelContext::returnVideoContentLayer()
         m_manager->returnVideoContentLayer(m_contextId);
 }
 
+void VideoFullscreenModelContext::returnVideoView()
+{
+    if (m_manager)
+        m_manager->returnVideoView(m_contextId);
+}
+
 void VideoFullscreenModelContext::didSetupFullscreen()
 {
     if (m_manager)
@@ -888,6 +894,23 @@ void VideoFullscreenManagerProxy::requestVideoContentLayer(PlaybackSessionContex
 void VideoFullscreenManagerProxy::returnVideoContentLayer(PlaybackSessionContextIdentifier contextId)
 {
     m_page->send(Messages::VideoFullscreenManager::ReturnVideoContentLayer(contextId));
+}
+
+void VideoFullscreenManagerProxy::returnVideoView(PlaybackSessionContextIdentifier contextId)
+{
+#if PLATFORM(IOS_FAMILY)
+    auto& model = ensureModel(contextId);
+    auto *playerView = model.playerView();
+    auto *videoView = model.layerHostView();
+    if (playerView && videoView) {
+        auto *playerLayer = (WebAVPlayerLayer *)[model.playerView() layer];
+        [playerLayer addSublayer:[videoView layer]];
+        [playerView setNeedsLayout];
+        [playerView layoutIfNeeded];
+    }
+#else
+    UNUSED_PARAM(contextId);
+#endif
 }
 
 void VideoFullscreenManagerProxy::didSetupFullscreen(PlaybackSessionContextIdentifier contextId)


### PR DESCRIPTION
#### e64627c9a4d48063a2c59af1f39fdb0195fc83cf
<pre>
REGRESSION(260774@main): [iPad] Video turns black after entering element fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=253225">https://bugs.webkit.org/show_bug.cgi?id=253225</a>
rdar://105990736

Reviewed by Tim Horton.

Prior to &quot;no-double-layer-hosting&quot;, the fullscreen machinery would create an AVPlayerLayerView and AVPlayerLayerViewController
simply to handle the case where the user might exit _element_ fullscreen when playing a video, and that video may need to
immediately enter picture-in-picture mode. As part of that process, the new AVPlayerLayerView would &quot;steal&quot; the video
content from an existing layer. This wasn&apos;t a problem in the double layer hosting world; there wasn&apos;t anything to steal then,
as the video layer being stolen was empty.

However, in the &quot;no-double-layer-hosting&quot; world, stealing the video layer results in no video being visible in the WKWebView,
as that video layer is the one inserted into the UI-side compositing tree. This code could benefit from a complete re-write,
now that there&apos;s a pre-existing AVPlayerLayerView in the web compositing hierarchy. For now, simply work around the problem
by not stealing the video layer prematurely, and by notifying the VideoFullscreenManagerProxy when PiP has ended and the
video layer can be returned to its rightful owner.

* Source/WebCore/platform/cocoa/VideoFullscreenChangeObserver.h:
* Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.mm:
(VideoFullscreenInterfaceAVKit::doSetup):
(VideoFullscreenInterfaceAVKit::returnToStandby):
* Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm:
* Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm:
(WebKit::VideoFullscreenModelContext::returnToStandby):
(WebKit::VideoFullscreenManagerProxy::returnToStandby):

Canonical link: <a href="https://commits.webkit.org/261143@main">https://commits.webkit.org/261143@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/216fb84463af6649c3738b74972d828fd473466c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110589 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19669 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43178 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1940 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119452 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114548 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21089 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10796 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/1437 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116331 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15709 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98898 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102853 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97669 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30566 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43979 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12320 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31904 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/86623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12879 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8854 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18243 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51520 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7720 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14764 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->