### PR TITLE
Add experimental feature for post-processing Canvas image data

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1351,6 +1351,20 @@ CanvasFiltersEnabled:
     WebCore:
       default: false
 
+CanvasNoiseInjectionEnabled:
+  type: bool
+  status: stable
+  category: dom
+  humanReadableName: "Canvas Noise Injection"
+  humanReadableDescription: "Enable canvas (2D/WebGL) noise injection"
+  defaultValue:
+    WebKitLegacy:
+      default: true
+    WebKit:
+      default: true
+    WebCore:
+      default: true
+
 CanvasUsesAcceleratedDrawing:
   type: bool
   status: embedder

--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -106,8 +106,10 @@ AffineTransform CanvasBase::baseTransform() const
 
 void CanvasBase::makeRenderingResultsAvailable()
 {
-    if (auto* context = renderingContext())
+    if (auto* context = renderingContext()) {
         context->paintRenderingResultsToCanvas();
+        context->postProcessPixelBuffer();
+    }
 }
 
 size_t CanvasBase::memoryCost() const
@@ -354,6 +356,70 @@ RefPtr<ImageBuffer> CanvasBase::allocateImageBuffer(bool usesDisplayListDrawing,
     context.graphicsClient = graphicsClient();
     context.avoidIOSurfaceSizeCheckInWebProcessForTesting = avoidBackendSizeCheckForTesting;
     return ImageBuffer::create(size(), RenderingPurpose::Canvas, 1, colorSpace, pixelFormat, bufferOptions, context);
+}
+
+bool CanvasBase::postProcessPixelBuffer(Ref<PixelBuffer> pixelBuffer, bool wasLastDrawByBitMap, const HashSet<uint32_t>& suppliedColors) const
+{
+    if (!scriptExecutionContext() || !scriptExecutionContext()->noiseInjectionHashSalt() || wasLastDrawByBitMap || !scriptExecutionContext()->settingsValues().canvasNoiseInjectionEnabled)
+        return false;
+
+    ASSERT(pixelBuffer->format().pixelFormat == PixelFormat::RGBA8);
+
+    constexpr auto contextString { "Canvas2DContextString"_s };
+    unsigned salt = computeHash<String, uint64_t>(contextString, *scriptExecutionContext()->noiseInjectionHashSalt());
+    constexpr int bytesPerPixel = 4;
+    auto* bytes = pixelBuffer->bytes();
+    HashMap<uint32_t, uint32_t> pixelColorMap;
+    bool wasPixelBufferModified { false };
+
+    for (size_t i = 0; i < pixelBuffer->sizeInBytes(); i += bytesPerPixel) {
+        auto& redChannel = bytes[i];
+        auto& greenChannel = bytes[i + 1];
+        auto& blueChannel = bytes[i + 2];
+        auto& alphaChannel = bytes[i + 3];
+        bool isBlack { !redChannel && !greenChannel && !blueChannel };
+
+        uint32_t pixel = (redChannel << 24) | (greenChannel << 16) | (blueChannel << 8) | alphaChannel;
+        // FIXME: Consider isEquivalentColor comparision instead of exact match
+        if (!pixel || !alphaChannel || !suppliedColors.isValidValue(pixel) || suppliedColors.contains(pixel))
+            continue;
+
+        if (auto color = pixelColorMap.get(pixel)) {
+            alphaChannel = static_cast<uint8_t>(color);
+            blueChannel = static_cast<uint8_t>(color >> 8);
+            greenChannel = static_cast<uint8_t>(color >> 16);
+            redChannel = static_cast<uint8_t>(color >> 24);
+            continue;
+        }
+
+        auto pixelHash = computeHash(salt, redChannel, greenChannel, blueChannel, alphaChannel);
+
+        auto clampedFivePercent = static_cast<int>((static_cast<float>(pixelHash / std::numeric_limits<uint32_t>::max())) * 26 - 13);
+        ASSERT(clampedFivePercent);
+
+        auto clampedColorComponentOffset = [](int colorComponentOffset, int originalComponentValue) {
+            if (colorComponentOffset + originalComponentValue > std::numeric_limits<uint8_t>::max())
+                return std::numeric_limits<uint8_t>::max() - originalComponentValue;
+            if (colorComponentOffset + originalComponentValue < 0)
+                return -originalComponentValue;
+            return colorComponentOffset;
+        };
+
+        // If alpha is non-zero and the color channels are zero, then only tweak the alpha channel's value;
+        if (isBlack)
+            alphaChannel += clampedColorComponentOffset(clampedFivePercent, alphaChannel);
+        else {
+            // If alpha and any of the color channels are non-zero, then tweak all of the channels;
+            redChannel += clampedColorComponentOffset(clampedFivePercent, redChannel);
+            greenChannel += clampedColorComponentOffset(clampedFivePercent, greenChannel);
+            blueChannel += clampedColorComponentOffset(clampedFivePercent, blueChannel);
+            alphaChannel += clampedColorComponentOffset(clampedFivePercent, alphaChannel);
+        }
+        uint32_t modifiedPixel = (redChannel << 24) | (greenChannel << 16) | (blueChannel << 8) | alphaChannel;
+        pixelColorMap.set(pixel, modifiedPixel);
+        wasPixelBufferModified = true;
+    }
+    return wasPixelBufferModified;
 }
 
 size_t CanvasBase::activePixelMemory()

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "IntSize.h"
+#include "PixelBuffer.h"
 #include "TaskSource.h"
 #include <wtf/HashSet.h>
 #include <wtf/TypeCasts.h>
