### PR TITLE
_WKContextMenuElementInfo should expose a hasEntireImage property

### DIFF
--- a/Source/WebCore/page/ContextMenuContext.cpp
+++ b/Source/WebCore/page/ContextMenuContext.cpp
@@ -42,6 +42,7 @@ ContextMenuContext::ContextMenuContext(Type type, const HitTestResult& hitTestRe
     : m_type(type)
     , m_hitTestResult(hitTestResult)
     , m_event(event)
+    , m_hasEntireImage(hitTestResult.hasEntireImage())
 {
 }
 

--- a/Source/WebCore/page/ContextMenuContext.h
+++ b/Source/WebCore/page/ContextMenuContext.h
@@ -62,6 +62,8 @@ public:
     void setSelectedText(const String& selectedText) { m_selectedText = selectedText; }
     const String& selectedText() const { return m_selectedText; }
 
+    bool hasEntireImage() const { return m_hasEntireImage; }
+
 #if ENABLE(SERVICE_CONTROLS)
     void setControlledImage(Image* controlledImage) { m_controlledImage = controlledImage; }
     Image* controlledImage() const { return m_controlledImage.get(); }
@@ -80,6 +82,7 @@ private:
     HitTestResult m_hitTestResult;
     RefPtr<Event> m_event;
     String m_selectedText;
+    bool m_hasEntireImage;
 
 #if ENABLE(SERVICE_CONTROLS)
     RefPtr<Image> m_controlledImage;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -25,6 +25,7 @@
 #include "AnimationFrameRate.h"
 #include "AppHighlightStorage.h"
 #include "ApplicationCacheStorage.h"
+#include "ArchiveResource.h"
 #include "AttachmentElementClient.h"
 #include "AuthenticatorCoordinator.h"
 #include "AuthenticatorCoordinatorClient.h"
@@ -95,6 +96,7 @@
 #include "LowPowerModeNotifier.h"
 #include "MediaCanStartListener.h"
 #include "MediaRecorderProvider.h"
+#include "MemoryCache.h"
 #include "ModelPlayerProvider.h"
 #include "NavigationScheduler.h"
 #include "Navigator.h"
@@ -151,6 +153,7 @@
 #include "StyleResolver.h"
 #include "StyleScope.h"
 #include "SubframeLoader.h"
+#include "SubresourceLoader.h"
 #include "TextIterator.h"
 #include "TextRecognitionResult.h"
 #include "TextResourceDecoder.h"
@@ -3741,6 +3744,19 @@ bool Page::allowsLoadFromURL(const URL& url, MainFrameMainResource mainFrameMain
     if (!url.protocolIsInHTTPFamily() && !url.protocolIs("ws"_s) && !url.protocolIs("wss"_s))
         return true;
     return m_allowedNetworkHosts->contains<StringViewHashTranslator>(url.host());
+}
+
+bool Page::hasLocalDataForURL(const URL& url)
+{
+    if (url.isLocalFile())
+        return true;
+
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(mainFrame());
+    DocumentLoader* documentLoader = localMainFrame ? localMainFrame->loader().documentLoader() : nullptr;
+    if (documentLoader && documentLoader->subresource(MemoryCache::removeFragmentIdentifierIfNeeded(url)))
+        return true;
+
+    return false;
 }
 
 void Page::applicationWillResignActive()

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -915,6 +915,8 @@ public:
     bool isUtilityPage() const { return m_isUtilityPage; }
 
     WEBCORE_EXPORT bool allowsLoadFromURL(const URL&, MainFrameMainResource) const;
+    WEBCORE_EXPORT bool hasLocalDataForURL(const URL&);
+
     ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking() const { return m_shouldRelaxThirdPartyCookieBlocking; }
 
     bool isLowPowerModeEnabled() const { return m_throttlingReasons.contains(ThrottlingReason::LowPowerMode); }

--- a/Source/WebCore/rendering/HitTestResult.cpp
+++ b/Source/WebCore/rendering/HitTestResult.cpp
@@ -374,6 +374,22 @@ IntRect HitTestResult::imageRect() const
     return imageNode->renderBox()->absoluteContentQuad().enclosingBoundingBox();
 }
 
