### PR TITLE
Move background fetch quota check to BackgroundFetchStoreManager

### DIFF
--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetch.h
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetch.h
@@ -124,6 +124,7 @@ public:
     uint64_t downloadTotal() const { return  m_options.downloadTotal; }
     uint64_t uploadTotal() const { return m_uploadTotal; }
 
+    void doStore(CompletionHandler<void(BackgroundFetchStore::StoreResult)>&&);
     void unsetRecordsAvailableFlag();
 
 private:
@@ -136,7 +137,6 @@ private:
     void handleStoreResult(BackgroundFetchStore::StoreResult);
     void updateBackgroundFetchStatus(BackgroundFetchResult, BackgroundFetchFailureReason);
 
-    void doStore();
     void setRecords(Vector<Ref<Record>>&& records) { m_records = WTFMove(records); }
 
     String m_identifier;

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchEngine.cpp
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchEngine.cpp
@@ -69,31 +69,26 @@ void BackgroundFetchEngine::startBackgroundFetch(SWServerRegistration& registrat
         return;
     }
 
-    WeakPtr fetch { *result.iterator->value };
-
-    // FIXME: We should wait for upload data to be fully read.
-    uint64_t expectedSpace;
-    bool isSafe = WTF::safeAdd(fetch->downloadTotal(), fetch->uploadTotal(), expectedSpace);
-    if (!isSafe) {
-        callback(makeUnexpected(ExceptionData { QuotaExceededError, "Background fetch requested space is above quota"_s }));
-        return;
-    }
-
-    m_server->requestBackgroundFetchSpace(fetch->origin(), expectedSpace, [server = m_server, fetch = WTFMove(fetch), callback = WTFMove(callback)](bool result) mutable {
+    auto& fetch = *result.iterator->value;
+    fetch.doStore([server = m_server, fetch = WeakPtr { fetch }, callback = WTFMove(callback)](auto result) mutable {
         if (!fetch || !server) {
             callback(makeUnexpected(ExceptionData { TypeError, "Background fetch is gone"_s }));
             return;
         }
-        if (!result) {
+        switch (result) {
+        case BackgroundFetchStore::StoreResult::QuotaError:
             callback(makeUnexpected(ExceptionData { QuotaExceededError, "Background fetch requested space is above quota"_s }));
-            return;
-        }
-
-        fetch->perform([server = WTFMove(server)](auto& client, auto& request, auto& origin) mutable {
-            return server ? server->createBackgroundFetchRecordLoader(client, request, origin) : nullptr;
-        });
-
-        callback(fetch->information());
+            break;
+        case BackgroundFetchStore::StoreResult::InternalError:
+            callback(makeUnexpected(ExceptionData { TypeError, "Background fetch store operation failed"_s }));
+            break;
+        case BackgroundFetchStore::StoreResult::OK:
+            fetch->perform([server = WTFMove(server)](auto& client, auto& request, auto& origin) mutable {
+                return server ? server->createBackgroundFetchRecordLoader(client, request, origin) : nullptr;
+            });
+            callback(fetch->information());
+            break;
+        };
     });
 }
 

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchStore.h
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchStore.h
@@ -58,7 +58,7 @@ public:
     virtual void clearAllFetches(const ServiceWorkerRegistrationKey&, CompletionHandler<void()>&& = [] { }) = 0;
 
     enum class StoreResult : uint8_t { OK, QuotaError, InternalError };
-    virtual void storeFetch(const ServiceWorkerRegistrationKey&, const String&, Vector<uint8_t>&&, CompletionHandler<void(StoreResult)>&&) = 0;
+    virtual void storeFetch(const ServiceWorkerRegistrationKey&, const String&, uint64_t downloadTotal, uint64_t uploadTotal, Vector<uint8_t>&&, CompletionHandler<void(StoreResult)>&&) = 0;
     virtual void storeFetchResponseBodyChunk(const ServiceWorkerRegistrationKey&, const String&, size_t, const SharedBuffer&, CompletionHandler<void(StoreResult)>&&) = 0;
 
     using RetrieveRecordResponseBodyCallback = Function<void(Expected<RefPtr<SharedBuffer>, ResourceError>&&)>;

--- a/Source/WebCore/workers/service/server/SWServer.h
+++ b/Source/WebCore/workers/service/server/SWServer.h
@@ -282,7 +282,6 @@ public:
 
     void requestBackgroundFetchPermission(const ClientOrigin& clientOrigin, CompletionHandler<void(bool)>&& callback) { m_delegate->requestBackgroundFetchPermission(clientOrigin, WTFMove(callback)); }
     std::unique_ptr<BackgroundFetchRecordLoader> createBackgroundFetchRecordLoader(BackgroundFetchRecordLoader::Client& client, const BackgroundFetchRequest& request, const WebCore::ClientOrigin& origin) { return m_delegate->createBackgroundFetchRecordLoader(client, request, origin); }
-    void requestBackgroundFetchSpace(const ClientOrigin& origin, uint64_t size, CompletionHandler<void(bool)>&& callback) { m_delegate->requestBackgroundFetchSpace(origin, size, WTFMove(callback)); }
     Ref<BackgroundFetchStore> createBackgroundFetchStore() { return m_delegate->createBackgroundFetchStore(); }
 
 private:

--- a/Source/WebCore/workers/service/server/SWServerDelegate.h
+++ b/Source/WebCore/workers/service/server/SWServerDelegate.h
@@ -56,7 +56,6 @@ public:
 
     virtual void requestBackgroundFetchPermission(const ClientOrigin&, CompletionHandler<void(bool)>&&) = 0;
     virtual std::unique_ptr<BackgroundFetchRecordLoader> createBackgroundFetchRecordLoader(BackgroundFetchRecordLoader::Client&, const BackgroundFetchRequest&, const WebCore::ClientOrigin&) = 0;
-    virtual void requestBackgroundFetchSpace(const ClientOrigin&, uint64_t size, CompletionHandler<void(bool)>&&) = 0;
     virtual Ref<BackgroundFetchStore> createBackgroundFetchStore() = 0;
 };
 

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -746,11 +746,6 @@ std::unique_ptr<BackgroundFetchRecordLoader> NetworkSession::createBackgroundFet
     return makeUnique<BackgroundFetchLoad>(m_networkProcess.get(), m_sessionID, client, request, clientOrigin);
 }
 
