### PR TITLE
[web-animations] add a dedicated timeline object for accelerated effects

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -466,6 +466,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     accessibility/isolatedtree/AXIsolatedObject.h
     accessibility/isolatedtree/AXIsolatedTree.h
 
+    animation/AcceleratedTimeline.h
     animation/AnimationFrameRatePreset.h
     animation/CSSPropertyBlendingClient.h
     animation/CustomAnimationOptions.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -491,6 +491,7 @@ accessibility/AccessibilityTree.cpp
 accessibility/AccessibilityTreeItem.cpp
 accessibility/isolatedtree/AXIsolatedObject.cpp
 accessibility/isolatedtree/AXIsolatedTree.cpp
+animation/AcceleratedTimeline.cpp
 animation/AnimationEffect.cpp
 animation/AnimationEventBase.cpp
 animation/AnimationPlaybackEvent.cpp

--- a/Source/WebCore/animation/AcceleratedTimeline.cpp
+++ b/Source/WebCore/animation/AcceleratedTimeline.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "AcceleratedTimeline.h"
+
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+
+#include "DOMWindow.h"
+#include "Document.h"
+#include "Page.h"
+#include "Performance.h"
+#include "RenderElement.h"
+#include "RenderLayer.h"
+#include "RenderLayerBacking.h"
+#include "RenderLayerModelObject.h"
+#include "RenderStyleConstants.h"
+#include "Styleable.h"
+#include "WebAnimation.h"
+#include <wtf/MonotonicTime.h>
+
+namespace WebCore {
+
+AcceleratedTimeline::AcceleratedTimeline(Document& document)
+{
+    auto now = MonotonicTime::now();
+    m_timeOrigin = now.secondsSinceEpoch();
+    if (auto* domWindow = document.domWindow())
+        m_timeOrigin -= Seconds::fromMilliseconds(domWindow->performance().relativeTimeFromTimeOriginInReducedResolution(now));
+}
+
+void AcceleratedTimeline::updateEffectStacks()
+{
+    auto targetsPendingUpdate = std::exchange(m_targetsPendingUpdate, { });
+    for (auto hashedStyleable : targetsPendingUpdate) {
+        auto* element = hashedStyleable.first;
+        if (!element)
+            continue;
+
+        auto pseudoId = static_cast<PseudoId>(hashedStyleable.second);
+        Styleable target { *element, pseudoId };
+
+        auto* renderer = target.renderer();
+        if (!renderer || !renderer->isComposited() || !is<RenderLayerModelObject>(renderer))
+            continue;
+
+        auto* renderLayer = downcast<RenderLayerModelObject>(*renderer).layer();
+        ASSERT(renderLayer && renderLayer->backing());
+        renderLayer->backing()->updateAcceleratedEffectsAndBaseValues();
+    }
+}
+
+void AcceleratedTimeline::updateEffectStackForTarget(const Styleable& target)
+{
+    m_targetsPendingUpdate.add({ &target.element, static_cast<unsigned>(target.pseudoId) });
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(THREADED_ANIMATION_RESOLUTION)

--- a/Source/WebCore/animation/AcceleratedTimeline.h
+++ b/Source/WebCore/animation/AcceleratedTimeline.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+
+#include "AcceleratedEffect.h"
+#include <wtf/HashSet.h>
+#include <wtf/Seconds.h>
+
+namespace WebCore {
+
+class Document;
+class Element;
+struct Styleable;
+
+class AcceleratedTimeline {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    AcceleratedTimeline(Document&);
+
+    void updateEffectStacks();
+    void updateEffectStackForTarget(const Styleable&);
+    
+    Seconds timeOrigin() const { return m_timeOrigin; }
+    
+protected:
+    
+private:
+    using HashedStyleable = std::pair<Element*, unsigned>;
+    HashSet<HashedStyleable> m_targetsPendingUpdate;
+    Seconds m_timeOrigin;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(THREADED_ANIMATION_RESOLUTION)

--- a/Source/WebCore/animation/DocumentTimeline.cpp
+++ b/Source/WebCore/animation/DocumentTimeline.cpp
@@ -48,6 +48,10 @@
 #include "RenderLayerBacking.h"
 #include "WebAnimationTypes.h"
 
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+#include "AcceleratedTimeline.h"
+#endif
+
 namespace WebCore {
 
 Ref<DocumentTimeline> DocumentTimeline::create(Document& document)
@@ -407,6 +411,15 @@ void DocumentTimeline::animationAcceleratedRunningStateDidChange(WebAnimation& a
 
 void DocumentTimeline::applyPendingAcceleratedAnimations()
 {
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    if (m_document && m_document->settings().threadedAnimationResolutionEnabled()) {
+        m_acceleratedAnimationsPendingRunningStateChange.clear();
+        if (auto* acceleratedTimeline = m_document->existingAcceleratedTimeline())
+            acceleratedTimeline->updateEffectStacks();
+        return;
+    }
+#endif
+
     auto acceleratedAnimationsPendingRunningStateChange = m_acceleratedAnimationsPendingRunningStateChange;
     m_acceleratedAnimationsPendingRunningStateChange.clear();
 

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -231,6 +231,7 @@ private:
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
     bool threadedAnimationResolutionEnabled() const;
+    void updateAssociatedThreadedEffectStack(const std::optional<const Styleable>&);
 #endif
 
     // AnimationEffect

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -367,6 +367,10 @@
 #include "HTMLVideoElement.h"
 #endif
 
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+#include "AcceleratedTimeline.h"
+#endif
+
 #define DOCUMENT_RELEASE_LOG(channel, fmt, ...) RELEASE_LOG(channel, "%p - [pageID=%" PRIu64 ", frameID=%" PRIu64 ", isMainFrame=%d] Document::" fmt, this, valueOrDefault(pageID()).toUInt64(), valueOrDefault(frameID()).object().toUInt64(), this == &topDocument(), ##__VA_ARGS__)
 #define DOCUMENT_RELEASE_LOG_ERROR(channel, fmt, ...) RELEASE_LOG_ERROR(channel, "%p - [pageID=%" PRIu64 ", frameID=%" PRIu64 ", isMainFrame=%d] Document::" fmt, this, valueOrDefault(pageID()).toUInt64(), valueOrDefault(frameID()).object().toUInt64(), this == &topDocument(), ##__VA_ARGS__)
 
@@ -8858,6 +8862,15 @@ DocumentTimeline& Document::timeline()
 
     return *m_timeline;
 }
+
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+AcceleratedTimeline& Document::acceleratedTimeline()
+{
+    if (!m_acceleratedTimeline)
+        m_acceleratedTimeline = makeUnique<AcceleratedTimeline>(*this);
+    return *m_acceleratedTimeline;
+}
+#endif
 
 Vector<RefPtr<WebAnimation>> Document::getAnimations()
 {

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -241,6 +241,10 @@ class ContentChangeObserver;
 class DOMTimerHoldingTank;
 #endif
 
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+class AcceleratedTimeline;
+#endif
+
 struct ApplicationManifest;
 struct BoundaryPoint;
 struct ClientOrigin;
@@ -1612,6 +1616,11 @@ public:
     WEBCORE_EXPORT DocumentTimelinesController& ensureTimelinesController();
     void keyframesRuleDidChange(const String& name);
 
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    AcceleratedTimeline* existingAcceleratedTimeline() const { return m_acceleratedTimeline.get(); }
+    AcceleratedTimeline& acceleratedTimeline();
+#endif
+
     void addTopLayerElement(Element&);
     void removeTopLayerElement(Element&);
     const ListHashSet<Ref<Element>>& topLayerElements() const { return m_topLayerElements; }
@@ -2352,6 +2361,10 @@ private:
     bool m_userHasInteractedWithMediaElement { false };
 
     bool m_updateTitleTaskScheduled { false };
+
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    std::unique_ptr<AcceleratedTimeline> m_acceleratedTimeline;
+#endif
 
     bool m_isRunningUserScripts { false };
     bool m_shouldPreventEnteringBackForwardCacheForTesting { false };


### PR DESCRIPTION
#### e3d89dcbb53baaa501b9adbcf1ce470b2e176412
<pre>
[web-animations] add a dedicated timeline object for accelerated effects
<a href="https://bugs.webkit.org/show_bug.cgi?id=253312">https://bugs.webkit.org/show_bug.cgi?id=253312</a>

Reviewed by Dean Jackson.

Add a new AcceleratedTimeline class on which elements targeted by effects animating
accelerated properties are registered. Then as the document&apos;s timeline is updated,
we go through these registered elements and update the accelerated effect stack for
them through their RenderLayerBacking.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/animation/AcceleratedTimeline.cpp: Added.
(WebCore::AcceleratedTimeline::AcceleratedTimeline):
(WebCore::AcceleratedTimeline::updateEffectStacks):
(WebCore::AcceleratedTimeline::updateEffectStackForTarget):
* Source/WebCore/animation/AcceleratedTimeline.h: Added.
(WebCore::AcceleratedTimeline::timeOrigin const):
* Source/WebCore/animation/DocumentTimeline.cpp:
(WebCore::DocumentTimeline::applyPendingAcceleratedAnimations):
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::updateAssociatedThreadedEffectStack):
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::acceleratedTimeline):
* Source/WebCore/dom/Document.h:
(WebCore::Document::existingAcceleratedTimeline const):

Canonical link: <a href="https://commits.webkit.org/261160@main">https://commits.webkit.org/261160@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/27a02d823acb4a5ae4227af8878a226a32934d4b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110735 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19816 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43292 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2079 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119562 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114701 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21223 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10928 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/1728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116480 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103108 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30649 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/44201 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/12429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31986 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/86081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12993 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18371 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51605 "Passed tests") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/14950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4213 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->