### PR TITLE
[Win] Get UnitsPerEm font metrics

### DIFF
--- a/Source/WebCore/platform/graphics/win/SimpleFontDataCairoWin.cpp
+++ b/Source/WebCore/platform/graphics/win/SimpleFontDataCairoWin.cpp
@@ -67,34 +67,36 @@ void Font::platformInit()
 
     cairo_win32_scaled_font_select_font(scaledFont, dc);
 
+    OUTLINETEXTMETRIC metrics;
+    GetOutlineTextMetrics(dc, sizeof(metrics), &metrics);
+
+    cairo_win32_scaled_font_done_font(scaledFont);
+    RestoreDC(dc, -1);
+
     // FIXME: Needs to take OS/2 USE_TYPO_METRICS flag into account
     // https://bugs.webkit.org/show_bug.cgi?id=199186
-    TEXTMETRIC textMetrics;
-    GetTextMetrics(dc, &textMetrics);
-    float ascent = textMetrics.tmAscent * metricsMultiplier;
-    float descent = textMetrics.tmDescent * metricsMultiplier;
-    float capHeight = (textMetrics.tmAscent - textMetrics.tmInternalLeading) * metricsMultiplier;
-    float lineGap = textMetrics.tmExternalLeading * metricsMultiplier;
+    float ascent = metrics.otmTextMetrics.tmAscent * metricsMultiplier;
+    float descent = metrics.otmTextMetrics.tmDescent * metricsMultiplier;
+    float capHeight = (metrics.otmTextMetrics.tmAscent - metrics.otmTextMetrics.tmInternalLeading) * metricsMultiplier;
+    float lineGap = metrics.otmTextMetrics.tmExternalLeading * metricsMultiplier;
 
     m_fontMetrics.setAscent(ascent);
     m_fontMetrics.setDescent(descent);
     m_fontMetrics.setCapHeight(capHeight);
     m_fontMetrics.setLineGap(lineGap);
     m_fontMetrics.setLineSpacing(lroundf(ascent) + lroundf(descent) + lroundf(lineGap));
-    m_avgCharWidth = textMetrics.tmAveCharWidth * metricsMultiplier;
-    m_maxCharWidth = textMetrics.tmMaxCharWidth * metricsMultiplier;
+    m_fontMetrics.setUnitsPerEm(metrics.otmEMSquare);
+    m_avgCharWidth = metrics.otmTextMetrics.tmAveCharWidth * metricsMultiplier;
+    m_maxCharWidth = metrics.otmTextMetrics.tmMaxCharWidth * metricsMultiplier;
 
     cairo_text_extents_t extents;
     cairo_scaled_font_text_extents(scaledFont, "x", &extents);
     float xHeight = -extents.y_bearing;
 
     m_fontMetrics.setXHeight(xHeight);
-    cairo_win32_scaled_font_done_font(scaledFont);
 
     m_scriptCache = 0;
     m_scriptFontProperties = 0;
-
-    RestoreDC(dc, -1);
 }
 
 void Font::determinePitch()


### PR DESCRIPTION
#### 3ad2e0b37791680cad1ffc23c6ff56c4b35d731d
<pre>
[Win] Get UnitsPerEm font metrics
<a href="https://bugs.webkit.org/show_bug.cgi?id=253264">https://bugs.webkit.org/show_bug.cgi?id=253264</a>

Reviewed by Don Olmstead.

MathML is using UnitsPerEm.

* Source/WebCore/platform/graphics/win/SimpleFontDataCairoWin.cpp:
(WebCore::Font::platformInit):
Use GetOutlineTextMetrics to get the font metrics as AppleWin port did.

Canonical link: <a href="https://commits.webkit.org/261110@main">https://commits.webkit.org/261110@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8ec0665d16ad42e7bd30a55b420a069c6a761d3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-16-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wincairo ](https://ews-build.webkit.org/#/builders/WinCairo-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-16-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-9-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-9-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4190 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->