### PR TITLE
Add WK API to be notified of background fetch changes

### DIFF
--- a/LayoutTests/http/wpt/background-fetch/sw.js
+++ b/LayoutTests/http/wpt/background-fetch/sw.js
@@ -21,7 +21,8 @@ onbackgroundfetchabort= (event) => {
     waitForAbortPort.postMessage(event.registration.id);
 }
 
-onbackgroundfetchsuccess = async (event) => {
+async function sendResponseText(event)
+{
   if (!waitForSuccessPort)
     return;
   try {
@@ -31,4 +32,8 @@ onbackgroundfetchsuccess = async (event) => {
   } catch(e) {
     waitForSuccessPort.postMessage("" + e);
   }
+}
+
+onbackgroundfetchsuccess = async (event) => {
+  event.waitUntil(sendResponseText(event));
 }

--- a/Source/WebCore/workers/service/WorkerSWClientConnection.cpp
+++ b/Source/WebCore/workers/service/WorkerSWClientConnection.cpp
@@ -542,6 +542,7 @@ void WorkerSWClientConnection::retrieveRecordResponseBody(BackgroundFetchRecordI
                 if (!error.isNull()) {
                     iterator->value(makeUnexpected(WTFMove(error)));
                     callbacks.remove(iterator);
+                    return;
                 }
                 bool isDone = !buffer;
                 iterator->value(WTFMove(buffer));

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetch.cpp
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetch.cpp
@@ -189,15 +189,17 @@ void BackgroundFetch::updateBackgroundFetchStatus(BackgroundFetchResult result, 
     m_result = result;
     m_failureReason = failureReason;
     m_isActive = m_result == BackgroundFetchResult::EmptyString && m_failureReason == BackgroundFetchFailureReason::EmptyString;
-    m_notificationCallback(information());
+    m_notificationCallback(*this);
 }
 
 void BackgroundFetch::unsetRecordsAvailableFlag()
 {
-    ASSERT(m_recordsAvailableFlag);
+    if (!m_recordsAvailableFlag)
+        return;
+
     m_recordsAvailableFlag = false;
     m_store->clearFetch(m_registrationKey, m_identifier);
-    m_notificationCallback(information());
+    m_notificationCallback(*this);
 }
 
 BackgroundFetch::Record::Record(BackgroundFetch& fetch, BackgroundFetchRequest&& request, size_t index)

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetch.h
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetch.h
@@ -52,7 +52,7 @@ struct CacheQueryOptions;
 class BackgroundFetch : public CanMakeWeakPtr<BackgroundFetch> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    using NotificationCallback = Function<void(BackgroundFetchInformation&&)>;
+    using NotificationCallback = Function<void(BackgroundFetch&)>;
     BackgroundFetch(SWServerRegistration&, const String&, Vector<BackgroundFetchRequest>&&, BackgroundFetchOptions&&, Ref<BackgroundFetchStore>&&, NotificationCallback&&);
     BackgroundFetch(SWServerRegistration&, String&&, BackgroundFetchOptions&&, Ref<BackgroundFetchStore>&&, NotificationCallback&&);
     ~BackgroundFetch();
@@ -60,8 +60,9 @@ public:
     static std::unique_ptr<BackgroundFetch> createFromStore(Span<const uint8_t>, SWServer&, Ref<BackgroundFetchStore>&&, NotificationCallback&&);
 
     String identifier() const { return m_identifier; }
-    BackgroundFetchInformation information() const;
+    WEBCORE_EXPORT BackgroundFetchInformation information() const;
     const ServiceWorkerRegistrationKey& registrationKey() const { return m_registrationKey; }
+    const BackgroundFetchOptions& options() const { return m_options; }
 
     using RetrieveRecordResponseCallback = CompletionHandler<void(Expected<ResourceResponse, ExceptionData>&&)>;
     using RetrieveRecordResponseBodyCallback = Function<void(Expected<RefPtr<SharedBuffer>, ResourceError>&&)>;

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchEngine.h
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchEngine.h
@@ -57,6 +57,7 @@ public:
 
     void remove(SWServerRegistration&);
 
+    WEBCORE_EXPORT WeakPtr<BackgroundFetch> backgroundFetch(const ServiceWorkerRegistrationKey&, const String&) const;
     WEBCORE_EXPORT void addFetchFromStore(Span<const uint8_t>, CompletionHandler<void(const ServiceWorkerRegistrationKey&, const String&)>&&);
 
     WEBCORE_EXPORT void abortBackgroundFetch(const ServiceWorkerRegistrationKey&, const String&);
@@ -65,7 +66,7 @@ public:
     WEBCORE_EXPORT void clickBackgroundFetch(const ServiceWorkerRegistrationKey&, const String&);
 
 private:
-    void notifyBackgroundFetchUpdate(BackgroundFetchInformation&&);
+    void notifyBackgroundFetchUpdate(BackgroundFetch&);
 
     WeakPtr<SWServer> m_server;
     Ref<BackgroundFetchStore> m_store;

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchResult.idl
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchResult.idl
@@ -25,4 +25,5 @@
 
 [
     Conditional=SERVICE_WORKER,
+    ExportMacro=WEBCORE_EXPORT,
 ] enum BackgroundFetchResult { "", "success", "failure" };

--- a/Source/WebCore/workers/service/context/ServiceWorkerThread.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThread.cpp
@@ -332,13 +332,13 @@ void ServiceWorkerThread::queueTaskToFireBackgroundFetchEvent(BackgroundFetchInf
         RefPtr<ExtendableEvent> event;
         switch (info.failureReason) {
         case BackgroundFetchFailureReason::EmptyString:
-            event = BackgroundFetchUpdateUIEvent::create(eventNames().backgroundfetchsuccessEvent, WTFMove(eventInit));
+            event = BackgroundFetchUpdateUIEvent::create(eventNames().backgroundfetchsuccessEvent, WTFMove(eventInit), Event::IsTrusted::Yes);
             break;
         case BackgroundFetchFailureReason::Aborted:
-            event = BackgroundFetchEvent::create(eventNames().backgroundfetchabortEvent, WTFMove(eventInit));
+            event = BackgroundFetchEvent::create(eventNames().backgroundfetchabortEvent, WTFMove(eventInit), Event::IsTrusted::Yes);
             break;
         default:
-            event = BackgroundFetchEvent::create(eventNames().backgroundfetchfailEvent, WTFMove(eventInit));
+            event = BackgroundFetchEvent::create(eventNames().backgroundfetchfailEvent, WTFMove(eventInit), Event::IsTrusted::Yes);
             break;
         };
 

--- a/Source/WebCore/workers/service/server/SWServer.h
+++ b/Source/WebCore/workers/service/server/SWServer.h
@@ -259,7 +259,7 @@ public:
 
     enum class ShouldSkipEvent : bool { No, Yes };
     void fireFunctionalEvent(SWServerRegistration&, CompletionHandler<void(Expected<SWServerToContextConnection*, ShouldSkipEvent>)>&&);
-    void fireBackgroundFetchEvent(SWServerRegistration&, BackgroundFetchInformation&&);
+    void fireBackgroundFetchEvent(SWServerRegistration&, BackgroundFetchInformation&&, CompletionHandler<void()>&&);
     void fireBackgroundFetchClickEvent(SWServerRegistration&, BackgroundFetchInformation&&);
 
     ScriptExecutionContextIdentifier clientIdFromVisibleClientId(const String& visibleIdentifier) const { return m_visibleClientIdToInternalClientIdMap.get(visibleIdentifier); }

--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -529,6 +529,7 @@ set(WebKit_SERIALIZATION_IN_FILES
     NetworkProcess/NetworkProcessCreationParameters.serialization.in
     NetworkProcess/NetworkResourceLoadParameters.serialization.in
 
+    Shared/BackgroundFetchState.serialization.in
     Shared/CallbackID.serialization.in
     Shared/DisplayListArgumentCoders.serialization.in
     Shared/EditorState.serialization.in

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -167,6 +167,7 @@ $(PROJECT_DIR)/Shared/ApplePay/PaymentSetupConfiguration.serialization.in
 $(PROJECT_DIR)/Shared/ApplePay/WebPaymentCoordinatorProxy.messages.in
 $(PROJECT_DIR)/Shared/Authentication/AuthenticationManager.messages.in
 $(PROJECT_DIR)/Shared/AuxiliaryProcess.messages.in
+$(PROJECT_DIR)/Shared/BackgroundFetchState.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CacheStoragePolicy.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/DataDetectionResult.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/RevealItem.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -481,6 +481,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/Cocoa/RevealItem.serialization.in \
 	Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in \
 	Shared/CallbackID.serialization.in \
+	Shared/BackgroundFetchState.serialization.in \
 	Shared/DisplayListArgumentCoders.serialization.in \
 	Shared/EditorState.serialization.in \
 	Shared/Extensions/WebExtensionEventListenerType.serialization.in \

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -31,6 +31,7 @@
 #include "Attachment.h"
 #include "AuthenticationManager.h"
 #include "AuxiliaryProcessMessages.h"
+#include "BackgroundFetchState.h"
 #include "DataReference.h"
 #include "Download.h"
 #include "DownloadProxyMessages.h"
@@ -2389,6 +2390,17 @@ void NetworkProcess::getAllBackgroundFetchIdentifiers(PAL::SessionID sessionID, 
     }
 
     session->getAllBackgroundFetchIdentifiers(WTFMove(callback));
+}
+
+void NetworkProcess::getBackgroundFetchState(PAL::SessionID sessionID, const String& identifier, CompletionHandler<void(std::optional<BackgroundFetchState>&&)>&& callback)
+{
+    auto* session = networkSession(sessionID);
+    if (!session) {
+        callback({ });
+        return;
+    }
+
+    session->getBackgroundFetchState(identifier, WTFMove(callback));
 }
 
 void NetworkProcess::abortBackgroundFetch(PAL::SessionID sessionID, const String& identifier, CompletionHandler<void()>&& callback)

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -117,6 +117,7 @@ enum class ShouldGrandfatherStatistics : bool;
 enum class StorageAccessStatus : uint8_t;
 enum class WebsiteDataFetchOption : uint8_t;
 enum class WebsiteDataType : uint32_t;
+struct BackgroundFetchState;
 struct NetworkProcessCreationParameters;
 struct WebPushMessage;
 struct WebsiteDataStoreParameters;
@@ -386,6 +387,7 @@ public:
     void processNotificationEvent(WebCore::NotificationData&&, WebCore::NotificationEventType, CompletionHandler<void(bool)>&&);
 
     void getAllBackgroundFetchIdentifiers(PAL::SessionID, CompletionHandler<void(Vector<String>&&)>&&);
+    void getBackgroundFetchState(PAL::SessionID, const String&, CompletionHandler<void(std::optional<BackgroundFetchState>&&)>&&);
     void abortBackgroundFetch(PAL::SessionID, const String&, CompletionHandler<void()>&&);
     void pauseBackgroundFetch(PAL::SessionID, const String&, CompletionHandler<void()>&&);
     void resumeBackgroundFetch(PAL::SessionID, const String&, CompletionHandler<void()>&&);

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -222,6 +222,7 @@ messages -> NetworkProcess LegacyReceiver {
     ProcessNotificationEvent(struct WebCore::NotificationData data, enum:bool WebCore::NotificationEventType eventType) -> (bool didSucceed)
 
     GetAllBackgroundFetchIdentifiers(PAL::SessionID sessionID) -> (Vector<String> fetches);
+    GetBackgroundFetchState(PAL::SessionID sessionID, String identifier) -> (std::optional<WebKit::BackgroundFetchState> state);
     AbortBackgroundFetch(PAL::SessionID sessionID, String identifier) -> ();
     PauseBackgroundFetch(PAL::SessionID sessionID, String identifier) -> ();
     ResumeBackgroundFetch(PAL::SessionID sessionID, String identifier) -> ();

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -27,6 +27,7 @@
 #include "NetworkSession.h"
 
 #include "BackgroundFetchLoad.h"
+#include "BackgroundFetchState.h"
 #include "BackgroundFetchStoreImpl.h"
 #include "CacheStorageEngine.h"
 #include "LoadedWebArchive.h"
@@ -761,6 +762,11 @@ BackgroundFetchStoreImpl& NetworkSession::ensureBackgroundFetchStore()
 void NetworkSession::getAllBackgroundFetchIdentifiers(CompletionHandler<void(Vector<String>&&)>&& callback)
 {
     ensureBackgroundFetchStore().getAllBackgroundFetchIdentifiers(WTFMove(callback));
+}
+
+void NetworkSession::getBackgroundFetchState(const String& identifier, CompletionHandler<void(std::optional<BackgroundFetchState>&&)>&& callback)
+{
+    ensureBackgroundFetchStore().getBackgroundFetchState(identifier, WTFMove(callback));
 }
 
 void NetworkSession::abortBackgroundFetch(const String& identifier, CompletionHandler<void()>&& callback)

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -86,6 +86,7 @@ class WebSharedWorkerServer;
 class WebSocketTask;
 class WebSWOriginStore;
 class WebSWServerConnection;
+struct BackgroundFetchState;
 struct NetworkSessionCreationParameters;
 struct SessionSet;
 
@@ -218,6 +219,7 @@ public:
     bool hasServiceWorkerDatabasePath() const;
 
     void getAllBackgroundFetchIdentifiers(CompletionHandler<void(Vector<String>&&)>&&);
+    void getBackgroundFetchState(const String&, CompletionHandler<void(std::optional<BackgroundFetchState>&&)>&&);
     void abortBackgroundFetch(const String&, CompletionHandler<void()>&&);
     void pauseBackgroundFetch(const String&, CompletionHandler<void()>&&);
     void resumeBackgroundFetch(const String&, CompletionHandler<void()>&&);

--- a/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.h
+++ b/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.h
@@ -42,6 +42,7 @@ class SWServer;
 namespace WebKit {
 
 class NetworkStorageManager;
+struct BackgroundFetchState;
 
 class BackgroundFetchStoreImpl :  public WebCore::BackgroundFetchStore {
 public:
@@ -49,6 +50,7 @@ public:
     ~BackgroundFetchStoreImpl();
 
     void getAllBackgroundFetchIdentifiers(CompletionHandler<void(Vector<String>&&)>&&);
+    void getBackgroundFetchState(const String&, CompletionHandler<void(std::optional<BackgroundFetchState>&&)>&&);
     void abortBackgroundFetch(const String&, CompletionHandler<void()>&&);
     void pauseBackgroundFetch(const String&, CompletionHandler<void()>&&);
     void resumeBackgroundFetch(const String&, CompletionHandler<void()>&&);

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "NetworkStorageManager.h"
 
+#include "BackgroundFetchChange.h"
 #include "BackgroundFetchStoreManager.h"
 #include "CacheStorageCache.h"
 #include "CacheStorageManager.h"
@@ -1357,7 +1358,12 @@ void NetworkStorageManager::dispatchTaskToBackgroundFetchManager(const WebCore::
         callback(&originStorageManager.backgroundFetchManager(WTFMove(queue)));
     });
 }
-#endif
+
+void NetworkStorageManager::notifyBackgroundFetchChange(const String& identifier, BackgroundFetchChange change)
+{
+    IPC::Connection::send(m_parentConnection, Messages::NetworkProcessProxy::NotifyBackgroundFetchChange(m_sessionID, identifier, change), 0);
+}
+#endif // ENABLE(SERVICE_WORKER)
 
 } // namespace WebKit
 

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -70,6 +70,7 @@ enum class StorageType : uint8_t;
 
 namespace WebKit {
 
+enum class BackgroundFetchChange : uint8_t;
 enum class UnifiedOriginStorageLevel : uint8_t;
 class FileSystemStorageHandleRegistry;
 class IDBStorageRegistry;
@@ -112,6 +113,7 @@ public:
 
 #if ENABLE(SERVICE_WORKER)
     void dispatchTaskToBackgroundFetchManager(const WebCore::ClientOrigin&, Function<void(BackgroundFetchStoreManager*)>&&);
+    void notifyBackgroundFetchChange(const String&, BackgroundFetchChange);
 #endif // ENABLE(SERVICE_WORKER)
 
 private:

--- a/Source/WebKit/Shared/BackgroundFetchChange.h
+++ b/Source/WebKit/Shared/BackgroundFetchChange.h
@@ -8,7 +8,7 @@
  *    notice, this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
- *    and/or other materials provided with the distribution.
+ *    documentation and/or other materials provided with the distribution.
  *
  * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
@@ -23,21 +23,31 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    Conditional=SERVICE_WORKER,
-    ExportMacro=WEBCORE_EXPORT,
-] enum BackgroundFetchFailureReason {
-    // The background fetch has not completed yet, or was successful.
-    "",
-    // The operation was aborted by the user, or abort() was called.
-    "aborted",
-    // A response had a not-ok-status.
-    "bad-status",
-    // A fetch failed for other reasons, e.g. CORS, MIX, an invalid partial response,
-    // or a general network failure for a fetch that cannot be retried.
-    "fetch-error",
-    // Storage quota was reached during the operation.
-    "quota-exceeded",
-    // The provided downloadTotal was exceeded.
-    "download-total-exceeded"
+#pragma once
+
+#include <wtf/EnumTraits.h>
+
+namespace WebKit {
+
+enum class BackgroundFetchChange : uint8_t {
+    Addition,
+    Removal,
+    Update
 };
+
+} // namespace WebKit
+
+namespace WTF {
+    
+template<> struct EnumTraits<WebKit::BackgroundFetchChange> {
+    using values = EnumValues<
+    WebKit::BackgroundFetchChange,
+    WebKit::BackgroundFetchChange::Addition,
+    WebKit::BackgroundFetchChange::Removal,
+    WebKit::BackgroundFetchChange::Update
+    >;
+};
+    
+} // namespace WTF
+
+

--- a/Source/WebKit/Shared/BackgroundFetchState.h
+++ b/Source/WebKit/Shared/BackgroundFetchState.h
@@ -8,7 +8,7 @@
  *    notice, this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
- *    and/or other materials provided with the distribution.
+ *    documentation and/or other materials provided with the distribution.
  *
  * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
@@ -23,21 +23,41 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    Conditional=SERVICE_WORKER,
-    ExportMacro=WEBCORE_EXPORT,
-] enum BackgroundFetchFailureReason {
-    // The background fetch has not completed yet, or was successful.
-    "",
-    // The operation was aborted by the user, or abort() was called.
-    "aborted",
-    // A response had a not-ok-status.
-    "bad-status",
-    // A fetch failed for other reasons, e.g. CORS, MIX, an invalid partial response,
-    // or a general network failure for a fetch that cannot be retried.
-    "fetch-error",
-    // Storage quota was reached during the operation.
-    "quota-exceeded",
-    // The provided downloadTotal was exceeded.
-    "download-total-exceeded"
+#pragma once
+
+#include <WebCore/BackgroundFetchFailureReason.h>
+#include <WebCore/BackgroundFetchOptions.h>
+#include <WebCore/BackgroundFetchResult.h>
+#include <WebCore/SecurityOriginData.h>
+#include <wtf/URL.h>
+
+#if PLATFORM(COCOA)
+OBJC_CLASS NSDictionary;
+#endif
+
+namespace WebKit {
+
+struct BackgroundFetchState {
+    WebCore::SecurityOriginData topOrigin;
+    URL scope;
+    String identifier;
+    
+    WebCore::BackgroundFetchOptions options;
+    
+    uint64_t downloadTotal { 0 };
+    uint64_t downloaded { 0 };
+    uint64_t uploadTotal { 0 };
+    uint64_t uploaded { 0 };
+    
+    WebCore::BackgroundFetchResult result { WebCore::BackgroundFetchResult::EmptyString };
+    WebCore::BackgroundFetchFailureReason failureReason { WebCore::BackgroundFetchFailureReason::EmptyString };
+    
+    bool isActive { false };
+    
+#if PLATFORM(COCOA)
+    NSDictionary *toDictionary() const;
+#endif
 };
+
+} // namespace WebKit
+

--- a/Source/WebKit/Shared/BackgroundFetchState.serialization.in
+++ b/Source/WebKit/Shared/BackgroundFetchState.serialization.in
@@ -1,0 +1,39 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+header: "BackgroundFetchState.h"
+
+#if ENABLE(SERVICE_WORKER)
+struct WebKit::BackgroundFetchState {
+    WebCore::SecurityOriginData topOrigin;
+    URL scope;
+    String identifier;
+    WebCore::BackgroundFetchOptions options;
+    uint64_t downloadTotal;
+    uint64_t downloaded;
+    uint64_t uploadTotal;
+    uint64_t uploaded;
+    WebCore::BackgroundFetchResult result;
+    WebCore::BackgroundFetchFailureReason failureReason;
+    bool isActive;
+};
+#endif

--- a/Source/WebKit/Shared/Cocoa/BackgroundFetchStateCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/BackgroundFetchStateCocoa.mm
@@ -8,7 +8,7 @@
  *    notice, this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
- *    and/or other materials provided with the distribution.
+ *    documentation and/or other materials provided with the distribution.
  *
  * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
@@ -23,21 +23,32 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    Conditional=SERVICE_WORKER,
-    ExportMacro=WEBCORE_EXPORT,
-] enum BackgroundFetchFailureReason {
-    // The background fetch has not completed yet, or was successful.
-    "",
-    // The operation was aborted by the user, or abort() was called.
-    "aborted",
-    // A response had a not-ok-status.
-    "bad-status",
-    // A fetch failed for other reasons, e.g. CORS, MIX, an invalid partial response,
-    // or a general network failure for a fetch that cannot be retried.
-    "fetch-error",
-    // Storage quota was reached during the operation.
-    "quota-exceeded",
-    // The provided downloadTotal was exceeded.
-    "download-total-exceeded"
-};
+#import "config.h"
+#import "BackgroundFetchState.h"
+
+namespace WebCore {
+String convertEnumerationToString(BackgroundFetchResult);
+String convertEnumerationToString(BackgroundFetchFailureReason);
+}
+
+namespace WebKit {
+
+NSDictionary *BackgroundFetchState::toDictionary() const
+{
+    // FIXME: Expose icon URLS.
+    return @{
+        @"TopOrigin" : (NSString *)topOrigin.toString(),
+        @"Scope" : (NSURL *)scope,
+        @"WebIdentifier" : (NSString *)identifier,
+        @"Title" : (NSString *)options.title,
+        @"DownloadTotal" : @(downloadTotal),
+        @"Downloaded" : @(downloaded),
+        @"UploadTotal" : @(uploadTotal),
+        @"Uploaded" : @(uploaded),
+        @"Result" : (NSString *)(convertEnumerationToString(result)),
+        @"FailureReason" : (NSString *)(convertEnumerationToString(failureReason)),
+        @"IsActive" : @(isActive),
+    };
+}
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h
@@ -125,11 +125,12 @@ typedef NS_OPTIONS(NSUInteger, _WKWebsiteDataStoreFetchOptions) {
 -(void)_setBackupExclusionPeriodForTesting:(double)seconds completionHandler:(void(^)(void))completionHandler WK_API_AVAILABLE(macos(13.0), ios(16.0));
 
 -(void)_getAllBackgroundFetchIdentifiers:(void(^)(NSArray<NSString *> *identifiers))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+-(void)_getBackgroundFetchState:(NSString *) identifier completionHandler:(void(^)(NSDictionary *state))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 -(void)_abortBackgroundFetch:(NSString *)identifier completionHandler:(void(^_Nullable)(void))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 -(void)_pauseBackgroundFetch:(NSString *)identifier completionHandler:(void(^_Nullable)(void))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 -(void)_resumeBackgroundFetch:(NSString *)identifier completionHandler:(void(^_Nullable)(void))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 -(void)_clickBackgroundFetch:(NSString *)identifier completionHandler:(void(^_Nullable)(void))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
-    
+
 @property (nonatomic, readonly) NSUUID *_identifier;
 @property (nonatomic, readonly) NSString *_webPushPartition;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreDelegate.h
@@ -31,6 +31,19 @@
 @class WKWebView;
 @class _WKNotificationData;
 
+/*! @enum WKNavigationActionPolicy
+ @abstract The policy to pass back to the decision handler from the
+ webView:decidePolicyForNavigationAction:decisionHandler: method.
+ @constant WKNavigationActionPolicyCancel   Cancel the navigation.
+ @constant WKNavigationActionPolicyAllow    Allow the navigation to continue.
+ @constant WKNavigationActionPolicyDownload    Turn the navigation into a download.
+ */
+typedef NS_ENUM(NSInteger, WKBackgroundFetchChange) {
+    WKBackgroundFetchChangeAddition,
+    WKBackgroundFetchChangeRemoval,
+    WKBackgroundFetchChangeUpdate,
+} WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
 WK_API_AVAILABLE(macos(10.15), ios(13.0))
 @protocol _WKWebsiteDataStoreDelegate <NSObject>
 
@@ -42,4 +55,5 @@ WK_API_AVAILABLE(macos(10.15), ios(13.0))
 - (void)websiteDataStore:(WKWebsiteDataStore *)dataStore showNotification:(_WKNotificationData *)notificationData;
 - (void)websiteDataStore:(WKWebsiteDataStore *)dataStore workerOrigin:(WKSecurityOrigin *)workerOrigin updatedAppBadge:(NSNumber *)badge;
 - (void)requestBackgroundFetchPermission:(NSURL *)mainFrameURL frameOrigin:(NSURL *)frameURL  decisionHandler:(void (^)(bool isGranted))decisionHandler;
+- (void)notifyBackgroundFetchChange:(NSString *)backgroundFetchIdentifier change:(WKBackgroundFetchChange)change;
 @end

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -88,6 +88,7 @@ class DownloadProxyMap;
 class WebPageProxy;
 class WebUserContentControllerProxy;
 
+enum class BackgroundFetchChange : uint8_t;
 enum class ProcessTerminationReason;
 enum class RemoteWorkerType : bool;
 enum class ShouldGrandfatherStatistics : bool;
@@ -292,6 +293,7 @@ public:
     void processNotificationEvent(const WebCore::NotificationData&, WebCore::NotificationEventType, CompletionHandler<void(bool wasProcessed)>&&);
 
     void getAllBackgroundFetchIdentifiers(PAL::SessionID, CompletionHandler<void(Vector<String>&&)>&&);
+    void getBackgroundFetchState(PAL::SessionID, const String&, CompletionHandler<void(std::optional<BackgroundFetchState>&&)>&&);
     void abortBackgroundFetch(PAL::SessionID, const String&, CompletionHandler<void()>&&);
     void pauseBackgroundFetch(PAL::SessionID, const String&, CompletionHandler<void()>&&);
     void resumeBackgroundFetch(PAL::SessionID, const String&, CompletionHandler<void()>&&);
@@ -375,6 +377,7 @@ private:
     void startServiceWorkerBackgroundProcessing(WebCore::ProcessIdentifier serviceWorkerProcessIdentifier);
     void endServiceWorkerBackgroundProcessing(WebCore::ProcessIdentifier serviceWorkerProcessIdentifier);
     void requestBackgroundFetchPermission(PAL::SessionID, const WebCore::ClientOrigin&, CompletionHandler<void(bool)>&&);
+    void notifyBackgroundFetchChange(PAL::SessionID, const String&, BackgroundFetchChange);
 #endif
     void remoteWorkerContextConnectionNoLongerNeeded(RemoteWorkerType, WebCore::ProcessIdentifier);
     void establishRemoteWorkerContextConnectionToNetworkProcess(RemoteWorkerType, WebCore::RegistrableDomain&&, std::optional<WebCore::ProcessIdentifier> requestingProcessIdentifier, std::optional<WebCore::ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier, PAL::SessionID, CompletionHandler<void(WebCore::ProcessIdentifier)>&&);

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.messages.in
@@ -56,6 +56,7 @@ messages -> NetworkProcessProxy LegacyReceiver {
     StartServiceWorkerBackgroundProcessing(WebCore::ProcessIdentifier serviceWorkerProcessIdentifier)
     EndServiceWorkerBackgroundProcessing(WebCore::ProcessIdentifier serviceWorkerProcessIdentifier)
     RequestBackgroundFetchPermission(PAL::SessionID sessionID, struct WebCore::ClientOrigin origin) -> (bool result)
+    NotifyBackgroundFetchChange(PAL::SessionID sessionID, String backgroundFetchIdentifier, enum:uint8_t WebKit::BackgroundFetchChange change)
 #endif
     EstablishRemoteWorkerContextConnectionToNetworkProcess(enum:bool WebKit::RemoteWorkerType workerType, WebCore::RegistrableDomain registrableDomain, std::optional<WebCore::ProcessIdentifier> requestingProcessIdentifier, std::optional<WebCore::ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier, PAL::SessionID sessionID) -> (WebCore::ProcessIdentifier remoteProcessIdentifier)
     RemoteWorkerContextConnectionNoLongerNeeded(enum:bool WebKit::RemoteWorkerType workerType, WebCore::ProcessIdentifier identifier)

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreClient.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreClient.h
@@ -28,6 +28,7 @@
 #include "AuthenticationChallengeDisposition.h"
 #include "AuthenticationChallengeProxy.h"
 #include "AuthenticationDecisionListener.h"
+#include "BackgroundFetchChange.h"
 #include <wtf/CompletionHandler.h>
 
 namespace WebCore {
@@ -76,6 +77,10 @@ public:
     virtual void requestBackgroundFetchPermission(const WebCore::SecurityOriginData& topOrigin, const WebCore::SecurityOriginData& frameOrigin, CompletionHandler<void(bool)>&& completionHandler)
     {
         completionHandler(false);
+    }
+
+    virtual void notifyBackgroundFetchChange(const String&, BackgroundFetchChange)
+    {
     }
 };
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -899,6 +899,9 @@
 		413075B01DE85F580039EC69 /* WebRTCMonitor.h in Headers */ = {isa = PBXBuildFile; fileRef = 413075A31DE85EE70039EC69 /* WebRTCMonitor.h */; };
 		413075B21DE85F580039EC69 /* LibWebRTCSocketFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 413075A61DE85EE70039EC69 /* LibWebRTCSocketFactory.h */; };
 		413075B41DE85F580039EC69 /* LibWebRTCProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 413075A81DE85EE70039EC69 /* LibWebRTCProvider.h */; };
+		413E5C9029B0CC9B002F4987 /* BackgroundFetchState.serialization.in in Resources */ = {isa = PBXBuildFile; fileRef = 413E5C8F29B0C8EA002F4987 /* BackgroundFetchState.serialization.in */; };
+		413E5C9229B0CF7C002F4987 /* BackgroundFetchStateCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 413E5C9129B0CF7B002F4987 /* BackgroundFetchStateCocoa.mm */; };
+		413E5C9429B15174002F4987 /* CacheStorageCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 935BF7FB2936BF1A00B41326 /* CacheStorageCache.cpp */; };
 		4176901422FDD41B00B1576D /* NetworkRTCProvider.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4176901322FDD41B00B1576D /* NetworkRTCProvider.mm */; };
 		417915AF2256BB7500D6F97E /* WebSocketChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = 417915AD2256BB7400D6F97E /* WebSocketChannel.h */; };
 		417915B12256C0D600D6F97E /* WebSocketChannelManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 417915B02256C0D600D6F97E /* WebSocketChannelManager.h */; };
