### PR TITLE
REGRESSION(260774@main):[ iOS ] 7X media/video layout-tests broke

### DIFF
--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -2364,17 +2364,6 @@ webkit.org/b/246357 imported/w3c/web-platform-tests/feature-policy/reporting/pay
 
 webkit.org/b/245967 imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allowed-for-some-override.https.sub.html [ Pass Failure ]
 
-# webkit.org/b/253035 REGRESSION(260774@main):[ iOS ] 7X media/video layout-tests broke (253035)
-fast/mediastream/getUserMedia-to-canvas-2.html [ Timeout ]
-media/track/track-description-cue.html [ Failure ]
-media/track/track-extended-descriptions.html [ Failure ]
-media/track/track-language-preference.html [ Pass Failure ]
-webrtc/concurrentVideoPlayback.html [ Timeout ]
-webrtc/concurrentVideoPlayback2.html [ Timeout ] 
-webrtc/video-rotation.html [ Timeout ]
-webrtc/video-sframe.html [ Timeout ]
-webrtc/video-unmute.html [ Timeout ] 
-
 webkit.org/b/252866 [ Debug ] fast/text/glyph-display-lists/glyph-display-list-svg-unshared.html [ Pass Failure ]
 webkit.org/b/252866 [ Debug ] fast/text/glyph-display-lists/glyph-display-list-colr-unshared.html [ Pass Failure ]
 

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
@@ -133,16 +133,22 @@ void PlaybackSessionModelContext::setPlaybackRate(double playbackRate)
         m_manager->setPlaybackRate(m_contextId, playbackRate);
 }
 
-void PlaybackSessionModelContext::selectAudioMediaOption(uint64_t optionId)
+void PlaybackSessionModelContext::selectAudioMediaOption(uint64_t index)
 {
+    if (m_audioMediaSelectedIndex == index)
+        return;
+
     if (m_manager)
-        m_manager->selectAudioMediaOption(m_contextId, optionId);
+        m_manager->selectAudioMediaOption(m_contextId, index);
 }
 
-void PlaybackSessionModelContext::selectLegibleMediaOption(uint64_t optionId)
+void PlaybackSessionModelContext::selectLegibleMediaOption(uint64_t index)
 {
+    if (m_legibleMediaSelectedIndex == index)
+        return;
+
     if (m_manager)
-        m_manager->selectLegibleMediaOption(m_contextId, optionId);
+        m_manager->selectLegibleMediaOption(m_contextId, index);
 }
 
 void PlaybackSessionModelContext::togglePictureInPicture()
@@ -159,12 +165,18 @@ void PlaybackSessionModelContext::toggleMuted()
 
 void PlaybackSessionModelContext::setMuted(bool muted)
 {
+    if (muted == m_muted)
+        return;
+
     if (m_manager)
         m_manager->setMuted(m_contextId, muted);
 }
 
 void PlaybackSessionModelContext::setVolume(double volume)
 {
+    if (volume == m_volume)
+        return;
+
     if (m_manager)
         m_manager->setVolume(m_contextId, volume);
 }


### PR DESCRIPTION
#### 671758683829fb90eae4056dd9609e424cef927c
<pre>
REGRESSION(260774@main):[ iOS ] 7X media/video layout-tests broke
<a href="https://bugs.webkit.org/show_bug.cgi?id=253035">https://bugs.webkit.org/show_bug.cgi?id=253035</a>
rdar://105998972

Reviewed by Eric Carlson.

In 260774@main, remote layer hosting was made possible by creating an instance of
a WebAVPlayerLayer, WebAVPlayerLayerView, and WebAVPlayerController, the latter which
has its properties set by PlaybackSessionManager/Proxy and subsequently pushes changes
to those properties back down through PlaybackSessionManager/Proxy to the HTMLMediaElement
backing it. When tracks are added to the HTMLMediaElement, that change is propogated up
from the WebProcess to the UIProcess and pushed into the WebAVPlayerController. And in
response the WebAVPlayerController notified the PlaybackSessionManagerProxy that its
values had been changed. However, there was no validation inside the
PlaybackSessionManagerProxy that the values in question were different than the ones
it had just set, so each change from the HTMLMediaElement got reflected back.

Add simple checks to a few setters in PlaybackSessionModelContext that did not
already have them that validate that the new value represented a change before propogating
that change back down to the HTMLMediaElement.

* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm:
(WebKit::PlaybackSessionModelContext::selectAudioMediaOption):
(WebKit::PlaybackSessionModelContext::selectLegibleMediaOption):
(WebKit::PlaybackSessionModelContext::setMuted):
(WebKit::PlaybackSessionModelContext::setVolume):

Canonical link: <a href="https://commits.webkit.org/261295@main">https://commits.webkit.org/261295@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e23ac7e0ac116c03e5fcb3f2b7080ef942fb52da

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110854 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19940 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43494 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2208 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119730 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21432 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11160 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/1993 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116606 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15923 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99107 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103381 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97883 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30772 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44325 "") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12534 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32280 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/86504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13091 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9083 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18492 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7830 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15036 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->