### PR TITLE
[macOS] Show correction panel for grammar errors

### DIFF
--- a/Source/WebCore/page/AlternativeTextClient.h
+++ b/Source/WebCore/page/AlternativeTextClient.h
@@ -42,6 +42,7 @@ enum class AlternativeTextType : uint8_t {
     Correction = 0,
     Reversion,
     SpellingSuggestions,
+    GrammarSuggestions,
     DictationAlternatives
 };
 
@@ -76,6 +77,7 @@ template<> struct EnumTraits<WebCore::AlternativeTextType> {
         WebCore::AlternativeTextType::Correction,
         WebCore::AlternativeTextType::Reversion,
         WebCore::AlternativeTextType::SpellingSuggestions,
+        WebCore::AlternativeTextType::GrammarSuggestions,
         WebCore::AlternativeTextType::DictationAlternatives
     >;
 };

--- a/Source/WebKit/UIProcess/mac/CorrectionPanel.mm
+++ b/Source/WebKit/UIProcess/mac/CorrectionPanel.mm
@@ -40,6 +40,7 @@ static inline NSCorrectionIndicatorType correctionIndicatorType(WebCore::Alterna
     case WebCore::AlternativeTextType::Reversion:
         return NSCorrectionIndicatorTypeReversion;
     case WebCore::AlternativeTextType::SpellingSuggestions:
+    case WebCore::AlternativeTextType::GrammarSuggestions:
         return NSCorrectionIndicatorTypeGuesses;
     case WebCore::AlternativeTextType::DictationAlternatives:
         ASSERT_NOT_REACHED();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
@@ -489,9 +489,9 @@ void WebEditorClient::textWillBeDeletedInTextField(Element& element)
 
 bool WebEditorClient::shouldEraseMarkersAfterChangeSelection(WebCore::TextCheckingType type) const
 {
-    // This prevents erasing spelling markers on OS X Lion or later to match AppKit on these Mac OS X versions.
+    // This prevents erasing spelling and grammar markers to match AppKit.
 #if PLATFORM(COCOA)
-    return type != TextCheckingType::Spelling;
+    return !(type == TextCheckingType::Spelling || type == TextCheckingType::Grammar);
 #else
     UNUSED_PARAM(type);
     return true;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/CorrectionPanel.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/CorrectionPanel.mm
@@ -40,6 +40,7 @@ static inline NSCorrectionIndicatorType correctionIndicatorType(AlternativeTextT
     case AlternativeTextType::Reversion:
         return NSCorrectionIndicatorTypeReversion;
     case AlternativeTextType::SpellingSuggestions:
+    case AlternativeTextType::GrammarSuggestions:
         return NSCorrectionIndicatorTypeGuesses;
     case AlternativeTextType::DictationAlternatives:
         ASSERT_NOT_REACHED();


### PR DESCRIPTION
#### 81727684efeb8846fc178d34aa3479307b2ab8ee
<pre>
[macOS] Show correction panel for grammar errors
<a href="https://bugs.webkit.org/show_bug.cgi?id=253294">https://bugs.webkit.org/show_bug.cgi?id=253294</a>
rdar://105738781

Reviewed by Wenson Hsieh.

Native text views on macOS display a correction panel when grammar checking is
enabled and the cursor is at the end of a grammar error, or when at the end of
a misspelled word.

Currently, WebKit only implements this behavior for misspelled words. This
patch adds support for showing a correction panel for grammar errors, matching
AppKit behavior.

* Source/WebCore/editing/AlternativeTextController.cpp:
(WebCore::AlternativeTextController::timerFired):

Obtain suggestions for an ungrammatical phrase.

(WebCore::AlternativeTextController::handleAlternativeTextUIResult):

Insert accepted suggestions the same way as spelling suggestions.

(WebCore::AlternativeTextController::shouldStartTimerFor const):

Add grammar markers to the allowlist of markers that can display alternative text.

Improve the readability of the method by using a switch statement.

(WebCore::AlternativeTextController::respondToMarkerAtEndOfWord):

Start the timer to get grammar suggestions for the current word.

* Source/WebCore/page/AlternativeTextClient.h:
* Source/WebKit/UIProcess/mac/CorrectionPanel.mm:
(correctionIndicatorType):

The correction panel for grammar suggestions should appear the same as the
panel for spelling suggestions.

* Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp:
(WebKit::WebEditorClient::shouldEraseMarkersAfterChangeSelection const):

Prevent grammar markers from being removed on selection changes, matching
native behavior.

* Source/WebKitLegacy/mac/WebCoreSupport/CorrectionPanel.mm:
(correctionIndicatorType):

The correction panel for grammar suggestions should appear the same as the
panel for spelling suggestions.

Canonical link: <a href="https://commits.webkit.org/261151@main">https://commits.webkit.org/261151@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d3629b304dffc478fc863b073123bd991ee2e50

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110676 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19757 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43242 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2014 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119514 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114644 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21166 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10869 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/1537 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116417 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15762 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102981 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30613 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44092 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/12395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31951 "Found 1 new test failure: media/video-playback-quality.html (failure)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/85985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12944 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8908 "Found 1 new test failure: imported/w3c/web-platform-tests/background-fetch/mixed-content-and-allowed-schemes.https.window.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18314 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51568 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14882 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4209 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->