### PR TITLE
Code outside of ScrollingTree should not access scrolling tree nodes directly

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTree.cpp
@@ -283,6 +283,12 @@ void ScrollingTree::traverseScrollingTreeRecursive(ScrollingTreeNode& node, cons
         traverseScrollingTreeRecursive(child.get(), visitorFunction);
 }
 
+void ScrollingTree::scrollingTreeNodeDidScroll(ScrollingTreeScrollingNode& node, ScrollingLayerPositionAction)
+{
+    if (node.isRootNode())
+        setMainFrameScrollPosition(node.currentScrollPosition());
+}
+
 void ScrollingTree::mainFrameViewportChangedViaDelegatedScrolling(const FloatPoint& scrollPosition, const FloatRect& layoutViewport, double)
 {
     LOG_WITH_STREAM(Scrolling, stream << "ScrollingTree::viewportChangedViaDelegatedScrolling - layoutViewport " << layoutViewport);
@@ -520,7 +526,7 @@ void ScrollingTree::clearLatchedNode()
 
 FloatPoint ScrollingTree::mainFrameScrollPosition() const
 {
-    ASSERT(m_treeStateLock.isLocked());
+    Locker locker { m_treeStateLock };
     return m_treeState.mainFrameScrollPosition;
 }
 
@@ -528,6 +534,18 @@ void ScrollingTree::setMainFrameScrollPosition(FloatPoint position)
 {
     Locker locker { m_treeStateLock };
     m_treeState.mainFrameScrollPosition = position;
+}
+
+OverscrollBehavior ScrollingTree::mainFrameHorizontalOverscrollBehavior() const
+{
+    Locker locker { m_treeLock };
+    return m_rootNode ? m_rootNode->horizontalOverscrollBehavior() : OverscrollBehavior::Auto;
+}
+
+OverscrollBehavior ScrollingTree::mainFrameVerticalOverscrollBehavior() const
+{
+    Locker locker { m_treeLock };
+    return m_rootNode ? m_rootNode->verticalOverscrollBehavior() : OverscrollBehavior::Auto;
 }
 
 void ScrollingTree::setGestureState(std::optional<WheelScrollGestureState> gestureState)

--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -116,7 +116,7 @@ public:
 
     // Called after a scrolling tree node has handled a scroll and updated its layers.
     // Updates FrameView/RenderLayer scrolling state and GraphicsLayers.
-    virtual void scrollingTreeNodeDidScroll(ScrollingTreeScrollingNode&, ScrollingLayerPositionAction = ScrollingLayerPositionAction::Sync) = 0;
+    WEBCORE_EXPORT virtual void scrollingTreeNodeDidScroll(ScrollingTreeScrollingNode&, ScrollingLayerPositionAction = ScrollingLayerPositionAction::Sync);
     virtual void scrollingTreeNodeWillStartAnimatedScroll(ScrollingTreeScrollingNode&) { }
     virtual void scrollingTreeNodeDidStopAnimatedScroll(ScrollingTreeScrollingNode&) { }
     virtual void scrollingTreeNodeWillStartWheelEventScroll(ScrollingTreeScrollingNode&) { }
@@ -223,10 +223,14 @@ public:
 
     virtual void removePendingScrollAnimationForNode(ScrollingNodeID) { }
 
+    WEBCORE_EXPORT FloatPoint mainFrameScrollPosition() const;
+
+    WEBCORE_EXPORT OverscrollBehavior mainFrameHorizontalOverscrollBehavior() const;
+    WEBCORE_EXPORT OverscrollBehavior mainFrameVerticalOverscrollBehavior() const;
+
 protected:
     WheelEventHandlingResult handleWheelEventWithNode(const PlatformWheelEvent&, OptionSet<WheelEventProcessingSteps>, ScrollingTreeNode*, EventTargeting = EventTargeting::Propagate);
 
-    FloatPoint mainFrameScrollPosition() const WTF_REQUIRES_LOCK(m_treeStateLock);
     void setMainFrameScrollPosition(FloatPoint);
 
     void setGestureState(std::optional<WheelScrollGestureState>);
@@ -244,7 +248,7 @@ protected:
     HashSet<ScrollingNodeID> nodesWithActiveScrollAnimations();
     WEBCORE_EXPORT void serviceScrollAnimations(MonotonicTime) WTF_REQUIRES_LOCK(m_treeLock);
 
-    Lock m_treeLock; // Protects the scrolling tree.
+    mutable Lock m_treeLock; // Protects the scrolling tree.
 
 private:
     void updateTreeFromStateNodeRecursive(const ScrollingStateNode*, struct CommitTreeState&) WTF_REQUIRES_LOCK(m_treeLock);
@@ -288,7 +292,7 @@ private:
         HashSet<ScrollingNodeID> nodesWithActiveScrollAnimations;
     };
     