@@ -124,6 +125,7 @@ public:
 
     virtual void queueTaskKeepingObjectAlive(TaskSource, Function<void()>&&) = 0;
     virtual void dispatchEvent(Event&) = 0;
+    bool postProcessPixelBuffer(Ref<PixelBuffer>, bool, const HashSet<uint32_t>&) const;
 
 protected:
     explicit CanvasBase(IntSize);

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -815,6 +815,9 @@ RefPtr<ImageData> HTMLCanvasElement::getImageData()
     if (!is<ByteArrayPixelBuffer>(pixelBuffer))
         return nullptr;
 
+    if (pixelBuffer)
+        postProcessPixelBuffer(*pixelBuffer, false, { });
+
     return ImageData::create(static_reference_cast<ByteArrayPixelBuffer>(pixelBuffer.releaseNonNull()));
 #else
     return nullptr;

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.h
@@ -94,6 +94,8 @@ public:
     virtual PixelFormat pixelFormat() const;
     virtual DestinationColorSpace colorSpace() const;
 
+    virtual void postProcessPixelBuffer() const { }
+
 protected:
     explicit CanvasRenderingContext(CanvasBase&);
     bool taintsOrigin(const CanvasPattern*);

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -236,6 +236,8 @@ public:
     using Direction = CanvasDirection;
     void setDirection(Direction);
 
+    const HashSet<uint32_t>& suppliedColors() const { return m_suppliedColors; }
+
     class FontProxy final : public FontSelectorClient {
     public:
         FontProxy() = default;
@@ -321,6 +323,8 @@ protected:
     Ref<TextMetrics> measureTextInternal(const String& text);
 
     bool usesCSSCompatibilityParseMode() const { return m_usesCSSCompatibilityParseMode; }
+
+    void postProcessPixelBuffer() const final;
 
 private:
     void applyLineDash() const;
@@ -420,7 +424,9 @@ private:
     unsigned m_unrealizedSaveCount { 0 };
     bool m_usesCSSCompatibilityParseMode;
     bool m_usesDisplayListDrawing { false };
+    bool m_wasLastDrawPutImageData { false };
     mutable std::unique_ptr<DisplayList::DrawingContext> m_recordingContext;
+    HashSet<uint32_t> m_suppliedColors;
     CanvasRenderingContext2DSettings m_settings;
 };
 

--- a/Source/WebCore/html/canvas/CanvasStyle.h
+++ b/Source/WebCore/html/canvas/CanvasStyle.h
@@ -54,6 +54,7 @@ public:
     std::optional<float> overrideAlpha() const { return std::get<CurrentColor>(m_style).overrideAlpha; }
 
     String color() const;
+    std::optional<Color> srgbaColor() const;
     RefPtr<CanvasGradient> canvasGradient() const;
     RefPtr<CanvasPattern> canvasPattern() const;
 
@@ -103,6 +104,11 @@ inline RefPtr<CanvasPattern> CanvasStyle::canvasPattern() const
 inline String CanvasStyle::color() const
 {
     return serializationForHTML(std::get<Color>(m_style));
+}
+
+inline std::optional<Color> CanvasStyle::srgbaColor() const
+{
+    return std::holds_alternative<Color>(m_style) ? std::optional { std::get<Color>(m_style) } : std::nullopt;
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 1a169d095a6691b2461810e3b639fffed1cf87f6
<pre>
Add experimental feature for post-processing Canvas image data
<a href="https://bugs.webkit.org/show_bug.cgi?id=243555">https://bugs.webkit.org/show_bug.cgi?id=243555</a>
rdar://98525861

Reviewed by Wenson Hsieh.

In this new experimental feature we post-process the Canvas2D and WebGL buffers
by adding small amounts of noise in the rendered image data. The approach this
patch takes is similar to a proposed patch by Eli Lucherini. In that patch, for
every pixel of the rendered canvas, with some probability one primary color
channel of a pixel might have a small amount of noise added. In this patch,
instead we add small amounts of noise depending on the whole pixel&apos;s value.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/html/CanvasBase.cpp:
(WebCore::CanvasBase::makeRenderingResultsAvailable):
(WebCore::CanvasBase::postProcessPixelBuffer const):
* Source/WebCore/html/CanvasBase.h:
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::getImageData):
* Source/WebCore/html/canvas/CanvasRenderingContext.h:
(WebCore::CanvasRenderingContext::postProcessPixelBuffer const):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::setFillStyle):
(WebCore::computeImageDataRect):
(WebCore::CanvasRenderingContext2DBase::postProcessPixelBuffer const):
(WebCore::CanvasRenderingContext2DBase::didDraw):
(WebCore::CanvasRenderingContext2DBase::getImageData const):
(WebCore::CanvasRenderingContext2DBase::putImageData):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:
(WebCore::CanvasRenderingContext2DBase::suppliedColors const):
* Source/WebCore/html/canvas/CanvasStyle.h:
(WebCore::CanvasStyle::srgbaColor const):

Canonical link: <a href="https://commits.webkit.org/261197@main">https://commits.webkit.org/261197@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bab07e3bd5a951168deccaa9a224ce2d3f908e8e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110848 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19934 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/43397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/2199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/119725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114809 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/21359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/11071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/87/builds/2199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116599 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/21359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/43397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/103215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/21359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/43397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/103215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/99480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/12529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/43397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/103215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/10627 "Built successfully and passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/13086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/11071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/100581 "Built successfully") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/18487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/43397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31370 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/7778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/15031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/108611 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4238 "Built successfully and passed tests") | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26773 "Passed tests") | 
<!--EWS-Status-Bubble-End-->