### PR TITLE
Add proxy API to WKWebsiteDataStore.

### DIFF
--- a/Source/WTF/wtf/PlatformHave.h
+++ b/Source/WTF/wtf/PlatformHave.h
@@ -1413,3 +1413,7 @@
     || (PLATFORM(APPLETV) && __TV_OS_VERSION_MIN_REQUIRED >= 170000))
 #define HAVE_SETUSEIOSURFACEFORTILES 1
 #endif
+
+#if __has_include(<Network/proxy_config.h>)
+#define HAVE_NW_PROXY_CONFIG 1
+#endif

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -477,6 +477,11 @@ private:
     void removeWebPageNetworkParameters(PAL::SessionID, WebPageProxyIdentifier);
     void countNonDefaultSessionSets(PAL::SessionID, CompletionHandler<void(size_t)>&&);
 
+#if HAVE(NW_PROXY_CONFIG)
+    void clearProxyConfigData(PAL::SessionID);
+    void setProxyConfigData(PAL::SessionID, const IPC::DataReference& proxyConfigData, const IPC::DataReference& proxyIdentifierData);
+#endif
+    
 #if USE(SOUP)
     void setIgnoreTLSErrors(PAL::SessionID, bool);
     void userPreferredLanguagesChanged(const Vector<String>&);

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -235,4 +235,10 @@ messages -> NetworkProcess LegacyReceiver {
 #if ENABLE(INSPECTOR_NETWORK_THROTTLING)
     SetEmulatedConditions(PAL::SessionID sessionID, std::optional<int64_t> bytesPerSecondLimit)
 #endif
+
+#if HAVE(NW_PROXY_CONFIG)
+    ClearProxyConfigData(PAL::SessionID sessionID)
+    SetProxyConfigData(PAL::SessionID sessionID, IPC::DataReference proxyConfigData, IPC::DataReference proxyIdentifierData)
+#endif
+
 }

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -266,6 +266,11 @@ public:
     void setEmulatedConditions(std::optional<int64_t>&& bytesPerSecondLimit);
 #endif
 
+#if HAVE(NW_PROXY_CONFIG)
+    virtual void clearProxyConfigData() { }
+    virtual void setProxyConfigData(const IPC::DataReference&, const IPC::DataReference&) { }
+#endif
+                                    
 protected:
     NetworkSession(NetworkProcess&, const NetworkSessionCreationParameters&);
 

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
@@ -216,14 +216,32 @@ const String& NetworkProcess::uiProcessBundleIdentifier() const
 }
 
 #if PLATFORM(IOS_FAMILY)
-
 void NetworkProcess::setBackupExclusionPeriodForTesting(PAL::SessionID sessionID, Seconds period, CompletionHandler<void()>&& completionHandler)
 {
     auto callbackAggregator = CallbackAggregator::create(WTFMove(completionHandler));
     if (auto* session = networkSession(sessionID))
         session->storageManager().setBackupExclusionPeriodForTesting(period, [callbackAggregator] { });
 }
+#endif // PLATFORM(IOS_FAMILY)
 
-#endif
+#if HAVE(NW_PROXY_CONFIG)
+void NetworkProcess::clearProxyConfigData(PAL::SessionID sessionID)
+{
+    auto* session = networkSession(sessionID);
+    if (!session)
+        return;
+
+    session->clearProxyConfigData();
+}
+
+void NetworkProcess::setProxyConfigData(PAL::SessionID sessionID, const IPC::DataReference& proxyConfigData, const IPC::DataReference& proxyIdentifierData)
+{
+    auto* session = networkSession(sessionID);
+    if (!session)
+        return;
+
+    session->setProxyConfigData(proxyConfigData, proxyIdentifierData);
+}
+#endif // HAVE(NW_PROXY_CONFIG)
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h
@@ -147,6 +147,12 @@ public:
 
     void removeDataTask(DataTaskIdentifier);
 
+#if HAVE(NW_PROXY_CONFIG)
+    nw_proxy_config_t proxyConfig() const { return m_nwProxyConfig.get(); }
+    void clearProxyConfigData() final;
+    void setProxyConfigData(const IPC::DataReference& proxyConfigData, const IPC::DataReference& proxyIdentifierData) final;
+#endif
+
 private:
     void invalidateAndCancel() override;
     HashSet<WebCore::SecurityOriginData> originsWithCredentials() final;
@@ -178,6 +184,8 @@ private:
     void removeWebPageNetworkParameters(WebPageProxyIdentifier) final;
     size_t countNonDefaultSessionSets() const final;
 
+    void forEachSessionWrapper(Function<void(SessionWrapper&)>&&);
+
     Ref<SessionSet> m_defaultSessionSet;
     HashMap<WebPageProxyIdentifier, Ref<SessionSet>> m_perPageSessionSets;
     HashMap<WebPageNetworkParameters, WeakPtr<SessionSet>> m_perParametersSessionSets;
@@ -191,6 +199,9 @@ private:
     String m_sourceApplicationBundleIdentifier;
     String m_sourceApplicationSecondaryIdentifier;
     RetainPtr<CFDictionaryRef> m_proxyConfiguration;
