### PR TITLE
Make HTTP/2-only WPT tests use the HTTP/2 server

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/status.h2.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/status.h2.any-expected.txt
@@ -1,9 +1,9 @@
 
-FAIL statusText over H2 for status 200 should be the empty string assert_equals: statusText should be the empty string expected "" but got "OMG"
-FAIL statusText over H2 for status 210 should be the empty string assert_equals: statusText should be the empty string expected "" but got "OMG"
-FAIL statusText over H2 for status 400 should be the empty string assert_equals: statusText should be the empty string expected "" but got "OMG"
-FAIL statusText over H2 for status 404 should be the empty string assert_equals: statusText should be the empty string expected "" but got "OMG"
-FAIL statusText over H2 for status 410 should be the empty string assert_equals: statusText should be the empty string expected "" but got "OMG"
-FAIL statusText over H2 for status 500 should be the empty string assert_equals: statusText should be the empty string expected "" but got "OMG"
-FAIL statusText over H2 for status 502 should be the empty string assert_equals: statusText should be the empty string expected "" but got "OMG"
+PASS statusText over H2 for status 200 should be the empty string
+PASS statusText over H2 for status 210 should be the empty string
+PASS statusText over H2 for status 400 should be the empty string
+PASS statusText over H2 for status 404 should be the empty string
+PASS statusText over H2 for status 410 should be the empty string
+PASS statusText over H2 for status 500 should be the empty string
+PASS statusText over H2 for status 502 should be the empty string
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/status.h2.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/status.h2.any.worker-expected.txt
@@ -1,9 +1,9 @@
 
-FAIL statusText over H2 for status 200 should be the empty string assert_equals: statusText should be the empty string expected "" but got "OMG"
-FAIL statusText over H2 for status 210 should be the empty string assert_equals: statusText should be the empty string expected "" but got "OMG"
-FAIL statusText over H2 for status 400 should be the empty string assert_equals: statusText should be the empty string expected "" but got "OMG"
-FAIL statusText over H2 for status 404 should be the empty string assert_equals: statusText should be the empty string expected "" but got "OMG"
-FAIL statusText over H2 for status 410 should be the empty string assert_equals: statusText should be the empty string expected "" but got "OMG"
-FAIL statusText over H2 for status 500 should be the empty string assert_equals: statusText should be the empty string expected "" but got "OMG"
-FAIL statusText over H2 for status 502 should be the empty string assert_equals: statusText should be the empty string expected "" but got "OMG"
+PASS statusText over H2 for status 200 should be the empty string
+PASS statusText over H2 for status 210 should be the empty string
+PASS statusText over H2 for status 400 should be the empty string
+PASS statusText over H2 for status 404 should be the empty string
+PASS statusText over H2 for status 410 should be the empty string
+PASS statusText over H2 for status 500 should be the empty string
+PASS statusText over H2 for status 502 should be the empty string
 

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/status.h2.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/status.h2.window-expected.txt
@@ -1,9 +1,9 @@
 
-FAIL statusText over H2 for status 200 should be the empty string assert_equals: statusText should be the empty string expected "" but got "OMG"
-FAIL statusText over H2 for status 210 should be the empty string assert_equals: statusText should be the empty string expected "" but got "OMG"
-FAIL statusText over H2 for status 400 should be the empty string assert_equals: statusText should be the empty string expected "" but got "OMG"
-FAIL statusText over H2 for status 404 should be the empty string assert_equals: statusText should be the empty string expected "" but got "OMG"
-FAIL statusText over H2 for status 410 should be the empty string assert_equals: statusText should be the empty string expected "" but got "OMG"
-FAIL statusText over H2 for status 500 should be the empty string assert_equals: statusText should be the empty string expected "" but got "OMG"
-FAIL statusText over H2 for status 502 should be the empty string assert_equals: statusText should be the empty string expected "" but got "OMG"
+PASS statusText over H2 for status 200 should be the empty string
+PASS statusText over H2 for status 210 should be the empty string
+PASS statusText over H2 for status 400 should be the empty string
+PASS statusText over H2 for status 404 should be the empty string
+PASS statusText over H2 for status 410 should be the empty string
+PASS statusText over H2 for status 500 should be the empty string
+PASS statusText over H2 for status 502 should be the empty string
 

--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -2405,3 +2405,7 @@ webkit.org/b/243494 [ Debug ] compositing/layer-creation/scale-rotation-animatio
 
 # Early hints require network callbacks that are only present in macOS 12 / iOS 15 or greater.
 http/wpt/loading/early-hints [ Pass ]