@@ -4453,6 +4456,10 @@
 		4135FBCF1F4FB7F20074C47B /* CacheStorageEngineCaches.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CacheStorageEngineCaches.cpp; sourceTree = "<group>"; };
 		4135FBD01F4FB7F20074C47B /* CacheStorageEngineCaches.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CacheStorageEngineCaches.h; sourceTree = "<group>"; };
 		413C542227C90F4C002FCDA8 /* RemoteVideoFrameObjectHeap.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = RemoteVideoFrameObjectHeap.messages.in; sourceTree = "<group>"; };
+		413E5C8E29B0C5F4002F4987 /* BackgroundFetchState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BackgroundFetchState.h; sourceTree = "<group>"; };
+		413E5C8F29B0C8EA002F4987 /* BackgroundFetchState.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = BackgroundFetchState.serialization.in; sourceTree = "<group>"; };
+		413E5C9129B0CF7B002F4987 /* BackgroundFetchStateCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = BackgroundFetchStateCocoa.mm; sourceTree = "<group>"; };
+		413E5C9329B0EDF3002F4987 /* BackgroundFetchChange.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BackgroundFetchChange.h; sourceTree = "<group>"; };
 		4150A5A023E06C910051264A /* GPUProcessSessionParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GPUProcessSessionParameters.h; sourceTree = "<group>"; };
 		41518535222704F5005430C6 /* ServiceWorkerFetchTask.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ServiceWorkerFetchTask.h; sourceTree = "<group>"; };
 		41518536222704F6005430C6 /* ServiceWorkerFetchTask.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ServiceWorkerFetchTask.cpp; sourceTree = "<group>"; };
@@ -7841,6 +7848,9 @@
 				7BDDA340275652EA0038659E /* AuxiliaryProcessCreationParameters.cpp */,
 				7BDDA33F275652EA0038659E /* AuxiliaryProcessCreationParameters.h */,
 				290F4271172A0C7400939FF0 /* AuxiliaryProcessSupplement.h */,
