### PR TITLE
[web-animations] ensure accelerated effects do not contain calculated values

### DIFF
--- a/Source/WebCore/platform/animation/AcceleratedEffect.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.cpp
@@ -35,6 +35,7 @@
 #include "Document.h"
 #include "KeyframeEffect.h"
 #include "KeyframeList.h"
+#include "LayoutSize.h"
 #include "WebAnimation.h"
 #include "WebAnimationTypes.h"
 #include <wtf/IsoMallocInlines.h>
@@ -85,14 +86,9 @@ static AcceleratedEffectProperty acceleratedPropertyFromCSSProperty(AnimatablePr
     }
 }
 
-Ref<AcceleratedEffect> AcceleratedEffect::copyWithProperties(OptionSet<AcceleratedEffectProperty>& propertyFilter)
+Ref<AcceleratedEffect> AcceleratedEffect::create(const KeyframeEffect& effect, const IntRect& borderBoxRect)
 {
-    return adoptRef(*new AcceleratedEffect(*this, propertyFilter));
-}
-
-Ref<AcceleratedEffect> AcceleratedEffect::create(const KeyframeEffect& effect)
-{
-    return adoptRef(*new AcceleratedEffect(effect));
+    return adoptRef(*new AcceleratedEffect(effect, borderBoxRect));
 }
 
 Ref<AcceleratedEffect> AcceleratedEffect::create(Vector<AcceleratedEffectKeyframe>&& keyframes, WebAnimationType type, FillMode fill, PlaybackDirection direction, CompositeOperation composite, RefPtr<TimingFunction>&& timingFunction, RefPtr<TimingFunction>&& defaultKeyframeTimingFunction, OptionSet<WebCore::AcceleratedEffectProperty>&& animatedProperties, bool paused, double iterationStart, double iterations, double playbackRate, Seconds delay, Seconds endDelay, Seconds iterationDuration, Seconds activeDuration, Seconds endTime, std::optional<Seconds> startTime, std::optional<Seconds> holdTime)
@@ -100,7 +96,12 @@ Ref<AcceleratedEffect> AcceleratedEffect::create(Vector<AcceleratedEffectKeyfram
     return adoptRef(*new AcceleratedEffect(WTFMove(keyframes), type, fill, direction, composite, WTFMove(timingFunction), WTFMove(defaultKeyframeTimingFunction), WTFMove(animatedProperties), paused, iterationStart, iterations, playbackRate, delay, endDelay, iterationDuration, activeDuration, endTime, startTime, holdTime));
 }
 
