### PR TITLE
[web-animations] store, encode and decode accelerated effects on GraphicsLayer and PlatformCALayer

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.cpp
@@ -39,6 +39,10 @@
 #include <wtf/text/TextStream.h>
 #include <wtf/text/WTFString.h>
 
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+#include "AcceleratedEffectStack.h"
+#endif
+
 #ifndef NDEBUG
 #include <stdio.h>
 #endif
@@ -727,6 +731,22 @@ int GraphicsLayer::validateFilterOperations(const KeyframeValueList& valueList)
     
     return firstIndex;
 }
+
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+void GraphicsLayer::setAcceleratedEffectsAndBaseValues(AcceleratedEffects&& effects, AcceleratedEffectValues&& baseValues)
+{
+    if (effects.isEmpty()) {
+        m_effectStack = nullptr;
+        return;
+    }
+
+    if (!m_effectStack)
+        m_effectStack = makeUnique<AcceleratedEffectStack>();
+
+    m_effectStack->setEffects(WTFMove(effects));
+    m_effectStack->setBaseValues(WTFMove(baseValues));
+}
+#endif
 
 double GraphicsLayer::backingStoreMemoryEstimate() const
 {

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -53,6 +53,10 @@
 #include "GraphicsTypes.h"
 #endif
 
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+#include "AcceleratedEffectStack.h"
+#endif
+
 namespace WTF {
 class TextStream;
 }
@@ -70,6 +74,10 @@ class Model;
 class TiledBacking;
 class TimingFunction;
 class TransformationMatrix;
+
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+struct AcceleratedEffectValues;
+#endif
 
 namespace DisplayList {
 enum class AsTextFlag : uint8_t;
@@ -666,6 +674,11 @@ public:
 
     static void traverse(GraphicsLayer&, const Function<void(GraphicsLayer&)>&);
 
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    AcceleratedEffectStack* acceleratedEffectStack() const { return m_effectStack.get(); }
+    WEBCORE_EXPORT virtual void setAcceleratedEffectsAndBaseValues(AcceleratedEffects&&, AcceleratedEffectValues&&);
+#endif
+
 protected:
     WEBCORE_EXPORT explicit GraphicsLayer(Type, GraphicsLayerClient&);
 
@@ -702,6 +715,10 @@ protected:
     virtual void dumpAdditionalProperties(WTF::TextStream&, OptionSet<LayerTreeAsTextOptions>) const { }
 
     WEBCORE_EXPORT virtual void getDebugBorderInfo(Color&, float& width) const;
+
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    std::unique_ptr<AcceleratedEffectStack> m_effectStack;
+#endif
 
     GraphicsLayerClient* m_client; // Always non-null.
     String m_name;

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -202,6 +202,10 @@ public:
 
     WEBCORE_EXPORT RefPtr<GraphicsLayerAsyncContentsDisplayDelegate> createAsyncContentsDisplayDelegate() override;
 
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    WEBCORE_EXPORT void setAcceleratedEffectsAndBaseValues(AcceleratedEffects&&, AcceleratedEffectValues&&) override;
+#endif
+
 private:
     bool isGraphicsLayerCA() const override { return true; }
 

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayer.cpp
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayer.cpp
@@ -183,6 +183,16 @@ void PlatformCALayer::clearContents()
     setContents(nullptr);
 }
 
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+void PlatformCALayer::clearAcceleratedEffectsAndBaseValues()
+{
+}
+
+void PlatformCALayer::setAcceleratedEffectsAndBaseValues(const AcceleratedEffects&, AcceleratedEffectValues&)
+{
+}
+#endif
+
 void PlatformCALayer::dumpAdditionalProperties(TextStream&, OptionSet<PlatformLayerTreeAsTextFlags>)
 {
 }

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
@@ -52,6 +52,11 @@ class PlatformCALayerClient;
 
 typedef Vector<RefPtr<PlatformCALayer>> PlatformCALayerList;
 
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+class AcceleratedEffect;
+struct AcceleratedEffectValues;
+#endif
+
 #if HAVE(IOSURFACE)
 class IOSurface;
 #endif
@@ -145,6 +150,11 @@ public:
     virtual void addAnimationForKey(const String& key, PlatformCAAnimation&) = 0;
     virtual void removeAnimationForKey(const String& key) = 0;
     virtual RefPtr<PlatformCAAnimation> animationForKey(const String& key) = 0;
+
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    virtual void clearAcceleratedEffectsAndBaseValues();
+    virtual void setAcceleratedEffectsAndBaseValues(const AcceleratedEffects&, AcceleratedEffectValues&);
+#endif
 
     virtual void setMask(PlatformCALayer*) = 0;
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
@@ -51,6 +51,11 @@
 #include "DynamicViewportSizeUpdate.h"
 #endif
 
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+#include <WebCore/AcceleratedEffect.h>
+#include <WebCore/AcceleratedEffectValues.h>
+#endif
+
 namespace IPC {
 class Decoder;
 class Encoder;
@@ -166,6 +171,10 @@ public:
 
         Vector<std::pair<String, PlatformCAAnimationRemote::Properties>> addedAnimations;
         HashSet<String> keysOfAnimationsToRemove;
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+        Vector<Ref<WebCore::AcceleratedEffect>> effects;
+        WebCore::AcceleratedEffectValues baseValues;
+#endif
 
         WebCore::FloatPoint3D position;
         WebCore::FloatPoint3D anchorPoint { 0.5, 0.5, 0 };

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
@@ -131,6 +131,10 @@ RemoteLayerTreeTransaction::LayerProperties::LayerProperties(const LayerProperti
     , children(other.children)
     , addedAnimations(other.addedAnimations)
     , keysOfAnimationsToRemove(other.keysOfAnimationsToRemove)
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    , effects(other.effects)
+    , baseValues(other.baseValues)
+#endif
     , position(other.position)
     , anchorPoint(other.anchorPoint)
     , bounds(other.bounds)
@@ -198,6 +202,10 @@ void RemoteLayerTreeTransaction::LayerProperties::encode(IPC::Encoder& encoder) 
     if (changedProperties & LayerChange::AnimationsChanged) {
         encoder << addedAnimations;
         encoder << keysOfAnimationsToRemove;
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+        encoder << effects;
+        encoder << baseValues;
+#endif
     }
 
     if (changedProperties & LayerChange::PositionChanged)
@@ -354,6 +362,13 @@ bool RemoteLayerTreeTransaction::LayerProperties::decode(IPC::Decoder& decoder, 
 
         if (!decoder.decode(result.keysOfAnimationsToRemove))
             return false;
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+        if (!decoder.decode(result.effects))
+            return false;
+
+        if (!decoder.decode(result.baseValues))
+            return false;
+#endif
     }
 
     if (result.changedProperties & LayerChange::PositionChanged) {

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.cpp
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.cpp
@@ -44,6 +44,11 @@
 #import <WebCore/TiledBacking.h>
 #import <wtf/PointerComparison.h>
 
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+#import <WebCore/AcceleratedEffect.h>
+#import <WebCore/AcceleratedEffectValues.h>
+#endif
+
 namespace WebKit {
 using namespace WebCore;
 
@@ -1035,5 +1040,23 @@ LayerPool& PlatformCALayerRemote::layerPool()
 {
     return m_context->layerPool();
 }
+
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+void PlatformCALayerRemote::clearAcceleratedEffectsAndBaseValues()
+{
+    m_properties.effects = { };
+    m_properties.baseValues = { };
+
+    m_properties.notePropertiesChanged(LayerChange::AnimationsChanged);
+}
+
+void PlatformCALayerRemote::setAcceleratedEffectsAndBaseValues(const AcceleratedEffects& effects, AcceleratedEffectValues& baseValues)
+{
+    m_properties.effects = effects;
+    m_properties.baseValues = baseValues;
+
+    m_properties.notePropertiesChanged(LayerChange::AnimationsChanged);
+}
+#endif
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
@@ -32,6 +32,10 @@
 
 namespace WebCore {
 class LayerPool;
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+class AcceleratedEffect;
+struct AcceleratedEffectValues;
+#endif
 }
 
 namespace WebKit {
@@ -77,6 +81,11 @@ public:
     RefPtr<WebCore::PlatformCAAnimation> animationForKey(const String& key) override;
     void animationStarted(const String& key, MonotonicTime beginTime) override;
     void animationEnded(const String& key) override;
+
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    void clearAcceleratedEffectsAndBaseValues() override;
+    void setAcceleratedEffectsAndBaseValues(const WebCore::AcceleratedEffects&, WebCore::AcceleratedEffectValues&) override;
+#endif
 
     void setMask(WebCore::PlatformCALayer*) override;
 


### PR DESCRIPTION
#### 94f65684e16fb6ab5e40dedf6c118d1a80abb6af
<pre>
[web-animations] store, encode and decode accelerated effects on GraphicsLayer and PlatformCALayer
<a href="https://bugs.webkit.org/show_bug.cgi?id=253240">https://bugs.webkit.org/show_bug.cgi?id=253240</a>

Reviewed by Dean Jackson.

Add a way to store accelerated effects and base values on a GraphicsLayer using an AcceleratedEffectStack,
encoding and decoding those effects through a PlatformCALayerRemote and its backing RemoteLayerTreeTransaction.

* Source/WebCore/platform/graphics/GraphicsLayer.cpp:
(WebCore::GraphicsLayer::setAcceleratedEffectsAndBaseValues):
* Source/WebCore/platform/graphics/GraphicsLayer.h:
(WebCore::GraphicsLayer::acceleratedEffectStack const):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
* Source/WebCore/platform/graphics/ca/PlatformCALayer.cpp:
(WebCore::PlatformCALayer::clearAcceleratedEffectsAndBaseValues):
(WebCore::PlatformCALayer::setAcceleratedEffectsAndBaseValues):
* Source/WebCore/platform/graphics/ca/PlatformCALayer.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm:
(WebKit::RemoteLayerTreeTransaction::LayerProperties::LayerProperties):
(WebKit::RemoteLayerTreeTransaction::LayerProperties::encode const):
(WebKit::RemoteLayerTreeTransaction::LayerProperties::decode):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.cpp:
(WebKit::PlatformCALayerRemote::clearAcceleratedEffectsAndBaseValues):
(WebKit::PlatformCALayerRemote::setAcceleratedEffectsAndBaseValues):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h:

Canonical link: <a href="https://commits.webkit.org/261099@main">https://commits.webkit.org/261099@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7926507aa0c01415a73f997d50163b1424abe84

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110526 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19609 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43110 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1892 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119408 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114473 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21039 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10752 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102760 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116268 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43905 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30524 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85777 "Found 2 new API test failures: /TestWebKit:WebKit.OnDeviceChangeCrash, /TestWebKit:WebKit.PrivateBrowsingPushStateNoHistoryCallback (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12264 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31859 "Found 1 new test failure: media/video-playback-quality.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12837 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18200 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51479 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14707 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4183 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->