### PR TITLE
Re-import html/semantics/popovers WPT

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-anchor-idl-property.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-anchor-idl-property.html
@@ -8,7 +8,7 @@
 
 <button id=b1>This is an anchor button</button>
 <div popover id=p1 anchor=b1>This is a popover</div>
-<button id=b2 popovertoggletarget=p1>This button invokes the popover but isn't an anchor</button>
+<button id=b2 popovertarget=p1>This button invokes the popover but isn't an anchor</button>
 
 <script>
   test(function() {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-anchor-nested-display.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-anchor-nested-display.html
@@ -5,11 +5,11 @@
 <link rel=help href="https://html.spec.whatwg.org/multipage/popover.html">
 <link rel=match href="popover-anchor-nested-display-ref.html">
 
-<button id=main-menu-button popovertoggletarget=main-menu>Show menu</button>
+<button id=main-menu-button popovertarget=main-menu>Show menu</button>
 
 <div id=main-menu popover anchor=main-menu-button>
   <div>Foo</div>
-  <button id=nested-menu-button popovertoggletarget=nested-menu>
+  <button id=nested-menu-button popovertarget=nested-menu>
     Show nested menu
   </button>
   <div>Bar</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic-expected.txt
@@ -1,10 +1,11 @@
-Pop upDialog with popover=manualInvalid popover value - defaults to popover=manualInvalid popover value - defaults to popover=manualInvalid popover value - defaults to popover=manual
+Pop upPop upDialog with popover=manualInvalid popover value - defaults to popover=manualInvalid popover value - defaults to popover=manualInvalid popover value - defaults to popover=manual
 Not a popover
 Dialog without popover attribute
 
 FAIL The element <div popover="" id="boolean">Pop up</div> should behave as a popover. Element has unexpected visibility state
 FAIL The element <div popover="">Pop up</div> should behave as a popover. Element has unexpected visibility state
 FAIL The element <div popover="auto">Pop up</div> should behave as a popover. Element has unexpected visibility state
+FAIL The element <div popover="hint">Pop up</div> should behave as a popover. Element has unexpected visibility state
 FAIL The element <div popover="manual">Pop up</div> should behave as a popover. Element has unexpected visibility state
 FAIL The element <article popover="">Different element type</article> should behave as a popover. Element has unexpected visibility state
 FAIL The element <header popover="">Different element type</header> should behave as a popover. Element has unexpected visibility state
@@ -204,7 +205,7 @@ FAIL A <video> element should *not* behave as a popover. assert_throws_dom: Call
 PASS IDL attribute reflection
 FAIL Popover attribute value should be case insensitive Element has unexpected visibility state
 FAIL Changing attribute values for popover should work Element has unexpected visibility state
-PASS Changing attribute values should close open popovers
+FAIL Changing attribute values should close open popovers assert_false: expected false got true
 PASS Removing a visible popover=auto element from the document should close the popover
 PASS A showing popover=auto does not match :modal
 PASS Removing a visible popover=manual element from the document should close the popover

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic.html
@@ -15,6 +15,7 @@
   <div popover id=boolean>Pop up</div>
   <div popover="">Pop up</div>
   <div popover=auto>Pop up</div>
+  <div popover=hint>Pop up</div>
   <div popover=manual>Pop up</div>
   <article popover>Different element type</article>
   <header popover>Different element type</header>
@@ -163,6 +164,10 @@ window.onload = () => {
     assert_equals(popover.popover,'manual','Invalid values should reflect as "manual"');
     popover.removeAttribute('popover');
     assert_equals(popover.popover,null,'No value should reflect as null');
+    if (popoverHintSupported()) {
+      popover.popover='hint';
+      assert_equals(popover.getAttribute('popover'),'hint');
+    }
     popover.popover='auto';
     assert_equals(popover.getAttribute('popover'),'auto');
     popover.popover='';
@@ -223,7 +228,13 @@ window.onload = () => {
     const popover = createPopover(t);
     popover.showPopover();
     assert_true(popover.matches(':open'));
-    popover.setAttribute('popover','manual'); // Change popover type
+    if (popoverHintSupported()) {
+      popover.setAttribute('popover','hint'); // Change popover type
+      assert_false(popover.matches(':open'));
+      popover.showPopover();
+      assert_true(popover.matches(':open'));
+      popover.setAttribute('popover','manual');
+    }
     assert_false(popover.matches(':open'));
     popover.showPopover();
     assert_true(popover.matches(':open'));
@@ -237,7 +248,7 @@ window.onload = () => {
     assert_false(popover.matches(':open'),'From "auto" to "invalid" (which is interpreted as "manual") should close the popover');
   },'Changing attribute values should close open popovers');
 
-  const validTypes = ["auto","manual"];
+  const validTypes = popoverHintSupported() ? ["auto","hint","manual"] : ["auto","manual"];
   validTypes.forEach(type => {
     test((t) => {
       const popover = createPopover(t);
@@ -376,6 +387,7 @@ window.onload = () => {
                     popover.hidePopover();
                     break;
                   case 'auto':
+                  case 'hint':
                     assert_false(popover.matches(':open'),'A popover=auto should light-dismiss');
                     break;
                 }

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-backdrop-appearance.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-backdrop-appearance.html
@@ -36,7 +36,7 @@
 <p>Test for [popover]::backdrop presence and stacking order. The test passes
   if there are 3 stacked boxes, with the brightest green on top.</p>
 <div popover id=bottom>Bottom
-  <div popover id=middle>Middle
+  <div popover=hint id=middle>Middle
     <div popover=manual id=top>Top</div>
   </div>
 </div>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2-expected.txt
@@ -4,7 +4,7 @@ Show popover
 
 FAIL Popover focus navigation assert_equals: Hidden popover should be skipped expected Element node <button id="button2">Button2</button> but got Element node <body><div id="fixup">
   <button id="button1">Button1</bu...
-FAIL Circular reference tab navigation assert_equals: Step 2 expected Element node <button id="circular1" autofocus="" popoverhidetarget="po... but got Element node <body><div id="fixup">
+FAIL Circular reference tab navigation assert_equals: Step 2 expected Element node <button id="circular1" autofocus="" popovertarget="popove... but got Element node <body><div id="fixup">
   <button id="button1">Button1</bu...
 FAIL Popover focus returns when popover is hidden by invoker assert_true: popover should be invoked by invoker expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2.html
@@ -14,15 +14,15 @@
   <button id=button1>Button1</button>
   <div popover id=popover1 style="top:100px">
     <button id=inside_popover1>Inside1</button>
-    <button id=invoker2 popovertoggletarget=popover2>Nested Invoker 2</button>
+    <button id=invoker2 popovertarget=popover2>Nested Invoker 2</button>
     <button id=inside_popover2>Inside2</button>
   </div>
   <button id=button2>Button2</button>
-  <button popovertoggletarget=popover1 id=invoker1>Invoker1</button>
+  <button popovertarget=popover1 id=invoker1>Invoker1</button>
   <button id=button3>Button3</button>
   <div popover id=popover2 style="top:200px">
     <button id=inside_popover3>Inside3</button>
-    <button id=invoker3 popovertoggletarget=popover3>Nested Invoker 3</button>
+    <button id=invoker3 popovertarget=popover3>Nested Invoker 3</button>
   </div>
   <div popover id=popover3 style="top:300px">
     Non-focusable popover
@@ -90,11 +90,11 @@ promise_test(async t => {
 }, "Popover focus navigation");
 </script>
 
-<button id=circular0 popovertoggletarget=popover4>Invoker</button>
+<button id=circular0 popovertarget=popover4>Invoker</button>
 <div id=popover4 popover>
-  <button id=circular1 autofocus popoverhidetarget=popover4></button>
-  <button id=circular2 popovershowtarget=popover4></button>
-  <button id=circular3 popovertoggletarget=popover4></button>
+  <button id=circular1 autofocus popovertarget=popover4 popovertargetaction=hide></button>
+  <button id=circular2 popovertarget=popover4 popovertargetaction=show></button>
+  <button id=circular3 popovertarget=popover4></button>
 </div>
 <button id=circular4>after</button>
 <script>
@@ -107,16 +107,16 @@ promise_test(async t => {
 </script>
 
 <div id=deleted>
-  <button popovershowtarget=deleted1>Show popover</button>
+  <button popovertarget=deleted1 popovertargetaction=show>Show popover</button>
   <div popover id=deleted1>
-    <button popoverhidetarget=deleted1 autofocus>Hide popover</button>
+    <button popovertarget=deleted1 popovertargetaction=hide autofocus>Hide popover</button>
   </div>
 </div>
 <script>
 promise_test(async t => {
   const invoker = document.querySelector('#deleted>button');
   const popover = document.querySelector('#deleted>[popover]');
-  const hideButton = popover.querySelector('[popoverhidetarget]');
+  const hideButton = popover.querySelector('[popovertargetaction=hide]');
   invoker.focus(); // Make sure button is focused.
   assert_equals(document.activeElement,invoker);
   await sendEnter(); // Activate the invoker

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus.html
@@ -71,7 +71,7 @@
       button.remove();
     });
     popover.id = popoverId;
-    button.setAttribute('popovertoggletarget', popoverId);
+    button.setAttribute('popovertarget', popoverId);
     return button;
   }
   function addPriorFocus(t) {
@@ -187,7 +187,7 @@
       const priorFocus = addPriorFocus(t);
       assert_false(popover.matches(':open'), 'popover should start out hidden');
       let button = addInvoker(t, popover);
-      assert_equals(button.getAttribute('popovertoggletarget'), popover.id, 'This test assumes the button uses `popovertoggletarget`.');
+      assert_equals(button.getAttribute('popovertarget'), popover.id, 'This test assumes the button uses `popovertarget`.');
       assert_not_equals(button, priorFocus, 'Stranger things have happened');
       assert_false(popover.contains(button), 'Start with a non-contained button');
       priorFocus.focus();
@@ -200,8 +200,8 @@
       assert_false(isElementVisible(popover));
 
       // Same thing, but the button is contained within the popover
-      button.removeAttribute('popovertoggletarget');
-      button.setAttribute('popoverhidetarget', popover.id);
+      button.setAttribute('popovertarget', popover.id);
+      button.setAttribute('popovertargetaction', 'hide');
       popover.appendChild(button);
       t.add_cleanup(() => button.remove());
       priorFocus.focus();
@@ -216,7 +216,7 @@
       assert_equals(document.activeElement, priorFocus, 'Contained button should return focus to the previously focused element');
       assert_false(isElementVisible(popover));
 
-      // Same thing, but the button is unrelated (no popovertoggletarget)
+      // Same thing, but the button is unrelated (no popovertarget)
       button = document.createElement('button');
       document.body.appendChild(button);
       priorFocus.focus();

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-invoking-attribute-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-invoking-attribute-expected.txt
@@ -1,935 +1,1403 @@
 Toggle Popover 1
 
-PASS Test <button type="button">, t=0, s=0, h=0, Content Attr, with popover=auto
-PASS Test <button type="button">, t=0, s=0, h=0, IDL, with popover=auto
-FAIL Test <button type="button">, t=0, s=0, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=0, s=0, h=1, IDL, with popover=auto assert_equals: Toggle or hide should hide the popover expected false but got true
-FAIL Test <button type="button">, t=0, s=0, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=0, s=0, h=2, IDL, with popover=auto assert_equals: Toggle or hide should hide the popover expected false but got true
-FAIL Test <button type="button">, t=0, s=1, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=0, s=1, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=0, s=1, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=0, s=1, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=0, s=1, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=0, s=1, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=0, s=2, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=0, s=2, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=0, s=2, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=0, s=2, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=0, s=2, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=0, s=2, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=1, s=0, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=1, s=0, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=1, s=0, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=1, s=0, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=1, s=0, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=1, s=0, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=1, s=1, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=1, s=1, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=1, s=1, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=1, s=1, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=1, s=1, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=1, s=1, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=1, s=2, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=1, s=2, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=1, s=2, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=1, s=2, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=1, s=2, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=1, s=2, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=2, s=0, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=2, s=0, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=2, s=0, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=2, s=0, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=2, s=0, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=2, s=0, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=2, s=1, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=2, s=1, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=2, s=1, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=2, s=1, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=2, s=1, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=2, s=1, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=2, s=2, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=2, s=2, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=2, s=2, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=2, s=2, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=2, s=2, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=2, s=2, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-PASS Test <button type="reset">, t=0, s=0, h=0, Content Attr, with popover=auto
-PASS Test <button type="reset">, t=0, s=0, h=0, IDL, with popover=auto
-FAIL Test <button type="reset">, t=0, s=0, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=0, s=0, h=1, IDL, with popover=auto assert_equals: Toggle or hide should hide the popover expected false but got true
-FAIL Test <button type="reset">, t=0, s=0, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=0, s=0, h=2, IDL, with popover=auto assert_equals: Toggle or hide should hide the popover expected false but got true
-FAIL Test <button type="reset">, t=0, s=1, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=0, s=1, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=0, s=1, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=0, s=1, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=0, s=1, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=0, s=1, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=0, s=2, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=0, s=2, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=0, s=2, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=0, s=2, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=0, s=2, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=0, s=2, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=1, s=0, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=1, s=0, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=1, s=0, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=1, s=0, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=1, s=0, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=1, s=0, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=1, s=1, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=1, s=1, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=1, s=1, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=1, s=1, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=1, s=1, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=1, s=1, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=1, s=2, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=1, s=2, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=1, s=2, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=1, s=2, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=1, s=2, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=1, s=2, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=2, s=0, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=2, s=0, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=2, s=0, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=2, s=0, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=2, s=0, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=2, s=0, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=2, s=1, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=2, s=1, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=2, s=1, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=2, s=1, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=2, s=1, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=2, s=1, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=2, s=2, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=2, s=2, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=2, s=2, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=2, s=2, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=2, s=2, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=2, s=2, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-PASS Test <button type="submit">, t=0, s=0, h=0, Content Attr, with popover=auto
-PASS Test <button type="submit">, t=0, s=0, h=0, IDL, with popover=auto
-FAIL Test <button type="submit">, t=0, s=0, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=0, s=0, h=1, IDL, with popover=auto assert_equals: Toggle or hide should hide the popover expected false but got true
-FAIL Test <button type="submit">, t=0, s=0, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=0, s=0, h=2, IDL, with popover=auto assert_equals: Toggle or hide should hide the popover expected false but got true
-FAIL Test <button type="submit">, t=0, s=1, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=0, s=1, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=0, s=1, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=0, s=1, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=0, s=1, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=0, s=1, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=0, s=2, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=0, s=2, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=0, s=2, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=0, s=2, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=0, s=2, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=0, s=2, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=1, s=0, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=1, s=0, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=1, s=0, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=1, s=0, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=1, s=0, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=1, s=0, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=1, s=1, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=1, s=1, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=1, s=1, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=1, s=1, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=1, s=1, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=1, s=1, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=1, s=2, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=1, s=2, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=1, s=2, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=1, s=2, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=1, s=2, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=1, s=2, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=2, s=0, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=2, s=0, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=2, s=0, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=2, s=0, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=2, s=0, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=2, s=0, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=2, s=1, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=2, s=1, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=2, s=1, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=2, s=1, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=2, s=1, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=2, s=1, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=2, s=2, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=2, s=2, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=2, s=2, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=2, s=2, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=2, s=2, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=2, s=2, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-PASS Test <button type="">, t=0, s=0, h=0, Content Attr, with popover=auto
-PASS Test <button type="">, t=0, s=0, h=0, IDL, with popover=auto
-FAIL Test <button type="">, t=0, s=0, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=0, s=0, h=1, IDL, with popover=auto assert_equals: Toggle or hide should hide the popover expected false but got true
-FAIL Test <button type="">, t=0, s=0, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=0, s=0, h=2, IDL, with popover=auto assert_equals: Toggle or hide should hide the popover expected false but got true
-FAIL Test <button type="">, t=0, s=1, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=0, s=1, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=0, s=1, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=0, s=1, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=0, s=1, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=0, s=1, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=0, s=2, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=0, s=2, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=0, s=2, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=0, s=2, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=0, s=2, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=0, s=2, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=1, s=0, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=1, s=0, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=1, s=0, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=1, s=0, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=1, s=0, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=1, s=0, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=1, s=1, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=1, s=1, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=1, s=1, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=1, s=1, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=1, s=1, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=1, s=1, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=1, s=2, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=1, s=2, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=1, s=2, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=1, s=2, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=1, s=2, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=1, s=2, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=2, s=0, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=2, s=0, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=2, s=0, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=2, s=0, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=2, s=0, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=2, s=0, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=2, s=1, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=2, s=1, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=2, s=1, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=2, s=1, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=2, s=1, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=2, s=1, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=2, s=2, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=2, s=2, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=2, s=2, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=2, s=2, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=2, s=2, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=2, s=2, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-PASS Test <input type="button">, t=0, s=0, h=0, Content Attr, with popover=auto
-PASS Test <input type="button">, t=0, s=0, h=0, IDL, with popover=auto
-FAIL Test <input type="button">, t=0, s=0, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=0, s=0, h=1, IDL, with popover=auto assert_equals: Toggle or hide should hide the popover expected false but got true
-FAIL Test <input type="button">, t=0, s=0, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=0, s=0, h=2, IDL, with popover=auto assert_equals: Toggle or hide should hide the popover expected false but got true
-FAIL Test <input type="button">, t=0, s=1, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=0, s=1, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=0, s=1, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=0, s=1, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=0, s=1, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=0, s=1, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=0, s=2, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=0, s=2, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=0, s=2, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=0, s=2, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=0, s=2, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=0, s=2, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=1, s=0, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=1, s=0, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=1, s=0, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=1, s=0, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=1, s=0, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=1, s=0, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=1, s=1, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=1, s=1, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=1, s=1, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=1, s=1, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=1, s=1, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=1, s=1, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=1, s=2, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=1, s=2, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=1, s=2, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=1, s=2, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=1, s=2, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=1, s=2, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=2, s=0, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=2, s=0, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=2, s=0, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=2, s=0, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=2, s=0, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=2, s=0, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=2, s=1, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=2, s=1, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=2, s=1, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=2, s=1, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=2, s=1, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=2, s=1, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=2, s=2, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=2, s=2, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=2, s=2, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=2, s=2, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=2, s=2, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=2, s=2, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-PASS Test <input type="reset">, t=0, s=0, h=0, Content Attr, with popover=auto
-PASS Test <input type="reset">, t=0, s=0, h=0, IDL, with popover=auto
-FAIL Test <input type="reset">, t=0, s=0, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=0, s=0, h=1, IDL, with popover=auto assert_equals: Toggle or hide should hide the popover expected false but got true
-FAIL Test <input type="reset">, t=0, s=0, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=0, s=0, h=2, IDL, with popover=auto assert_equals: Toggle or hide should hide the popover expected false but got true
-FAIL Test <input type="reset">, t=0, s=1, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=0, s=1, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=0, s=1, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=0, s=1, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=0, s=1, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=0, s=1, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=0, s=2, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=0, s=2, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=0, s=2, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=0, s=2, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=0, s=2, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=0, s=2, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=1, s=0, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=1, s=0, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=1, s=0, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=1, s=0, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=1, s=0, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=1, s=0, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=1, s=1, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=1, s=1, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=1, s=1, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=1, s=1, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=1, s=1, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=1, s=1, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=1, s=2, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=1, s=2, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=1, s=2, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=1, s=2, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=1, s=2, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=1, s=2, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=2, s=0, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=2, s=0, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=2, s=0, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=2, s=0, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=2, s=0, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=2, s=0, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=2, s=1, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=2, s=1, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=2, s=1, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=2, s=1, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=2, s=1, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=2, s=1, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=2, s=2, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=2, s=2, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=2, s=2, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=2, s=2, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=2, s=2, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=2, s=2, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-PASS Test <input type="submit">, t=0, s=0, h=0, Content Attr, with popover=auto
-PASS Test <input type="submit">, t=0, s=0, h=0, IDL, with popover=auto
-FAIL Test <input type="submit">, t=0, s=0, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=0, s=0, h=1, IDL, with popover=auto assert_equals: Toggle or hide should hide the popover expected false but got true
-FAIL Test <input type="submit">, t=0, s=0, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=0, s=0, h=2, IDL, with popover=auto assert_equals: Toggle or hide should hide the popover expected false but got true
-FAIL Test <input type="submit">, t=0, s=1, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=0, s=1, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=0, s=1, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=0, s=1, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=0, s=1, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=0, s=1, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=0, s=2, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=0, s=2, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=0, s=2, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=0, s=2, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=0, s=2, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=0, s=2, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=1, s=0, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=1, s=0, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=1, s=0, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=1, s=0, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=1, s=0, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=1, s=0, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=1, s=1, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=1, s=1, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=1, s=1, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=1, s=1, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=1, s=1, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=1, s=1, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=1, s=2, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=1, s=2, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=1, s=2, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=1, s=2, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=1, s=2, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=1, s=2, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=2, s=0, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=2, s=0, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=2, s=0, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=2, s=0, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=2, s=0, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=2, s=0, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=2, s=1, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=2, s=1, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=2, s=1, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=2, s=1, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=2, s=1, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=2, s=1, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=2, s=2, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=2, s=2, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=2, s=2, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=2, s=2, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=2, s=2, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=2, s=2, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-PASS Test <input type="image">, t=0, s=0, h=0, Content Attr, with popover=auto
-PASS Test <input type="image">, t=0, s=0, h=0, IDL, with popover=auto
-FAIL Test <input type="image">, t=0, s=0, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=0, s=0, h=1, IDL, with popover=auto assert_equals: Toggle or hide should hide the popover expected false but got true
-FAIL Test <input type="image">, t=0, s=0, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=0, s=0, h=2, IDL, with popover=auto assert_equals: Toggle or hide should hide the popover expected false but got true
-FAIL Test <input type="image">, t=0, s=1, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=0, s=1, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=0, s=1, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=0, s=1, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=0, s=1, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=0, s=1, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=0, s=2, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=0, s=2, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=0, s=2, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=0, s=2, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=0, s=2, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=0, s=2, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=1, s=0, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=1, s=0, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=1, s=0, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=1, s=0, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=1, s=0, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=1, s=0, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=1, s=1, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=1, s=1, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=1, s=1, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=1, s=1, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=1, s=1, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=1, s=1, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=1, s=2, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=1, s=2, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=1, s=2, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=1, s=2, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=1, s=2, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=1, s=2, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=2, s=0, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=2, s=0, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=2, s=0, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=2, s=0, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=2, s=0, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=2, s=0, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=2, s=1, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=2, s=1, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=2, s=1, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=2, s=1, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=2, s=1, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=2, s=1, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=2, s=2, h=0, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=2, s=2, h=0, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=2, s=2, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=2, s=2, h=1, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=2, s=2, h=2, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=2, s=2, h=2, IDL, with popover=auto assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="text">, t=1, s=1, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-PASS Test <input type="text">, t=1, s=1, h=1, IDL, with popover=auto
-FAIL Test <input type="email">, t=1, s=1, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-PASS Test <input type="email">, t=1, s=1, h=1, IDL, with popover=auto
-FAIL Test <input type="password">, t=1, s=1, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-PASS Test <input type="password">, t=1, s=1, h=1, IDL, with popover=auto
-FAIL Test <input type="search">, t=1, s=1, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-PASS Test <input type="search">, t=1, s=1, h=1, IDL, with popover=auto
-FAIL Test <input type="tel">, t=1, s=1, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-PASS Test <input type="tel">, t=1, s=1, h=1, IDL, with popover=auto
-FAIL Test <input type="url">, t=1, s=1, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-PASS Test <input type="url">, t=1, s=1, h=1, IDL, with popover=auto
-FAIL Test <input type="checkbox">, t=1, s=1, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-PASS Test <input type="checkbox">, t=1, s=1, h=1, IDL, with popover=auto
-FAIL Test <input type="radio">, t=1, s=1, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-PASS Test <input type="radio">, t=1, s=1, h=1, IDL, with popover=auto
-FAIL Test <input type="range">, t=1, s=1, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-PASS Test <input type="range">, t=1, s=1, h=1, IDL, with popover=auto
-FAIL Test <input type="file">, t=1, s=1, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-PASS Test <input type="file">, t=1, s=1, h=1, IDL, with popover=auto
-FAIL Test <input type="color">, t=1, s=1, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-PASS Test <input type="color">, t=1, s=1, h=1, IDL, with popover=auto
-FAIL Test <input type="date">, t=1, s=1, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-PASS Test <input type="date">, t=1, s=1, h=1, IDL, with popover=auto
-FAIL Test <input type="datetime-local">, t=1, s=1, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-PASS Test <input type="datetime-local">, t=1, s=1, h=1, IDL, with popover=auto
-FAIL Test <input type="month">, t=1, s=1, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-PASS Test <input type="month">, t=1, s=1, h=1, IDL, with popover=auto
-FAIL Test <input type="time">, t=1, s=1, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-PASS Test <input type="time">, t=1, s=1, h=1, IDL, with popover=auto
-FAIL Test <input type="week">, t=1, s=1, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-PASS Test <input type="week">, t=1, s=1, h=1, IDL, with popover=auto
-FAIL Test <input type="number">, t=1, s=1, h=1, Content Attr, with popover=auto assert_equals: expected (object) null but got (undefined) undefined
-PASS Test <input type="number">, t=1, s=1, h=1, IDL, with popover=auto
-PASS Test <button type="button">, t=0, s=0, h=0, Content Attr, with popover=manual
-PASS Test <button type="button">, t=0, s=0, h=0, IDL, with popover=manual
-FAIL Test <button type="button">, t=0, s=0, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=0, s=0, h=1, IDL, with popover=manual assert_equals: Toggle or hide should hide the popover expected false but got true
-FAIL Test <button type="button">, t=0, s=0, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=0, s=0, h=2, IDL, with popover=manual assert_equals: Toggle or hide should hide the popover expected false but got true
-FAIL Test <button type="button">, t=0, s=1, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=0, s=1, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=0, s=1, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=0, s=1, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=0, s=1, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=0, s=1, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=0, s=2, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=0, s=2, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=0, s=2, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=0, s=2, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=0, s=2, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=0, s=2, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=1, s=0, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=1, s=0, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=1, s=0, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=1, s=0, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=1, s=0, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=1, s=0, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=1, s=1, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=1, s=1, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=1, s=1, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=1, s=1, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=1, s=1, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=1, s=1, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=1, s=2, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=1, s=2, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=1, s=2, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=1, s=2, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=1, s=2, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=1, s=2, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=2, s=0, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=2, s=0, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=2, s=0, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=2, s=0, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=2, s=0, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=2, s=0, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=2, s=1, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=2, s=1, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=2, s=1, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=2, s=1, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=2, s=1, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=2, s=1, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=2, s=2, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=2, s=2, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=2, s=2, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=2, s=2, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="button">, t=2, s=2, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, t=2, s=2, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-PASS Test <button type="reset">, t=0, s=0, h=0, Content Attr, with popover=manual
-PASS Test <button type="reset">, t=0, s=0, h=0, IDL, with popover=manual
-FAIL Test <button type="reset">, t=0, s=0, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=0, s=0, h=1, IDL, with popover=manual assert_equals: Toggle or hide should hide the popover expected false but got true
-FAIL Test <button type="reset">, t=0, s=0, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=0, s=0, h=2, IDL, with popover=manual assert_equals: Toggle or hide should hide the popover expected false but got true
-FAIL Test <button type="reset">, t=0, s=1, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=0, s=1, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=0, s=1, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=0, s=1, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=0, s=1, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=0, s=1, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=0, s=2, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=0, s=2, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=0, s=2, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=0, s=2, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=0, s=2, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=0, s=2, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=1, s=0, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=1, s=0, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=1, s=0, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=1, s=0, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=1, s=0, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=1, s=0, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=1, s=1, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=1, s=1, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=1, s=1, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=1, s=1, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=1, s=1, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=1, s=1, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=1, s=2, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=1, s=2, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=1, s=2, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=1, s=2, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=1, s=2, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=1, s=2, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=2, s=0, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=2, s=0, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=2, s=0, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=2, s=0, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=2, s=0, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=2, s=0, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=2, s=1, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=2, s=1, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=2, s=1, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=2, s=1, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=2, s=1, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=2, s=1, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=2, s=2, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=2, s=2, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=2, s=2, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=2, s=2, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="reset">, t=2, s=2, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, t=2, s=2, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-PASS Test <button type="submit">, t=0, s=0, h=0, Content Attr, with popover=manual
-PASS Test <button type="submit">, t=0, s=0, h=0, IDL, with popover=manual
-FAIL Test <button type="submit">, t=0, s=0, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=0, s=0, h=1, IDL, with popover=manual assert_equals: Toggle or hide should hide the popover expected false but got true
-FAIL Test <button type="submit">, t=0, s=0, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=0, s=0, h=2, IDL, with popover=manual assert_equals: Toggle or hide should hide the popover expected false but got true
-FAIL Test <button type="submit">, t=0, s=1, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=0, s=1, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=0, s=1, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=0, s=1, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=0, s=1, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=0, s=1, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=0, s=2, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=0, s=2, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=0, s=2, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=0, s=2, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=0, s=2, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=0, s=2, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=1, s=0, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=1, s=0, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=1, s=0, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=1, s=0, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=1, s=0, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=1, s=0, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=1, s=1, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=1, s=1, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=1, s=1, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=1, s=1, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=1, s=1, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=1, s=1, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=1, s=2, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=1, s=2, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=1, s=2, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=1, s=2, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=1, s=2, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=1, s=2, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=2, s=0, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=2, s=0, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=2, s=0, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=2, s=0, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=2, s=0, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=2, s=0, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=2, s=1, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=2, s=1, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=2, s=1, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=2, s=1, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=2, s=1, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=2, s=1, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=2, s=2, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=2, s=2, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=2, s=2, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=2, s=2, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="submit">, t=2, s=2, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, t=2, s=2, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-PASS Test <button type="">, t=0, s=0, h=0, Content Attr, with popover=manual
-PASS Test <button type="">, t=0, s=0, h=0, IDL, with popover=manual
-FAIL Test <button type="">, t=0, s=0, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=0, s=0, h=1, IDL, with popover=manual assert_equals: Toggle or hide should hide the popover expected false but got true
-FAIL Test <button type="">, t=0, s=0, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=0, s=0, h=2, IDL, with popover=manual assert_equals: Toggle or hide should hide the popover expected false but got true
-FAIL Test <button type="">, t=0, s=1, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=0, s=1, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=0, s=1, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=0, s=1, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=0, s=1, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=0, s=1, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=0, s=2, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=0, s=2, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=0, s=2, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=0, s=2, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=0, s=2, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=0, s=2, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=1, s=0, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=1, s=0, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=1, s=0, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=1, s=0, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=1, s=0, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=1, s=0, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=1, s=1, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=1, s=1, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=1, s=1, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=1, s=1, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=1, s=1, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=1, s=1, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=1, s=2, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=1, s=2, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=1, s=2, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=1, s=2, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=1, s=2, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=1, s=2, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=2, s=0, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=2, s=0, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=2, s=0, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=2, s=0, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=2, s=0, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=2, s=0, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=2, s=1, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=2, s=1, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=2, s=1, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=2, s=1, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=2, s=1, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=2, s=1, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=2, s=2, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=2, s=2, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=2, s=2, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=2, s=2, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <button type="">, t=2, s=2, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, t=2, s=2, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-PASS Test <input type="button">, t=0, s=0, h=0, Content Attr, with popover=manual
-PASS Test <input type="button">, t=0, s=0, h=0, IDL, with popover=manual
-FAIL Test <input type="button">, t=0, s=0, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=0, s=0, h=1, IDL, with popover=manual assert_equals: Toggle or hide should hide the popover expected false but got true
-FAIL Test <input type="button">, t=0, s=0, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=0, s=0, h=2, IDL, with popover=manual assert_equals: Toggle or hide should hide the popover expected false but got true
-FAIL Test <input type="button">, t=0, s=1, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=0, s=1, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=0, s=1, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=0, s=1, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=0, s=1, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=0, s=1, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=0, s=2, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=0, s=2, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=0, s=2, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=0, s=2, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=0, s=2, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=0, s=2, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=1, s=0, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=1, s=0, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=1, s=0, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=1, s=0, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=1, s=0, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=1, s=0, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=1, s=1, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=1, s=1, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=1, s=1, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=1, s=1, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=1, s=1, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=1, s=1, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=1, s=2, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=1, s=2, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=1, s=2, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=1, s=2, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=1, s=2, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=1, s=2, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=2, s=0, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=2, s=0, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=2, s=0, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=2, s=0, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=2, s=0, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=2, s=0, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=2, s=1, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=2, s=1, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=2, s=1, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=2, s=1, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=2, s=1, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=2, s=1, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=2, s=2, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=2, s=2, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=2, s=2, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=2, s=2, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="button">, t=2, s=2, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, t=2, s=2, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-PASS Test <input type="reset">, t=0, s=0, h=0, Content Attr, with popover=manual
-PASS Test <input type="reset">, t=0, s=0, h=0, IDL, with popover=manual
-FAIL Test <input type="reset">, t=0, s=0, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=0, s=0, h=1, IDL, with popover=manual assert_equals: Toggle or hide should hide the popover expected false but got true
-FAIL Test <input type="reset">, t=0, s=0, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=0, s=0, h=2, IDL, with popover=manual assert_equals: Toggle or hide should hide the popover expected false but got true
-FAIL Test <input type="reset">, t=0, s=1, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=0, s=1, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=0, s=1, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=0, s=1, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=0, s=1, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=0, s=1, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=0, s=2, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=0, s=2, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=0, s=2, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=0, s=2, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=0, s=2, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=0, s=2, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=1, s=0, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=1, s=0, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=1, s=0, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=1, s=0, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=1, s=0, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=1, s=0, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=1, s=1, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=1, s=1, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=1, s=1, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=1, s=1, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=1, s=1, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=1, s=1, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=1, s=2, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=1, s=2, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=1, s=2, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=1, s=2, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=1, s=2, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=1, s=2, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=2, s=0, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=2, s=0, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=2, s=0, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=2, s=0, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=2, s=0, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=2, s=0, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=2, s=1, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=2, s=1, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=2, s=1, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=2, s=1, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=2, s=1, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=2, s=1, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=2, s=2, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=2, s=2, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=2, s=2, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=2, s=2, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="reset">, t=2, s=2, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, t=2, s=2, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-PASS Test <input type="submit">, t=0, s=0, h=0, Content Attr, with popover=manual
-PASS Test <input type="submit">, t=0, s=0, h=0, IDL, with popover=manual
-FAIL Test <input type="submit">, t=0, s=0, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=0, s=0, h=1, IDL, with popover=manual assert_equals: Toggle or hide should hide the popover expected false but got true
-FAIL Test <input type="submit">, t=0, s=0, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=0, s=0, h=2, IDL, with popover=manual assert_equals: Toggle or hide should hide the popover expected false but got true
-FAIL Test <input type="submit">, t=0, s=1, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=0, s=1, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=0, s=1, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=0, s=1, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=0, s=1, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=0, s=1, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=0, s=2, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=0, s=2, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=0, s=2, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=0, s=2, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=0, s=2, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=0, s=2, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=1, s=0, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=1, s=0, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=1, s=0, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=1, s=0, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=1, s=0, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=1, s=0, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=1, s=1, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=1, s=1, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=1, s=1, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=1, s=1, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=1, s=1, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=1, s=1, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=1, s=2, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=1, s=2, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=1, s=2, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=1, s=2, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=1, s=2, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=1, s=2, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=2, s=0, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=2, s=0, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=2, s=0, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=2, s=0, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=2, s=0, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=2, s=0, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=2, s=1, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=2, s=1, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=2, s=1, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=2, s=1, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=2, s=1, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=2, s=1, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=2, s=2, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=2, s=2, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=2, s=2, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=2, s=2, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="submit">, t=2, s=2, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, t=2, s=2, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-PASS Test <input type="image">, t=0, s=0, h=0, Content Attr, with popover=manual
-PASS Test <input type="image">, t=0, s=0, h=0, IDL, with popover=manual
-FAIL Test <input type="image">, t=0, s=0, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=0, s=0, h=1, IDL, with popover=manual assert_equals: Toggle or hide should hide the popover expected false but got true
-FAIL Test <input type="image">, t=0, s=0, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=0, s=0, h=2, IDL, with popover=manual assert_equals: Toggle or hide should hide the popover expected false but got true
-FAIL Test <input type="image">, t=0, s=1, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=0, s=1, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=0, s=1, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=0, s=1, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=0, s=1, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=0, s=1, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=0, s=2, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=0, s=2, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=0, s=2, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=0, s=2, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=0, s=2, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=0, s=2, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=1, s=0, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=1, s=0, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=1, s=0, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=1, s=0, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=1, s=0, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=1, s=0, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=1, s=1, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=1, s=1, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=1, s=1, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=1, s=1, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=1, s=1, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=1, s=1, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=1, s=2, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=1, s=2, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=1, s=2, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=1, s=2, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=1, s=2, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=1, s=2, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=2, s=0, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=2, s=0, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=2, s=0, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=2, s=0, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=2, s=0, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=2, s=0, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=2, s=1, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=2, s=1, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=2, s=1, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=2, s=1, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=2, s=1, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=2, s=1, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=2, s=2, h=0, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=2, s=2, h=0, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=2, s=2, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=2, s=2, h=1, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="image">, t=2, s=2, h=2, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, t=2, s=2, h=2, IDL, with popover=manual assert_equals: Toggle or show should show the popover expected true but got false
-FAIL Test <input type="text">, t=1, s=1, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-PASS Test <input type="text">, t=1, s=1, h=1, IDL, with popover=manual
-FAIL Test <input type="email">, t=1, s=1, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-PASS Test <input type="email">, t=1, s=1, h=1, IDL, with popover=manual
-FAIL Test <input type="password">, t=1, s=1, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-PASS Test <input type="password">, t=1, s=1, h=1, IDL, with popover=manual
-FAIL Test <input type="search">, t=1, s=1, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-PASS Test <input type="search">, t=1, s=1, h=1, IDL, with popover=manual
-FAIL Test <input type="tel">, t=1, s=1, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-PASS Test <input type="tel">, t=1, s=1, h=1, IDL, with popover=manual
-FAIL Test <input type="url">, t=1, s=1, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-PASS Test <input type="url">, t=1, s=1, h=1, IDL, with popover=manual
-FAIL Test <input type="checkbox">, t=1, s=1, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-PASS Test <input type="checkbox">, t=1, s=1, h=1, IDL, with popover=manual
-FAIL Test <input type="radio">, t=1, s=1, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-PASS Test <input type="radio">, t=1, s=1, h=1, IDL, with popover=manual
-FAIL Test <input type="range">, t=1, s=1, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-PASS Test <input type="range">, t=1, s=1, h=1, IDL, with popover=manual
-FAIL Test <input type="file">, t=1, s=1, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-PASS Test <input type="file">, t=1, s=1, h=1, IDL, with popover=manual
-FAIL Test <input type="color">, t=1, s=1, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-PASS Test <input type="color">, t=1, s=1, h=1, IDL, with popover=manual
-FAIL Test <input type="date">, t=1, s=1, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-PASS Test <input type="date">, t=1, s=1, h=1, IDL, with popover=manual
-FAIL Test <input type="datetime-local">, t=1, s=1, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-PASS Test <input type="datetime-local">, t=1, s=1, h=1, IDL, with popover=manual
-FAIL Test <input type="month">, t=1, s=1, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-PASS Test <input type="month">, t=1, s=1, h=1, IDL, with popover=manual
-FAIL Test <input type="time">, t=1, s=1, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-PASS Test <input type="time">, t=1, s=1, h=1, IDL, with popover=manual
-FAIL Test <input type="week">, t=1, s=1, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-PASS Test <input type="week">, t=1, s=1, h=1, IDL, with popover=manual
-FAIL Test <input type="number">, t=1, s=1, h=1, Content Attr, with popover=manual assert_equals: expected (object) null but got (undefined) undefined
-PASS Test <input type="number">, t=1, s=1, h=1, IDL, with popover=manual
+FAIL Test <button type="button">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="button">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <button type="button">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="button">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="button">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="button">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <button type="button">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="button">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="button">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="button">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <button type="button">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="button">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="button">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="button">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <button type="button">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="button">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="button">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="button">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <button type="button">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="button">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="button">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="button">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <button type="button">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="button">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="button">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="button">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <button type="button">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="button">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="reset">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="reset">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <button type="reset">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="reset">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="reset">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="reset">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <button type="reset">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="reset">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="reset">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="reset">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <button type="reset">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="reset">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="reset">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="reset">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <button type="reset">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="reset">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="reset">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="reset">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <button type="reset">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="reset">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="reset">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="reset">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <button type="reset">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="reset">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="reset">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="reset">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <button type="reset">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="reset">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="submit">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="submit">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <button type="submit">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="submit">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="submit">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="submit">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <button type="submit">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="submit">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="submit">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="submit">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <button type="submit">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="submit">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="submit">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="submit">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <button type="submit">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="submit">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="submit">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="submit">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <button type="submit">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="submit">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="submit">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="submit">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <button type="submit">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="submit">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="submit">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="submit">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <button type="submit">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="submit">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <button type="">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <button type="">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <button type="">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <button type="">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <button type="">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <button type="">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <button type="">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="button">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="button">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <input type="button">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="button">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="button">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="button">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <input type="button">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="button">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="button">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="button">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <input type="button">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="button">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="button">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="button">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <input type="button">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="button">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="button">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="button">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <input type="button">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="button">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="button">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="button">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <input type="button">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="button">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="button">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="button">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <input type="button">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="button">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="reset">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="reset">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <input type="reset">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="reset">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="reset">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="reset">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <input type="reset">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="reset">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="reset">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="reset">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <input type="reset">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="reset">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="reset">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="reset">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <input type="reset">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="reset">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="reset">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="reset">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <input type="reset">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="reset">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="reset">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="reset">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <input type="reset">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="reset">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="reset">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="reset">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <input type="reset">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="reset">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="submit">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="submit">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <input type="submit">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="submit">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="submit">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="submit">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <input type="submit">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="submit">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="submit">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="submit">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <input type="submit">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="submit">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="submit">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="submit">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <input type="submit">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="submit">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="submit">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="submit">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <input type="submit">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="submit">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="submit">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="submit">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <input type="submit">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="submit">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="submit">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="submit">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <input type="submit">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="submit">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="image">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="image">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <input type="image">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="image">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="image">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="image">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <input type="image">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="image">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="image">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="image">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <input type="image">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="image">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="image">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="image">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <input type="image">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="image">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="image">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="image">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <input type="image">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="image">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="image">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="image">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <input type="image">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="image">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="image">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="image">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <input type="image">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="image">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="text">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="text">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <input type="text">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="text">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="text">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="text">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <input type="text">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="text">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="text">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="text">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <input type="text">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="text">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="text">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="text">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <input type="text">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="text">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="text">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="text">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <input type="text">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="text">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="text">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="text">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <input type="text">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="text">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="text">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="text">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <input type="text">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="text">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="email">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="email">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <input type="email">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="email">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="email">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="email">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <input type="email">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="email">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="email">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="email">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <input type="email">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="email">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="email">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="email">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <input type="email">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="email">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="email">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="email">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <input type="email">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="email">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="email">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="email">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <input type="email">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="email">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="email">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="email">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <input type="email">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="email">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="password">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="password">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <input type="password">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="password">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="password">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="password">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <input type="password">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="password">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="password">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="password">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <input type="password">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="password">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="password">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="password">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <input type="password">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="password">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="password">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="password">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <input type="password">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="password">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="password">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="password">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <input type="password">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="password">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="password">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="password">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <input type="password">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="password">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="search">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="search">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <input type="search">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="search">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="search">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="search">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <input type="search">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="search">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="search">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="search">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <input type="search">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="search">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="search">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="search">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <input type="search">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="search">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="search">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="search">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <input type="search">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="search">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="search">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="search">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <input type="search">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="search">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="search">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="search">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <input type="search">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="search">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="tel">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="tel">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <input type="tel">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="tel">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="tel">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="tel">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <input type="tel">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="tel">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="tel">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="tel">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <input type="tel">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="tel">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="tel">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="tel">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <input type="tel">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="tel">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="tel">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="tel">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <input type="tel">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="tel">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="tel">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="tel">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <input type="tel">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="tel">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="tel">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="tel">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <input type="tel">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="tel">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="url">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="url">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <input type="url">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="url">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="url">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="url">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <input type="url">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="url">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="url">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="url">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <input type="url">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="url">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="url">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="url">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <input type="url">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="url">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="url">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="url">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <input type="url">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="url">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="url">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="url">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <input type="url">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="url">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="url">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="url">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <input type="url">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="url">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="checkbox">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="checkbox">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <input type="checkbox">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="checkbox">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="checkbox">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="checkbox">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <input type="checkbox">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="checkbox">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="checkbox">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="checkbox">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <input type="checkbox">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="checkbox">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="checkbox">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="checkbox">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <input type="checkbox">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="checkbox">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="checkbox">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="checkbox">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <input type="checkbox">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="checkbox">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="checkbox">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="checkbox">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <input type="checkbox">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="checkbox">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="checkbox">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="checkbox">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <input type="checkbox">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="checkbox">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="radio">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="radio">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <input type="radio">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="radio">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="radio">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="radio">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <input type="radio">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="radio">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="radio">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="radio">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <input type="radio">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="radio">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="radio">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="radio">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <input type="radio">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="radio">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="radio">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="radio">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <input type="radio">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="radio">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="radio">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="radio">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <input type="radio">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="radio">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="radio">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="radio">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <input type="radio">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="radio">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="range">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="range">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <input type="range">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="range">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="range">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="range">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <input type="range">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="range">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="range">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="range">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <input type="range">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="range">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="range">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="range">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <input type="range">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="range">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="range">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="range">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <input type="range">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="range">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="range">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="range">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <input type="range">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="range">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="range">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="range">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <input type="range">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="range">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="file">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="file">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <input type="file">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="file">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="file">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="file">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <input type="file">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="file">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="file">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="file">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <input type="file">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="file">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="file">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="file">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <input type="file">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="file">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="file">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="file">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <input type="file">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="file">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="file">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="file">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <input type="file">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="file">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="file">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="file">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <input type="file">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="file">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="color">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="color">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <input type="color">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="color">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="color">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="color">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <input type="color">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="color">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="color">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="color">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <input type="color">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="color">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="color">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="color">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <input type="color">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="color">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="color">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="color">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <input type="color">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="color">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="color">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="color">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <input type="color">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="color">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="color">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="color">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <input type="color">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="color">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="date">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="date">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <input type="date">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="date">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="date">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="date">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <input type="date">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="date">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="date">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="date">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <input type="date">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="date">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="date">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="date">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <input type="date">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="date">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="date">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="date">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <input type="date">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="date">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="date">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="date">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <input type="date">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="date">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="date">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="date">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <input type="date">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="date">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="datetime-local">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="datetime-local">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <input type="datetime-local">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="datetime-local">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="datetime-local">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="datetime-local">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <input type="datetime-local">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="datetime-local">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="datetime-local">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="datetime-local">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <input type="datetime-local">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="datetime-local">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="datetime-local">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="datetime-local">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <input type="datetime-local">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="datetime-local">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="datetime-local">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="datetime-local">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <input type="datetime-local">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="datetime-local">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="datetime-local">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="datetime-local">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <input type="datetime-local">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="datetime-local">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="datetime-local">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="datetime-local">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <input type="datetime-local">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="datetime-local">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="month">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="month">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <input type="month">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="month">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="month">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="month">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <input type="month">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="month">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="month">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="month">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <input type="month">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="month">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="month">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="month">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <input type="month">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="month">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="month">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="month">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <input type="month">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="month">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="month">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="month">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <input type="month">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="month">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="month">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="month">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <input type="month">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="month">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="time">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="time">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <input type="time">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="time">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="time">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="time">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <input type="time">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="time">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="time">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="time">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <input type="time">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="time">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="time">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="time">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <input type="time">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="time">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="time">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="time">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <input type="time">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="time">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="time">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="time">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <input type="time">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="time">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="time">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="time">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <input type="time">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="time">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="week">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="week">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <input type="week">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="week">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="week">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="week">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <input type="week">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="week">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="week">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="week">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <input type="week">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="week">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="week">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="week">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <input type="week">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="week">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="week">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="week">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <input type="week">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="week">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="week">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="week">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <input type="week">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="week">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="week">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="week">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <input type="week">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="week">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="number">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="number">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <input type="number">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="number">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="number">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="number">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <input type="number">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="number">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="number">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="number">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <input type="number">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="number">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="number">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="number">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <input type="number">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="number">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="number">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="number">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <input type="number">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="number">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="number">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="number">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <input type="number">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="number">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="number">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="number">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <input type="number">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="number">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="button">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="button">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <button type="button">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="button">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="button">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="button">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <button type="button">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="button">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="button">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="button">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <button type="button">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="button">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="button">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="button">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <button type="button">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="button">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="button">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="button">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <button type="button">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="button">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="button">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="button">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <button type="button">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="button">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="button">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="button">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <button type="button">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="button">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="reset">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="reset">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <button type="reset">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="reset">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="reset">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="reset">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <button type="reset">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="reset">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="reset">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="reset">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <button type="reset">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="reset">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="reset">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="reset">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <button type="reset">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="reset">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="reset">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="reset">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <button type="reset">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="reset">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="reset">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="reset">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <button type="reset">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="reset">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="reset">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="reset">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <button type="reset">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="reset">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="submit">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="submit">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <button type="submit">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="submit">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="submit">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="submit">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <button type="submit">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="submit">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="submit">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="submit">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <button type="submit">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="submit">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="submit">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="submit">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <button type="submit">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="submit">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="submit">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="submit">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <button type="submit">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="submit">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="submit">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="submit">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <button type="submit">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="submit">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="submit">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="submit">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <button type="submit">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="submit">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <button type="">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <button type="">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <button type="">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <button type="">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <button type="">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <button type="">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <button type="">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <button type="">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <button type="">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="button">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="button">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <input type="button">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="button">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="button">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="button">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <input type="button">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="button">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="button">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="button">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <input type="button">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="button">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="button">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="button">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <input type="button">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="button">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="button">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="button">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <input type="button">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="button">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="button">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="button">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <input type="button">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="button">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="button">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="button">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <input type="button">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="button">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="reset">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="reset">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <input type="reset">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="reset">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="reset">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="reset">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <input type="reset">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="reset">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="reset">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="reset">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <input type="reset">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="reset">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="reset">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="reset">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <input type="reset">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="reset">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="reset">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="reset">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <input type="reset">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="reset">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="reset">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="reset">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <input type="reset">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="reset">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="reset">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="reset">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <input type="reset">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="reset">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="submit">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="submit">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <input type="submit">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="submit">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="submit">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="submit">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <input type="submit">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="submit">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="submit">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="submit">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <input type="submit">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="submit">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="submit">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="submit">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <input type="submit">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="submit">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="submit">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="submit">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <input type="submit">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="submit">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="submit">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="submit">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <input type="submit">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="submit">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="submit">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="submit">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <input type="submit">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="submit">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="image">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="image">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <input type="image">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="image">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="image">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="image">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <input type="image">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="image">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="image">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="image">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <input type="image">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="image">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="image">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="image">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <input type="image">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="image">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="image">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="image">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <input type="image">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="image">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="image">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="image">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <input type="image">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="image">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="image">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="image">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <input type="image">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="image">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="text">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="text">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <input type="text">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="text">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="text">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="text">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <input type="text">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="text">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="text">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="text">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <input type="text">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="text">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="text">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="text">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <input type="text">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="text">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="text">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="text">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <input type="text">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="text">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="text">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="text">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <input type="text">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="text">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="text">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="text">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <input type="text">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="text">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="email">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="email">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <input type="email">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="email">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="email">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="email">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <input type="email">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="email">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="email">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="email">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <input type="email">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="email">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="email">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="email">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <input type="email">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="email">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="email">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="email">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <input type="email">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="email">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="email">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="email">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <input type="email">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="email">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="email">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="email">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <input type="email">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="email">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="password">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="password">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <input type="password">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="password">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="password">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="password">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <input type="password">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="password">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="password">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="password">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <input type="password">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="password">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="password">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="password">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <input type="password">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="password">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="password">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="password">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <input type="password">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="password">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="password">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="password">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <input type="password">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="password">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="password">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="password">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <input type="password">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="password">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="search">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="search">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <input type="search">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="search">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="search">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="search">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <input type="search">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="search">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="search">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="search">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <input type="search">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="search">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="search">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="search">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <input type="search">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="search">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="search">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="search">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <input type="search">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="search">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="search">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="search">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <input type="search">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="search">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="search">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="search">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <input type="search">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="search">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="tel">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="tel">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <input type="tel">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="tel">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="tel">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="tel">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <input type="tel">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="tel">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="tel">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="tel">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <input type="tel">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="tel">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="tel">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="tel">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <input type="tel">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="tel">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="tel">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="tel">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <input type="tel">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="tel">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="tel">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="tel">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <input type="tel">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="tel">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="tel">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="tel">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <input type="tel">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="tel">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="url">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="url">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <input type="url">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="url">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="url">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="url">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <input type="url">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="url">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="url">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="url">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <input type="url">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="url">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="url">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="url">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <input type="url">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="url">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="url">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="url">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <input type="url">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="url">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="url">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="url">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <input type="url">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="url">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="url">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="url">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <input type="url">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="url">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="checkbox">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="checkbox">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <input type="checkbox">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="checkbox">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="checkbox">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="checkbox">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <input type="checkbox">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="checkbox">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="checkbox">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="checkbox">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <input type="checkbox">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="checkbox">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="checkbox">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="checkbox">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <input type="checkbox">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="checkbox">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="checkbox">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="checkbox">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <input type="checkbox">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="checkbox">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="checkbox">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="checkbox">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <input type="checkbox">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="checkbox">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="checkbox">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="checkbox">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <input type="checkbox">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="checkbox">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="radio">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="radio">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <input type="radio">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="radio">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="radio">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="radio">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <input type="radio">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="radio">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="radio">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="radio">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <input type="radio">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="radio">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="radio">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="radio">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <input type="radio">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="radio">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="radio">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="radio">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <input type="radio">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="radio">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="radio">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="radio">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <input type="radio">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="radio">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="radio">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="radio">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <input type="radio">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="radio">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="range">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="range">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <input type="range">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="range">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="range">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="range">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <input type="range">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="range">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="range">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="range">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <input type="range">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="range">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="range">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="range">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <input type="range">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="range">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="range">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="range">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <input type="range">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="range">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="range">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="range">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <input type="range">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="range">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="range">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="range">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <input type="range">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="range">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="file">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="file">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <input type="file">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="file">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="file">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="file">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <input type="file">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="file">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="file">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="file">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <input type="file">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="file">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="file">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="file">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <input type="file">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="file">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="file">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="file">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <input type="file">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="file">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="file">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="file">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <input type="file">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="file">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="file">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="file">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <input type="file">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="file">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="color">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="color">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <input type="color">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="color">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="color">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="color">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <input type="color">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="color">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="color">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="color">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <input type="color">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="color">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="color">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="color">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <input type="color">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="color">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="color">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="color">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <input type="color">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="color">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="color">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="color">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <input type="color">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="color">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="color">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="color">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <input type="color">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="color">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="date">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="date">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <input type="date">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="date">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="date">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="date">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <input type="date">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="date">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="date">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="date">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <input type="date">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="date">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="date">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="date">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <input type="date">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="date">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="date">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="date">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <input type="date">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="date">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="date">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="date">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <input type="date">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="date">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="date">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="date">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <input type="date">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="date">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="datetime-local">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="datetime-local">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <input type="datetime-local">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="datetime-local">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="datetime-local">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="datetime-local">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <input type="datetime-local">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="datetime-local">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="datetime-local">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="datetime-local">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <input type="datetime-local">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="datetime-local">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="datetime-local">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="datetime-local">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <input type="datetime-local">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="datetime-local">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="datetime-local">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="datetime-local">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <input type="datetime-local">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="datetime-local">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="datetime-local">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="datetime-local">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <input type="datetime-local">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="datetime-local">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="datetime-local">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="datetime-local">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <input type="datetime-local">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="datetime-local">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="month">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="month">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <input type="month">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="month">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="month">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="month">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <input type="month">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="month">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="month">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="month">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <input type="month">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="month">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="month">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="month">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <input type="month">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="month">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="month">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="month">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <input type="month">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="month">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="month">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="month">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <input type="month">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="month">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="month">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="month">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <input type="month">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="month">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="time">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="time">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <input type="time">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="time">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="time">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="time">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <input type="time">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="time">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="time">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="time">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <input type="time">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="time">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="time">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="time">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <input type="time">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="time">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="time">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="time">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <input type="time">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="time">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="time">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="time">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <input type="time">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="time">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="time">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="time">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <input type="time">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="time">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="week">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="week">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <input type="week">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="week">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="week">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="week">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <input type="week">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="week">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="week">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="week">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <input type="week">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="week">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="week">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="week">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <input type="week">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="week">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="week">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="week">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <input type="week">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="week">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="week">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="week">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <input type="week">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="week">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="week">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="week">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <input type="week">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="week">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="number">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="number">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
+FAIL Test <input type="number">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="number">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="number">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="number">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
+FAIL Test <input type="number">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="number">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="number">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="number">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
+FAIL Test <input type="number">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="number">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="number">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="number">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
+FAIL Test <input type="number">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="number">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="number">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="number">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
+FAIL Test <input type="number">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="number">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="number">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="number">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
+FAIL Test <input type="number">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="number">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="number">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
+FAIL Test <input type="number">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
+FAIL Test <input type="number">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+FAIL Test <input type="number">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-invoking-attribute.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-invoking-attribute.html
@@ -10,22 +10,19 @@
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-actions.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/popover-utils.js"></script>
 
 <body>
 <script>
-const buttonLogic = (t,s,h) => {
-  // This mimics the expected logic for button invokers:
-  let expectedBehavior = t ? "toggle" : (s ? "show" : (h ? "hide" : "none"));
-  let expectedId = t || s || h || 1;
-  if (!t && s && h) {
-    // Special case - only use toggle if the show/hide idrefs match.
-    expectedBehavior = (s === h) ? "toggle" : "show";
+const actionReflectionLogic = (action) => {
+  switch (action?.toLowerCase()) {
+    case "show": return "show";
+    case "hide": return "hide";
+    default: return "toggle";
   }
-  return {expectedBehavior, expectedId};
 }
-const noActivationLogic = (t,s,h) => {
-  // This does not activate any popovers.
-  return {expectedBehavior: "none", expectedId: 1};
+const noActivationLogic = (action) => {
+  return "none";
 }
 function makeElementWithType(element,type) {
   return (test) => {
@@ -35,17 +32,12 @@ function makeElementWithType(element,type) {
     return el;
   };
 }
-function setInvokingContentAttribute(invoker,attr,idref) {
-  invoker.setAttribute(attr,idref);
-  assert_equals(invoker[attr + "Element"],document.getElementById(idref));
-}
 const supportedButtonTypes = ['button','reset','submit',''].map(type => {
   return   {
     name: `<button type="${type}">`,
     makeElement: makeElementWithType('button',type),
     invokeFn: el => {el.focus(); el.click()},
-    getExpectedLogic: buttonLogic,
-    supported: true,
+    getExpectedLogic: actionReflectionLogic,
   };
 });
 const supportedInputButtonTypes = ['button','reset','submit','image'].map(type => {
@@ -53,8 +45,7 @@ const supportedInputButtonTypes = ['button','reset','submit','image'].map(type =
     name: `<input type="${type}">`,
     makeElement: makeElementWithType('input',type),
     invokeFn: el => {el.focus(); el.click()},
-    getExpectedLogic: buttonLogic,
-    supported: true,
+    getExpectedLogic: actionReflectionLogic,
   };
 });
 const unsupportedTypes = ['text','email','password','search','tel','url','checkbox','radio','range','file','color','date','datetime-local','month','time','week','number'].map(type => {
@@ -63,7 +54,6 @@ const unsupportedTypes = ['text','email','password','search','tel','url','checkb
     makeElement: makeElementWithType('input',type),
     invokeFn: (el) => {el.focus();},
     getExpectedLogic: noActivationLogic, // None of these support popover invocation
-    supported: false,
   };
 });
 const invokers = [
@@ -71,89 +61,74 @@ const invokers = [
   ...supportedInputButtonTypes,
   ...unsupportedTypes,
 ];
+const validTypes = popoverHintSupported() ? ["auto","hint","manual"] : ["auto","manual"];
 window.addEventListener('load', () => {
-  ["auto","manual"].forEach(type => {
+  validTypes.forEach(type => {
     invokers.forEach(testcase => {
-      let t_set = [1], s_set = [1], h_set = [1];
-      if (testcase.supported) {
-        t_set = s_set = h_set = [0,1,2]; // Test all permutations
-      }
-      t_set.forEach(t => {
-        s_set.forEach(s => {
-          h_set.forEach(h => {
-            [false,true].forEach(use_idl => {
-              promise_test(async test => {
-                const popover1 = Object.assign(document.createElement('div'),{popover: type, id: 'popover-1'});
-                const popover2 = Object.assign(document.createElement('div'),{popover: type, id: 'popover-2'});
-                assert_equals(popover1.popover,type);
-                assert_equals(popover2.popover,type);
-                assert_not_equals(popover1.id,popover2.id);
-                const invoker = testcase.makeElement(test);
-                if (use_idl) {
-                  invoker.popoverToggleTargetElement = t===1 ? popover1 : (t===2 ? popover2 : null);
-                  invoker.popoverShowTargetElement = s===1 ? popover1 : (s===2 ? popover2 : null);
-                  invoker.popoverHideTargetElement = h===1 ? popover1 : (h===2 ? popover2 : null);
-                } else {
-                  if (t) setInvokingContentAttribute(invoker,'popoverToggleTarget',t===1 ? popover1.id : popover2.id);
-                  if (s) setInvokingContentAttribute(invoker,'popoverShowTarget',s===1 ? popover1.id : popover2.id);
-                  if (h) setInvokingContentAttribute(invoker,'popoverHideTarget',h===1 ? popover1.id : popover2.id);
-                }
-                assert_true(!document.getElementById(popover1.id));
-                assert_true(!document.getElementById(popover2.id));
-                document.body.appendChild(popover1);
-                document.body.appendChild(popover2);
-                test.add_cleanup(() => {
-                  popover1.remove();
-                  popover2.remove();
-                });
-                const {expectedBehavior, expectedId} = testcase.getExpectedLogic(t,s,h);
-                const otherId = expectedId !== 1 ? 1 : 2;
-                function assertPopoverShowing(num,state,message) {
-                  assert_true(num>0,`Invalid expectedId ${num}`);
-                  assert_equals((num===1 ? popover1 : popover2).matches(':open'),state,message || "");
-                }
-                assertPopoverShowing(expectedId,false);
-                assertPopoverShowing(otherId,false);
-                await testcase.invokeFn(invoker);
-                assert_equals(document.activeElement,invoker,'Focus should end up on the invoker');
-                assertPopoverShowing(otherId,false,'The other popover should never change');
-                switch (expectedBehavior) {
-                  case "toggle":
-                  case "show":
-                    assertPopoverShowing(expectedId,true,'Toggle or show should show the popover');
-                    (expectedId===1 ? popover1 : popover2).hidePopover(); // Hide the popover
-                    break;
-                  case "hide":
-                  case "none":
-                    assertPopoverShowing(expectedId,false,'Hide or none should leave the popover hidden');
-                    break;
-                  default:
-                    assert_unreached();
-                }
-                if (expectedBehavior === "none") {
-                  // If no behavior is expected, then there is nothing left to test. Even re-focusing
-                  // a control that has no expected behavior may hide an open popover via light dismiss.
-                  return;
-                }
-                (expectedId===1 ? popover1 : popover2).showPopover(); // Show the popover directly
-                assert_equals(document.activeElement,invoker,'The popover should not shift focus');
-                assertPopoverShowing(expectedId,true);
-                assertPopoverShowing(otherId,false);
-                await testcase.invokeFn(invoker);
-                assertPopoverShowing(otherId,false,'The other popover should never change');
-                switch (expectedBehavior) {
-                  case "toggle":
-                  case "hide":
-                    assertPopoverShowing(expectedId,false,'Toggle or hide should hide the popover');
-                    break;
-                  case "show":
-                    assertPopoverShowing(expectedId,true,'Show should leave the popover showing');
-                    break;
-                  default:
-                    assert_unreached();
-                }
-              },`Test ${testcase.name}, t=${t}, s=${s}, h=${h}, ${use_idl ? "IDL" : "Content Attr"}, with popover=${type}`);
-            });
+      ["toggle","hide","show","ShOw","garbage",null,undefined].forEach(action => {
+        [false,true].forEach(use_idl_for_target => {
+          [false,true].forEach(use_idl_for_action => {
+            promise_test(async test => {
+              const popover = Object.assign(document.createElement('div'),{popover: type, id: 'my-popover'});
+              assert_equals(popover.popover,type,'reflection');
+              const invoker = testcase.makeElement(test);
+              if (use_idl_for_target) {
+                invoker.popoverTargetElement = popover;
+                assert_equals(invoker.getAttribute('popovertarget'),'','attribute value');
+              } else {
+                invoker.setAttribute('popovertarget',popover.id);
+              }
+              if (use_idl_for_action) {
+                invoker.popoverTargetAction = action;
+                assert_equals(invoker.getAttribute('popovertargetaction'),String(action),'action reflection');
+              } else {
+                invoker.setAttribute('popovertargetaction',action);
+              }
+              assert_true(!document.getElementById(popover.id));
+              assert_equals(invoker.popoverTargetElement,null,'targetElement should be null before the popover is in the document');
+              assert_equals(invoker.popoverTargetAction,actionReflectionLogic(action),'action should be correct immediately');
+              document.body.appendChild(popover);
+              test.add_cleanup(() => {popover.remove();});
+              assert_equals(invoker.popoverTargetElement,popover,'target element should be returned once it\'s in the document');
+              assert_false(popover.matches(':open'));
+              await testcase.invokeFn(invoker);
+              assert_equals(document.activeElement,invoker,'Focus should end up on the invoker');
+              expectedBehavior = testcase.getExpectedLogic(action);
+              switch (expectedBehavior) {
+                case "toggle":
+                case "show":
+                  assert_true(popover.matches(':open'),'Toggle or show should show the popover');
+                  popover.hidePopover(); // Hide the popover
+                  break;
+                case "hide":
+                case "none":
+                  assert_false(popover.matches(':open'),'Hide or none should leave the popover hidden');
+                  break;
+                default:
+                  assert_unreached();
+              }
+              if (expectedBehavior === "none") {
+                // If no behavior is expected, then there is nothing left to test. Even re-focusing
+                // a control that has no expected behavior may hide an open popover via light dismiss.
+                return;
+              }
+              assert_false(popover.matches(':open'));
+              popover.showPopover(); // Show the popover directly
+              assert_equals(document.activeElement,invoker,'The popover should not shift focus');
+              assert_true(popover.matches(':open'));
+              await testcase.invokeFn(invoker);
+              switch (expectedBehavior) {
+                case "toggle":
+                case "hide":
+                  assert_false(popover.matches(':open'),'Toggle or hide should hide the popover');
+                  break;
+                case "show":
+                  assert_true(popover.matches(':open'),'Show should leave the popover showing');
+                  break;
+                default:
+                  assert_unreached();
+              }
+            },`Test ${testcase.name}, action=${action}, ${use_idl_for_target ? "popoverTarget IDL" : "popovertarget attr"}, ${use_idl_for_action ? "popoverTargetAction IDL" : "popovertargetaction attr"}, with popover=${type}`);
           });
         });
       });
@@ -164,7 +139,7 @@ window.addEventListener('load', () => {
 
 
 
-<button popovertoggletarget=p1>Toggle Popover 1</button>
+<button popovertarget=p1>Toggle Popover 1</button>
 <div popover id=p1 style="border: 5px solid red;top: 100px;left: 100px;">This is popover #1</div>
 
 <script>
@@ -206,7 +181,7 @@ window.addEventListener('load', () => {
     await assertState(true,2,1);
     popover.hidePopover();
     await assertState(false,2,2);
-  }, "Clicking a popovertoggletarget button opens a closed popover (also check event counts)");
+  }, "Clicking a popovertarget button opens a closed popover (also check event counts)");
 
   promise_test(async () => {
     showCount = hideCount = 0;
@@ -215,6 +190,6 @@ window.addEventListener('load', () => {
     await assertState(true,1,0);
     await clickOn(button);
     await assertState(false,1,1);
-  }, "Clicking a popovertoggletarget button closes an open popover (also check event counts)");
+  }, "Clicking a popovertarget button closes an open popover (also check event counts)");
 });
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt
@@ -1,7 +1,4 @@
-CONSOLE MESSAGE: TypeError: null is not an object (evaluating 'document.querySelector('#myElement').shadowRoot.querySelector')
 Popover 1 Popover 1 Popover1 anchor (no action) Outside all popovers  Next control after popover1  Popover 3 - button 3 Popover 6  Popover8 anchor (no action)  Open convoluted popover Popover 1
-
-Harness Error (FAIL), message = TypeError: null is not an object (evaluating 'document.querySelector('#myElement').shadowRoot.querySelector')
 
 PASS Clicking outside a popover will dismiss the popover
 FAIL Canceling pointer events should not keep clicks from light dismissing popovers assert_false: preventDefault should not prevent light dismiss expected false got true
@@ -15,13 +12,15 @@ FAIL Clicking on invoking element, after using it for activation, shouldn't clos
 FAIL Clicking on invoking element, after using it for activation, shouldn't close its popover (nested case) assert_true: button2 should activate popover2 expected true got false
 FAIL Clicking on invoking element, after using it for activation, shouldn't close its popover (nested case, not used for invocation) promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
 FAIL Clicking on invoking element, even if it wasn't used for activation, shouldn't close its popover promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
-FAIL Clicking on popovertoggletarget element, even if it wasn't used for activation, should hide it exactly once promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
+FAIL Clicking on popovertarget element, even if it wasn't used for activation, should hide it exactly once promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
 FAIL Clicking on anchor element (that isn't an invoking element) shouldn't prevent its popover from being closed promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
 FAIL Dragging from an open popover outside an open popover should leave the popover open promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
 FAIL A popover inside an invoking element doesn't participate in that invoker's ancestor chain assert_true: invoking element should open popover expected true got false
 FAIL An invoking element that was not used to invoke the popover can still be part of the ancestor chain assert_true: expected true got false
 FAIL Scrolling within a popover should not close the popover promise_test: Unhandled rejection with value: object "Error: Unknown source type "wheel"."
-FAIL Moving focus back to the anchor element should not dismiss the popover assert_equals: Focus should move to the anchor element expected Element node <button id="p8anchor">Popover8 anchor (no action)</button> but got Element node <body><button id="b1t" popovertoggletarget="p1">Popover 1...
+PASS Clicking inside a shadow DOM popover does not close that popover
+PASS Clicking outside a shadow DOM popover should close that popover
+FAIL Moving focus back to the anchor element should not dismiss the popover assert_equals: Focus should move to the anchor element expected Element node <button id="p8anchor">Popover8 anchor (no action)</button> but got Element node <body><button id="b1t" popovertarget="p1">Popover 1</butt...
 FAIL Ensure circular/convoluted ancestral relationships are functional assert_true: expected true got false
 FAIL Ensure circular/convoluted ancestral relationships are functional, with a direct showPopover() promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
 PASS Hide the target popover during "hide all popovers until"

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss.html
@@ -11,13 +11,13 @@
 <script src="/resources/testdriver-vendor.js"></script>
 <script src="resources/popover-utils.js"></script>
 
-<button id=b1t popovertoggletarget='p1'>Popover 1</button>
-<button id=b1s popovershowtarget='p1'>Popover 1</button>
+<button id=b1t popovertarget='p1'>Popover 1</button>
+<button id=b1s popovertarget='p1' popovertargetaction=show>Popover 1</button>
 <button id=p1anchor>Popover1 anchor (no action)</button>
 <span id=outside>Outside all popovers</span>
 <div popover id=p1 anchor=p1anchor>
   <span id=inside1>Inside popover 1</span>
-  <button id=b2 popovershowtarget='p2'>Popover 2</button>
+  <button id=b2 popovertarget='p2' popovertargetaction=show>Popover 2</button>
   <span id=inside1after>Inside popover 1 after button</span>
 </div>
 <div popover id=p2 anchor=b2>
@@ -234,9 +234,9 @@
     await waitForRender();
     p1HideCount = popover1HideCount;
     await clickOn(button1toggle);
-    assert_false(popover1.matches(':open'),'popover1 should be hidden by popovertoggletarget');
-    assert_equals(popover1HideCount,p1HideCount+1,'popover1 should get hidden only once by popovertoggletarget');
-  },'Clicking on popovertoggletarget element, even if it wasn\'t used for activation, should hide it exactly once');
+    assert_false(popover1.matches(':open'),'popover1 should be hidden by popovertarget');
+    assert_equals(popover1HideCount,p1HideCount+1,'popover1 should get hidden only once by popovertarget');
+  },'Clicking on popovertarget element, even if it wasn\'t used for activation, should hide it exactly once');
 
   promise_test(async () => {
     popover1.showPopover();
@@ -265,12 +265,12 @@
   },'Dragging from an open popover outside an open popover should leave the popover open');
 </script>
 
-<button id=b3 popovertoggletarget=p3>Popover 3 - button 3
+<button id=b3 popovertarget=p3>Popover 3 - button 3
   <div popover id=p4>Inside popover 4</div>
 </button>
 <div popover id=p3>Inside popover 3</div>
 <div popover id=p5>Inside popover 5
-  <button popovertoggletarget=p3>Popover 3 - button 4 - unused</button>
+  <button popovertarget=p3>Popover 3 - button 4 - unused</button>
 </div>
 <style>
   #p3 {top:100px;}
@@ -309,7 +309,7 @@
   <div style="height:2000px;background:lightgreen"></div>
   Bottom of popover6
 </div>
-<button popovertoggletarget=p6>Popover 6</button>
+<button popovertarget=p6>Popover 6</button>
 <style>
   #p6 {
     width: 300px;
@@ -332,7 +332,7 @@
 </script>
 
 <my-element id="myElement">
-  <template shadowroot="open">
+  <template shadowrootmode="open">
     <button id=b7 onclick='showPopover7()'>Popover7</button>
     <div popover id=p7 anchor=b7 style="top: 100px;">
       <p>Popover content.</p>
@@ -388,16 +388,16 @@
 <!-- Convoluted ancestor relationship -->
 <div popover id=convoluted_p1>Popover 1
   <div id=convoluted_anchor>Anchor
-    <button popovertoggletarget=convoluted_p2>Open Popover 2</button>
+    <button popovertarget=convoluted_p2>Open Popover 2</button>
     <div popover id=convoluted_p4><p>Popover 4</p></div>
   </div>
 </div>
 <div popover id=convoluted_p2 anchor=convoluted_p2>Popover 2 (self-anchor-linked)
-  <button popovertoggletarget=convoluted_p3>Open Popover 3</button>
-  <button popovershowtarget=convoluted_p2>Self-linked invoker</button>
+  <button popovertarget=convoluted_p3>Open Popover 3</button>
+  <button popovertarget=convoluted_p2 popovertargetaction=show>Self-linked invoker</button>
 </div>
 <div popover id=convoluted_p3 anchor=convoluted_anchor>Popover 3
-  <button popovertoggletarget=convoluted_p4>Open Popover 4</button>
+  <button popovertarget=convoluted_p4>Open Popover 4</button>
 </div>
 <button onclick="convoluted_p1.showPopover()">Open convoluted popover</button>
 <style>
@@ -461,6 +461,52 @@ promise_test(async () => {
 },'Ensure circular/convoluted ancestral relationships are functional, with a direct showPopover()');
 </script>
 
+<div popover id=p10>Popover</div>
+<div popover=hint id=p11>Hint</div>
+<div popover=manual id=p12>Manual</div>
+<style>
+  #p10 {top:100px;}
+  #p11 {top:200px;}
+  #p12 {top:300px;}
+</style>
+<script>
+if (popoverHintSupported()) {
+  promise_test(async () => {
+    const auto = document.querySelector('#p10');
+    const hint = document.querySelector('#p11');
+    const manual = document.querySelector('#p12');
+    // All three can be open at once, if shown in this order:
+    auto.showPopover();
+    hint.showPopover();
+    manual.showPopover();
+    assert_true(auto.matches(':open'));
+    assert_true(hint.matches(':open'));
+    assert_true(manual.matches(':open'));
+    // Clicking the hint will close the auto, but not the manual.
+    await clickOn(hint);
+    assert_false(auto.matches(':open'),'auto should be hidden');
+    assert_true(hint.matches(':open'),'hint should stay open');
+    assert_true(manual.matches(':open'),'manual does not light dismiss');
+    // Clicking outside should close the hint, but not the manual:
+    await clickOn(outside);
+    assert_false(auto.matches(':open'));
+    assert_false(hint.matches(':open'),'hint should close');
+    assert_true(manual.matches(':open'),'manual does not light dismiss');
+    manual.hidePopover();
+    assert_false(manual.matches(':open'));
+    auto.showPopover();
+    hint.showPopover();
+    assert_true(auto.matches(':open'));
+    assert_true(hint.matches(':open'));
+    // Clicking on the auto should close the hint:
+    await clickOn(auto);
+    assert_true(auto.matches(':open'),'auto should stay open');
+    assert_false(hint.matches(':open'),'hint should light dismiss');
+    auto.hidePopover();
+    assert_false(auto.matches(':open'));
+  },'Light dismiss of mixed popover types including hints');
+}
+</script>
 <div popover id=p13>Popover 1
   <div popover id=p14>Popover 2
     <div popover id=p15>Popover 3</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-shadow-dom.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-shadow-dom.html
@@ -45,7 +45,7 @@
 <div id=test1>
   <button onclick='showTestPopover("test1",0)'>Test1 Popover</button>
   <my-element>
-    <template shadowroot=open>
+    <template shadowrootmode=open>
       <div popover>
         <p>This should show, even though it is inside shadow DOM.</p>
       </div>
@@ -71,7 +71,7 @@
     <button id=t2b2 onclick='showTestPopover("test2",1)'>Test 2 Popover 2</button>
   </div>
   <my-element>
-    <template shadowroot=open>
+    <template shadowrootmode=open>
       <div popover anchor=t2b2 style="top: 400px;">
         <p>Hiding this popover will hide *all* open popovers,</p>
         <p>because t2b2 doesn't exist in this context.</p>
@@ -98,7 +98,7 @@
 
 <div id=test3>
   <my-element>
-    <template shadowroot=open>
+    <template shadowrootmode=open>
       <button id=t3b1 onclick='showTestPopover("test3",0)'>Test 3 Popover 1</button>
       <div popover anchor=t3b1>
         <p>This popover will stay open when popover2 shows.</p>
@@ -138,7 +138,7 @@
   <div popover anchor=t4b1>
     <p>This should not get hidden when popover2 opens.</p>
     <my-element>
-      <template shadowroot=open>
+      <template shadowrootmode=open>
         <button id=t4b2 onclick='showTestPopover("test4",1)'>Test 4 Popover 2</button>
         <div popover anchor=t4b2>
           <p>This should not hide popover1.</p>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-stacking-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-stacking-expected.txt
@@ -2,9 +2,9 @@ Direct DOM children
 
 Grandchildren
 
-popovertoggletarget attribute relationship
+popovertarget attribute relationship
 
-nested popovertoggletarget attribute relationship
+nested popovertarget attribute relationship
 
 anchor attribute relationship
 
@@ -14,8 +14,8 @@ Popover 1  Dialog
 
 PASS Direct DOM children
 PASS Grandchildren
-FAIL popovertoggletarget attribute relationship assert_true: expected true got false
-FAIL nested popovertoggletarget attribute relationship assert_true: expected true got false
+FAIL popovertarget attribute relationship assert_true: expected true got false
+FAIL nested popovertarget attribute relationship assert_true: expected true got false
 FAIL anchor attribute relationship assert_true: expected true got false
 FAIL indirect anchor attribute relationship assert_true: expected true got false
 FAIL more complex nesting, all using anchor ancestry assert_equals: Popover #1 incorrect state expected true but got false

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-stacking.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-stacking.html
@@ -27,19 +27,19 @@
 </div>
 
 <div class="example">
-  <p>popovertoggletarget attribute relationship</p>
+  <p>popovertarget attribute relationship</p>
   <div popover class=ancestor><p>Ancestor popover</p>
-    <button popovertoggletarget=trigger1 class=clickme>Button</button>
+    <button popovertarget=trigger1 class=clickme>Button</button>
   </div>
   <div id=trigger1 popover class=child><p>Child popover</p></div>
 </div>
 
 <div class="example">
-  <p>nested popovertoggletarget attribute relationship</p>
+  <p>nested popovertarget attribute relationship</p>
   <div popover class=ancestor><p>Ancestor popover</p>
     <div>
       <div>
-        <button popovertoggletarget=trigger2 class=clickme>Button</button>
+        <button popovertarget=trigger2 class=clickme>Button</button>
       </div>
     </div>
   </div>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-target-element-disabled.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-target-element-disabled.html
@@ -5,7 +5,7 @@
 <script src="/resources/testharnessreport.js"></script>
 
 <div id=outerpopover popover=auto>
-  <button popovertoggletarget=innerpopover disabled>toggle popover</button>
+  <button popovertarget=innerpopover disabled>toggle popover</button>
 </div>
 <div id=innerpopover popover=auto>popover</div>
 <script>
@@ -20,7 +20,7 @@ test(() => {
 </script>
 
 <div id=outerpopover2 popover=auto>
-  <button id=togglebutton2 popovertoggletarget=innerpopover2>toggle popover</button>
+  <button id=togglebutton2 popovertarget=innerpopover2>toggle popover</button>
 </div>
 <div id=innerpopover2 popover=auto>popover</div>
 <script>
@@ -41,7 +41,7 @@ test(() => {
 </script>
 
 <div id=outerpopover3 popover=auto>
-  <button id=togglebutton3 popovertoggletarget=innerpopover3>toggle popover</button>
+  <button id=togglebutton3 popovertarget=innerpopover3>toggle popover</button>
 </div>
 <div id=innerpopover3 popover=auto>popover</div>
 <script>
@@ -62,7 +62,7 @@ test(() => {
 </script>
 
 <div id=outerpopover4 popover=auto>
-  <button id=togglebutton4 popovertoggletarget=innerpopover4>toggle popover</button>
+  <button id=togglebutton4 popovertarget=innerpopover4>toggle popover</button>
 </div>
 <div id=innerpopover4 popover=auto>popover</div>
 <form id=submitform>form</form>
@@ -84,7 +84,7 @@ test(() => {
 </script>
 
 <div id=outerpopover5 popover=auto>
-  <input type=button id=togglebutton5 popovertoggletarget=innerpopover5>toggle popover</button>
+  <input type=button id=togglebutton5 popovertarget=innerpopover5>toggle popover</button>
 </div>
 <div id=innerpopover5 popover=auto>popover</div>
 <script>
@@ -105,7 +105,7 @@ test(() => {
 </script>
 
 <div id=outerpopover6 popover=auto>
-  <button id=togglebutton6 popovertoggletarget=innerpopover6>toggle popover</button>
+  <button id=togglebutton6 popovertarget=innerpopover6>toggle popover</button>
 </div>
 <div id=innerpopover6 popover=auto>popover</div>
 <script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-combinations.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-combinations.html
@@ -118,9 +118,8 @@ window.onload = () => requestAnimationFrame(() => requestAnimationFrame(() => {
       const button = document.createElement('button');
       t.add_cleanup(() => button.remove());
       document.body.appendChild(button);
-      assert_equals(ex.id,'');
-      ex.id = 'popover-id';
-      button.popoverToggleTargetElement = ex;
+      button.popoverTargetElement = ex;
+      button.popoverTargetAction = "toggle";
       assert_true(ex.matches(':closed'));
       await clickOn(button);
       ensureIsOpenPopover(ex,'Invoking element should be able to invoke all popovers');

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/resources/popover-utils.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/resources/popover-utils.js
@@ -107,3 +107,10 @@ function showDefaultopenPopoversOnLoad() {
     window.addEventListener('load',show,{once:true});
   }
 }
+function popoverHintSupported() {
+  // TODO(crbug.com/1416284): This function should be removed, and
+  // any calls replaced with `true`, once popover=hint ships.
+  const testElement = document.createElement('div');
+  testElement.popover = 'hint';
+  return testElement.popover === 'hint';
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/w3c-import.log
@@ -76,5 +76,6 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-target-element-disabled.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-combinations.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-interactions.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-types-with-hints.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-types.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/toggleevent-interface.html

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2-expected.txt
@@ -3,6 +3,6 @@ Invoker  after
 Show popover
 
 FAIL Popover focus navigation assert_true: popover1 should be invoked by invoker1 expected true got false
-FAIL Circular reference tab navigation assert_equals: Step 2 expected Element node <button id="circular1" autofocus="" popoverhidetarget="po... but got Element node <button id="circular4">after</button>
+FAIL Circular reference tab navigation assert_equals: Step 2 expected Element node <button id="circular1" autofocus="" popovertarget="popove... but got Element node <button id="circular4">after</button>
 FAIL Popover focus returns when popover is hidden by invoker assert_true: popover should be invoked by invoker expected true got false
 

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt
@@ -1,7 +1,4 @@
-CONSOLE MESSAGE: TypeError: null is not an object (evaluating 'document.querySelector('#myElement').shadowRoot.querySelector')
 Popover 1 Popover 1 Popover1 anchor (no action) Outside all popovers  Next control after popover1 Popover 3 - button 3   Popover 6  Popover8 anchor (no action)  Open convoluted popover Popover 1
-
-Harness Error (FAIL), message = TypeError: null is not an object (evaluating 'document.querySelector('#myElement').shadowRoot.querySelector')
 
 PASS Clicking outside a popover will dismiss the popover
 FAIL Canceling pointer events should not keep clicks from light dismissing popovers assert_false: preventDefault should not prevent light dismiss expected false got true
@@ -15,12 +12,14 @@ FAIL Clicking on invoking element, after using it for activation, shouldn't clos
 FAIL Clicking on invoking element, after using it for activation, shouldn't close its popover (nested case) assert_true: button2 should activate popover2 expected true got false
 FAIL Clicking on invoking element, after using it for activation, shouldn't close its popover (nested case, not used for invocation) promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
 FAIL Clicking on invoking element, even if it wasn't used for activation, shouldn't close its popover promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
-FAIL Clicking on popovertoggletarget element, even if it wasn't used for activation, should hide it exactly once promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
+FAIL Clicking on popovertarget element, even if it wasn't used for activation, should hide it exactly once promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
 FAIL Clicking on anchor element (that isn't an invoking element) shouldn't prevent its popover from being closed promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
 FAIL Dragging from an open popover outside an open popover should leave the popover open promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
 FAIL A popover inside an invoking element doesn't participate in that invoker's ancestor chain assert_true: invoking element should open popover expected true got false
 FAIL An invoking element that was not used to invoke the popover can still be part of the ancestor chain assert_true: expected true got false
 FAIL Scrolling within a popover should not close the popover promise_test: Unhandled rejection with value: object "Error: Unknown source type "wheel"."
+PASS Clicking inside a shadow DOM popover does not close that popover
+PASS Clicking outside a shadow DOM popover should close that popover
 PASS Moving focus back to the anchor element should not dismiss the popover
 FAIL Ensure circular/convoluted ancestral relationships are functional assert_true: expected true got false
 FAIL Ensure circular/convoluted ancestral relationships are functional, with a direct showPopover() promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic-expected.txt
@@ -1,10 +1,11 @@
-Pop upDialog with popover=manualInvalid popover value - defaults to popover=manualInvalid popover value - defaults to popover=manualInvalid popover value - defaults to popover=manual
+Pop upPop upDialog with popover=manualInvalid popover value - defaults to popover=manualInvalid popover value - defaults to popover=manualInvalid popover value - defaults to popover=manual
 Not a popover
 Dialog without popover attribute
 
 FAIL The element <div popover="" id="boolean">Pop up</div> should behave as a popover. Element has unexpected visibility state
 FAIL The element <div popover="">Pop up</div> should behave as a popover. Element has unexpected visibility state
 FAIL The element <div popover="auto">Pop up</div> should behave as a popover. Element has unexpected visibility state
+FAIL The element <div popover="hint">Pop up</div> should behave as a popover. Element has unexpected visibility state
 FAIL The element <div popover="manual">Pop up</div> should behave as a popover. Element has unexpected visibility state
 FAIL The element <article popover="">Different element type</article> should behave as a popover. Element has unexpected visibility state
 FAIL The element <header popover="">Different element type</header> should behave as a popover. Element has unexpected visibility state
@@ -204,7 +205,7 @@ FAIL A <video> element should *not* behave as a popover. assert_throws_dom: Call
 PASS IDL attribute reflection
 FAIL Popover attribute value should be case insensitive Element has unexpected visibility state
 FAIL Changing attribute values for popover should work Element has unexpected visibility state
-PASS Changing attribute values should close open popovers
+FAIL Changing attribute values should close open popovers assert_false: expected false got true
 PASS Removing a visible popover=auto element from the document should close the popover
 PASS A showing popover=auto does not match :modal
 PASS Removing a visible popover=manual element from the document should close the popover

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2-expected.txt
@@ -3,6 +3,6 @@ Invoker  after
 Show popover
 
 FAIL Popover focus navigation assert_equals: Hidden popover should be skipped expected Element node <button id="button2">Button2</button> but got Element node <button id="button1">Button1</button>
-FAIL Circular reference tab navigation assert_equals: Step 2 expected Element node <button id="circular1" autofocus="" popoverhidetarget="po... but got Element node <button id="circular0" popovertoggletarget="popover4">Inv...
+FAIL Circular reference tab navigation assert_equals: Step 2 expected Element node <button id="circular1" autofocus="" popovertarget="popove... but got Element node <button id="circular0" popovertarget="popover4">Invoker</...
 FAIL Popover focus returns when popover is hidden by invoker assert_true: popover should be invoked by invoker expected true got false
 

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt
@@ -1,7 +1,4 @@
-CONSOLE MESSAGE: TypeError: null is not an object (evaluating 'document.querySelector('#myElement').shadowRoot.querySelector')
 Popover 1 Popover 1 Popover1 anchor (no action) Outside all popovers  Next control after popover1  Popover 3 - button 3 Popover 6  Popover8 anchor (no action)  Open convoluted popover Popover 1
-
-Harness Error (FAIL), message = TypeError: null is not an object (evaluating 'document.querySelector('#myElement').shadowRoot.querySelector')
 
 FAIL Clicking outside a popover will dismiss the popover assert_false: expected false got true
 FAIL Canceling pointer events should not keep clicks from light dismissing popovers assert_false: expected false got true
@@ -15,13 +12,15 @@ PASS Clicking on invoking element, after using it for activation, shouldn't clos
 FAIL Clicking on invoking element, after using it for activation, shouldn't close its popover (nested case) assert_true: button2 should activate popover2 expected true got false
 FAIL Clicking on invoking element, after using it for activation, shouldn't close its popover (nested case, not used for invocation) promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
 FAIL Clicking on invoking element, even if it wasn't used for activation, shouldn't close its popover promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
-FAIL Clicking on popovertoggletarget element, even if it wasn't used for activation, should hide it exactly once promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
+FAIL Clicking on popovertarget element, even if it wasn't used for activation, should hide it exactly once promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
 FAIL Clicking on anchor element (that isn't an invoking element) shouldn't prevent its popover from being closed promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
 FAIL Dragging from an open popover outside an open popover should leave the popover open promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
 FAIL A popover inside an invoking element doesn't participate in that invoker's ancestor chain assert_true: invoking element should open popover expected true got false
 FAIL An invoking element that was not used to invoke the popover can still be part of the ancestor chain assert_true: expected true got false
 FAIL Scrolling within a popover should not close the popover promise_test: Unhandled rejection with value: object "Error: Unknown source type "wheel"."
-FAIL Moving focus back to the anchor element should not dismiss the popover assert_equals: Focus should move to the anchor element expected Element node <button id="p8anchor">Popover8 anchor (no action)</button> but got Element node <body><button id="b1t" popovertoggletarget="p1">Popover 1...
+PASS Clicking inside a shadow DOM popover does not close that popover
+FAIL Clicking outside a shadow DOM popover should close that popover assert_false: expected false got true
+FAIL Moving focus back to the anchor element should not dismiss the popover assert_equals: Focus should move to the anchor element expected Element node <button id="p8anchor">Popover8 anchor (no action)</button> but got Element node <body><button id="b1t" popovertarget="p1">Popover 1</butt...
 FAIL Ensure circular/convoluted ancestral relationships are functional assert_true: expected true got false
 FAIL Ensure circular/convoluted ancestral relationships are functional, with a direct showPopover() promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
 PASS Hide the target popover during "hide all popovers until"


### PR DESCRIPTION
#### 04443688436be33ec89237497b200153bc0f1b4b
<pre>
Re-import html/semantics/popovers WPT
<a href="https://bugs.webkit.org/show_bug.cgi?id=253271">https://bugs.webkit.org/show_bug.cgi?id=253271</a>
rdar://106167662

Reviewed by Aditya Keerthi.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/0e15e4513cc00bf0874af8c66078aace4db604e4">https://github.com/web-platform-tests/wpt/commit/0e15e4513cc00bf0874af8c66078aace4db604e4</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-anchor-idl-property.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-anchor-nested-display.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-backdrop-appearance.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-invoking-attribute-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-invoking-attribute.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-shadow-dom.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-stacking-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-stacking.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-target-element-disabled.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-combinations.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/resources/popover-utils.js:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/w3c-import.log:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2-expected.txt:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt:
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic-expected.txt:
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2-expected.txt:
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt:

Canonical link: <a href="https://commits.webkit.org/261155@main">https://commits.webkit.org/261155@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4418f15f8aadd16c3c75f561e99e1ba0cc305c7f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110759 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19841 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/43313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2106 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/119582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21248 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10952 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/1812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116505 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/43313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103107 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/43313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/44199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/12447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/43313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/86079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/13014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18392 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/43313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7730 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/14966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->