### PR TITLE
Regression(256456@main) Express checkout is broken on victoriasecret.com

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2402,11 +2402,13 @@ FetchMetadataEnabled:
   humanReadableDescription: "Enable Fetch Metadata headers"
   defaultValue:
     WebCore:
+      "PLATFORM(COCOA)" : false
       default: true
     WebKit:
+      "PLATFORM(COCOA)" : false
       default: true
     WebKitLegacy:
-      default: true
+      default: false
 
 FileReaderAPIEnabled:
   type: bool


### PR DESCRIPTION
#### e77a71062db731f4d7b89098cac8a04fb8005728
<pre>
Regression(256456@main) Express checkout is broken on victoriasecret.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=253265">https://bugs.webkit.org/show_bug.cgi?id=253265</a>
rdar://104818312

Reviewed by NOBODY (OOPS!).

Disable Fetch Metadata temporarily for Cocoa ports since it broke express checkout
on victoriasecret.com.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
</pre>