-void NetworkSession::requestBackgroundFetchSpace(const ClientOrigin& origin, uint64_t size, CompletionHandler<void(bool)>&& callback)
-{
-    m_storageManager->requestSpace(origin, size, WTFMove(callback));
-}
-
 Ref<BackgroundFetchStore> NetworkSession::createBackgroundFetchStore()
 {
     return BackgroundFetchStoreImpl::create(m_storageManager.get());

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -275,7 +275,6 @@ protected:
     void addAllowedFirstPartyForCookies(WebCore::ProcessIdentifier, std::optional<WebCore::ProcessIdentifier>, WebCore::RegistrableDomain&&) final;
     void requestBackgroundFetchPermission(const WebCore::ClientOrigin&, CompletionHandler<void(bool)>&&) final;
     std::unique_ptr<WebCore::BackgroundFetchRecordLoader> createBackgroundFetchRecordLoader(WebCore::BackgroundFetchRecordLoader::Client&, const WebCore::BackgroundFetchRequest&, const WebCore::ClientOrigin&) final;
-    void requestBackgroundFetchSpace(const WebCore::ClientOrigin&, uint64_t size, CompletionHandler<void(bool)>&&) final;
     Ref<WebCore::BackgroundFetchStore> createBackgroundFetchStore() final;
 #endif // ENABLE(SERVICE_WORKER)
 

--- a/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.cpp
+++ b/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.cpp
@@ -182,7 +182,7 @@ void BackgroundFetchStoreImpl::clearAllFetches(const ServiceWorkerRegistrationKe
     });
 }
 