+bool HitTestResult::hasEntireImage() const
+{
+    auto imageURL = absoluteImageURL();
+    if (imageURL.isEmpty() || imageRect().isEmpty())
+        return false;
+
+    auto* innerFrame = innerNodeFrame();
+    if (!innerFrame)
+        return false;
+
+    if (auto page = innerFrame->page())
+        return page->hasLocalDataForURL(imageURL);
+
+    return false;
+}
+
 URL HitTestResult::absoluteImageURL() const
 {
     auto imageNode = nodeForImageData();

--- a/Source/WebCore/rendering/HitTestResult.h
+++ b/Source/WebCore/rendering/HitTestResult.h
@@ -103,6 +103,7 @@ public:
     WEBCORE_EXPORT String titleDisplayString() const;
     WEBCORE_EXPORT Image* image() const;
     WEBCORE_EXPORT IntRect imageRect() const;
+    bool hasEntireImage() const;
     WEBCORE_EXPORT URL absoluteImageURL() const;
     WEBCORE_EXPORT URL absolutePDFURL() const;
     WEBCORE_EXPORT URL absoluteMediaURL() const;

--- a/Source/WebKit/Shared/ContextMenuContextData.cpp
+++ b/Source/WebKit/Shared/ContextMenuContextData.cpp
@@ -53,6 +53,7 @@ ContextMenuContextData::ContextMenuContextData(const IntPoint& menuLocation, con
     , m_menuItems(menuItems)
     , m_webHitTestResultData({ context.hitTestResult(), true })
     , m_selectedText(context.selectedText())
+    , m_hasEntireImage(context.hasEntireImage())
 #if ENABLE(SERVICE_CONTROLS)
     , m_selectionIsEditable(false)
 #endif
@@ -117,6 +118,7 @@ void ContextMenuContextData::encode(IPC::Encoder& encoder) const
     encoder << m_menuItems;
     encoder << m_webHitTestResultData;
     encoder << m_selectedText;
+    encoder << m_hasEntireImage;
 
 #if ENABLE(SERVICE_CONTROLS)
     ShareableBitmapHandle handle;
@@ -166,6 +168,9 @@ bool ContextMenuContextData::decode(IPC::Decoder& decoder, ContextMenuContextDat
         return false;
 
     if (!decoder.decode(result.m_selectedText))
+        return false;
+
+    if (!decoder.decode(result.m_hasEntireImage))
         return false;
 
 #if ENABLE(SERVICE_CONTROLS)

--- a/Source/WebKit/Shared/ContextMenuContextData.h
+++ b/Source/WebKit/Shared/ContextMenuContextData.h
@@ -55,6 +55,8 @@ public:
     const std::optional<WebHitTestResultData>& webHitTestResultData() const { return m_webHitTestResultData; }
     const String& selectedText() const { return m_selectedText; }
 
+    bool hasEntireImage() const { return m_hasEntireImage; }
+
 #if ENABLE(SERVICE_CONTROLS)
     ContextMenuContextData(const WebCore::IntPoint& menuLocation, const Vector<uint8_t>& selectionData, const Vector<String>& selectedTelephoneNumbers, bool isEditable)
         : m_type(Type::ServicesMenu)
@@ -108,6 +110,7 @@ private:
 
     std::optional<WebHitTestResultData> m_webHitTestResultData;
     String m_selectedText;
+    bool m_hasEntireImage;
 
 #if ENABLE(SERVICE_CONTROLS)
     void setImage(WebCore::Image&);

--- a/Source/WebKit/UIProcess/API/APIContextMenuElementInfoMac.h
+++ b/Source/WebKit/UIProcess/API/APIContextMenuElementInfoMac.h
@@ -28,6 +28,7 @@
 #if PLATFORM(MAC)
 
 #include "APIObject.h"
+#include "ContextMenuContextData.h"
 #include "WebHitTestResultData.h"
 
 namespace API {
@@ -40,15 +41,18 @@ public:
     }
 
     const WebKit::WebHitTestResultData& hitTestResultData() const { return m_hitTestResultData; }
-    const WTF::String& qrCodePayloadString() const { return m_qrCodePayloadString; };
+    const WTF::String& qrCodePayloadString() const { return m_qrCodePayloadString; }
+    bool hasEntireImage() const { return m_hasEntireImage; }
 
 private:
-    ContextMenuElementInfoMac(const WebKit::WebHitTestResultData& hitTestResultData, const WTF::String& qrCodePayloadString)
-        : m_hitTestResultData(hitTestResultData)
-        , m_qrCodePayloadString(qrCodePayloadString) { }
+    ContextMenuElementInfoMac(const WebKit::ContextMenuContextData& data)
+        : m_hitTestResultData(data.webHitTestResultData().value())
+        , m_qrCodePayloadString(data.qrCodePayloadString())
+        , m_hasEntireImage(data.hasEntireImage()) { }
 
     WebKit::WebHitTestResultData m_hitTestResultData;
     WTF::String m_qrCodePayloadString;
+    bool m_hasEntireImage;
 };
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKContextMenuElementInfo.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKContextMenuElementInfo.h
@@ -36,6 +36,7 @@ WK_CLASS_AVAILABLE(macos(10.12))
 
 @property (nonatomic, readonly, copy) _WKHitTestResult *hitTestResult WK_API_AVAILABLE(macos(13.3));
 @property (nonatomic, readonly, copy, nullable) NSString *qrCodePayloadString WK_API_AVAILABLE(macos(WK_MAC_TBA));
+@property (nonatomic, readonly) BOOL hasEntireImage WK_API_AVAILABLE(macos(WK_MAC_TBA));
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKContextMenuElementInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKContextMenuElementInfo.mm
@@ -63,6 +63,11 @@
     return nsStringNilIfEmpty(qrCodePayloadString);
 }
 
+- (BOOL)hasEntireImage
+{
+    return _contextMenuElementInfoMac->hasEntireImage();
+}
+
 // MARK: WKObject protocol implementation
 
 - (API::Object&)_apiObject

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
@@ -240,7 +240,7 @@ void UIDelegate::ContextMenuClient::menuFromProposedMenu(WebPageProxy&, NSMenu *
     if (!delegate)
         return completionHandler(menu);
 
-    auto contextMenuElementInfo = API::ContextMenuElementInfoMac::create(data.webHitTestResultData().value(), data.qrCodePayloadString());
+    auto contextMenuElementInfo = API::ContextMenuElementInfoMac::create(data);
     if (m_uiDelegate->m_delegateMethods.webViewGetContextMenuFromProposedMenuForElementUserInfoCompletionHandler) {
         auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:getContextMenuFromProposedMenu:forElement:userInfo:completionHandler:));
         [(id<WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() getContextMenuFromProposedMenu:menu forElement:wrapper(contextMenuElementInfo.get()) userInfo:userInfo ? static_cast<id<NSSecureCoding>>(userInfo->wrapper()) : nil completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler), checker = WTFMove(checker)] (NSMenu *menu) mutable {

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
@@ -475,7 +475,7 @@ void WKBundlePageSetFooterBanner(WKBundlePageRef pageRef, WKBundlePageBannerRef 
 
 bool WKBundlePageHasLocalDataForURL(WKBundlePageRef pageRef, WKURLRef urlRef)
 {
-    return WebKit::toImpl(pageRef)->hasLocalDataForURL(URL { WebKit::toWTFString(urlRef) });
+    return WebKit::toImpl(pageRef)->corePage()->hasLocalDataForURL(URL { WebKit::toWTFString(urlRef) });
 }
 
 bool WKBundlePageCanHandleRequest(WKURLRequestRef requestRef)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -222,7 +222,6 @@
 #include <WebCore/LocalFrameView.h>
 #include <WebCore/LocalizedStrings.h>
 #include <WebCore/MIMETypeRegistry.h>
-#include <WebCore/MemoryCache.h>
 #include <WebCore/MouseEvent.h>
 #include <WebCore/NotImplemented.h>
 #include <WebCore/NotificationController.h>
@@ -5667,18 +5666,6 @@ void WebPage::SandboxExtensionTracker::didFailProvisionalLoad(WebFrame* frame)
     // We can also have a non-null m_pendingProvisionalSandboxExtension if a new load is being started
     // (notably, if the current one fails because the new one cancels it). This extension is not cleared,
     // because it does not pertain to the failed load, and will be needed.
-}
-
-bool WebPage::hasLocalDataForURL(const URL& url)
-{
-    if (url.isLocalFile())
-        return true;
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
-    DocumentLoader* documentLoader = localMainFrame ? localMainFrame->loader().documentLoader() : nullptr;
-    if (documentLoader && documentLoader->subresource(MemoryCache::removeFragmentIdentifierIfNeeded(url)))
-        return true;
-
-    return false;
 }
 
 void WebPage::setCustomTextEncodingName(const String& encoding)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -940,8 +940,6 @@ public:
     WebContextMenu* contextMenuAtPointInWindow(const WebCore::IntPoint&);
 #endif
 
-    bool hasLocalDataForURL(const URL&);
-
     static bool canHandleRequest(const WebCore::ResourceRequest&);
 
     class SandboxExtensionTracker {

--- a/Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm
@@ -470,6 +470,20 @@ TEST(ContextMenuTests, ContextMenuElementInfoContainsQRCodePayloadStringSVGPageZ
 
 #endif // ENABLE(CONTEXT_MENU_QR_CODE_DETECTION)
 
+TEST(ContextMenuTests, ContextMenuElementInfoHasEntireImage)
+{
+    CGFloat iconWidth = 215;
+    CGFloat iconHeight = 174;
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, iconWidth * 2, iconHeight * 2)]);
+    [webView synchronouslyLoadHTMLString:@"<img src='icon.png'></img>"];
+
+    _WKContextMenuElementInfo *elementInfo = [webView rightClickAtPointAndWaitForContextMenu:NSMakePoint(iconWidth, iconHeight)];
+    EXPECT_TRUE(elementInfo.hasEntireImage);
+
+    elementInfo = [webView rightClickAtPointAndWaitForContextMenu:NSMakePoint(10, 10)];
+    EXPECT_FALSE(elementInfo.hasEntireImage);
+}
+
 } // namespace TestWebKitAPI
 
 #endif // PLATFORM(MAC)


