### PR TITLE
[Cocoa|MSE] Playback of protected audio tracks stalls

### DIFF
--- a/LayoutTests/http/tests/media/fairplay/fps-mse-unmuxed-audio-only-expected.txt
+++ b/LayoutTests/http/tests/media/fairplay/fps-mse-unmuxed-audio-only-expected.txt
@@ -1,0 +1,29 @@
+
+PROMISE: requestMediaKeySystemAccess resolved
+PROMISE: createMediaKeys resolved
+FETCH: resources/cert.der OK
+PROMISE: keys.setServerCertificate resolved
+PROMISE: setMediaKeys() resolved
+Created mediaSource
+EVENT(sourceopen)
+-
+Appending Encrypted Audio Header
+Created sourceBuffer
+FETCH: content/elementary-stream-audio-header-keyid-1.m4a OK
+EVENT(encrypted)
+EVENT(message)
+PROMISE: licenseResponse resolved
+PROMISE: session.update() resolved
+EVENT(updateend)
+-
+Appending Encrypted Audio Payload
+FETCH: content/elementary-stream-audio-payload.m4a OK
+EVENT(updateend)
+EVENT(canplay)
+-
+Playing
+RUN(audio.play())
+Promise resolved OK
+EXPECTED (audio.currentTime > '0.1') OK
+END OF TEST
+

--- a/LayoutTests/http/tests/media/fairplay/fps-mse-unmuxed-audio-only.html
+++ b/LayoutTests/http/tests/media/fairplay/fps-mse-unmuxed-audio-only.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>fps-mse-unmuxed-audio-only</title>
+    <script src=../../../media-resources/video-test.js></script>
+    <script src=support.js></script>
+    <script src="eme2016.js"></script>
+    <script>
+    window.addEventListener('load', async event => {
+        startTest().then(endTest).catch(failTest);
+    });
+
+    async function startTest() {
+        window.audio = document.querySelector('audio');
+        let keys = await startEME({video: audio, capabilities: [{
+            initDataTypes: ['sinf'],
+            audioCapabilities: [{ contentType: 'audio/mp4', robustness: '' }],
+            distinctiveIdentifier: 'not-allowed',
+            persistentState: 'not-allowed',
+            sessionTypes: ['temporary'],
+        }]});
+
+        let mediaSource = new MediaSource;
+        audio.srcObject = mediaSource;
+        consoleWrite('Created mediaSource');
+        await waitFor(mediaSource, 'sourceopen');
+
+        consoleWrite('-');
+        consoleWrite('Appending Encrypted Audio Header');
+
+        let {sourceBuffer: sourceBuffer, session: session} = await createBufferAppendAndWaitForEncrypted(audio, mediaSource, 'audio/mp4', 'content/elementary-stream-audio-header-keyid-1.m4a');
+
+        consoleWrite('-');
+        consoleWrite('Appending Encrypted Audio Payload');
+
+        let fetchPromise = fetchAndAppend(sourceBuffer, 'content/elementary-stream-audio-payload.m4a')
+        let canplayPromise = waitFor(audio, 'canplay');
+        await Promise.all([fetchPromise, canplayPromise]);
+
+        consoleWrite('-');
+        consoleWrite('Playing');
+        await shouldResolve(run('audio.play()'));
+
+        await testExpectedEventually('audio.currentTime', '0.1', '>', 1000);
+    }
+    </script>
+</head>
+<body>
+    <audio controls width="480"></audio>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
@@ -1255,7 +1255,7 @@ bool SourceBufferPrivateAVFObjC::canEnqueueSample(uint64_t trackID, const MediaS
         return false;
 
     // DecompressionSessions doesn't support encrypted media.
-    if (!m_displayLayer)
+    if (trackID == m_enabledVideoTrackID && !m_displayLayer)
         return false;
 
     // if sample is encrypted, and keyIDs match the current set of keyIDs: enqueue sample.


### PR DESCRIPTION
#### 781b0d137b97d8f5abaabfa191b9e97eeaf1d399
<pre>
[Cocoa|MSE] Playback of protected audio tracks stalls
<a href="https://bugs.webkit.org/show_bug.cgi?id=253281">https://bugs.webkit.org/show_bug.cgi?id=253281</a>
rdar://104882715

Reviewed by Eric Carlson.

In 256805@main, a check was added to ensure we did not try to enqueue protected samples
if a decompression session existed. However, that did not account for a SampleBuffer with
only a protected audio track. Modify the check to test for the existence of a displayLayer
only if the track in question is the enabled video track.

* LayoutTests/http/tests/media/fairplay/fps-mse-unmuxed-audio-only-expected.txt: Added.
* LayoutTests/http/tests/media/fairplay/fps-mse-unmuxed-audio-only.html: Added.
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::canEnqueueSample):

Canonical link: <a href="https://commits.webkit.org/261144@main">https://commits.webkit.org/261144@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79d8ba0660b25dd859edcc87069bae4e53115942

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110645 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19726 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43219 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1985 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119492 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114604 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21138 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10842 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/1515 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116386 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15739 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98921 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102940 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97700 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30588 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44052 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12371 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31926 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/85957 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12921 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8885 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18288 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51543 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7719 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14860 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->