+				413E5C9329B0EDF3002F4987 /* BackgroundFetchChange.h */,
+				413E5C8E29B0C5F4002F4987 /* BackgroundFetchState.h */,
+				413E5C8F29B0C8EA002F4987 /* BackgroundFetchState.serialization.in */,
 				E164A2EF191AF14E0010737D /* BlobDataFileReferenceWithSandboxExtension.cpp */,
 				E164A2F0191AF14E0010737D /* BlobDataFileReferenceWithSandboxExtension.h */,
 				4F601430155C5A32001FBDE0 /* BlockingResponseMap.h */,
@@ -10082,6 +10092,7 @@
 				52EB68CB279E2145005C98D9 /* ARKitSoftLink.h */,
 				52EB68CC279E2145005C98D9 /* ARKitSoftLink.mm */,
 				1A698F171E4910220064E881 /* AuxiliaryProcessCocoa.mm */,
+				413E5C9129B0CF7B002F4987 /* BackgroundFetchStateCocoa.mm */,
 				4413795F2964F0C2003C34C6 /* CacheStoragePolicy.h */,
 				441379602964F0C2003C34C6 /* CacheStoragePolicy.serialization.in */,
 				CE11AD511CBC482F00681EE5 /* CodeSigning.h */,
@@ -15755,6 +15766,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				413E5C9029B0CC9B002F4987 /* BackgroundFetchState.serialization.in in Resources */,
 				372EBB412017E64300085064 /* WebContentProcess.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -16765,6 +16777,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				650994CF28C942B7006EE6DB /* AuxiliaryProcessMain.cpp in Sources */,
