### PR TITLE
[GTK][WPE] Remote Web Inspector: replace deprecated CSS method 'matches' with 'is'

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/AuditTreeElement.css
+++ b/Source/WebInspectorUI/UserInterface/Views/AuditTreeElement.css
@@ -35,14 +35,14 @@
     height: 100%;
 }
 
-.tree-outline .item.audit:matches(.test-case, .test-group):not(.unsupported, .manager-active):hover > .status > img {
+.tree-outline .item.audit:is(.test-case, .test-group):not(.unsupported, .manager-active):hover > .status > img {
     width: 75%;
     height: 75%;
     margin: 0 auto;
     content: url(../Images/AuditStart.svg) !important;
 }
 
-body:not(.window-inactive, .window-docked-inactive) .tree-outline:focus-within .item.audit:matches(.test-case, .test-group):not(.unsupported, .manager-active).selected:hover > .status > img,
+body:not(.window-inactive, .window-docked-inactive) .tree-outline:focus-within .item.audit:is(.test-case, .test-group):not(.unsupported, .manager-active).selected:hover > .status > img,
 body:not(.window-inactive, .window-docked-inactive) .tree-outline:focus-within .item.audit.test-case.selected > .status > .indeterminate-progress-spinner,
 body:not(.window-inactive, .window-docked-inactive) .tree-outline:focus-within .item.audit.test-group.selected > .status > progress {
     filter: var(--filter-invert);
@@ -60,7 +60,7 @@ body:not(.window-inactive, .window-docked-inactive) .tree-outline:focus-within .
     display: none;
 }
 
-.tree-outline .item.audit.unsupported:not(.selected) > :matches(.icon, .titles) {
+.tree-outline .item.audit.unsupported:not(.selected) > :is(.icon, .titles) {
     opacity: 0.5;
 }
 
@@ -108,7 +108,7 @@ body:not(.window-inactive, .window-docked-inactive) .tree-outline:focus-within .
 }
 
 @media (prefers-color-scheme: dark) {
-    .tree-outline .item.audit:matches(.test-case, .test-group):not(.unsupported, .manager-active):hover > .status > img {
+    .tree-outline .item.audit:is(.test-case, .test-group):not(.unsupported, .manager-active):hover > .status > img {
         filter: var(--filter-invert) brightness(90%);
     }
 

--- a/Source/WebInspectorUI/UserInterface/Views/BlackboxSettingsView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/BlackboxSettingsView.css
@@ -23,7 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-.settings-view.blackbox > :matches(p, table) {
+.settings-view.blackbox > :is(p, table) {
     width: 100%;
     max-width: calc(min(50em, 100% - 40px));
     margin: 1em auto 2em;
@@ -83,7 +83,7 @@
     border: 1px solid var(--border-color);
 }
 
-.settings-view.blackbox > table :matches(th, td).url {
+.settings-view.blackbox > table :is(th, td).url {
     text-align: start;
 }
 
@@ -97,7 +97,7 @@
     background-color: transparent;
 }
 
-.settings-view.blackbox > table :matches(th, td):matches(.case-sensitive, .remove-blackbox) {
+.settings-view.blackbox > table :is(th, td):is(.case-sensitive, .remove-blackbox) {
     width: 1px;
     white-space: nowrap;
     text-align: center;

--- a/Source/WebInspectorUI/UserInterface/Views/BoxModelDetailsSectionRow.css
+++ b/Source/WebInspectorUI/UserInterface/Views/BoxModelDetailsSectionRow.css
@@ -119,45 +119,45 @@
     z-index: 2;
 }
 
-.details-section .row.box-model :matches(.top, .right, .bottom, .left) {
+.details-section .row.box-model :is(.top, .right, .bottom, .left) {
     display: inline-block;
     vertical-align: middle;
 }
 
-.details-section .row.box-model :matches(.top, .right, .bottom, .left):not(.editing),
-.details-section .row.box-model :matches(.top-left, .top-right, .bottom-right, .bottom-left) {
+.details-section .row.box-model :is(.top, .right, .bottom, .left):not(.editing),
+.details-section .row.box-model :is(.top-left, .top-right, .bottom-right, .bottom-left) {
     margin: 0 0.25em;
 }
 
-.details-section .row.box-model :matches(.top-left, .top-right, .bottom-right, .bottom-left) {
+.details-section .row.box-model :is(.top-left, .top-right, .bottom-right, .bottom-left) {
     position: absolute;
 }
 
-.details-section .row.box-model :matches(.top-left, .top-right) {
+.details-section .row.box-model :is(.top-left, .top-right) {
     top: 4px;
 }
 
-.details-section .row.box-model :matches(.bottom-left, .bottom-right):not(.editing) {
+.details-section .row.box-model :is(.bottom-left, .bottom-right):not(.editing) {
     bottom: 3px;
 }
 
-.details-section .row.box-model :matches(.bottom-left, .bottom-right).editing {
+.details-section .row.box-model :is(.bottom-left, .bottom-right).editing {
     bottom: 2px;
 }
 
-.details-section .row.box-model :matches(.top-left, .bottom-left):not(.editing) {
+.details-section .row.box-model :is(.top-left, .bottom-left):not(.editing) {
     left: 3px;
 }
 
-.details-section .row.box-model :matches(.top-left, .bottom-left).editing {
+.details-section .row.box-model :is(.top-left, .bottom-left).editing {
     left: 1px;
 }
 
-.details-section .row.box-model :matches(.top-right, .bottom-right):not(.editing) {
+.details-section .row.box-model :is(.top-right, .bottom-right):not(.editing) {
     right: 3px;
 }
 
-.details-section .row.box-model :matches(.top-right, .bottom-right).editing {
+.details-section .row.box-model :is(.top-right, .bottom-right).editing {
     right: 1px;
 }
 
@@ -176,8 +176,8 @@
         color: var(--text-color);
     }
 
-    .details-section .row.box-model:not(.hovered) .box:matches(.margin, .border, .padding, .content),
-    .details-section .row.box-model .box.active:matches(.margin, .border, .padding, .content) {
+    .details-section .row.box-model:not(.hovered) .box:is(.margin, .border, .padding, .content),
+    .details-section .row.box-model .box.active:is(.margin, .border, .padding, .content) {
         color: black;
     }
 

--- a/Source/WebInspectorUI/UserInterface/Views/BreakpointActionView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/BreakpointActionView.css
@@ -35,7 +35,7 @@ body[dir=rtl] .breakpoint-action-button-container {
     float: left;
 }
 
-:matches(.breakpoint-action-append-button, .breakpoint-action-remove-button) {
+:is(.breakpoint-action-append-button, .breakpoint-action-remove-button) {
     background-origin: border-box;
     width: 13px;
     height: 13px;

--- a/Source/WebInspectorUI/UserInterface/Views/ButtonNavigationItem.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ButtonNavigationItem.css
@@ -78,11 +78,11 @@
     color: var(--glyph-color-pressed);
 }
 
-.navigation-bar .item.button:not(.disabled):matches(.activate.activated, .radio.selected) > .glyph {
+.navigation-bar .item.button:not(.disabled):is(.activate.activated, .radio.selected) > .glyph {
     color: var(--glyph-color-active);
 }
 
-.navigation-bar .item.button:not(.disabled):active:matches(.activate.activated, .radio.selected) > .glyph {
+.navigation-bar .item.button:not(.disabled):active:is(.activate.activated, .radio.selected) > .glyph {
     color: var(--glyph-color-active-pressed);
 }
 

--- a/Source/WebInspectorUI/UserInterface/Views/CPUTimelineView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/CPUTimelineView.css
@@ -177,7 +177,7 @@
     fill: var(--cpu-paint-fill-color);
 }
 
-.timeline-view.cpu :matches(.area-chart, .stacked-area-chart) svg > path {
+.timeline-view.cpu :is(.area-chart, .stacked-area-chart) svg > path {
     fill: var(--cpu-other-thread-fill-color);
     stroke: var(--cpu-other-thread-stroke-color);
 }
@@ -194,7 +194,7 @@
     stroke: var(--cpu-worker-thread-stroke-color);
 }
 
-.timeline-view.cpu :matches(.area-chart, .stacked-area-chart) .markers {
+.timeline-view.cpu :is(.area-chart, .stacked-area-chart) .markers {
     position: absolute;
     top: 0;
     left: 0;
@@ -203,7 +203,7 @@
     pointer-events: none;
 }
 
-.timeline-view.cpu :matches(.area-chart, .stacked-area-chart) .markers > div {
+.timeline-view.cpu :is(.area-chart, .stacked-area-chart) .markers > div {
     position: absolute;
     z-index: 10;
     width: 100%;
@@ -212,18 +212,18 @@
     background-color: var(--graph-line-color);
 }
 
-body[dir=rtl] .timeline-view.cpu :matches(.area-chart, .stacked-area-chart) .markers > div {
+body[dir=rtl] .timeline-view.cpu :is(.area-chart, .stacked-area-chart) .markers > div {
     transform: scaleX(-1);
 }
 
-.timeline-view.cpu :matches(.area-chart, .stacked-area-chart) .markers > div > .label {
+.timeline-view.cpu :is(.area-chart, .stacked-area-chart) .markers > div > .label {
     padding: 2px;
     font-size: 8px;
     color: var(--text-color-secondary);
     background-color: var(--background-color-content);
 }
 
-.timeline-view.cpu :matches(.area-chart, .stacked-area-chart) circle {
+.timeline-view.cpu :is(.area-chart, .stacked-area-chart) circle {
     r: 3;
     fill: var(--cpu-overlay-color);
 }
@@ -339,7 +339,7 @@ body[dir=rtl] .timeline-view.cpu :matches(.area-chart, .stacked-area-chart) .mar
     cursor: pointer;
 }
 
-.timeline-view.cpu > .content > .overview > .chart > .container.stats > table :matches(.filter, .filter-clear):hover {
+.timeline-view.cpu > .content > .overview > .chart > .container.stats > table :is(.filter, .filter-clear):hover {
     opacity: 0.7;
 }
 

--- a/Source/WebInspectorUI/UserInterface/Views/CPUUsageCombinedView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/CPUUsageCombinedView.css
@@ -31,8 +31,8 @@
 }
 
 .cpu-usage-combined-view > .graph,
-.cpu-usage-combined-view > .graph > :matches(.stacked-area-chart, .range-chart),
-.cpu-usage-combined-view > .graph > :matches(.stacked-area-chart, .range-chart) > svg {
+.cpu-usage-combined-view > .graph > :is(.stacked-area-chart, .range-chart),
+.cpu-usage-combined-view > .graph > :is(.stacked-area-chart, .range-chart) > svg {
     width: 100%;
     height: 100%;
 }
@@ -63,7 +63,7 @@
     -webkit-user-select: text;
 }
 
-.cpu-usage-combined-view > :matches(.details, .legend) > .name {
+.cpu-usage-combined-view > :is(.details, .legend) > .name {
     color: var(--text-color);
     white-space: nowrap;
 }

--- a/Source/WebInspectorUI/UserInterface/Views/CanvasContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/CanvasContentView.css
@@ -46,7 +46,7 @@
     max-height: 100%;
 }
 
-.content-view.canvas > :matches(header, footer) {
+.content-view.canvas > :is(header, footer) {
     display: none;
 }
 

--- a/Source/WebInspectorUI/UserInterface/Views/CanvasOverviewContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/CanvasOverviewContentView.css
@@ -48,7 +48,7 @@
     border-color: red;
 }
 
-.content-view.canvas-overview > .content-view.canvas > :matches(header, footer) {
+.content-view.canvas-overview > .content-view.canvas > :is(header, footer) {
     display: flex;
     flex-direction: row;
     flex-shrink: 0;
@@ -76,7 +76,7 @@
     color: var(--text-color-gray-dark);
 }
 
-.content-view.canvas-overview > .content-view.canvas > header > .titles > :matches(.subtitle, .color-space),
+.content-view.canvas-overview > .content-view.canvas > header > .titles > :is(.subtitle, .color-space),
 .content-view.canvas-overview > .content-view.canvas > footer .memory-cost {
     color: var(--text-color-gray-medium);
 }
@@ -108,7 +108,7 @@
     transition: opacity 200ms ease-in-out;
 }
 
-.content-view.canvas-overview > .content-view.canvas:matches(:hover, .recording-active) > header > .navigation-bar {
+.content-view.canvas-overview > .content-view.canvas:is(:hover, .recording-active) > header > .navigation-bar {
     opacity: 1;
     transition: opacity 200ms ease-in-out;
 }
@@ -160,7 +160,7 @@
     align-items: center;
 }
 
-.content-view.canvas-overview > .content-view.canvas > footer > .view-related-items > :matches(.view-shader, .view-recording) {
+.content-view.canvas-overview > .content-view.canvas > footer > .view-related-items > :is(.view-shader, .view-recording) {
     width: 16px;
     height: 16px;
 }

--- a/Source/WebInspectorUI/UserInterface/Views/CanvasSidebarPanel.css
+++ b/Source/WebInspectorUI/UserInterface/Views/CanvasSidebarPanel.css
@@ -35,11 +35,11 @@
     opacity: 0.5;
 }
 
-.sidebar > .panel.navigation.canvas > .content > .tree-outline .item.canvas:matches(.canvas-2d, .bitmaprenderer) .icon {
+.sidebar > .panel.navigation.canvas > .content > .tree-outline .item.canvas:is(.canvas-2d, .bitmaprenderer) .icon {
     content: url(../Images/Canvas2D.svg);
 }
 
-.sidebar > .panel.navigation.canvas > .content > .tree-outline .item.canvas:matches(.webgl, .webgl2, .webgpu, .webmetal) .icon {
+.sidebar > .panel.navigation.canvas > .content > .tree-outline .item.canvas:is(.webgl, .webgl2, .webgpu, .webmetal) .icon {
     content: url(../Images/Canvas3D.svg);
 }
 
@@ -60,7 +60,7 @@
 }
 
 .sidebar > .panel.navigation.canvas:not(.has-recordings) > .filter-bar,
-.sidebar > .panel.navigation.canvas:not(.has-recordings) > .content > :matches(.navigation-bar, .recording-content) {
+.sidebar > .panel.navigation.canvas:not(.has-recordings) > .content > :is(.navigation-bar, .recording-content) {
     display: none;
 }
 

--- a/Source/WebInspectorUI/UserInterface/Views/CodeMirrorRegexMode.css
+++ b/Source/WebInspectorUI/UserInterface/Views/CodeMirrorRegexMode.css
@@ -31,11 +31,11 @@
     color: var(--syntax-highlight-number-color);
 }
 
-.cm-s-default :matches(.cm-regex-escape, .cm-regex-escape-2, .cm-regex-escape-3) {
+.cm-s-default :is(.cm-regex-escape, .cm-regex-escape-2, .cm-regex-escape-3) {
     color: var(--syntax-highlight-symbol-color);
 }
 
-.cm-s-default :matches(.cm-regex-group, .cm-regex-lookahead) {
+.cm-s-default :is(.cm-regex-group, .cm-regex-lookahead) {
     color: var(--syntax-highlight-regex-group-color);
 }
 
@@ -43,6 +43,6 @@
     color: var(--syntax-highlight-number-color);
 }
 
-.cm-s-default :matches(.cm-regex-literal, .cm-regex-special, .cm-regex-backreference) {
+.cm-s-default :is(.cm-regex-literal, .cm-regex-special, .cm-regex-backreference) {
     color: var(--syntax-highlight-boolean-color);
 }

--- a/Source/WebInspectorUI/UserInterface/Views/ColorPicker.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ColorPicker.css
@@ -37,7 +37,7 @@
     white-space: nowrap;
 }
 
-.color-picker :matches(.color-square, .slider) {
+.color-picker :is(.color-square, .slider) {
     display: inline-block;
 }
 

--- a/Source/WebInspectorUI/UserInterface/Views/ComputedStyleDetailsPanel.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ComputedStyleDetailsPanel.css
@@ -28,7 +28,7 @@
     --disclosure-button-size: 15px;
 }
 
-.sidebar > .panel.details.css-style > .content > .computed > .details-section:not(.collapsed) > :matches(.header, .content) {
+.sidebar > .panel.details.css-style > .content > .computed > .details-section:not(.collapsed) > :is(.header, .content) {
     background-color: var(--background-color);
 }
 

--- a/Source/WebInspectorUI/UserInterface/Views/ConsoleDrawer.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ConsoleDrawer.css
@@ -40,7 +40,7 @@
     cursor: default;
 }
 
-.console-drawer > .navigation-bar > :matches(.item.button, .log-scope-bar) {
+.console-drawer > .navigation-bar > :is(.item.button, .log-scope-bar) {
     pointer-events: none;
 }
 

--- a/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.css
@@ -67,7 +67,7 @@
     -webkit-user-select: text;
 }
 
-.console-message-body > span > :matches(.console-message-enclosed, .console-message-preview, .console-message-preview-divider) {
+.console-message-body > span > :is(.console-message-enclosed, .console-message-preview, .console-message-preview-divider) {
     -webkit-user-select: none;
 }
 
@@ -76,7 +76,7 @@
     --checkerboard-light-square: var(--background-color);
 }
 
-.console-image > .console-message-body > :matches(hr, img) {
+.console-image > .console-message-body > :is(hr, img) {
     display: block;
     margin: 4px 0;
 }
@@ -117,7 +117,7 @@
     background-image: url(../Images/DisclosureTriangles.svg#open-normal);
 }
 
-.console-message.expandable.expanded :matches(.console-message-preview, .console-message-preview-divider):not(.inline-lossless) {
+.console-message.expandable.expanded :is(.console-message-preview, .console-message-preview-divider):not(.inline-lossless) {
     display: none;
 }
 
@@ -226,12 +226,12 @@
     content: url(../Images/UserInputPromptPrevious.svg);
 }
 
-:matches(.console-warning-level, .console-error-level, .console-log-level, .console-info-level, .console-debug-level).console-message {
+:is(.console-warning-level, .console-error-level, .console-log-level, .console-info-level, .console-debug-level).console-message {
  /* Move non-monospace log/warning/error text up a bit. */
     padding: 3px 12px 3px 20px;
 }
 
-:matches(.console-warning-level, .console-error-level, .console-log-level, .console-info-level, .console-debug-level)::before {
+:is(.console-warning-level, .console-error-level, .console-log-level, .console-info-level, .console-debug-level)::before {
  /* Re-center log/warning/error icons. */
     padding-top: 1px;
 }

--- a/Source/WebInspectorUI/UserInterface/Views/CookiePopover.css
+++ b/Source/WebInspectorUI/UserInterface/Views/CookiePopover.css
@@ -45,7 +45,7 @@
     padding-inline-start: 4px;
 }
 
-.popover .cookie-popover-content > table > tr > td > input:matches([type="text"], [type="datetime-local"]) {
+.popover .cookie-popover-content > table > tr > td > input:is([type="text"], [type="datetime-local"]) {
     width: 100%;
     padding: 3px 4px 2px;
     font-family: Menlo, monospace;
@@ -54,7 +54,7 @@
     appearance: none;
 }
 
-.popover .cookie-popover-content > table > tr > td > input:matches([type="text"], [type="datetime-local"]):matches(:invalid, .invalid) {
+.popover .cookie-popover-content > table > tr > td > input:is([type="text"], [type="datetime-local"]):is(:invalid, .invalid) {
     border-color: var(--error-text-color);
 }
 

--- a/Source/WebInspectorUI/UserInterface/Views/DOMEventsBreakdownView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMEventsBreakdownView.css
@@ -38,7 +38,7 @@
     border-collapse: collapse;
 }
 
-.dom-events-breakdown tr > :matches(th, td) {
+.dom-events-breakdown tr > :is(th, td) {
     padding: 4px;
     text-align: start;
 }
@@ -57,7 +57,7 @@
     --img-size: 14px;
 }
 
-.dom-events-breakdown .graph > :matches(img, .area) {
+.dom-events-breakdown .graph > :is(img, .area) {
     position: absolute;
 }
 

--- a/Source/WebInspectorUI/UserInterface/Views/DOMStorageContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMStorageContentView.css
@@ -31,12 +31,12 @@
     bottom: 0;
 }
 
-.content-view.dom-storage > .data-grid tr:matches(.duplicate-key, .missing-key) td.key-column,
+.content-view.dom-storage > .data-grid tr:is(.duplicate-key, .missing-key) td.key-column,
 .content-view.dom-storage > .data-grid tr.missing-value td.value-column {
     background-color: hsl(0, 100%, 96%);
 }
 
-.content-view.dom-storage > .data-grid:focus tr.selected:matches(.duplicate-key, .missing-key) td.key-column,
+.content-view.dom-storage > .data-grid:focus tr.selected:is(.duplicate-key, .missing-key) td.key-column,
 .content-view.dom-storage > .data-grid:focus tr.selected.missing-value td.value-column {
     background-color: hsl(0, 42%, 76%);
 }

--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeContentView.css
@@ -61,7 +61,7 @@ body[dir=rtl] .content-view.dom-tree .tree-outline.dom li .status-image {
     fill: var(--breakpoint-color);
 }
 
-body:not(.window-inactive, .window-docked-inactive) .content-view.dom-tree .tree-outline.dom:focus-within li:matches(.selected, .hovered) .status-image.breakpoint {
+body:not(.window-inactive, .window-docked-inactive) .content-view.dom-tree .tree-outline.dom:focus-within li:is(.selected, .hovered) .status-image.breakpoint {
     stroke: var(--selected-foreground-color);
 }
 
@@ -78,7 +78,7 @@ body:not(.window-inactive, .window-docked-inactive) .content-view.dom-tree .tree
     stroke: var(--breakpoint-color);
 }
 
-body:not(.window-inactive, .window-docked-inactive) .content-view.dom-tree .tree-outline.dom:focus-within li:matches(.selected, .hovered) .status-image.breakpoint.subtree {
+body:not(.window-inactive, .window-docked-inactive) .content-view.dom-tree .tree-outline.dom:focus-within li:is(.selected, .hovered) .status-image.breakpoint.subtree {
     stroke: var(--selected-foreground-color);
 }
 

--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.css
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.css
@@ -111,13 +111,13 @@ body:is(.window-inactive, .window-docked-inactive) .content-view.dom-tree.deemph
     display: block;
 }
 
-.tree-outline.dom li:matches(.hovered, .selected) + ol.children.expanded {
+.tree-outline.dom li:is(.hovered, .selected) + ol.children.expanded {
     margin-inline-start: var(--sublist-margin-start);
     padding-inline-start: var(--sublist-padding-start);
     border: 0 solid hsla(0, 0%, 83%, 0.5);
 }
 
-.tree-outline.dom li:matches(.hovered, .selected) + ol.children.expanded {
+.tree-outline.dom li:is(.hovered, .selected) + ol.children.expanded {
     border-left-width: var(--sublist-border-width-start);
 }
 

--- a/Source/WebInspectorUI/UserInterface/Views/DataGrid.css
+++ b/Source/WebInspectorUI/UserInterface/Views/DataGrid.css
@@ -102,7 +102,7 @@
     background-color: var(--background-color-pressed);
 }
 
-.data-grid th:matches(.sort-ascending, .sort-descending) {
+.data-grid th:is(.sort-ascending, .sort-descending) {
     font-weight: var(--sorted-header-font-weight);
 }
 
@@ -197,7 +197,7 @@
     border-inline-end-color: var(--border-end-color);
 }
 
-.data-grid :matches(th, td) > div {
+.data-grid :is(th, td) > div {
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;
@@ -220,11 +220,11 @@
     position: relative;
 }
 
-.data-grid th:matches(.sort-ascending, .sort-descending) > .header-cell-content:first-child {
+.data-grid th:is(.sort-ascending, .sort-descending) > .header-cell-content:first-child {
     padding-inline-end: calc(12px + var(--data-grid-header-horizontal-padding)); /* Add 12px for the sorting chevron. */
 }
 
-.data-grid th:matches(.sort-ascending, .sort-descending) > .header-cell-content:first-child::after {
+.data-grid th:is(.sort-ascending, .sort-descending) > .header-cell-content:first-child::after {
     position: absolute;
     top: 1px;
     bottom: 0;
@@ -339,7 +339,7 @@ body[dir=rtl] .data-grid td .go-to-arrow {
     float: left;
 }
 
-.data-grid tr:matches(.selected, :hover) .go-to-arrow {
+.data-grid tr:is(.selected, :hover) .go-to-arrow {
     display: block;
 }
 
@@ -389,7 +389,7 @@ body:not(.window-inactive, .window-docked-inactive) .data-grid:focus tr.editable
         background-color: unset;
     }
 
-    .data-grid th:matches(.sort-ascending, .sort-descending) > .header-cell-content:first-child::after {
+    .data-grid th:is(.sort-ascending, .sort-descending) > .header-cell-content:first-child::after {
         filter: invert();
     }
 }

--- a/Source/WebInspectorUI/UserInterface/Views/DatabaseContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/DatabaseContentView.css
@@ -64,7 +64,7 @@
     content: url(../Images/UserInputPrompt.svg);
 }
 
-:matches(.database-user-query, .database-query-result)::before {
+:is(.database-user-query, .database-query-result)::before {
     position: absolute;
     display: block;
     z-index: 1;

--- a/Source/WebInspectorUI/UserInterface/Views/DetailsSection.css
+++ b/Source/WebInspectorUI/UserInterface/Views/DetailsSection.css
@@ -281,7 +281,7 @@ body[dir=rtl] .details-section > .header::before {
     word-break: break-all;
 }
 
-.details-section > .content > .group > .row:matches(.empty, .text) {
+.details-section > .content > .group > .row:is(.empty, .text) {
     padding: 0 6px 7px 6px;
     text-align: center;
     color: var(--text-color-secondary);

--- a/Source/WebInspectorUI/UserInterface/Views/FilterBar.css
+++ b/Source/WebInspectorUI/UserInterface/Views/FilterBar.css
@@ -54,7 +54,7 @@
     margin-inline-start: 6px;
 }
 
-:matches(.filter-bar, .search-bar) > input[type="search"] {
+:is(.filter-bar, .search-bar) > input[type="search"] {
     height: 22px;
     padding-top: 0;
     color: var(--text-color-active);
@@ -66,11 +66,11 @@
     appearance: none;
 }
 
-:matches(.filter-bar, .search-bar) > input[type="search"]:matches(:focus, :not(:placeholder-shown)) {
+:is(.filter-bar, .search-bar) > input[type="search"]:is(:focus, :not(:placeholder-shown)) {
     background-color: var(--background-color-content);
 }
 
-:matches(.filter-bar, .search-bar) > input[type="search"]::-webkit-search-decoration {
+:is(.filter-bar, .search-bar) > input[type="search"]::-webkit-search-decoration {
     align-self: center;
     width: 13px;
     height: 13px;
@@ -79,40 +79,40 @@
     appearance: none;
 }
 
-:matches(.filter-bar, .search-bar) > input[type="search"]::-webkit-search-results-button {
+:is(.filter-bar, .search-bar) > input[type="search"]::-webkit-search-results-button {
     margin-inline-end: 4px;
 }
 
 /* FIXME: use a different image for ::-webkit-search-decoration when :not(:placeholder-shown) */
 
-:matches(.filter-bar, .search-bar) > input[type="search"]::placeholder {
+:is(.filter-bar, .search-bar) > input[type="search"]::placeholder {
     color: var(--text-color-secondary);
 }
 
-:matches(.filter-bar, .search-bar) > input[type="search"]:matches(:not(:focus), :placeholder-shown)::-webkit-search-cancel-button {
+:is(.filter-bar, .search-bar) > input[type="search"]:is(:not(:focus), :placeholder-shown)::-webkit-search-cancel-button {
     display: none;
 }
 
-:matches(.filter-bar, .search-bar) > .navigation-bar + input[type="search"] {
+:is(.filter-bar, .search-bar) > .navigation-bar + input[type="search"] {
     margin-inline-start: 0;
 }
 
-:matches(.filter-bar, .search-bar) > input[type="search"]:focus {
+:is(.filter-bar, .search-bar) > input[type="search"]:focus {
     margin-inline-end: 6px;
 }
 
-:matches(.filter-bar, .search-bar) > input[type="search"] + :empty {
+:is(.filter-bar, .search-bar) > input[type="search"] + :empty {
     margin-inline-start: 6px;
 }
 
-:matches(.filter-bar, .search-bar) > input[type="search"]:focus ~ * {
+:is(.filter-bar, .search-bar) > input[type="search"]:focus ~ * {
     display: none;
 }
 
-:matches(.filter-bar, .search-bar) > input[type="search"] + .navigation-bar > .item.scope-bar:last-child {
+:is(.filter-bar, .search-bar) > input[type="search"] + .navigation-bar > .item.scope-bar:last-child {
     margin-inline-end: 4px;
 }
 
-:matches(.filter-bar, .search-bar).invalid > input[type="search"] {
+:is(.filter-bar, .search-bar).invalid > input[type="search"] {
     border-color: var(--error-text-color);
 }

--- a/Source/WebInspectorUI/UserInterface/Views/FindBanner.css
+++ b/Source/WebInspectorUI/UserInterface/Views/FindBanner.css
@@ -52,7 +52,7 @@
     transition-timing-function: ease-out;
 }
 
-.no-find-banner-transition:matches(.find-banner, .supports-find-banner) {
+.no-find-banner-transition:is(.find-banner, .supports-find-banner) {
     transition-duration: 0s !important;
 }
 
@@ -254,7 +254,7 @@ body[dir=rtl] .find-banner.console-find-banner > input[type="search"] {
     border-bottom-right-radius: var(--console-find-banner-search-box-border-radius-start);
 }
 
-.find-banner.console-find-banner > :matches(input[type="search"], button) {
+.find-banner.console-find-banner > :is(input[type="search"], button) {
     background-color: inherit;
     height: 22px;
 }

--- a/Source/WebInspectorUI/UserInterface/Views/FontResourceContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/FontResourceContentView.css
@@ -32,7 +32,7 @@
     overflow-y: auto;
 }
 
-.content-view.resource.font > :matches(.local-resource-override-label-view, .local-resource-override-warning-view):not([hidden]) ~ .drop-zone {
+.content-view.resource.font > :is(.local-resource-override-label-view, .local-resource-override-warning-view):not([hidden]) ~ .drop-zone {
     top: calc(var(--navigation-bar-height) - 2px); /* borders */
 }
 

--- a/Source/WebInspectorUI/UserInterface/Views/FormattedValue.css
+++ b/Source/WebInspectorUI/UserInterface/Views/FormattedValue.css
@@ -29,7 +29,7 @@
     color: black;
 }
 
-:matches(.formatted-array, .formatted-map, .formatted-set, .formatted-weakmap, .formatted-weakset) > .size {
+:is(.formatted-array, .formatted-map, .formatted-set, .formatted-weakmap, .formatted-weakset) > .size {
     font-style: normal;
     color: var(--console-secondary-text-color);
 }

--- a/Source/WebInspectorUI/UserInterface/Views/GeneralStyleDetailsSidebarPanel.css
+++ b/Source/WebInspectorUI/UserInterface/Views/GeneralStyleDetailsSidebarPanel.css
@@ -144,7 +144,7 @@
     margin: 0;
 }
 
-.sidebar > .panel.details.css-style > .content ~ .class-list-container > *:matches(.new-class, .class-toggle) {
+.sidebar > .panel.details.css-style > .content ~ .class-list-container > *:is(.new-class, .class-toggle) {
     margin: 1px 3px;
 }
 

--- a/Source/WebInspectorUI/UserInterface/Views/GradientSlider.css
+++ b/Source/WebInspectorUI/UserInterface/Views/GradientSlider.css
@@ -85,7 +85,7 @@
     opacity: 0;
 }
 
-.gradient-slider-knob > :matches(img, div) {
+.gradient-slider-knob > :is(img, div) {
     position: absolute;
 
     left: 5px;

--- a/Source/WebInspectorUI/UserInterface/Views/GraphicsTabContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/GraphicsTabContentView.css
@@ -31,7 +31,7 @@
     content: url(../Images/Canvas2D.svg);
 }
 
-.content-view.tab.graphics .navigation-bar > .item .canvas:matches(.webgl, .webgl2, .webgpu, .webmetal) .icon {
+.content-view.tab.graphics .navigation-bar > .item .canvas:is(.webgl, .webgl2, .webgpu, .webmetal) .icon {
     content: url(../Images/Canvas3D.svg);
 }
 

--- a/Source/WebInspectorUI/UserInterface/Views/HeapSnapshotInstancesContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/HeapSnapshotInstancesContentView.css
@@ -72,7 +72,7 @@
     color: hsl(0, 0%, 85%);
 }
 
-.heap-snapshot > .data-grid tr:matches(.selected, :hover) td .go-to-arrow {
+.heap-snapshot > .data-grid tr:is(.selected, :hover) td .go-to-arrow {
     float: none;
     display: inline-block;
     vertical-align: top;

--- a/Source/WebInspectorUI/UserInterface/Views/HierarchicalPathComponent.css
+++ b/Source/WebInspectorUI/UserInterface/Views/HierarchicalPathComponent.css
@@ -59,7 +59,7 @@
     height: 16px;
 }
 
-.hierarchical-path-component > :matches(.icon, .selector-arrows) {
+.hierarchical-path-component > :is(.icon, .selector-arrows) {
     margin-top: 2px;
     margin-bottom: 2px;
     margin-inline: 4px 3px;

--- a/Source/WebInspectorUI/UserInterface/Views/HoverMenu.css
+++ b/Source/WebInspectorUI/UserInterface/Views/HoverMenu.css
@@ -44,7 +44,7 @@
     left: 0;
 }
 
-.hover-menu > svg > :matches(path, rect) {
+.hover-menu > svg > :is(path, rect) {
     stroke: hsla(0, 0%, 0%, 0.22);
     stroke-width: 2px;
     fill: none;
@@ -67,7 +67,7 @@
 }
 
 @media (prefers-color-scheme: dark) {
-    .hover-menu > svg > :matches(path, rect) {
+    .hover-menu > svg > :is(path, rect) {
         stroke: hsla(0, 0%, 100%, 0.3);
     }
 }

--- a/Source/WebInspectorUI/UserInterface/Views/ImageResourceContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ImageResourceContentView.css
@@ -33,7 +33,7 @@
     overflow-y: auto;
 }
 
-.content-view.resource.image > :matches(.local-resource-override-label-view, .local-resource-override-warning-view):not([hidden]) ~ .drop-zone {
+.content-view.resource.image > :is(.local-resource-override-label-view, .local-resource-override-warning-view):not([hidden]) ~ .drop-zone {
     top: calc(var(--navigation-bar-height) - 2px); /* borders */
 }
 

--- a/Source/WebInspectorUI/UserInterface/Views/IndexedDatabaseObjectStoreContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/IndexedDatabaseObjectStoreContentView.css
@@ -43,7 +43,7 @@
     border-right-color: hsl(210, 70%, 75%);
 }
 
-.content-view.indexed-database-object-store > .data-grid .object-tree > :matches(.title, .object-preview)::before {
+.content-view.indexed-database-object-store > .data-grid .object-tree > :is(.title, .object-preview)::before {
  /* The line-height inside a data-grid is 17px instead of 13px, this will center vertically on the top line. */
     top: 2px;
 }

--- a/Source/WebInspectorUI/UserInterface/Views/InlineSwatch.css
+++ b/Source/WebInspectorUI/UserInterface/Views/InlineSwatch.css
@@ -37,11 +37,11 @@
 }
 
 .inline-swatch:not(.box-shadow),
-.inline-swatch.box-shadow:matches(:hover, :active) {
+.inline-swatch.box-shadow:is(:hover, :active) {
     background-color: var(--background-color-content);
 }
 
-.inline-swatch:matches(.color, .gradient) {
+.inline-swatch:is(.color, .gradient) {
     /* Make a checkered background for transparent colors to show against. */
     background-image: linear-gradient(to bottom, hsl(0, 0%, 80%), hsl(0, 0%, 80%)),
                       linear-gradient(to bottom, hsl(0, 0%, 80%), hsl(0, 0%, 80%));
@@ -50,19 +50,19 @@
     background-repeat: no-repeat;
 }
 
-.inline-swatch:matches(.bezier, .spring, .variable) {
+.inline-swatch:is(.bezier, .spring, .variable) {
     color: var(--glyph-color-active);
 }
 
-.inline-swatch:matches(.bezier, .box-shadow, .spring, .variable) {
+.inline-swatch:is(.bezier, .box-shadow, .spring, .variable) {
     margin-right: 2px;
 }
 
-.inline-swatch:not(.read-only):matches(.bezier, .box-shadow, .spring, .variable, .alignment):hover {
+.inline-swatch:not(.read-only):is(.bezier, .box-shadow, .spring, .variable, .alignment):hover {
     filter: brightness(0.9);
 }
 
-.inline-swatch:not(.read-only):matches(.bezier, .box-shadow, .spring, .variable, .alignment):active {
+.inline-swatch:not(.read-only):is(.bezier, .box-shadow, .spring, .variable, .alignment):active {
     filter: brightness(0.8);
 }
 
@@ -94,7 +94,7 @@
     border-color: hsl(0, 0%, 25%);
 }
 
-.inline-swatch:matches(.bezier, .box-shadow, .spring, .variable) > span {
+.inline-swatch:is(.bezier, .box-shadow, .spring, .variable) > span {
     display: none;
 }
 

--- a/Source/WebInspectorUI/UserInterface/Views/LayerDetailsSidebarPanel.css
+++ b/Source/WebInspectorUI/UserInterface/Views/LayerDetailsSidebarPanel.css
@@ -44,11 +44,11 @@
     content: url(../Images/TypeIcons.svg#PseudoElement-light);
 }
 
-.panel.details.layer .name-column :matches(.pseudo-element, .reflection) {
+.panel.details.layer .name-column :is(.pseudo-element, .reflection) {
     color: var(--text-color-gray-medium);
 }
 
-.panel.details.layer tr.selected .name-column :matches(.pseudo-element, .reflection) {
+.panel.details.layer tr.selected .name-column :is(.pseudo-element, .reflection) {
     color: var(--selected-secondary-text-color);
 }
 

--- a/Source/WebInspectorUI/UserInterface/Views/LayerTreeDetailsSidebarPanel.css
+++ b/Source/WebInspectorUI/UserInterface/Views/LayerTreeDetailsSidebarPanel.css
@@ -45,11 +45,11 @@
     content: url(../Images/TypeIcons.svg#PseudoElement-light);
 }
 
-.panel.details.layer-tree .name-column :matches(.pseudo-element, .reflection) {
+.panel.details.layer-tree .name-column :is(.pseudo-element, .reflection) {
     color: hsl(0, 0%, 50%);
 }
 
-.panel.details.layer-tree tr.selected .name-column :matches(.pseudo-element, .reflection) {
+.panel.details.layer-tree tr.selected .name-column :is(.pseudo-element, .reflection) {
     color: hsla(0, 0%, 100%, 0.75);
 }
 

--- a/Source/WebInspectorUI/UserInterface/Views/LocalResourceOverridePopover.css
+++ b/Source/WebInspectorUI/UserInterface/Views/LocalResourceOverridePopover.css
@@ -81,7 +81,7 @@
     width: 330px;
 }
 
-.popover .local-resource-override-popover-content label:matches(.is-case-sensitive, .is-regex) {
+.popover .local-resource-override-popover-content label:is(.is-case-sensitive, .is-regex) {
     display: inline-block;
 }
 
@@ -106,7 +106,7 @@
     margin-bottom: 6px;
 }
 
-.popover .local-resource-override-popover-content .data-grid tr.header-content-type > :matches(.name-column, .value-column) {
+.popover .local-resource-override-popover-content .data-grid tr.header-content-type > :is(.name-column, .value-column) {
     opacity: 0.5;
 }
 

--- a/Source/WebInspectorUI/UserInterface/Views/Main.css
+++ b/Source/WebInspectorUI/UserInterface/Views/Main.css
@@ -167,7 +167,7 @@ input[type=range]::-webkit-slider-runnable-track {
     height: 100%;
 }
 
-body.docked:matches(.right, .left) #navigation-sidebar.collapsed > .resizer {
+body.docked:is(.right, .left) #navigation-sidebar.collapsed > .resizer {
     pointer-events: none;
 }
 
@@ -460,7 +460,7 @@ body[dir=rtl] [dir=ltr] .go-to-arrow {
     }
 }
 
-:matches(img, canvas).show-grid {
+:is(img, canvas).show-grid {
     background-color: var(--checkerboard-light-square);
     background-image: linear-gradient(315deg, transparent 75%, var(--checkerboard-dark-square) 75%),
                       linear-gradient(45deg, transparent 75%, var(--checkerboard-dark-square) 75%),
@@ -519,7 +519,7 @@ body[dir=rtl] [dir=ltr] .go-to-arrow {
     50% { opacity: 0.6; }
 }
 
-.tab-bar > .navigation-bar :matches(.console-warnings, .console-errors):not(.disabled).pulsing {
+.tab-bar > .navigation-bar :is(.console-warnings, .console-errors):not(.disabled).pulsing {
     animation-name: tab-bar-console-item-pulse;
     animation-duration: 0.75s;
 }
@@ -562,7 +562,7 @@ body[dir=rtl] [dir=ltr] .go-to-arrow {
         color: inherit;
     }
 
-    :matches(img, canvas).show-grid {
+    :is(img, canvas).show-grid {
         --checkerboard-dark-square: hsl(0, 0%, 5%);
     }
 }

--- a/Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.css
@@ -171,7 +171,7 @@ body[dir=rtl] .network-table > .table .cell.dom-node.name .disclosure {
     color: hsla(0, 0%, 100%, 0.9);
 }
 
-.network-table > .table li:not(.selected) .cell:matches(.cache-type, .multiple) {
+.network-table > .table li:not(.selected) .cell:is(.cache-type, .multiple) {
     color: var(--text-color-gray-medium);
 }
 
@@ -222,7 +222,7 @@ body[dir=rtl] .network-table > .table .cell.name > .status {
     color: transparent;
 }
 
-.network-table > .table .header .cell.waterfall:matches(.sort-ascending, .sort-descending) {
+.network-table > .table .header .cell.waterfall:is(.sort-ascending, .sort-descending) {
     background-color: var(--background-color-selected);
 }
 
@@ -336,8 +336,8 @@ body[dir=rtl] .waterfall.network .block {
     --end-radius: 0;
 }
 
-.waterfall.network .block:matches(.mouse-tracking, .filler) + .block:not(.mouse-tracking, .filler),
-.waterfall.network .block:not(.request, .response) + :matches(.request, .response) {
+.waterfall.network .block:is(.mouse-tracking, .filler) + .block:not(.mouse-tracking, .filler),
+.waterfall.network .block:not(.request, .response) + :is(.request, .response) {
     --start-radius: 2px;
 }
 

--- a/Source/WebInspectorUI/UserInterface/Views/ObjectTreePropertyTreeElement.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ObjectTreePropertyTreeElement.css
@@ -111,7 +111,7 @@
     padding-inline-start: 0px;
 }
 
-.object-tree-property :matches(.getter, .setter) {
+.object-tree-property :is(.getter, .setter) {
     position: relative;
     opacity: 0.6;
     vertical-align: top;
@@ -143,7 +143,7 @@
     margin-left: 1px;
 }
 
-.object-tree-property :matches(.getter, .setter).disabled {
+.object-tree-property :is(.getter, .setter).disabled {
     opacity: 0.35;
 }
 

--- a/Source/WebInspectorUI/UserInterface/Views/ObjectTreeView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ObjectTreeView.css
@@ -31,7 +31,7 @@
     font-size: 11px;
 }
 
-.object-tree > :matches(.title, .object-preview)::before {
+.object-tree > :is(.title, .object-preview)::before {
     display: inline-block;
 
     vertical-align: baseline;
@@ -49,15 +49,15 @@
     content: "";
 }
 
-.object-tree:not(.lossless-preview) > :matches(.title, .object-preview) {
+.object-tree:not(.lossless-preview) > :is(.title, .object-preview) {
     margin-left: 0;
 }
 
-.object-tree.expanded > :matches(.title, .object-preview)::before {
+.object-tree.expanded > :is(.title, .object-preview)::before {
     background-image: url(../Images/DisclosureTriangles.svg#open-normal);
 }
 
-.object-tree.properties-only > :matches(.title, .object-preview) {
+.object-tree.properties-only > :is(.title, .object-preview) {
     display: none;
 }
 
@@ -69,7 +69,7 @@
     line-height: 16px;
 }
 
-.object-tree.lossless-preview > :matches(.title, .object-preview)::before {
+.object-tree.lossless-preview > :is(.title, .object-preview)::before {
     background: none;
     width: 0px;
 }

--- a/Source/WebInspectorUI/UserInterface/Views/ProbeSetDataGrid.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ProbeSetDataGrid.css
@@ -86,7 +86,7 @@
     left: -6px;
 }
 
-.details-section.probe-set .data-grid .object-tree > :matches(.title, .object-preview)::before {
+.details-section.probe-set .data-grid .object-tree > :is(.title, .object-preview)::before {
  /* The line-height inside a data-grid is 17px instead of 13px, this will center vertically on the top line. */
     top: 2px;
 }

--- a/Source/WebInspectorUI/UserInterface/Views/ProfileView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ProfileView.css
@@ -65,7 +65,7 @@
     content: url(../Images/TypeIcons.svg#Program-light);
 }
 
-.profile > .data-grid tr:matches(.selected, :hover) .go-to-arrow {
+.profile > .data-grid tr:is(.selected, :hover) .go-to-arrow {
     float: none;
     display: inline-block;
     vertical-align: top;

--- a/Source/WebInspectorUI/UserInterface/Views/QuickConsole.css
+++ b/Source/WebInspectorUI/UserInterface/Views/QuickConsole.css
@@ -116,7 +116,7 @@
 
 @media (prefers-color-scheme: dark) {
     .CodeMirror .jump-to-symbol-highlight,
-    .meta-key-pressed .spreadsheet-css-declaration:not(.locked) :matches(.name, .value):not(.editing):hover {
+    .meta-key-pressed .spreadsheet-css-declaration:not(.locked) :is(.name, .value):not(.editing):hover {
         color: var(--syntax-highlight-link-color) !important;
     }
 

--- a/Source/WebInspectorUI/UserInterface/Views/RadioButtonNavigationItem.css
+++ b/Source/WebInspectorUI/UserInterface/Views/RadioButtonNavigationItem.css
@@ -46,11 +46,11 @@
     z-index: -1;
 }
 
-.navigation-bar .item.radio.button.text-only:matches(.selected, :hover) {
+.navigation-bar .item.radio.button.text-only:is(.selected, :hover) {
     color: var(--selected-foreground-color);
 }
 
-.navigation-bar .item.radio.button.text-only:matches(.selected, :hover)::before {
+.navigation-bar .item.radio.button.text-only:is(.selected, :hover)::before {
     background-color: var(--glyph-color-active);
 }
 

--- a/Source/WebInspectorUI/UserInterface/Views/RecordingContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/RecordingContentView.css
@@ -77,7 +77,7 @@
     height: -webkit-fill-available;
 }
 
-.content-view.recording :matches(img, canvas) {
+.content-view.recording :is(img, canvas) {
     position: absolute;
     max-width: 100%;
     max-height: 100%;

--- a/Source/WebInspectorUI/UserInterface/Views/ResourceHeadersContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ResourceHeadersContentView.css
@@ -31,7 +31,7 @@ body[dir] .resource-headers > section.error > .details {
     border-color: var(--network-error-color);
 }
 
-body[dir] .resource-headers > section:matches(.redirect, .headers) > .details {
+body[dir] .resource-headers > section:is(.redirect, .headers) > .details {
     border-color: var(--network-header-color);
 }
 

--- a/Source/WebInspectorUI/UserInterface/Views/ResourceIcons.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ResourceIcons.css
@@ -55,11 +55,11 @@
     content: url(../Images/DocumentIcons.svg#font-light-override);
 }
 
-:matches(.resource-icon.resource-type-style-sheet, .style-sheet-icon) .icon {
+:is(.resource-icon.resource-type-style-sheet, .style-sheet-icon) .icon {
     content: url(../Images/DocumentIcons.svg#css-light);
 }
 
-:matches(.resource-icon.resource-type-style-sheet.override, .style-sheet-icon.override) .icon {
+:is(.resource-icon.resource-type-style-sheet.override, .style-sheet-icon.override) .icon {
     content: url(../Images/DocumentIcons.svg#css-light-override);
 }
 
@@ -148,10 +148,10 @@ body:not(.window-inactive, .window-docked-inactive) .tree-outline:focus-within .
         content: url(../Images/DocumentIcons.svg#font-dark-override);
     }
 
-    :matches(.resource-icon.resource-type-style-sheet, .style-sheet-icon) .icon {
+    :is(.resource-icon.resource-type-style-sheet, .style-sheet-icon) .icon {
         content: url(../Images/DocumentIcons.svg#css-dark);
     }
-    :matches(.resource-icon.resource-type-style-sheet.override, .style-sheet-icon.override) .icon {
+    :is(.resource-icon.resource-type-style-sheet.override, .style-sheet-icon.override) .icon {
         content: url(../Images/DocumentIcons.svg#css-dark-override);
     }
 

--- a/Source/WebInspectorUI/UserInterface/Views/ResourceSecurityContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ResourceSecurityContentView.css
@@ -23,7 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-body[dir] .resource-security > section:matches(.connection, .certificate) > .details {
+body[dir] .resource-security > section:is(.connection, .certificate) > .details {
     border-color: var(--network-dns-color);
 }
 
@@ -54,7 +54,7 @@ body[dir] .resource-security > section:matches(.connection, .certificate) > .det
 }
 
 @media (prefers-color-scheme: dark) {
-    body[dir] .resource-security > section:matches(.connection, .certificate) > .details {
+    body[dir] .resource-security > section:is(.connection, .certificate) > .details {
         border-color: var(--network-pseudo-header-color);
     }
 

--- a/Source/WebInspectorUI/UserInterface/Views/ResourceTreeElement.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ResourceTreeElement.css
@@ -42,12 +42,12 @@
 
 .item.resource.resource-type-websocket:not(.selected) .status .ready-state.open,
 .tree-outline:not(:focus-within) .item.resource.resource-type-websocket.selected .status .ready-state.open,
-body:matches(.window-inactive, .window-docked-inactive) .item.resource.resource-type-websocket.selected .status .ready-state.open {
+body:is(.window-inactive, .window-docked-inactive) .item.resource.resource-type-websocket.selected .status .ready-state.open {
     background-color: limegreen;
 }
 
 .item.resource.resource-type-websocket:not(.selected) .status .ready-state.connecting,
 .tree-outline:not(:focus-within) .item.resource.resource-type-websocket.selected .status .ready-state.connecting,
-body:matches(.window-inactive, .window-docked-inactive) .item.resource.resource-type-websocket.selected .status .ready-state.connecting {
+body:is(.window-inactive, .window-docked-inactive) .item.resource.resource-type-websocket.selected .status .ready-state.connecting {
     background-color: yellow;
 }

--- a/Source/WebInspectorUI/UserInterface/Views/ScopeBar.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ScopeBar.css
@@ -71,7 +71,7 @@
     outline: none;
 }
 
-.scope-bar > li:matches(.selected, :hover) {
+.scope-bar > li:is(.selected, :hover) {
     --scope-bar-text-color-default: var(--selected-foreground-color);
     --scope-bar-background-color-default: var(--glyph-color-active);
     --scope-bar-border-color-default: var(--glyph-color-active);

--- a/Source/WebInspectorUI/UserInterface/Views/SearchSidebarPanel.css
+++ b/Source/WebInspectorUI/UserInterface/Views/SearchSidebarPanel.css
@@ -23,7 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-.sidebar > .panel.navigation.search > :matches(.content, .message-text-view) {
+.sidebar > .panel.navigation.search > :is(.content, .message-text-view) {
     top: calc(var(--navigation-bar-height) - 1px);
 }
 
@@ -73,6 +73,6 @@ body[dir=rtl] .sidebar > .panel.navigation.search .item.source-code-match {
     cursor: pointer;
 }
 
-.sidebar > .panel.navigation.search.changed > :matches(.content, .message-text-view) {
+.sidebar > .panel.navigation.search.changed > :is(.content, .message-text-view) {
     top: calc(var(--navigation-bar-height) + 40px - 1px);
 }

--- a/Source/WebInspectorUI/UserInterface/Views/SourcesNavigationSidebarPanel.css
+++ b/Source/WebInspectorUI/UserInterface/Views/SourcesNavigationSidebarPanel.css
@@ -66,7 +66,7 @@
     display: none;
 }
 
-.sidebar > .panel.navigation.sources > .content > :matches(.pause-reason-container, .call-stack-container, .breakpoints-container, .local-overrides-container, .console-snippets-container) {
+.sidebar > .panel.navigation.sources > .content > :is(.pause-reason-container, .call-stack-container, .breakpoints-container, .local-overrides-container, .console-snippets-container) {
     border-bottom: 1px solid var(--border-color);
 }
 
@@ -126,7 +126,7 @@
         --details-section-header-top: 0;
     }
 
-    .sidebar > .panel.navigation.sources > .content > :matches(.call-stack-container, .breakpoints-container, .resources-container, .local-overrides-container, .console-snippets-container) {
+    .sidebar > .panel.navigation.sources > .content > :is(.call-stack-container, .breakpoints-container, .resources-container, .local-overrides-container, .console-snippets-container) {
         height: 100%;
         overflow-y: auto;
     }

--- a/Source/WebInspectorUI/UserInterface/Views/SpreadsheetCSSStyleDeclarationEditor.css
+++ b/Source/WebInspectorUI/UserInterface/Views/SpreadsheetCSSStyleDeclarationEditor.css
@@ -72,11 +72,11 @@ body.meta-key-pressed .spreadsheet-style-declaration-editor > .property:not(.dis
     vertical-align: bottom;
 }
 
-.spreadsheet-style-declaration-editor :matches(.name, .value):not(.editing) {
+.spreadsheet-style-declaration-editor :is(.name, .value):not(.editing) {
     outline: none;
 }
 
-.spreadsheet-style-declaration-editor :matches(.name, .value).editing {
+.spreadsheet-style-declaration-editor :is(.name, .value).editing {
     outline: 1px solid white !important;
     box-shadow: 0 1px 2px 1px hsla(0, 0%, 0%, 0.6);
     margin-bottom: 0 !important;
@@ -104,7 +104,7 @@ body.meta-key-pressed .spreadsheet-style-declaration-editor > .property:not(.dis
     margin: 0;
 }
 
-.spreadsheet-css-declaration:matches(:hover, :focus) .property:not(:matches(.invalid-name, .invalid-value)) .property-toggle,
+.spreadsheet-css-declaration:is(:hover, :focus) .property:not(:is(.invalid-name, .invalid-value)) .property-toggle,
 .spreadsheet-style-declaration-editor .property.disabled .property-toggle {
     visibility: visible;
 }
@@ -120,21 +120,21 @@ body.meta-key-pressed .spreadsheet-style-declaration-editor > .property:not(.dis
     color: var(--text-color-secondary);
 }
 
-.spreadsheet-style-declaration-editor > .property:matches(.invalid-name, .other-vendor, .overridden):not(.disabled) > .content > *:not(.name, .value-container),
-.spreadsheet-style-declaration-editor > .property:matches(.invalid-name, .other-vendor, .overridden):not(.disabled) > .content > .value-container > *:not(.value),
-body:not(.meta-key-pressed) .spreadsheet-style-declaration-editor > .property:matches(.invalid-name, .other-vendor, .overridden):not(.disabled) > .content > :matches(.name, .value-container):not(.editing),
-body:not(.meta-key-pressed) .spreadsheet-style-declaration-editor > .property:matches(.invalid-name, .other-vendor, .overridden):not(.disabled) > .content > .value-container > .value:not(.editing),
-body.meta-key-pressed .spreadsheet-style-declaration-editor > .property:matches(.invalid-name, .other-vendor, .overridden):not(.disabled) > .content > :matches(.name, .value-container):not(:hover, .editing),
-body.meta-key-pressed .spreadsheet-style-declaration-editor > .property:matches(.invalid-name, .other-vendor, .overridden):not(.disabled) > .content > .value-container > .value:not(:hover, .editing) {
+.spreadsheet-style-declaration-editor > .property:is(.invalid-name, .other-vendor, .overridden):not(.disabled) > .content > *:not(.name, .value-container),
+.spreadsheet-style-declaration-editor > .property:is(.invalid-name, .other-vendor, .overridden):not(.disabled) > .content > .value-container > *:not(.value),
+body:not(.meta-key-pressed) .spreadsheet-style-declaration-editor > .property:is(.invalid-name, .other-vendor, .overridden):not(.disabled) > .content > :is(.name, .value-container):not(.editing),
+body:not(.meta-key-pressed) .spreadsheet-style-declaration-editor > .property:is(.invalid-name, .other-vendor, .overridden):not(.disabled) > .content > .value-container > .value:not(.editing),
+body.meta-key-pressed .spreadsheet-style-declaration-editor > .property:is(.invalid-name, .other-vendor, .overridden):not(.disabled) > .content > :is(.name, .value-container):not(:hover, .editing),
+body.meta-key-pressed .spreadsheet-style-declaration-editor > .property:is(.invalid-name, .other-vendor, .overridden):not(.disabled) > .content > .value-container > .value:not(:hover, .editing) {
     text-decoration: line-through;
     text-decoration-color: hsla(0, 0%, var(--foreground-lightness), 0.6);
 }
 
 .spreadsheet-style-declaration-editor > .property.invalid-name:not(.disabled) > .content > *:not(.name, .value-container),
 .spreadsheet-style-declaration-editor > .property.invalid-name:not(.disabled) > .content > .value-container > *:not(.value),
-body:not(.meta-key-pressed) .spreadsheet-style-declaration-editor > .property.invalid-name:not(.disabled) > .content > :matches(.name, .value-container):not(.editing),
+body:not(.meta-key-pressed) .spreadsheet-style-declaration-editor > .property.invalid-name:not(.disabled) > .content > :is(.name, .value-container):not(.editing),
 body:not(.meta-key-pressed) .spreadsheet-style-declaration-editor > .property.invalid-name:not(.disabled) > .content > .value-container > .value:not(.editing),
-body.meta-key-pressed .spreadsheet-style-declaration-editor > .property.invalid-name:not(.disabled) > .content > :matches(.name, .value-container):not(:hover, .editing),
+body.meta-key-pressed .spreadsheet-style-declaration-editor > .property.invalid-name:not(.disabled) > .content > :is(.name, .value-container):not(:hover, .editing),
 body.meta-key-pressed .spreadsheet-style-declaration-editor > .property.invalid-name:not(.disabled) > .content > .value-container > .value:not(:hover, .editing) {
     text-decoration-color: hsla(0, 100%, 50%, 0.5);
 }
@@ -182,7 +182,7 @@ body.meta-key-pressed .spreadsheet-style-declaration-editor > .property.invalid-
     background-color: var(--background-color-selected);
 }
 
-body:matches(.window-docked-inactive, .window-inactive) .spreadsheet-style-declaration-editor .property.selected {
+body:is(.window-docked-inactive, .window-inactive) .spreadsheet-style-declaration-editor .property.selected {
     background-color: var(--selected-background-color-unfocused);
 }
 
@@ -190,7 +190,7 @@ body:matches(.window-docked-inactive, .window-inactive) .spreadsheet-style-decla
     border-left-color: var(--border-color-selected);
 }
 
-.spreadsheet-style-declaration-editor .property:matches(.implicit, .not-inherited) .content > * {
+.spreadsheet-style-declaration-editor .property:is(.implicit, .not-inherited) .content > * {
     opacity: 0.5;
 }
 
@@ -244,7 +244,7 @@ body.meta-key-pressed .spreadsheet-style-declaration-editor > .property:not(.dis
     margin-left: var(--property-indentation);
 }
 
-body.meta-key-pressed .spreadsheet-css-declaration:not(.locked) > .spreadsheet-style-declaration-editor > .property > .content :matches(.name, .value):not(.editing):hover {
+body.meta-key-pressed .spreadsheet-css-declaration:not(.locked) > .spreadsheet-style-declaration-editor > .property > .content :is(.name, .value):not(.editing):hover {
     color: var(--syntax-highlight-link-color) !important;
     text-decoration: underline !important;
     cursor: pointer !important;
@@ -268,7 +268,7 @@ body.meta-key-pressed .spreadsheet-style-declaration-editor > .property:not(.dis
 }
 
 @media (prefers-color-scheme: dark) {
-    .spreadsheet-style-declaration-editor :matches(.name, .value).editing {
+    .spreadsheet-style-declaration-editor :is(.name, .value).editing {
         outline-color: var(--background-color-secondary) !important;
     }
 

--- a/Source/WebInspectorUI/UserInterface/Views/SpreadsheetCSSStyleDeclarationSection.css
+++ b/Source/WebInspectorUI/UserInterface/Views/SpreadsheetCSSStyleDeclarationSection.css
@@ -39,11 +39,11 @@
     -webkit-user-select: none;
 }
 
-.spreadsheet-css-declaration :matches(.header, .header-groupings) {
+.spreadsheet-css-declaration :is(.header, .header-groupings) {
     padding: 0 var(--css-declaration-horizontal-padding);
 }
 
-.spreadsheet-css-declaration :matches(.header, .header-groupings):first-child {
+.spreadsheet-css-declaration :is(.header, .header-groupings):first-child {
     padding-top: var(--css-declaration-vertical-padding);
 }
 

--- a/Source/WebInspectorUI/UserInterface/Views/SpringEditor.css
+++ b/Source/WebInspectorUI/UserInterface/Views/SpringEditor.css
@@ -81,11 +81,11 @@
     inset-inline-end: 0;
 }
 
-.spring-editor > :matches(.spring-preview, .spring-timing) > div {
+.spring-editor > :is(.spring-preview, .spring-timing) > div {
     transition-property: none;
 }
 
-.spring-editor > .animate:matches(.spring-preview, .spring-timing) > div {
+.spring-editor > .animate:is(.spring-preview, .spring-timing) > div {
     transition-property: transform;
 }
 

--- a/Source/WebInspectorUI/UserInterface/Views/SyntaxHighlightingDefaultTheme.css
+++ b/Source/WebInspectorUI/UserInterface/Views/SyntaxHighlightingDefaultTheme.css
@@ -34,18 +34,18 @@
 }
 
 .cm-s-default .cm-comment,
-.syntax-highlighted :matches(.css-comment, .javascript-comment, .html-comment) {
+.syntax-highlighted :is(.css-comment, .javascript-comment, .html-comment) {
     color: var(--syntax-highlight-comment-color);
 }
 
-.cm-s-default :matches(.cm-tag, .cm-bracket, .cm-atom, .cm-keyword, .cm-m-javascript.cm-builtin),
-.cm-s-default .cm-m-css:matches(.cm-atom, .cm-meta, .cm-variable-2, .cm-variable-3, .cm-property),
-.syntax-highlighted :matches(.css-keyword, .css-tag, .css-at-rule, .css-important, .javascript-keyword, .html-tag) {
+.cm-s-default :is(.cm-tag, .cm-bracket, .cm-atom, .cm-keyword, .cm-m-javascript.cm-builtin),
+.cm-s-default .cm-m-css:is(.cm-atom, .cm-meta, .cm-variable-2, .cm-variable-3, .cm-property),
+.syntax-highlighted :is(.css-keyword, .css-tag, .css-at-rule, .css-important, .javascript-keyword, .html-tag) {
     color: var(--syntax-highlight-boolean-color);
 }
 
-.cm-s-default :matches(.cm-number, .cm-atom.cm-hex-color),
-.syntax-highlighted :matches(.css-number, .javascript-number) {
+.cm-s-default :is(.cm-number, .cm-atom.cm-hex-color),
+.syntax-highlighted :is(.css-number, .javascript-number) {
     color: var(--syntax-highlight-number-color);
 }
 
@@ -54,14 +54,14 @@
     color: var(--syntax-highlight-bigint-color);
 }
 
-.cm-s-default :matches(.cm-def, .cm-operator, .cm-variable, .cm-variable-2),
-.cm-s-default .cm-m-css:matches(.cm-tag, .cm-string-2, .cm-builtin, .cm-qualifier),
-.syntax-highlighted :matches(.css-property, .css-selector, .javascript-ident) {
+.cm-s-default :is(.cm-def, .cm-operator, .cm-variable, .cm-variable-2),
+.cm-s-default .cm-m-css:is(.cm-tag, .cm-string-2, .cm-builtin, .cm-qualifier),
+.syntax-highlighted :is(.css-property, .css-selector, .javascript-ident) {
     color: inherit;
 }
 
 .cm-s-default .cm-string,
-.syntax-highlighted :matches(.css-string, .javascript-string, .html-attribute-value) {
+.syntax-highlighted :is(.css-string, .javascript-string, .html-attribute-value) {
     color: var(--syntax-highlight-string-color);
 }
 
@@ -71,7 +71,7 @@
 }
 
 .cm-s-default .cm-m-xml.cm-meta,
-.syntax-highlighted :matches(.html-doctype, .html-processing-instruction) {
+.syntax-highlighted :is(.html-doctype, .html-processing-instruction) {
     color: hsl(0, 0%, 75%);
 }
 
@@ -111,12 +111,12 @@
     color: hsl(119, 27%, 65%);
 }
 
-.cm-s-default .basic-block-has-not-executed:matches(.cm-tag, .cm-bracket, .cm-atom, .cm-keyword, .cm-m-javascript.cm-builtin),
-.cm-s-default .basic-block-has-not-executed.cm-m-css:matches(.cm-atom, .cm-meta, .cm-variable-2, .cm-variable-3, .cm-property) {
+.cm-s-default .basic-block-has-not-executed:is(.cm-tag, .cm-bracket, .cm-atom, .cm-keyword, .cm-m-javascript.cm-builtin),
+.cm-s-default .basic-block-has-not-executed.cm-m-css:is(.cm-atom, .cm-meta, .cm-variable-2, .cm-variable-3, .cm-property) {
     color: hsl(309, 21%, 70%);
 }
 
-.cm-s-default .basic-block-has-not-executed:matches(.cm-number, .cm-atom.cm-hex-color) {
+.cm-s-default .basic-block-has-not-executed:is(.cm-number, .cm-atom.cm-hex-color) {
     color: hsl(248, 52%, 78%);
 }
 

--- a/Source/WebInspectorUI/UserInterface/Views/TabBar.css
+++ b/Source/WebInspectorUI/UserInterface/Views/TabBar.css
@@ -310,7 +310,7 @@ body.window-inactive .tab-bar > .tabs > .item:not(.disabled).selected > .name {
     position: relative;
 }
 
-.tab-bar > .tabs.static-layout > :matches(.flexible-space, .item) {
+.tab-bar > .tabs.static-layout > :is(.flexible-space, .item) {
     position: absolute;
     top: 0;
 }
@@ -321,7 +321,7 @@ body.window-inactive .tab-bar > .tabs > .item:not(.disabled).selected > .name {
     transition-timing-function: ease-in-out;
 }
 
-.tab-bar > .tabs.animating:matches(.expanding-tabs, .inserting-tab) > .item {
+.tab-bar > .tabs.animating:is(.expanding-tabs, .inserting-tab) > .item {
     transition-property: left, width;
     transition-duration: 250ms;
     transition-timing-function: ease-in-out;

--- a/Source/WebInspectorUI/UserInterface/Views/Table.css
+++ b/Source/WebInspectorUI/UserInterface/Views/Table.css
@@ -50,12 +50,12 @@
     background-color: var(--background-color-pressed);
 }
 
-.table > .header > :matches(.sort-ascending, .sort-descending) {
+.table > .header > :is(.sort-ascending, .sort-descending) {
     font-weight: var(--sorted-header-font-weight);
     padding-inline-end: 18px;
 }
 
-.table > .header > :matches(.sort-ascending, .sort-descending)::after {
+.table > .header > :is(.sort-ascending, .sort-descending)::after {
     position: absolute;
     top: 1px;
     bottom: 0;
@@ -179,7 +179,7 @@
 }
 
 @media (prefers-color-scheme: dark) {
-    .table > .header > :matches(.sort-ascending, .sort-descending)::after {
+    .table > .header > :is(.sort-ascending, .sort-descending)::after {
         filter: invert();
     }
 }

--- a/Source/WebInspectorUI/UserInterface/Views/TimelineDataGrid.css
+++ b/Source/WebInspectorUI/UserInterface/Views/TimelineDataGrid.css
@@ -37,7 +37,7 @@
     border-top: none;
 }
 
-.data-grid th.graph-column:matches(.sort-ascending, .sort-descending) {
+.data-grid th.graph-column:is(.sort-ascending, .sort-descending) {
     background-color: var(--background-color-selected);
 }
 
@@ -53,7 +53,7 @@
     position: absolute;
 }
 
-.data-grid.timeline th:matches(.sort-ascending, .sort-descending) > .header-cell-content.timeline-ruler:first-child::after {
+.data-grid.timeline th:is(.sort-ascending, .sort-descending) > .header-cell-content.timeline-ruler:first-child::after {
     top: calc(var(--data-grid-header-height) / 2 - var(--data-grid-sorting-indicator-height) / 2);
     bottom: unset;
 }

--- a/Source/WebInspectorUI/UserInterface/Views/TimelineOverview.css
+++ b/Source/WebInspectorUI/UserInterface/Views/TimelineOverview.css
@@ -27,12 +27,12 @@
     --timeline-sidebar-width: 197px;
 }
 
-.timeline-overview > :matches(.navigation-bar.timelines, .tree-outline.timelines) {
+.timeline-overview > :is(.navigation-bar.timelines, .tree-outline.timelines) {
     border-inline-end: 1px solid var(--border-color);
     inset-inline-start: 0;
 }
 
-.timeline-overview:not(.frames) > :matches(.scroll-container, .timeline-ruler, .graphs-container) {
+.timeline-overview:not(.frames) > :is(.scroll-container, .timeline-ruler, .graphs-container) {
     inset-inline-start: var(--timeline-sidebar-width);
 }
 
@@ -53,11 +53,11 @@
     color: hsl(0, 0%, 50%);
 }
 
-.navigation-bar.timelines .item.button.toggle-edit-instruments:not(.disabled):matches(:focus, .activate.activated, .radio.selected) {
+.navigation-bar.timelines .item.button.toggle-edit-instruments:not(.disabled):is(:focus, .activate.activated, .radio.selected) {
     color: var(--glyph-color-active);
 }
 
-.navigation-bar.timelines .item.button.toggle-edit-instruments:not(.disabled):active:matches(:focus, .activate.activated, .radio.selected) {
+.navigation-bar.timelines .item.button.toggle-edit-instruments:not(.disabled):active:is(:focus, .activate.activated, .radio.selected) {
     color: var(--glyph-color-active-pressed);
 }
 
@@ -112,7 +112,7 @@
     border-top-color: hsla(0, 0%, var(--foreground-lightness), 0.09);
 }
 
-body:matches(.window-inactive, .window-docked-inactive) .timeline-overview:not(.edit-instruments) > .tree-outline.timelines .item.selected + .item {
+body:is(.window-inactive, .window-docked-inactive) .timeline-overview:not(.edit-instruments) > .tree-outline.timelines .item.selected + .item {
     border-top-color: var(--selected-background-color-unfocused);
 }
 
@@ -134,7 +134,7 @@ body:not(.window-inactive, .window-docked-inactive) .timeline-overview:not(.edit
     z-index: calc(var(--z-index-resizer) + 1);
 }
 
-.timeline-overview.frames > :matches(.tree-outline.timelines, .navigation-bar.timelines) {
+.timeline-overview.frames > :is(.tree-outline.timelines, .navigation-bar.timelines) {
     display: none;
 }
 

--- a/Source/WebInspectorUI/UserInterface/Views/TimelineRecordBar.css
+++ b/Source/WebInspectorUI/UserInterface/Views/TimelineRecordBar.css
@@ -29,7 +29,7 @@
     height: 12px;
 }
 
-.timeline-record-bar > :matches(img, .segment) {
+.timeline-record-bar > :is(img, .segment) {
     position: absolute;
     z-index: var(--timeline-record-z-index);
 }
@@ -164,7 +164,7 @@ body[dir=rtl] .timeline-record-bar > .segment:last-of-type {
     background-color: var(--text-color-quaternary);
 }
 
-.timeline-record-bar.has-custom-children.timeline-record-type-media > .segment:matches(.css-animation-delay, .media-element-paused) {
+.timeline-record-bar.has-custom-children.timeline-record-type-media > .segment:is(.css-animation-delay, .media-element-paused) {
     background-color: hsl(143, 24%, 84%);
 }
 

--- a/Source/WebInspectorUI/UserInterface/Views/TimelineRecordingContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/TimelineRecordingContentView.css
@@ -59,7 +59,7 @@
     --scope-bar-border-color-override: transparent;
 }
 
-.content-view.timeline-recording > .content-browser :matches(.recording-progress, .recording-imported) {
+.content-view.timeline-recording > .content-browser :is(.recording-progress, .recording-imported) {
     position: absolute;
     left: 0;
     right: 0;
@@ -69,7 +69,7 @@
     background-color: var(--panel-background-color-light);
 }
 
-.content-view.timeline-recording > .content-browser :matches(.recording-progress, .recording-imported) > .status {
+.content-view.timeline-recording > .content-browser :is(.recording-progress, .recording-imported) > .status {
     margin-top: 40px;
     margin-bottom: 10px;
     text-align: center;

--- a/Source/WebInspectorUI/UserInterface/Views/TimelineRuler.css
+++ b/Source/WebInspectorUI/UserInterface/Views/TimelineRuler.css
@@ -44,12 +44,12 @@
 }
 
 body[dir=ltr] .timeline-ruler > .header > .divider,
-body[dir=ltr] .timeline-ruler > .markers > :matches(.divider, .marker) {
+body[dir=ltr] .timeline-ruler > .markers > :is(.divider, .marker) {
     transform: translateX(var(--timeline-ruler-marker-translateX));
 }
 
 body[dir=rtl] .timeline-ruler > .header > .divider,
-body[dir=rtl] .timeline-ruler > .markers > :matches(.divider, .marker) {
+body[dir=rtl] .timeline-ruler > .markers > :is(.divider, .marker) {
     transform: translateX(calc(-1 * var(--timeline-ruler-marker-translateX)));
 }
 
@@ -209,7 +209,7 @@ body.window-inactive .timeline-ruler > .header > .divider {
     display: none;
 }
 
-.timeline-ruler.selection-hidden > :matches(.selection-drag, .selection-handle, .shaded-area) {
+.timeline-ruler.selection-hidden > :is(.selection-drag, .selection-handle, .shaded-area) {
     display: none;
 }
 

--- a/Source/WebInspectorUI/UserInterface/Views/TimelineTabContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/TimelineTabContentView.css
@@ -28,15 +28,15 @@
     filter: brightness(100%);
 }
 
-.timeline.tab.content-view .navigation-bar > .item:matches(.record-start-stop, .record-continue):hover {
+.timeline.tab.content-view .navigation-bar > .item:is(.record-start-stop, .record-continue):hover {
     filter: brightness(95%);
 }
 
-.timeline.tab.content-view .navigation-bar > .item:matches(.record-start-stop, .record-continue):active {
+.timeline.tab.content-view .navigation-bar > .item:is(.record-start-stop, .record-continue):active {
     filter: brightness(80%);
 }
 
-.timeline.tab.content-view .navigation-bar > .item:matches(.record-start-stop, .record-continue) * {
+.timeline.tab.content-view .navigation-bar > .item:is(.record-start-stop, .record-continue) * {
     pointer-events: none;
 }
 

--- a/Source/WebInspectorUI/UserInterface/Views/TreeOutline.css
+++ b/Source/WebInspectorUI/UserInterface/Views/TreeOutline.css
@@ -70,12 +70,12 @@
     background-color: var(--selected-background-color-unfocused);
 }
 
-body[dir=ltr] .tree-outline .item :matches(.disclosure-button, .icon),
-body[dir=rtl] [dir=ltr] .tree-outline .item :matches(.disclosure-button, .icon) {
+body[dir=ltr] .tree-outline .item :is(.disclosure-button, .icon),
+body[dir=rtl] [dir=ltr] .tree-outline .item :is(.disclosure-button, .icon) {
     float: left;
 }
 
-body[dir=rtl] .tree-outline .item :matches(.disclosure-button, .icon) {
+body[dir=rtl] .tree-outline .item :is(.disclosure-button, .icon) {
     float: right;
 }
 


### PR DESCRIPTION
#### 1e4c1a8d21b792f379051eb919494afb6d2f92a5
<pre>
[GTK][WPE] Remote Web Inspector: replace deprecated CSS method &apos;matches&apos; with &apos;is&apos;
<a href="https://bugs.webkit.org/show_bug.cgi?id=253180">https://bugs.webkit.org/show_bug.cgi?id=253180</a>

Reviewed by Tim Nguyen.

The :matches() selector was renamed to :is() in:
<a href="https://github.com/w3c/csswg-drafts/issues/3258">https://github.com/w3c/csswg-drafts/issues/3258</a>

:matches() is no longer supported by some browsers (like Chromium and
Firefox) and breaks Web Inspector UI in such browsers when we connect
via HTTP.

In case GTK/WPE WebKit, we use HTTP version of the inspector and it
can be used from any browser.

* Source/WebInspectorUI/UserInterface/Views/AuditTreeElement.css:
(.tree-outline .item.audit:is(.test-case, .test-group):not(.unsupported, .manager-active):hover &gt; .status &gt; img):
(body:not(.window-inactive, .window-docked-inactive) .tree-outline:focus-within .item.audit:is(.test-case, .test-group):not(.unsupported, .manager-active).selected:hover &gt; .status &gt; img,):
(.tree-outline .item.audit.unsupported:not(.selected) &gt; :is(.icon, .titles)):
(@media (prefers-color-scheme: dark) .tree-outline .item.audit:is(.test-case, .test-group):not(.unsupported, .manager-active):hover &gt; .status &gt; img):
(.tree-outline .item.audit:matches(.test-case, .test-group):not(.unsupported, .manager-active):hover &gt; .status &gt; img): Deleted.
(body:not(.window-inactive, .window-docked-inactive) .tree-outline:focus-within .item.audit:matches(.test-case, .test-group):not(.unsupported, .manager-active).selected:hover &gt; .status &gt; img,): Deleted.
(.tree-outline .item.audit.unsupported:not(.selected) &gt; :matches(.icon, .titles)): Deleted.
(@media (prefers-color-scheme: dark) .tree-outline .item.audit:matches(.test-case, .test-group):not(.unsupported, .manager-active):hover &gt; .status &gt; img): Deleted.
* Source/WebInspectorUI/UserInterface/Views/BlackboxSettingsView.css:
(.settings-view.blackbox &gt; :is(p, table)):
(.settings-view.blackbox &gt; table :is(th, td).url):
(.settings-view.blackbox &gt; table :is(th, td):is(.case-sensitive, .remove-blackbox)):
(.settings-view.blackbox &gt; :matches(p, table)): Deleted.
(.settings-view.blackbox &gt; table :matches(th, td).url): Deleted.
(.settings-view.blackbox &gt; table :matches(th, td):matches(.case-sensitive, .remove-blackbox)): Deleted.
* Source/WebInspectorUI/UserInterface/Views/BoxModelDetailsSectionRow.css:
(.details-section .row.box-model :is(.top, .right, .bottom, .left)):
(.details-section .row.box-model :is(.top, .right, .bottom, .left):not(.editing),):
(.details-section .row.box-model :is(.top-left, .top-right, .bottom-right, .bottom-left)):
(.details-section .row.box-model :is(.top-left, .top-right)):
(.details-section .row.box-model :is(.bottom-left, .bottom-right):not(.editing)):
(.details-section .row.box-model :is(.bottom-left, .bottom-right).editing):
(.details-section .row.box-model :is(.top-left, .bottom-left):not(.editing)):
(.details-section .row.box-model :is(.top-left, .bottom-left).editing):
(.details-section .row.box-model :is(.top-right, .bottom-right):not(.editing)):
(.details-section .row.box-model :is(.top-right, .bottom-right).editing):
(@media (prefers-color-scheme: dark) .details-section .row.box-model:not(.hovered) .box:is(.margin, .border, .padding, .content),):
(.details-section .row.box-model :matches(.top, .right, .bottom, .left)): Deleted.
(.details-section .row.box-model :matches(.top, .right, .bottom, .left):not(.editing),): Deleted.
(.details-section .row.box-model :matches(.top-left, .top-right, .bottom-right, .bottom-left)): Deleted.
(.details-section .row.box-model :matches(.top-left, .top-right)): Deleted.
(.details-section .row.box-model :matches(.bottom-left, .bottom-right):not(.editing)): Deleted.
(.details-section .row.box-model :matches(.bottom-left, .bottom-right).editing): Deleted.
(.details-section .row.box-model :matches(.top-left, .bottom-left):not(.editing)): Deleted.
(.details-section .row.box-model :matches(.top-left, .bottom-left).editing): Deleted.
(.details-section .row.box-model :matches(.top-right, .bottom-right):not(.editing)): Deleted.
(.details-section .row.box-model :matches(.top-right, .bottom-right).editing): Deleted.
(@media (prefers-color-scheme: dark) .details-section .row.box-model:not(.hovered) .box:matches(.margin, .border, .padding, .content),): Deleted.
* Source/WebInspectorUI/UserInterface/Views/BreakpointActionView.css:
(:is(.breakpoint-action-append-button, .breakpoint-action-remove-button)):
(:matches(.breakpoint-action-append-button, .breakpoint-action-remove-button)): Deleted.
* Source/WebInspectorUI/UserInterface/Views/ButtonNavigationItem.css:
(.navigation-bar .item.button:not(.disabled):is(.activate.activated, .radio.selected) &gt; .glyph):
(.navigation-bar .item.button:not(.disabled):active:is(.activate.activated, .radio.selected) &gt; .glyph):
(.navigation-bar .item.button:not(.disabled):matches(.activate.activated, .radio.selected) &gt; .glyph): Deleted.
(.navigation-bar .item.button:not(.disabled):active:matches(.activate.activated, .radio.selected) &gt; .glyph): Deleted.
* Source/WebInspectorUI/UserInterface/Views/CPUTimelineView.css:
(.timeline-view.cpu :is(.area-chart, .stacked-area-chart) svg &gt; path):
(.timeline-view.cpu :is(.area-chart, .stacked-area-chart) .markers):
(.timeline-view.cpu :is(.area-chart, .stacked-area-chart) .markers &gt; div):
(body[dir=rtl] .timeline-view.cpu :is(.area-chart, .stacked-area-chart) .markers &gt; div):
(.timeline-view.cpu :is(.area-chart, .stacked-area-chart) .markers &gt; div &gt; .label):
(.timeline-view.cpu :is(.area-chart, .stacked-area-chart) circle):
(.timeline-view.cpu &gt; .content &gt; .overview &gt; .chart &gt; .container.stats &gt; table :is(.filter, .filter-clear):hover):
(.timeline-view.cpu :matches(.area-chart, .stacked-area-chart) svg &gt; path): Deleted.
(.timeline-view.cpu :matches(.area-chart, .stacked-area-chart) .markers): Deleted.
(.timeline-view.cpu :matches(.area-chart, .stacked-area-chart) .markers &gt; div): Deleted.
(body[dir=rtl] .timeline-view.cpu :matches(.area-chart, .stacked-area-chart) .markers &gt; div): Deleted.
(.timeline-view.cpu :matches(.area-chart, .stacked-area-chart) .markers &gt; div &gt; .label): Deleted.
(.timeline-view.cpu :matches(.area-chart, .stacked-area-chart) circle): Deleted.
(.timeline-view.cpu &gt; .content &gt; .overview &gt; .chart &gt; .container.stats &gt; table :matches(.filter, .filter-clear):hover): Deleted.
* Source/WebInspectorUI/UserInterface/Views/CPUUsageCombinedView.css:
(.cpu-usage-combined-view &gt; .graph,):
(.cpu-usage-combined-view &gt; :is(.details, .legend) &gt; .name):
(.cpu-usage-combined-view &gt; :matches(.details, .legend) &gt; .name): Deleted.
* Source/WebInspectorUI/UserInterface/Views/CanvasContentView.css:
(.content-view.canvas &gt; :is(header, footer)):
(.content-view.canvas &gt; :matches(header, footer)): Deleted.
* Source/WebInspectorUI/UserInterface/Views/CanvasOverviewContentView.css:
(.content-view.canvas-overview &gt; .content-view.canvas &gt; :is(header, footer)):
(.content-view.canvas-overview &gt; .content-view.canvas &gt; header &gt; .titles &gt; :is(.subtitle, .color-space),):
(.content-view.canvas-overview &gt; .content-view.canvas:is(:hover, .recording-active) &gt; header &gt; .navigation-bar):
(.content-view.canvas-overview &gt; .content-view.canvas &gt; footer &gt; .view-related-items &gt; :is(.view-shader, .view-recording)):
(.content-view.canvas-overview &gt; .content-view.canvas &gt; :matches(header, footer)): Deleted.
(.content-view.canvas-overview &gt; .content-view.canvas &gt; header &gt; .titles &gt; :matches(.subtitle, .color-space),): Deleted.
(.content-view.canvas-overview &gt; .content-view.canvas:matches(:hover, .recording-active) &gt; header &gt; .navigation-bar): Deleted.
(.content-view.canvas-overview &gt; .content-view.canvas &gt; footer &gt; .view-related-items &gt; :matches(.view-shader, .view-recording)): Deleted.
* Source/WebInspectorUI/UserInterface/Views/CanvasSidebarPanel.css:
(.sidebar &gt; .panel.navigation.canvas &gt; .content &gt; .tree-outline .item.canvas:is(.canvas-2d, .bitmaprenderer) .icon):
(.sidebar &gt; .panel.navigation.canvas &gt; .content &gt; .tree-outline .item.canvas:is(.webgl, .webgl2, .webgpu, .webmetal) .icon):
(.sidebar &gt; .panel.navigation.canvas:not(.has-recordings) &gt; .filter-bar,):
(.sidebar &gt; .panel.navigation.canvas &gt; .content &gt; .tree-outline .item.canvas:matches(.canvas-2d, .bitmaprenderer) .icon): Deleted.
(.sidebar &gt; .panel.navigation.canvas &gt; .content &gt; .tree-outline .item.canvas:matches(.webgl, .webgl2, .webgpu, .webmetal) .icon): Deleted.
* Source/WebInspectorUI/UserInterface/Views/CodeMirrorRegexMode.css:
(.cm-s-default :is(.cm-regex-escape, .cm-regex-escape-2, .cm-regex-escape-3)):
(.cm-s-default :is(.cm-regex-group, .cm-regex-lookahead)):
(.cm-s-default :is(.cm-regex-literal, .cm-regex-special, .cm-regex-backreference)):
(.cm-s-default :matches(.cm-regex-escape, .cm-regex-escape-2, .cm-regex-escape-3)): Deleted.
(.cm-s-default :matches(.cm-regex-group, .cm-regex-lookahead)): Deleted.
(.cm-s-default :matches(.cm-regex-literal, .cm-regex-special, .cm-regex-backreference)): Deleted.
* Source/WebInspectorUI/UserInterface/Views/ColorPicker.css:
(.color-picker :is(.color-square, .slider)):
(.color-picker :matches(.color-square, .slider)): Deleted.
* Source/WebInspectorUI/UserInterface/Views/ComputedStyleDetailsPanel.css:
(.sidebar &gt; .panel.details.css-style &gt; .content &gt; .computed &gt; .details-section:not(.collapsed) &gt; :is(.header, .content)):
(.sidebar &gt; .panel.details.css-style &gt; .content &gt; .computed &gt; .details-section:not(.collapsed) &gt; :matches(.header, .content)): Deleted.
* Source/WebInspectorUI/UserInterface/Views/ConsoleDrawer.css:
(.console-drawer &gt; .navigation-bar &gt; :is(.item.button, .log-scope-bar)):
(.console-drawer &gt; .navigation-bar &gt; :matches(.item.button, .log-scope-bar)): Deleted.
* Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.css:
(.console-message-body &gt; span &gt; :is(.console-message-enclosed, .console-message-preview, .console-message-preview-divider)):
(.console-image &gt; .console-message-body &gt; :is(hr, img)):
(.console-message.expandable.expanded :is(.console-message-preview, .console-message-preview-divider):not(.inline-lossless)):
(:is(.console-warning-level, .console-error-level, .console-log-level, .console-info-level, .console-debug-level).console-message):
(:is(.console-warning-level, .console-error-level, .console-log-level, .console-info-level, .console-debug-level)::before):
(.console-message-body &gt; span &gt; :matches(.console-message-enclosed, .console-message-preview, .console-message-preview-divider)): Deleted.
(.console-image &gt; .console-message-body &gt; :matches(hr, img)): Deleted.
(.console-message.expandable.expanded :matches(.console-message-preview, .console-message-preview-divider):not(.inline-lossless)): Deleted.
(:matches(.console-warning-level, .console-error-level, .console-log-level, .console-info-level, .console-debug-level).console-message): Deleted.
(:matches(.console-warning-level, .console-error-level, .console-log-level, .console-info-level, .console-debug-level)::before): Deleted.
* Source/WebInspectorUI/UserInterface/Views/CookiePopover.css:
(.popover .cookie-popover-content &gt; table &gt; tr &gt; td &gt; input:is([type=&quot;text&quot;], [type=&quot;datetime-local&quot;])):
(.popover .cookie-popover-content &gt; table &gt; tr &gt; td &gt; input:is([type=&quot;text&quot;], [type=&quot;datetime-local&quot;]):is(:invalid, .invalid)):
(.popover .cookie-popover-content &gt; table &gt; tr &gt; td &gt; input:matches([type=&quot;text&quot;], [type=&quot;datetime-local&quot;])): Deleted.
(.popover .cookie-popover-content &gt; table &gt; tr &gt; td &gt; input:matches([type=&quot;text&quot;], [type=&quot;datetime-local&quot;]):matches(:invalid, .invalid)): Deleted.
* Source/WebInspectorUI/UserInterface/Views/DOMEventsBreakdownView.css:
(.dom-events-breakdown tr &gt; :is(th, td)):
(.dom-events-breakdown .graph &gt; :is(img, .area)):
(.dom-events-breakdown tr &gt; :matches(th, td)): Deleted.
(.dom-events-breakdown .graph &gt; :matches(img, .area)): Deleted.
* Source/WebInspectorUI/UserInterface/Views/DOMStorageContentView.css:
(.content-view.dom-storage &gt; .data-grid tr:is(.duplicate-key, .missing-key) td.key-column,):
(.content-view.dom-storage &gt; .data-grid:focus tr.selected:is(.duplicate-key, .missing-key) td.key-column,):
(.content-view.dom-storage &gt; .data-grid tr:matches(.duplicate-key, .missing-key) td.key-column,): Deleted.
(.content-view.dom-storage &gt; .data-grid:focus tr.selected:matches(.duplicate-key, .missing-key) td.key-column,): Deleted.
* Source/WebInspectorUI/UserInterface/Views/DOMTreeContentView.css:
(body:not(.window-inactive, .window-docked-inactive) .content-view.dom-tree .tree-outline.dom:focus-within li:is(.selected, .hovered) .status-image.breakpoint):
(body:not(.window-inactive, .window-docked-inactive) .content-view.dom-tree .tree-outline.dom:focus-within li:is(.selected, .hovered) .status-image.breakpoint.subtree):
(body:not(.window-inactive, .window-docked-inactive) .content-view.dom-tree .tree-outline.dom:focus-within li:matches(.selected, .hovered) .status-image.breakpoint): Deleted.
(body:not(.window-inactive, .window-docked-inactive) .content-view.dom-tree .tree-outline.dom:focus-within li:matches(.selected, .hovered) .status-image.breakpoint.subtree): Deleted.
* Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.css:
(.tree-outline.dom li:is(.hovered, .selected) + ol.children.expanded):
(.tree-outline.dom li:matches(.hovered, .selected) + ol.children.expanded): Deleted.
* Source/WebInspectorUI/UserInterface/Views/DataGrid.css:
(.data-grid th:is(.sort-ascending, .sort-descending)):
(.data-grid :is(th, td) &gt; div):
(.data-grid th:is(.sort-ascending, .sort-descending) &gt; .header-cell-content:first-child):
(.data-grid th:is(.sort-ascending, .sort-descending) &gt; .header-cell-content:first-child::after):
(.data-grid tr:is(.selected, :hover) .go-to-arrow):
(@media (prefers-color-scheme: dark) .data-grid th:is(.sort-ascending, .sort-descending) &gt; .header-cell-content:first-child::after):
(.data-grid th:matches(.sort-ascending, .sort-descending)): Deleted.
(.data-grid :matches(th, td) &gt; div): Deleted.
(.data-grid th:matches(.sort-ascending, .sort-descending) &gt; .header-cell-content:first-child): Deleted.
(.data-grid th:matches(.sort-ascending, .sort-descending) &gt; .header-cell-content:first-child::after): Deleted.
(.data-grid tr:matches(.selected, :hover) .go-to-arrow): Deleted.
(@media (prefers-color-scheme: dark) .data-grid th:matches(.sort-ascending, .sort-descending) &gt; .header-cell-content:first-child::after): Deleted.
* Source/WebInspectorUI/UserInterface/Views/DatabaseContentView.css:
(:is(.database-user-query, .database-query-result)::before):
(:matches(.database-user-query, .database-query-result)::before): Deleted.
* Source/WebInspectorUI/UserInterface/Views/DetailsSection.css:
(.details-section &gt; .content &gt; .group &gt; .row:is(.empty, .text)):
(.details-section &gt; .content &gt; .group &gt; .row:matches(.empty, .text)): Deleted.
* Source/WebInspectorUI/UserInterface/Views/FilterBar.css:
(:is(.filter-bar, .search-bar) &gt; input[type=&quot;search&quot;]):
(:is(.filter-bar, .search-bar) &gt; input[type=&quot;search&quot;]:is(:focus, :not(:placeholder-shown))):
(:is(.filter-bar, .search-bar) &gt; input[type=&quot;search&quot;]::-webkit-search-decoration):
(:is(.filter-bar, .search-bar) &gt; input[type=&quot;search&quot;]::-webkit-search-results-button):
(:is(.filter-bar, .search-bar) &gt; input[type=&quot;search&quot;]::placeholder):
(:is(.filter-bar, .search-bar) &gt; input[type=&quot;search&quot;]:is(:not(:focus), :placeholder-shown)::-webkit-search-cancel-button):
(:is(.filter-bar, .search-bar) &gt; .navigation-bar + input[type=&quot;search&quot;]):
(:is(.filter-bar, .search-bar) &gt; input[type=&quot;search&quot;]:focus):
(:is(.filter-bar, .search-bar) &gt; input[type=&quot;search&quot;] + :empty):
(:is(.filter-bar, .search-bar) &gt; input[type=&quot;search&quot;]:focus ~ *):
(:is(.filter-bar, .search-bar) &gt; input[type=&quot;search&quot;] + .navigation-bar &gt; .item.scope-bar:last-child):
(:is(.filter-bar, .search-bar).invalid &gt; input[type=&quot;search&quot;]):
(:matches(.filter-bar, .search-bar) &gt; input[type=&quot;search&quot;]): Deleted.
(:matches(.filter-bar, .search-bar) &gt; input[type=&quot;search&quot;]:matches(:focus, :not(:placeholder-shown))): Deleted.
(:matches(.filter-bar, .search-bar) &gt; input[type=&quot;search&quot;]::-webkit-search-decoration): Deleted.
(:matches(.filter-bar, .search-bar) &gt; input[type=&quot;search&quot;]::-webkit-search-results-button): Deleted.
(:matches(.filter-bar, .search-bar) &gt; input[type=&quot;search&quot;]::placeholder): Deleted.
(:matches(.filter-bar, .search-bar) &gt; input[type=&quot;search&quot;]:matches(:not(:focus), :placeholder-shown)::-webkit-search-cancel-button): Deleted.
(:matches(.filter-bar, .search-bar) &gt; .navigation-bar + input[type=&quot;search&quot;]): Deleted.
(:matches(.filter-bar, .search-bar) &gt; input[type=&quot;search&quot;]:focus): Deleted.
(:matches(.filter-bar, .search-bar) &gt; input[type=&quot;search&quot;] + :empty): Deleted.
(:matches(.filter-bar, .search-bar) &gt; input[type=&quot;search&quot;]:focus ~ *): Deleted.
(:matches(.filter-bar, .search-bar) &gt; input[type=&quot;search&quot;] + .navigation-bar &gt; .item.scope-bar:last-child): Deleted.
(:matches(.filter-bar, .search-bar).invalid &gt; input[type=&quot;search&quot;]): Deleted.
* Source/WebInspectorUI/UserInterface/Views/FindBanner.css:
(.no-find-banner-transition:is(.find-banner, .supports-find-banner)):
(.find-banner.console-find-banner &gt; :is(input[type=&quot;search&quot;], button)):
(.no-find-banner-transition:matches(.find-banner, .supports-find-banner)): Deleted.
(.find-banner.console-find-banner &gt; :matches(input[type=&quot;search&quot;], button)): Deleted.
* Source/WebInspectorUI/UserInterface/Views/FontResourceContentView.css:
(.content-view.resource.font &gt; :is(.local-resource-override-label-view, .local-resource-override-warning-view):not([hidden]) ~ .drop-zone):
(.content-view.resource.font &gt; :matches(.local-resource-override-label-view, .local-resource-override-warning-view):not([hidden]) ~ .drop-zone): Deleted.
* Source/WebInspectorUI/UserInterface/Views/FormattedValue.css:
(:is(.formatted-array, .formatted-map, .formatted-set, .formatted-weakmap, .formatted-weakset) &gt; .size):
(:matches(.formatted-array, .formatted-map, .formatted-set, .formatted-weakmap, .formatted-weakset) &gt; .size): Deleted.
* Source/WebInspectorUI/UserInterface/Views/GeneralStyleDetailsSidebarPanel.css:
(.sidebar &gt; .panel.details.css-style &gt; .content ~ .class-list-container &gt; *:is(.new-class, .class-toggle)):
(.sidebar &gt; .panel.details.css-style &gt; .content ~ .class-list-container &gt; *:matches(.new-class, .class-toggle)): Deleted.
* Source/WebInspectorUI/UserInterface/Views/GradientSlider.css:
(.gradient-slider-knob &gt; :is(img, div)):
(.gradient-slider-knob &gt; :matches(img, div)): Deleted.
* Source/WebInspectorUI/UserInterface/Views/GraphicsTabContentView.css:
(.content-view.tab.graphics .navigation-bar &gt; .item .canvas:is(.webgl, .webgl2, .webgpu, .webmetal) .icon):
(.content-view.tab.graphics .navigation-bar &gt; .item .canvas:matches(.webgl, .webgl2, .webgpu, .webmetal) .icon): Deleted.
* Source/WebInspectorUI/UserInterface/Views/HeapSnapshotInstancesContentView.css:
(.heap-snapshot &gt; .data-grid tr:is(.selected, :hover) td .go-to-arrow):
(.heap-snapshot &gt; .data-grid tr:matches(.selected, :hover) td .go-to-arrow): Deleted.
* Source/WebInspectorUI/UserInterface/Views/HierarchicalPathComponent.css:
(.hierarchical-path-component &gt; :is(.icon, .selector-arrows)):
(.hierarchical-path-component &gt; :matches(.icon, .selector-arrows)): Deleted.
* Source/WebInspectorUI/UserInterface/Views/HoverMenu.css:
(.hover-menu &gt; svg &gt; :is(path, rect)):
(@media (prefers-color-scheme: dark) .hover-menu &gt; svg &gt; :is(path, rect)):
(.hover-menu &gt; svg &gt; :matches(path, rect)): Deleted.
(@media (prefers-color-scheme: dark) .hover-menu &gt; svg &gt; :matches(path, rect)): Deleted.
* Source/WebInspectorUI/UserInterface/Views/ImageResourceContentView.css:
(.content-view.resource.image &gt; :is(.local-resource-override-label-view, .local-resource-override-warning-view):not([hidden]) ~ .drop-zone):
(.content-view.resource.image &gt; :matches(.local-resource-override-label-view, .local-resource-override-warning-view):not([hidden]) ~ .drop-zone): Deleted.
* Source/WebInspectorUI/UserInterface/Views/IndexedDatabaseObjectStoreContentView.css:
(.content-view.indexed-database-object-store &gt; .data-grid .object-tree &gt; :is(.title, .object-preview)::before):
(.content-view.indexed-database-object-store &gt; .data-grid .object-tree &gt; :matches(.title, .object-preview)::before): Deleted.
* Source/WebInspectorUI/UserInterface/Views/InlineSwatch.css:
(.inline-swatch:not(.box-shadow),):
(.inline-swatch:is(.color, .gradient)):
(.inline-swatch:is(.bezier, .spring, .variable)):
(.inline-swatch:is(.bezier, .box-shadow, .spring, .variable)):
(.inline-swatch:not(.read-only):is(.bezier, .box-shadow, .spring, .variable, .alignment):hover):
(.inline-swatch:not(.read-only):is(.bezier, .box-shadow, .spring, .variable, .alignment):active):
(.inline-swatch:is(.bezier, .box-shadow, .spring, .variable) &gt; span):
(.inline-swatch:matches(.color, .gradient)): Deleted.
(.inline-swatch:matches(.bezier, .spring, .variable)): Deleted.
(.inline-swatch:matches(.bezier, .box-shadow, .spring, .variable)): Deleted.
(.inline-swatch:not(.read-only):matches(.bezier, .box-shadow, .spring, .variable, .alignment):hover): Deleted.
(.inline-swatch:not(.read-only):matches(.bezier, .box-shadow, .spring, .variable, .alignment):active): Deleted.
(.inline-swatch:matches(.bezier, .box-shadow, .spring, .variable) &gt; span): Deleted.
* Source/WebInspectorUI/UserInterface/Views/LayerDetailsSidebarPanel.css:
(.panel.details.layer .name-column :is(.pseudo-element, .reflection)):
(.panel.details.layer tr.selected .name-column :is(.pseudo-element, .reflection)):
(.panel.details.layer .name-column :matches(.pseudo-element, .reflection)): Deleted.
(.panel.details.layer tr.selected .name-column :matches(.pseudo-element, .reflection)): Deleted.
* Source/WebInspectorUI/UserInterface/Views/LayerTreeDetailsSidebarPanel.css:
(.panel.details.layer-tree .name-column :is(.pseudo-element, .reflection)):
(.panel.details.layer-tree tr.selected .name-column :is(.pseudo-element, .reflection)):
(.panel.details.layer-tree .name-column :matches(.pseudo-element, .reflection)): Deleted.
(.panel.details.layer-tree tr.selected .name-column :matches(.pseudo-element, .reflection)): Deleted.
* Source/WebInspectorUI/UserInterface/Views/LocalResourceOverridePopover.css:
(.popover .local-resource-override-popover-content label:is(.is-case-sensitive, .is-regex)):
(.popover .local-resource-override-popover-content .data-grid tr.header-content-type &gt; :is(.name-column, .value-column)):
(.popover .local-resource-override-popover-content label:matches(.is-case-sensitive, .is-regex)): Deleted.
(.popover .local-resource-override-popover-content .data-grid tr.header-content-type &gt; :matches(.name-column, .value-column)): Deleted.
* Source/WebInspectorUI/UserInterface/Views/Main.css:
(body.docked:is(.right, .left) #navigation-sidebar.collapsed &gt; .resizer):
(:is(img, canvas).show-grid):
(.tab-bar &gt; .navigation-bar :is(.console-warnings, .console-errors):not(.disabled).pulsing):
(@media (prefers-color-scheme: dark) :is(img, canvas).show-grid):
(body.docked:matches(.right, .left) #navigation-sidebar.collapsed &gt; .resizer): Deleted.
(:matches(img, canvas).show-grid): Deleted.
(.tab-bar &gt; .navigation-bar :matches(.console-warnings, .console-errors):not(.disabled).pulsing): Deleted.
(@media (prefers-color-scheme: dark) :matches(img, canvas).show-grid): Deleted.
* Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.css:
(.network-table &gt; .table li:not(.selected) .cell:is(.cache-type, .multiple)):
(.network-table &gt; .table .header .cell.waterfall:is(.sort-ascending, .sort-descending)):
(.waterfall.network .block:is(.mouse-tracking, .filler) + .block:not(.mouse-tracking, .filler),):
(.network-table &gt; .table li:not(.selected) .cell:matches(.cache-type, .multiple)): Deleted.
(.network-table &gt; .table .header .cell.waterfall:matches(.sort-ascending, .sort-descending)): Deleted.
(.waterfall.network .block:matches(.mouse-tracking, .filler) + .block:not(.mouse-tracking, .filler),): Deleted.
* Source/WebInspectorUI/UserInterface/Views/ObjectTreePropertyTreeElement.css:
(.object-tree-property :is(.getter, .setter)):
(.object-tree-property :is(.getter, .setter).disabled):
(.object-tree-property :matches(.getter, .setter)): Deleted.
(.object-tree-property :matches(.getter, .setter).disabled): Deleted.
* Source/WebInspectorUI/UserInterface/Views/ObjectTreeView.css:
(.object-tree &gt; :is(.title, .object-preview)::before):
(.object-tree:not(.lossless-preview) &gt; :is(.title, .object-preview)):
(.object-tree.expanded &gt; :is(.title, .object-preview)::before):
(.object-tree.properties-only &gt; :is(.title, .object-preview)):
(.object-tree.lossless-preview &gt; :is(.title, .object-preview)::before):
(.object-tree &gt; :matches(.title, .object-preview)::before): Deleted.
(.object-tree:not(.lossless-preview) &gt; :matches(.title, .object-preview)): Deleted.
(.object-tree.expanded &gt; :matches(.title, .object-preview)::before): Deleted.
(.object-tree.properties-only &gt; :matches(.title, .object-preview)): Deleted.
(.object-tree.lossless-preview &gt; :matches(.title, .object-preview)::before): Deleted.
* Source/WebInspectorUI/UserInterface/Views/ProbeSetDataGrid.css:
(.details-section.probe-set .data-grid .object-tree &gt; :is(.title, .object-preview)::before):
(.details-section.probe-set .data-grid .object-tree &gt; :matches(.title, .object-preview)::before): Deleted.
* Source/WebInspectorUI/UserInterface/Views/ProfileView.css:
(.profile &gt; .data-grid tr:is(.selected, :hover) .go-to-arrow):
(.profile &gt; .data-grid tr:matches(.selected, :hover) .go-to-arrow): Deleted.
* Source/WebInspectorUI/UserInterface/Views/QuickConsole.css:
(@media (prefers-color-scheme: dark) .CodeMirror .jump-to-symbol-highlight,):
* Source/WebInspectorUI/UserInterface/Views/RadioButtonNavigationItem.css:
(.navigation-bar .item.radio.button.text-only:is(.selected, :hover)):
(.navigation-bar .item.radio.button.text-only:is(.selected, :hover)::before):
(.navigation-bar .item.radio.button.text-only:matches(.selected, :hover)): Deleted.
(.navigation-bar .item.radio.button.text-only:matches(.selected, :hover)::before): Deleted.
* Source/WebInspectorUI/UserInterface/Views/RecordingContentView.css:
(.content-view.recording :is(img, canvas)):
(.content-view.recording :matches(img, canvas)): Deleted.
* Source/WebInspectorUI/UserInterface/Views/ResourceHeadersContentView.css:
(body[dir] .resource-headers &gt; section:is(.redirect, .headers) &gt; .details):
(body[dir] .resource-headers &gt; section:matches(.redirect, .headers) &gt; .details): Deleted.
* Source/WebInspectorUI/UserInterface/Views/ResourceIcons.css:
(:is(.resource-icon.resource-type-style-sheet, .style-sheet-icon) .icon):
(:is(.resource-icon.resource-type-style-sheet.override, .style-sheet-icon.override) .icon):
(@media (prefers-color-scheme: dark) :is(.resource-icon.resource-type-style-sheet, .style-sheet-icon) .icon):
(@media (prefers-color-scheme: dark) :is(.resource-icon.resource-type-style-sheet.override, .style-sheet-icon.override) .icon):
(:matches(.resource-icon.resource-type-style-sheet, .style-sheet-icon) .icon): Deleted.
(:matches(.resource-icon.resource-type-style-sheet.override, .style-sheet-icon.override) .icon): Deleted.
(@media (prefers-color-scheme: dark) :matches(.resource-icon.resource-type-style-sheet, .style-sheet-icon) .icon): Deleted.
(@media (prefers-color-scheme: dark) :matches(.resource-icon.resource-type-style-sheet.override, .style-sheet-icon.override) .icon): Deleted.
* Source/WebInspectorUI/UserInterface/Views/ResourceSecurityContentView.css:
(body[dir] .resource-security &gt; section:is(.connection, .certificate) &gt; .details):
(@media (prefers-color-scheme: dark) body[dir] .resource-security &gt; section:is(.connection, .certificate) &gt; .details):
(body[dir] .resource-security &gt; section:matches(.connection, .certificate) &gt; .details): Deleted.
(@media (prefers-color-scheme: dark) body[dir] .resource-security &gt; section:matches(.connection, .certificate) &gt; .details): Deleted.
* Source/WebInspectorUI/UserInterface/Views/ResourceTreeElement.css:
(.item.resource.resource-type-websocket:not(.selected) .status .ready-state.open,):
(.item.resource.resource-type-websocket:not(.selected) .status .ready-state.connecting,):
* Source/WebInspectorUI/UserInterface/Views/ScopeBar.css:
(.scope-bar &gt; li:is(.selected, :hover)):
(.scope-bar &gt; li:matches(.selected, :hover)): Deleted.
* Source/WebInspectorUI/UserInterface/Views/SearchSidebarPanel.css:
(.sidebar &gt; .panel.navigation.search &gt; :is(.content, .message-text-view)):
(.sidebar &gt; .panel.navigation.search.changed &gt; :is(.content, .message-text-view)):
(.sidebar &gt; .panel.navigation.search &gt; :matches(.content, .message-text-view)): Deleted.
(.sidebar &gt; .panel.navigation.search.changed &gt; :matches(.content, .message-text-view)): Deleted.
* Source/WebInspectorUI/UserInterface/Views/SourcesNavigationSidebarPanel.css:
(.sidebar &gt; .panel.navigation.sources &gt; .content &gt; :is(.pause-reason-container, .call-stack-container, .breakpoints-container, .local-overrides-container, .console-snippets-container)):
(@media (min-height: 650px) .sidebar &gt; .panel.navigation.sources &gt; .content &gt; :is(.call-stack-container, .breakpoints-container, .resources-container, .local-overrides-container, .console-snippets-container)):
(.sidebar &gt; .panel.navigation.sources &gt; .content &gt; :matches(.pause-reason-container, .call-stack-container, .breakpoints-container, .local-overrides-container, .console-snippets-container)): Deleted.
(@media (min-height: 650px) .sidebar &gt; .panel.navigation.sources &gt; .content &gt; :matches(.call-stack-container, .breakpoints-container, .resources-container, .local-overrides-container, .console-snippets-container)): Deleted.
* Source/WebInspectorUI/UserInterface/Views/SpreadsheetCSSStyleDeclarationEditor.css:
(.spreadsheet-style-declaration-editor :is(.name, .value):not(.editing)):
(.spreadsheet-style-declaration-editor :is(.name, .value).editing):
(.spreadsheet-css-declaration:is(:hover, :focus) .property:not(:is(.invalid-name, .invalid-value)) .property-toggle,):
(.spreadsheet-style-declaration-editor &gt; .property:is(.invalid-name, .other-vendor, .overridden):not(.disabled) &gt; .content &gt; *:not(.name, .value-container),):
(.spreadsheet-style-declaration-editor &gt; .property.invalid-name:not(.disabled) &gt; .content &gt; *:not(.name, .value-container),):
(body:is(.window-docked-inactive, .window-inactive) .spreadsheet-style-declaration-editor .property.selected):
(.spreadsheet-style-declaration-editor .property:is(.implicit, .not-inherited) .content &gt; *):
(body.meta-key-pressed .spreadsheet-css-declaration:not(.locked) &gt; .spreadsheet-style-declaration-editor &gt; .property &gt; .content :is(.name, .value):not(.editing):hover):
(@media (prefers-color-scheme: dark) .spreadsheet-style-declaration-editor :is(.name, .value).editing):
(.spreadsheet-style-declaration-editor :matches(.name, .value):not(.editing)): Deleted.
(.spreadsheet-style-declaration-editor :matches(.name, .value).editing): Deleted.
(.spreadsheet-css-declaration:matches(:hover, :focus) .property:not(:matches(.invalid-name, .invalid-value)) .property-toggle,): Deleted.
(.spreadsheet-style-declaration-editor &gt; .property:matches(.invalid-name, .other-vendor, .overridden):not(.disabled) &gt; .content &gt; *:not(.name, .value-container),): Deleted.
(body:matches(.window-docked-inactive, .window-inactive) .spreadsheet-style-declaration-editor .property.selected): Deleted.
(.spreadsheet-style-declaration-editor .property:matches(.implicit, .not-inherited) .content &gt; *): Deleted.
(body.meta-key-pressed .spreadsheet-css-declaration:not(.locked) &gt; .spreadsheet-style-declaration-editor &gt; .property &gt; .content :matches(.name, .value):not(.editing):hover): Deleted.
(@media (prefers-color-scheme: dark) .spreadsheet-style-declaration-editor :matches(.name, .value).editing): Deleted.
* Source/WebInspectorUI/UserInterface/Views/SpreadsheetCSSStyleDeclarationSection.css:
(.spreadsheet-css-declaration :is(.header, .header-groupings)):
(.spreadsheet-css-declaration :is(.header, .header-groupings):first-child):
(.spreadsheet-css-declaration :matches(.header, .header-groupings)): Deleted.
(.spreadsheet-css-declaration :matches(.header, .header-groupings):first-child): Deleted.
* Source/WebInspectorUI/UserInterface/Views/SpringEditor.css:
(.spring-editor &gt; :is(.spring-preview, .spring-timing) &gt; div):
(.spring-editor &gt; .animate:is(.spring-preview, .spring-timing) &gt; div):
(.spring-editor &gt; :matches(.spring-preview, .spring-timing) &gt; div): Deleted.
(.spring-editor &gt; .animate:matches(.spring-preview, .spring-timing) &gt; div): Deleted.
* Source/WebInspectorUI/UserInterface/Views/SyntaxHighlightingDefaultTheme.css:
(.cm-s-default .cm-comment,):
(.cm-s-default :is(.cm-tag, .cm-bracket, .cm-atom, .cm-keyword, .cm-m-javascript.cm-builtin),):
(.cm-s-default :is(.cm-number, .cm-atom.cm-hex-color),):
(.cm-s-default :is(.cm-def, .cm-operator, .cm-variable, .cm-variable-2),):
(.cm-s-default .cm-string,):
(.cm-s-default .cm-m-xml.cm-meta,):
(.cm-s-default .basic-block-has-not-executed:is(.cm-tag, .cm-bracket, .cm-atom, .cm-keyword, .cm-m-javascript.cm-builtin),):
(.cm-s-default .basic-block-has-not-executed:is(.cm-number, .cm-atom.cm-hex-color)):
(.cm-s-default :matches(.cm-tag, .cm-bracket, .cm-atom, .cm-keyword, .cm-m-javascript.cm-builtin),): Deleted.
(.cm-s-default :matches(.cm-number, .cm-atom.cm-hex-color),): Deleted.
(.cm-s-default :matches(.cm-def, .cm-operator, .cm-variable, .cm-variable-2),): Deleted.
(.cm-s-default .basic-block-has-not-executed:matches(.cm-tag, .cm-bracket, .cm-atom, .cm-keyword, .cm-m-javascript.cm-builtin),): Deleted.
(.cm-s-default .basic-block-has-not-executed:matches(.cm-number, .cm-atom.cm-hex-color)): Deleted.
* Source/WebInspectorUI/UserInterface/Views/TabBar.css:
(.tab-bar &gt; .tabs.static-layout &gt; :is(.flexible-space, .item)):
(.tab-bar &gt; .tabs.animating:is(.expanding-tabs, .inserting-tab) &gt; .item):
(.tab-bar &gt; .tabs.static-layout &gt; :matches(.flexible-space, .item)): Deleted.
(.tab-bar &gt; .tabs.animating:matches(.expanding-tabs, .inserting-tab) &gt; .item): Deleted.
* Source/WebInspectorUI/UserInterface/Views/Table.css:
(.table &gt; .header &gt; :is(.sort-ascending, .sort-descending)):
(.table &gt; .header &gt; :is(.sort-ascending, .sort-descending)::after):
(@media (prefers-color-scheme: dark) .table &gt; .header &gt; :is(.sort-ascending, .sort-descending)::after):
(.table &gt; .header &gt; :matches(.sort-ascending, .sort-descending)): Deleted.
(.table &gt; .header &gt; :matches(.sort-ascending, .sort-descending)::after): Deleted.
(@media (prefers-color-scheme: dark) .table &gt; .header &gt; :matches(.sort-ascending, .sort-descending)::after): Deleted.
* Source/WebInspectorUI/UserInterface/Views/TimelineDataGrid.css:
(.data-grid th.graph-column:is(.sort-ascending, .sort-descending)):
(.data-grid.timeline th:is(.sort-ascending, .sort-descending) &gt; .header-cell-content.timeline-ruler:first-child::after):
(.data-grid th.graph-column:matches(.sort-ascending, .sort-descending)): Deleted.
(.data-grid.timeline th:matches(.sort-ascending, .sort-descending) &gt; .header-cell-content.timeline-ruler:first-child::after): Deleted.
* Source/WebInspectorUI/UserInterface/Views/TimelineOverview.css:
(.timeline-overview &gt; :is(.navigation-bar.timelines, .tree-outline.timelines)):
(.timeline-overview:not(.frames) &gt; :is(.scroll-container, .timeline-ruler, .graphs-container)):
(.navigation-bar.timelines .item.button.toggle-edit-instruments:not(.disabled):is(:focus, .activate.activated, .radio.selected)):
(.navigation-bar.timelines .item.button.toggle-edit-instruments:not(.disabled):active:is(:focus, .activate.activated, .radio.selected)):
(body:is(.window-inactive, .window-docked-inactive) .timeline-overview:not(.edit-instruments) &gt; .tree-outline.timelines .item.selected + .item):
(.timeline-overview.frames &gt; :is(.tree-outline.timelines, .navigation-bar.timelines)):
(.timeline-overview &gt; :matches(.navigation-bar.timelines, .tree-outline.timelines)): Deleted.
(.timeline-overview:not(.frames) &gt; :matches(.scroll-container, .timeline-ruler, .graphs-container)): Deleted.
(.navigation-bar.timelines .item.button.toggle-edit-instruments:not(.disabled):matches(:focus, .activate.activated, .radio.selected)): Deleted.
(.navigation-bar.timelines .item.button.toggle-edit-instruments:not(.disabled):active:matches(:focus, .activate.activated, .radio.selected)): Deleted.
(body:matches(.window-inactive, .window-docked-inactive) .timeline-overview:not(.edit-instruments) &gt; .tree-outline.timelines .item.selected + .item): Deleted.
(.timeline-overview.frames &gt; :matches(.tree-outline.timelines, .navigation-bar.timelines)): Deleted.
* Source/WebInspectorUI/UserInterface/Views/TimelineRecordBar.css:
(.timeline-record-bar &gt; :is(img, .segment)):
(.timeline-record-bar.has-custom-children.timeline-record-type-media &gt; .segment:is(.css-animation-delay, .media-element-paused)):
(.timeline-record-bar &gt; :matches(img, .segment)): Deleted.
(.timeline-record-bar.has-custom-children.timeline-record-type-media &gt; .segment:matches(.css-animation-delay, .media-element-paused)): Deleted.
* Source/WebInspectorUI/UserInterface/Views/TimelineRecordingContentView.css:
(.content-view.timeline-recording &gt; .content-browser :is(.recording-progress, .recording-imported)):
(.content-view.timeline-recording &gt; .content-browser :is(.recording-progress, .recording-imported) &gt; .status):
(.content-view.timeline-recording &gt; .content-browser :matches(.recording-progress, .recording-imported)): Deleted.
(.content-view.timeline-recording &gt; .content-browser :matches(.recording-progress, .recording-imported) &gt; .status): Deleted.
* Source/WebInspectorUI/UserInterface/Views/TimelineRuler.css:
(body[dir=ltr] .timeline-ruler &gt; .header &gt; .divider,):
(body[dir=rtl] .timeline-ruler &gt; .header &gt; .divider,):
(.timeline-ruler.selection-hidden &gt; :is(.selection-drag, .selection-handle, .shaded-area)):
(.timeline-ruler.selection-hidden &gt; :matches(.selection-drag, .selection-handle, .shaded-area)): Deleted.
* Source/WebInspectorUI/UserInterface/Views/TimelineTabContentView.css:
(.timeline.tab.content-view .navigation-bar &gt; .item:is(.record-start-stop, .record-continue):hover):
(.timeline.tab.content-view .navigation-bar &gt; .item:is(.record-start-stop, .record-continue):active):
(.timeline.tab.content-view .navigation-bar &gt; .item:is(.record-start-stop, .record-continue) *):
(.timeline.tab.content-view .navigation-bar &gt; .item:matches(.record-start-stop, .record-continue):hover): Deleted.
(.timeline.tab.content-view .navigation-bar &gt; .item:matches(.record-start-stop, .record-continue):active): Deleted.
(.timeline.tab.content-view .navigation-bar &gt; .item:matches(.record-start-stop, .record-continue) *): Deleted.
* Source/WebInspectorUI/UserInterface/Views/TreeOutline.css:
(body[dir=ltr] .tree-outline .item :is(.disclosure-button, .icon),):
(body[dir=rtl] .tree-outline .item :is(.disclosure-button, .icon)):
(body[dir=ltr] .tree-outline .item :matches(.disclosure-button, .icon),): Deleted.
(body[dir=rtl] .tree-outline .item :matches(.disclosure-button, .icon)): Deleted.

Canonical link: <a href="https://commits.webkit.org/261264@main">https://commits.webkit.org/261264@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c6a6ff9fecadbd374d48fb08ea3db62720ad2b3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110477 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19561 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43158 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1846 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119368 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20991 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10709 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/1309 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116219 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15629 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98888 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102712 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97590 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30555 "Found 1 new test failure: imported/w3c/web-platform-tests/preload/onerror-event.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43869 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12215 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31893 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85736 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12792 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8788 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18155 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51509 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7813 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14659 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->