### PR TITLE
Regions too big to be interactions should still be checked for occlusions

### DIFF
--- a/LayoutTests/interaction-region/full-page-overlay-expected.txt
+++ b/LayoutTests/interaction-region/full-page-overlay-expected.txt
@@ -10,7 +10,25 @@
       (event region
         (rect (0,0) width=1536 height=2008)
       )
-      (children 1
+      (children 2
+        (GraphicsLayer
+          (preserves3D 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 1536.00 2008.00)
+              (contentsOpaque 1)
+              (event region
+                (rect (0,0) width=1536 height=2008)
+
+              (interaction regions [
+                (occlusion
+                    (rect (0,0) width=1536 height=2008)
+)
+                (borderRadius 0.00)])
+              )
+            )
+          )
+        )
         (GraphicsLayer
           (preserves3D 1)
           (children 1

--- a/LayoutTests/interaction-region/full-page-overlay.html
+++ b/LayoutTests/interaction-region/full-page-overlay.html
@@ -19,6 +19,10 @@
             background-color: purple;
         }
 
+        .tappable-overlay {
+            cursor: pointer;
+        }
+
         .spacer {
             height: 2000px;
         }
@@ -26,10 +30,15 @@
 </head>
 <body>
 <div class="overlay"></div>
+<div class="tappable-overlay overlay"></div>
 <div class="spacer"></div>
 
 <pre id="results"></pre>
 <script>
+document.body.addEventListener("click", function(e) {
+    console.log(e, "event delegation");
+});
+
 if (window.testRunner)
     testRunner.dumpAsText();
 

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -163,7 +163,8 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
     // FIXME: Consider also allowing elements that only receive touch events.
     bool hasListener = renderer.style().eventListenerRegionTypes().contains(EventListenerRegionType::MouseClick);
     bool hasPointer = cursorTypeForElement(*matchedElement) == CursorType::Pointer || shouldAllowNonPointerCursorForElement(*matchedElement);
-    if (!hasListener || !hasPointer) {
+    bool isTooBigForInteraction = checkedRegionArea.value() > frameViewArea / 2;
+    if (!hasListener || !hasPointer || isTooBigForInteraction) {
         bool isOverlay = checkedRegionArea.value() <= frameViewArea && (renderer.style().specifiedZIndex() > 0 || renderer.isFixedPositioned());
         if (isOverlay && isOriginalMatch) {
             Region boundsRegion;
@@ -179,9 +180,6 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
 
         return std::nullopt;
     }
-
-    if (checkedRegionArea.value() > frameViewArea / 2)
-        return std::nullopt;
 
     bool isInlineNonBlock = renderer.isInline() && !renderer.isReplacedOrInlineBlock();
 


### PR DESCRIPTION
#### 53cde672f341f27622950ce540b8bf3be392cda0
<pre>
Regions too big to be interactions should still be checked for occlusions
<a href="https://bugs.webkit.org/show_bug.cgi?id=253241">https://bugs.webkit.org/show_bug.cgi?id=253241</a>
&lt;rdar://105909931&gt;

Reviewed by Tim Horton.

Before we discard an interaction region based on its area, check to
see if we should generate a corresponding occlusion region.
(Occlusions use a higher area limit.)

* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::interactionRegionForRenderedRegion):
Extract the interaction area check to a variable.
Use it as part of the occlusion branch&apos;s condition.

* LayoutTests/interaction-region/full-page-overlay-expected.txt:
* LayoutTests/interaction-region/full-page-overlay.html:
Update the overlay test to cover this case.

Canonical link: <a href="https://commits.webkit.org/261108@main">https://commits.webkit.org/261108@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/653c0a01a4eae5366487045d5bd39cae1d5415c9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110501 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19585 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/43167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1871 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119389 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114448 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21015 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10733 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102736 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116243 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15659 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98858 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43884 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97610 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30505 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85752 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12239 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31840 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12816 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8807 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18179 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51460 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7699 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14683 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->