+				413E5C9429B15174002F4987 /* CacheStorageCache.cpp in Sources */,
 				650994D028C942B7006EE6DB /* XPCServiceMain.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -16836,6 +16849,7 @@
 				9955A6F61C7986E300EB6A93 /* AutomationProtocolObjects.cpp in Sources */,
 				51FAEC3B1B0657680009C4E7 /* AuxiliaryProcessMessageReceiver.cpp in Sources */,
 				E326E357284E580E00157372 /* AuxiliaryProcessProxyCocoa.mm in Sources */,
+				413E5C9229B0CF7C002F4987 /* BackgroundFetchStateCocoa.mm in Sources */,
 				517CF0E3163A486C00C2950F /* CacheStorageEngineConnectionMessageReceiver.cpp in Sources */,
 				1C62747E288B4C3E00CED3A2 /* CocoaHelpers.mm in Sources */,
 				49DC1DE127E5129100C1CB36 /* CSPExtensionUtilities.mm in Sources */,

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -261,6 +261,9 @@ interface TestRunner {
 
     undefined setAllowsAnySSLCertificate(boolean value);
     undefined setBackgroundFetchPermission(boolean value);
+    DOMString lastAddedBackgroundFetchIdentifier();
+    DOMString lastRemovedBackgroundFetchIdentifier();
+    DOMString lastUpdatedBackgroundFetchIdentifier();
 
     undefined setShouldSwapToEphemeralSessionOnNextNavigation(boolean value);
     undefined setShouldSwapToDefaultSessionOnNextNavigation(boolean value);

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
@@ -910,6 +910,27 @@ bool InjectedBundle::statisticsNotifyObserver()
     return WKBundleResourceLoadStatisticsNotifyObserver(m_bundle.get());
 }
 
