### PR TITLE
[git-webkit] Handle interupts while pushing

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/setup.py
+++ b/Tools/Scripts/libraries/webkitcorepy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='webkitcorepy',
-    version='0.14.2',
+    version='0.14.3',
     description='Library containing various Python support classes and functions.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
@@ -48,7 +48,7 @@ from webkitcorepy.null_context import NullContext
 from webkitcorepy.filtered_call import filtered_call
 from webkitcorepy.partial_proxy import PartialProxy
 
-version = Version(0, 14, 2)
+version = Version(0, 14, 3)
 
 from webkitcorepy.autoinstall import Package, AutoInstall
 if sys.version_info > (3, 0):

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/terminal.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/terminal.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021, 2022 Apple Inc. All rights reserved.
+# Copyright (C) 2021-2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -22,6 +22,7 @@
 
 import contextlib
 import io
+import logging
 import sys
 
 if not sys.platform.startswith('win'):
@@ -137,6 +138,17 @@ class Terminal(object):
                 del cls._atty_overrides[key]
             else:
                 cls._atty_overrides[key] = previous
+
+    @classmethod
+    @contextlib.contextmanager
+    def disable_keyboard_interrupt_stacktracktrace(cls, logging_level=logging.INFO):
+        try:
+            yield
+        except KeyboardInterrupt:
+            if logging.root.level <= logging_level:
+                raise
+            sys.stderr.write('\nUser interrupted program\n')
+            sys.exit(1)
 
     @classmethod
     def open_url(cls, url, prompt=None, alert_after=RING_INTERVAL):

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/terminal_unittest.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/terminal_unittest.py
@@ -20,6 +20,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import logging
 import sys
 import unittest
 
@@ -111,3 +112,14 @@ class TerminalTests(unittest.TestCase):
 
         self.assertEqual(caught.exception.code, 1)
         self.assertEqual(captured.stderr.getvalue(), '\nUser interrupted program\n')
+
+    def test_interrupt_decorator(self):
+        with OutputCapture() as captured, self.assertRaises(SystemExit) as caught:
+            with Terminal.disable_keyboard_interrupt_stacktracktrace(logging.root.level - 1):
+                raise KeyboardInterrupt
+        self.assertEqual(caught.exception.code, 1)
+        self.assertEqual(captured.stderr.getvalue(), '\nUser interrupted program\n')
+
+        with self.assertRaises(KeyboardInterrupt):
+            with Terminal.disable_keyboard_interrupt_stacktracktrace(logging.root.level):
+                raise KeyboardInterrupt

--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.14.3',
+    version='5.14.4',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 14, 3)
+version = Version(5, 14, 4)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
@@ -52,7 +52,7 @@ from .trace import Trace
 from .track import Track
 
 from webkitbugspy import log as webkitbugspy_log
-from webkitcorepy import arguments, filtered_call, log as webkitcorepy_log
+from webkitcorepy import arguments, filtered_call, log as webkitcorepy_log, Terminal
 from webkitscmpy import local, log, remote
 
 
@@ -177,12 +177,13 @@ def main(
         parser.print_help()
         return -1
 
-    return parsed.main(
-        args=parsed,
-        repository=repository,
-        identifier_template=identifier_template,
-        subversion=subversion,
-        additional_setup=additional_setup,
-        hooks=hooks,
-        canonical_svn=canonical_svn,
-    )
+    with Terminal.disable_keyboard_interrupt_stacktracktrace():
+        return parsed.main(
+            args=parsed,
+            repository=repository,
+            identifier_template=identifier_template,
+            subversion=subversion,
+            additional_setup=additional_setup,
+            hooks=hooks,
+            canonical_svn=canonical_svn,
+        )


### PR DESCRIPTION
#### 2ce712d5507689221c0f5f2e2ed918cafc093f0a
<pre>
[git-webkit] Handle interupts while pushing
<a href="https://bugs.webkit.org/show_bug.cgi?id=253327">https://bugs.webkit.org/show_bug.cgi?id=253327</a>
rdar://106201813

Reviewed by Elliott Williams.

We should gracefully handle keyboard interupts when running push commands,
since that is a common (and expected) place for engineers to interupt git-webkit.

* Tools/Scripts/libraries/webkitcorepy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/terminal.py:
(Terminal.disable_keyboard_interrupt_stacktracktrace): Disable KeyboardInterupt stacktraces based on logging level.
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/terminal_unittest.py:
(TerminalTests.test_interrupt_decorator):
* Tools/Scripts/libraries/webkitcorepy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py: Disable KeyboardInterupt stacktraces
at the default logging level.

Canonical link: <a href="https://commits.webkit.org/261487@main">https://commits.webkit.org/261487@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8057c9e8c08ef12e63ec7a172941aad8c3d8d164

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/111851 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/20978 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/90/builds/461 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/3610 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/120542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/115915 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/22328 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/12036 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/87/builds/3610 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/117615 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/22328 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/90/builds/461 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/104859 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/5/builds/115279 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/22328 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/90/builds/461 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/104859 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/13428 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/90/builds/461 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/104859 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/13943 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/12036 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/20/builds/110614 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/19379 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/90/builds/461 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/15911 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4359 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->