### PR TITLE
ImageBufferIOSurfaceBackend should flush only when GraphicsContextCG has drawn

### DIFF
--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -214,6 +214,18 @@ bool GraphicsContextCG::hasPlatformContext() const
 
 CGContextRef GraphicsContextCG::platformContext() const
 {
+    return const_cast<GraphicsContextCG*>(this)->contextForDraw(); // Conservative estimate.
+}
+
+CGContextRef GraphicsContextCG::contextForDraw()
+{
+    ASSERT(m_cgContext);
+    m_hasDrawn = true;
+    return m_cgContext.get();
+}
+
+CGContextRef GraphicsContextCG::contextForState() const
+{
     ASSERT(m_cgContext);
     return m_cgContext.get();
 }
@@ -242,7 +254,7 @@ const DestinationColorSpace& GraphicsContextCG::colorSpace() const
 void GraphicsContextCG::save()
 {
     GraphicsContext::save();
-    CGContextSaveGState(platformContext());
+    CGContextSaveGState(contextForState());
 }
 
 void GraphicsContextCG::restore()
@@ -251,7 +263,7 @@ void GraphicsContextCG::restore()
         return;
 
     GraphicsContext::restore();
-    CGContextRestoreGState(platformContext());
+    CGContextRestoreGState(contextForState());
     m_userToDeviceTransformKnownToBeIdentity = false;
 }
 
@@ -1569,6 +1581,11 @@ void GraphicsContextCG::addDestinationAtPoint(const String& name, const FloatPoi
 bool GraphicsContextCG::canUseShadowBlur() const
 {
     return (renderingMode() == RenderingMode::Unaccelerated) && hasBlurredShadow() && !m_state.shadowsIgnoreTransforms();
+}
+
+bool GraphicsContextCG::consumeHasDrawn()
+{
+    return std::exchange(m_hasDrawn, false);
 }
 
 }

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h
@@ -57,6 +57,8 @@ public:
 
 protected:
     CGContextRef ensurePlatformContext();
+    // Returns true if flush happened.
+    bool flushContextDraws();
     IntSize backendSize() const override;
     
     RefPtr<NativeImage> copyNativeImage(BackingStoreCopy = CopyBackingStore) override;
@@ -84,11 +86,14 @@ protected:
     void prepareForExternalRead();
     void prepareForExternalWrite();
 
+    RetainPtr<CGImageRef> createImage();
+    RetainPtr<CGImageRef> createImageReference();
+
     std::unique_ptr<IOSurface> m_surface;
     RetainPtr<CGContextRef> m_platformContext;
+    const PlatformDisplayID m_displayID;
     bool m_mayHaveOutstandingBackingStoreReferences { false };
     VolatilityState m_volatilityState { VolatilityState::NonVolatile };
-    const PlatformDisplayID m_displayID;
     RefPtr<IOSurfacePool> m_ioSurfacePool;
 };
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
@@ -111,9 +111,7 @@ private:
     Ref<RemoteImageBufferProxyFlushState> m_flushState;
     WeakPtr<RemoteRenderingBackendProxy> m_remoteRenderingBackendProxy;
     RemoteDisplayListRecorderProxy m_remoteDisplayList;
-    // First command might be putPixelBuffer. With canMapBackingStore() == true, it needs to flush
-    // the surface initialization.
-    bool m_needsFlush { true };
+    bool m_needsFlush { false };
 };
 
 class RemoteImageBufferProxyFlushState : public ThreadSafeRefCounted<RemoteImageBufferProxyFlushState> {

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBackend.cpp
@@ -57,6 +57,7 @@ std::unique_ptr<ImageBufferShareableMappedIOSurfaceBackend> ImageBufferShareable
         return nullptr;
 
     CGContextClearRect(cgContext.get(), FloatRect(FloatPoint::zero(), backendSize));
+    CGContextFlush(cgContext.get());
 
     return makeUnique<ImageBufferShareableMappedIOSurfaceBackend>(parameters, WTFMove(surface), WTFMove(cgContext), 0, creationContext.surfacePool);
 }

--- a/Tools/TestWebKitAPI/Tests/WebCore/cg/GraphicsContextCGTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cg/GraphicsContextCGTests.mm
@@ -188,6 +188,27 @@ TEST(GraphicsContextTests, LargeLayerRenderingModeIsExpected)
     }
 }
 
