### PR TITLE
[PlayStation] Load additional libraries at runtime

### DIFF
--- a/Source/WebCore/PlatformPlayStation.cmake
+++ b/Source/WebCore/PlatformPlayStation.cmake
@@ -80,6 +80,7 @@ set(WebCore_USER_AGENT_SCRIPTS
 
 list(APPEND WebCore_LIBRARIES
     WPE::libwpe
+    WebKitRequirements::WebKitResources
 )
 
 if (ENABLE_GAMEPAD)
@@ -123,6 +124,7 @@ if (EGL_EXTRAS)
 endif ()
 
 set(WebCore_MODULES
+    Brotli
     CURL
     Cairo
     EGL
@@ -131,8 +133,11 @@ set(WebCore_MODULES
     HarfBuzz
     ICU
     JPEG
+    LibPSL
+    LibXml2
     OpenSSL
     PNG
+    SQLite
     WebKitRequirements
     WebP
 )

--- a/Source/WebKit/NetworkProcess/EntryPoint/playstation/NetworkProcessMain.cpp
+++ b/Source/WebKit/NetworkProcess/EntryPoint/playstation/NetworkProcessMain.cpp
@@ -48,8 +48,17 @@ int main(int argc, char** argv)
     }
 
     loadLibraryOrExit(OpenSSL_LOAD_AT);
+#if defined(Brotli_LOAD_AT)
+    loadLibraryOrExit(Brotli_LOAD_AT);
+#endif
     loadLibraryOrExit(CURL_LOAD_AT);
     loadLibraryOrExit(ICU_LOAD_AT);
+#if defined(LibPSL_LOAD_AT)
+    loadLibraryOrExit(LibPSL_LOAD_AT);
+#endif
+#if defined(SQLite_LOAD_AT)
+    loadLibraryOrExit(SQLite_LOAD_AT);
+#endif
     loadLibraryOrExit(WebKitRequirements_LOAD_AT);
 #if !ENABLE(STATIC_JSC)
     loadLibraryOrExit("libJavaScriptCore");

--- a/Source/WebKit/WebProcess/EntryPoint/playstation/WebProcessMain.cpp
+++ b/Source/WebKit/WebProcess/EntryPoint/playstation/WebProcessMain.cpp
@@ -59,6 +59,12 @@ int main(int argc, char** argv)
     loadLibraryOrExit(Fontconfig_LOAD_AT);
     loadLibraryOrExit(HarfBuzz_LOAD_AT);
     loadLibraryOrExit(Cairo_LOAD_AT);
+#if defined(LibPSL_LOAD_AT)
+    loadLibraryOrExit(LibPSL_LOAD_AT);
+#endif
+#if defined(LibXml2_LOAD_AT)
+    loadLibraryOrExit(LibXml2_LOAD_AT);
+#endif
     loadLibraryOrExit(WebKitRequirements_LOAD_AT);
 #if !ENABLE(STATIC_JSC)
     loadLibraryOrExit("libJavaScriptCore");

--- a/Source/cmake/OptionsPlayStation.cmake
+++ b/Source/cmake/OptionsPlayStation.cmake
@@ -78,9 +78,15 @@ if (ENABLE_WEBCORE)
         OPTIONAL_COMPONENTS ${WebKitRequirements_OPTIONAL_COMPONENTS}
     )
 
+    set(Brotli_NAMES SceVshBrotli)
+    set(Brotli_DEC_NAMES ${Brotli_NAMES})
+    set(Cairo_NAMES SceCairoForWebKit)
+    set(HarfBuzz_NAMES SceVshHarfbuzz)
+    set(HarfBuzz_ICU_NAMES ${HarfBuzz_NAMES})
     # The OpenGL ES implementation is in the same library as the EGL implementation
     set(OpenGLES2_NAMES ${EGL_NAMES})
 
+    find_package(Brotli OPTIONAL_COMPONENTS dec)
     find_package(CURL 7.77.0 REQUIRED)
     find_package(Cairo REQUIRED)
     find_package(EGL REQUIRED)
@@ -92,6 +98,7 @@ if (ENABLE_WEBCORE)
     find_package(PNG REQUIRED)
 
     list(APPEND PlayStationModule_TARGETS
+        Brotli::dec
         CURL::libcurl
         Cairo::Cairo
         Fontconfig::Fontconfig
@@ -108,6 +115,7 @@ if (ENABLE_WEBCORE)
     endif ()
 
     if (NOT TARGET LibPSL::LibPSL)
+        set(LibPSL_NAMES SceVshPsl)
         find_package(LibPSL 0.20.2 REQUIRED)
         list(APPEND PlayStationModule_TARGETS LibPSL::LibPSL)
     endif ()

--- a/Tools/MiniBrowser/playstation/main.cpp
+++ b/Tools/MiniBrowser/playstation/main.cpp
@@ -62,6 +62,9 @@ static void initialize()
     loadLibraryOrExit(Cairo_LOAD_AT);
     loadLibraryOrExit(ToolKitten_LOAD_AT);
     loadLibraryOrExit(WebKitRequirements_LOAD_AT);
+#if defined(LibPSL_LOAD_AT)
+    loadLibraryOrExit(LibPSL_LOAD_AT);
+#endif
 #if defined(WPE_LOAD_AT)
     loadLibraryOrExit(WPE_LOAD_AT);
 #endif


### PR DESCRIPTION
#### d71d6fe6c3e249fc8fddec3fa009b4b346da4bda
<pre>
[PlayStation] Load additional libraries at runtime
<a href="https://bugs.webkit.org/show_bug.cgi?id=253255">https://bugs.webkit.org/show_bug.cgi?id=253255</a>

Reviewed by Fujii Hironori.

Add additional libraries to copy during the build when compiled as
`SHARED`. Load them at runtime if present.

* Source/WebCore/PlatformPlayStation.cmake:
* Source/WebKit/NetworkProcess/EntryPoint/playstation/NetworkProcessMain.cpp:
* Source/WebKit/WebProcess/EntryPoint/playstation/WebProcessMain.cpp:
* Source/cmake/OptionsPlayStation.cmake:
* Tools/MiniBrowser/playstation/main.cpp:

Canonical link: <a href="https://commits.webkit.org/261091@main">https://commits.webkit.org/261091@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbb68c996b30a47711a1a3d1dc89000953790b13

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110549 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19631 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/43126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/1908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/119424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114499 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21058 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/10768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102778 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116291 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/43126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/43921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/43126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/85795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/99236 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12286 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/43126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/100279 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/10344 "Built successfully and passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/12853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/10768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31291 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/18217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/43126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/108303 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7679 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14729 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26699 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->