+WKRetainPtr<WKStringRef> InjectedBundle::lastAddedBackgroundFetchIdentifier() const
+{
+    WKTypeRef result = nullptr;
+    WKBundlePagePostSynchronousMessageForTesting(page()->page(), toWK("LastAddedBackgroundFetchIdentifier").get(), 0, &result);
+    return static_cast<WKStringRef>(result);
+}
+
+WKRetainPtr<WKStringRef> InjectedBundle::lastRemovedBackgroundFetchIdentifier() const
+{
+    WKTypeRef result = nullptr;
+    WKBundlePagePostSynchronousMessageForTesting(page()->page(), toWK("LastRemovedBackgroundFetchIdentifier").get(), 0, &result);
+    return static_cast<WKStringRef>(result);
+}
+
+WKRetainPtr<WKStringRef> InjectedBundle::lastUpdatedBackgroundFetchIdentifier() const
+{
+    WKTypeRef result = nullptr;
+    WKBundlePagePostSynchronousMessageForTesting(page()->page(), toWK("LastUpdatedBackgroundFetchIdentifier").get(), 0, &result);
+    return static_cast<WKStringRef>(result);
+}
+
 void InjectedBundle::textDidChangeInTextField()
 {
     m_testRunner->textDidChangeInTextFieldCallback();

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
@@ -157,6 +157,9 @@ public:
     void reloadFromOrigin();
 
     WKRetainPtr<WKStringRef> getBackgroundFetchIdentifier();
+    WKRetainPtr<WKStringRef> lastAddedBackgroundFetchIdentifier() const;
+    WKRetainPtr<WKStringRef> lastRemovedBackgroundFetchIdentifier() const;
+    WKRetainPtr<WKStringRef> lastUpdatedBackgroundFetchIdentifier() const;
 
 private:
     InjectedBundle() = default;

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -457,6 +457,24 @@ void TestRunner::setBackgroundFetchPermission(bool enabled)
     postSynchronousPageMessage("SetBackgroundFetchPermission", enabled);
 }
 
