### PR TITLE
[WGSL] Save inferred types in the AST

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTExpression.h
+++ b/Source/WebGPU/WGSL/AST/ASTExpression.h
@@ -27,10 +27,16 @@
 
 #include "ASTNode.h"
 
-namespace WGSL::AST {
+namespace WGSL {
+class TypeChecker;
+struct Type;
+
+namespace AST {
 
 class Expression : public Node {
     WTF_MAKE_FAST_ALLOCATED;
+    friend TypeChecker;
+
 public:
     using Ref = UniqueRef<Expression>;
     using Ptr = std::unique_ptr<Expression>;
@@ -41,9 +47,15 @@ public:
     { }
 
     virtual ~Expression() { }
+
+    const Type* inferredType() const { return m_inferredType; }
+
+private:
+    const Type* m_inferredType;
 };
 
-} // namespace WGSL::AST
+} // namespace AST
+} // namespace WGSL
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WGSL::AST::Expression)
 static bool isType(const WGSL::AST::Node& node)

--- a/Source/WebGPU/WGSL/AST/ASTTypeName.h
+++ b/Source/WebGPU/WGSL/AST/ASTTypeName.h
@@ -30,13 +30,16 @@
 
 namespace WGSL {
 class ResolveTypeReferences;
-} // namespace WGSL
+class TypeChecker;
+struct Type;
 
-namespace WGSL::AST {
+namespace AST {
 class Structure;
 
 class TypeName : public Node, public RefCounted<TypeName> {
     WTF_MAKE_FAST_ALLOCATED;
+    friend TypeChecker;
+
 public:
     using Ref = WTF::Ref<TypeName>;
     using Ptr = RefPtr<TypeName>;
@@ -44,6 +47,11 @@ public:
     TypeName(SourceSpan span)
         : Node(span)
     { }
+
+    const Type* resolvedType() const { return m_resolvedType; }
+
+private:
+    const Type* m_resolvedType;
 };
 
 class ArrayTypeName : public TypeName {
@@ -183,7 +191,8 @@ private:
 };
 
 
-} // namespace WGSL::AST
+} // namespace AST
+} // namespace WGSL
 
 #define SPECIALIZE_TYPE_TRAITS_WGSL_TYPE(ToValueTypeName, predicate) \
 SPECIALIZE_TYPE_TRAITS_BEGIN(WGSL::AST::ToValueTypeName) \

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -491,39 +491,35 @@ Type* TypeChecker::infer(AST::Expression& expression)
     AST::Visitor::visit(expression);
     ASSERT(m_inferredType);
 
-    auto* type = m_inferredType;
-
     if (shouldDumpInferredTypes) {
         dataLog("> Type inference [expression]: ");
         dumpNode(WTF::dataFile(), expression);
         dataLog(" : ");
-        dataLogLn(*type);
+        dataLogLn(*m_inferredType);
     }
 
-    // FIXME: store resolved type in the expression
+    expression.m_inferredType = m_inferredType;
+    Type* inferredType = m_inferredType;
     m_inferredType = nullptr;
 
-    return type;
+    return inferredType;
 }
 
 Type* TypeChecker::resolve(AST::TypeName& type)
 {
     ASSERT(!m_inferredType);
-    // FIXME: this should call the base class and TypeChecker::visit should assert
-    // that it is never called directly on types
     AST::Visitor::visit(type);
     ASSERT(m_inferredType);
-
-    auto* inferredType = m_inferredType;
 
     if (shouldDumpInferredTypes) {
         dataLog("> Type inference [type]: ");
         dumpNode(WTF::dataFile(), type);
         dataLog(" : ");
-        dataLogLn(*inferredType);
+        dataLogLn(*m_inferredType);
     }
 
-    // FIXME: store resolved type in the AST type
+    type.m_resolvedType = m_inferredType;
+    Type* inferredType = m_inferredType;
     m_inferredType = nullptr;
 
     return inferredType;


### PR DESCRIPTION
#### 965666e1f9dd69a52efd9c162b325be68bea104c
<pre>
[WGSL] Save inferred types in the AST
<a href="https://bugs.webkit.org/show_bug.cgi?id=253324">https://bugs.webkit.org/show_bug.cgi?id=253324</a>
&lt;rdar://problem/106199533&gt;

Reviewed by Myles C. Maxfield.

Other phases depend on the type information generated during type
checking, so we store in the AST so they can use it later.

* Source/WebGPU/WGSL/AST/ASTExpression.h:
(WGSL::AST::Expression::inferredType const):
* Source/WebGPU/WGSL/AST/ASTTypeName.h:
(WGSL::AST::TypeName::resolvedType const):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::infer):
(WGSL::TypeChecker::resolve):

Canonical link: <a href="https://commits.webkit.org/261276@main">https://commits.webkit.org/261276@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc44651760ec4b8edb4cbba59cc690dc398136e5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111118 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20258 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43683 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2545 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119962 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21631 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11360 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2181 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116873 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16070 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99254 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103635 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98027 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30918 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44547 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12775 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/32252 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86447 "Found 2 new API test failures: /TestWebKit:WebKit.OnDeviceChangeCrash, /TestWebKit:WebKit.PrivateBrowsingPushStateNoHistoryCallback (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13315 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9238 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18734 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7816 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15266 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->