### PR DESCRIPTION
#### 9643b29c75f08b2aed6b8abd2ae1b45f73e42015
<pre>
_WKContextMenuElementInfo should expose a hasEntireImage property
<a href="https://bugs.webkit.org/show_bug.cgi?id=253258">https://bugs.webkit.org/show_bug.cgi?id=253258</a>
&lt;rdar://106152692&gt;

Reviewed by Aditya Keerthi.

Add a hasEntireImage property to _WKContextMenuElementInfo. This property is true if we&apos;re showing a
context menu for an image and the image has been loaded.

As part of this I moved hasLocalDataForURL() from WebKit::WebPage to WebCore::Page so we can can use
it from HitTestResult::hasEntireImage() in WebCore. I also changed
API::ContextMenuElementInfoMac::create() to take a single const WebKit::ContextMenuContextData&amp;
parameter rather than adding a third parameter since all of the information needed to create this
class is derived from ContextMenuContextData.

* Source/WebCore/page/ContextMenuContext.cpp:
(WebCore::ContextMenuContext::ContextMenuContext):
* Source/WebCore/page/ContextMenuContext.h:
(WebCore::ContextMenuContext::hasEntireImage const):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::hasLocalDataForURL):
Moved from WebKit::WebPage.

* Source/WebCore/page/Page.h:
* Source/WebCore/rendering/HitTestResult.cpp:
(WebCore::HitTestResult::hasEntireImage const):
Returns true if the context menu is for an image, the image rectangle isn&apos;t empty, and the page has
loaded the image data.