+#if HAVE(NW_PROXY_CONFIG)
+    RetainPtr<nw_proxy_config_t> m_nwProxyConfig;
+#endif
     RetainPtr<DMFWebsitePolicyMonitor> m_deviceManagementPolicyMonitor;
     bool m_deviceManagementRestrictionsEnabled { false };
     bool m_allLoadsBlockedByDeviceManagementRestrictionsForTesting { false };

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.mm
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.mm
@@ -73,6 +73,7 @@ rtc::ProxyInfo NetworkRTCProvider::proxyInfoFromSession(const RTCNetwork::Socket
 {
     // FIXME: We should check for kCFNetworkProxiesExceptionsList to decide whether to use proxy or not.
     // FIXME: We should also get username/password for authentication cases.
+    // FIXME: We should also handle the new style nw_proxy_config once enough API exists to support it.
     RetainPtr<CFDictionaryRef> proxyDictionary = static_cast<NetworkSessionCocoa&>(session).proxyConfiguration();
     if (!proxyDictionary)
         proxyDictionary = adoptCF(CFNetworkCopySystemProxySettings());

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.h
@@ -27,6 +27,10 @@
 
 #import <WebKit/WKWebsiteDataRecord.h>
 
+#if __has_include(<Network/proxy_config.h>)
+#import <Network/Network.h>
+#endif
+
 NS_ASSUME_NONNULL_BEGIN
 
 @class WKHTTPCookieStore;
@@ -78,6 +82,12 @@ WK_CLASS_AVAILABLE(macos(10.11), ios(9.0))
 
 /*! @abstract Returns the cookie store representing HTTP cookies in this website data store. */
 @property (nonatomic, readonly) WKHTTPCookieStore *httpCookieStore WK_API_AVAILABLE(macos(10.13), ios(11.0));
+
+#if __has_include(<Network/proxy_config.h>)
+/*! @abstract Sets the proxy configuration to be used for networking in all WKWebViews that use this WKWebsiteDataStore.
+ @param proxyConfiguration The proxy configuration to use.
+*/- (void)setProxyConfiguration:(nw_proxy_config_t)proxyConfiguration WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+#endif
 
 @end
 

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -2346,4 +2346,17 @@ void WebsiteDataStore::resumeDownload(const DownloadProxy& downloadProxy, const 
     networkProcess().send(Messages::NetworkProcess::ResumeDownload(m_sessionID, downloadProxy.downloadID(), resumeData.dataReference(), path, sandboxExtensionHandle, callDownloadDidStart), 0);
 }
 
+#if HAVE(NW_PROXY_CONFIG)
+void WebsiteDataStore::clearProxyConfigData()
+{
+    networkProcess().send(Messages::NetworkProcess::ClearProxyConfigData(m_sessionID), 0);
+}
+
+void WebsiteDataStore::setProxyConfigData(const API::Data& data, uuid_t proxyIdentifier)
+{
+    auto proxyIdentifierData = IPC::DataReference(reinterpret_cast<uint8_t *>(proxyIdentifier), sizeof(uuid_t));
+    networkProcess().send(Messages::NetworkProcess::SetProxyConfigData(m_sessionID, data.dataReference(), WTFMove(proxyIdentifierData)), 0);
+}
+#endif // HAVE(NW_PROXY_CONFIG)
+
 }

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -438,6 +438,11 @@ public:
     void saveRecentSearches(const String& name, const Vector<WebCore::RecentSearch>&);
     void loadRecentSearches(const String& name, CompletionHandler<void(Vector<WebCore::RecentSearch>&&)>&&);
 
+#if HAVE(NW_PROXY_CONFIG)
+    void clearProxyConfigData();
+    void setProxyConfigData(const API::Data&, uuid_t proxyIdentifier);
+#endif
+    
 private:
     enum class ForceReinitialization : bool { No, Yes };
 #if ENABLE(APP_BOUND_DOMAINS)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Proxy.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Proxy.mm
@@ -155,6 +155,87 @@ TEST(WebKit, SOCKS5)
     EXPECT_WK_STREQ([webView _test_waitForAlert], "success!");
 }
 