+JSRetainPtr<JSStringRef>  TestRunner::lastAddedBackgroundFetchIdentifier() const
+{
+    auto identifier = InjectedBundle::singleton().lastAddedBackgroundFetchIdentifier();
+    return WKStringCopyJSString(identifier.get());
+}
+
+JSRetainPtr<JSStringRef>  TestRunner::lastRemovedBackgroundFetchIdentifier() const
+{
+    auto identifier = InjectedBundle::singleton().lastRemovedBackgroundFetchIdentifier();
+    return WKStringCopyJSString(identifier.get());
+}
+
+JSRetainPtr<JSStringRef> TestRunner::lastUpdatedBackgroundFetchIdentifier() const
+{
+    auto identifier = InjectedBundle::singleton().lastUpdatedBackgroundFetchIdentifier();
+    return WKStringCopyJSString(identifier.get());
+}
+
 void TestRunner::setShouldSwapToEphemeralSessionOnNextNavigation(bool shouldSwap)
 {
     postSynchronousPageMessage("SetShouldSwapToEphemeralSessionOnNextNavigation", shouldSwap);

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -114,6 +114,10 @@ public:
     void setAsynchronousSpellCheckingEnabled(bool);
     void setAllowsAnySSLCertificate(bool);
     void setBackgroundFetchPermission(bool);
+    JSRetainPtr<JSStringRef> lastAddedBackgroundFetchIdentifier() const;
+    JSRetainPtr<JSStringRef> lastRemovedBackgroundFetchIdentifier() const;
+    JSRetainPtr<JSStringRef> lastUpdatedBackgroundFetchIdentifier() const;
+
     void setShouldSwapToEphemeralSessionOnNextNavigation(bool);
     void setShouldSwapToDefaultSessionOnNextNavigation(bool);
     void setCustomUserAgent(JSStringRef);

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1438,6 +1438,22 @@ void TestController::setBackgroundFetchPermission(bool)
 {
     // FIXME: Add support.
 }
+
+WKRetainPtr<WKStringRef> TestController::lastAddedBackgroundFetchIdentifier() const
+{
+    return adoptWK(WKStringCreateWithUTF8CString("not implemented"));
+}
+
+WKRetainPtr<WKStringRef> TestController::lastRemovedBackgroundFetchIdentifier() const
+{
+    return adoptWK(WKStringCreateWithUTF8CString("not implemented"));
+}
+
+WKRetainPtr<WKStringRef> TestController::lastUpdatedBackgroundFetchIdentifier() const
+{
+    return adoptWK(WKStringCreateWithUTF8CString("not implemented"));
+}
+
 #endif
 
 WKURLRef TestController::createTestURL(const char* pathOrURL)

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -189,6 +189,9 @@ public:
     void setAuthenticationPassword(String password) { m_authenticationPassword = password; }
     void setAllowsAnySSLCertificate(bool);
     void setBackgroundFetchPermission(bool);
+    WKRetainPtr<WKStringRef> lastAddedBackgroundFetchIdentifier() const;
+    WKRetainPtr<WKStringRef> lastRemovedBackgroundFetchIdentifier() const;
+    WKRetainPtr<WKStringRef> lastUpdatedBackgroundFetchIdentifier() const;
 
     void setShouldSwapToEphemeralSessionOnNextNavigation(bool value) { m_shouldSwapToEphemeralSessionOnNextNavigation = value; }
     void setShouldSwapToDefaultSessionOnNextNavigation(bool value) { m_shouldSwapToDefaultSessionOnNextNavigation = value; }

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -953,6 +953,13 @@ WKRetainPtr<WKTypeRef> TestInvocation::didReceiveSynchronousMessageFromInjectedB
         return nullptr;
     }
 