+TEST(GraphicsContextTests, DrawsReportHasDrawn)
+{
+    auto srgb = DestinationColorSpace::SRGB();
+    IntSize size { 3, 3 };
+    auto surface = WebCore::IOSurface::create(nullptr, size, srgb);
+    ASSERT_NE(surface, nullptr);
+    auto bitsPerPixel = 32;
+    auto bitsPerComponent = 8;
+    auto bitmapInfo = static_cast<CGBitmapInfo>(kCGImageAlphaPremultipliedFirst) | static_cast<CGBitmapInfo>(kCGBitmapByteOrder32Host);
+    auto cgContext = adoptCF(CGIOSurfaceContextCreate(surface->surface(), size.width(), size.height(), bitsPerComponent, bitsPerPixel, srgb.platformColorSpace(), bitmapInfo));
+    GraphicsContextCG context(cgContext.get());
+
+    // Context starts saying has drawn, conservative estimate.
+    EXPECT_TRUE(context.consumeHasDrawn());
+    EXPECT_FALSE(context.consumeHasDrawn());
+
+    context.fillRect({ 0, 0, 1, 1 });
+    EXPECT_TRUE(context.consumeHasDrawn());
+    EXPECT_FALSE(context.consumeHasDrawn());
+}
+
 } // namespace TestWebKitAPI
 
 #endif // USE(CG)


### PR DESCRIPTION
#### 9e8259e401bec8f175f796fac39c34888bcbc5cb
<pre>
ImageBufferIOSurfaceBackend should flush only when GraphicsContextCG has drawn
<a href="https://bugs.webkit.org/show_bug.cgi?id=253309">https://bugs.webkit.org/show_bug.cgi?id=253309</a>
rdar://106192612

Reviewed by Simon Fraser.

Track draws in GraphicsContextCG. Currently it overestimates when the
draw happens.

Use this information in ImageBufferIOSurfaceBackend. The backend
needs to know if the surface has been drawn to before doing an external
operation. If draw to has happened, the drawing context needs to be
flushed before external operation can happen. Conversely, the flush
can be skipped if we know that there was no drawing.

Consider case:
i1.draw(something);   // Initial image
i1.getPixelBuffer();  // Flush
i1.putPixelBuffer();  // No flush needed, no draws since flush. &lt;-- example of skipped flush.
i2.draw(i1);          // Creates an image from i1 (flushes currently).

i1.getPixelBuffer();  // No flush &lt;-- example of skipped flush.
i1.putPixelBuffer();  // Invalidates, flush needed due to invalidate, no draws.
i2.draw(i1);          // Creates an image from i1 (flushes currently).

* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::platformContext const):
(WebCore::GraphicsContextCG::contextForDraw):
(WebCore::GraphicsContextCG::contextForState const):
(WebCore::GraphicsContextCG::save):
(WebCore::GraphicsContextCG::restore):
(WebCore::GraphicsContextCG::consumeHasDrawn):
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.h:
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp:
(WebCore::ImageBufferIOSurfaceBackend::context):
(WebCore::ImageBufferIOSurfaceBackend::flushContext):
(WebCore::ImageBufferIOSurfaceBackend::flushContextIfNeeded):
(WebCore::ImageBufferIOSurfaceBackend::invalidateCachedNativeImage):
(WebCore::ImageBufferIOSurfaceBackend::copyNativeImage):
(WebCore::ImageBufferIOSurfaceBackend::copyNativeImageForDrawing):
(WebCore::ImageBufferIOSurfaceBackend::prepareForExternalRead):
(WebCore::ImageBufferIOSurfaceBackend::prepareForExternalWrite):
(WebCore::ImageBufferIOSurfaceBackend::ensureSurfaceContext):
(WebCore::ImageBufferIOSurfaceBackend::createImage):
(WebCore::ImageBufferIOSurfaceBackend::createImageReference):
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h:
* Tools/TestWebKitAPI/Tests/WebCore/cg/GraphicsContextCGTests.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/262010@main">https://commits.webkit.org/262010@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f349f1bf29aacdad394462ddf3f5800693d11d5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/95 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/97 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/77 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/90 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/89 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/72 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/79 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/73 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/86 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/82 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/72 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/68 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/84 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/62 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/86 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->