### PR TITLE
REGRESSION(255420@main) Embed-loading PDFs from newly opened about:blank terminates web process

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -429,6 +429,10 @@ bool NetworkProcess::allowsFirstPartyForCookies(WebCore::ProcessIdentifier proce
 
 bool NetworkProcess::allowsFirstPartyForCookies(WebCore::ProcessIdentifier processIdentifier, const RegistrableDomain& firstPartyDomain)
 {
+    // FIXME: This shouldn't be needed but it is hit sometimes at least with PDFs.
+    if (firstPartyDomain.isEmpty())
+        return true;
+
     if (!decltype(m_allowedFirstPartiesForCookies)::isValidKey(processIdentifier)) {
         ASSERT_NOT_REACHED();
         return false;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/CookiePrivateBrowsing.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/CookiePrivateBrowsing.mm
@@ -25,6 +25,7 @@
 
 #import "config.h"
 
+#import "HTTPServer.h"
 #import "PlatformUtilities.h"
 #import "Test.h"
 #import "TestWKWebView.h"
@@ -155,4 +156,29 @@ TEST(WebKit, CookieCachePruning)
         }];
         TestWebKitAPI::Util::run(&doneEvaluatingJavaScript);
     }
+}
+
+TEST(WebKit, CookieAccessFromPDFInAboutBlank)
+{
+    auto delegate = adoptNS([TestUIDelegate new]);
+    __block RetainPtr<WKWebView> openedWebView;
+    delegate.get().createWebViewWithConfiguration = ^(WKWebViewConfiguration *configuration, WKNavigationAction *, WKWindowFeatures *) {
+        openedWebView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+        return openedWebView.get();
+    };
+
+    auto webProcessStarter = adoptNS([TestWKWebView new]);
+    [webProcessStarter synchronouslyLoadHTMLString:@"start network process so the creation of the second web view doesn't send NetworkProcessCreationParameters" baseURL:nil];
+
+    TestWebKitAPI::HTTPServer server({ { "/"_s, { "hi"_s } } });
+    auto webView = adoptNS([TestWKWebView new]);
+    webView.get().UIDelegate = delegate.get();
+    NSString *html = [NSString stringWithFormat:@"<script>"
+        "var w = window.open();"
+        "w.document.write('<embed type=\"application/pdf\" src=\"%@\"></embed>');"
+        "</script>", server.request().URL];
+    [webView loadHTMLString:html baseURL:server.request().URL];
+
+    while (!server.totalRequests())
+        TestWebKitAPI::Util::spinRunLoop();
 }


### PR DESCRIPTION
#### 6dd3a73e5aa2eae8951508f3b66d2014078a65aa
<pre>
REGRESSION(255420@main) Embed-loading PDFs from newly opened about:blank terminates web process
<a href="https://bugs.webkit.org/show_bug.cgi?id=253285">https://bugs.webkit.org/show_bug.cgi?id=253285</a>
rdar://105201326

Reviewed by J Pascoe.

In 255420@main I introduced checks in the network process to make sure that firstPartyForCookies
is an allowed domain for that process.  There are a few places in WebKit where we still have
about:blank or a null firstPartyForCookies, which is fine most of the time because
ResourceRequest::allowCookies is false so it doesn&apos;t matter that there&apos;s no firstPartyForCookies.
Sometimes, though, we have a piece of code that loads without a firstPartyForCookies and allows
cookies.  This is an existing bug and should probably be fixed, but it is not catastrophic
because the result is that no cookie access is given.  However, with 255420@main it became catastrophic
because we terminate the web content process, which I&apos;m told is undesirable when a user is trying to do
something like download a PDF.  This change makes it no longer terminate the web content process.

* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::allowsFirstPartyForCookies):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/CookiePrivateBrowsing.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/261142@main">https://commits.webkit.org/261142@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a3d651e4984e1be8539cf328f84d170671dc9bf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110647 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19728 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43220 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1989 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119493 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114606 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21140 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10844 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/1518 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116388 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15745 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/98923 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102944 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30590 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44056 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12373 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31928 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/85959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12922 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8888 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18290 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51545 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14861 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4207 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->