### PR TITLE
RenderElement::updateOutlineAutoAncestor should deal with moved out renderers

### DIFF
--- a/LayoutTests/fast/rendering/outline-auto-for-moved-out-element-crash-expected.txt
+++ b/LayoutTests/fast/rendering/outline-auto-for-moved-out-element-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/rendering/outline-auto-for-moved-out-element-crash.html
+++ b/LayoutTests/fast/rendering/outline-auto-for-moved-out-element-crash.html
@@ -1,0 +1,28 @@
+<style>
+    * {
+        outline: auto;
+    }
+    body {
+        column-count: 2;
+        column-span: all;
+    }
+    html {
+        overflow: -webkit-paged-y;
+    }
+</style>
+<html id="htmlID">
+<body>
+    foobar
+    <div id="divID" style="float: left; width: 10px; height: 10px;"></div>
+</body>
+<script>
+    if (window.testRunner)
+        testRunner.dumpAsText();
+    document.body.offsetHeight;
+    document.getElementById("htmlID").style.outline = "1px solid";
+    document.body.offsetHeight;
+    document.body.style.columnSpan = "none";
+    document.body.offsetHeight;
+    document.body.innerHTML = 'PASS if no crash.';
+</script>
+</html>

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -55,6 +55,7 @@
 #include "RenderDeprecatedFlexibleBox.h"
 #include "RenderDescendantIterator.h"
 #include "RenderFlexibleBox.h"
+#include "RenderFragmentContainer.h"
 #include "RenderFragmentedFlow.h"
 #include "RenderGrid.h"
 #include "RenderImage.h"
@@ -68,7 +69,7 @@
 #if ASSERT_ENABLED
 #include "RenderListMarker.h"
 #endif
-#include "RenderFragmentContainer.h"
+#include "RenderMultiColumnSpannerPlaceholder.h"
 #include "RenderSVGViewportContainer.h"
 #include "RenderStyle.h"
 #include "RenderTableCaption.h"
@@ -1838,6 +1839,12 @@ void RenderElement::issueRepaintForOutlineAuto(float outlineSize)
 
 void RenderElement::updateOutlineAutoAncestor(bool hasOutlineAuto)
 {
+    if (is<RenderMultiColumnSpannerPlaceholder>(*this)) {
+        auto* spanner = downcast<RenderMultiColumnSpannerPlaceholder>(*this).spanner();
+        spanner->setHasOutlineAutoAncestor(hasOutlineAuto);
+        spanner->updateOutlineAutoAncestor(hasOutlineAuto);
+    }
+
     for (auto& child : childrenOfType<RenderObject>(*this)) {
         if (hasOutlineAuto == child.hasOutlineAutoAncestor())
             continue;


### PR DESCRIPTION
#### 81bc2a0b0fb755976082c1ae57a0667cb9c4e2be
<pre>
RenderElement::updateOutlineAutoAncestor should deal with moved out renderers
<a href="https://bugs.webkit.org/show_bug.cgi?id=253270">https://bugs.webkit.org/show_bug.cgi?id=253270</a>
rdar://105873104

Reviewed by Alan Baradlay.

Before this change, when RenderElement::updateOutlineAutoAncestor was
called on RenderMultiColumnSpannerPlaceholder, we never looked at the
children of the moved out element. This means that we would have an
invalid outline auto set in the hierarchy of the moved out element,
which can cause stack overflow. This change fixes it by making it so
that we recurse through children of the moved out element to set the
right state when dealing with RenderMultiColumnSpannerPlaceholder.

* LayoutTests/fast/rendering/outline-auto-for-moved-out-element-crash-expected.txt: Added.
* LayoutTests/fast/rendering/outline-auto-for-moved-out-element-crash.html: Added.
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::updateOutlineAutoAncestor):

Canonical link: <a href="https://commits.webkit.org/261148@main">https://commits.webkit.org/261148@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0eed38dc177da7877f03bcbbb813104340a8ef60

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110618 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19698 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43195 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1960 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119469 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114577 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21111 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10817 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/1504 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116359 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15720 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98907 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102880 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97680 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30574 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44001 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12346 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31912 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85914 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12898 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8870 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18263 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51528 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7725 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14838 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->