+    if (WKStringIsEqualToUTF8CString(messageName, "LastAddedBackgroundFetchIdentifier"))
+        return TestController::singleton().lastAddedBackgroundFetchIdentifier();
+    if (WKStringIsEqualToUTF8CString(messageName, "LastRemovedBackgroundFetchIdentifier"))
+        return TestController::singleton().lastRemovedBackgroundFetchIdentifier();
+    if (WKStringIsEqualToUTF8CString(messageName, "LastUpdatedBackgroundFetchIdentifier"))
+        return TestController::singleton().lastUpdatedBackgroundFetchIdentifier();
+
     if (WKStringIsEqualToUTF8CString(messageName, "SetShouldSwapToEphemeralSessionOnNextNavigation")) {
         TestController::singleton().setShouldSwapToEphemeralSessionOnNextNavigation(booleanValue(messageBody));
         return nullptr;

--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -539,6 +539,21 @@ void TestController::setBackgroundFetchPermission(bool value)
     [globalWebsiteDataStoreDelegateClient() setBackgroundFetchPermission: value];
 }
 
+WKRetainPtr<WKStringRef> TestController::lastAddedBackgroundFetchIdentifier() const
+{
+    return adoptWK(WKStringCreateWithCFString((__bridge CFStringRef)[globalWebsiteDataStoreDelegateClient() lastAddedBackgroundFetchIdentifier]));
+}
+
+WKRetainPtr<WKStringRef> TestController::lastRemovedBackgroundFetchIdentifier() const
+{
+    return adoptWK(WKStringCreateWithCFString((__bridge CFStringRef)[globalWebsiteDataStoreDelegateClient() lastRemovedBackgroundFetchIdentifier]));
+}
+
+WKRetainPtr<WKStringRef> TestController::lastUpdatedBackgroundFetchIdentifier() const
+{
+    return adoptWK(WKStringCreateWithCFString((__bridge CFStringRef)[globalWebsiteDataStoreDelegateClient() lastUpdatedBackgroundFetchIdentifier]));
+}
+
 void TestController::setAllowedMenuActions(const Vector<String>& actions)
 {
 #if PLATFORM(IOS_FAMILY)

--- a/Tools/WebKitTestRunner/cocoa/TestWebsiteDataStoreDelegate.h
+++ b/Tools/WebKitTestRunner/cocoa/TestWebsiteDataStoreDelegate.h
@@ -24,12 +24,17 @@
  */
 
 #import <WebKit/_WKWebsiteDataStoreDelegate.h>
+#import <wtf/RetainPtr.h>
 
 @interface TestWebsiteDataStoreDelegate: NSObject <_WKWebsiteDataStoreDelegate> {
 @private
     BOOL _shouldAllowRaisingQuota;
     BOOL _shouldAllowAnySSLCertificate;
     BOOL _shouldAllowBackgroundFetchPermission;
+    RetainPtr<NSString> _lastAddedBackgroundFetchIdentifier;
+    RetainPtr<NSString> _lastRemovedBackgroundFetchIdentifier;
+    RetainPtr<NSString> _lastUpdatedBackgroundFetchIdentifier;
+
     NSUInteger _quota;
 }
 - (instancetype)init;
@@ -37,4 +42,7 @@
 - (void)setQuota:(NSUInteger)quota;
 - (void)setAllowAnySSLCertificate:(BOOL)shouldAllowAnySSLCertificate;
 - (void)setBackgroundFetchPermission:(BOOL)shouldAllowBackgroundFetchPermission;
+- (NSString*)lastAddedBackgroundFetchIdentifier;
+- (NSString*)lastRemovedBackgroundFetchIdentifier;
+- (NSString*)lastUpdatedBackgroundFetchIdentifier;
 @end

--- a/Tools/WebKitTestRunner/cocoa/TestWebsiteDataStoreDelegate.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestWebsiteDataStoreDelegate.mm
@@ -46,7 +46,7 @@
     auto totalSpaceRequired = currentSize + spaceRequired;
     if (_shouldAllowRaisingQuota || totalSpaceRequired <= _quota)
         return decisionHandler(totalSpaceRequired);
-
+    
     // Deny request by not changing quota.
     decisionHandler(currentQuota);
 }
@@ -83,9 +83,9 @@
 {
     auto* newView = WTR::TestController::singleton().createOtherPlatformWebView(nullptr, nullptr, nullptr, nullptr);
     WKWebView *webView = newView->platformView();
-
+    
     ASSERT(webView.configuration.websiteDataStore == dataStore);
-
+    
     [webView loadRequest:[NSURLRequest requestWithURL:url]];
     completionHandler(webView);
 }
@@ -100,4 +100,30 @@
 {
     decisionHandler(_shouldAllowBackgroundFetchPermission);
 }
