### PR TITLE
REGRESSION(260512@main): HDR images should be drawn directly if the destination context has HDR color space

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -69,6 +69,7 @@ class GraphicsContext {
     friend class BifurcatedGraphicsContext;
     friend class DisplayList::DrawNativeImage;
     friend class NativeImage;
+    friend class ImageBuffer;
 public:
     WEBCORE_EXPORT GraphicsContext(const GraphicsContextState::ChangeFlags& = { }, InterpolationQuality = InterpolationQuality::Default);
     WEBCORE_EXPORT GraphicsContext(const GraphicsContextState&);

--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -421,10 +421,10 @@ void ImageBuffer::draw(GraphicsContext& destContext, const FloatRect& destRect, 
     if (auto* backend = ensureBackendCreated()) {
         if (&destContext == &context()) {
             if (auto image = copyNativeImage(CopyBackingStore))
-                destContext.drawNativeImage(*image, backendSize(), destRect, srcRectScaled, options);
+                destContext.drawNativeImageInternal(*image, backendSize(), destRect, srcRectScaled, options);
         } else {
             if (auto image = copyNativeImageForDrawing(destContext)) {
-                destContext.drawNativeImage(*image, backendSize(), destRect, srcRectScaled, options);
+                destContext.drawNativeImageInternal(*image, backendSize(), destRect, srcRectScaled, options);
                 backend->finalizeDrawIntoContext(destContext);
             }
         }
@@ -451,7 +451,7 @@ void ImageBuffer::drawConsuming(GraphicsContext& destContext, const FloatRect& d
     if (auto* backend = ensureBackendCreated()) {
         auto backendSize = backend->backendSize();
         if (auto image = sinkIntoNativeImage())
-            destContext.drawNativeImage(*image, backendSize, destRect, adjustedSrcRect, options);
+            destContext.drawNativeImageInternal(*image, backendSize, destRect, adjustedSrcRect, options);
     }
 }
 


### PR DESCRIPTION
#### 9180e60fc30a62f676cedb224f881ff24ef8f682
<pre>
REGRESSION(260512@main): HDR images should be drawn directly if the destination context has HDR color space
<a href="https://bugs.webkit.org/show_bug.cgi?id=253275">https://bugs.webkit.org/show_bug.cgi?id=253275</a>
rdar://106055782

Reviewed by Simon Fraser.

CoreGraphics should draw the HDR images directly to the destination context if
it has HDR color space.

ImageBuffer::draw() should call GraphicsContext::drawNativeImageInternal() to
prevent the possible recursion from NativeImage::draw() to ImageBuffer::draw().

* Source/WebCore/platform/graphics/GraphicsContext.h:
* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::draw):
(WebCore::ImageBuffer::drawConsuming):
* Source/WebCore/platform/graphics/cg/NativeImageCG.cpp:
(WebCore::NativeImage::draw):

Canonical link: <a href="https://commits.webkit.org/261149@main">https://commits.webkit.org/261149@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df744fccaa651ce32f5eb6cbc2d09150159657d4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110719 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19801 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43278 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2060 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119551 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114686 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21208 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10913 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/1678 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116463 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103061 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30637 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/44164 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/12423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/31974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/86044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12980 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18356 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51593 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7718 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/14929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->