### PR TITLE
[GTK] Remove the fallback code when GTK fails to create the GL context under wayland

### DIFF
--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.cpp
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.cpp
@@ -28,8 +28,9 @@
 
 #include "HardwareAccelerationManager.h"
 #include "WebPageProxy.h"
-#include <WebCore/CairoUtilities.h>
 #include <WebCore/PlatformDisplay.h>
+#include <gtk/gtk.h>
+#include <wtf/glib/GUniquePtr.h>
 
 #if PLATFORM(WAYLAND)
 #include "AcceleratedBackingStoreWayland.h"
@@ -42,11 +43,34 @@
 namespace WebKit {
 using namespace WebCore;
 
+#if PLATFORM(WAYLAND)
+static bool gtkCanUseHardwareAcceleration()
+{
+    static bool canUseHardwareAcceleration;
+    static std::once_flag onceFlag;
+    std::call_once(onceFlag, [] {
+        GUniqueOutPtr<GError> error;
+#if USE(GTK4)
+        canUseHardwareAcceleration = gdk_display_prepare_gl(gdk_display_get_default(), &error.outPtr());
+#else
+        auto* window = gtk_window_new(GTK_WINDOW_POPUP);
+        gtk_widget_realize(window);
+        auto context = adoptGRef(gdk_window_create_gl_context(gtk_widget_get_window(window), &error.outPtr()));
+        canUseHardwareAcceleration = !!context;
+        gtk_widget_destroy(window);
+#endif
+        if (!canUseHardwareAcceleration)
+            g_warning("Disabled hardware acceleration because GTK failed to initialize GL: %s.", error->message);
+    });
+    return canUseHardwareAcceleration;
+}
+#endif
+
 bool AcceleratedBackingStore::checkRequirements()
 {
 #if PLATFORM(WAYLAND)
     if (PlatformDisplay::sharedDisplay().type() == PlatformDisplay::Type::Wayland)
-        return AcceleratedBackingStoreWayland::checkRequirements();
+        return AcceleratedBackingStoreWayland::checkRequirements() && gtkCanUseHardwareAcceleration();
 #endif
 #if PLATFORM(X11)
     if (PlatformDisplay::sharedDisplay().type() == PlatformDisplay::Type::X11)

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreWayland.h
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreWayland.h
@@ -40,7 +40,6 @@ struct wpe_fdo_egl_exported_image;
 struct wpe_fdo_shm_exported_buffer;
 
 namespace WebCore {
-class GLContext;
 class IntSize;
 }
 
@@ -58,13 +57,12 @@ public:
 private:
     AcceleratedBackingStoreWayland(WebPageProxy&);
 
-    void tryEnsureGLContext();
+    void ensureGLContext();
     void displayImage(struct wpe_fdo_egl_exported_image*);
 #if WPE_FDO_CHECK_VERSION(1,7,0)
     void displayBuffer(struct wpe_fdo_shm_exported_buffer*);
 #endif
     bool tryEnsureTexture(unsigned&, WebCore::IntSize&);
-    void downloadTexture(unsigned, const WebCore::IntSize&);
 
 #if USE(GTK4)
     void snapshot(GtkSnapshot*) override;
@@ -77,9 +75,7 @@ private:
     int renderHostFileDescriptor() override;
 
     RefPtr<cairo_surface_t> m_surface;
-    bool m_glContextInitialized { false };
     GRefPtr<GdkGLContext> m_gdkGLContext;
-    std::unique_ptr<WebCore::GLContext> m_glContext;
 
     struct wpe_view_backend_exportable_fdo* m_exportable { nullptr };
     uint64_t m_surfaceID { 0 };

--- a/Source/cmake/OptionsGTK.cmake
+++ b/Source/cmake/OptionsGTK.cmake
@@ -172,7 +172,7 @@ include(GStreamerDependencies)
 WEBKIT_OPTION_END()
 
 if (USE_GTK4)
-    set(GTK_MINIMUM_VERSION 3.98.5)
+    set(GTK_MINIMUM_VERSION 4.4.0)
     set(GTK_PC_NAME gtk4)
 else ()
     set(GTK_MINIMUM_VERSION 3.22.0)


### PR DESCRIPTION
#### c1109bfc0991d9d552025256e5744fb3bff89492
<pre>
[GTK] Remove the fallback code when GTK fails to create the GL context under wayland
<a href="https://bugs.webkit.org/show_bug.cgi?id=253233">https://bugs.webkit.org/show_bug.cgi?id=253233</a>

Reviewed by Adrian Perez de Castro.

If GTK can&apos;t do hardware acceleration (which is quite unlikely) it&apos;s
better to to just disable acceleration in Webkit too, instead of using
the glReadPixels fallback solution that is slow and mostly untested.

* Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.cpp:
(WebKit::gtkCanUseHardwareAcceleration):
(WebKit::AcceleratedBackingStore::checkRequirements):
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreWayland.cpp:
(WebKit::AcceleratedBackingStoreWayland::unrealize):
(WebKit::AcceleratedBackingStoreWayland::ensureGLContext):
(WebKit::AcceleratedBackingStoreWayland::makeContextCurrent):
(WebKit::AcceleratedBackingStoreWayland::snapshot):
(WebKit::AcceleratedBackingStoreWayland::paint):
(WebKit::AcceleratedBackingStoreWayland::tryEnsureGLContext): Deleted.
(WebKit::AcceleratedBackingStoreWayland::downloadTexture): Deleted.
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreWayland.h:
* Source/cmake/OptionsGTK.cmake:

Canonical link: <a href="https://commits.webkit.org/261126@main">https://commits.webkit.org/261126@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e660938503425830fcbfec84455a4c543e765429

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110682 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19763 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/43245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2020 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/119517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21172 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10875 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/1543 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116423 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/43245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102988 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/43245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/44096 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/99343 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/12398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/43245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/85989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/10471 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12947 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/100409 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18320 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/43245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31321 "Passed tests") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/14885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/108437 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4201 "Built successfully and passed tests") | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26730 "Passed tests") | 
<!--EWS-Status-Bubble-End-->