### PR TITLE
[web-animations] update the accelerated effect stack as KeyframeEffect properties change

### DIFF
--- a/Source/WebCore/animation/AnimationEffect.h
+++ b/Source/WebCore/animation/AnimationEffect.h
@@ -67,6 +67,7 @@ public:
     virtual void animationWasCanceled() { };
     virtual void animationSuspensionStateDidChange(bool) { };
     virtual void animationTimelineDidChange(AnimationTimeline*) { };
+    virtual void animationDidFinish() { };
 
     WebAnimation* animation() const { return m_animation.get(); }
     virtual void setAnimation(WebAnimation*);

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -4288,6 +4288,22 @@ CSSPropertyID CSSPropertyAnimation::getPropertyAtIndex(int i, std::optional<bool
     return wrapper->property();
 }
 
+std::optional<CSSPropertyID> CSSPropertyAnimation::getAcceleratedPropertyAtIndex(int i, const Settings& settings)
+{
+    // FIXME: We really ought to expose an iterator to go over all animatable properties.
+    // https://bugs.webkit.org/show_bug.cgi?id=252807
+    auto& map = CSSPropertyAnimationWrapperMap::singleton();
+
+    if (i < 0 || static_cast<unsigned>(i) >= map.size())
+        return std::nullopt;
+
+    auto* wrapper = map.wrapperForIndex(i);
+    if (wrapper->isShorthandWrapper() || !wrapper->animationIsAccelerated(settings))
+        return std::nullopt;
+
+    return wrapper->property();
+}
+
 int CSSPropertyAnimation::getNumProperties()
 {
     return CSSPropertyAnimationWrapperMap::singleton().size();

--- a/Source/WebCore/animation/CSSPropertyAnimation.h
+++ b/Source/WebCore/animation/CSSPropertyAnimation.h
@@ -50,6 +50,7 @@ public:
     static bool propertiesEqual(AnimatableProperty, const RenderStyle& a, const RenderStyle& b, const Document&);
     static bool canPropertyBeInterpolated(AnimatableProperty, const RenderStyle& a, const RenderStyle& b, const Document&);
     static CSSPropertyID getPropertyAtIndex(int, std::optional<bool>& isShorthand);
+    static std::optional<CSSPropertyID> getAcceleratedPropertyAtIndex(int, const Settings&);
     static int getNumProperties();
 
     static void blendProperty(const CSSPropertyBlendingClient&, AnimatableProperty, RenderStyle& destination, const RenderStyle& from, const RenderStyle& to, double progress, CompositeOperation, IterationCompositeOperation = IterationCompositeOperation::Replace, double currentIteration = 0);

--- a/Source/WebCore/animation/CSSTransition.cpp
+++ b/Source/WebCore/animation/CSSTransition.cpp
@@ -69,6 +69,8 @@ void CSSTransition::resolve(RenderStyle& targetStyle, const Style::ResolutionCon
 
 void CSSTransition::animationDidFinish()
 {
+    DeclarativeAnimation::animationDidFinish();
+
     if (auto owningElement = this->owningElement())
         owningElement->removeDeclarativeAnimationFromListsForOwningElement(*this);
 }

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -794,6 +794,12 @@ void WebAnimation::enqueueAnimationEvent(Ref<AnimationEventBase>&& event)
     }
 }
 
+void WebAnimation::animationDidFinish()
+{
+    if (m_effect)
+        m_effect->animationDidFinish();
+}
+
 void WebAnimation::resetPendingTasks()
 {
     // The procedure to reset an animation's pending tasks for animation is as follows:
@@ -1424,7 +1430,9 @@ bool WebAnimation::virtualHasPendingActivity() const
 
 void WebAnimation::updateRelevance()
 {
-    m_isRelevant = computeRelevance();
+    auto wasRelevant = std::exchange(m_isRelevant, computeRelevance());
+    if (wasRelevant != m_isRelevant && is<KeyframeEffect>(m_effect))
+        downcast<KeyframeEffect>(*m_effect).animationRelevancyDidChange();
 }
 
 bool WebAnimation::computeRelevance()

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -166,7 +166,7 @@ protected:
 
     void initialize();
     void enqueueAnimationEvent(Ref<AnimationEventBase>&&);
-    virtual void animationDidFinish() { };
+    virtual void animationDidFinish();
 
 private:
     enum class DidSeek : uint8_t { Yes, No };


### PR DESCRIPTION
#### 7aaf5f7967bd256f5eace5dc479a30436191a5ee
<pre>
[web-animations] update the accelerated effect stack as KeyframeEffect properties change
<a href="https://bugs.webkit.org/show_bug.cgi?id=253320">https://bugs.webkit.org/show_bug.cgi?id=253320</a>

Reviewed by Dean Jackson.

We must make sure to update the accelerated effect stack when a number of KeyframeEffect
or WebAnimation properties change with threaded animation resolution enabled. We must also
disable any of the acceleration prevention with threaded animation resolution since these
situations will no longer arise.

* Source/WebCore/animation/AnimationEffect.h:
(WebCore::AnimationEffect::animationDidFinish):
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyAnimation::getAcceleratedPropertyAtIndex):
* Source/WebCore/animation/CSSPropertyAnimation.h:
* Source/WebCore/animation/CSSTransition.cpp:
(WebCore::CSSTransition::animationDidFinish):
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::transformFunctionListPrefix const):
(WebCore::KeyframeEffect::animationTimelineDidChange):
(WebCore::KeyframeEffect::animationRelevancyDidChange):
(WebCore::KeyframeEffect::updateEffectStackMembership):
(WebCore::KeyframeEffect::didChangeTargetStyleable):
(WebCore::KeyframeEffect::preventsAcceleration const):
(WebCore::KeyframeEffect::updateAcceleratedAnimationIfNecessary):
(WebCore::KeyframeEffect::animationDidFinish):
(WebCore::KeyframeEffect::animationWasCanceled):
(WebCore::KeyframeEffect::willChangeRenderer):
(WebCore::KeyframeEffect::animationSuspensionStateDidChange):
(WebCore::KeyframeEffect::setComposite):
(WebCore::KeyframeEffect::abilityToBeAcceleratedDidChange):
(WebCore::KeyframeEffect::CanBeAcceleratedMutationScope::CanBeAcceleratedMutationScope):
(WebCore::KeyframeEffect::CanBeAcceleratedMutationScope::~CanBeAcceleratedMutationScope):
(WebCore::acceleratedPropertyDidChange):
(WebCore::KeyframeEffect::lastStyleChangeEventStyleDidChange):
(WebCore::KeyframeEffect::StackMembershipMutationScope::StackMembershipMutationScope):
(WebCore::KeyframeEffect::StackMembershipMutationScope::~StackMembershipMutationScope):
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::animationDidFinish):
(WebCore::WebAnimation::updateRelevance):
* Source/WebCore/animation/WebAnimation.h:
(WebCore::WebAnimation::animationDidFinish): Deleted.

Canonical link: <a href="https://commits.webkit.org/261242@main">https://commits.webkit.org/261242@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a536411903ce721b1609e2a1e7ce8eeb510fb4c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110950 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20089 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43517 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2377 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119797 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114909 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21464 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11190 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2047 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116702 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15944 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99124 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103425 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97905 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30788 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44366 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12609 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32125 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86289 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13157 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9103 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18567 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15103 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4262 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->