### PR TITLE
[web-animations] add a class to store accelerated effects and base values

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1551,6 +1551,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/WindowsKeyboardCodes.h
 
     platform/animation/AcceleratedEffect.h
+    platform/animation/AcceleratedEffectStack.h
     platform/animation/AcceleratedEffectValues.h
     platform/animation/Animation.h
     platform/animation/AnimationList.h

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -244,6 +244,7 @@ page/scrolling/mac/ScrollingTreeMac.mm
 page/scrolling/mac/ScrollingTreeOverflowScrollingNodeMac.mm
 page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
 platform/VideoFrame.mm
+platform/animation/AcceleratedEffectStack.mm @no-unify
 platform/audio/AudioSession.cpp
 platform/audio/cocoa/AudioDestinationCocoa.cpp
 platform/audio/cocoa/AudioFileReaderCocoa.cpp

--- a/Source/WebCore/platform/animation/AcceleratedEffect.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.cpp
@@ -85,6 +85,11 @@ static AcceleratedEffectProperty acceleratedPropertyFromCSSProperty(AnimatablePr
     }
 }
 
+Ref<AcceleratedEffect> AcceleratedEffect::copyWithProperties(OptionSet<AcceleratedEffectProperty>& propertyFilter)
+{
+    return adoptRef(*new AcceleratedEffect(*this, propertyFilter));
+}
+
 Ref<AcceleratedEffect> AcceleratedEffect::create(const KeyframeEffect& effect)
 {
     return adoptRef(*new AcceleratedEffect(effect));
@@ -181,6 +186,44 @@ AcceleratedEffect::AcceleratedEffect(Vector<AcceleratedEffectKeyframe>&& keyfram
     , m_startTime(startTime)
     , m_holdTime(holdTime)
 {
+}
+
+AcceleratedEffect::AcceleratedEffect(const AcceleratedEffect& source, OptionSet<AcceleratedEffectProperty>& propertyFilter)
+{
+    m_animationType = source.m_animationType;
+    m_fill = source.m_fill;
+    m_direction = source.m_direction;
+    m_compositeOperation = source.m_compositeOperation;
+    m_paused = source.m_paused;
+    m_iterationStart = source.m_iterationStart;
+    m_iterations = source.m_iterations;
+    m_playbackRate = source.m_playbackRate;
+    m_delay = source.m_delay;
+    m_endDelay = source.m_endDelay;
+    m_iterationDuration = source.m_iterationDuration;
+    m_activeDuration = source.m_activeDuration;
+    m_endTime = source.m_endTime;
+    m_startTime = source.m_startTime;
+    m_holdTime = source.m_holdTime;
+
+    m_timingFunction = source.m_timingFunction.copyRef();
+    m_defaultKeyframeTimingFunction = source.m_defaultKeyframeTimingFunction.copyRef();
+
+    for (auto& srcKeyframe : source.m_keyframes) {
+        auto& animatedProperties = srcKeyframe.animatedProperties;
+        if (!animatedProperties.containsAny(propertyFilter))
+            continue;
+
+        AcceleratedEffectKeyframe keyframe;
+        keyframe.offset = srcKeyframe.offset;
+        keyframe.values = srcKeyframe.values;
+        keyframe.compositeOperation = srcKeyframe.compositeOperation;
+        keyframe.animatedProperties = srcKeyframe.animatedProperties & propertyFilter;
+        keyframe.timingFunction = srcKeyframe.timingFunction.copyRef();
+
+        m_animatedProperties.add(keyframe.animatedProperties);
+        m_keyframes.append(WTFMove(keyframe));
+    }
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/animation/AcceleratedEffect.h
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.h
@@ -76,6 +76,8 @@ public:
 
     virtual ~AcceleratedEffect() = default;
 
+    WEBCORE_EXPORT Ref<AcceleratedEffect> copyWithProperties(OptionSet<AcceleratedEffectProperty>&);
+
     // Encoding and decoding support
     const Vector<AcceleratedEffectKeyframe>& keyframes() const { return m_keyframes; }
     WebAnimationType animationType() const { return m_animationType; }
@@ -100,6 +102,7 @@ public:
 private:
     AcceleratedEffect(const KeyframeEffect&);
     explicit AcceleratedEffect(Vector<AcceleratedEffectKeyframe>&&, WebAnimationType, FillMode, PlaybackDirection, CompositeOperation, RefPtr<TimingFunction>&& timingFunction, RefPtr<TimingFunction>&& defaultKeyframeTimingFunction, OptionSet<AcceleratedEffectProperty>&&, bool paused, double iterationStart, double iterations, double playbackRate, WTF::Seconds delay, WTF::Seconds endDelay, WTF::Seconds iterationDuration, WTF::Seconds activeDuration, WTF::Seconds endTime, std::optional<WTF::Seconds> startTime, std::optional<WTF::Seconds> holdTime);
+    explicit AcceleratedEffect(const AcceleratedEffect&, OptionSet<AcceleratedEffectProperty>&);
 
     Vector<AcceleratedEffectKeyframe> m_keyframes;
     WebAnimationType m_animationType { WebAnimationType::WebAnimation };

--- a/Source/WebCore/platform/animation/AcceleratedEffectStack.h
+++ b/Source/WebCore/platform/animation/AcceleratedEffectStack.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+
+#include "AcceleratedEffectValues.h"
+
+namespace WebCore {
+
+class AcceleratedEffect;
+
+using AcceleratedEffects = Vector<Ref<AcceleratedEffect>>;
+
+class AcceleratedEffectStack {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    WEBCORE_EXPORT explicit AcceleratedEffectStack();
+    WEBCORE_EXPORT ~AcceleratedEffectStack();
+
+    WEBCORE_EXPORT bool hasEffects() const;
+    const AcceleratedEffects& primaryLayerEffects() const { return m_primaryLayerEffects; }
+    const AcceleratedEffects& backdropLayerEffects() const { return m_backdropLayerEffects; }
+    WEBCORE_EXPORT void setEffects(AcceleratedEffects&&);
+
+    const AcceleratedEffectValues& baseValues() { return m_baseValues; }
+    WEBCORE_EXPORT void setBaseValues(AcceleratedEffectValues&&);
+
+private:
+    AcceleratedEffectValues m_baseValues;
+    AcceleratedEffects m_primaryLayerEffects;
+    AcceleratedEffects m_backdropLayerEffects;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(THREADED_ANIMATION_RESOLUTION)

--- a/Source/WebCore/platform/animation/AcceleratedEffectStack.mm
+++ b/Source/WebCore/platform/animation/AcceleratedEffectStack.mm
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "AcceleratedEffectStack.h"
+
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+
+#include "AcceleratedEffect.h"
+
+namespace WebCore {
+
+AcceleratedEffectStack::AcceleratedEffectStack()
+{
+}
+
+AcceleratedEffectStack::~AcceleratedEffectStack()
+{
+}
+
+bool AcceleratedEffectStack::hasEffects() const
+{
+    return !m_primaryLayerEffects.isEmpty() || !m_backdropLayerEffects.isEmpty();
+}
+
+void AcceleratedEffectStack::setEffects(AcceleratedEffects&& effects)
+{
+    m_primaryLayerEffects.clear();
+    m_backdropLayerEffects.clear();
+
+    for (auto effect : effects) {
+        auto& animatedProperties = effect->animatedProperties();
+
+        // If we don't have a keyframe targeting backdrop-filter, we can add the effect
+        // as-is to the set of effects targeting the primary layer.
+        if (!animatedProperties.contains(AcceleratedEffectProperty::BackdropFilter)) {
+            m_primaryLayerEffects.append(effect);
+            continue;
+        }
+
+        // If the only property targeted is backdrop-filter, we can add the effect
+        // as-is to the set of effects targeting the backdrop layer.
+        if (animatedProperties.hasExactlyOneBitSet()) {
+            m_backdropLayerEffects.append(effect);
+            continue;
+        }
+
+        // Otherwise, this means we have effects targeting both the primary and backdrop
+        // layers, so we must split the effect in two: one for backdrop-filter, and one
+        // for all other properties.
+        OptionSet<AcceleratedEffectProperty> primaryProperties = animatedProperties - AcceleratedEffectProperty::BackdropFilter;
+        m_primaryLayerEffects.append(effect->copyWithProperties(primaryProperties));
+        OptionSet<AcceleratedEffectProperty> backdropProperties = { AcceleratedEffectProperty::BackdropFilter };
+        m_backdropLayerEffects.append(effect->copyWithProperties(backdropProperties));
+    }
+}
+
+void AcceleratedEffectStack::setBaseValues(AcceleratedEffectValues&& values)
+{
+    m_baseValues = WTFMove(values);
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(THREADED_ANIMATION_RESOLUTION)


### PR DESCRIPTION
#### a72ec6fd7a8a6760edb59b3fb9ee079ac58b4b57
<pre>
[web-animations] add a class to store accelerated effects and base values
<a href="https://bugs.webkit.org/show_bug.cgi?id=253238">https://bugs.webkit.org/show_bug.cgi?id=253238</a>

Reviewed by Dean Jackson.

Add a new AcceleratedEffectStack class which we will use to store a sorted stack
of accelerated effects and the base values to be used for blending on platform layers.

Since there are separate layers for backdrop-filter and all other accelerated properties,
we separate the set of effects passed to AcceleratedEffectStack::setEffects() between
effects that will target primary layers and those affecting backdrop layers.

* Source/WebCore/Headers.cmake:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/animation/AcceleratedEffect.cpp:
(WebCore::AcceleratedEffect::copyWithProperties):
(WebCore::AcceleratedEffect::AcceleratedEffect):
* Source/WebCore/platform/animation/AcceleratedEffect.h:
* Source/WebCore/platform/animation/AcceleratedEffectStack.h: Added.
(WebCore::AcceleratedEffectStack::primaryLayerEffects const):
(WebCore::AcceleratedEffectStack::backdropLayerEffects const):
(WebCore::AcceleratedEffectStack::baseValues):
* Source/WebCore/platform/animation/AcceleratedEffectStack.mm: Added.
(WebCore::AcceleratedEffectStack::AcceleratedEffectStack):
(WebCore::AcceleratedEffectStack::~AcceleratedEffectStack):
(WebCore::AcceleratedEffectStack::hasEffects const):
(WebCore::AcceleratedEffectStack::setEffects):
(WebCore::AcceleratedEffectStack::setBaseValues):

Canonical link: <a href="https://commits.webkit.org/261067@main">https://commits.webkit.org/261067@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a5bab22a03c15a3ed09e87332e133af0189b9d7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110496 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19580 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43086 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1865 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119384 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114443 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21010 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10728 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102731 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116238 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43880 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/30503 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/85754 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12234 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31838 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12811 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18174 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51458 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14678 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4171 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->