### PR TITLE
Drop dead code from WebCoreOpaqueRoot

### DIFF
--- a/Source/WebCore/bindings/js/WebCoreOpaqueRoot.h
+++ b/Source/WebCore/bindings/js/WebCoreOpaqueRoot.h
@@ -35,18 +35,15 @@ public:
     template<typename T, typename = typename std::enable_if_t<!std::is_same_v<T, void>>>
     explicit WebCoreOpaqueRoot(T* pointer)
         : m_pointer(static_cast<void*>(pointer))
-        , m_isNode(pointer && std::is_base_of_v<Node, T>)
     {
     }
 
     WebCoreOpaqueRoot(std::nullptr_t) { }
 
-    bool isNode() const { return m_isNode; }
     void* pointer() const { return m_pointer; }
 
 private:
     void* m_pointer { nullptr };
-    bool m_isNode { false };
 };
 
 template<typename Visitor>


### PR DESCRIPTION
#### ee5e4b4b0053a29f4611a284dee7a116214aa643
<pre>
Drop dead code from WebCoreOpaqueRoot
<a href="https://bugs.webkit.org/show_bug.cgi?id=253256">https://bugs.webkit.org/show_bug.cgi?id=253256</a>

Reviewed by Darin Adler.

* Source/WebCore/bindings/js/WebCoreOpaqueRoot.h:
(WebCore::WebCoreOpaqueRoot::WebCoreOpaqueRoot):
(WebCore::WebCoreOpaqueRoot::isNode const): Deleted.

Canonical link: <a href="https://commits.webkit.org/261146@main">https://commits.webkit.org/261146@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2d2f42abd2a47fd80409925065a4613f5b45604

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110554 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19636 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43137 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1918 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119429 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114504 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21063 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10776 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/1376 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116296 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15694 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98874 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102783 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97654 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30541 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43934 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12291 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31879 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85806 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12858 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8847 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18222 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51495 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7723 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14734 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->