### PR TITLE
ImageBufferIOSurfaceBackend bitmap draws spend time maintaining the color conversion cache

### DIFF
--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -290,10 +290,10 @@ void GraphicsContextCG::drawNativeImageInternal(NativeImage& nativeImage, const 
         }
 
 #if CACHE_SUBIMAGES
-        return CGSubimageCacheWithTimer::getSubimage(image, physicalSubimageRect);
-#else
-        return adoptCF(CGImageCreateWithImageInRect(image, physicalSubimageRect));
+        if (!(CGImageGetCachingFlags(image) & kCGImageCachingTransient))
+            return CGSubimageCacheWithTimer::getSubimage(image, physicalSubimageRect);
 #endif
+        return adoptCF(CGImageCreateWithImageInRect(image, physicalSubimageRect));
     };
 
     auto imageLogicalSize = [](CGImageRef image, const ImagePaintingOptions& options) -> FloatSize {

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
@@ -162,11 +162,18 @@ RefPtr<NativeImage> ImageBufferIOSurfaceBackend::copyNativeImageForDrawing(Graph
         // The destination backend needs to read the actual pixels. Returning non-refence will
         // copy the pixels and but still cache the image to the context. This means we must
         // return the reference or cleanup later if we return the non-reference.
-        return NativeImage::create(adoptCF(CGIOSurfaceContextCreateImageReference(m_surface->ensurePlatformContext())));
+        if (auto image = adoptCF(CGIOSurfaceContextCreateImageReference(m_surface->ensurePlatformContext()))) {
+            // CG has internal caches for some operations related to software bitmap draw. 
+            // One of these caches are per-image color matching cache. Since these will not get any hits
+            // from an image that is recreated every time, mark the image transient to skip these caches.
+            // This also skips WebKit GraphicsContext subimage cache.
+            CGImageSetCachingFlags(image.get(), kCGImageCachingTransient);
+            return NativeImage::create(WTFMove(image));
+        }
+        return nullptr;
     }
     // Other backends are deferred (iosurface, display list) or potentially deferred. Must copy for drawing.
     return ImageBufferIOSurfaceBackend::copyNativeImage(CopyBackingStore);
-
 }
 
 RefPtr<NativeImage> ImageBufferIOSurfaceBackend::sinkIntoNativeImage()


### PR DESCRIPTION
#### 40ecc82d81c30df348048138b0d54c8fc677bb72
<pre>
ImageBufferIOSurfaceBackend bitmap draws spend time maintaining the color conversion cache
<a href="https://bugs.webkit.org/show_bug.cgi?id=253151">https://bugs.webkit.org/show_bug.cgi?id=253151</a>
rdar://106082568

Reviewed by Simon Fraser.

When drawing small GPUP IOSurface canvases to WP small bitmap layer tiles,
the tiles would have display colorspace. The CG bitmap draw would do color
matching.

The color matching conversion result for the source image would be
stored in a cache inside CG.

This cache is redundant, as we cannot currently hold on to the
bitmap CGImages created from GPUP IOSurfaces. This would mean that the
cache was maintained redundantly, as each image would be a new one
and the cache would not see any hits.

Mark the bitmap images as transient to avoid the cache, rather color
match during blit to the layer bitmap.

Also avoid putting any transient bitmaps into GraphicsContextCG
subimage cache, for consistency.

* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::drawNativeImageInternal):
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp:
(WebCore::ImageBufferIOSurfaceBackend::copyNativeImageForDrawing):

Canonical link: <a href="https://commits.webkit.org/261309@main">https://commits.webkit.org/261309@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6b98b98d92a0846df4b01cb798887498c1ea57c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111093 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20233 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43657 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2520 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119937 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115050 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21606 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11335 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2157 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116848 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16048 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99231 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103605 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98005 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30895 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44519 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12750 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32229 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86421 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13291 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9216 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18709 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7841 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15242 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->