+#if HAVE(NW_PROXY_CONFIG)
+// FIXME: Enabling blocked by rdar://106168249
+TEST(WebKit, DISABLED_HTTPSProxyAPI)
+{
+    HTTPServer server(HTTPServer::respondWithOK, HTTPServer::Protocol::HttpsProxy);
+
+    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)]);
+    auto delegate = adoptNS([ProxyDelegate new]);
+    [webView setNavigationDelegate:delegate.get()];
+    [webView setUIDelegate:delegate.get()];
+
+    auto endpoint = adoptNS(nw_endpoint_create_host("127.0.0.1", std::to_string(server.port()).c_str()));
+    auto proxyConfig = adoptNS(nw_proxy_config_create_http_connect(endpoint.get(), nil));
+    [webView.get().configuration.websiteDataStore setProxyConfiguration:proxyConfig.get()];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/"]]];
+    EXPECT_WK_STREQ([delegate waitForAlert], "success!");
+}
+
+TEST(WebKit, SOCKS5API)
+{
+    constexpr uint8_t socks5Version = 0x5; // https://tools.ietf.org/html/rfc1928#section-3
+    constexpr uint8_t noAuthenticationRequired = 0x00; // https://tools.ietf.org/html/rfc1928#section-3
+    constexpr uint8_t connect = 0x01; // https://tools.ietf.org/html/rfc1928#section-4
+    constexpr uint8_t reserved = 0x00; // https://tools.ietf.org/html/rfc1928#section-4
+    constexpr uint8_t domainName = 0x03; // https://tools.ietf.org/html/rfc1928#section-4
+    constexpr uint8_t requestSucceeded = 0x00; // https://tools.ietf.org/html/rfc1928#section-6
+
+    using namespace TestWebKitAPI;
+    HTTPServer server([](Connection connection) {
+        connection.receiveBytes([=] (Vector<uint8_t>&& bytes) {
+            constexpr uint8_t expectedAuthenticationMethodCount = 1;
+            Vector<uint8_t> expectedClientGreeting { socks5Version, expectedAuthenticationMethodCount, noAuthenticationRequired };
+            EXPECT_EQ(bytes, expectedClientGreeting);
+            connection.send(Vector<uint8_t> { socks5Version, noAuthenticationRequired }, [=] {
+                connection.receiveBytes([=] (Vector<uint8_t>&& bytes) {
+                    constexpr uint8_t httpPortFirstByte = 0;
+                    constexpr uint8_t httpPortSecondByte = 80;
+                    Vector<uint8_t> expectedConnectRequest {
+                        socks5Version,
+                        connect,
+                        reserved,
+                        domainName,
+                        static_cast<uint8_t>(strlen("example.com")),
+                        'e', 'x', 'a', 'm', 'p', 'l', 'e', '.', 'c', 'o', 'm',
+                        httpPortFirstByte, httpPortSecondByte
+                    };
+                    EXPECT_EQ(bytes, expectedConnectRequest);
+
+                    Vector<uint8_t> response { socks5Version, requestSucceeded, reserved,
+                        domainName,
+                        static_cast<uint8_t>(strlen("example.com")),
+                        'e', 'x', 'a', 'm', 'p', 'l', 'e', '.', 'c', 'o', 'm',
+                        httpPortFirstByte, httpPortSecondByte
+                    };
+                    connection.send(WTFMove(response), [=] {
+                        connection.receiveHTTPRequest([=] (Vector<char>&&) {
+                            connection.send(
+                                "HTTP/1.1 200 OK\r\n"
+                                "Content-Length: 34\r\n"
+                                "\r\n"
+                                "<script>alert('success!')</script>"_s
+                            );
+                        });
+                    });
+                });
+            });
+        });
+    });
+
+    auto endpoint = adoptNS(nw_endpoint_create_host("127.0.0.1", std::to_string(server.port()).c_str()));
+    auto proxyConfig = adoptNS(nw_proxy_config_create_socksv5(endpoint.get()));
+
+    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)]);
+    [webView.get().configuration.websiteDataStore setProxyConfiguration:proxyConfig.get()];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"http://example.com/"]]];
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "success!");
+}
+#endif // HAVE(NW_PROXY_CONFIG)
+
 static HTTPServer proxyAuthenticationServer()
 {
     return HTTPServer(HTTPServer::respondWithOK, HTTPServer::Protocol::HttpsProxyWithAuthentication);


### PR DESCRIPTION
#### 54478bf81a3e2217d723fef889df7b8d7b88bec9
<pre>
Add proxy API to WKWebsiteDataStore.
<a href="https://bugs.webkit.org/show_bug.cgi?id=253288">https://bugs.webkit.org/show_bug.cgi?id=253288</a>
rdar://100583135

Reviewed by Chris Dumez.

* Source/WTF/wtf/PlatformHave.h:
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/NetworkProcess/NetworkSession.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm:
(WebKit::NetworkProcess::clearProxyConfigData):
(WebKit::NetworkProcess::setProxyConfigData):
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::SessionWrapper::initialize):
(WebKit::NetworkSessionCocoa::forEachSessionWrapper):
(WebKit::NetworkSessionCocoa::clearProxyConfigData):
(WebKit::NetworkSessionCocoa::setProxyConfigData):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.mm:
(WebKit::NetworkRTCProvider::proxyInfoFromSession):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(-[WKWebsiteDataStore setProxyConfig:]):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::clearProxyConfigData):
(WebKit::WebsiteDataStore::setProxyConfigData):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Proxy.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/261181@main">https://commits.webkit.org/261181@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4fab17e159858ede4a729a84144fb905fe579e14

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110813 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19899 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/43357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/2162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/119625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114775 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21296 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11000 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/87/builds/2162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116563 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/43357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103174 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/43357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/44245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/99457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/12506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/43357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/86126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/10598 "Built successfully and passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/13065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/100545 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18439 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/43357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31359 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/7749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/15010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/108575 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4225 "Built successfully and passed tests") | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26765 "Passed tests") | 
<!--EWS-Status-Bubble-End-->