### PR TITLE
Factor Shape computation into a standalone function

### DIFF
--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -2884,7 +2884,7 @@ bool RenderBlockFlow::positionNewFloats()
         m_floatingObjects->addPlacedObject(&floatingObject);
 
         if (ShapeOutsideInfo* shapeOutside = childBox.shapeOutsideInfo())
-            shapeOutside->setReferenceBoxLogicalSize(logicalSizeForChild(childBox));
+            shapeOutside->invalidateForSizeChangeIfNeeded();
         // If the child moved, we have to repaint it.
         if (childBox.checkForRepaintDuringLayout())
             childBox.repaintDuringLayoutIfMoved(oldRect);

--- a/Source/WebCore/rendering/shapes/ShapeOutsideInfo.h
+++ b/Source/WebCore/rendering/shapes/ShapeOutsideInfo.h
@@ -41,6 +41,8 @@ class RenderBox;
 class StyleImage;
 class FloatingObject;
 
+std::unique_ptr<Shape> makeShapeForShapeOutside(const RenderBox&);
+
 class ShapeOutsideDeltas final {
 public:
     ShapeOutsideDeltas()
@@ -90,7 +92,7 @@ public:
 
     ShapeOutsideDeltas computeDeltasForContainingBlockLine(const RenderBlockFlow&, const FloatingObject&, LayoutUnit lineTop, LayoutUnit lineHeight);
 
-    void setReferenceBoxLogicalSize(LayoutSize);
+    void invalidateForSizeChangeIfNeeded();
 
     LayoutUnit shapeLogicalTop() const { return computedShape().shapeMarginLogicalBoundingBox().y() + logicalTopOffset(); }
     LayoutUnit shapeLogicalBottom() const { return computedShape().shapeMarginLogicalBoundingBox().maxY() + logicalTopOffset(); }
@@ -120,8 +122,6 @@ public:
     static ShapeOutsideInfo* info(const RenderBox& key) { return infoMap().get(&key); }
 
 private:
-    std::unique_ptr<Shape> createShapeForImage(StyleImage*, float shapeImageThreshold, WritingMode, float margin) const;
-
     LayoutUnit logicalTopOffset() const;
     LayoutUnit logicalLeftOffset() const;
 
@@ -135,7 +135,7 @@ private:
     const RenderBox& m_renderer;
 
     mutable std::unique_ptr<Shape> m_shape;
-    LayoutSize m_referenceBoxLogicalSize;
+    LayoutSize m_cachedShapeLogicalSize;
 
     ShapeOutsideDeltas m_shapeOutsideDeltas;
 };


### PR DESCRIPTION
#### 5e4a6f09f5f94236200aee53d376984ed905e897
<pre>
Factor Shape computation into a standalone function
<a href="https://bugs.webkit.org/show_bug.cgi?id=253313">https://bugs.webkit.org/show_bug.cgi?id=253313</a>
rdar://106194842

Reviewed by Alan Baradlay.

This will help in supporting shape-outside in LFC.

* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::positionNewFloats):
* Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp:
(WebCore::referenceBox):
(WebCore::computeLogicalBoxSize):
(WebCore::ShapeOutsideInfo::invalidateForSizeChangeIfNeeded):
(WebCore::makeShapeForShapeOutside):
(WebCore::checkShapeImageOrigin):
(WebCore::ShapeOutsideInfo::computedShape const):
(WebCore::ShapeOutsideInfo::setReferenceBoxLogicalSize): Deleted.
(WebCore::ShapeOutsideInfo::createShapeForImage const): Deleted.
* Source/WebCore/rendering/shapes/ShapeOutsideInfo.h:

Canonical link: <a href="https://commits.webkit.org/261169@main">https://commits.webkit.org/261169@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4347640ccb2443e03c524794070bfb5297149cc4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110792 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19877 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/43340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/2141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/119606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114757 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/21279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/10983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/87/builds/2141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116541 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/21279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/43340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/103147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/21279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/43340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/103147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/12470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/43340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/103147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/13039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/10983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18422 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/43340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7736 "Failed to push commit to Webkit repository") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/14994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->