### PR TITLE
Network process shouldn't load Cairo

### DIFF
--- a/Source/WebCore/platform/graphics/cairo/CairoUtilities.cpp
+++ b/Source/WebCore/platform/graphics/cairo/CairoUtilities.cpp
@@ -48,19 +48,23 @@
 
 namespace WebCore {
 
-static NeverDestroyed<cairo_font_options_t*> s_defaultCairoFontOptions = cairo_font_options_create();
+static cairo_font_options_t* defaultCairoFontOptions()
+{
+    static cairo_font_options_t* s_defaultCairoFontOptions = cairo_font_options_create();
+    return s_defaultCairoFontOptions;
+}
 
 const cairo_font_options_t* getDefaultCairoFontOptions()
 {
-    return s_defaultCairoFontOptions;
+    return defaultCairoFontOptions();
 }
 
 static bool s_disableCairoFontHintingForTesting = false;
 
 void disableCairoFontHintingForTesting()
 {
-    cairo_font_options_set_hint_metrics(s_defaultCairoFontOptions, CAIRO_HINT_METRICS_ON);
-    cairo_font_options_set_hint_style(s_defaultCairoFontOptions, CAIRO_HINT_STYLE_NONE);
+    cairo_font_options_set_hint_metrics(defaultCairoFontOptions(), CAIRO_HINT_METRICS_ON);
+    cairo_font_options_set_hint_style(defaultCairoFontOptions(), CAIRO_HINT_STYLE_NONE);
 
     s_disableCairoFontHintingForTesting = true;
 }
@@ -70,14 +74,14 @@ void setDefaultCairoHintOptions(cairo_hint_metrics_t hintMetrics, cairo_hint_sty
     if (s_disableCairoFontHintingForTesting)
         return;
 
-    cairo_font_options_set_hint_metrics(s_defaultCairoFontOptions, hintMetrics);
-    cairo_font_options_set_hint_style(s_defaultCairoFontOptions, hintStyle);
+    cairo_font_options_set_hint_metrics(defaultCairoFontOptions(), hintMetrics);
+    cairo_font_options_set_hint_style(defaultCairoFontOptions(), hintStyle);
 }
 
 void setDefaultCairoAntialiasOptions(cairo_antialias_t antialias, cairo_subpixel_order_t subpixelOrder)
 {
-    cairo_font_options_set_antialias(s_defaultCairoFontOptions, antialias);
-    cairo_font_options_set_subpixel_order(s_defaultCairoFontOptions, subpixelOrder);
+    cairo_font_options_set_antialias(defaultCairoFontOptions(), antialias);
+    cairo_font_options_set_subpixel_order(defaultCairoFontOptions(), subpixelOrder);
 }
 
 void copyContextProperties(cairo_t* srcCr, cairo_t* dstCr)


### PR DESCRIPTION
#### 4fac13b14ab43258032797d51b868da33064af9e
<pre>
Network process shouldn&apos;t load Cairo
<a href="https://bugs.webkit.org/show_bug.cgi?id=253254">https://bugs.webkit.org/show_bug.cgi?id=253254</a>

Reviewed by Fujii Hironori.

Move creation of `s_defaultCairoFontOptions` to function scope so it is
only created when needed.

* Source/WebCore/platform/graphics/cairo/CairoUtilities.cpp:

Canonical link: <a href="https://commits.webkit.org/261107@main">https://commits.webkit.org/261107@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ba7693dce55c2aa58009970cd52428c396dac14

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110553 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19635 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43136 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1917 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119428 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114503 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21074 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10775 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102782 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116295 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43932 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30536 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85800 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12290 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31874 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12857 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18221 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51490 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7698 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14733 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->