### PR TITLE
Addition of response status code to Resource Timing API

### DIFF
--- a/Source/WebCore/page/PerformanceResourceTiming.cpp
+++ b/Source/WebCore/page/PerformanceResourceTiming.cpp
@@ -55,7 +55,7 @@ static double fetchStart(MonotonicTime timeOrigin, const ResourceTiming& resourc
 {
     if (auto fetchStart = resourceTiming.networkLoadMetrics().fetchStart; fetchStart && !resourceTiming.networkLoadMetrics().failsTAOCheck)
         return networkLoadTimeToDOMHighResTimeStamp(timeOrigin, fetchStart);
-
+    
     // fetchStart is a required property.
     auto startTime = resourceTiming.resourceLoadTiming().startTime();
     ASSERT(startTime);
@@ -67,10 +67,10 @@ static double entryStartTime(MonotonicTime timeOrigin, const ResourceTiming& res
     if (resourceTiming.networkLoadMetrics().failsTAOCheck
         || !resourceTiming.networkLoadMetrics().redirectCount)
         return fetchStart(timeOrigin, resourceTiming);
-
+    
     if (resourceTiming.networkLoadMetrics().redirectStart)
         return networkLoadTimeToDOMHighResTimeStamp(timeOrigin, resourceTiming.networkLoadMetrics().redirectStart);
-
+    
     return networkLoadTimeToDOMHighResTimeStamp(timeOrigin, resourceTiming.resourceLoadTiming().startTime());
 }
 
@@ -78,7 +78,7 @@ static double entryEndTime(MonotonicTime timeOrigin, const ResourceTiming& resou
 {
     if (resourceTiming.networkLoadMetrics().responseEnd)
         return networkLoadTimeToDOMHighResTimeStamp(timeOrigin, resourceTiming.networkLoadMetrics().responseEnd);
-
+    
     return networkLoadTimeToDOMHighResTimeStamp(timeOrigin, resourceTiming.resourceLoadTiming().endTime());
 }
 
@@ -101,7 +101,7 @@ const String& PerformanceResourceTiming::nextHopProtocol() const
 {
     if (m_resourceTiming.networkLoadMetrics().failsTAOCheck)
         return emptyString();
-
+    
     return m_resourceTiming.networkLoadMetrics().protocol;
 }
 
@@ -109,7 +109,7 @@ double PerformanceResourceTiming::workerStart() const
 {
     if (m_resourceTiming.networkLoadMetrics().failsTAOCheck)
         return 0.0;
-
+    
     return networkLoadTimeToDOMHighResTimeStamp(m_timeOrigin, m_resourceTiming.networkLoadMetrics().workerStart);
 }
 
@@ -117,13 +117,13 @@ double PerformanceResourceTiming::redirectStart() const
 {
     if (m_resourceTiming.networkLoadMetrics().failsTAOCheck)
         return 0.0;
-
+    
     if (m_resourceTiming.isLoadedFromServiceWorker())
         return 0.0;
-
+    
     if (!m_resourceTiming.networkLoadMetrics().redirectCount)
         return 0.0;
-
+    
     return networkLoadTimeToDOMHighResTimeStamp(m_timeOrigin, m_resourceTiming.networkLoadMetrics().redirectStart);
 }
 
@@ -131,13 +131,13 @@ double PerformanceResourceTiming::redirectEnd() const
 {
     if (m_resourceTiming.networkLoadMetrics().failsTAOCheck)
         return 0.0;
-
+    
     if (m_resourceTiming.isLoadedFromServiceWorker())
         return 0.0;
-
+    
     if (!m_resourceTiming.networkLoadMetrics().redirectCount)
         return 0.0;
-
+    
     // These two times are so close to each other that we don't record two timestamps.
     // See https://www.w3.org/TR/resource-timing-2/#attribute-descriptions
     return fetchStart();
@@ -152,13 +152,13 @@ double PerformanceResourceTiming::domainLookupStart() const
 {
     if (m_resourceTiming.networkLoadMetrics().failsTAOCheck)
         return 0.0;
-
+    
     if (m_resourceTiming.isLoadedFromServiceWorker())
         return fetchStart();
-
+    
     if (!m_resourceTiming.networkLoadMetrics().domainLookupStart)
         return fetchStart();
-
+    
     return networkLoadTimeToDOMHighResTimeStamp(m_timeOrigin, m_resourceTiming.networkLoadMetrics().domainLookupStart);
 }
 
@@ -166,13 +166,13 @@ double PerformanceResourceTiming::domainLookupEnd() const
 {
     if (m_resourceTiming.networkLoadMetrics().failsTAOCheck)
         return 0.0;
-
+    
     if (m_resourceTiming.isLoadedFromServiceWorker())
         return fetchStart();
-
+    
     if (!m_resourceTiming.networkLoadMetrics().domainLookupEnd)
         return domainLookupStart();
-
+    
     return networkLoadTimeToDOMHighResTimeStamp(m_timeOrigin, m_resourceTiming.networkLoadMetrics().domainLookupEnd);
 }
 
@@ -180,13 +180,13 @@ double PerformanceResourceTiming::connectStart() const
 {
     if (m_resourceTiming.networkLoadMetrics().failsTAOCheck)
         return 0.0;
-
+    
     if (m_resourceTiming.isLoadedFromServiceWorker())
         return fetchStart();
-
+    
     if (!m_resourceTiming.networkLoadMetrics().connectStart)
         return domainLookupEnd();
-
+    
     return networkLoadTimeToDOMHighResTimeStamp(m_timeOrigin, m_resourceTiming.networkLoadMetrics().connectStart);
 }
 
@@ -194,13 +194,13 @@ double PerformanceResourceTiming::connectEnd() const
 {
     if (m_resourceTiming.networkLoadMetrics().failsTAOCheck)
         return 0.0;
-
+    
     if (m_resourceTiming.isLoadedFromServiceWorker())
         return fetchStart();
-
+    
     if (!m_resourceTiming.networkLoadMetrics().connectEnd)
         return connectStart();
-
+    
     return networkLoadTimeToDOMHighResTimeStamp(m_timeOrigin, m_resourceTiming.networkLoadMetrics().connectEnd);
 }
 
@@ -208,13 +208,13 @@ double PerformanceResourceTiming::secureConnectionStart() const
 {
     if (m_resourceTiming.networkLoadMetrics().failsTAOCheck)
         return 0.0;
-
+    
     if (m_resourceTiming.networkLoadMetrics().secureConnectionStart == reusedTLSConnectionSentinel)
         return fetchStart();
-
+    
     if (!m_resourceTiming.networkLoadMetrics().secureConnectionStart)
         return 0.0;
-
+    
     return networkLoadTimeToDOMHighResTimeStamp(m_timeOrigin, m_resourceTiming.networkLoadMetrics().secureConnectionStart);
 }
 
@@ -222,11 +222,11 @@ double PerformanceResourceTiming::requestStart() const
 {
     if (m_resourceTiming.networkLoadMetrics().failsTAOCheck)
         return 0.0;
-
+    
     // requestStart is 0 when a network request is not made.
     if (!m_resourceTiming.networkLoadMetrics().requestStart)
         return connectEnd();
-
+    
     return networkLoadTimeToDOMHighResTimeStamp(m_timeOrigin, m_resourceTiming.networkLoadMetrics().requestStart);
 }
 
@@ -234,11 +234,11 @@ double PerformanceResourceTiming::responseStart() const
 {
     if (m_resourceTiming.networkLoadMetrics().failsTAOCheck)
         return 0.0;
-
+    
     // responseStart is 0 when a network request is not made.
     if (!m_resourceTiming.networkLoadMetrics().responseStart)
         return requestStart();
-
+    
     return networkLoadTimeToDOMHighResTimeStamp(m_timeOrigin, m_resourceTiming.networkLoadMetrics().responseStart);
 }
 
@@ -249,11 +249,11 @@ double PerformanceResourceTiming::responseEnd() const
     ASSERT(m_resourceTiming.networkLoadMetrics().isComplete()
         || m_resourceTiming.resourceLoadTiming().endTime()
         || performanceEntryType() == Type::Navigation);
-
+    
     if (m_resourceTiming.networkLoadMetrics().isComplete()) {
         if (m_resourceTiming.networkLoadMetrics().responseEnd)
             return networkLoadTimeToDOMHighResTimeStamp(m_timeOrigin, m_resourceTiming.networkLoadMetrics().responseEnd);
-
+        
         // responseEnd is 0 when a network request is not made.
         // This should mean all other properties are empty.
         ASSERT(!m_resourceTiming.networkLoadMetrics().responseStart);
@@ -265,7 +265,7 @@ double PerformanceResourceTiming::responseEnd() const
         ASSERT(!m_resourceTiming.networkLoadMetrics().domainLookupEnd);
         ASSERT(!m_resourceTiming.networkLoadMetrics().domainLookupStart);
     }
-
+    
     return networkLoadTimeToDOMHighResTimeStamp(m_timeOrigin, m_resourceTiming.resourceLoadTiming().endTime());
 }
 
@@ -275,11 +275,11 @@ uint64_t PerformanceResourceTiming::transferSize() const
     // See https://github.com/w3c/server-timing/issues/89
     if (!m_resourceTiming.isSameOriginRequest())
         return 0;
-
+    
     auto encodedBodySize = m_resourceTiming.networkLoadMetrics().responseBodyBytesReceived;
     if (encodedBodySize == std::numeric_limits<uint64_t>::max())
         return 0;
-
+    
     // https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-transfersize
     // Motivated by https://github.com/w3c/resource-timing/issues/238
     return encodedBodySize + 300;
@@ -291,11 +291,11 @@ uint64_t PerformanceResourceTiming::encodedBodySize() const
     // See https://github.com/w3c/server-timing/issues/89
     if (!m_resourceTiming.isSameOriginRequest())
         return 0;
-
+    
     auto encodedBodySize = m_resourceTiming.networkLoadMetrics().responseBodyBytesReceived;
     if (encodedBodySize == std::numeric_limits<uint64_t>::max())
         return 0;
-
+    
     return encodedBodySize;
 }
 
@@ -305,12 +305,20 @@ uint64_t PerformanceResourceTiming::decodedBodySize() const
     // See https://github.com/w3c/server-timing/issues/89
     if (!m_resourceTiming.isSameOriginRequest())
         return 0;
-
+    
     auto decodedBodySize = m_resourceTiming.networkLoadMetrics().responseBodyDecodedSize;
     if (decodedBodySize == std::numeric_limits<uint64_t>::max())
         return 0;
-
+    
     return decodedBodySize;
+}
+
+uint16_t PerformanceResourceTiming::responseStatus() const
+{
+    // FIXME: This should be a check for whether CORS has failed instead of just forbidding cross-origin response statuses.
+    if (!m_resourceTiming.isSameOriginRequest())
+        return 0;
+    return m_resourceTiming.networkLoadMetrics().responseStatus;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/PerformanceResourceTiming.h
+++ b/Source/WebCore/page/PerformanceResourceTiming.h
@@ -64,6 +64,7 @@ public:
     uint64_t transferSize() const;
     uint64_t encodedBodySize() const;
     uint64_t decodedBodySize() const;
+    uint16_t responseStatus() const;
 
     const Vector<Ref<PerformanceServerTiming>>& serverTiming() const { return m_serverTiming; }
 

--- a/Source/WebCore/page/PerformanceResourceTiming.idl
+++ b/Source/WebCore/page/PerformanceResourceTiming.idl
@@ -53,6 +53,7 @@ typedef double DOMHighResTimeStamp;
     [EnabledBySetting=PerformanceResourceTimingSensitivePropertiesEnabled] readonly attribute unsigned long long transferSize;
     [EnabledBySetting=PerformanceResourceTimingSensitivePropertiesEnabled] readonly attribute unsigned long long encodedBodySize;
     [EnabledBySetting=PerformanceResourceTimingSensitivePropertiesEnabled] readonly attribute unsigned long long decodedBodySize;
+    readonly attribute unsigned short responseStatus;
 
     // https://www.w3.org/TR/server-timing/#extension-to-the-performanceresourcetiming-interface
     [EnabledByDeprecatedGlobalSetting=ServerTimingEnabled] readonly attribute FrozenArray<PerformanceServerTiming> serverTiming;

--- a/Source/WebCore/platform/network/mac/WebCoreResourceHandleAsOperationQueueDelegate.mm
+++ b/Source/WebCore/platform/network/mac/WebCoreResourceHandleAsOperationQueueDelegate.mm
@@ -264,7 +264,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         ResourceResponse resourceResponse(r.get());
         m_handle->checkTAO(resourceResponse);
 
-        auto metrics = copyTimingData(connection.get(), *m_handle);
+        auto metrics = copyTimingData(connection.get(), r.get(), *m_handle);
         resourceResponse.setSource(ResourceResponse::Source::Network);
         resourceResponse.setDeprecatedNetworkLoadMetrics(Box<NetworkLoadMetrics> { metrics });
 


### PR DESCRIPTION
#### 798be59d63cbf7220733191c740ee06b5e41a6da
<pre>
Addition of response status code to Resource Timing API
<a href="https://bugs.webkit.org/show_bug.cgi?id=246857">https://bugs.webkit.org/show_bug.cgi?id=246857</a>
rdar://101429748

Reviewed by NOBODY (OOPS!).

* Source/WebCore/page/PerformanceResourceTiming.cpp:
(WebCore::fetchStart):
(WebCore::entryStartTime):
(WebCore::entryEndTime):
(WebCore::PerformanceResourceTiming::PerformanceResourceTiming):
(WebCore::PerformanceResourceTiming::nextHopProtocol const):
(WebCore::PerformanceResourceTiming::workerStart const):
(WebCore::PerformanceResourceTiming::redirectStart const):
(WebCore::PerformanceResourceTiming::redirectEnd const):
(WebCore::PerformanceResourceTiming::domainLookupStart const):
(WebCore::PerformanceResourceTiming::domainLookupEnd const):
(WebCore::PerformanceResourceTiming::connectStart const):
(WebCore::PerformanceResourceTiming::connectEnd const):
(WebCore::PerformanceResourceTiming::secureConnectionStart const):
(WebCore::PerformanceResourceTiming::requestStart const):
(WebCore::PerformanceResourceTiming::responseStart const):
(WebCore::PerformanceResourceTiming::responseEnd const):
(WebCore::PerformanceResourceTiming::transferSize const):
(WebCore::PerformanceResourceTiming::encodedBodySize const):
(WebCore::PerformanceResourceTiming::decodedBodySize const):
(WebCore::PerformanceResourceTiming::responseStatus const):
* Source/WebCore/page/PerformanceResourceTiming.h:
* Source/WebCore/page/PerformanceResourceTiming.idl:
* Source/WebCore/platform/network/NetworkLoadMetrics.h:
(WebCore::NetworkLoadMetrics::encode const):
(WebCore::NetworkLoadMetrics::decode):
* Source/WebCore/platform/network/cocoa/NetworkLoadMetrics.mm:
(WebCore::packageTimingData):
(WebCore::copyTimingData):
* Source/WebCore/platform/network/mac/WebCoreResourceHandleAsOperationQueueDelegate.mm:
(-[WebCoreResourceHandleAsOperationQueueDelegate connection:didReceiveResponse:]):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/798be59d63cbf7220733191c740ee06b5e41a6da

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110573 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19654 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43147 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1930 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119442 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114527 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21079 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10786 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102825 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116315 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15696 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98875 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43961 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97656 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30542 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85837 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12307 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31880 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12869 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8848 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18233 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51496 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14751 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->