+
+- (void)notifyBackgroundFetchChange:(NSString *)backgroundFetchIdentifier change:(WKBackgroundFetchChange)change
+{
+    if (change == WKBackgroundFetchChangeAddition) {
+        _lastAddedBackgroundFetchIdentifier = backgroundFetchIdentifier;
+        return;
+    }
+    if (change == WKBackgroundFetchChangeRemoval) {
+        _lastRemovedBackgroundFetchIdentifier = backgroundFetchIdentifier;
+        return;
+    }
+    _lastUpdatedBackgroundFetchIdentifier = backgroundFetchIdentifier;
+}
+
+- (NSString*)lastAddedBackgroundFetchIdentifier {
+    return _lastAddedBackgroundFetchIdentifier.get();
+}
+
+- (NSString*)lastRemovedBackgroundFetchIdentifier {
+    return _lastRemovedBackgroundFetchIdentifier.get();
+}
+
+- (NSString*)lastUpdatedBackgroundFetchIdentifier {
+    return _lastUpdatedBackgroundFetchIdentifier.get();
+}
+
 @end


### PR DESCRIPTION
#### 6de9a281e1ebf08e353a6f6184b51edea9296b3f
<pre>
Add WK API to be notified of background fetch changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=253305">https://bugs.webkit.org/show_bug.cgi?id=253305</a>
rdar://problem/106190496

Reviewed by Chris Dumez.

Add a Website data store delegate to be notified of new background fetch.
Add a Website data store private method to get backgorund fetch state information from a background fetch identifier.
The changes are: Addition, Removal, Update.
The states are exposed as a NSDictionary.
We add new test runner methods to make use of these website data store APIs.

Drive-by fixes to make the records no longer available once the termina background fetch (success/error/abort) event is fully handled.
This is necessary to pass the updated background-fetch layout test.

* LayoutTests/http/wpt/background-fetch/background-fetch-abort.window.js:
(promise_test.async t):
* Source/WebCore/workers/service/WorkerSWClientConnection.cpp:
(WebCore::WorkerSWClientConnection::retrieveRecordResponseBody):
* Source/WebCore/workers/service/background-fetch/BackgroundFetch.cpp:
(WebCore::BackgroundFetch::updateBackgroundFetchStatus):
(WebCore::BackgroundFetch::unsetRecordsAvailableFlag):
* Source/WebCore/workers/service/background-fetch/BackgroundFetch.h:
(WebCore::BackgroundFetch::options const):
* Source/WebCore/workers/service/background-fetch/BackgroundFetchEngine.cpp:
(WebCore::BackgroundFetchEngine::startBackgroundFetch):
(WebCore::BackgroundFetchEngine::notifyBackgroundFetchUpdate):
(WebCore::BackgroundFetchEngine::addFetchFromStore):
(WebCore::BackgroundFetchEngine::backgroundFetch const):
* Source/WebCore/workers/service/background-fetch/BackgroundFetchEngine.h:
* Source/WebCore/workers/service/background-fetch/BackgroundFetchFailureReason.idl:
* Source/WebCore/workers/service/background-fetch/BackgroundFetchResult.idl:
* Source/WebCore/workers/service/context/ServiceWorkerThread.cpp:
(WebCore::ServiceWorkerThread::queueTaskToFireBackgroundFetchEvent):
* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::fireBackgroundFetchEvent):
* Source/WebCore/workers/service/server/SWServer.h:
* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::getBackgroundFetchState):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::NetworkSession::getBackgroundFetchState):
* Source/WebKit/NetworkProcess/NetworkSession.h:
* Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.cpp:
(WebKit::BackgroundFetchStoreImpl::clearFetch):
(WebKit::BackgroundFetchStoreImpl::clearAllFetches):
(WebKit::BackgroundFetchStoreImpl::storeFetch):
(WebKit::BackgroundFetchStoreImpl::storeFetchResponseBodyChunk):
(WebKit::BackgroundFetchStoreImpl::getBackgroundFetchState):
* Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::notifyBackgroundFetchChange):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/Shared/BackgroundFetchChange.h: Added.
* Source/WebKit/Shared/BackgroundFetchState.h: Added.
* Source/WebKit/Shared/BackgroundFetchState.serialization.in: Added.
* Source/WebKit/Shared/Cocoa/BackgroundFetchStateCocoa.mm: Added.
(WebKit::BackgroundFetchState::toDictionary const):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(-[WKWebsiteDataStore _getBackgroundFetchState:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreDelegate.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::getAllBackgroundFetchIdentifiers):
(WebKit::NetworkProcessProxy::getBackgroundFetchState):
(WebKit::NetworkProcessProxy::notifyBackgroundFetchChange):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.messages.in:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreClient.h:
(WebKit::WebsiteDataStoreClient::notifyBackgroundFetchChange):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp:
(WTR::InjectedBundle::lastAddedBackgroundFetchIdentifier const):
(WTR::InjectedBundle::lastRemovedBackgroundFetchIdentifier const):
(WTR::InjectedBundle::lastUpdatedBackgroundFetchIdentifier const):
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::lastAddedBackgroundFetchIdentifier const):
(WTR::TestRunner::lastRemovedBackgroundFetchIdentifier const):
(WTR::TestRunner::lastUpdatedBackgroundFetchIdentifier const):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::lastAddedBackgroundFetchIdentifier const):
(WTR::TestController::lastRemovedBackgroundFetchIdentifier const):
(WTR::TestController::lastUpdatedBackgroundFetchIdentifier const):
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveSynchronousMessageFromInjectedBundle):
* Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm:
(WTR::TestController::lastAddedBackgroundFetchIdentifier const):
(WTR::TestController::lastRemovedBackgroundFetchIdentifier const):
(WTR::TestController::lastUpdatedBackgroundFetchIdentifier const):
* Tools/WebKitTestRunner/cocoa/TestWebsiteDataStoreDelegate.h:
* Tools/WebKitTestRunner/cocoa/TestWebsiteDataStoreDelegate.mm:
(-[TestWebsiteDataStoreDelegate requestStorageSpace:frameOrigin:quota:currentSize:spaceRequired:decisionHandler:]):
(-[TestWebsiteDataStoreDelegate websiteDataStore:openWindow:fromServiceWorkerOrigin:completionHandler:]):
(-[TestWebsiteDataStoreDelegate notifyBackgroundFetchChange:change:]):
(-[TestWebsiteDataStoreDelegate lastAddedBackgroundFetchIdentifier]):
(-[TestWebsiteDataStoreDelegate lastRemovedBackgroundFetchIdentifier]):
(-[TestWebsiteDataStoreDelegate lastUpdatedBackgroundFetchIdentifier]):

Canonical link: <a href="https://commits.webkit.org/261261@main">https://commits.webkit.org/261261@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/acc3adaa49a4ad14b8edd869a30b7dac04dae6d8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111092 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20232 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43656 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2519 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119936 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115049 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21605 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11334 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2156 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116847 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16046 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99230 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103603 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98003 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30894 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44517 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12749 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32228 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86420 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13290 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9215 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18708 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7812 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15241 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->