* Source/WebCore/rendering/HitTestResult.h:
* Source/WebKit/Shared/ContextMenuContextData.cpp:
(WebKit::ContextMenuContextData::encode const):
(WebKit::ContextMenuContextData::decode):
* Source/WebKit/Shared/ContextMenuContextData.h:
(WebKit::ContextMenuContextData::hasEntireImage const):
* Source/WebKit/UIProcess/API/APIContextMenuElementInfoMac.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKContextMenuElementInfo.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKContextMenuElementInfo.mm:
(-[_WKContextMenuElementInfo hasEntireImage]):
* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
(WebKit::UIDelegate::ContextMenuClient::menuFromProposedMenu):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp:
(WKBundlePageHasLocalDataForURL):
Call hasLocalDataForURL() on the WebCore::Page instead of the WebKit::WebPage. This was the only
caller of this function.

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::hasLocalDataForURL): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm:
(TestWebKitAPI::TEST):
Added a new ContextMenuElementInfoHasEntireImage test.

Canonical link: <a href="https://commits.webkit.org/261793@main">https://commits.webkit.org/261793@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d306002167eb98aa4a5d8109d5ad6eb4a117813

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112793 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21981 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1499 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4603 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121332 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116863 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23326 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13148 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5770 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118562 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17333 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100580 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105912 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99292 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1119 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46344 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14284 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1159 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14984 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10503 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20301 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53152 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8226 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16833 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->