### PR TITLE
Parse list-style-type custom-ident if counter-style is enabled

### DIFF
--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -3999,7 +3999,10 @@
             ],
             "codegen-properties": {
                 "custom": "All",
-                "parser-grammar": "<<values>> | <string> | <custom-ident>"
+                "parser-function": "consumeListStyleType",
+                "parser-function-requires-context": true,
+                "parser-grammar-unused": "<<values>> | <string> | <custom-ident>",
+                "parser-grammar-unused-reason": "custom-ident should be consumed depending on settings."
             },
             "specification": {
                 "category": "css-lists",

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -79,6 +79,7 @@ CSSParserContext::CSSParserContext(const Document& document, const URL& sheetBas
     , colorMixEnabled { document.settings().cssColorMixEnabled() }
     , constantPropertiesEnabled { document.settings().constantPropertiesEnabled() }
     , counterStyleAtRuleImageSymbolsEnabled { document.settings().cssCounterStyleAtRuleImageSymbolsEnabled() }
+    , counterStyleAtRuleEnabled { document.settings().cssCounterStyleAtRulesEnabled() }
     , cssColor4 { document.settings().cssColor4() }
     , relativeColorSyntaxEnabled { document.settings().cssRelativeColorSyntaxEnabled() }
     , springTimingFunctionEnabled { document.settings().springTimingFunctionEnabled() }
@@ -117,6 +118,7 @@ bool operator==(const CSSParserContext& a, const CSSParserContext& b)
         && a.colorMixEnabled == b.colorMixEnabled
         && a.constantPropertiesEnabled == b.constantPropertiesEnabled
         && a.counterStyleAtRuleImageSymbolsEnabled == b.counterStyleAtRuleImageSymbolsEnabled
+        && a.counterStyleAtRuleEnabled == b.counterStyleAtRuleEnabled
         && a.cssColor4 == b.cssColor4
         && a.relativeColorSyntaxEnabled == b.relativeColorSyntaxEnabled
         && a.springTimingFunctionEnabled == b.springTimingFunctionEnabled

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -81,6 +81,7 @@ struct CSSParserContext {
     bool colorMixEnabled { false };
     bool constantPropertiesEnabled { false };
     bool counterStyleAtRuleImageSymbolsEnabled { false };
+    bool counterStyleAtRuleEnabled { false };
     bool cssColor4 { false };
     bool relativeColorSyntaxEnabled { false };
     bool springTimingFunctionEnabled { false };

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -6867,6 +6867,22 @@ RefPtr<CSSValue> consumePathOperation(CSSParserTokenRange& range, const CSSParse
     return consumeBasicShapeOrBox(range, context);
 }
 
+RefPtr<CSSValue> consumeListStyleType(CSSParserTokenRange& range, const CSSParserContext& context)
+{
+    if (range.peek().id() == CSSValueNone)
+        return consumeIdent(range);
+    if (range.peek().type() == StringToken)
+        return consumeString(range);
+
+    if (auto predefinedValues = consumeIdentRange(range, CSSValueDisc, CSSValueEthiopicNumeric))
+        return predefinedValues;
+
+    if (context.counterStyleAtRuleEnabled)
+        return consumeCustomIdent(range);
+
+    return nullptr;
+}
+
 RefPtr<CSSValue> consumeShapeOutside(CSSParserTokenRange& range, const CSSParserContext& context)
 {
     if (auto imageValue = consumeImageOrNone(range, context))

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
@@ -255,6 +255,7 @@ RefPtr<CSSValue> consumeRepeatStyle(CSSParserTokenRange&, const CSSParserContext
 RefPtr<CSSValue> consumePositionX(CSSParserTokenRange&, const CSSParserContext&);
 RefPtr<CSSValue> consumePositionY(CSSParserTokenRange&, const CSSParserContext&);
 RefPtr<CSSValue> consumePaintStroke(CSSParserTokenRange&, const CSSParserContext&);
+RefPtr<CSSValue> consumeListStyleType(CSSParserTokenRange&, const CSSParserContext&);
 RefPtr<CSSValue> consumePaintOrder(CSSParserTokenRange&);
 RefPtr<CSSValue> consumeStrokeDasharray(CSSParserTokenRange&);
 RefPtr<CSSValue> consumeCursor(CSSParserTokenRange&, const CSSParserContext&, bool inQuirksMode);

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -774,13 +774,8 @@ inline void BuilderCustom::applyValueListStyleType(BuilderState& builderState, C
         return;
     }
     if (primitiveValue.isCustomIdent()) {
-        if (builderState.document().settings().cssCounterStyleAtRulesEnabled()) {
-            builderState.style().setListStyleType(ListStyleType::CustomCounterStyle);
-            builderState.style().setListStyleStringValue(AtomString { primitiveValue.stringValue() });
-        } else {
-            builderState.style().setListStyleType(ListStyleType::Decimal);
-            builderState.style().setListStyleStringValue(RenderStyle::initialListStyleStringValue());
-        }
+        builderState.style().setListStyleType(ListStyleType::CustomCounterStyle);
+        builderState.style().setListStyleStringValue(AtomString { primitiveValue.stringValue() });
         return;
     }
     builderState.style().setListStyleType(ListStyleType::String);


### PR DESCRIPTION
#### eb7c428cb8ebaaf0a6f48a1be8128abec5f5f741
<pre>
Parse list-style-type custom-ident if counter-style is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=253291">https://bugs.webkit.org/show_bug.cgi?id=253291</a>
rdar://problem/106175917

Reviewed by Tim Nguyen.

list-style-type should accept custom-ident
values only if counter-styles-at-rule is enabled.

* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::operator==):
* Source/WebCore/css/parser/CSSParserContext.h:
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeListStyleType):
* Source/WebCore/css/parser/CSSPropertyParserHelpers.h:
* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyValueListStyleType):

Canonical link: <a href="https://commits.webkit.org/261154@main">https://commits.webkit.org/261154@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ae8b6d5e4b553ce44322e5dd1aa8d58c100ed2d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110723 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19805 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43281 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2065 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119554 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114690 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21212 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10917 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/1698 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116467 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103054 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30640 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44165 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/12424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/31977 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/86045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12983 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18360 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51596 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7729 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/14932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->