-    Lock m_treeStateLock;
+    mutable Lock m_treeStateLock;
     TreeState m_treeState WTF_GUARDED_BY_LOCK(m_treeStateLock);
 
     struct SwipeState {

--- a/Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp
@@ -225,12 +225,10 @@ bool ThreadedScrollingTree::canUpdateLayersOnScrollingThread() const
 
 void ThreadedScrollingTree::scrollingTreeNodeDidScroll(ScrollingTreeScrollingNode& node, ScrollingLayerPositionAction scrollingLayerPositionAction)
 {
+    ScrollingTree::scrollingTreeNodeDidScroll(node, scrollingLayerPositionAction);
+
     if (!m_scrollingCoordinator)
         return;
-
-    auto scrollPosition = node.currentScrollPosition();
-    if (node.isRootNode())
-        setMainFrameScrollPosition(scrollPosition);
 
     if (isHandlingProgrammaticScroll())
         return;
@@ -239,6 +237,7 @@ void ThreadedScrollingTree::scrollingTreeNodeDidScroll(ScrollingTreeScrollingNod
     if (is<ScrollingTreeFrameScrollingNode>(node))
         layoutViewportOrigin = downcast<ScrollingTreeFrameScrollingNode>(node).layoutViewport().location();
 
+    auto scrollPosition = node.currentScrollPosition();
     auto scrollUpdate = ScrollUpdate { node.scrollingNodeID(), scrollPosition, layoutViewportOrigin, ScrollUpdateType::PositionUpdate, scrollingLayerPositionAction };
 
     if (RunLoop::isMain()) {

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -913,13 +913,8 @@ static void changeContentOffsetBoundedInValidRange(UIScrollView *scrollView, Web
     [_scrollView setMaximumZoomScale:layerTreeTransaction.maximumScaleFactor()];
     [_scrollView _setZoomEnabledInternal:layerTreeTransaction.allowsUserScaling()];
 
-    auto horizontalOverscrollBehavior = WebCore::OverscrollBehavior::Auto;
-    auto verticalOverscrollBehavior = WebCore::OverscrollBehavior::Auto;
-
-    if (auto rootNode = _page->scrollingCoordinatorProxy()->rootNode()) {
-        horizontalOverscrollBehavior = rootNode->horizontalOverscrollBehavior();
-        verticalOverscrollBehavior = rootNode->verticalOverscrollBehavior();
-    }
+    auto horizontalOverscrollBehavior = _page->scrollingCoordinatorProxy()->mainFrameHorizontalOverscrollBehavior();
+    auto verticalOverscrollBehavior = _page->scrollingCoordinatorProxy()->mainFrameVerticalOverscrollBehavior();
     
     WebKit::ScrollingTreeScrollingNodeDelegateIOS::updateScrollViewForOverscrollBehavior(_scrollView.get(), horizontalOverscrollBehavior, verticalOverscrollBehavior, WebKit::ScrollingTreeScrollingNodeDelegateIOS::AllowOverscrollToPreventScrollPropagation::No);
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -58,6 +58,7 @@ RemoteScrollingCoordinatorProxy::~RemoteScrollingCoordinatorProxy()
 
 ScrollingNodeID RemoteScrollingCoordinatorProxy::rootScrollingNodeID() const
 {
+    // FIXME: Locking
     if (!m_scrollingTree->rootNode())
         return 0;
 
@@ -254,13 +255,19 @@ String RemoteScrollingCoordinatorProxy::scrollingTreeAsText() const
 
 bool RemoteScrollingCoordinatorProxy::hasScrollableMainFrame() const
 {
+    // FIXME: Locking
     auto* rootNode = m_scrollingTree->rootNode();
     return rootNode && rootNode->canHaveScrollbars();
 }
 
-ScrollingTreeScrollingNode* RemoteScrollingCoordinatorProxy::rootNode() const
+OverscrollBehavior RemoteScrollingCoordinatorProxy::mainFrameHorizontalOverscrollBehavior() const
 {
-    return m_scrollingTree->rootNode();
+    return m_scrollingTree->mainFrameHorizontalOverscrollBehavior();
+}
+
+OverscrollBehavior RemoteScrollingCoordinatorProxy::mainFrameVerticalOverscrollBehavior() const
+{
+    return m_scrollingTree->mainFrameVerticalOverscrollBehavior();
 }
 
 void RemoteScrollingCoordinatorProxy::displayDidRefresh(PlatformDisplayID displayID)
@@ -270,6 +277,7 @@ void RemoteScrollingCoordinatorProxy::displayDidRefresh(PlatformDisplayID displa
 
 bool RemoteScrollingCoordinatorProxy::hasScrollableOrZoomedMainFrame() const
 {
+    // FIXME: Locking
     auto* rootNode = m_scrollingTree->rootNode();
     if (!rootNode)
         return false;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -109,7 +109,10 @@ public:
     bool hasFixedOrSticky() const { return m_scrollingTree->hasFixedOrSticky(); }
     bool hasScrollableMainFrame() const;
     bool hasScrollableOrZoomedMainFrame() const;
-    
+
+    WebCore::OverscrollBehavior mainFrameHorizontalOverscrollBehavior() const;
+    WebCore::OverscrollBehavior mainFrameVerticalOverscrollBehavior() const;
+
     virtual bool propagatesMainFrameScrolls() const { return true; }
 
     virtual void scrollingTreeNodeWillStartPanGesture(WebCore::ScrollingNodeID) { }
@@ -121,7 +124,6 @@ public:
     String scrollingTreeAsText() const;
 
     void resetStateAfterProcessExited();
-    WebCore::ScrollingTreeScrollingNode* rootNode() const;
 
     virtual void displayDidRefresh(WebCore::PlatformDisplayID);
     void reportExposedUnfilledArea(MonotonicTime, unsigned unfilledArea);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
@@ -64,6 +64,8 @@ void RemoteScrollingTree::scrollingTreeNodeDidScroll(ScrollingTreeScrollingNode&
 {
     ASSERT(isMainRunLoop());
 
+    ScrollingTree::scrollingTreeNodeDidScroll(node, scrollingLayerPositionAction);
+
     if (!m_scrollingCoordinatorProxy)
         return;
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
@@ -278,6 +278,7 @@ bool RemoteScrollingCoordinatorProxyIOS::shouldSetScrollViewDecelerationRateFast
 
 void RemoteScrollingCoordinatorProxyIOS::setRootNodeIsInUserScroll(bool value)
 {
+    // FIXME: Locking
     auto* rootNode = scrollingTree()->rootNode();
     if (!rootNode)
         return;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
@@ -193,9 +193,6 @@ void RemoteLayerTreeDrawingAreaProxyMac::adjustTransientZoom(double scale, Float
     m_transientZoomOrigin = origin;
 
     applyTransientZoomToLayer();
-
-    if (auto* rootNode = dynamicDowncast<ScrollingTreeFrameScrollingNode>(m_webPageProxy.scrollingCoordinatorProxy()->rootNode()))
-        m_webPageProxy.adjustLayersForLayoutViewport(rootNode->currentScrollPosition(), rootNode->layoutViewport(), scale);
     
     // FIXME: Only send these messages as fast as the web process is responding to them.
     m_webPageProxy.send(Messages::DrawingArea::AdjustTransientZoom(scale, origin), m_identifier);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
@@ -40,6 +40,8 @@ public:
     explicit RemoteScrollingCoordinatorProxyMac(WebPageProxy&);
     ~RemoteScrollingCoordinatorProxyMac();
 
+    WebCore::FloatPoint currentMainFrameScrollPosition() const;
+
 private:
     void handleWheelEvent(const NativeWebWheelEvent&, WebCore::RectEdges<bool> rubberBandableEdges) override;
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
@@ -61,6 +61,11 @@ RemoteScrollingCoordinatorProxyMac::~RemoteScrollingCoordinatorProxyMac()
 #endif
 }
 
+FloatPoint RemoteScrollingCoordinatorProxyMac::currentMainFrameScrollPosition() const
+{
+    return scrollingTree()->mainFrameScrollPosition();
+}
+
 void RemoteScrollingCoordinatorProxyMac::handleWheelEvent(const NativeWebWheelEvent& nativeWheelEvent, RectEdges<bool> rubberBandableEdges)
 {
 #if ENABLE(SCROLLING_THREAD)


### PR DESCRIPTION
#### 087a80ea89a521c156f820554f1298dfcb94c2aa
<pre>
Code outside of ScrollingTree should not access scrolling tree nodes directly
<a href="https://bugs.webkit.org/show_bug.cgi?id=253276">https://bugs.webkit.org/show_bug.cgi?id=253276</a>
rdar://106168232

Reviewed by Tim Horton.

Access to the scrolling tree should be protected by locking, since on macOS with
both web-side and UI-side compositing, scrolling happens off the main thread.

So remove RemoteScrollingCoordinatorProxy::rootNode() and move the functionality
down into ScrollingTree, where we can lock.

ScrollingTree already had a field for `mainFrameScrollPosition`, protected by
a lock, so fix all ScrollingTree subclasses to correctly set that, and use it
from RemoteScrollingCoordinatorProxyMac::currentMainFrameScrollPosition().
This has &quot;current&quot; in the name to indicate that it&apos;s the live scroll position which
is changed by the scrolling thread.

* Source/WebCore/page/scrolling/ScrollingTree.cpp:
(WebCore::ScrollingTree::scrollingTreeNodeDidScroll):
(WebCore::ScrollingTree::mainFrameScrollPosition const):
(WebCore::ScrollingTree::mainFrameHorizontalOverscrollBehavior const):
(WebCore::ScrollingTree::mainFrameVerticalOverscrollBehavior const):
* Source/WebCore/page/scrolling/ScrollingTree.h:
* Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp:
(WebCore::ThreadedScrollingTree::scrollingTreeNodeDidScroll):
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _updateScrollViewForTransaction:]):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::rootScrollingNodeID const):
(WebKit::RemoteScrollingCoordinatorProxy::hasScrollableMainFrame const):
(WebKit::RemoteScrollingCoordinatorProxy::mainFrameHorizontalOverscrollBehavior const):
(WebKit::RemoteScrollingCoordinatorProxy::mainFrameVerticalOverscrollBehavior const):
(WebKit::RemoteScrollingCoordinatorProxy::hasScrollableOrZoomedMainFrame const):
(WebKit::RemoteScrollingCoordinatorProxy::rootNode const): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp:
(WebKit::RemoteScrollingTree::scrollingTreeNodeDidScroll):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm:
(WebKit::RemoteScrollingCoordinatorProxyIOS::setRootNodeIsInUserScroll):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::adjustTransientZoom):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm:
(WebKit::RemoteScrollingCoordinatorProxyMac::currentMainFrameScrollPosition const):

Canonical link: <a href="https://commits.webkit.org/261152@main">https://commits.webkit.org/261152@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5c17208d0733500b4ff664c3938aeff514f8b0c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110622 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19702 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43199 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1964 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119473 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114581 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21115 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10821 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/1497 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116363 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15721 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98910 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102885 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97681 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30577 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44006 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12350 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31915 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85919 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12902 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8872 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18267 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51531 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7726 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14842 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->