### PR TITLE
[WebGPU] Some command_encoder CTS tests do not pass

### DIFF
--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -869,6 +869,9 @@ void CommandEncoder::copyTextureToTexture(const WGPUImageCopyTexture& source, co
         // https://developer.apple.com/documentation/metal/mtlblitcommandencoder/1400756-copyfromtexture?language=objc
         // "When you copy to a 1D texture, height and depth must be 1."
         auto sourceSize = MTLSizeMake(copySize.width, 1, 1);
+        if (!sourceSize.width)
+            return;
+
         auto sourceOrigin = MTLOriginMake(source.origin.x, 0, 0);
         auto destinationOrigin = MTLOriginMake(destination.origin.x, 0, 0);
 
@@ -892,6 +895,9 @@ void CommandEncoder::copyTextureToTexture(const WGPUImageCopyTexture& source, co
         // https://developer.apple.com/documentation/metal/mtlblitcommandencoder/1400756-copyfromtexture?language=objc
         // "When you copy to a 2D texture, depth must be 1."
         auto sourceSize = MTLSizeMake(copySize.width, copySize.height, 1);
+        if (!sourceSize.width || !sourceSize.height)
+            return;
+
         auto sourceOrigin = MTLOriginMake(source.origin.x, source.origin.y, 0);
         auto destinationOrigin = MTLOriginMake(destination.origin.x, destination.origin.y, 0);
 
@@ -913,6 +919,9 @@ void CommandEncoder::copyTextureToTexture(const WGPUImageCopyTexture& source, co
     }
     case WGPUTextureDimension_3D: {
         auto sourceSize = MTLSizeMake(copySize.width, copySize.height, copySize.depthOrArrayLayers);
+        if (!sourceSize.width || !sourceSize.height || !sourceSize.depth)
+            return;
+
         auto sourceOrigin = MTLOriginMake(source.origin.x, source.origin.y, source.origin.z);
         auto destinationOrigin = MTLOriginMake(destination.origin.x, destination.origin.y, destination.origin.z);
 

--- a/Source/WebGPU/WebGPU/Texture.mm
+++ b/Source/WebGPU/WebGPU/Texture.mm
@@ -29,6 +29,7 @@
 #import "APIConversions.h"
 #import "Device.h"
 #import "TextureView.h"
+#import <bmalloc/Algorithm.h>
 #import <wtf/CheckedArithmetic.h>
 #import <wtf/MathExtras.h>
 
@@ -2380,21 +2381,25 @@ WGPUExtent3D Texture::physicalMiplevelSpecificTextureExtent(uint32_t mipLevel)
 
     auto logicalExtent = logicalMiplevelSpecificTextureExtent(mipLevel);
 
+    auto roundUpToMultipleOf = [](size_t a, size_t b) {
+        return static_cast<uint32_t>(bmalloc::roundUpToMultipleOfNonPowerOfTwo(a, b));
+    };
+
     switch (m_dimension) {
     case WGPUTextureDimension_1D:
         return {
-            static_cast<uint32_t>(WTF::roundUpToMultipleOf(texelBlockWidth(m_format), logicalExtent.width)),
+            roundUpToMultipleOf(texelBlockWidth(m_format), logicalExtent.width),
             1,
             logicalExtent.depthOrArrayLayers };
     case WGPUTextureDimension_2D:
         return {
-            static_cast<uint32_t>(WTF::roundUpToMultipleOf(texelBlockWidth(m_format), logicalExtent.width)),
-            static_cast<uint32_t>(WTF::roundUpToMultipleOf(texelBlockHeight(m_format), logicalExtent.height)),
+            roundUpToMultipleOf(texelBlockWidth(m_format), logicalExtent.width),
+            roundUpToMultipleOf(texelBlockHeight(m_format), logicalExtent.height),
             logicalExtent.depthOrArrayLayers };
     case WGPUTextureDimension_3D:
         return {
-            static_cast<uint32_t>(WTF::roundUpToMultipleOf(texelBlockWidth(m_format), logicalExtent.width)),
-            static_cast<uint32_t>(WTF::roundUpToMultipleOf(texelBlockHeight(m_format), logicalExtent.height)),
+            roundUpToMultipleOf(texelBlockWidth(m_format), logicalExtent.width),
+            roundUpToMultipleOf(texelBlockHeight(m_format), logicalExtent.height),
             logicalExtent.depthOrArrayLayers };
     case WGPUTextureDimension_Force32:
         ASSERT_NOT_REACHED();


### PR DESCRIPTION
#### e158a1d4ece234b2b2d612fd7a796a107e292b4a
<pre>
[WebGPU] Some command_encoder CTS tests do not pass
<a href="https://bugs.webkit.org/show_bug.cgi?id=253325">https://bugs.webkit.org/show_bug.cgi?id=253325</a>
&lt;radar://106199852&gt;

Reviewed by Myles C. Maxfield.

This patch fixes two issues:

(1) copying zero-size is a no-op according to the specification.
(2) texelBlockWidth/height are not generally powers of two, so we
can&apos;t use WTF::roundUpToMultipleOf which requires the first argument
to be a power of two.

* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::copyTextureToTexture):
No-op on zero size.

* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::Texture::physicalMiplevelSpecificTextureExtent):
We could have written our own, but there is already an implementation
in bmalloc which is usable with casting from size_t -&gt; uint32_t

Canonical link: <a href="https://commits.webkit.org/261303@main">https://commits.webkit.org/261303@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/678a62111fb102a9e6f139bb05e1673f3de53c80

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111184 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20325 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43741 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2608 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120016 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21697 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11425 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2227 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116942 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16117 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99299 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103762 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98074 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30961 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44650 "") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12839 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32296 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/86527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13373 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9285 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18797 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7835 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15325 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->