### PR TITLE
Resolve FIXME about creating emptyURLs without Objective-C

### DIFF
--- a/Source/WTF/wtf/URL.h
+++ b/Source/WTF/wtf/URL.h
@@ -220,10 +220,6 @@ private:
 
     friend WTF_EXPORT_PRIVATE bool protocolHostAndPortAreEqual(const URL&, const URL&);
 
-#if USE(CF)
-    static RetainPtr<CFURLRef> emptyCFURL();
-#endif
-
     String m_string;
 
     unsigned m_isValid : 1;

--- a/Source/WTF/wtf/cf/URLCF.cpp
+++ b/Source/WTF/wtf/cf/URLCF.cpp
@@ -42,22 +42,13 @@ URL::URL(CFURLRef url)
         *this = URLParser(bytesAsString(url)).result();
 }
 
-#if !USE(FOUNDATION)
-
-RetainPtr<CFURLRef> URL::emptyCFURL()
-{
-    return nullptr;
-}
-
-#endif
-
 RetainPtr<CFURLRef> URL::createCFURL() const
 {
     if (isNull())
         return nullptr;
 
     if (isEmpty())
-        return emptyCFURL();
+        return adoptCF(CFURLCreateWithString(kCFAllocatorDefault, CFSTR(""), nullptr));
 
     RetainPtr<CFURLRef> result;
     if (LIKELY(m_string.is8Bit() && m_string.isAllASCII()))

--- a/Source/WTF/wtf/cocoa/URLCocoa.mm
+++ b/Source/WTF/wtf/cocoa/URLCocoa.mm
@@ -50,13 +50,6 @@ URL::operator NSURL *() const
     return createCFURL().bridgingAutorelease();
 }
 
-RetainPtr<CFURLRef> URL::emptyCFURL()
-{
-    // We use the toll-free bridge to create an empty value that is distinct from null that no CFURL function can create.
-    // FIXME: When we originally wrote this, we thought that creating empty CF URLs was valuable; can we do without it now?
-    return bridge_cast(adoptNS([[NSURL alloc] initWithString:@""]));
-}
-
 bool URL::hostIsIPAddress(StringView host)
 {
     return [host.createNSStringWithoutCopying().get() _web_looksLikeIPAddress];

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
@@ -128,19 +128,19 @@ static constexpr NSString *baseURLKey = @"WK.baseURL";
     BOOL hasBaseURL;
     [coder decodeValueOfObjCType:"c" at:&hasBaseURL size:sizeof(hasBaseURL)];
 
-    RetainPtr<NSURL> baseURL;
+    NSURL *baseURL = nil;
     if (hasBaseURL)
         baseURL = (NSURL *)[coder decodeObjectOfClass:NSURL.class forKey:baseURLKey];
 
     NSUInteger length;
     if (auto bytes = (UInt8 *)[coder decodeBytesWithReturnedLength:&length]) {
-        m_wrappedURL = bridge_cast(adoptCF(CFURLCreateAbsoluteURLWithBytes(nullptr, bytes, length, kCFStringEncodingUTF8, bridge_cast(baseURL.get()), true)));
+        m_wrappedURL = bridge_cast(adoptCF(CFURLCreateWithBytes(kCFAllocatorDefault, bytes, length, kCFStringEncodingUTF8, bridge_cast(baseURL))));
         if (!m_wrappedURL)
             LOG_ERROR("Failed to decode NSURL due to invalid encoding of length %d. Substituting a blank URL", length);
     }
 
     if (!m_wrappedURL)
-        m_wrappedURL = [NSURL URLWithString:@""];
+        m_wrappedURL = adoptNS([[NSURL alloc] initWithString:@""]);
 
     return selfPtr.leakRef();
 }

--- a/Source/WebKit/Shared/cf/ArgumentCodersCF.cpp
+++ b/Source/WebKit/Shared/cf/ArgumentCodersCF.cpp
@@ -728,17 +728,11 @@ std::optional<RetainPtr<CFURLRef>> ArgumentCoder<RetainPtr<CFURLRef>>::decode(De
     if (!urlBytes)
         return std::nullopt;
 
-#if USE(FOUNDATION)
-    // FIXME: Move this to ArgumentCodersCFMac.mm and change this file back to be C++
-    // instead of Objective-C++.
     if (urlBytes->empty()) {
-        // CFURL can't hold an empty URL, unlike NSURL.
-        // FIXME: This discards base URL, which seems incorrect.
-        return {{ (__bridge CFURLRef)[NSURL URLWithString:@""] }};
+        return adoptCF(CFURLCreateWithString(kCFAllocatorDefault, CFSTR(""), nullptr));
     }
-#endif
 
-    auto result = adoptCF(CFURLCreateAbsoluteURLWithBytes(nullptr, reinterpret_cast<const UInt8*>(urlBytes->data()), urlBytes->size(), kCFStringEncodingUTF8, baseURL.get(), true));
+    auto result = adoptCF(CFURLCreateWithBytes(kCFAllocatorDefault, urlBytes->data(), urlBytes->size(), kCFStringEncodingUTF8, baseURL.get()));
     if (!result)
         return std::nullopt;
     return WTFMove(result);


### PR DESCRIPTION
#### fb9d435d895dc53d26bd894458a1cf8462940888
<pre>
Resolve FIXME about creating emptyURLs without Objective-C
<a href="https://bugs.webkit.org/show_bug.cgi?id=253248">https://bugs.webkit.org/show_bug.cgi?id=253248</a>

Reviewed by NOBODY (OOPS!).

We can create an empty url by passing an empty CFString to
CFURLCreateWithString.

* Source/WTF/wtf/URL.h:(emptyCFURL): Removed.

* Source/WTF/wtf/cf/URLCF.cpp: Inline emptyURL.

* Source/WTF/wtf/cocoa/URLCocoa.mm:(emptyURL): Removed.

* Source/WebKit/Shared/cf/ArgumentCodersCF.cpp: Remove preprocessor and
  use CF functions to create an empty CFURL object.

* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm: Prevent passing a
  null array to CFURLCreateAbsoluteURLWithBytes.

Note: If there is some wacky setting or manual script somewhere that
forces Apple platforms to interpret this file as Objective-C, please
tell me where I can fix that now that it is no longer needed.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb9d435d895dc53d26bd894458a1cf8462940888

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1483 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1513 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1563 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2408 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1307 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1574 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1572 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1427 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1495 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1358 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1344 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2247 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1363 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1327 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1285 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/1272 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1350 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1367 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2436 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/1432 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1402 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1245 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/1522 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1318 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1334 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/320 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1447 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/1562 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/433 "Passed tests") | 
<!--EWS-Status-Bubble-End-->