### PR TITLE
Marked text does not honor foreground color when spellchecking is on

### DIFF
--- a/Source/WebCore/rendering/TextBoxPainter.h
+++ b/Source/WebCore/rendering/TextBoxPainter.h
@@ -63,7 +63,7 @@ protected:
     void paintForegroundAndDecorations();
     void paintCompositionBackground();
     void paintCompositionUnderlines();
-    void paintCompositionForeground();
+    void paintCompositionForeground(const StyledMarkedText&);
     void paintPlatformDocumentMarkers();
 
     enum class BackgroundStyle { Normal, Rounded };


### PR DESCRIPTION
#### 96f9d0c2e5a5ddbd7421e225fa514c7c2073a61a
<pre>
Marked text does not honor foreground color when spellchecking is on
<a href="https://bugs.webkit.org/show_bug.cgi?id=253283">https://bugs.webkit.org/show_bug.cgi?id=253283</a>
rdar://106127073

Reviewed by Aditya Keerthi and Antti Koivisto.

When spellchecking is on, `m_document.markers().hasMarkers()` is `true`, which
meant that `contentMayNeedStyledMarkedText` is `true`, resulting in `paintCompositionForeground`
never getting called and so the composition was never being applied.

This PR fixes this by calling `paintCompositionForeground` in all call sites where
`paintComposition` was called previously, and then if there is no composition, it
just calls `paintForeground` normally like before.

* Source/WebCore/rendering/TextBoxPainter.cpp:
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::paintCompositionForeground):
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::paintForegroundAndDecorations):
* Source/WebCore/rendering/TextBoxPainter.h:

Canonical link: <a href="https://commits.webkit.org/261170@main">https://commits.webkit.org/261170@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f8280f64125d6a0c10ebb4666365c89f771bfc9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110793 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19878 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/43341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/2142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/119607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114758 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21280 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/10984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/87/builds/2142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116542 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/43341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/103148 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/43341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/103148 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/12471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/43341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/103148 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/13040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/10984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18423 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/43341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7737 "Failed to push commit to Webkit repository") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/14995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->