+
+webkit.org/b/253533 imported/w3c/web-platform-tests/fetch/api/basic/status.h2.any.html [ Pass ]
+webkit.org/b/253533 imported/w3c/web-platform-tests/fetch/api/basic/status.h2.any.worker.html [ Pass ]
+webkit.org/b/253533 imported/w3c/web-platform-tests/xhr/status.h2.window.html [ Pass ]

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2469,3 +2469,5 @@ fullscreen/fullscreen-iframe-navigation.html [ Skip ]
 # Timeout testing is not applicable to in-process webgl, only webgl in gpu process.
 fast/canvas/webgl/lose-context-on-timeout-async.html [ Skip ]
 fast/canvas/webgl/lose-context-on-timeout.html [ Skip ]
+
+webkit.org/b/253533 imported/w3c/web-platform-tests/xhr/status.h2.window.html [ Skip ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1830,3 +1830,7 @@ webkit.org/b/253153 [ BigSur+ ] media/media-source/media-source-webm.html [ Pass
 
 # Early hints require network callbacks that are only present in macOS 12 / iOS 15 or greater.
 [ Monterey+ ] http/wpt/loading/early-hints [ Pass ]
+
+webkit.org/b/253533 imported/w3c/web-platform-tests/fetch/api/basic/status.h2.any.html [ Pass ]
+webkit.org/b/253533 imported/w3c/web-platform-tests/fetch/api/basic/status.h2.any.worker.html [ Pass ]
+webkit.org/b/253533 imported/w3c/web-platform-tests/xhr/status.h2.window.html [ Pass ]

--- a/LayoutTests/platform/wk2/TestExpectations
+++ b/LayoutTests/platform/wk2/TestExpectations
@@ -862,3 +862,7 @@ http/tests/permissions/ [ Pass ]
 imported/w3c/web-platform-tests/storage/ [ Pass ]
 
 fast/canvas/large-getImageData.html [ Pass ]
+
+webkit.org/b/253533 imported/w3c/web-platform-tests/fetch/api/basic/status.h2.any.html [ Pass Failure ]
+webkit.org/b/253533 imported/w3c/web-platform-tests/fetch/api/basic/status.h2.any.worker.html [ Pass Failure ]
+webkit.org/b/253533 imported/w3c/web-platform-tests/xhr/status.h2.window.html [ Pass Failure ]

--- a/Tools/Scripts/webkitpy/port/driver.py
+++ b/Tools/Scripts/webkitpy/port/driver.py
@@ -359,8 +359,12 @@ class Driver(object):
         return test_name.startswith(self.web_platform_test_server_doc_root)
 
     def wpt_test_path_to_uri(self, path):
-        should_use_https = ".https." in path or ".serviceworker." in path or ".serviceworker-module." in path
-        return self.web_platform_test_server_base_https_url + path if should_use_https else self.web_platform_test_server_base_http_url + path
+        if ".h2." in path:
+            return self.web_platform_test_server_base_h2_url + path
+        elif ".https." in path or ".serviceworker." in path or ".serviceworker-module." in path:
+            return self.web_platform_test_server_base_https_url + path
+        else:
+            return self.web_platform_test_server_base_http_url + path
 
     def wpt_webkit_test_path_to_uri(self, path):
         # Our custom test cases currently hardcode localhost/127.0.0.1 for all tests.


### PR DESCRIPTION
#### 7fb8f632008099b0c4e93664481ce76a02e890fa
<pre>
Make HTTP/2-only WPT tests use the HTTP/2 server
<a href="https://bugs.webkit.org/show_bug.cgi?id=253043">https://bugs.webkit.org/show_bug.cgi?id=253043</a>
rdar://problem/106003603

Reviewed by Jon Bedard.

Currently HTTP/2-only WPT tests actually run on the HTTP/1.1 server. This makes them run against the
HTTP/2 server instead as intended.

* LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/status.h2.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/status.h2.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/xhr/status.h2.window-expected.txt:
* LayoutTests/platform/ios-wk2/TestExpectations:
* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/platform/wk2/TestExpectations:
* Tools/Scripts/webkitpy/port/driver.py:
(Driver.wpt_test_path_to_uri):

Canonical link: <a href="https://commits.webkit.org/261489@main">https://commits.webkit.org/261489@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59c5b847f354d35d27d51909a89d51547a620f5f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111757 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20888 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/372 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3539 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120475 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115817 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22247 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11967 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/3280 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117522 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16520 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99676 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104719 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/115185 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98470 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/252 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45462 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13359 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/253 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/88073 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13855 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9686 "9 flakes 3 failures") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19299 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52254 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7995 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15841 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->