-void BackgroundFetchStoreImpl::storeFetch(const ServiceWorkerRegistrationKey& key, const String& identifier, Vector<uint8_t>&& fetch, CompletionHandler<void(StoreResult)>&& callback)
+void BackgroundFetchStoreImpl::storeFetch(const ServiceWorkerRegistrationKey& key, const String& identifier, uint64_t downloadTotal, uint64_t uploadTotal, Vector<uint8_t>&& fetch, CompletionHandler<void(StoreResult)>&& callback)
 {
     if (!m_manager) {
         callback(StoreResult::InternalError);
@@ -209,14 +209,14 @@ void BackgroundFetchStoreImpl::storeFetch(const ServiceWorkerRegistrationKey& ke
         callback(result);
     };
 
-    m_manager->dispatchTaskToBackgroundFetchManager(origin, [fetchStorageIdentifier = crossThreadCopy(fetchStorageIdentifier), fetch = WTFMove(fetch), internalCallback = WTFMove(internalCallback)](auto* backgroundFetchManager) mutable {
+    m_manager->dispatchTaskToBackgroundFetchManager(origin, [fetchStorageIdentifier = crossThreadCopy(fetchStorageIdentifier), downloadTotal, uploadTotal, fetch = WTFMove(fetch), internalCallback = WTFMove(internalCallback)](auto* backgroundFetchManager) mutable {
         if (!backgroundFetchManager) {
             callOnMainRunLoop([internalCallback = WTFMove(internalCallback)]() mutable {
                 internalCallback(StoreResult::InternalError);
             });
             return;
         }
-        backgroundFetchManager->storeFetch(fetchStorageIdentifier, WTFMove(fetch), [internalCallback = WTFMove(internalCallback)](auto result) mutable {
+        backgroundFetchManager->storeFetch(fetchStorageIdentifier, downloadTotal, uploadTotal, WTFMove(fetch), [internalCallback = WTFMove(internalCallback)](auto result) mutable {
             callOnMainRunLoop([result, internalCallback = WTFMove(internalCallback)]() mutable {
                 internalCallback(result);
             });

--- a/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.h
+++ b/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.h
@@ -49,7 +49,7 @@ private:
     void initializeFetches(WebCore::BackgroundFetchEngine&, const WebCore::ServiceWorkerRegistrationKey&, CompletionHandler<void()>&&) final;
     void clearFetch(const WebCore::ServiceWorkerRegistrationKey&, const String&, CompletionHandler<void()>&&) final;
     void clearAllFetches(const WebCore::ServiceWorkerRegistrationKey&, CompletionHandler<void()>&&) final;
-    void storeFetch(const WebCore::ServiceWorkerRegistrationKey&, const String&, Vector<uint8_t>&&, CompletionHandler<void(StoreResult)>&&) final;
+    void storeFetch(const WebCore::ServiceWorkerRegistrationKey&, const String&, uint64_t downloadTotal, uint64_t uploadTotal, Vector<uint8_t>&&, CompletionHandler<void(StoreResult)>&&) final;
     void storeFetchResponseBodyChunk(const WebCore::ServiceWorkerRegistrationKey&, const String&, size_t, const WebCore::SharedBuffer&, CompletionHandler<void(StoreResult)>&&) final;
     void retrieveResponseBody(const WebCore::ServiceWorkerRegistrationKey&, const String&, size_t, RetrieveRecordResponseBodyCallback&&) final;
 


### PR DESCRIPTION
#### 6ca935cd0146420d7abb35ae3b666152f26db1d1
<pre>
Move background fetch quota check to BackgroundFetchStoreManager
<a href="https://bugs.webkit.org/show_bug.cgi?id=253234">https://bugs.webkit.org/show_bug.cgi?id=253234</a>
rdar://problem/106135736

Reviewed by Chris Dumez.

Move the quota check from WebCore/BackgroundFetchEngine to WebKit/BackgroundFetchStoreManager.
We pass down downloadTotal and uploadTotal for that reason.

Resolve the background fetch promise after the quota check and the store operation have been done.
This should solve http/wpt/background-fetch/background-fetch-persistency.window.html flakiness.

* Source/WebCore/workers/service/background-fetch/BackgroundFetch.cpp:
(WebCore::BackgroundFetch::storeResponse):
(WebCore::BackgroundFetch::doStore):
* Source/WebCore/workers/service/background-fetch/BackgroundFetch.h:
* Source/WebCore/workers/service/background-fetch/BackgroundFetchEngine.cpp:
(WebCore::BackgroundFetchEngine::startBackgroundFetch):
* Source/WebCore/workers/service/background-fetch/BackgroundFetchStore.h:
* Source/WebCore/workers/service/server/SWServer.h:
(WebCore::SWServer::createBackgroundFetchRecordLoader):
(WebCore::SWServer::requestBackgroundFetchSpace): Deleted.
* Source/WebCore/workers/service/server/SWServerDelegate.h:
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::NetworkSession::requestBackgroundFetchSpace): Deleted.
* Source/WebKit/NetworkProcess/NetworkSession.h:
* Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.cpp:
(WebKit::BackgroundFetchStoreImpl::storeFetch):
* Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.h:
* Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreManager.cpp:
(WebKit::BackgroundFetchStoreManager::BackgroundFetchStoreManager):
(WebKit::BackgroundFetchStoreManager::storeFetch):
(WebKit::BackgroundFetchStoreManager::storeFetchAfterQuotaCheck):
* Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreManager.h:
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp:
(WebKit::OriginStorageManager::StorageBucket::backgroundFetchManager):
(WebKit::OriginStorageManager::backgroundFetchManager):

Canonical link: <a href="https://commits.webkit.org/261095@main">https://commits.webkit.org/261095@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc76346e5e4299da0ce15e021faaa5a3de3f6239

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110484 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19568 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/43161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1853 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119373 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114431 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20998 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10716 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102719 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116226 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15635 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98821 "Build was cancelled. Recent messages:Encountered some issues during cleanup") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43868 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97596 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30492 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85735 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12222 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31827 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12799 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8793 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18162 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51447 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7689 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14666 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->