### PR TITLE
[GStreamer] GRefPtr template specialization for GstDeviceMonitor

### DIFF
--- a/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp
@@ -63,7 +63,7 @@ static unsigned long maximumNumberOfOutputChannels()
         auto monitor = adoptGRef(gst_device_monitor_new());
         auto caps = adoptGRef(gst_caps_new_empty_simple("audio/x-raw"));
         gst_device_monitor_add_filter(monitor.get(), "Audio/Sink", caps.get());
-        gst_device_monitor_start(monitor.get());
+        bool started = gst_device_monitor_start(monitor.get());
         auto* devices = gst_device_monitor_get_devices(monitor.get());
         while (devices) {
             auto device = adoptGRef(GST_DEVICE_CAST(devices->data));
@@ -81,7 +81,8 @@ static unsigned long maximumNumberOfOutputChannels()
             devices = g_list_delete_link(devices, devices);
         }
         GST_DEBUG("maximumNumberOfOutputChannels: %d", count);
-        gst_device_monitor_stop(monitor.get());
+        if (started)
+            gst_device_monitor_stop(monitor.get());
     });
 
     return count;

--- a/Source/WebCore/platform/graphics/gstreamer/GRefPtrGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GRefPtrGStreamer.cpp
@@ -464,6 +464,28 @@ void derefGPtr<GstClock>(GstClock* ptr)
         gst_object_unref(ptr);
 }
 
+template <>
+GRefPtr<GstDeviceMonitor> adoptGRef(GstDeviceMonitor* ptr)
+{
+    return GRefPtr<GstDeviceMonitor>(ptr, GRefPtrAdopt);
+}
+
+template <>
+GstDeviceMonitor* refGPtr<GstDeviceMonitor>(GstDeviceMonitor* ptr)
+{
+    if (ptr)
+        gst_object_ref(GST_OBJECT_CAST(ptr));
+
+    return ptr;
+}
+
+template <>
+void derefGPtr<GstDeviceMonitor>(GstDeviceMonitor* ptr)
+{
+    if (ptr)
+        gst_object_unref(ptr);
+}
+
 template <> GRefPtr<WebKitVideoSink> adoptGRef(WebKitVideoSink* ptr)
 {
     ASSERT(!ptr || !g_object_is_floating(ptr));

--- a/Source/WebCore/platform/graphics/gstreamer/GRefPtrGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GRefPtrGStreamer.h
@@ -145,6 +145,10 @@ template<> GRefPtr<GstClock> adoptGRef(GstClock*);
 template<> GstClock* refGPtr<GstClock>(GstClock*);
 template<> void derefGPtr<GstClock>(GstClock*);
 
+template<> GRefPtr<GstDeviceMonitor> adoptGRef(GstDeviceMonitor*);
+template<> GstDeviceMonitor* refGPtr<GstDeviceMonitor>(GstDeviceMonitor*);
+template<> void derefGPtr<GstDeviceMonitor>(GstDeviceMonitor*);
+
 #if USE(GSTREAMER_GL)
 template<> GRefPtr<GstGLDisplay> adoptGRef(GstGLDisplay* ptr);
 template<> GstGLDisplay* refGPtr<GstGLDisplay>(GstGLDisplay* ptr);


### PR DESCRIPTION
#### c9a7acf64ee345688a8b9d4bec7a63a0128be7e3
<pre>
[GStreamer] GRefPtr template specialization for GstDeviceMonitor
<a href="https://bugs.webkit.org/show_bug.cgi?id=253237">https://bugs.webkit.org/show_bug.cgi?id=253237</a>

Reviewed by Xabier Rodriguez-Calvar.

We&apos;re (hopefully) not fixing a leak here, since without specialization the generic
g_object_ref/unref would be called. But having a specialization for this object is still a good
thing, allowing for instance the GStreamer leak tracer to correctly track lifetime of device
monitors.

Also, drive-by, stop the monitor only if it was successfully started, similarily to the
CaptureDeviceManager implementation.

* Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp:
(WebCore::maximumNumberOfOutputChannels):
* Source/WebCore/platform/graphics/gstreamer/GRefPtrGStreamer.cpp:
(WTF::adoptGRef):
(WTF::refGPtr&lt;GstDeviceMonitor&gt;):
(WTF::derefGPtr&lt;GstDeviceMonitor&gt;):
* Source/WebCore/platform/graphics/gstreamer/GRefPtrGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/261070@main">https://commits.webkit.org/261070@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3bfb1ca1ea95f79e35706b855472e6972a4fab37

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110494 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19578 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43084 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1863 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119382 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114441 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21008 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10726 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102729 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116236 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43876 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30500 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85743 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12232 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31835 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12809 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8801 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18172 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51455 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7671 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14676 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->