-AcceleratedEffect::AcceleratedEffect(const KeyframeEffect& effect)
+Ref<AcceleratedEffect> AcceleratedEffect::copyWithProperties(OptionSet<AcceleratedEffectProperty>& propertyFilter)
+{
+    return adoptRef(*new AcceleratedEffect(*this, propertyFilter));
+}
+
+AcceleratedEffect::AcceleratedEffect(const KeyframeEffect& effect, const IntRect& borderBoxRect)
 {
     m_fill = effect.fill();
     m_direction = effect.direction();
@@ -155,7 +156,7 @@ AcceleratedEffect::AcceleratedEffect(const KeyframeEffect& effect)
 
         acceleratedKeyframe.values = [&]() -> AcceleratedEffectValues {
             if (auto* style = srcKeyframe.style())
-                return { *style };
+                return { *style, borderBoxRect };
             return { };
         }();
 

--- a/Source/WebCore/platform/animation/AcceleratedEffect.h
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.h
@@ -40,6 +40,7 @@
 
 namespace WebCore {
 
+class IntRect;
 class KeyframeEffect;
 
 enum class AcceleratedEffectProperty : uint16_t {
@@ -71,7 +72,7 @@ struct AcceleratedEffectKeyframe {
 class AcceleratedEffect : public RefCounted<AcceleratedEffect> {
     WTF_MAKE_ISO_ALLOCATED(AcceleratedEffect);
 public:
-    static Ref<AcceleratedEffect> create(const KeyframeEffect&);
+    static Ref<AcceleratedEffect> create(const KeyframeEffect&, const IntRect&);
     WEBCORE_EXPORT static Ref<AcceleratedEffect> create(Vector<AcceleratedEffectKeyframe>&&, WebAnimationType, FillMode, PlaybackDirection, CompositeOperation, RefPtr<TimingFunction>&& timingFunction, RefPtr<TimingFunction>&& defaultKeyframeTimingFunction, OptionSet<AcceleratedEffectProperty>&&, bool paused, double iterationStart, double iterations, double playbackRate, Seconds delay, Seconds endDelay, Seconds iterationDuration, Seconds activeDuration, Seconds endTime, std::optional<Seconds> startTime, std::optional<Seconds> holdTime);
 
     virtual ~AcceleratedEffect() = default;
@@ -100,7 +101,7 @@ public:
     std::optional<Seconds> holdTime() const { return m_holdTime; }
 
 private:
-    AcceleratedEffect(const KeyframeEffect&);
+    AcceleratedEffect(const KeyframeEffect&, const IntRect&);
     explicit AcceleratedEffect(Vector<AcceleratedEffectKeyframe>&&, WebAnimationType, FillMode, PlaybackDirection, CompositeOperation, RefPtr<TimingFunction>&& timingFunction, RefPtr<TimingFunction>&& defaultKeyframeTimingFunction, OptionSet<AcceleratedEffectProperty>&&, bool paused, double iterationStart, double iterations, double playbackRate, WTF::Seconds delay, WTF::Seconds endDelay, WTF::Seconds iterationDuration, WTF::Seconds activeDuration, WTF::Seconds endTime, std::optional<WTF::Seconds> startTime, std::optional<WTF::Seconds> holdTime);
     explicit AcceleratedEffect(const AcceleratedEffect&, OptionSet<AcceleratedEffectProperty>&);
 

--- a/Source/WebCore/platform/animation/AcceleratedEffectValues.h
+++ b/Source/WebCore/platform/animation/AcceleratedEffectValues.h
@@ -41,6 +41,9 @@
 
 namespace WebCore {
 
+class IntRect;
+class Path;
+
 struct AcceleratedEffectValues {
     float opacity { 1 };
     LengthPoint transformOrigin { };
@@ -57,7 +60,7 @@ struct AcceleratedEffectValues {
 #if ENABLE(FILTERS_LEVEL_2)
     FilterOperations backdropFilter { };
 #endif
-    
+
     AcceleratedEffectValues()
     {
     }
@@ -78,10 +81,8 @@ struct AcceleratedEffectValues {
     }
 
     WEBCORE_EXPORT AcceleratedEffectValues(const AcceleratedEffectValues&);
-    AcceleratedEffectValues(const RenderStyle&);
+    AcceleratedEffectValues(const RenderStyle&, const IntRect&);
     AcceleratedEffectValues& operator=(const AcceleratedEffectValues&) = default;
-    
-    void copyTransformOperations(const TransformOperations&);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/transforms/TransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/TransformOperation.h
@@ -71,6 +71,7 @@ public:
     virtual ~TransformOperation() = default;
 
     virtual Ref<TransformOperation> clone() const = 0;
+    virtual Ref<TransformOperation> selfOrCopyWithResolvedCalculatedValues(const FloatSize&) { return *this; }
 
     virtual bool operator==(const TransformOperation&) const = 0;
     bool operator!=(const TransformOperation& o) const { return !(*this == o); }

--- a/Source/WebCore/platform/graphics/transforms/TranslateTransformOperation.cpp
+++ b/Source/WebCore/platform/graphics/transforms/TranslateTransformOperation.cpp
@@ -72,4 +72,14 @@ void TranslateTransformOperation::dump(TextStream& ts) const
     ts << type() << "(" << m_x << ", " << m_y << ", " << m_z << ")";
 }
 
+Ref<TransformOperation> TranslateTransformOperation::selfOrCopyWithResolvedCalculatedValues(const FloatSize& borderBoxSize)
+{
+    if (!m_x.isCalculated() && !m_y.isCalculated() && !m_z.isCalculated())
+        return TransformOperation::selfOrCopyWithResolvedCalculatedValues(borderBoxSize);
+
+    Length x = { xAsFloat(borderBoxSize), LengthType::Fixed };
+    Length y = { yAsFloat(borderBoxSize), LengthType::Fixed };
+    return create(x, y, m_z, type());
+}
+
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/transforms/TranslateTransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/TranslateTransformOperation.h
@@ -47,6 +47,8 @@ public:
         return adoptRef(*new TranslateTransformOperation(m_x, m_y, m_z, type()));
     }
 
+    Ref<TransformOperation> selfOrCopyWithResolvedCalculatedValues(const FloatSize&) override;
+
     float xAsFloat(const FloatSize& borderBoxSize) const { return floatValueForLength(m_x, borderBoxSize.width()); }
     float yAsFloat(const FloatSize& borderBoxSize) const { return floatValueForLength(m_y, borderBoxSize.height()); }
     float zAsFloat() const { return floatValueForLength(m_z, 1); }

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -3994,6 +3994,7 @@ bool RenderLayerBacking::updateAcceleratedEffectsAndBaseValues()
     ASSERT(target);
 
     bool hasInterpolatingEffect = false;
+    auto borderBoxRect = snappedIntRect(m_owningLayer.rendererBorderBoxRect());
 
     AcceleratedEffects acceleratedEffects;
     if (auto* effectStack = target->keyframeEffectStack()) {
@@ -4002,7 +4003,7 @@ bool RenderLayerBacking::updateAcceleratedEffectsAndBaseValues()
                 continue;
             if (!hasInterpolatingEffect && effect->isRunningAccelerated())
                 hasInterpolatingEffect = true;
-            acceleratedEffects.append(AcceleratedEffect::create(*effect));
+            acceleratedEffects.append(AcceleratedEffect::create(*effect, borderBoxRect));
         }
     }
 
@@ -4014,7 +4015,7 @@ bool RenderLayerBacking::updateAcceleratedEffectsAndBaseValues()
 
     auto baseValues = [&]() -> AcceleratedEffectValues {
         if (auto* style = target->lastStyleChangeEventStyle())
-            return { *style };
+            return { *style, borderBoxRect };
         return { };
     }();
 


### PR DESCRIPTION
#### fd6859ad60cd1cb51fabdb4169bf0e4de09f502a
<pre>
[web-animations] ensure accelerated effects do not contain calculated values
<a href="https://bugs.webkit.org/show_bug.cgi?id=253243">https://bugs.webkit.org/show_bug.cgi?id=253243</a>

Reviewed by Dean Jackson.

Since we will lack the ability to encode calculated values when committing PlatformCALayerRemote,
we must ensure those values are pre-calculated when the accelerated effect is created.

To do this, we pass down the border box of the RenderLayerBacking&apos;s associated renderer down to
AcceleratedEffectValues to correctly resolve any Length-backed value that is calculated. In the
case of transform operations, we add a new selfOrCopyWithResolvedCalculatedValues() method that
will only create a new operation if needed.

* Source/WebCore/platform/animation/AcceleratedEffect.cpp:
(WebCore::AcceleratedEffect::create):
(WebCore::AcceleratedEffect::copyWithProperties):
(WebCore::AcceleratedEffect::AcceleratedEffect):
* Source/WebCore/platform/animation/AcceleratedEffect.h:
* Source/WebCore/platform/animation/AcceleratedEffectValues.cpp:
(WebCore::AcceleratedEffectValues::AcceleratedEffectValues):
(WebCore::nonCalculatedLengthPoint):
(WebCore::AcceleratedEffectValues::copyTransformOperations): Deleted.
* Source/WebCore/platform/animation/AcceleratedEffectValues.h:
* Source/WebCore/platform/graphics/transforms/TransformOperation.h:
(WebCore::TransformOperation::selfOrCopyWithResolvedCalculatedValues):
* Source/WebCore/platform/graphics/transforms/TranslateTransformOperation.cpp:
(WebCore::TranslateTransformOperation::selfOrCopyWithResolvedCalculatedValues):
* Source/WebCore/platform/graphics/transforms/TranslateTransformOperation.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateAcceleratedEffectsAndBaseValues):

Canonical link: <a href="https://commits.webkit.org/261132@main">https://commits.webkit.org/261132@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f8ad4302f009a65a5db3f9b380c294b9345e93f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110685 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19766 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43248 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2023 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/119520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114653 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21175 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10878 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/1549 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116426 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102997 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/30612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/44117 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/12401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/31950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/86005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12950 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18323 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51567 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14888 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4203 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->